### PR TITLE
docker: Allow forced removal of images

### DIFF
--- a/pkg/docker/client.js
+++ b/pkg/docker/client.js
@@ -616,12 +616,14 @@
                 });
         };
 
-        this.rmi = function rmi(id) {
+        this.rmi = function rmi(id, forced) {
+            forced = forced || false;
             waiting(id);
             util.docker_debug("deleting:", id);
             return http.request({
                 method: "DELETE",
                 path: "/v1.12/images/" + encodeURIComponent(id),
+                params: { "force": forced },
                 body: ""
             })
                 .fail(function(ex) {
@@ -724,6 +726,17 @@
                 perform_connect();
             }
             return connected.promise();
+        };
+
+        this.containers_for_image = function containers_for_image(id) {
+            util.docker_debug('containers search on image id: ', id);
+            return http.get('/v1.12/containers/json', { all: 1 , filters: JSON.stringify({ ancestor: [ id ] }) })
+                .fail(function(ex) {
+                    util.docker_debug('containers search on image id failed:', id, ex);
+                })
+                .done(function(data) {
+                    util.docker_debug('containers search on image id succeeded:', id);
+                }).then(JSON.parse);
         };
 
         /* Initially empty info data */

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -628,3 +628,18 @@ table.drive-list td:nth-child(2) img {
     padding-left: 20px;
     padding-right: 20px;
 }
+
+#delete-image-confirmation-dialog-containers {
+    max-height: 300px;
+    overflow-y: auto;
+    border: 1px solid #BABABA;
+    margin-top: 10px;
+}
+
+#delete-image-confirmation-dialog-containers .listing-ct-body {
+    border: none;
+}
+
+#delete-image-confirmation-dialog-containers .table {
+    margin-bottom: 0px;
+}

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -753,4 +753,34 @@
     </div>
   </div>
 
+  <!-- DELETE IMAGE CONFIRMATION DIALOG -->
+  <div class="modal" id="delete-image-confirmation-dialog"
+       tabindex="-1" role="dialog"
+       data-backdrop="static">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" id="delete-image-confirmation-dialog-title"></h4>
+        </div>
+        <div class="modal-body">
+          <div id="delete-image-confirmation-dialog-body"
+               tabindex="-1">
+          </div>
+          <div id="delete-image-confirmation-dialog-containers">
+            <table class="table table-hover">
+              <tbody class="listing-ct-body">
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-default" translatable="yes" id="delete-image-confirmation-dialog-cancel">Cancel</button>
+          <span data-toggle="tooltip">
+            <button class="btn btn-danger" id="delete-image-confirmation-dialog-confirm" />
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </body>

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -40,6 +40,14 @@ class TestDocker(MachineCase):
         with b.wait_timeout(5):
             b.wait_popdown("confirmation-dialog")
 
+    def deleteImageConfirm(self):
+        b = self.browser
+        b.wait_popup('delete-image-confirmation-dialog')
+        b.click('#delete-image-confirmation-dialog-confirm')
+        # popdown could be delayed because of running containers
+        with b.wait_timeout(20):
+            b.wait_popdown('delete-image-confirmation-dialog')
+
     def del_container_from_details(self, container_name):
         b = self.browser
         b.wait_visible("#container-details-delete:not([disabled])")
@@ -196,9 +204,58 @@ class TestDocker(MachineCase):
 
         # Delete image itself
         b.click("#image-details-delete")
-        self.confirm()
+        self.deleteImageConfirm()
         b.wait_visible("#containers")
         b.wait_not_in_text('#containers-images', 'busybox:latest')
+
+    def testDeleteImages(self):
+        b = self.browser
+        m = self.machine
+        m.execute("systemctl start docker || systemctl start docker-latest")
+        self.login_and_go("/docker")
+        b.wait_in_text("#containers-images", "busybox:latest")
+
+        # Deleting an image without depending containers has no container list
+        b.wait_visible('#containers-images tr:contains("busybox:latest") td.listing-ct-toggle')
+        b.click('#containers-images tr:contains("busybox:latest") td.listing-ct-toggle')
+        b.wait_visible('#containers-images tr:contains("busybox:latest") + tr .btn-delete')
+        b.click('#containers-images tr:contains("busybox:latest") + tr .btn-delete')
+        b.wait_popup('delete-image-confirmation-dialog')
+        self.assertFalse(b.is_visible('#delete-image-confirmation-dialog-containers'))
+        b.click('#delete-image-confirmation-dialog-cancel')
+        b.wait_popdown('delete-image-confirmation-dialog')
+        b.click('#containers-images tr:contains("busybox:latest") td.listing-ct-toggle')
+
+        # Create some containers
+        b.click('#containers-images tr:contains("busybox:latest") button.fa-play')
+        b.wait_popup('containers_run_image_dialog')
+        b.set_val('#containers-run-image-name', 'C1')
+        b.click('#containers-run-image-run');
+        b.wait_popdown('containers_run_image_dialog')
+        b.wait_in_text('#containers-containers', 'C1')
+        b.wait_in_text('#containers-containers', 'busybox:latest')
+        b.click('#containers-images tr:contains("busybox:latest") button.fa-play')
+        b.wait_popup('containers_run_image_dialog')
+        b.set_val('#containers-run-image-name', 'C2')
+        b.click('#containers-run-image-run');
+        b.wait_popdown('containers_run_image_dialog')
+        b.wait_in_text('#containers-containers', 'C2')
+        b.wait_in_text('#containers-containers', 'busybox:latest')
+
+        # Delete image itself without deleting depending containers
+        b.click('#containers-images tr:contains("busybox:latest")')
+        b.wait_visible('#image-details-delete')
+        b.click('#image-details-delete')
+        b.wait_popup('delete-image-confirmation-dialog')
+        b.wait_visible('#delete-image-confirmation-dialog-containers')
+
+        # Delete image with running containers
+        b.click('#image-details-delete')
+        b.wait_popup('delete-image-confirmation-dialog')
+        b.wait_in_text('#delete-image-confirmation-dialog-confirm', 'Stop and delete')
+        self.deleteImageConfirm()
+        b.wait_visible('#containers')
+        b.wait_not_present('#containers-images tr:contains("busybox:latest")')
 
     def testExpose(self):
         b = self.browser


### PR DESCRIPTION
When containers depend on an image which is about to be deleted, list
them in the confirm dialog, warning the user they will be deleted.

Fixes #9474