### PR TITLE
test: Make unit test work in C locale

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -93,9 +93,10 @@ class CDP:
     def command(self, cmd):
         if not self._driver:
             self.start()
-        self._driver.stdin.write(cmd + "\n")
+        self._driver.stdin.write(cmd.encode("UTF-8"))
+        self._driver.stdin.write(b"\n")
         self._driver.stdin.flush()
-        line = self._driver.stdout.readline()
+        line = self._driver.stdout.readline().decode("UTF-8")
         if not line:
             self.kill()
             raise RuntimeError("CDP broken")
@@ -200,7 +201,6 @@ class CDP:
                                         env=environ,
                                         stdout=subprocess.PIPE,
                                         stdin=subprocess.PIPE,
-                                        universal_newlines=True,
                                         close_fds=True)
         self.valid = True
 

--- a/test/common/tap-cdp
+++ b/test/common/tap-cdp
@@ -56,6 +56,12 @@ if opts.strip and opts.test.startswith(opts.strip):
 
 cdp = cdp.CDP("C.utf8")
 
+if sys.version[0] >= '3':
+    # with Python 3, don't rely on external locale, in case it is C
+    import codecs
+    sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
+    sys.stderr = codecs.getwriter("utf-8")(sys.stderr.detach())
+
 if not cdp.get_browser_path():
     print('1..0 # skip web browser not found')
     sys.exit(0)


### PR DESCRIPTION
Don't rely on locale when talking to CDP driver, but encode/decode
ourselves. Also force stdout/err encoding to UTF-8 in tap-cdp .

This avoids `Unicode{En,De}codeError` when running tests in C locales.

----

Disclaimer: I really hate these hacks, and they just work around broken C locales in some situations. It doesn't really make things more consistent to force UTF-8 onto an ASCII terminal. But if it helps @stefwalter, then alas..