### PR TITLE
Implement Flow control

### DIFF
--- a/doc/routing.md
+++ b/doc/routing.md
@@ -1,0 +1,73 @@
+
+
+Flow Control
+------------
+
+Cockpit's protocol passes messages on reliable, ordered underlying
+transports (eg: WebSockets, HTTP responses, stdio) between multiple
+peers, aranged in in a non-rooted tree graph.
+
+Cockpit's flow control is not about replaying messages, but avoiding
+flooding any peer by sending messages along any link in the graph
+too rapidly.
+
+Cockpit's flow control operates at the level of channels in the protocol
+(described in doc/protocol.md). A simple blocking of any peer's message input
+would block all channels, and not have the desired effect of slowing
+down a certain channel which is flooding communication.
+
+Therefore we use a windowing flow control protocol. It is based around
+per-channel "ping" control messages. In the Cockpit protocol "ping"
+messages in a channel are responded to by specific leaves of the graph.
+They are replied to with a "pong" contaning otherwise identical content.
+Other "ping" messages are used as keep alives, but these are beyond the
+scope of this description.
+
+Each channel leaf that participates in flow control sends "ping"
+messages with a sequence number, and waits to see the corresponding
+"pong" message with the same sequence and channel number. By checking
+the "ping" sequence numbers responded to, a channel can slow input and/or
+transmission to wait for the opposite leaf to catch up.
+
+Sadly this is not enough. The leaves in of Cockpit's tree often do not
+consume data themselves, but pass it on to other sockets, streams, files
+and so on.
+
+Various leaves monitor their output edge queues and hold back responding
+to "ping" messages if their output edge queue is too full. This is done
+by use of "pressure" signals on the output queue to indicate when pressure
+is high or low.
+
+This results in flow control that achieves its intent, but does not
+make guarantees. In addition only some channels and leaves implement flow
+control at this point:
+
+ * cockpit.js: Responds to "ping" messages indicating that a given
+   sequence has reached the browser.
+
+ * CockpitChannel: Sends sequence pings, every so often in the channel.
+   Is responsible for responding to channel pings, and holding back
+   responses to pings if a related queue has output "pressure".
+   Slows down an input pipe via a "pressure" signal when too many
+   sequences are outstanding and have not been responded to.
+
+ * CockpitStream: Can listen to "pressure" signals and pause reading its
+   input stream. Can generate "pressure" signals when its output queue
+   is too full.
+
+ * CockpitPipe: Can listen to "pressure" signals and pause reading its
+   input file descriptor. Can generate "pressure" signals when its
+   output queue is too full.
+
+ * CockpitWebResponse: Can generate "pressure" signals when its output
+   queue is too full.
+
+ * WebSocketConnection: Can listen to "pressure" signals and pause accepting
+   incoming web socket messages. Can generate "pressure" signals when its
+   output queue is too full.
+
+ * CockpitHttpStream: Uses CockpitStream and CockpitChannel together to
+   implement flow control on a HTTP client connection.
+
+ * CockpitFsRead: Listens to "pressure" signals from the CockpitChannel
+   to tell it to pause reading a file.

--- a/src/bridge/cockpitfsread.c
+++ b/src/bridge/cockpitfsread.c
@@ -21,6 +21,7 @@
 
 #include "cockpitfsread.h"
 
+#include "common/cockpitflow.h"
 #include "common/cockpitjson.h"
 #include "common/cockpitpipe.h"
 
@@ -271,6 +272,12 @@ cockpit_fsread_prepare (CockpitChannel *channel)
   fd = -1;
 
   self->start_tag = cockpit_get_file_tag_from_fd (self->fd);
+
+  /* Let the channel throttle the pipe's input flow*/
+  cockpit_flow_throttle (COCKPIT_FLOW (self->pipe), COCKPIT_FLOW (self));
+
+  /* Let the pipe input the channel peer's output flow */
+  cockpit_flow_throttle (COCKPIT_FLOW (channel), COCKPIT_FLOW (self->pipe));
 
   self->sig_read = g_signal_connect (self->pipe, "read", G_CALLBACK (on_pipe_read), self);
   self->sig_close = g_signal_connect (self->pipe, "close", G_CALLBACK (on_pipe_close), self);

--- a/src/bridge/cockpitpipechannel.c
+++ b/src/bridge/cockpitpipechannel.c
@@ -23,6 +23,7 @@
 
 #include "cockpitconnect.h"
 
