### PR TITLE
login: check for `CSS.support()` (@supports in CSS)

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -49,7 +49,7 @@ REDHAT_VERIFY = {
     "verify/rhel-7-6-distropkg": [ ],
     "verify/rhel-x": [ 'master', 'rhel-8.0' ],
     "verify/rhel-atomic": [ 'master' ],
-    'selenium/explorer': [ 'master' ],
+    'selenium/explorer': [],
     'selenium/edge': [ 'master' ],
 }
 

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -154,7 +154,9 @@
                req("defineProperty", Object) &&
                req("console", window) &&
                req("pushState", window.history) &&
-               req("textContent", document);
+               req("textContent", document) &&
+               req("CSS", window) &&
+               req("supports", window.CSS);
     }
 
     function trim(s) {


### PR DESCRIPTION
Checking for CSS `@supports` effectively removes all versions of IE, yet keeps all modern browsers.

Depends:
  - [x] PR #9735 
  - [x] PR #9438