### PR TITLE
bots: Adjust test scanning for new rhel-7.6 branch

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -20,7 +20,7 @@
 
 BASELINE_PRIORITY = 10
 
-BRANCHES = [ 'master', 'rhel-7.5' ]
+BRANCHES = [ 'master', 'rhel-7.5', 'rhel-7.6' ]
 
 DEFAULT_VERIFY = {
     'avocado/fedora': BRANCHES,
@@ -28,14 +28,14 @@ DEFAULT_VERIFY = {
     'container/bastion': BRANCHES,
     'selenium/firefox': BRANCHES,
     'selenium/chrome': BRANCHES,
-    'verify/centos-7': BRANCHES,
+    'verify/centos-7': [ 'master' ],
     'verify/continuous-atomic': [ ],
     'verify/debian-stable': [ 'master' ],
     'verify/debian-testing': [ 'master' ],
-    'verify/fedora-i386': BRANCHES,
+    'verify/fedora-i386': [ 'master' ],
     'verify/fedora-27': [ ],
     'verify/fedora-28': [ 'master' ],
-    'verify/fedora-atomic': BRANCHES,
+    'verify/fedora-atomic': [ 'master' ],
     'verify/fedora-testing': [ ],
     'verify/ubuntu-1604': [ 'master' ],
     'verify/ubuntu-stable': [ 'master' ],
@@ -45,7 +45,7 @@ DEFAULT_VERIFY = {
 REDHAT_VERIFY = {
     "verify/rhel-7-5": [ 'master', 'rhel-7.5' ],
     "verify/rhel-7-5-distropkg": [ 'master' ],
-    "verify/rhel-7-6": [ ],
+    "verify/rhel-7-6": [ 'rhel-7.6' ],
     "verify/rhel-x": [ 'master' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/explorer': [ 'master' ],


### PR DESCRIPTION
 * Run container/selenium and rhel-7-6 tests on rhel-7.6 PRs.
 * Stop running Fedora and CentOS tests on non-master branches, as we
   only use them for RHEL.

----

This cannot be tested by CI, thus just triggering a dummy task. Test this with calling `bots/tests-scan -v -d` or `bots/tests-scan -d` to ensure that it picks up my dummy PR #9741 against the rhel-7.6 branch:

```
pull-9741   selenium/firefox          da82270     6
pull-9741   verify/rhel-7-6           da82270     5
pull-9741   selenium/chrome           da82270     5
pull-9741   container/kubernetes      da82270     5
pull-9741   container/bastion         da82270     5
pull-9741   avocado/fedora            da82270     5
```
This is the expected set of tests to run for rhel-7.6 branches.