### PR TITLE
Revert "build: Skip test-httpstream unit test with GnuTLS 3.6.3"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -528,14 +528,6 @@ fi
 AM_CONDITIONAL([WITH_COVERAGE], [test "$enable_coverage" = "yes"])
 AC_MSG_RESULT([$enable_coverage])
 
-# Broken libraries
-
-# HACK: https://gitlab.com/gnutls/gnutls/issues/530; GnuTLS 3.6.3 fails to
-# connect to GnuTLS servers. This is outside of our control. We don't have the
-# devel headers installed, so check the shlib itself
-AM_CONDITIONAL([BROKEN_GNUTLS],
-               [grep -q GNUTLS_3_6_3 $(/sbin/ldconfig -p | grep libgnutls.so | sed 's/^.*=> *//')])
-
 # Strict
 
 AC_ARG_ENABLE(strict, [

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -161,16 +161,13 @@ BRIDGE_CHECKS = \
 	test-metrics \
 	test-connect \
 	test-stream \
+	test-httpstream \
 	test-setup \
 	test-websocketstream \
 	test-process \
 	test-bridge \
 	test-router \
 	$(NULL)
-
-if !BROKEN_GNUTLS
-BRIDGE_CHECKS += test-httpstream
-endif
 
 mock_bridge_SOURCES = src/bridge/mock-bridge.c
 mock_bridge_CFLAGS = \


### PR DESCRIPTION
The proper fix landed upstream, in Fedora rawhide and testing, and
rhel-x, so this isn't necessary any more.

This reverts commit 1f1866811e3790c4cd5f68a3d0567685838f16a5.

Fixes #9723