### PR TITLE
test: Ignore unrelated messages about missing tuned

### DIFF
--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -65,6 +65,7 @@ case "$RELEASE" in
         COCKPIT_DEPS="${COCKPIT_DEPS/pcp /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/libblockdev-mdraid2 /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/udisks2-lvm2 /}"
+        # keep in sync with allowed messages in test/common/testlib.py
         COCKPIT_DEPS="${COCKPIT_DEPS/tuned /}"
 
         echo >> /etc/apt/sources.list
@@ -83,6 +84,7 @@ case "$RELEASE" in
         # these packages are not in Ubuntu 16.04
         COCKPIT_DEPS="${COCKPIT_DEPS/libblockdev-mdraid2 /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/udisks2-lvm2 /}"
+        # keep in sync with allowed messages in test/common/testlib.py
         COCKPIT_DEPS="${COCKPIT_DEPS/tuned /}"
 
         # NFS and NetworkManager don't work together

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -823,6 +823,10 @@ class MachineCase(unittest.TestCase):
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1573501
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { create } for .*comm="nft" .*firewalld_t.*')
 
+        # these images don't have tuned; keep in sync with bots/images/scripts/debian.setup
+        if self.image in ["ubuntu-1604", "debian-stable"]:
+            self.allowed_messages.append('com.redhat.tuned: .*org.freedesktop.DBus.Error.ServiceUnknown.*')
+
         all_found = True
         first = None
         for m in messages:


### PR DESCRIPTION
ubuntu-1604 and debian-stable don't have tuned. This occasionally causes
tests to fail with an unexpected message:

    Error: com.redhat.tuned: couldn't get managed objects at /org/freedesktop/realmd:
    GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown:
    The name com.redhat.tuned was not provided by any .service files

Ignore these messages on these two OSes.