### PR TITLE
build: Skip test-httpstream unit test with GnuTLS 3.6.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -528,6 +528,14 @@ fi
 AM_CONDITIONAL([WITH_COVERAGE], [test "$enable_coverage" = "yes"])
 AC_MSG_RESULT([$enable_coverage])
 
+# Broken libraries
+
+# HACK: https://gitlab.com/gnutls/gnutls/issues/530; GnuTLS 3.6.3 fails to
+# connect to GnuTLS servers. This is outside of our control. We don't have the
+# devel headers installed, so check the shlib itself
+AM_CONDITIONAL([BROKEN_GNUTLS],
+               [grep -q GNUTLS_3_6_3 $(/sbin/ldconfig -p | grep libgnutls.so | sed 's/^.*=> *//')])
+
 # Strict
 
 AC_ARG_ENABLE(strict, [

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -161,13 +161,16 @@ BRIDGE_CHECKS = \
 	test-metrics \
 	test-connect \
 	test-stream \
-	test-httpstream \
 	test-setup \
 	test-websocketstream \
 	test-process \
 	test-bridge \
 	test-router \
 	$(NULL)
+
+if !BROKEN_GNUTLS
+BRIDGE_CHECKS += test-httpstream
+endif
 
 mock_bridge_SOURCES = src/bridge/mock-bridge.c
 mock_bridge_CFLAGS = \


### PR DESCRIPTION
GnuTLS 3.6.3 fails to build up TLS connections to other GnuTLS servers
(https://gitlab.com/gnutls/gnutls/issues/530) when not providing
certificates. test-httpstream detects this.

This is outside of our control, and causes package build failures in
Fedora and RHEL. This is a cowboy hack, but as the regression is already
fixed upstream it won't last very long.