### PR TITLE
test: Robustify TestMachines.testCreate

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -1191,30 +1191,22 @@ class TestMachines(MachineCase):
                         b.wait_present(vendor_item_selector)
                         b.wait_visible(vendor_item_selector)
                         b.click(vendor_item_selector)
-                except Exception:
+                except RuntimeError:
                     # vendor not found which is ok
                     b.click(vendor_selector)  # close
                     return self
             b.wait_in_text(vendor_selector, self.os_vendor)
             # vendor successfully found
 
+            # then it should filter os_name
             system_selector = "#system-select button span:nth-of-type(1)"
             system_item_selector = "#system-select ul li[data-value*='{0}'] a".format(self.os_name)
 
             b.wait_visible(system_selector)
             b.click(system_selector)
-            try:
-                with b.wait_timeout(1):
-                    b.wait_present(system_item_selector)
-                    b.wait_visible(system_item_selector)
-                # os found which is not ok
-                raise AssertionError("{0} was not filtered".format(self.os_name))
-            except AssertionError as e:
-                raise
-            except Exception:
-                # os not found which is ok
-                b.click(system_selector)  # close
-                return self
+            b.wait_not_present(system_item_selector)
+            b.click(system_selector)  # close
+            return self
 
         def fill(self):
             b = self.browser


### PR DESCRIPTION
Rewrite the checkOsOrVendorFiltered() function to not expect a
wait_present() failure, and avoid catching blanket exceptions. Use
`wait_not_present()` instead.

Otherwise this unhandled exception from `ph_wait_cond()` bubbles up to
the actual page, which is confusing when running the tests in an
interactive browser for debugging.