### PR TITLE
bots: Skip install of cockpit-docker on rhel-x

### DIFF
--- a/bots/images/scripts/rhel-x.install
+++ b/bots/images/scripts/rhel-x.install
@@ -2,4 +2,5 @@
 
 set -e
 
-/var/lib/testvm/fedora.install --rhel --skip cockpit-kubernetes "$@"
+/var/lib/testvm/fedora.install --rhel --skip cockpit-kubernetes \
+                               --skip cockpit-docker "$@"

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -40,6 +40,7 @@ def can_manage(machine):
             machine.image not in rootfs_not_in_volume_group_images)
 
 @skipImage("No cockpit-docker on i386", "fedora-i386")
+@skipImage("No docker packaged", "rhel-x")
 @skipPackage("cockpit-docker")
 class TestDockerStorageDirect(MachineCase):
 
@@ -57,6 +58,7 @@ class TestDockerStorageDirect(MachineCase):
             b.wait_present("#containers-storage-details a")
 
 @skipImage("No cockpit-docker on i386", "fedora-i386")
+@skipImage("No docker packaged", "rhel-x")
 @skipPackage("cockpit-docker")
 class TestDockerStorage(MachineCase):
     provision = { "machine1" : { "address": "10.111.113.1/20" } }


### PR DESCRIPTION
Skip all docker tests on rhel-x as cockpit-docker isn't installed.