### PR TITLE
build: Drop check for libssh_threads

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ AC_MSG_CHECKING([build with cockpit-ssh])
 if test "$enable_ssh" != "no"; then
   enable_ssh="yes"
   AC_MSG_RESULT([$enable_ssh])
-  PKG_CHECK_MODULES(LIBSSH, [libssh >= $LIBSSH_VERSION libssh_threads])
+  PKG_CHECK_MODULES(LIBSSH, [libssh >= $LIBSSH_VERSION])
 
   AC_DEFINE_UNQUOTED(WITH_COCKPIT_SSH, 1, [Build cockpit-ssh and include libssh dependency])
 


### PR DESCRIPTION
This library got dropped from libssh 0.8.0, so the configure test fails:

    Package 'libssh_threads', required by 'virtual:world', not found

We don't actually use it anywhere, so just drop the check.

https://koji.fedoraproject.org/koji/taskinfo?taskID=29002300
https://bugzilla.redhat.com/show_bug.cgi?id=1615508