### PR TITLE
bots: Add Fedora 27 naughty override for modules.dep.bin SELinux denial

### DIFF
--- a/bots/naughty/fedora-27/8100-selinux-modules.dep.bin
+++ b/bots/naughty/fedora-27/8100-selinux-modules.dep.bin
@@ -1,0 +1,1 @@
+Error: audit: type=1400*avc:  denied  { map } for * path="/usr/lib/modules*/modules.dep.bin"


### PR DESCRIPTION
This is an old bug, but the override didn't get applied to Fedora 27
yet. It still causes test failures in the container/kubernetes tests.