### PR TITLE
machines: change AddDisk dialog

### DIFF
--- a/pkg/machines/components/diskAdd.css
+++ b/pkg/machines/components/diskAdd.css
@@ -20,11 +20,8 @@
     padding-bottom: 0px !important;
 }
 
-.add-disk-body {
-    margin-top: 1em;
-}
-
-.add-disk-body .row {
+.add-disk-body .row,
+.add-disk-dialog .row {
     padding-bottom: 0.5em;
 }
 
@@ -64,3 +61,21 @@
 }
 
 .add-disk-attach-perm > input[type=checkbox] { }
+
+.add-disk-source {
+    padding-left: 5px;
+}
+
+.add-disk-select-source {
+    padding: 0px;
+    width: auto;
+    padding-right: 20px;
+}
+
+.add-disk-select-source > label {
+    margin-left: 5px;
+    text-align: left;
+    color: #363636;
+}
+
+.add-disk-select-source > input[type=radio] { }

--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -317,14 +317,40 @@ class AddDisk extends React.Component {
 
         return (
             <div className='modal-body add-disk-dialog'>
-                <ul className="nav nav-tabs nav-tabs-pf">
-                    <li key='one' className={this.state.mode === CREATE_NEW && "active"}>
-                        <a href="#" onClick={() => this.onValueChanged('mode', CREATE_NEW)}>{_("Create New")}</a>
-                    </li>
-                    <li key='two' className={this.state.mode === USE_EXISTING && "active"}>
-                        <a href="#" onClick={() => this.onValueChanged('mode', USE_EXISTING)}>{_("Use Existing")}</a>
-                    </li>
-                </ul>
+                <div className="container-fluid">
+                    <div className="row">
+                        <div className="col-sm-1 dialog-field add-disk-source-label">
+                            <label className="control-label" htmlFor={`${idPrefix}-source`}>
+                                {_("Source")}
+                            </label>
+                        </div>
+                        <div className="col-sm-11 dialog-field add-disk-source" id={`${idPrefix}-source`}>
+                            <div key='one' className="col-sm-3 add-disk-select-source">
+                                <input id={`${idPrefix}-createnew`}
+                                       type="radio"
+                                       name="source"
+                                       checked={this.state.mode === CREATE_NEW}
+                                       onChange={e => this.onValueChanged('mode', CREATE_NEW)}
+                                       extraClass={this.state.mode === CREATE_NEW && "active"} />
+                                <label className="control-label" htmlFor={`${idPrefix}-createnew`}>
+                                    {_("Create New")}
+                                </label>
+                            </div>
+
+                            <div key='two' className="col-sm-3 add-disk-select-source">
+                                <input id={`${idPrefix}-useexisting`}
+                                       type="radio"
+                                       name="source"
+                                       checked={this.state.mode === USE_EXISTING}
+                                       onChange={e => this.onValueChanged('mode', USE_EXISTING)}
+                                       extraClass={this.state.mode === USE_EXISTING && "active"} />
+                                <label className="control-label" htmlFor={`${idPrefix}-useexisting`}>
+                                    {_("Use Existing")}
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 {this.state.mode === CREATE_NEW && (
                     <CreateNewDisk idPrefix={`${idPrefix}-new`}
                                    onValueChanged={this.onValueChanged}

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -530,7 +530,7 @@ class TestMachines(MachineCase):
 
         b.wait_present("#vm-subVmTest1-disks-adddisk") # button
         b.click("#vm-subVmTest1-disks-adddisk")
-        b.wait_present(".add-disk-dialog ul li a:contains(Create New)") # subtab title in the modal dialog
+        b.wait_present(".add-disk-dialog label:contains(Create New)") # radio button label in the modal dialog
         b.wait_present("#vm-subVmTest1-disks-adddisk-new-select-pool")
 
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", "myPoolOne")
@@ -568,8 +568,8 @@ class TestMachines(MachineCase):
         b.wait_in_text("#vm-subVmTest1-disks-vda-source", "/mnt/vm_one/mydiskofpoolone_permanent") # should survive the shut down
 
         b.click("#vm-subVmTest1-disks-adddisk")
-        b.wait_present(".add-disk-dialog ul li a:contains(Use Existing)") # dialog subtab title
-        b.click(".add-disk-dialog ul li a:contains(Use Existing)")
+        b.wait_present(".add-disk-dialog label:contains(Use Existing)") # radio button label in the modal dialog
+        b.click(".add-disk-dialog label:contains(Use Existing)") # radio button label in the modal dialog
         b.wait_present("#vm-subVmTest1-disks-adddisk-existing-select-pool")
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "myPoolOne")
         b.wait_present("#vm-subVmTest1-disks-adddisk-existing-select-volume button.disabled span i:contains(The pool is empty)") # since both disks are already attached
@@ -577,8 +577,8 @@ class TestMachines(MachineCase):
         b.wait_not_present("#cockpit_modal_dialog")
 
         b.click("#vm-subVmTest1-disks-adddisk")
-        b.wait_present(".add-disk-dialog ul li a:contains(Use Existing)") # dialog subtab title
-        b.click(".add-disk-dialog ul li a:contains(Use Existing)")
+        b.wait_present(".add-disk-dialog label:contains(Use Existing)") # radio button label in the modal dialog
+        b.click(".add-disk-dialog label:contains(Use Existing)") # radio button label in the modal dialog
         b.wait_present("#vm-subVmTest1-disks-adddisk-existing-select-volume")
         b.wait_present("#vm-subVmTest1-disks-adddisk-existing-permanent")
         b.click("#vm-subVmTest1-disks-adddisk-existing-permanent")
@@ -594,8 +594,8 @@ class TestMachines(MachineCase):
         b.wait_in_text("#vm-subVmTest1-disks-vdd-source", "/mnt/vm_two/mydiskofpooltwo_permanent")
 
         b.click("#vm-subVmTest1-disks-adddisk")
-        b.wait_present(".add-disk-dialog ul li a:contains(Use Existing)") # dialog subtab title
-        b.click(".add-disk-dialog ul li a:contains(Use Existing)")
+        b.wait_present(".add-disk-dialog label:contains(Use Existing)") # radio button label in the modal dialog
+        b.click(".add-disk-dialog label:contains(Use Existing)") # radio button label in the modal dialog
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "myPoolTwo")
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-select-volume", "mydiskofpooltwo")
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-target", "vdb")


### PR DESCRIPTION
change unordered list to radio buttons for selecting "Create New" or "Use Existing"

fix vertical alignment of labels

update check-machines test to represent changes

Follow-up for #9166

Part of #9681 fix