### PR TITLE
docker: align spinner to center

### DIFF
--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -166,6 +166,7 @@ div.spinner {
 }
 
 #containers-search-image-waiting.spinner {
+    display: block;
     margin: auto;
     margin-top: 150px;
 }


### PR DESCRIPTION
There seems to have been a regression that caused the spinner to not align horizontally. It needs to be set to a block element (`display: block;`) to use `margin: auto;` for horizontally centering.

fixes #6016