### PR TITLE
bots: Use "/usr/bin/mock" consistently in fedora.install

### DIFF
--- a/bots/images/scripts/lib/fedora.install
+++ b/bots/images/scripts/lib/fedora.install
@@ -111,5 +111,5 @@ if [ -n "$do_install" ]; then
 fi
 
 if [ -n "$do_build" ]; then
-    su builder -c "mock --clean"
+    su builder -c "/usr/bin/mock --clean"
 fi


### PR DESCRIPTION
Otherwise one might get this error:

    + su builder -c 'mock --clean'
    ERROR: [Errno 1] Operation not permitted
    ERROR: The most common cause for this error is trying to run /usr/sbin/mock as an unprivileged user.
    ERROR: Check your path to make sure that /usr/bin/ is listed before /usr/sbin, or manually run /usr/bin/mock to see if that fixes this problem.