### PR TITLE
test: Run avocado/selenium tests on Fedora 28

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -33,14 +33,14 @@ TRIGGERS = {
     ],
     "fedora-27": [
         "verify/fedora-27",
-        "selenium/explorer",
-        "selenium/chrome",
-        "selenium/firefox",
-        "avocado/fedora",
         "container/kubernetes",
         "container/bastion",
     ],
     "fedora-28": [
+        "selenium/explorer",
+        "selenium/chrome",
+        "selenium/firefox",
+        "avocado/fedora",
         "verify/fedora-28",
         "verify/fedora-atomic",
     ],

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -308,7 +308,9 @@ class PullTask(object):
         # Split a value like verify/fedora-atomic
         (prefix, unused, value) = self.context.partition("/")
 
-        if prefix in [ 'selenium', 'avocado', 'container' ]:
+        if prefix in [ 'selenium', 'avocado' ]:
+            image = 'fedora-28'
+        elif prefix in [ 'container' ]:
             image = 'fedora-27'
         else:
             image = value

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -162,7 +162,7 @@ done;
 
 def run_avocado(avocado_tests, verbose, browser, download_logs, sit):
     use_selenium = (browser != 'none')
-    image = os.environ.get("TEST_OS", "fedora-27")
+    image = os.environ.get("TEST_OS", "fedora-28")
     network = testvm.VirtNetwork()
     machine = testvm.VirtMachine(verbose=verbose, networking=network.host(), image=image)
     selenium = windows = None


### PR DESCRIPTION
This is another big step towards dropping the fedora-27 image.