### PR TITLE
naughty: Close 9592:  avc: denied { map } for comm="local" path="/usr/libexec/postfix/local

### DIFF
--- a/bots/naughty/rhel-7/9592-selinux-postfix-local
+++ b/bots/naughty/rhel-7/9592-selinux-postfix-local
@@ -1,1 +1,0 @@
-Error: type=1400 audit(*): avc:  denied  { map } for * path="/usr/libexec/postfix/local"


### PR DESCRIPTION
Known issue which has not occurred in 27 days

 avc: denied { map } for comm="local" path="/usr/libexec/postfix/local

Fixes #9592