### PR TITLE
test: Fail CDP commands on unhandled exceptions

### DIFF
--- a/bots/naughty/debian-stable/9641-xtermjs-dimensions-crash
+++ b/bots/naughty/debian-stable/9641-xtermjs-dimensions-crash
@@ -1,5 +1,4 @@
 Traceback (most recent call last):
   File "test/verify/check-machines", line *, in testSerialConsole
-    b.wait_not_present("div.terminal canvas.xterm-text-layer")
 *
-Error: timeout
+RuntimeError: TypeError: Cannot read property 'dimensions' of undefined

--- a/bots/naughty/debian-testing/9641-xtermjs-dimensions-crash
+++ b/bots/naughty/debian-testing/9641-xtermjs-dimensions-crash
@@ -1,5 +1,4 @@
 Traceback (most recent call last):
   File "test/verify/check-machines", line *, in testSerialConsole
-    b.wait_not_present("div.terminal canvas.xterm-text-layer")
 *
-Error: timeout
+RuntimeError: TypeError: Cannot read property 'dimensions' of undefined

--- a/bots/naughty/fedora-27/9641-xtermjs-dimensions-crash
+++ b/bots/naughty/fedora-27/9641-xtermjs-dimensions-crash
@@ -1,5 +1,4 @@
 Traceback (most recent call last):
   File "test/verify/check-machines", line *, in testSerialConsole
-    b.wait_not_present("div.terminal canvas.xterm-text-layer")
 *
-Error: timeout
+RuntimeError: TypeError: Cannot read property 'dimensions' of undefined

--- a/bots/naughty/fedora-28/9641-xtermjs-dimensions-crash
+++ b/bots/naughty/fedora-28/9641-xtermjs-dimensions-crash
@@ -1,5 +1,4 @@
 Traceback (most recent call last):
   File "test/verify/check-machines", line *, in testSerialConsole
-    b.wait_not_present("div.terminal canvas.xterm-text-layer")
 *
-Error: timeout
+RuntimeError: TypeError: Cannot read property 'dimensions' of undefined

--- a/bots/naughty/rhel-7/9641-xtermjs-dimensions-crash
+++ b/bots/naughty/rhel-7/9641-xtermjs-dimensions-crash
@@ -1,5 +1,4 @@
 Traceback (most recent call last):
   File "test/verify/check-machines", line *, in testSerialConsole
-    b.wait_not_present("div.terminal canvas.xterm-text-layer")
 *
-Error: timeout
+RuntimeError: TypeError: Cannot read property 'dimensions' of undefined

--- a/bots/naughty/rhel-x/9641-xtermjs-dimensions-crash
+++ b/bots/naughty/rhel-x/9641-xtermjs-dimensions-crash
@@ -1,5 +1,4 @@
 Traceback (most recent call last):
   File "test/verify/check-machines", line *, in testSerialConsole
-    b.wait_not_present("div.terminal canvas.xterm-text-layer")
 *
-Error: timeout
+RuntimeError: TypeError: Cannot read property 'dimensions' of undefined

--- a/bots/naughty/ubuntu-1604/9641-xtermjs-dimensions-crash
+++ b/bots/naughty/ubuntu-1604/9641-xtermjs-dimensions-crash
@@ -1,5 +1,4 @@
 Traceback (most recent call last):
   File "test/verify/check-machines", line *, in testSerialConsole
-    b.wait_not_present("div.terminal canvas.xterm-text-layer")
 *
-Error: timeout
+RuntimeError: TypeError: Cannot read property 'dimensions' of undefined

--- a/bots/naughty/ubuntu-stable/9641-xtermjs-dimensions-crash
+++ b/bots/naughty/ubuntu-stable/9641-xtermjs-dimensions-crash
@@ -1,5 +1,4 @@
 Traceback (most recent call last):
   File "test/verify/check-machines", line *, in testSerialConsole
-    b.wait_not_present("div.terminal canvas.xterm-text-layer")
 *
-Error: timeout
+RuntimeError: TypeError: Cannot read property 'dimensions' of undefined

--- a/pkg/storaged/optional-panel.jsx
+++ b/pkg/storaged/optional-panel.jsx
@@ -81,7 +81,8 @@ export class OptionalPanel extends React.Component {
                 self.setState({ just_installed: "just-installed" });
                 window.setTimeout(() => { self.setState({ just_installed: "just-installed faded" }); },
                                   4000);
-            });
+            },
+                                                  () => null /* ignore cancel */);
         }
 
         var heading_right = null;

--- a/test/common/cdp-driver.js
+++ b/test/common/cdp-driver.js
@@ -83,8 +83,15 @@ function setupLogging(client) {
         if (details.exception && details.exception.className === "PhWaitCondTimeout")
             return;
 
-        unhandledExceptions.push(details)
         process.stderr.write(details.description || JSON.stringify(details) + "\n");
+
+        // ignore c3 crashes (https://github.com/c3js/c3/issues/2187)
+        if (details.exception && details.exception.description &&
+            details.exception.description.indexOf("TypeError: Cannot read property 'data_types' of null") >= 0 &&
+            details.exception.description.indexOf("/kubernetes.js") >= 0)
+            return;
+
+        unhandledExceptions.push(details)
     });
 
     client.Log.enable();

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -184,6 +184,12 @@ function ph_focus(sel)
     ph_find(sel).focus();
 }
 
+class PhWaitCondTimeout extends Error {
+    constructor() {
+        super("condition did not become true");
+    }
+}
+
 function ph_wait_cond(cond, timeout) {
     return new Promise((resolve, reject) => {
         // poll every 100 ms for now;  FIXME: poll less often and re-check on mutations using
@@ -192,7 +198,7 @@ function ph_wait_cond(cond, timeout) {
         let tm = window.setTimeout( () => {
                 if (stepTimer)
                     window.clearTimeout(stepTimer);
-                reject("condition did not become true");
+                reject(new PhWaitCondTimeout());
             }, timeout);
         function step() {
             try {


### PR DESCRIPTION
Install a Chrome Devtools Protocol handler for unhandled exceptions, and
fail the next CDP command with it.

This got lost with the move from PhantomJS to Chrome.

 - [x] adjust naughty override for `testSerialConsole`
 - [x] investigate crash in [testNfsMissingPackages](https://fedorapeople.org/groups/cockpit/logs/pull-9639-20180713-035353-9190fd3b-verify-debian-testing/log.html#153)
 - [x] fix failures of tests which expect `ph_*` rejections
 - [x] fix `Cannot read property 'data_types' of null` crash in `test/verify/check-openshift TestOpenshift.testKubevirtMachinesList`