### PR TITLE
machines: re-add support for Redux DevTools Extension

### DIFF
--- a/pkg/machines/store.es6
+++ b/pkg/machines/store.es6
@@ -17,15 +17,14 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import reducer from './reducers.es6';
 import thunkMiddleware from 'redux-thunk';
 
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const store = createStore(
     reducer,
-    applyMiddleware(
-        thunkMiddleware, // lets us dispatch() functions
-    )
+    composeEnhancers(applyMiddleware(thunkMiddleware))
 );
 
 export default store;


### PR DESCRIPTION
With commit 342278 I unwillingly removed support for redux devtools extension.
Bring it back since it's very useful for debugging and development.