### PR TITLE
lib: Use current ES6 in cockpit-components-{listing,select}.jsx

### DIFF
--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -17,11 +17,9 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-"use strict";
-
-var React = require('react');
-
-require('./listing.less');
+import PropTypes from 'prop-types';
+import React from 'react';
+import './listing.less';
 
 /* entry for an alert in the listing, can be expanded (with details) or standard
  * rowId optional: an identifier for the row which will be set as "data-row-id" attribute on the <tr>
@@ -47,55 +45,43 @@ require('./listing.less');
  * initiallyExpanded optional: the entry will be initially rendered as expanded, but then behaves normally
  * expandChanged optional: callback will be used if the row is either expanded or collapsed passing single `isExpanded` boolean argument
  */
-var ListingRow = React.createClass({
-    propTypes: {
-        rowId: React.PropTypes.string,
-        columns: React.PropTypes.array.isRequired,
-        tabRenderers: React.PropTypes.array,
-        navigateToItem: React.PropTypes.func,
-        listingDetail: React.PropTypes.node,
-        listingActions: React.PropTypes.arrayOf(React.PropTypes.node),
-        selectChanged: React.PropTypes.func,
-        selected: React.PropTypes.bool,
-        initiallyExpanded: React.PropTypes.bool,
-        expandChanged: React.PropTypes.func,
-        initiallyActiveTab: React.PropTypes.bool,
-    },
-    getDefaultProps: function () {
-        return {
-            tabRenderers: [],
-            navigateToItem: null,
-        };
-    },
-    getInitialState: function() {
-        return {
+export class ListingRow extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
             expanded: this.props.initiallyExpanded, // show expanded view if true, otherwise one line compact
             activeTab: this.props.initiallyActiveTab ? this.props.initiallyActiveTab : 0, // currently active tab in expanded mode, defaults to first tab
             loadedTabs: {}, // which tabs were already loaded - this is important for 'loadOnDemand' setting
             // contains tab indices
             selected: this.props.selected, // whether the current row is selected
         };
-    },
-    handleNavigateClick: function(e) {
+        this.handleNavigateClick = this.handleNavigateClick.bind(this);
+        this.handleExpandClick = this.handleExpandClick.bind(this);
+        this.handleSelectClick = this.handleSelectClick.bind(this);
+        this.handleTabClick = this.handleTabClick.bind(this);
+    }
+
+    handleNavigateClick(e) {
         // only consider primary mouse button
         if (!e || e.button !== 0)
             return;
         this.props.navigateToItem();
-    },
-    handleExpandClick: function(e) {
+    }
+
+    handleExpandClick(e) {
         // only consider primary mouse button
         if (!e || e.button !== 0)
             return;
 
-        var willBeExpanded = !this.state.expanded && this.props.tabRenderers.length > 0;
+        let willBeExpanded = !this.state.expanded && this.props.tabRenderers.length > 0;
         this.setState({ expanded: willBeExpanded });
 
-        var loadedTabs = {};
+        let loadedTabs = {};
         // unload all tabs if not expanded
         if (willBeExpanded) {
             // see if we should preload some tabs
-            var tabIdx;
-            var tabPresence;
+            let tabIdx;
+            let tabPresence;
             for (tabIdx = 0; tabIdx < this.props.tabRenderers.length; tabIdx++) {
                 if ('presence' in this.props.tabRenderers[tabIdx])
                     tabPresence = this.props.tabRenderers[tabIdx].presence;
@@ -115,13 +101,14 @@ var ListingRow = React.createClass({
 
         e.stopPropagation();
         e.preventDefault();
-    },
-    handleSelectClick: function(e) {
+    }
+
+    handleSelectClick(e) {
         // only consider primary mouse button
         if (!e || e.button !== 0)
             return;
 
-        var selected = !this.state.selected;
+        let selected = !this.state.selected;
         this.setState({ selected: selected });
 
         if (this.props.selectChanged)
@@ -129,14 +116,15 @@ var ListingRow = React.createClass({
 
         e.stopPropagation();
         e.preventDefault();
-    },
-    handleTabClick: function(tabIdx, e) {
+    }
+
+    handleTabClick(tabIdx, e) {
         // only consider primary mouse button
         if (!e || e.button !== 0)
             return;
-        var prevTab = this.state.activeTab;
-        var prevTabPresence = 'default';
-        var loadedTabs = this.state.loadedTabs;
+        let prevTab = this.state.activeTab;
+        let prevTabPresence = 'default';
+        let loadedTabs = this.state.loadedTabs;
         if (prevTab !== tabIdx) {
             // see if we need to unload the previous tab
             if ('presence' in this.props.tabRenderers[prevTab])
@@ -151,13 +139,14 @@ var ListingRow = React.createClass({
         }
         e.stopPropagation();
         e.preventDefault();
-    },
-    render: function() {
-        var self = this;
-        // only enable navigation if a function is provided and the row isn't expanded (prevent accidental navigation)
-        var allowNavigate = !!this.props.navigateToItem && !this.state.expanded;
+    }
 
-        var headerEntries = this.props.columns.map((itm, index) => {
+    render() {
+        let self = this;
+        // only enable navigation if a function is provided and the row isn't expanded (prevent accidental navigation)
+        let allowNavigate = !!this.props.navigateToItem && !this.state.expanded;
+
+        let headerEntries = this.props.columns.map((itm, index) => {
             if (typeof itm === 'string' || typeof itm === 'number' || itm === null || itm === undefined || itm instanceof String || React.isValidElement(itm))
                 return (<td key={index}>{itm}</td>);
             else if ('header' in itm && itm.header)
@@ -168,8 +157,8 @@ var ListingRow = React.createClass({
                 return (<td key={index}>{itm.name}</td>);
         });
 
-        var allowExpand = (this.props.tabRenderers.length > 0);
-        var expandToggle;
+        let allowExpand = (this.props.tabRenderers.length > 0);
+        let expandToggle;
         if (allowExpand) {
             expandToggle = <td key="expandToggle" className="listing-ct-toggle" onClick={ allowNavigate ? this.handleExpandClick : undefined }>
                 <i className="fa fa-fw" />
@@ -178,14 +167,14 @@ var ListingRow = React.createClass({
             expandToggle = <td key="expandToggle-empty" className="listing-ct-toggle" />;
         }
 
-        var listingItemClasses = ["listing-ct-item"];
+        let listingItemClasses = ["listing-ct-item"];
         if (!allowNavigate)
             listingItemClasses.push("listing-ct-nonavigate");
         if (!allowExpand)
             listingItemClasses.push("listing-ct-noexpand");
 
-        var allowSelect = !(allowNavigate || allowExpand) && (this.state.selected !== undefined);
-        var clickHandler;
+        let allowSelect = !(allowNavigate || allowExpand) && (this.state.selected !== undefined);
+        let clickHandler;
         if (allowSelect) {
             clickHandler = this.handleSelectClick;
             if (this.state.selected)
@@ -197,7 +186,7 @@ var ListingRow = React.createClass({
                 clickHandler = this.handleExpandClick;
         }
 
-        var listingItem = (
+        let listingItem = (
             <tr data-row-id={ this.props.rowId }
                 className={ listingItemClasses.join(' ') }
                 onClick={clickHandler}>
@@ -207,18 +196,18 @@ var ListingRow = React.createClass({
         );
 
         if (this.state.expanded) {
-            var links = this.props.tabRenderers.map((itm, idx) => {
+            let links = this.props.tabRenderers.map((itm, idx) => {
                 return (
                     <li key={idx} className={ (idx === self.state.activeTab) ? "active" : ""} >
                         <a href="#" tabIndex="0" onClick={ self.handleTabClick.bind(self, idx) }>{itm.name}</a>
                     </li>
                 );
             });
-            var tabs = [];
-            var tabIdx;
-            var Renderer;
-            var rendererData;
-            var row;
+            let tabs = [];
+            let tabIdx;
+            let Renderer;
+            let rendererData;
+            let row;
             for (tabIdx = 0; tabIdx < this.props.tabRenderers.length; tabIdx++) {
                 Renderer = this.props.tabRenderers[tabIdx].renderer;
                 rendererData = this.props.tabRenderers[tabIdx].data;
@@ -231,7 +220,7 @@ var ListingRow = React.createClass({
                     tabs.push(<div className="listing-ct-body" key={tabIdx} hidden>{row}</div>);
             }
 
-            var listingDetail;
+            let listingDetail;
             if ('listingDetail' in this.props) {
                 listingDetail = (
                     <span className="listing-ct-caption">
@@ -268,8 +257,26 @@ var ListingRow = React.createClass({
             );
         }
     }
-});
+}
 
+ListingRow.defaultProps = {
+    tabRenderers: [],
+    navigateToItem: null,
+};
+
+ListingRow.propTypes = {
+    rowId: PropTypes.string,
+    columns: PropTypes.array.isRequired,
+    tabRenderers: PropTypes.array,
+    navigateToItem: PropTypes.func,
+    listingDetail: PropTypes.node,
+    listingActions: PropTypes.arrayOf(PropTypes.node),
+    selectChanged: PropTypes.func,
+    selected: PropTypes.bool,
+    initiallyExpanded: PropTypes.bool,
+    expandChanged: PropTypes.func,
+    initiallyActiveTab: PropTypes.bool
+};
 /* Implements a PatternFly 'List View' pattern
  * https://www.patternfly.org/list-view/
  * Properties:
@@ -281,85 +288,77 @@ var ListingRow = React.createClass({
  *                     receives the column index as argument
  * - actions: additional listing-wide actions (displayed next to the list's title)
  */
-var Listing = React.createClass({
-    propTypes: {
-        title: React.PropTypes.string,
-        fullWidth: React.PropTypes.bool,
-        emptyCaption: React.PropTypes.string.isRequired,
-        columnTitles: React.PropTypes.arrayOf(
-            React.PropTypes.oneOfType([
-                React.PropTypes.string,
-                React.PropTypes.element,
-            ])),
-        columnTitleClick: React.PropTypes.func,
-        actions: React.PropTypes.arrayOf(React.PropTypes.node)
-    },
-    getDefaultProps: function () {
-        return {
-            title: '',
-            fullWidth: true,
-            columnTitles: [],
-            actions: []
-        };
-    },
-    render: function() {
-        var self = this;
-        var bodyClasses = ["listing", "listing-ct"];
-        if (this.props.fullWidth)
-            bodyClasses.push("listing-ct-wide");
-        var headerClasses;
-        var headerRow;
-        var selectableRows;
-        if (!this.props.children || this.props.children.length === 0) {
-            headerClasses = "listing-ct-empty";
-            headerRow = <tr><td>{this.props.emptyCaption}</td></tr>;
-        } else if (this.props.columnTitles.length) {
-            // check if any of the children are selectable
-            selectableRows = false;
-            this.props.children.forEach(function(r) {
-                if (r.props.selected !== undefined)
-                    selectableRows = true;
+export const Listing = (props) => {
+    let bodyClasses = ["listing", "listing-ct"];
+    if (props.fullWidth)
+        bodyClasses.push("listing-ct-wide");
+    let headerClasses;
+    let headerRow;
+    let selectableRows;
+    if (!props.children || props.children.length === 0) {
+        headerClasses = "listing-ct-empty";
+        headerRow = <tr><td>{props.emptyCaption}</td></tr>;
+    } else if (props.columnTitles.length) {
+        // check if any of the children are selectable
+        selectableRows = false;
+        props.children.forEach(function(r) {
+            if (r.props.selected !== undefined)
+                selectableRows = true;
+        });
+
+        if (selectableRows) {
+            // now make sure that if one is set, it's available on all items
+            props.children.forEach(function(r) {
+                if (r.props.selected === undefined)
+                    r.props.selected = false;
             });
-
-            if (selectableRows) {
-                // now make sure that if one is set, it's available on all items
-                this.props.children.forEach(function(r) {
-                    if (r.props.selected === undefined)
-                        r.props.selected = false;
-                });
-            }
-
-            headerRow = (
-                <tr>
-                    <th key="empty" className="listing-ct-toggle" />
-                    { this.props.columnTitles.map((title, index) => {
-                        var clickHandler = null;
-                        if (self.props.columnTitleClick)
-                            clickHandler = function() { self.props.columnTitleClick(index) };
-                        return <th key={index} onClick={clickHandler}>{title}</th>;
-                    }) }
-                </tr>
-            );
-        } else {
-            headerRow = <tr />;
         }
-        var caption;
-        if (this.props.title || (this.props.actions && this.props.actions.length > 0))
-            caption = <caption className="cockpit-caption">{this.props.title}{this.props.actions}</caption>;
 
-        return (
-            <table className={ bodyClasses.join(" ") }>
-                {caption}
-                <thead className={headerClasses}>
-                    {headerRow}
-                </thead>
-                {this.props.children}
-            </table>
+        headerRow = (
+            <tr>
+                <th key="empty" className="listing-ct-toggle" />
+                { props.columnTitles.map((title, index) => {
+                    let clickHandler = null;
+                    if (props.columnTitleClick)
+                        clickHandler = function() { props.columnTitleClick(index) };
+                    return <th key={index} onClick={clickHandler}>{title}</th>;
+                }) }
+            </tr>
         );
-    },
-});
+    } else {
+        headerRow = <tr />;
+    }
+    let caption;
+    if (props.title || (props.actions && props.actions.length > 0))
+        caption = <caption className="cockpit-caption">{props.title}{props.actions}</caption>;
 
-module.exports = {
-    ListingRow: ListingRow,
-    Listing: Listing,
+    return (
+        <table className={ bodyClasses.join(" ") }>
+            {caption}
+            <thead className={headerClasses}>
+                {headerRow}
+            </thead>
+            {props.children}
+        </table>
+    );
+};
+
+Listing.defaultProps = {
+    title: '',
+    fullWidth: true,
+    columnTitles: [],
+    actions: []
+};
+
+Listing.propTypes = {
+    title: PropTypes.string,
+    fullWidth: PropTypes.bool,
+    emptyCaption: PropTypes.string.isRequired,
+    columnTitles: PropTypes.arrayOf(
+        PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.element,
+        ])),
+    columnTitleClick: PropTypes.func,
+    actions: PropTypes.arrayOf(PropTypes.node)
 };

--- a/pkg/lib/cockpit-components-select.jsx
+++ b/pkg/lib/cockpit-components-select.jsx
@@ -17,215 +17,204 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import cockpit from "cockpit";
 
-    const cockpit = require("cockpit");
-    const React = require("react");
-    const ReactDOM = require("react-dom");
+import "page.css";
 
-    require("page.css");
+const _ = cockpit.gettext;
 
-    const _ = cockpit.gettext;
+const textForUndefined = _("undefined");
 
-    const textForUndefined = _("undefined");
+/* React pattern component for a dropdown/select control
+ * Entries should be child components of type SelectEntry (html <a>)
+ *
+ * User of this component should listen onChange and set selected prop of it
+ *
+ * Expected properties:
+ *  - selected (optional) explicit data to select, default: first entry
+ *  - onChange (optional) callback (parameter data) when the selection has changed
+ *  - id (optional) html id of the top level node
+ *  - enabled (optional) whether the component is enabled or not; defaults to true
+ *  - extraClass (optional) CSS class name(s) to be added to the main <div> of the component
+ */
+export class StatelessSelect extends React.Component {
+    constructor() {
+        super();
+        this.clickHandler = this.clickHandler.bind(this);
 
-    /* React pattern component for a dropdown/select control
-     * Entries should be child components of type SelectEntry (html <a>)
-     *
-     * User of this component should listen onChange and set selected prop of it
-     *
-     * Expected properties:
-     *  - selected (optional) explicit data to select, default: first entry
-     *  - onChange (optional) callback (parameter data) when the selection has changed
-     *  - id (optional) html id of the top level node
-     *  - enabled (optional) whether the component is enabled or not; defaults to true
-     *  - extraClass (optional) CSS class name(s) to be added to the main <div> of the component
-     */
-    class StatelessSelect extends React.Component {
-        constructor() {
-            super();
-            this.clickHandler = this.clickHandler.bind(this);
+        this.state = {
+            open: false,
+            documentClickHandler: undefined,
+        };
+    }
 
-            this.state = {
-                open: false,
-                documentClickHandler: undefined,
-            };
-        }
+    componentDidMount() {
+        const handler = this.handleDocumentClick.bind(this, ReactDOM.findDOMNode(this));
+        this.setState({ documentClickHandler: handler });
+        document.addEventListener('click', handler, false);
+    }
 
-        componentDidMount() {
-            const handler = this.handleDocumentClick.bind(this, ReactDOM.findDOMNode(this));
-            this.setState({ documentClickHandler: handler });
-            document.addEventListener('click', handler, false);
-        }
+    componentWillUnmount() {
+        document.removeEventListener('click', this.state.documentClickHandler, false);
+    }
 
-        componentWillUnmount() {
-            document.removeEventListener('click', this.state.documentClickHandler, false);
-        }
+    handleDocumentClick(node, ev) {
+        // clicking outside the select control should ensure it's closed
+        if (!node.contains(ev.target))
+            this.setState({ open: false });
+    }
 
-        handleDocumentClick(node, ev) {
-            // clicking outside the select control should ensure it's closed
-            if (!node.contains(ev.target))
-                this.setState({ open: false });
-        }
+    clickHandler(ev) {
+        // only consider clicks with the primary button
+        if (ev && ev.button !== 0)
+            return;
 
-        clickHandler(ev) {
-            // only consider clicks with the primary button
-            if (ev && ev.button !== 0)
+        if (ev.target.tagName === 'A') {
+            const liElement = ev.target.offsetParent;
+            if (liElement.className.indexOf("disabled") >= 0)
                 return;
+            let elementData;
+            if ('data-data' in liElement.attributes)
+                elementData = liElement.attributes['data-data'].value;
 
-            if (ev.target.tagName === 'A') {
-                const liElement = ev.target.offsetParent;
-                if (liElement.className.indexOf("disabled") >= 0)
-                    return;
-                let elementData;
-                if ('data-data' in liElement.attributes)
-                    elementData = liElement.attributes['data-data'].value;
-
-                this.setState({ open: false });
-                // if the item didn't change, don't do anything
-                if (elementData === this.props.selected)
-                    return;
-                if (this.props.onChange)
-                    this.props.onChange(elementData);
-            } else {
-                this.setState({ open: !this.state.open });
-            }
-        }
-
-        render() {
-            const getItemData = (item) => (item && item.props && ('data' in item.props) ? item.props.data : undefined);
-            const getItemValue = (item) => (item && item.props && (item.props.children !== undefined) ? item.props.children : textForUndefined);
-
-            const entries = React.Children.toArray(this.props.children).filter(item => item && item.props && ('data' in item.props));
-
-            let selectedEntries = entries.filter(item => this.props.selected === getItemData(item));
-
-            let selectedEntry;
-            if (selectedEntries.length > 0)
-                selectedEntry = selectedEntries[0];
-            else if (entries.length > 0)
-                selectedEntry = entries[0]; // default to first item if selected item not found
-
-            const currentValue = getItemValue(selectedEntry);
-
-            let classes = "btn-group bootstrap-select dropdown";
-            if (this.state.open)
-                classes += " open";
-            if (this.props.extraClass) {
-                classes += " " + this.props.extraClass;
-            }
-
-            let buttonClasses = "btn btn-default dropdown-toggle";
-            if (this.props.enabled === false)
-                buttonClasses += " disabled";
-
-            return (
-                <div className={classes} onClick={this.clickHandler} id={this.props.id}>
-                    <button className={buttonClasses} type="button">
-                        <span className="pull-left">{currentValue}</span>
-                        <span className="caret" />
-                    </button>
-                    <ul className="dropdown-menu">
-                        {this.props.children}
-                    </ul>
-                </div>
-            );
+            this.setState({ open: false });
+            // if the item didn't change, don't do anything
+            if (elementData === this.props.selected)
+                return;
+            if (this.props.onChange)
+                this.props.onChange(elementData);
+        } else {
+            this.setState({ open: !this.state.open });
         }
     }
 
-    StatelessSelect.propTypes = {
-        selected: React.PropTypes.string,
-        onChange: React.PropTypes.func,
-        id: React.PropTypes.string,
-        enabled: React.PropTypes.bool,
-        extraClass: React.PropTypes.string,
-    };
+    render() {
+        const getItemData = (item) => (item && item.props && ('data' in item.props) ? item.props.data : undefined);
+        const getItemValue = (item) => (item && item.props && (item.props.children !== undefined) ? item.props.children : textForUndefined);
 
-    class Select extends React.Component {
-        constructor(props) {
-            super();
-            this.onChange = this.onChange.bind(this);
+        const entries = React.Children.toArray(this.props.children).filter(item => item && item.props && ('data' in item.props));
 
-            this.state = {
-                currentData: props.initial,
-            };
+        let selectedEntries = entries.filter(item => this.props.selected === getItemData(item));
+
+        let selectedEntry;
+        if (selectedEntries.length > 0)
+            selectedEntry = selectedEntries[0];
+        else if (entries.length > 0)
+            selectedEntry = entries[0]; // default to first item if selected item not found
+
+        const currentValue = getItemValue(selectedEntry);
+
+        let classes = "btn-group bootstrap-select dropdown";
+        if (this.state.open)
+            classes += " open";
+        if (this.props.extraClass) {
+            classes += " " + this.props.extraClass;
         }
 
-        onChange(data) {
-            this.setState({ currentData: data });
-            if (typeof this.props.onChange === 'function')
-                this.props.onChange(data);
-        }
+        let buttonClasses = "btn btn-default dropdown-toggle";
+        if (this.props.enabled === false)
+            buttonClasses += " disabled";
 
-        componentWillReceiveProps(nextProps) {
-            this.setState({ currentData: nextProps.initial });
-        }
-
-        render() {
-            return (
-                <StatelessSelect onChange={this.onChange}
-                                 selected={this.state.currentData}
-                                 id={this.props.id}
-                                 enabled={this.props.enabled}
-                                 extraClass={this.props.extraClass}>
-                    {this.props.children}
-                </StatelessSelect>
-            );
-        }
-    }
-
-    Select.propTypes = {
-        initial: React.PropTypes.string,
-        onChange: React.PropTypes.func,
-        id: React.PropTypes.string,
-        enabled: React.PropTypes.bool,
-        extraClass: React.PropTypes.string,
-    };
-
-    /* Entry class for the select component
-     * Dynamic lists should make sure to also provide 'key' props for react to use
-     * Expected properties:
-     *  - data (required), will be passed to the select's onChange callback
-     *  - disabled (optional): whether or not the entry is disabled.
-     * Example: <SelectEntry data="foo">Some entry</SelectEntry>
-     */
-    class SelectEntry extends React.Component {
-        render() {
-            const value = (this.props.children !== undefined) ? this.props.children : textForUndefined;
-            return (
-                <li className={this.props.disabled ? "disabled" : ""}
-                    data-value={value} data-data={this.props.data}>
-                    <a>{value}</a>
-                </li>
-            );
-        }
-    }
-
-    /* Divider
-     * Example: <SelectDivider/>
-     */
-    const SelectDivider = () => <li role="separator" className="divider" />;
-
-    /* Header
-     * Example: <SelectHeader>Some header</SelectHeader>
-     */
-    const SelectHeader = ({ children }) => {
-        const value = (children !== undefined) ? children : textForUndefined;
         return (
-            <li className="dropdown-header">{value}</li>
+            <div className={classes} onClick={this.clickHandler} id={this.props.id}>
+                <button className={buttonClasses} type="button">
+                    <span className="pull-left">{currentValue}</span>
+                    <span className="caret" />
+                </button>
+                <ul className="dropdown-menu">
+                    {this.props.children}
+                </ul>
+            </div>
         );
-    };
+    }
+}
 
-    SelectEntry.propTypes = {
-        data: React.PropTypes.string.isRequired,
-    };
+StatelessSelect.propTypes = {
+    selected: PropTypes.string,
+    onChange: PropTypes.func,
+    id: PropTypes.string,
+    enabled: PropTypes.bool,
+    extraClass: PropTypes.string,
+};
 
-    module.exports = {
-        Select,
-        StatelessSelect,
-        SelectEntry,
-        SelectDivider,
-        SelectHeader,
-    };
-}());
+export class Select extends React.Component {
+    constructor(props) {
+        super();
+        this.onChange = this.onChange.bind(this);
+
+        this.state = {
+            currentData: props.initial,
+        };
+    }
+
+    onChange(data) {
+        this.setState({ currentData: data });
+        if (typeof this.props.onChange === 'function')
+            this.props.onChange(data);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({ currentData: nextProps.initial });
+    }
+
+    render() {
+        return (
+            <StatelessSelect onChange={this.onChange}
+                             selected={this.state.currentData}
+                             id={this.props.id}
+                             enabled={this.props.enabled}
+                             extraClass={this.props.extraClass}>
+                {this.props.children}
+            </StatelessSelect>
+        );
+    }
+}
+
+Select.propTypes = {
+    initial: PropTypes.string,
+    onChange: PropTypes.func,
+    id: PropTypes.string,
+    enabled: PropTypes.bool,
+    extraClass: PropTypes.string,
+};
+
+/* Entry class for the select component
+ * Dynamic lists should make sure to also provide 'key' props for react to use
+ * Expected properties:
+ *  - data (required), will be passed to the select's onChange callback
+ *  - disabled (optional): whether or not the entry is disabled.
+ * Example: <SelectEntry data="foo">Some entry</SelectEntry>
+ */
+export class SelectEntry extends React.Component {
+    render() {
+        const value = (this.props.children !== undefined) ? this.props.children : textForUndefined;
+        return (
+            <li key={value} className={this.props.disabled ? "disabled" : ""}
+                data-value={value} data-data={this.props.data}>
+                <a>{value}</a>
+            </li>
+        );
+    }
+}
+
+/* Divider
+ * Example: <SelectDivider/>
+ */
+export const SelectDivider = () => <li role="separator" className="divider" />;
+
+/* Header
+ * Example: <SelectHeader>Some header</SelectHeader>
+ */
+export const SelectHeader = ({ children }) => {
+    const value = (children !== undefined) ? children : textForUndefined;
+    return (
+        <li className="dropdown-header">{value}</li>
+    );
+};
+
+SelectEntry.propTypes = {
+    data: PropTypes.string.isRequired,
+};

--- a/pkg/machines/components/consoles.jsx
+++ b/pkg/machines/components/consoles.jsx
@@ -18,7 +18,7 @@
  */
 import React, { PropTypes } from "react";
 import cockpit from 'cockpit';
-import Select from "cockpit-components-select.jsx";
+import * as Select from "cockpit-components-select.jsx";
 
 import SerialConsole from './serialConsole.jsx';
 import Vnc, { VncActions } from './vnc.jsx';

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -20,7 +20,7 @@
 import cockpit from 'cockpit';
 import React, { PropTypes } from "react";
 import DialogPattern from 'cockpit-components-dialog.jsx';
-import Select from "cockpit-components-select.jsx";
+import * as Select from "cockpit-components-select.jsx";
 import FileAutoComplete from "cockpit-components-file-autocomplete.jsx";
 import { createVm } from '../../actions/provider-actions.es6';
 import { addErrorNotification } from '../../actions/store-actions.es6';

--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -20,7 +20,7 @@ import React from 'react';
 import cockpit from 'cockpit';
 
 import DialogPattern from 'cockpit-components-dialog.jsx';
-import Select from "cockpit-components-select.jsx";
+import * as Select from "cockpit-components-select.jsx";
 
 import { mouseClick, units, convertToUnit, digitFilter, toFixedPrecision } from '../helpers.es6';
 import { volumeCreateAndAttach, attachDisk, getVm, getStoragePools } from '../actions/provider-actions.es6';

--- a/pkg/machines/components/memorySelectRow.jsx
+++ b/pkg/machines/components/memorySelectRow.jsx
@@ -19,7 +19,7 @@
 import React from 'react';
 import cockpit from 'cockpit';
 
-import Select from "cockpit-components-select.jsx";
+import * as Select from "cockpit-components-select.jsx";
 
 import { digitFilter, toFixedPrecision, units } from "../helpers.es6";
 

--- a/pkg/machines/components/vcpuModal.jsx
+++ b/pkg/machines/components/vcpuModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import cockpit from 'cockpit';
 
 import { show_modal_dialog } from 'cockpit-components-dialog.jsx';
-import SelectComponent from 'cockpit-components-select.jsx';
+import * as SelectComponent from 'cockpit-components-select.jsx';
 import InfoRecord from './infoRecord.jsx';
 import { Alert } from './notification/inlineNotification.jsx';
 import { setVCPUSettings } from "../actions/provider-actions.es6";

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -21,7 +21,7 @@ import cockpit from "cockpit";
 import React from "react";
 
 import OnOffSwitch from "cockpit-components-onoff.jsx";
-import Select from "cockpit-components-select.jsx";
+import * as Select from "cockpit-components-select.jsx";
 import { install_dialog } from "cockpit-components-install-dialog.jsx";
 
 const _ = cockpit.gettext;

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -26,7 +26,7 @@ import utils from "./utils.js";
 
 import React from "react";
 
-import CockpitListing from "cockpit-components-listing.jsx";
+import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 import { StorageButton, StorageLink } from "./storage-controls.jsx";
 import { format_dialog } from "./format-dialog.jsx";
 
@@ -377,10 +377,10 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
     ];
 
     rows.push(
-        <CockpitListing.ListingRow key={key}
-                                   columns={cols}
-                                   tabRenderers={tabs.renderers}
-                                   listingActions={tabs.actions} />
+        <ListingRow key={key}
+                    columns={cols}
+                    tabRenderers={tabs.renderers}
+                    listingActions={tabs.actions} />
     );
 }
 
@@ -426,7 +426,7 @@ function append_partitions(client, rows, level, block) {
         ];
 
         rows.push(
-            <CockpitListing.ListingRow columns={cols} key={"free-space-" + rows.length.toString()} />
+            <ListingRow columns={cols} key={"free-space-" + rows.length.toString()} />
         );
     }
 
@@ -536,11 +536,11 @@ const BlockContent = ({ client, block, allow_partitions }) => {
             </div>);
 
     return (
-        <CockpitListing.Listing title={_("Content")}
-                                actions={[ format_disk_btn ]}
-                                emptyCaption="">
+        <Listing title={_("Content")}
+                 actions={[ format_disk_btn ]}
+                 emptyCaption="">
             { block_rows(client, block) }
-        </CockpitListing.Listing>
+        </Listing>
     );
 };
 
@@ -692,11 +692,11 @@ var VGroup = React.createClass({
             </div>);
 
         return (
-            <CockpitListing.Listing title="Logical Volumes"
-                                    actions={[ new_volume_link ]}
-                                    emptyCaption={_("No Logical Volumes")}>
+            <Listing title="Logical Volumes"
+                     actions={[ new_volume_link ]}
+                     emptyCaption={_("No Logical Volumes")}>
                 { vgroup_rows(self.props.client, vgroup) }
-            </CockpitListing.Listing>
+            </Listing>
         );
     }
 });


### PR DESCRIPTION
 - Use `import` instead ofo `require`
 - Use proper `class`es
 - Declare property types and defaults in a React 16 compatible way
 - Don't assign to `module.exports`, this does not work any more with
   Babel 7. Use the `export` keyword.
 - Don't use a top-level anonymous function wrapper. `export` only works
   at the top level, and the concept of exports already takes care of
   not leaking private stuff.

Backported from downstream changes in cockpit-podman. This helps
re-using these components in third-party projets.