### PR TITLE
naughty: Close 9507: SELinux denied { map } comm="mdadm" path="/usr/sbin/mdadm"

### DIFF
--- a/bots/naughty/fedora-27/9507-selinux-map-mdadm
+++ b/bots/naughty/fedora-27/9507-selinux-map-mdadm
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { map } for * comm="mdadm" path="/usr/sbin/mdadm"


### PR DESCRIPTION
Known issue which has not occurred in 21 days

SELinux denied { map } comm="mdadm" path="/usr/sbin/mdadm"

Fixes #9507