### PR TITLE
naughty: Close 9328: SELinux denies chronyd access to its socket

### DIFF
--- a/bots/naughty/fedora-28/9328-selinux-chronyd-socket
+++ b/bots/naughty/fedora-28/9328-selinux-chronyd-socket
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { sendto } for * comm="chronyd" path="/run/chrony/chrony*.sock"


### PR DESCRIPTION
Known issue which has not occurred in 21 days

SELinux denies chronyd access to its socket

Fixes #9328