### PR TITLE
tools: Fix Debian arch-indep build

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -79,7 +79,7 @@ override_dh_install:
 	dh_install --fail-missing -Xusr/src/debug
 	make install-tests DESTDIR=debian/cockpit-tests
 
-	if [ -z "$(FIREWALLD_SERVICE)" ]; then rm debian/cockpit-ws/usr/lib/firewalld/services/cockpit.xml; rmdir -p --ignore-fail-on-non-empty debian/cockpit-ws/usr/lib/firewalld/services/; fi
+	if [ -z "$(FIREWALLD_SERVICE)" ] && [ -d debian/cockpit-ws ]; then rm debian/cockpit-ws/usr/lib/firewalld/services/cockpit.xml; rmdir -p --ignore-fail-on-non-empty debian/cockpit-ws/usr/lib/firewalld/services/; fi
 
 override_dh_gencontrol:
 	dh_gencontrol -- -Vbridge:minversion="$(shell tools/min-base-version)" -Vws:Conflicts="$(WS_CONFLICTS)"


### PR DESCRIPTION
When building only arch-indep packages, the cockpit-ws package does not
get built, and trying to remove the firewalld service failed.

https://bugs.debian.org/907108

---
I already applied this downstream.