### PR TITLE
bots: Adjust rhel-x naughty override for Python 3

### DIFF
--- a/bots/naughty/rhel-x/8881-systemd-coredump-wrongargs
+++ b/bots/naughty/rhel-x/8881-systemd-coredump-wrongargs
@@ -2,4 +2,4 @@ Traceback (most recent call last):
   File "test/verify/check-connection", line *, in testBasic
     wait(lambda: m.execute("journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'"))
 *
-CalledProcessError: Command 'journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'' returned non-zero exit status 1
+*CalledProcessError: Command 'journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'' returned non-zero exit status 1


### PR DESCRIPTION
Similar to commit 81891d5516148, exceptions other than `testlib.Error`
are now being shown including the module name. Adjust the rhel-x naughty
override to work for both cases.

(This is the only naughty override that is not a `testlib.Error`.)