### PR TITLE
Respond to "ping" messages with "pong"

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -65,7 +65,7 @@ containing the id of the channel. It is invalid to have a present but empty
 
 Unknown control messages are ignored. Control messages that have a channel are
 forwarded to the correct endpoint. Control messages without a channel are not
-forwarded automatically.
+forwarded, but only travel a single hop.
 
 
 Command: init
@@ -282,7 +282,8 @@ Command: ping
 
 The "ping" command is simply a keep alive.
 
-No additional fields are defined.
+No additional fields are defined, but any are allowed. If a "channel"
+is set this "ping" will be forwarded. Otherwise it be limited to a single hop.
 
 An example of a ping:
 
@@ -290,7 +291,10 @@ An example of a ping:
         "command": "ping",
     }
 
-Any protocol participant can send this message, but it is not responded to.
+Any protocol participant can send a "ping". It is responded to by sending
+a "pong" with identical options as a reply. If a "ping" is sent with a
+"channel" field set to a channel that is not currently open, the "ping"
+will be ignored as expected, and no "pong" will be sent.
 
 Command: authorize
 ------------------

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -462,6 +462,8 @@ function Transport() {
         }
 
         check_health_timer = window.setInterval(function () {
+            if (self.ready)
+                ws.send("\n{ \"command\": \"ping\" }");
             if (!got_message) {
                 if (ignore_health_check) {
                     console.log("health check failure ignored");
@@ -621,8 +623,9 @@ function Transport() {
             }
             self.close(data);
 
+        /* Any pings get sent back */
         } else if (data.command == "ping") {
-            /* 'ping' messages are ignored */
+            self.send_control(data);
 
         } else if (data.command == "hint") {
             if (process_hints)

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -202,7 +202,8 @@ test_template_SOURCES = src/common/test-template.c
 test_template_LDADD = $(libcockpit_common_a_LIBS)
 
 test_transport_CFLAGS = $(libcockpit_common_a_CFLAGS)
-test_transport_SOURCES = src/common/test-transport.c
+test_transport_SOURCES = src/common/test-transport.c \
+	src/common/mock-transport.c src/common/mock-transport.h
 test_transport_LDADD = $(libcockpit_common_a_LIBS)
 
 test_unicode_CFLAGS = $(libcockpit_common_a_CFLAGS)

--- a/src/common/cockpitchannel.c
+++ b/src/common/cockpitchannel.c
@@ -175,7 +175,12 @@ process_control (CockpitChannel *self,
       return;
     }
 
-  if (g_str_equal (command, "done"))
+  if (g_str_equal (command, "ping"))
+    {
+      cockpit_channel_control (self, "pong", options);
+      return;
+    }
+  else if (g_str_equal (command, "done"))
     {
       if (self->priv->received_done)
         cockpit_channel_fail (self, "protocol-error", "channel received second done");


### PR DESCRIPTION
The protocol has been extended to respond to "ping" messages with "pong" messages. "ping" messages with channels are forwarded all the way through to their destination, before being responded to. "ping" messages without channels are responded to immediately and not forwarded.
    
The contents of a "pong" are identical to the ping except for the fact that the command has changed.

The now extended "ping" messages will be the basis for flow control.

 * [x] Blocked on #9551