### PR TITLE
bots: Disable cockpit-podman tests for now

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -63,9 +63,10 @@ EXTERNAL_PROJECTS = {
         'cockpit/rhel-atomic',
         'cockpit/continuous-atomic',
     ],
-    'cockpit-project/cockpit-podman': [
-        'cockpit/fedora-28',
-    ],
+    # Enable once tests actually work
+    #'cockpit-project/cockpit-podman': [
+    #    'cockpit/fedora-28',
+    #],
 }
 
 # Label: should a PR trigger external tests


### PR DESCRIPTION
Current podman in Fedora 28 has a broken varlink interface. This causes
all Cockpit PR tests to fail that touch bots/, so disable this for the
time being.