### PR TITLE
bots: Re-enable cockpit-podman tests

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -63,10 +63,9 @@ EXTERNAL_PROJECTS = {
         'cockpit/rhel-atomic',
         'cockpit/continuous-atomic',
     ],
-    # Enable once tests actually work
-    #'cockpit-project/cockpit-podman': [
-    #    'cockpit/fedora-28',
-    #],
+    'cockpit-project/cockpit-podman': [
+        'cockpit/fedora-28',
+    ],
 }
 
 # Label: should a PR trigger external tests


### PR DESCRIPTION
podman got fixed and the tests work again, let's make sure it stays that
way.

This reverts commit 3c937446131e683f0722a8b5b6a9b77d2ad887ce.