### PR TITLE
tools: Fix smoke test for RPM based systems

### DIFF
--- a/tools/debian/tests/smoke
+++ b/tools/debian/tests/smoke
@@ -15,6 +15,13 @@ check_out "^base1: /usr/share/cockpit/base1"
 check_out "^system:"
 check_out "^users:"
 
+# on an RPM based system we expect cockpit.socket not to be enabled by default;
+# on a Debian-based system we do
+if rpm -q cockpit >/dev/null 2>&1; then
+    systemctl start cockpit.socket
+fi
+
 echo " * socket unit is set up correctly, login page available"
-OUT=$(curl --silent --insecure https://localhost:9090)
+OUT=$(curl --silent --show-error --insecure https://localhost:9090)
 check_out "login-user-input.*User"
+echo "smoke test passed"


### PR DESCRIPTION
Only on Debian-like OSes we expect cockpit.socket to run after package
installation, not on RPM-based ones. So for the latter, explicitly start
cockpit.socket.

Also fix the curl invocation to not silently fail on connection errors.