+#include "common/cockpitflow.h"
 #include "common/cockpitpipe.h"
 #include "common/cockpitjson.h"
 #include "common/cockpitunicode.h"
@@ -500,6 +501,12 @@ cockpit_pipe_channel_prepare (CockpitChannel *channel)
       self->pipe = cockpit_pipe_connect (self->name, address);
       g_object_unref (address);
     }
+
+  /* Let the channel throttle the pipe's input flow*/
+  cockpit_flow_throttle (COCKPIT_FLOW (self->pipe), COCKPIT_FLOW (self));
+
+  /* Let the pipe throttle the channel peer's output flow */
+  cockpit_flow_throttle (COCKPIT_FLOW (channel), COCKPIT_FLOW (self->pipe));
 
   self->sig_read = g_signal_connect (self->pipe, "read", G_CALLBACK (on_pipe_read), self);
   self->sig_close = g_signal_connect (self->pipe, "close", G_CALLBACK (on_pipe_close), self);

--- a/src/bridge/cockpitwebsocketstream.c
+++ b/src/bridge/cockpitwebsocketstream.c
@@ -25,6 +25,7 @@
 #include "cockpitstream.h"
 
 #include "common/cockpitchannel.h"
+#include "common/cockpitflow.h"
 #include "common/cockpitjson.h"
 
 #include "websocket/websocket.h"
