### PR TITLE
Really move verify tests to Python 3

### DIFF
--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -221,6 +221,9 @@ def normalize_traceback(trace):
     # replace noise in SELinux violations
     trace = re.sub('audit\([0-9.:]+\)', 'audit(0)', trace)
     trace = re.sub(r'\b(pid|ino)=[0-9]+ ', r'\1=0 ', trace)
+
+    # in Python 3, testlib.Error is shown with namespace
+    trace = re.sub('testlib\.Error', 'Error', trace)
     return trace
 
 def check_known_issue(api, trace, image):

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -555,6 +555,11 @@ class MachineCase(unittest.TestCase):
         return browser
 
     def checkSuccess(self):
+        if _PY3 and self._outcome:
+            # errors is a list of (method, exception) calls (usually multiple
+            # per method); None exception means success
+            return not any(e[1] for e in self._outcome.errors)
+
         if not self.currentResult:
             return False
         for error in self.currentResult.errors:
@@ -638,7 +643,10 @@ class MachineCase(unittest.TestCase):
 
         def sitter():
             if opts.sit and not self.checkSuccess():
-                self.currentResult.printErrors()
+                if _PY3 and self._outcome:
+                    [traceback.print_exception(*e[1]) for e in self._outcome.errors if e[1]]
+                else:
+                    self.currentResult.printErrors()
                 sit(self.machines)
         self.addCleanup(sitter)
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -572,14 +572,15 @@ class MachineCase(unittest.TestCase):
         return True
 
     def run(self, result=None):
-        orig_result = result
+        if not _PY3:
+            orig_result = result
 
-        # We need a result to intercept, so create one here
-        if result is None:
-            result = self.defaultTestResult()
-            startTestRun = getattr(result, 'startTestRun', None)
-            if startTestRun is not None:
-                startTestRun()
+            # We need a result to intercept, so create one here
+            if result is None:
+                result = self.defaultTestResult()
+                startTestRun = getattr(result, 'startTestRun', None)
+                if startTestRun is not None:
+                    startTestRun()
 
         self.currentResult = result
 
@@ -602,11 +603,12 @@ class MachineCase(unittest.TestCase):
 
         self.currentResult = None
 
-        # Standard book keeping that we have to do
-        if orig_result is None:
-            stopTestRun = getattr(result, 'stopTestRun', None)
-            if stopTestRun is not None:
-                stopTestRun()
+        if not _PY3:
+            # Standard book keeping that we have to do
+            if orig_result is None:
+                stopTestRun = getattr(result, 'stopTestRun', None)
+                if stopTestRun is not None:
+                    stopTestRun()
 
     def setUp(self):
         if opts.address and self.provision is not None:

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -139,7 +139,7 @@ class TestBotsVM(unittest.TestCase):
         self.assertEqual(ssh_command[0], "ssh")
         with testvm.Timeout(seconds=30, error_message="Timed out waiting for ssh command"):
             out = subprocess.check_output(ssh_command + ["cat", "/var/custom-test"])
-        self.assertEqual(out, "hello\n")
+        self.assertEqual(out, b"hello\n")
 
         # should cleanly stop on SIGTERM
         vm.terminate()

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -143,7 +143,7 @@ class TestConnection(MachineCase):
         self.assertIn("1 s:/OU=Intermediate", output)
 
         # login handler: correct password
-        m.execute("curl -k -c cockpit.jar -s --head --header 'Authorization: Basic {}' https://127.0.0.1:9090/cockpit/login".format(base64.b64encode(b"admin:foobar"), ))
+        m.execute("curl -k -c cockpit.jar -s --head --header 'Authorization: Basic {}' https://127.0.0.1:9090/cockpit/login".format(base64.b64encode(b"admin:foobar").decode(), ))
         headers = m.execute("curl -k --head -b cockpit.jar -s https://127.0.0.1:9090/")
         if m.image in ["rhel-7-5"]:
             self.assertIn("default-src 'self' https://127.0.0.1:9090; connect-src 'self' https://127.0.0.1:9090 ws: wss", headers)
