### PR TITLE
bots: Update CentOS Atomic cloud image download

### DIFF
--- a/bots/images/scripts/continuous-atomic.bootstrap
+++ b/bots/images/scripts/continuous-atomic.bootstrap
@@ -3,8 +3,8 @@
 
 set -e
 
-url="http://cloud.centos.org/centos/7/atomic/images"
-prefix="CentOS-Atomic-Host-7-GenericCloud.qcow2"
+url="https://cloud.centos.org/centos/7/atomic/images"
+prefix="CentOS-Atomic-Host-GenericCloud.qcow2"
 
 BASE=$(dirname $0)
 $BASE/atomic.bootstrap "$1" "$url" "$prefix"


### PR DESCRIPTION
The file name dropped the "-7". Also move to https:// URL.

Fixes #9971 

 - [ ] image-refresh continuous-atomic