### PR TITLE
bots: Put back blacklisting of cockpit-ostree onto VM images

### DIFF
--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -125,6 +125,8 @@ def run_install_script(machine, do_build, do_install, skips, arg, args):
     skips = list(skips or [])
     if "atomic" in machine.image:
         skips.append("cockpit-kubernetes")
+    else:
+        skips.append("cockpit-ostree")
 
     skip_args = [" --skip '%s'" % skip for skip in skips]
     cmd = "cd /var/tmp; ./%s.install%s%s%s%s%s%s" % (machine.image,


### PR DESCRIPTION
Revert that bit from commit 04623644131c. While cockpit-ostree isn't
built any more from master, and thus this isn't relevant there, it still
is relevant for the rhel-7.x back branches, and now breaking their
installation.