### PR TITLE
machines: Hide 'Add Disk' component for oVirt provider

### DIFF
--- a/pkg/machines/components/vmDisksTabLibvirt.jsx
+++ b/pkg/machines/components/vmDisksTabLibvirt.jsx
@@ -98,10 +98,14 @@ class VmDisksTabLibvirt extends React.Component {
                 .map(target => this.prepareDiskData(vm.disks[target],
                                                     vm.disksStats && vm.disksStats[target],
                                                     `${idPrefix}-${target}`));
+        let actions = [];
+
+        if (config.provider.name != 'oVirt')
+            actions = [<AddDiskAction dispatch={dispatch} provider={config.provider} idPrefix={idPrefix} vm={vm} storagePools={storagePools} />];
 
         return (
             <VmDisksTab idPrefix={idPrefix}
-                actions={[<AddDiskAction dispatch={dispatch} provider={config.provider} idPrefix={idPrefix} vm={vm} storagePools={storagePools} />]}
+                actions={actions}
                 disks={disks}
                 renderCapacity={areDiskStatsSupported}
                 notificationText={this.getNotification(vm, areDiskStatsSupported)} />


### PR DESCRIPTION
Since oVirt is not using libvirt's storage pools the list of pools
which is currently fetched from virsh pool-list command is of no
use in the oVirt plugin.
Having this in mind the storagePools property was not passed to the
HostVmsList React component reused from machines code, leading to
undefined property value.

This patch hides the Add Disk option until the pools discovery is
implemented inside oVirt plugin.

Fixes #9845