### PR TITLE
bots: Test image-refresh pull requests against external projects

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -146,6 +146,9 @@ def run(image, verbose=False, **kwargs):
         for trigger in triggers:
             api.post("statuses/{0}".format(head), { "state": "pending", "context": trigger,
                 "description": github.NOT_TESTED })
+        # pre-creating statuses circumvents tests-scan's detection of whether bots/ changed
+        # we want to validate all image refreshes with external projects
+        task.label(pull, ["test-external"])
 
 if __name__ == '__main__':
     task.main(function=run, title="Refresh image")


### PR DESCRIPTION
Human-made PRs start without any test statuses, and thus test-scan's
logic for checking if anything changed in bots/ kicks in. If so, that
adds a "test-external" label, so that third-party projects that use
Cockpit's bots get validated too.

But image-refresh circumvents this check, as it immediately adds test
statuses to the newly created PR, so that test-scan's caching logic
skips the check. As we *know* that an image refresh PR changes bots/,
always add the label.