@@ -255,13 +255,13 @@ class TestConnection(MachineCase):
 
         # login handler: wrong password
         headers = m.execute("curl -s --head --header 'Authorization: Basic {}' http://172.27.0.15:9090/cockpit/login".format(
-            base64.b64encode(b"admin:hahawrong")))
+            base64.b64encode(b"admin:hahawrong").decode()))
         self.assertIn("HTTP/1.1 401 Authentication failed\r\n", headers)
         self.assertNotIn("Set-Cookie:", headers)
 
         # login handler: correct password
         headers = m.execute("curl -s --head --header 'Authorization: Basic {}' http://172.27.0.15:9090/cockpit/login".format(
-            base64.b64encode(b"admin:foobar")))
+            base64.b64encode(b"admin:foobar").decode()))
         self.assertIn("HTTP/1.1 200 OK\r\n", headers)
         self.assertIn("Set-Cookie: cockpit", headers)
 

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -286,9 +286,10 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_restart_journal_messages()
 
     def curl_auth(self, url, userpass):
-        header = "Authorization: Basic " + base64.b64encode(userpass)
+        header = "Authorization: Basic " + base64.b64encode(userpass.encode()).decode()
         return subprocess.check_output(['/usr/bin/curl', '-s', '-k',  '-D', '-', '--header', header,
-               'http://{0}:{1}{2}'.format(self.machine.web_address, self.machine.web_port, url) ])
+               'http://{0}:{1}{2}'.format(self.machine.web_address, self.machine.web_port, url) ],
+               universal_newlines=True)
 
     def curl_auth_code(self, url, userpass):
         lines = self.curl_auth(url, userpass).splitlines()

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -483,7 +483,7 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
             if per_second:
                 units_regex += "/s"
             m = re.match(units_regex, b.text(selector))
-            return m.group(1) if m else None
+            return float(m.group(1)) if m else None
 
         wait(lambda: get_units_value("#memory-metric-title") > 0)
         self.assertGreaterEqual(get_units_value("#download-metric", True), 0)

--- a/test/verify/check-ostree
+++ b/test/verify/check-ostree
@@ -573,7 +573,7 @@ class OstreeCase(MachineCase):
         b.click("modal-dialog .group-buttons button.btn-primary")
         b.wait_present("modal-dialog .group-buttons div.dialog-error")
 
-        with open(os.path.join(TEST_DIR, "verify", "files", "publickey.asc"), 'rb') as fp:
+        with open(os.path.join(TEST_DIR, "verify", "files", "publickey.asc"), 'r') as fp:
             gpg_data = fp.read()
 
         b.set_val("modal-dialog #gpg-data", gpg_data)

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -49,7 +49,7 @@ class NetworkCase(MachineCase):
         ver = self.machine.execute("busctl --system get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Version || true")
         m = re.match('s "(.*)"', ver)
         if m:
-            self.networkmanager_version = map(int, m.group(1).split("."))
+            self.networkmanager_version = [int(x) for x in m.group(1).split(".")]
         else:
             self.networkmanager_version = [ 0 ]
 

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 import glob
 import imp
@@ -53,7 +53,8 @@ def main():
 
     revision = os.environ.get("TEST_REVISION")
     if not revision:
-        revision = subprocess.check_output([ "git", "rev-parse", "HEAD" ]).strip()
+        revision = subprocess.check_output([ "git", "rev-parse", "HEAD" ],
+                                           universal_newlines=True).strip()
 
     # Tell any subprocesses what we are testing
     os.environ["TEST_REVISION"] = revision


### PR DESCRIPTION
 - [x] fix artifact building and sit on failures (`checkSuccess` is always true even on failures)
 - [x] fix check-connection regressions
 - [x] fix other test regressions
 - [x] fix `check-ostree OstreeCase.testRemoteManagement`
 - [x] introduce `_PY3` in testlib.py (PR #9582)