### PR TITLE
containers: Set Unicode locale in unit-tests container

### DIFF
--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -30,6 +30,7 @@ RUN mv /usr/local/bin/node /usr/local/bin/nodejs
 ADD turd-polish /usr/local/bin/node
 
 USER builder
+ENV LANG=C.UTF-8
 
 VOLUME /source
 CMD ["/source/containers/unit-tests/run.sh"]


### PR DESCRIPTION
We often process non-ASCII strings in our tests and logs.  Set a proper
Unicode locale to avoid Unicode{En,De}codeErrors when running tests
manually in the container.

----

I rebuilt the unit-tests container, tested it locally, and pushed it. This PR will run with it.