### PR TITLE
lib/dialog: Log the actual error message, not the object

### DIFF
--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -107,7 +107,7 @@ var DialogFooter = React.createClass({
 
                     /* Always log global dialog errors for easier debugging */
                     if (error)
-                        console.warn(error);
+                        console.warn(error.message || error.toString());
 
                     self.setState({ action_in_progress: false, error_message: error });
                 });


### PR DESCRIPTION
Only strings will make it all the way through our testing machinery,
and we need to see them at the other end for detecting known issues.