### PR TITLE
bots: Declare fedora-29 image

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -35,6 +35,7 @@ DEFAULT_VERIFY = {
     'verify/fedora-i386': [ 'master' ],
     'verify/fedora-27': [ ],
     'verify/fedora-28': [ 'master' ],
+    'verify/fedora-29': [ ],
     'verify/fedora-atomic': [ 'master' ],
     'verify/fedora-testing': [ ],
     'verify/ubuntu-1604': [ 'master' ],


### PR DESCRIPTION
Fedora 29 has forked from Rawhide now [1], so we'll need an image for
this.

[1] https://fedoraproject.org/wiki/Releases/29/Schedule