### PR TITLE
test: Enable check-storage-vdop on rhel-x

### DIFF
--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -24,7 +24,6 @@ from testlib import *
 from storagelib import *
 from packagelib import *
 
-@skipImage("VDO is too badly broken still", "rhel-x")
 class TestStorage(StorageCase):
     def testVdo(self):
         m = self.machine
@@ -35,6 +34,9 @@ class TestStorage(StorageCase):
         if m.execute("which vdo || true") == "":
             b.wait_not_present("#vdos")
             return
+
+        # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1616247
+        m.execute("depmod")
 
         b.wait_visible("#vdos")
 


### PR DESCRIPTION
Let's see what happens.  We should at least document why we skip the test and preferably handle failures with known issues.