### PR TITLE
bots: Detect one more case of Anaconda stopping

### DIFF
--- a/bots/images/scripts/virt-install-fedora
+++ b/bots/images/scripts/virt-install-fedora
@@ -116,6 +116,9 @@ expect {
   "Please make your choice" { send_user "\n\n\n\nABORT - Anaconda stopped\n"
                               exit 1
                             }
+  "Please make a selection" { send_user "\n\n\n\nABORT - Anaconda stopped\n"
+                              exit 1
+                            }
 }
 EOF
 }


### PR DESCRIPTION
Newer versions seem to talk differently.

 * [ ] FAIL: image-refresh rhel-x
 * [x] image-refresh fedora-28