### PR TITLE
storage: Support NBDE with LUKSv2

### DIFF
--- a/pkg/storaged/clevis-luks-passphrase.sh
+++ b/pkg/storaged/clevis-luks-passphrase.sh
@@ -7,18 +7,32 @@ fi
 
 DEV="$1"
 
-# The UUID that clevis uses for its luksmeta slots,
-# see for example /usr/bin/clevis-luks-bind
-#
-CLEVIS_UUID=cb6e8904-81ff-40da-a84a-07ab9ab5715e
+if cryptsetup isLuks --type luks1 "$DEV"; then
 
-luksmeta test -d "$DEV" 2>/dev/null || exit 0
+    # The UUID that clevis uses for its luksmeta slots,
+    # see for example /usr/bin/clevis-luks-bind
+    #
+    CLEVIS_UUID=cb6e8904-81ff-40da-a84a-07ab9ab5715e
 
-luksmeta show -d "$DEV" | while read slot state uuid; do
-    if [ "$state" == "active" -a "$uuid" == "$CLEVIS_UUID" ]; then
-        if pp=$(luksmeta load -d "$DEV" -s "$slot" | clevis decrypt); then
-            echo $pp
+    luksmeta test -d "$DEV" 2>/dev/null || exit 0
+
+    luksmeta show -d "$DEV" | while read slot state uuid; do
+        if [ "$state" == "active" -a "$uuid" == "$CLEVIS_UUID" ]; then
+            if pp=$(luksmeta load -d "$DEV" -s "$slot" | clevis decrypt); then
+                echo $pp
+                break
+            fi
+        fi
+    done
+
+elif cryptsetup isLuks --type luks2 "$DEV"; then
+    for id in `cryptsetup luksDump "$DEV" | sed -rn 's|^\s+([0-9]+): clevis|\1|p'`; do
+        tok=`cryptsetup token export --token-id "$id" "$DEV"`
+        jwe=`jose fmt -j- -Og jwe -o- <<<"$tok" | jose jwe fmt -i- -c`
+
+        if pt=`echo -n "$jwe" | clevis decrypt`; then
+            echo $pt
             break
         fi
-    fi
-done
+    done
+fi

--- a/pkg/storaged/clevis-luks-passphrase.sh
+++ b/pkg/storaged/clevis-luks-passphrase.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -eu
+
 if [ $# -ne 1 ]; then
     echo "usage: $0 DEV" >&2
     exit 1

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -410,7 +410,7 @@
         }
 
         function enable_clevis_features() {
-            return cockpit.spawn([ "which", "clevis-bind-luks" ], { err: "ignore" }).then(
+            return cockpit.spawn([ "which", "clevis-luks-bind" ], { err: "ignore" }).then(
                 function () {
                     client.features.clevis = true;
                     return cockpit.resolve();

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -127,13 +127,9 @@ class TestStorage(StorageCase):
     @skipImage("No clevis/tang",
                "centos-7", "rhel-7-5", "rhel-7-5-distropkg", "rhel-7-6", "rhel-7-6-distropkg",
                "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
-    @skipImage("Cockpit can't do LUKSv2 yet", "rhel-x")
     def testClevisTang(self):
         m = self.machine
         b = self.browser
-
-        # HACK - clevis in rhel devel is too old
-        can_unlock = m.image not in [ "rhel-x" ]
 
         # We generate the keys and cache explicitly before starting
         # the socket.  This allows us to control their names, which
@@ -202,11 +198,10 @@ class TestStorage(StorageCase):
         b.wait_present(panel + ".table tr:nth-child(2)")
         b.wait_in_text(panel + ".table tr:nth-child(2)", "127.0.0.1")
 
-        if can_unlock:
-            # Unlock it.  This should succeed without prompting.
-            #
-            self.content_head_action(1, "Unlock")
-            self.content_row_wait_in_col(2, 1, "ext4 File System")
+        # Unlock it.  This should succeed without prompting.
+        #
+        self.content_head_action(1, "Unlock")
+        self.content_row_wait_in_col(2, 1, "ext4 File System")
 
         # Edit the key, without providing an existing passphrase
         #
@@ -231,11 +226,12 @@ class TestStorage(StorageCase):
     @skipImage("No clevis/tang",
                "centos-7", "rhel-7-5", "rhel-7-5-distropkg", "rhel-7-6", "rhel-7-6-distropkg",
                "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable")
-    @skipImage("Cockpit can't do LUKSv2 yet", "rhel-x")
     def testSlots(self):
         self.allow_journal_messages("Device is not initialized.*")
         m = self.machine
         b = self.browser
+
+        luks_2 = m.image in [ "rhel-x" ]
 
         self.login_and_go("/storage")
 
@@ -255,6 +251,7 @@ class TestStorage(StorageCase):
         # add one more passphrase
         tab = self.content_tab_expand(1, 1)
         panel = tab + " .panel:contains(Keys) "
+        b.wait_present(panel)
         b.click(panel + ".fa-plus")
         self.dialog_wait_open()
         self.dialog_wait_apply_enabled()
@@ -293,7 +290,7 @@ class TestStorage(StorageCase):
         b.wait_in_text(".dialog-error", "Error unlocking /dev/sda: Failed to activate device: Operation not permitted")
         self.dialog_cancel()
 
-        # add more passphrases, seven exactly, to reach the limit of eight
+        # add more passphrases, seven exactly, to reach the limit of eight for LUKSv1
         for i in range(1,8):
             b.click(panel + ".fa-plus")
             self.dialog_wait_open()
@@ -305,11 +302,13 @@ class TestStorage(StorageCase):
             self.dialog_apply()
             self.dialog_wait_close()
 
-        # check if add button is inactive
-        b.wait_present(panel + ".disabled")
-        # check if edit button is inactive
-        slots_table = tab + " .panel table "
-        b.wait_present(slots_table + ".disabled")
+        if not luks_2:
+            # check if add button is inactive
+            b.wait_present(panel + ".disabled")
+            # check if edit button is inactive
+            slots_table = tab + " .panel table "
+            b.wait_present(slots_table + ".disabled")
+
         # remove one slot
         slots_table = tab + " .panel table "
         b.wait_present(slots_table + "tbody tr:last-child .fa-minus")


### PR DESCRIPTION
We now enable the "Keys" panel in the Encryption tab also for LUKSv2
if we detect that the installed clevis can handle it.

The monitoring and passphrase recovery hacks have been extended to
retrieve the clevis configs also from LUKSv2 tokens.

cryptsetup has a limit of 32 slots with LUKSv2, which is quite a lot
and thus we only show how many remain when there are less than 6 left.

 - [x] Fix rhel-x image (PR #9894 )
 - [x] Tests