### PR TITLE
bots: Only ask bots to run one task per issue

### DIFF
--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -107,10 +107,20 @@ def tasks_for_issues():
         login = issue.get("user", { }).get("login", { })
         if login not in whitelist:
             continue
+
+        #
+        # We only consider the first unchecked item per issue
+        #
+        # The bots think the list needs to be done in order.
+        # If the first item in the checklist is not something
+        # the bots can do, then the bots will ignore this issue
+        # (below in output_task)
+        #
         checklist = github.Checklist(issue["body"])
         for item, checked in checklist.items.items():
             if not checked:
                 results.append((item, issue))
+                break
     return results
 
 def output_task(command, issue, verbose):


### PR DESCRIPTION
Bots can only run one task per issue anyway, since they
mark the issue with WIP while they're running it. So
make the order of tasks done in an issue predictable.

Closes #9589 

 * [ ] image-refresh fedora-27
 * [ ] image-refresh fedora-28