### PR TITLE
Login HTML fixes & accessibility improvements

### DIFF
--- a/src/ws/login.css
+++ b/src/ws/login.css
@@ -489,6 +489,9 @@ label {
   margin-left: -20px;
   margin-right: -20px;
 }
+#option-group a {
+  color: inherit;
+}
 
 #server-group:before {
   clear: both;

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -66,7 +66,7 @@
                         </polygon>
                     </svg>
                 </i>
-                <span translate>Other Options</span>
+                <a href="#" id="show-other-login-options" translate>Other Options</a>
               </div>
             </div>
 

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -81,8 +81,8 @@
             <div class="form-group">
               <div class="col-md-3 col-sm-3 login-button-container">
                 <button class="btn btn-primary btn-lg col-xs-12" id="login-button">
-                  <div class="spinner"></div>
-                  <div id="login-button-text" translate>Log In</div>
+                  <span class="spinner"></span>
+                  <span id="login-button-text" translate>Log In</span>
                 </button>
               </div>
             </div>

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -196,6 +196,13 @@
     }
 
     function toggle_options(ev, show) {
+        // On keypress, only accept spacebar (enter acts as a click)
+        if (ev && ev.type === 'keypress' && ev.key !== ' ')
+            return;
+        // Stop the <a>'s click handler, otherwise it causes a page reload
+        if (ev && ev.type === 'click')
+            ev.preventDefault();
+
         if (show === undefined)
             show = id("server-group").style.display === "none";
 
@@ -235,7 +242,8 @@
         if (!requisites())
             return;
 
-        id("option-group").addEventListener("click", toggle_options);
+        id("show-other-login-options").addEventListener("click", toggle_options);
+        id("show-other-login-options").addEventListener("keypress", toggle_options);
         id("server-clear").addEventListener("click", function () {
             var el = id("server-field");
             el.value = "";

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -379,12 +379,17 @@ class TestMultiMachine(MachineCase):
         b.click('#login-button')
         b.wait_visible("#login-error-message")
 
+        if m.image in ['rhel-7-5-distropkg', 'rhel-7-6-distropkg']:
+            login_options = '#option-group span'
+        else:
+            login_options = '#show-other-login-options'
+
         # Connect to bad machine
         b.set_val("#login-password-input", "bad-password")
-        b.click('#option-group span')
+        b.click(login_options)
         b.wait_visible("#server-group")
         b.set_val("#server-field", "bad")
-        b.click('#option-group span')
+        b.click(login_options)
         b.wait_not_visible("#server-group")
         b.click('#login-button')
         b.wait_visible("#server-group")


### PR DESCRIPTION
This fixes improper nesting in HTML (as a block-level element such as a `<div>` cannot reside inside of a `<button>`) and adds keyboard navigation to the "Other options" disclosure.

Keyboard navigation is especially needed for a11y (accessibility) reasons, but being able to navigate via keyboard benefits everyone ­— especially admins who are used to typing. :wink:

I've also tested the changes in Firefox on Windows 10 with NVDA screen reader and it appears to work much better now.