### PR TITLE
make-checkout: Preparations for running external tests

### DIFF
--- a/bots/make-checkout
+++ b/bots/make-checkout
@@ -37,10 +37,11 @@ def main():
     parser.add_argument("--base", nargs='?', help="Base branch that revision is for")
     parser.add_argument("--repo", nargs='?', help="Repository to check out")
     parser.add_argument("ref", help="The git ref to fetch")
-    parser.add_argument("revision", default="FETCH_HEAD", nargs='?',
-            help="Actual commit to check out, defaults to ref")
+    parser.add_argument("revision", nargs='?', help="Actual commit to check out, defaults to ref")
 
     opts = parser.parse_args()
+    if not opts.revision:
+        opts.revision = "FETCH_HEAD"
 
     def execute(*args):
         if opts.verbose:

--- a/bots/make-checkout
+++ b/bots/make-checkout
@@ -36,6 +36,7 @@ def main():
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     parser.add_argument("--base", nargs='?', help="Base branch that revision is for")
     parser.add_argument("--repo", nargs='?', help="Repository to check out")
+    parser.add_argument("--bots-ref", help="bots/ ref to check out from cockpit, for non-default --repo")
     parser.add_argument("ref", help="The git ref to fetch")
     parser.add_argument("revision", nargs='?', help="Actual commit to check out, defaults to ref")
 
@@ -54,6 +55,13 @@ def main():
             sys.stderr.write("> " + output + "\n")
         return output
 
+    # do this before fetching the actual test repo, so that FETCH_HEAD always points to that at the end
+    if opts.bots_ref:
+        execute("git", "fetch", "origin", opts.bots_ref)
+        bots_ref = execute("git", "rev-parse", "FETCH_HEAD").strip()
+    else:
+        bots_ref = "origin/master"
+
     if opts.repo:
         if "test\n" in subprocess.check_output([ "git", "remote" ], universal_newlines=True):
             execute("git", "remote", "remove", "test")
@@ -64,8 +72,8 @@ def main():
 
     # If the bots directory doesn't exist in this branch or repo, check it out from master
     if opts.repo or (opts.base and opts.base != "master"):
-        sys.stderr.write("Checking out bots directory from Cockpit master ...\n")
-        execute("git", "checkout", "--force", "origin/master", "--", "bots/")
+        sys.stderr.write("Checking out bots directory from Cockpit %s ...\n" % (opts.bots_ref or bots_ref))
+        execute("git", "checkout", "--force", bots_ref, "--", "bots/")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR has two commits that pave the way for triggering external project tests (starter-kit, cockpit-ostree, cockpit-podman) on every Cockpit PR that changes bots/. This PR changes nothing for Cockpit PRs.

make-checkout cannot be self-tested, it will always be used from master. Thus changes to it need to be tested very carefully in order to not break our CI completely. I believe I did that (see below), but the contingency plan is to do a clean revert directly on master.

First I tested a normal PR from Cockpit:

```
$ bots/tests-scan -d
PRIORITY=0009 bots/make-checkout --verbose --base='master' 'pull/9465/head' '132877094efaa4a0878c275fccd8506574e0a65d' && TEST_NAME='pull-9465-20180706-130606' TEST_REVISION='132877094efaa4a0878c275fccd8506574e0a65d' bots/tests-invoke --rebase='master' 'verify/centos-7' 'pull/9465/head'
```

When running that command in a cockpit/tests container, after the `make-checkout` the tree is in the expected state:
```
$ git status
HEAD detached at 132877094
nothing to commit, working tree clean
```
On https://github.com/cockpit-project/cockpit/pull/9465/commits the last commit is indeed that SHA.


Testing for the first commit in the series: The above specifies an explicit revision. With current master and this PR, not specifying it at al also works and yields the same result:
```
$ bots/make-checkout --verbose --base='master' 'pull/9465/head'
$ git status
HEAD detached at FETCH_HEAD
nothing to commit, working tree clean
$ git show | head -n1
commit 132877094efaa4a0878c275fccd8506574e0a65d
```

But when specifying the revision as `''` (empty but present arg), master currently fails:
```
[...]
+ git checkout --detach
warning: empty strings as pathspecs will be made invalid in upcoming releases. please use . instead if you meant to match all paths
fatal: git checkout: --detach does not take a path argument ''
bash-4.4$ echo $?
128
```
With this fix, it succeeds and behaves the same as if you hadn't specified it at all:
```
$ bots/make-checkout --verbose --base='master' 'pull/9465/head'  ''
$ git status
HEAD detached at FETCH_HEAD
nothing to commit, working tree clean
$ git show | head -n1
commit 132877094efaa4a0878c275fccd8506574e0a65d
```

For testing the second fix, let's pretend we want to check the starter-kit master against a current Cockpit PR; let's pick #9465, that adds a new "rhel-7-6" image which is not in master:
```
$ bots/make-checkout --verbose --base='master' --repo='cockpit-project/starter-kit' --bots-ref=pull/9580/head 'master'
$ git show | head -n1
commit 42579dcdc3579cb9cfd66dbe13775633e6b7465d
$ ls -l bots/images/rhel-7-6
lrwxrwxrwx 1 user user 79 Jul  6 11:14 bots/images/rhel-7-6 -> rhel-7-6-628fba4c1d77af6c1739628a6c5394f3436deda642c99818f342efc6d4b917ad.qcow2
```
So you see bots/ is indeed not the master version, but the version from #9465.