### PR TITLE
eslint: Enable "lines-between-class-members" rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
                 "ignoredNodes": [ "JSXAttribute" ]
             }],
         "newline-per-chained-call": ["error", { "ignoreChainWithDepth": 2 }],
+        "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
         "prefer-promise-reject-errors": ["error", { "allowEmptyReject": true }],
         "react/jsx-indent": ["error", 4],
 

--- a/pkg/kdump/config-client.es6
+++ b/pkg/kdump/config-client.es6
@@ -38,16 +38,19 @@ export class ConfigFile {
             this._parseText(rawContent);
         });
     }
+
     close() {
         if (this._fileHandle) {
             this._fileHandle.remove();
             this._fileHandle = undefined;
         }
     }
+
     // wait for data to have been read at least once
     wait() {
         return this._dataAvailable.promise();
     }
+
     /* parse lines of the config file
      * if a line has a valid config key, use that as key
      * and also store original line, line index, value and whether the line contains a comment

--- a/pkg/kdump/kdump-client.es6
+++ b/pkg/kdump/kdump-client.es6
@@ -74,6 +74,7 @@ export class KdumpClient {
             this.dispatchEvent("kdumpStatusChanged", this.state);
         });
     }
+
     ensureOn() {
         // we consider the state to be "on" when it's enabled and running
         return cockpit.all(
@@ -81,6 +82,7 @@ export class KdumpClient {
             this.kdumpService.start()
         );
     }
+
     ensureOff() {
         // we consider the state to be "off" when it's disabled and stopped
         return cockpit.all(
@@ -88,10 +90,12 @@ export class KdumpClient {
             this.kdumpService.disable()
         );
     }
+
     crashKernel() {
         // crash the system kernel
         return cockpit.script(crashKernelScript, [], { superuser: "require" });
     }
+
     testWriteLocation(settings) {
         var target = this.targetFromSettings(settings);
         var path;
@@ -112,6 +116,7 @@ export class KdumpClient {
         }
         return dfd.promise();
     }
+
     writeSettings(settings) {
         var dfd = cockpit.defer();
         this.configClient.write(settings)
@@ -124,6 +129,7 @@ export class KdumpClient {
                 .fail(dfd.reject);
         return dfd.promise();
     }
+
     targetFromSettings(settings) {
         // since local target is the default and can be used even without "path", we need to
         // check for the presence of all known targets


### PR DESCRIPTION
I think this is quite a useful rule which adds to readability + fixes the files