### PR TITLE
naughty: Close 9450: SELinux denies post{master,conf} reading resolv.conf

### DIFF
--- a/bots/naughty/rhel-7/9450-selinux-postmaster-resolv.conf
+++ b/bots/naughty/rhel-7/9450-selinux-postmaster-resolv.conf
@@ -1,1 +1,0 @@
-Error: type=1400 audit(*): avc:  denied  { read } for * comm="post*" name="resolv.conf"


### PR DESCRIPTION
Known issue which has not occurred in 27 days

SELinux denies post{master,conf} reading resolv.conf

Fixes #9450