### PR TITLE
bots: Add alternative naughty override for broken core dump on rhel-x

### DIFF
--- a/bots/naughty/rhel-x/8881-systemd-coredump-wrongargs-2
+++ b/bots/naughty/rhel-x/8881-systemd-coredump-wrongargs-2
@@ -1,0 +1,1 @@
+Not enough arguments passed by the kernel (6, expected 7).


### PR DESCRIPTION
Aside from the direct core dump test in check-connection, this can also
affect other tests if core dumps happen in the background. This then
triggers this unexpected message.

See known issue #8881