### PR TITLE
bots: Drop broken kernel core dump sysctl from rhel-x

### DIFF
--- a/bots/images/scripts/rhel-x.install
+++ b/bots/images/scripts/rhel-x.install
@@ -8,3 +8,8 @@ set -e
 # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1600452
 # packagekitd spins at 100% CPU on startup
 systemctl mask packagekit.service
+
+# HACK: https://github.com/cockpit-project/cockpit/issues/8881
+# rhel-x has a customized and broken core_pattern that overrides systemd's good one
+# remove this after the next rhel-x image rebuild after 2018-08-20
+rm -f /etc/sysctl.d/50-coredump.conf

--- a/bots/images/scripts/rhel.setup
+++ b/bots/images/scripts/rhel.setup
@@ -306,7 +306,10 @@ fi
 # Final tweaks
 
 rm -rf /var/log/journal/*
-echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
+# RHEL 7 does not enable systemd-coredump by default, later versions do
+if ! grep -qr core_pattern /usr/lib/sysctl.d/; then
+    echo "kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e" > /etc/sysctl.d/50-coredump.conf
+fi
 
 # Prevent SSH from hanging for a long time when no external network access
 echo 'UseDNS no' >> /etc/ssh/sshd_config

--- a/bots/naughty/rhel-x/8881-systemd-coredump-wrongargs
+++ b/bots/naughty/rhel-x/8881-systemd-coredump-wrongargs
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-connection", line *, in testBasic
-    wait(lambda: m.execute("journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'"))
-*
-*CalledProcessError: Command 'journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'' returned non-zero exit status 1

--- a/bots/naughty/rhel-x/8881-systemd-coredump-wrongargs-2
+++ b/bots/naughty/rhel-x/8881-systemd-coredump-wrongargs-2
@@ -1,1 +1,0 @@
-Not enough arguments passed by the kernel (6, expected 7).


### PR DESCRIPTION
Our rhel.setup installs /etc/sysctl.d/50-coredump.conf to enable
systemd-coredump, as on RHEL/CentOS 7 this does not happen by default.
On rhel-x it does through /usr/lib/sysctl.d/50-coredump.conf. Our own
one supplies the wrong number of parameters, which breaks coredumping
with

    Not enough arguments passed by the kernel (6, expected 7).

the reason for known issue #8881.

Drop our custom config file on on rhel-x (where the pattern is set in
/usr/lib/sysctl.d/ already).

As rhel-x rebuilds are currently broken, add a temporary workaround to
rhel-x.install to remove the file. This can be dropped after the next
rebuild.

Fixes #8881