### PR TITLE
bots: Declare rhel-7-6 image

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -45,6 +45,7 @@ DEFAULT_VERIFY = {
 REDHAT_VERIFY = {
     "verify/rhel-7": [ 'master' ],
     "verify/rhel-7-5": [ 'master', 'rhel-7.5' ],
+    "verify/rhel-7-6": [ ],
     "verify/rhel-x": [ 'master' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/explorer': [ 'master' ],


### PR DESCRIPTION
We should soon start to build nightly images so that we can properly test cockpit and general OS bugs. Declare the image to the bots, so that we can actually build and run them.