### PR TITLE
tools: Touch Makefile.in after applying patches

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -155,7 +155,7 @@ if [ -n "%{patches}" ]; then
     git config core.autocrlf false && git config core.safecrlf false && git config gc.auto 0
     git add -f . && git commit -a -q -m "Base" && git tag -a initial --message="initial"
     git am --whitespace=nowarn %{patches}
-    touch -r $(git diff --name-only initial..HEAD) .git
+    touch -r $(git diff --name-only initial..HEAD) .git Makefile.in
     rm -rf .git
 fi
 


### PR DESCRIPTION
If a patch changes configure.ac, but no Makefile.am, then the generated
build system patch will end up making configure and aclocal.m4 newer
than Makefile.in, and thus a downstream build wants to call automake to
update it. Avoid this by forcing Makefile.in to be as new as the patched
files.