### PR TITLE
packagekit: Fix low timeout calling failures on loaded servers

### DIFF
--- a/pkg/lib/packagekit.es6
+++ b/pkg/lib/packagekit.es6
@@ -172,7 +172,7 @@ export function watchTransaction(transactionPath, signalHandlers, notifyHandler)
  */
 export function transaction(method, arglist, signalHandlers, notifyHandler) {
     return new Promise((resolve, reject) => {
-        call("/org/freedesktop/PackageKit", "org.freedesktop.PackageKit", "CreateTransaction", [], {timeout: 5000})
+        call("/org/freedesktop/PackageKit", "org.freedesktop.PackageKit", "CreateTransaction", [])
                 .done(result => {
                     let transactionPath = result[0];
                     let watchPromise;


### PR DESCRIPTION
The timeout on CreateTransaction is just too low.  This is happening
during testing, but it will also happen on heavily loaded servers.

    Applying updates failed
    method call CreateTransaction timed out

Use Cockpit's default extremely high DBus timeout, much like the
rest of the Cockpit DBus calls.