### PR TITLE
Add basic back-pressure to CockpitPipe and CockpitStream

### DIFF
--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -220,7 +220,8 @@ test_setup_LDADD = $(libcockpit_bridge_LIBS)
 
 test_stream_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
 test_stream_SOURCES = src/bridge/test-stream.c \
-	src/common/mock-io-stream.c src/common/mock-io-stream.h
+	src/common/mock-io-stream.c src/common/mock-io-stream.h \
+	src/common/mock-pressure.c src/common/mock-pressure.h
 test_stream_LDADD = $(libcockpit_bridge_LIBS)
 
 test_process_SOURCES = src/bridge/test-process.c

--- a/src/bridge/cockpitinteracttransport.c
+++ b/src/bridge/cockpitinteracttransport.c
@@ -102,6 +102,9 @@ on_pipe_read (CockpitPipe *pipe,
         }
       g_bytes_unref (message);
     }
+
+  if (end_of_data)
+    cockpit_pipe_close (self->pipe, NULL);
 }
 
 static void

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -42,6 +42,8 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitchannel.c \
 	src/common/cockpitchannel.h \
 	src/common/cockpiterror.h src/common/cockpiterror.c \
+	src/common/cockpitflow.c \
+	src/common/cockpitflow.h \
 	src/common/cockpitframe.c \
 	src/common/cockpitframe.h \
 	src/common/cockpithash.c \
@@ -190,7 +192,8 @@ test_knownhosts_SOURCES = src/common/test-knownhosts.c
 test_knownhosts_LDADD = $(libcockpit_common_a_LIBS)
 
 test_pipe_CFLAGS = $(libcockpit_common_a_CFLAGS)
-test_pipe_SOURCES = src/common/test-pipe.c
+test_pipe_SOURCES = src/common/test-pipe.c \
+	src/common/mock-pressure.c src/common/mock-pressure.h
 test_pipe_LDADD = $(libcockpit_common_a_LIBS)
 
 test_system_CFLAGS = $(libcockpit_common_a_CFLAGS)

--- a/src/common/cockpitflow.c
+++ b/src/common/cockpitflow.c
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * CockpitFlow:
+ *
+ * An interface representing a bidirectional flow. Implementors are
+ * CockpitPipe and CockpitStream. Currently the interface functionality
+ * is limited to flow control.
+ *
+ *  - Its input can be throttled, it can listen to a "pressure" signal
+ *    from another object passed into cockpit_pipe_throttle()
+ *  - It can optionally control another flow, by emitting a "pressure" signal
+ *    when it's output queue is too large
+ */
+
+#include "config.h"
+
+#include "cockpitflow.h"
+
+typedef CockpitFlowIface CockpitFlowInterface;
+G_DEFINE_INTERFACE (CockpitFlow, cockpit_flow, 0);
+
+static guint cockpit_flow_signal_pressure = 0;
+
+static void
+cockpit_flow_default_init (CockpitFlowIface *iface)
+{
+  /**
+   * CockpitFlow::pressure:
+   * @throttle: Pressure on or off
+   *
+   * Emitted when the pipe wants to give back-pressure to other feeding
+   * streams. It does this when its output queue is too long and should
+   * slow down.
+   */
+  cockpit_flow_signal_pressure = g_signal_new ("pressure", COCKPIT_TYPE_FLOW, G_SIGNAL_RUN_FIRST,
+                                               0, NULL, NULL, g_cclosure_marshal_VOID__BOOLEAN,
+                                               G_TYPE_NONE, 1, G_TYPE_BOOLEAN);
+}
+
+/**
+ * cockpit_flow_throttle:
+ * @flow: The flow to have input throttled
+ * @controlling: A controlling flow that throttles this one
+ *
+ * When the @controlling flow has pressure, it will slow input on this
+ * flow. If @controlling is NULL
+ */
+void
+cockpit_flow_throttle (CockpitFlow *flow,
+                       CockpitFlow *controlling)
+{
+  CockpitFlowIface *iface;
+
+  g_return_if_fail (COCKPIT_IS_FLOW (flow));
+  g_return_if_fail (controlling == NULL || COCKPIT_IS_FLOW (controlling));
+
+  iface = COCKPIT_FLOW_GET_IFACE (flow);
+  g_return_if_fail (iface->throttle != NULL);
+  (iface->throttle) (flow, controlling);
+}
+
+/**
+ * cockpit_flow_emit_pressure:
+ * @flow: The flow
+ * @ressure: Whether to emit back-pressure or release it.
+ *
+ * Emit a "pressure" signal, which indicates back-pressure or
+ * releases it. Used by implementations of CockpitFlow
+ *
+ * This is used to throttle another flow's input if this
+ * flow is the controlling flow.
+ */
+void
+cockpit_flow_emit_pressure   (CockpitFlow *flow,
+                              gboolean pressure)
+{
+  g_return_if_fail (COCKPIT_IS_FLOW (flow));
+  g_signal_emit (flow, cockpit_flow_signal_pressure, 0, pressure);
+}

