### PR TITLE
Revert "images: Update debian-stable image (#9709)"

### DIFF
--- a/bots/images/debian-stable
+++ b/bots/images/debian-stable
@@ -1,1 +1,1 @@
-debian-stable-72817766a7c9198dd92d4f11ee3078ea1b0b4eb1a4fee0963049cd73882a32a1.qcow2
+debian-stable-a3248961d35af6f9bb6bcb5a0b717564726a58b32ac32accf9dc4df1de14bdfb.qcow2


### PR DESCRIPTION
The new image is almost unbootable, investigation is going on in
issue #9733.

This reverts commit bdea21a7f95520503e22ac7f3553bef2248d8b6b.