### PR TITLE
bots: Fix rhel-7-6 install script

### DIFF
--- a/bots/images/scripts/rhel-7-5.install
+++ b/bots/images/scripts/rhel-7-5.install
@@ -1,1 +1,8 @@
-rhel.install
+#! /bin/bash
+
+set -e
+
+# remove cockpit distro packages, testing with upstream master
+rpm --erase --verbose cockpit cockpit-ws cockpit-bridge cockpit-system
+
+/var/lib/testvm/fedora.install --rhel "$@"

--- a/bots/images/scripts/rhel-7-6.install
+++ b/bots/images/scripts/rhel-7-6.install
@@ -1,1 +1,5 @@
-rhel.install
+#! /bin/bash
+
+set -e
+
+/var/lib/testvm/fedora.install --rhel "$@"

--- a/bots/images/scripts/rhel.install
+++ b/bots/images/scripts/rhel.install
@@ -1,8 +1,0 @@
-#! /bin/bash
-
-set -e
-
-# remove cockpit distro packages, testing with upstream master
-rpm --erase --verbose cockpit cockpit-ws cockpit-bridge cockpit-system
-
-/var/lib/testvm/fedora.install --rhel "$@"


### PR DESCRIPTION
Commit b738b0947f caused rhel-7-6 to use the install script for rhel-7-5
that removed the pre-installed cockpit packages. This fails for the
rhel-7-6 image, as this does not have cockpit packages preinstalled.

Give each image its own script again, as they are already just simple
wrappers around fedora.install, and we sometimes need to customize them
(like rhel-x.install).