### PR TITLE
test: Fix flake in check-realms

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -302,6 +302,7 @@ class TestRealms(MachineCase):
         m.wait_reboot()
 
         self.allow_authorize_journal_messages()
+        self.allow_restart_journal_messages()
 
     def testNotSupported(self):
         m = self.machine


### PR DESCRIPTION
`testIpaUnqualifiedUsers` reboots, but forgot to allow the corresponding
messages. Fixes this failure:

```
Error: org.freedesktop.PackageKit: couldn't get all properties of org.freedesktop.PackageKit.Transaction at /5_beedcbdc: GDBus.Error:org.freedesktop.DBus.Error.NoReply: Message recipient disconnected from message bus without replying
```