--- a/src/common/cockpitflow.h
+++ b/src/common/cockpitflow.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COCKPIT_FLOW_H__
+#define COCKPIT_FLOW_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define COCKPIT_TYPE_FLOW             (cockpit_flow_get_type ())
+#define COCKPIT_FLOW(inst)            (G_TYPE_CHECK_INSTANCE_CAST ((inst), COCKPIT_TYPE_FLOW, CockpitFlow))
+#define COCKPIT_IS_FLOW(inst)         (G_TYPE_CHECK_INSTANCE_TYPE ((inst), COCKPIT_TYPE_FLOW))
+#define COCKPIT_FLOW_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_FLOW, CockpitFlowIface))
+
+typedef struct _CockpitFlow CockpitFlow;
+typedef struct _CockpitFlowIface CockpitFlowIface;
+
+struct _CockpitFlowIface {
+  GTypeInterface parent_iface;
+
+  void       (* throttle)         (CockpitFlow *flow,
+                                   CockpitFlow *controlling);
+};
+
+GType               cockpit_flow_get_type        (void) G_GNUC_CONST;
+
+void                cockpit_flow_throttle        (CockpitFlow *flow,
+                                                  CockpitFlow *controller);
+
+void                cockpit_flow_emit_pressure   (CockpitFlow *flow,
+                                                  gboolean pressure);
+
+G_END_DECLS
+
+#endif /* COCKPIT_FLOW_H__ */

--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -86,6 +86,9 @@ on_pipe_read (CockpitPipe *pipe,
   CockpitPipeTransport *self = COCKPIT_PIPE_TRANSPORT (user_data);
   cockpit_transport_read_from_pipe (COCKPIT_TRANSPORT (self), self->name,
                                     pipe, &self->closed, input, end_of_data);
+
+  if (end_of_data)
+    cockpit_pipe_close (self->pipe, NULL);
 }
 
 static void

--- a/src/common/mock-pressure.c
+++ b/src/common/mock-pressure.c
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "mock-pressure.h"
+
+typedef GObject MockPressure;
+typedef GObjectClass MockPressureClass;
+
+static void   mock_pressure_flow_iface_init   (CockpitFlowIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (MockPressure, mock_pressure, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_FLOW, mock_pressure_flow_iface_init));
+
+static void
+mock_pressure_init (MockPressure *self)
+{
+
+}
+
+static void
+mock_pressure_class_init (MockPressureClass *klass)
+{
+
+}
+
+static void
+mock_pressure_flow_iface_init (CockpitFlowIface *iface)
+{
+  /* No implementation */
+}
+
+CockpitFlow *
+mock_pressure_new (void)
+{
+  return g_object_new (MOCK_TYPE_PRESSURE, NULL);
+}

--- a/src/common/mock-pressure.h
+++ b/src/common/mock-pressure.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MOCK_PRESSURE_H
+#define MOCK_PRESSURE_H
+
+#include <glib-object.h>
+
+#include "cockpitflow.h"
+
+#define MOCK_TYPE_PRESSURE         (mock_pressure_get_type ())
+
+GType                mock_pressure_get_type      (void);
+
+CockpitFlow *        mock_pressure_new           (void);
+
+#endif /* MOCK_PRESSURE_H */

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -1895,6 +1895,9 @@ on_pipe_read (CockpitPipe *pipe,
       g_debug ("%s: dropping %d bytes", self->logname, buf->len);
       g_byte_array_free (buf, TRUE);
     }
+
+  if (end_of_data)
+    cockpit_pipe_close (pipe, NULL);
 }
 
 static void

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -412,7 +412,8 @@ test_resource_failure (TestResourceCase *tc,
   GBytes *bytes;
   GPid pid;
 
-  cockpit_expect_message ("*: external channel failed: terminated");
+  cockpit_expect_possible_log ("cockpit-protocol", G_LOG_LEVEL_WARNING, "*: bridge program failed:*");
+  cockpit_expect_possible_log ("cockpit-ws", G_LOG_LEVEL_MESSAGE, "*: external channel failed: *");
 
   /* Now kill the bridge */
   g_assert (cockpit_pipe_get_pid (tc->pipe, &pid));


### PR DESCRIPTION
I'm landing this seperately to make finding bugs and reviewing easier. On its own this really does nothing, but it changes some core pieces of IO that get used frequently ... and we need real assistance from the bots to validate that this change in and of itself does not introduce regressions.

This adds back pressure and throttling to CockpitPipe and CockpitStream. They have the ability to trigger a "pressure" signal when their output queue is too full, and also consume a "pressure" signal to control their input flow.
