### PR TITLE
bots: Add test scanning for rhel-8.0 branch

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -20,7 +20,7 @@
 
 BASELINE_PRIORITY = 10
 
-BRANCHES = [ 'master', 'rhel-7.5', 'rhel-7.6' ]
+BRANCHES = [ 'master', 'rhel-7.5', 'rhel-7.6', 'rhel-8.0' ]
 
 DEFAULT_VERIFY = {
     'avocado/fedora': BRANCHES,
@@ -47,7 +47,7 @@ REDHAT_VERIFY = {
     "verify/rhel-7-5-distropkg": [ 'master' ],
     "verify/rhel-7-6": [ 'master', 'rhel-7.6' ],
     "verify/rhel-7-6-distropkg": [ ],
-    "verify/rhel-x": [ 'master' ],
+    "verify/rhel-x": [ 'master', 'rhel-8.0' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/explorer': [ 'master' ],
     'selenium/edge': [ 'master' ],


### PR DESCRIPTION
Start testing PRs against the new rhel-8.0 branch.

---

This is very similar to the recent PR #9742 for rhel-7.6. This can be tested with
```
❱❱❱ bots/tests-scan -vd | grep 9868
pull-9868   selenium/firefox          b72a480     9
pull-9868   verify/rhel-x             b72a480     8
pull-9868   selenium/chrome           b72a480     8
pull-9868   container/kubernetes      b72a480     8
pull-9868   container/bastion         b72a480     8
pull-9868   avocado/fedora            b72a480     8
```
This will pick up testing for PR #9868.