### PR TITLE
tools: Add explicit gcc build requirement

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -75,6 +75,7 @@ Release:        1%{?dist}
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 %endif
 
+BuildRequires: gcc
 BuildRequires: pkgconfig(gio-unix-2.0)
 BuildRequires: pkgconfig(json-glib-1.0)
 BuildRequires: pkgconfig(polkit-agent-1) >= 0.105


### PR DESCRIPTION
Fedora 29 dropped gcc from default build roots [1], so it now needs to
be installed explicitly.

Fixes package build failure in Rawhide.

https://bugzilla.redhat.com/show_bug.cgi?id=1603669

[1] https://fedoraproject.org/wiki/Changes/Remove_GCC_from_BuildRoot