### PR TITLE
bots: Test rhel-7-6 for all PRs, stop testing rhel-7-5

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -43,9 +43,9 @@ DEFAULT_VERIFY = {
 
 # Non-public images used for testing
 REDHAT_VERIFY = {
-    "verify/rhel-7-5": [ 'master', 'rhel-7.5' ],
+    "verify/rhel-7-5": [ 'rhel-7.5' ],
     "verify/rhel-7-5-distropkg": [ 'master' ],
-    "verify/rhel-7-6": [ 'rhel-7.6' ],
+    "verify/rhel-7-6": [ 'master', 'rhel-7.6' ],
     "verify/rhel-x": [ 'master' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/explorer': [ 'master' ],


### PR DESCRIPTION
RHEL 7.6 is an important upcoming target, so let's make sure it stays
working (see e. g. #9685 how it bitrotted).

To avoid increasing the test load for every PR further, disable rhel-7-5
for master PRs instead. It is not an important target, as we don't plan
on updating the Base packages in 7.5 any more. The important one is
rhel-7-5-distropkg, which continues to run for every PR.