### PR TITLE
tools: Fix printing 'Invalid test number' message

### DIFF
--- a/tools/tap-driver
+++ b/tools/tap-driver
@@ -208,7 +208,7 @@ class TapDriver(Driver):
         try:
             num = int(num)
         except ValueError:
-            self.report_error("Invalid test number: %s" % data)
+            self.report_error("Invalid test number: %s" % num)
             return
         description = description.lstrip()
 


### PR DESCRIPTION
This message is displayed by tap-driver, but prints the wrong
diagnostics, making it hard to figure out what's gone wrong.