### PR TITLE
ssh: Query known hosts from sssd

### DIFF
--- a/bots/naughty/ubuntu-1604/9487-nsupdate-assert-2
+++ b/bots/naughty/ubuntu-1604/9487-nsupdate-assert-2
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-realms", line *, in testIpa
+    b.wait_in_text('#dashboard_setup_server_dialog', "Fingerprint")
+*
+warning: Cockpit could not contact the given host.

--- a/src/ssh/Makefile-ssh.am
+++ b/src/ssh/Makefile-ssh.am
@@ -78,12 +78,14 @@ EXTRA_DIST += \
 	src/ssh/test_rsa.pub \
 	src/ssh/mock_known_hosts \
 	src/ssh/mock-pid-cat \
+	src/ssh/mock-bin/sss_ssh_knownhostsproxy \
 	src/ssh/mock-config \
 	src/ssh/invalid_known_hosts \
 	$(NULL)
 
 noinst_SCRIPTS += \
 	src/ssh/mock-pid-cat \
+	src/ssh/mock-bin/sss_ssh_knownhostsproxy \
 	$(NULL)
 
 noinst_PROGRAMS += $(SSH_CHECKS)

--- a/src/ssh/mock-bin/sss_ssh_knownhostsproxy
+++ b/src/ssh/mock-bin/sss_ssh_knownhostsproxy
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+if [ "$1" != "--pubkey" ]; then
+    echo "This mock only supports the --pubkey operation" >&2
+    exit 1
+fi
+
+# recognize --port, but ignore it
+if [ "$2" = "--port" ]; then
+    shift 2
+fi
+
+# if the host does not match, don't print anything
+# sss_ssh_knownhostsproxy still succeeds in this case
+if [ "$2" = "$COCKPIT_MOCK_SSS_KNOWN_HOSTS_HOST" ]; then
+    echo "$COCKPIT_MOCK_SSS_KNOWN_HOSTS_KEY"
+fi

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -181,6 +181,7 @@ class TestRealms(MachineCase):
             b.wait_in_text('#service-unit', "dead")
             b.logout()
             b.password = orig_password
+            m.execute("chown -R admin /home/admin")
 
             self.allow_authorize_journal_messages()
 
@@ -190,6 +191,25 @@ class TestRealms(MachineCase):
             self.assertRaisesRegexp(subprocess.CalledProcessError, "returned non-zero exit status 6", m.execute,
                     ['curl', '-s', '--negotiate', '--delegation', 'always', '-u:', '-D-',
                      'http://x0.cockpit.lan:9090/cockpit/login'])
+
+        # check respecting FreeIPA's/sssd's ssh known host keys; this requires the new
+        # --privkey option of sss_ssh_knownhostproxy, thus only works on recent images
+        b.login_and_go("/dashboard")
+        b.wait_present('#dashboard-add')
+        b.click('#dashboard-add')
+        b.wait_popup('dashboard_setup_server_dialog')
+        b.set_val('#add-machine-address', 'x0.cockpit.lan')
+        b.wait_text('#dashboard_setup_server_dialog .btn-primary', "Add")
+        b.wait_present("#dashboard_setup_server_dialog .btn-primary:not([disabled])")
+        b.click('#dashboard_setup_server_dialog .btn-primary')
+
+        # with --pubkey support this should Just Work, otherwise confirm fingerprint
+        if '--pubkey' not in m.execute("sss_ssh_knownhostsproxy --help || true"):
+            b.wait_in_text('#dashboard_setup_server_dialog', "Fingerprint")
+            b.click('#dashboard_setup_server_dialog .btn-primary')
+        b.wait_popdown('dashboard_setup_server_dialog')
+        b.wait_present("#dashboard-hosts a[data-address='x0.cockpit.lan']")
+        b.logout()
 
         # Leave the domain
         b.login_and_go("/system")
@@ -479,8 +499,10 @@ class TestKerberos(MachineCase):
         b.wait_present("#troubleshoot-dialog .btn-primary:not([disabled])")
         b.wait_text('#troubleshoot-dialog .btn-primary', "Add")
         b.click('#troubleshoot-dialog .btn-primary')
-        b.wait_in_text('#troubleshoot-dialog', "Fingerprint")
-        b.click('#troubleshoot-dialog .btn-primary')
+        # with --pubkey support the fingerprint is already known, otherwise confirm fingerprint
+        if '--pubkey' not in m.execute("sss_ssh_knownhostsproxy --help || true"):
+            b.wait_in_text('#troubleshoot-dialog', "Fingerprint")
+            b.click('#troubleshoot-dialog .btn-primary')
         b.wait_in_text('#troubleshoot-dialog h4', "Log in to")
         b.wait_present("#troubleshoot-dialog .btn-primary:not([disabled])")
         b.wait_present("#login-type button")


### PR DESCRIPTION
When no local known_hosts file knows about the host to connect to, try
and ask `sss_ssh_knownhostsproxy` about it. This makes `cockpit-ssh`
work seamlessly with centrally managed known hosts list from FreeIPA.

This utilizes the new `--pubkey` option of sss_ssh_knownhostsproxy. If
it isn't available (on older releases), it will just fail fast and the
behaviour is as before.

https://bugzilla.redhat.com/show_bug.cgi?id=1622835

 - [x] integration tests
 - [x] Fix FreeIPA integration tests (#9959)