### PR TITLE
test: Skip flow control test on rhel-7-5

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -276,6 +276,7 @@ class TestConnection(MachineCase):
         headers = m.execute("curl -s --head http://172.27.0.15:9090/cockpit+123/channel/foo")
         self.assertIn("HTTP/1.1 404 Not Found\r\n", headers)
 
+    @skipImage("Fixed in Cockpit 173", "rhel-7-5")
     def testFlowControl(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
It is not meant to pass there, as rhel-7-5's bridge and ws version don't
have flow control yet. This also triggers some eternal hang in our test
suite machinery. See issue #9662 for details.

---

Priority as this currently breaks all PRs.