### PR TITLE
naughty: Close 9721: SETroubleshoot page does not work on rhel-x

### DIFF
--- a/bots/naughty/rhel-x/9721-setroubleshoot
+++ b/bots/naughty/rhel-x/9721-setroubleshoot
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-setroubleshoot", line *, in testTroubleshootAlerts
-    b.wait_present(row_selector)
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 27 days

SETroubleshoot page does not work on rhel-x

Fixes #9721