### PR TITLE
tools: Stop shipping firewall service file with recent firewalld

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -36,6 +36,13 @@
 # build optional extensions like cockpit-docker
 %define build_optional 1
 
+# cockpit's firewall service definition moved to firewalld
+%if 0%{?fedora} >= 29 || 0%{?rhel} >= 8
+%define firewalld_service 0
+%else
+%define firewalld_service 1
+%endif
+
 %define __lib lib
 
 # on RHEL 7.x we build subscriptions; superseded later by
@@ -174,6 +181,9 @@ make install-tests DESTDIR=%{buildroot}
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
+%if 0%{?firewalld_service} == 0
+rm -f %{buildroot}/%{_prefix}/%{__lib}/firewalld/services/cockpit.xml
+%endif
 install -p -m 644 AUTHORS COPYING README.md %{buildroot}%{_docdir}/cockpit/
 
 # On RHEL we don't yet show options for changing language
@@ -465,6 +475,11 @@ Summary: Cockpit Web Service
 Requires: glib-networking
 Requires: openssl
 Requires: glib2 >= 2.37.4
+%if 0%{?firewalld_service}
+Conflicts: firewalld >= 0.6.0-1
+%else
+Conflicts: firewalld < 0.6.0-1
+%endif
 %if 0%{?fedora} >= 24 || 0%{?rhel} >= 8
 Recommends: sscg >= 2.3
 %endif
@@ -489,7 +504,9 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %{_unitdir}/cockpit.service
 %{_unitdir}/cockpit-motd.service
 %{_unitdir}/cockpit.socket
+%if 0%{?firewalld_service}
 %{_prefix}/%{__lib}/firewalld/services/cockpit.xml
+%endif
 %{_prefix}/%{__lib}/tmpfiles.d/cockpit-tempfiles.conf
 %{_sbindir}/remotectl
 %{_libdir}/security/pam_ssh_add.so


### PR DESCRIPTION
firewalld 0.6 includes cockpit's firewall service, so that the default
firewall configuration can open cockpit's port.

To avoid a file conflict between the packages, stop shipping our
firewalld service file on Fedora ≥ 29 and RHEL ≥ 8.

https://bugzilla.redhat.com/show_bug.cgi?id=1609393

 - [x] fix rhel-x build and build proper rhel-8 rpms (PR #9774)