### PR TITLE
bots: Add Fedora 28 naughty for SELinux denying ssh reading motd

### DIFF
--- a/bots/naughty/fedora-28/9633-sselinux-ssh-motd
+++ b/bots/naughty/fedora-28/9633-sselinux-ssh-motd
@@ -1,0 +1,1 @@
+* audit: type=1400 audit(*): avc:  denied  { read } for * comm="sshd" name="active.motd"


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1584167
Known issue #9633 

Examples:
 - https://fedorapeople.org/groups/cockpit/logs/pull-9631-20180710-185353-66f611ad-verify-fedora-28/log.html#173
 - https://fedorapeople.org/groups/cockpit/logs/pull-9630-20180710-185454-c4d0dcbf-verify-fedora-28/log.html#40