### PR TITLE
lib: Dialog body scrolling is optional

### DIFF
--- a/pkg/lib/cockpit-components-dialog.css
+++ b/pkg/lib/cockpit-components-dialog.css
@@ -1,4 +1,4 @@
-#cockpit_modal_dialog .modal-body {
+#cockpit_modal_dialog .modal-body.scroll {
     max-height: calc(75vh - 10rem);
     overflow: auto;
 }

--- a/pkg/lib/cockpit-components-install-dialog.jsx
+++ b/pkg/lib/cockpit-components-install-dialog.jsx
@@ -102,7 +102,7 @@ export function install_dialog(pkg) {
             id: "dialog",
             title: _("Install Software"),
             body: (
-                <div className="modal-body">
+                <div className="modal-body scroll">
                     <p>{ format_to_array(_("$0 will be installed."), missing_name) }</p>
                     { remove_details }
                     { extra_details }


### PR DESCRIPTION
The "overflow: auto" also causes dropdowns to be clipped and make the
scrollbar appear.  Until we have a good fix for that, make the auto
scroll behavior optional.

We use it for the "Install" dialog since that one might otherwise get
arbitrarily tall when a package has many dependencies.