### PR TITLE
test: Fix race condition in NTP tests

### DIFF
--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -265,7 +265,9 @@ WantedBy=default.target
                 m.execute("cmd='systemctl list-timers'; until $cmd | grep -m 1 '%s'; do sleep 1; done" % time)
 
         m.execute("timedatectl set-timezone UTC")
-        m.execute("timedatectl set-ntp off; timedatectl set-time '2020-01-01 15:30:00'")
+        m.execute("timedatectl set-ntp off")
+        wait(lambda: "false" in m.execute("busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP"))
+        m.execute("timedatectl set-time '2020-01-01 15:30:00'")
         self.login_and_go("/system/services")
         b.click('#services-filter :nth-child(4)')
         b.wait_visible("#create-timer")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -238,7 +238,7 @@ class TestSystemInfo(MachineCase):
         b.click("#systime-apply-button")
         b.wait_popdown("system_information_change_systime")
 
-        self.assertTrue(ntp_enabled())
+        wait(ntp_enabled)
 
         # Change the date
         b.click("#system_information_systime_button")


### PR DESCRIPTION
systemd 239 seems to have a slight timing difference that
enabling/disabling NTP in timedated takes a little longer to take
effect. So wait until timesyncd is shown as enabled/disabled.