### PR TITLE
bots: Stop trying to refresh windows-8

### DIFF
--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -42,7 +42,6 @@ REFRESH = {
     'rhel-x': { },
     'rhel-atomic': { },
     "selenium": { "refresh-days": 30 },
-    'windows-8': { "refresh-days": 30 },
 }
 
 import argparse


### PR DESCRIPTION
The bots can't do it, we haven't done it in a long time, and the whole
image and IE are obsolete, so there's little point in continuing trying.

Fixes #9176