### PR TITLE
ws: Install issue.d symlink with proper extension

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -177,7 +177,7 @@ install-exec-hook::
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/motd.d
 	$(LN_S) -nf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/motd.d/cockpit
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/issue.d
-	$(LN_S) -nf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/issue.d/cockpit
+	$(LN_S) -nf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/issue.d/cockpit.issue
 
 tempconfdir = $(prefix)/lib/tmpfiles.d
 nodist_tempconf_DATA = src/ws/cockpit-tempfiles.conf

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -181,14 +181,14 @@ class TestConnection(MachineCase):
         m = self.machine
 
         if not m.image in ["rhel-7-5-distropkg"]:
-            self.assertIn("systemctl", m.execute("cat /etc/issue.d/cockpit"))
+            self.assertIn("systemctl", m.execute("cat /etc/issue.d/cockpit.issue"))
             self.assertIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
             self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
         m.start_cockpit()
 
         if not m.image in ["rhel-7-5-distropkg"]:
             self.assertNotIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
-            self.assertIn("9090", m.execute("cat /etc/issue.d/cockpit"))
+            self.assertIn("9090", m.execute("cat /etc/issue.d/cockpit.issue"))
             self.assertIn("9090", m.execute("cat /etc/motd.d/cockpit"))
 
         m.execute("systemctl stop cockpit.socket")
@@ -199,7 +199,7 @@ class TestConnection(MachineCase):
 
         # cockpit-ws from base package
         if not m.image in ["rhel-7-5-distropkg"]:
-            self.assertIn("systemctl", m.execute("cat /etc/issue.d/cockpit"))
+            self.assertIn("systemctl", m.execute("cat /etc/issue.d/cockpit.issue"))
             self.assertIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
             self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
             self.assertNotIn("443", m.execute("cat /etc/motd.d/cockpit"))
@@ -209,7 +209,7 @@ class TestConnection(MachineCase):
         if not m.image in ["rhel-7-5-distropkg"]:
             self.assertNotIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
             self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
-            self.assertIn("443", m.execute("cat /etc/issue.d/cockpit"))
+            self.assertIn("443", m.execute("cat /etc/issue.d/cockpit.issue"))
             self.assertIn("443", m.execute("cat /etc/motd.d/cockpit"))
 
         output = m.execute('curl -k https://localhost 2>&1 || true')

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -496,7 +496,7 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %doc %{_mandir}/man8/pam_ssh_add.8.gz
 %config(noreplace) %{_sysconfdir}/cockpit/ws-certs.d
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
-%config %{_sysconfdir}/issue.d/cockpit
+%config %{_sysconfdir}/issue.d/cockpit.issue
 %config %{_sysconfdir}/motd.d/cockpit
 %{_datadir}/cockpit/motd/update-motd
 %{_datadir}/cockpit/motd/inactive.motd

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -1,5 +1,5 @@
 etc/cockpit/ws-certs.d
-etc/issue.d/cockpit
+etc/issue.d/cockpit.issue
 etc/motd.d/cockpit
 etc/pam.d/cockpit
 lib/systemd/system/cockpit.service


### PR DESCRIPTION
Files in the /etc/issue.d directory are ignored unless they have the
extension ".issue".  Rename the file that we're installing and add some
postinst rules to clean up previous versions of the file that might be
laying around from older package versions.

Fixes #9659
Closes #9824