### PR TITLE
Add basic WebSocket and HTTP response back-pressure

### DIFF
--- a/src/websocket/Makefile-websocket.am
+++ b/src/websocket/Makefile-websocket.am
@@ -35,16 +35,23 @@ libwebsocket_a_SOURCES = \
 
 libwebsocket_a_CPPFLAGS = \
 	-DG_LOG_DOMAIN=\"WebSocket\" \
+	-I$(srcdir)/src \
 	$(GIO_CFLAGS) \
+	$(NULL)
+
+libwebsocket_a_LIBS = \
+	libcockpit-common.a \
+	$(GIO_LIBS) \
 	$(NULL)
 
 frob_websocket_SOURCES = src/websocket/frob-websocket.c
 frob_websocket_CPPFLAGS = $(libwebsocket_a_CPPFLAGS)
-frob_websocket_LDADD = libwebsocket.a $(GIO_LIBS)
+frob_websocket_LDADD = libwebsocket.a $(libwebsocket_a_LIBS)
 
-test_websocket_SOURCES = src/websocket/test-websocket.c
+test_websocket_SOURCES = src/websocket/test-websocket.c \
+	src/common/mock-pressure.c src/common/mock-pressure.h
 test_websocket_CPPFLAGS = $(libwebsocket_a_CPPFLAGS)
-test_websocket_LDADD = libwebsocket.a $(GIO_LIBS)
+test_websocket_LDADD = libwebsocket.a $(libwebsocket_a_LIBS)
 
 TESTS += \
 	test-websocket \

--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -776,6 +776,7 @@ test_pressure_throttle (Test *test,
   while (received->len < 10 * 1000 * 1000)
     g_main_context_iteration (NULL, TRUE);
 
+  g_byte_array_free (received, TRUE);
   g_object_unref (pressure);
 }
 


### PR DESCRIPTION
I'm landing this seperately to make finding bugs and reviewing easier. On its own this really does nothing, but it changes some core pieces of IO that get used frequently ... and we need real assistance from the bots to validate that this change in and of itself does not introduce regressions.

This adds back pressure and throttling to WebSocketConnection and CockpitWebResponse. They have the ability to trigger a "pressure" signal when their output queue is too full, and also consume a "pressure" signal to control their input flow.

 * [x] #9587