### PR TITLE
test: Reproduce crash with ssh MD5 fingerprint generation in FIPS mode

### DIFF
--- a/bots/naughty/rhel-7/9918-cockpit-ssh-crash-md5
+++ b/bots/naughty/rhel-7/9918-cockpit-ssh-crash-md5
@@ -1,0 +1,7 @@
+Traceback (most recent call last):
+  File "test/verify/check-multi-machine", line *, in testFIPS
+    add_machine(b, "10.111.113.2")
+  File "test/verify/check-multi-machine", line *, in start_machine_troubleshoot
+    b.wait_in_text('#troubleshoot-dialog', "Fingerprint")
+*
+Error: timeout

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -441,6 +441,22 @@ class TestMultiMachine(MachineCase):
         add_machine(b, "10.111.113.2")
         self.checkDirectLogin('/');
 
+    @skipImage("test VM image does not have FIPS support", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "rhel-x", "fedora-atomic")
+    def testFIPS(self):
+        b = self.browser
+
+        # enable FIPS
+        self.machine.execute(r'grubby --update-kernel=$(grubby --default-kernel) --args=fips=1')
+        self.machine.execute(r'uuid=$(findmnt -no uuid /boot); [ -n "$uuid" ] && grubby --update-kernel=$(grubby --default-kernel) --args=boot=UUID=${uuid}')
+        self.machine.spawn('sync && sync && sync && sleep 0.1 && reboot', 'reboot')
+        self.machine.wait_reboot()
+        # ensure it's really enabled
+        self.assertEqual(self.machine.execute('cat /proc/sys/crypto/fips_enabled').strip(), "1")
+
+        self.login_and_go("/dashboard")
+        add_machine(b, "10.111.113.2")
+        self.checkDirectLogin('/');
+
     def testUrlRoot(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
This hits an assertion in `ssh_get_publickey_hash()`:

    OpenSSL internal error, assertion failed: Digest MD5 forbidden in FIPS mode!

Fixing this requires SHA256 fingerprint support from libssh 0.8.2. But
add the test now, so that it's available when we need it.

https://bugzilla.redhat.com/show_bug.cgi?id=1585191