### PR TITLE
tools: Release into Fedora 29

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -14,8 +14,7 @@ RELEASE_SRPM=$PWD/_release/srpm
 RELEASE_DSC=$PWD/_release/dsc
 RELEASE_SOURCE=$PWD/_release/source
 
-# Fedora needs this crap. It's like packages are made
-# by cobblers not automated systems.
+# Authenticate for pushing into Fedora dist-git
 cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
 
 # Build the source tarball patches and srpm

--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -25,6 +25,7 @@ job release-srpm
 # Do fedora builds for the tag, using tarball
 job release-koji -k master
 job release-koji f28
+job release-koji f29
 
 # Upload release to github, using tarball
 job release-github
@@ -38,6 +39,7 @@ job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 
 # Push out a Bodhi update
 job release-bodhi F28
+job release-bodhi F29
 
 # Upload documentation
 job bots/release-guide dist/guide cockpit-project/cockpit-project.github.io


### PR DESCRIPTION
Fedora 29 has forked from Rawhide now.
    
See https://fedoraproject.org/wiki/Releases/29/Schedule
