### PR TITLE
naughty: Close 9505: Fedora 28: SELinux prevents rpc.gssd from getattr

### DIFF
--- a/bots/naughty/fedora-28/9505-selinux-rpc-gsssd-getattr
+++ b/bots/naughty/fedora-28/9505-selinux-rpc-gsssd-getattr
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { getattr } for * comm="gssproxy"*path="/usr/sbin/rpc.gssd"


### PR DESCRIPTION
Known issue which has not occurred in 27 days

Fedora 28: SELinux prevents rpc.gssd from getattr

Fixes #9505