### PR TITLE
machines: call getStoragePools in componentWillMount to force re-render AddDiskAction

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -422,24 +422,29 @@ const addDiskDialog = (dispatch, provider, idPrefix, vm, storagePools) => {
         ],
     };
 
-    // Refresh storage volume list before displaying the dialog.
-    // There are recently no Libvirt events for storage volumes and polling is ugly.
-    // https://bugzilla.redhat.com/show_bug.cgi?id=1578836
-    dispatch(getStoragePools(vm.connectionName))
-            .then(() => {
-                dialogObj = DialogPattern.show_modal_dialog(dialogProps, footerProps)
-            });
+    dialogObj = DialogPattern.show_modal_dialog(dialogProps, footerProps)
 };
 
-const AddDiskAction = ({ dispatch, provider, idPrefix, vm, storagePools }) => {
-    return (
-        <button type="button"
-                className="btn btn-primary pull-right"
-                id={`${idPrefix}-adddisk`}
-                onClick={mouseClick(() => addDiskDialog(dispatch, provider, idPrefix, vm, storagePools))}>
-            {_("Add Disk")}
-        </button>
-    );
-};
+class AddDiskAction extends React.Component {
+    componentWillMount() {
+        // Refresh storagePools prop before opening the Add Disk dialog.
+        // There are recently no Libvirt events for storage volumes and polling is ugly.
+        // https://bugzilla.redhat.com/show_bug.cgi?id=1578836
+        this.props.dispatch(getStoragePools(this.props.vm.connectionName));
+    }
+
+    render() {
+        const { dispatch, provider, idPrefix, vm, storagePools } = this.props;
+
+        return (
+            <button type="button"
+                    className="btn btn-primary pull-right"
+                    id={`${idPrefix}-adddisk`}
+                    onClick={mouseClick(() => addDiskDialog(dispatch, provider, idPrefix, vm, storagePools))}>
+                {_("Add Disk")}
+            </button>
+        );
+    }
+}
 
 export default AddDiskAction;

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -507,7 +507,6 @@ class TestMachines(MachineCase):
         # prepare libvirt storage pools
         m.execute("mkdir /mnt/vm_one ; mkdir /mnt/vm_two ; mkdir /mnt/vm_tmp ; chmod a+rwx /mnt/vm_one /mnt/vm_two /mnt/vm_tmp")
         m.execute("virsh pool-create-as default_tmp --type dir --target /mnt/vm_tmp")
-        m.execute("virsh pool-create-as myPoolOne --type dir --target /mnt/vm_one")
         m.execute("virsh pool-create-as myPoolTwo --type dir --target /mnt/vm_two")
 
         m.execute("virsh vol-create-as myPoolTwo mydiskofpooltwo --capacity 1G --format qcow2")
@@ -524,6 +523,9 @@ class TestMachines(MachineCase):
         b.click("tbody tr th") # click on the row header
         b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "running")
+
+        # Add one storagePool here to test correct re-rendering
+        m.execute("virsh pool-create-as myPoolOne --type dir --target /mnt/vm_one")
 
         b.wait_present("#vm-subVmTest1-disks") # wait for the tab
         b.click("#vm-subVmTest1-disks") # open the "Disks" subtab


### PR DESCRIPTION
Current implementation will cause re-render but after the AddDiskAction
component will be already mounted, thus pool changes will not be
visible to the user immediately.

The testAddDisk was adjusted to cover this case.