### PR TITLE
bots: Blacklist @patternfly/react-console and react-bootstrap in npm-update

### DIFF
--- a/bots/npm-update
+++ b/bots/npm-update
@@ -34,6 +34,10 @@ FRAGILE = [
     "patternfly",
     "paternfly-bootstrap-combobox",
     "requirejs",
+    # 1.4.x needs the full React 16, does not work with our react-lite 15
+    "@patternfly/react-console",
+    # version 0.32.2 switches to babel 7, which causes build failures with our babel 6 build system
+    "react-bootstrap",
 ]
 
 import collections


### PR DESCRIPTION
These cannot currently be updated, add appropriate comments.

--- 
This does not affect integration tests. I tested this with `bots/npm-update --dry -v`, and it now stops trying to update theses two, and gets on to mustache (which is legit). This avoids an eternal stream of invalid PRs like #9865 and #9857.