### PR TITLE
naughty: Close 9282: Docker resource limits regression: applying cgroup configuration for process caused "No such device or address"

### DIFF
--- a/bots/naughty/fedora-27/9282-docker-cgroup-failure
+++ b/bots/naughty/fedora-27/9282-docker-cgroup-failure
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-docker", line *, in testResources
-    b.wait_popdown("containers_run_image_dialog")
-*
-Error: timeout
-*
-warning: oci runtime error: * starting container process caused * applying cgroup configuration for process *No such device or address*

--- a/bots/naughty/fedora-27/9282-docker-cgroup-failure-2
+++ b/bots/naughty/fedora-27/9282-docker-cgroup-failure-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/kubelib.py", line *, in testDashboard
-    b.wait_text("#service-list tr[data-name='mock']:first-of-type td.containers", "1")
-*
-Error: timeout

--- a/bots/naughty/fedora-27/9282-docker-cgroup-failure-3
+++ b/bots/naughty/fedora-27/9282-docker-cgroup-failure-3
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/kubelib.py", line *, in testTopology
-    b.wait_text("#service-list tr[data-name='mock'] td.containers", "1")
-*
-Error: timeout

--- a/bots/naughty/fedora-28/9282-docker-cgroup-failure
+++ b/bots/naughty/fedora-28/9282-docker-cgroup-failure
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-docker", line *, in testResources
-    b.wait_popdown("containers_run_image_dialog")
-*
-Error: timeout
-*
-warning: oci runtime error: * starting container process caused * applying cgroup configuration for process *No such device or address*

--- a/bots/naughty/fedora-28/9282-docker-cgroup-failure-2
+++ b/bots/naughty/fedora-28/9282-docker-cgroup-failure-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/kubelib.py", line *, in testDashboard
-    b.wait_text("#service-list tr[data-name='mock']:first-of-type td.containers", "1")
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 21 days

Docker resource limits regression: applying cgroup configuration for process caused "No such device or address"

Fixes #9282