### PR TITLE
package.json: Pin jshint to previous version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "htmlparser": "~1.7.7",
     "imports-loader": "~0.6.5",
     "jed": "~1.1.0",
-    "jshint": "~2.9.1",
+    "jshint": "2.9.5",
     "jshint-loader": "~0.8.3",
     "less": "~3.0.1",
     "less-loader": "~4.0.6",


### PR DESCRIPTION
2.9.6 pulls in phantomjs due to a
[bad hack](https://github.com/jshint/jshint/pull/3215). This is a huge
and unnecessary `npm install` slow down, so avoid this by staying at
2.9.5 for now.

Reported at https://github.com/jshint/jshint/issues/3318