@@ -338,6 +339,12 @@ on_socket_connect (GObject *object,
   self->sig_closing = g_signal_connect (self->client, "closing", G_CALLBACK (on_web_socket_closing), self);
   self->sig_close = g_signal_connect (self->client, "close", G_CALLBACK (on_web_socket_close), self);
   self->sig_error = g_signal_connect (self->client, "error", G_CALLBACK (on_web_socket_error), self);
+
+  /* Let the channel throttle the websocket's input flow*/
+  cockpit_flow_throttle (COCKPIT_FLOW (self->client), COCKPIT_FLOW (self));
+
+  /* Let the websocket throtlte the channel peer's output flow */
+  cockpit_flow_throttle (COCKPIT_FLOW (channel), COCKPIT_FLOW (self->client));
 
   problem = NULL;
 

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -157,6 +157,7 @@ test_base64_LDADD = libretest.a
 
 test_channel_SOURCES = \
 	src/common/test-channel.c \
+	src/common/mock-pressure.c src/common/mock-pressure.h \
 	src/common/mock-transport.c src/common/mock-transport.h
 test_channel_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_channel_LDADD = $(libcockpit_common_a_LIBS)

--- a/src/common/mock-channel.c
+++ b/src/common/mock-channel.c
@@ -21,7 +21,7 @@
 
 #include "mock-channel.h"
 
-typedef CockpitTransportClass MockEchoChannelClass;
+typedef CockpitChannelClass MockEchoChannelClass;
 
 G_DEFINE_TYPE (MockEchoChannel, mock_echo_channel, COCKPIT_TYPE_CHANNEL);
 

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -22,6 +22,7 @@
 #include "cockpitchannelresponse.h"
 
 #include "common/cockpitchannel.h"
+#include "common/cockpitflow.h"
 #include "common/cockpitwebinject.h"
 #include "common/cockpitwebserver.h"
 #include "common/cockpitwebresponse.h"
@@ -393,6 +394,12 @@ cockpit_channel_response_prepare (CockpitChannel *channel)
   CockpitChannelResponse *self = COCKPIT_CHANNEL_RESPONSE (channel);
   const gchar *payload;
   JsonObject *open;
+
+  /*
+   * Tell the transport to throttle incoming flow on the given channel based on
+   * output pressure in the web response.
+   */
+  cockpit_flow_throttle (COCKPIT_FLOW (channel), COCKPIT_FLOW (self->response));
 
   open = cockpit_channel_get_options (channel);
   cockpit_json_get_string (open, "path", NULL, &self->logname);

--- a/src/ws/cockpitchannelsocket.c
+++ b/src/ws/cockpitchannelsocket.c
@@ -22,6 +22,7 @@
 #include "cockpitchannelsocket.h"
 
 #include "common/cockpitchannel.h"
+#include "common/cockpitflow.h"
 
 #include "websocket/websocket.h"
 
@@ -229,6 +230,12 @@ cockpit_channel_socket_open (CockpitWebService *service,
 
   /* Unref when the channel closes */
   g_signal_connect_after (self, "closed", G_CALLBACK (g_object_unref), NULL);
+
+  /* Tell the channel to throttle based on back pressure from socket */
+  cockpit_flow_throttle (COCKPIT_FLOW (self), COCKPIT_FLOW (self->socket));
+
+  /* Tell the socket peer's output to throttle based on back pressure */
+  cockpit_flow_throttle (COCKPIT_FLOW (self->socket), COCKPIT_FLOW (self));
 
 out:
   g_free (id);

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -20,7 +20,9 @@
 
 import parent
 from testlib import *
+
 import base64
+import time
 
 class TestConnection(MachineCase):
     def testBasic(self):
@@ -272,6 +274,31 @@ class TestConnection(MachineCase):
         # external channel handler; unauthenticated, thus 404
         headers = m.execute("curl -s --head http://172.27.0.15:9090/cockpit+123/channel/foo")
         self.assertIn("HTTP/1.1 404 Not Found\r\n", headers)
+
+    def testFlowControl(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/playground/speed", user="root")
+
+        # Check the speed playground page
+        b.switch_to_top()
+        b.go("/playground/speed")
+        b.enter_page("/playground/speed")
+
+        b.wait_text_not("#pid", "")
+        pid = b.text("#pid")
+
+        b.set_val("#read-path", "/dev/vda")
+        b.click("#read-sideband")
+
+        b.wait_text_not("#speed", "")
+        time.sleep(20)
+        output = m.execute("cat /proc/{}/statm".format(pid))
+        rss = int(output.split(" ")[0])
+
+        # This fails when flow control is not present
+        self.assertLess(rss, 200000)
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Cockpit's protocol passes messages on reliable, ordered underlying transports (eg: WebSockets, HTTP responses, stdio) between multiple peers, aranged in in a non-rooted tree graph.

Cockpit's flow control is not about replying messages, but avoiding flooding any peer by sending messages along any route in the graph too rapidly.

Cockpit's flow control operates at the level of channels in the protocol (described elsewhere). A simple blocking of any peer's message input would block all channels, and not have the desired effect of slowing down a certain channel which is flooding communication.

Therefore we use a windowing flow control protocol. It is based around per-channel "ping" control messages. In the Cockpit protocol "ping" messages in a channel are responded to by specific leafs of the graph. They are replied to with a "pong" contaning otherwise identical content. Other "ping" messages are used as keep alives, but these are beyond the scope of this description.

Each channel leaf that participates in flow control sends "ping" messages with a sequence number, and waits to see the corresponding "pong" message with the same sequence and channel number. By checking the "ping" sequence numbers responded to, a channel can slow input and/or transmission to wait for opposite leaf to catch up.

Sadly this is not enough. The leaf's in of Cockpit's tree often do not consume or generate data themselves, but pass it on to other sockets, streams, files and so on.

Various leaf's monitor their output edge queues and hold back responding to "ping" messages if their output edge queue is too full. This is done by use of "pressure" signals on the output queue to indicate when pressure is high or low.

This results in flow control that is achieves its intent, but does not make guarantees. In addition only some channels and leafs implement flow control at this point:

 * cockpit.js: Responds to "ping" messages indicating that a given sequence has reached the browser.

 * CockpitChannel: Sends sequence pings, every so often in the channel. Slows down an input pipe via a "pressure" signal when too many sequences are outstanding and have not been responded to.

 * CockpitStream: Can listen to "pressure" signals and pause reading its input stream. Can generate "pressure" signals when its output queue is too full.

 * CockpitPipe: Can listen to "pressure" signals and pause reading its input file descriptor. Can generate "pressure" signals when its output queue is too full.

 * CockpitWebResponse: Can generate "pressure" signals when its output queue is too full. WebSocketConnection: Can listen to "pressure" signals and pause accepting incoming web socket messages. Can generate "pressure" signals when its output queue is too full.

 * CockpitHttpStream: Uses CockpitStream and CockpitChannel together to implement flow control on a HTTP client connection.

 * CockpitFsRead: Listens to "pressure" signals from the CockpitChannel to tell it to pause reading a file.

Blocked on:

 * [x] Finish implementation
 * [x] Implement tests
 * [x] #9551 
 * [x] #9552
 * [x] #9560 
 * [x] #9585 
 * [x] #9586 
 * [x] #9587
 * [x] #9596