### PR TITLE
tools: Stop shipping firewall service in Debian

### DIFF
--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -9,7 +9,6 @@ lib/*/security/pam_ssh_add.so
 usr/lib/tmpfiles.d/cockpit-tempfiles.conf
 usr/lib/cockpit/cockpit-session
 usr/lib/cockpit/cockpit-ws
-usr/lib/firewalld/services/cockpit.xml
 usr/sbin/remotectl
 usr/share/cockpit/branding/
 usr/share/cockpit/motd/


### PR DESCRIPTION
This expands d8b6285 to cover Debian packaging.

https://github.com/firewalld/firewalld/issues/359
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=905389