### PR TITLE
naughty: Close 9449: SELinux denies chronyd to read drift file

### DIFF
--- a/bots/naughty/rhel-7/9449-selinux-chronyd-drift
+++ b/bots/naughty/rhel-7/9449-selinux-chronyd-drift
@@ -1,1 +1,0 @@
-Error: type=1400 audit(*): avc:  denied  { read } for * comm="chronyd" name="drift"


### PR DESCRIPTION
Known issue which has not occurred in 26 days

SELinux denies chronyd to read drift file

Fixes #9449