### PR TITLE
HACKING: Update

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -48,13 +48,53 @@ In addition, for testing, the following dependencies are required:
         libguestfs-tools qemu qemu-kvm rpm-build rsync xz \
         chromium-headless
 
+## Building
+
+Cockpit uses the autotools and thus there are the familiar `./configure`
+script and Makefile targets.
+
+After a fresh clone of the Cockpit sources, you need to prepare them by running
+`autogen.sh` like this:
+
+    $ ./autogen.sh --prefix=/usr --enable-debug
+
+As shown, `autogen.sh` runs 'configure' with the given options, and it
+also prepares the build tree by downloading various nodejs dependencies.
+
+When working with a Git clone, it is therefore best to simply always
+run `./autogen.sh` instead of `./configure`.
+
+Then run
+
+    $ make
+
+to build everything.  Cockpit has a single non-recursive Makefile.  You can
+only run `make` from the top-level and it will always rebuild the whole
+project.
+
+You can run unit tests of the current checkout:
+
+    $ make check
+
+These should finish very quickly and it is good practice to do it
+often.
+
+For debugging individual tests, there are compiled binaries in the
+build directory. For QUnit tests (JavaScript), you can run
+
+    $ ./test-server
+
+which will output a URL to connect to with a browser, such as
+`http://localhost:8765/dist/base1/test-dbus.html`. Adjust the path
+for different tests and inspect the results there.
+
 ## Running the integration test suite
 
-Refer to the [testing README](test/README) for details on running
+Refer to the [testing README](test/README.md) for details on running
 the Cockpit integration tests locally.
 
-
 ## Running eslint
+
 Cockpit uses [ESLint](https://eslint.org/) to automatically check
 JavaScript code style in `.jsx` and `.es6` files.
 
@@ -70,41 +110,10 @@ Violations of some rules can be fixed automatically by:
 
 Rules configuration can be found in the `.eslintrc.json` file.
 
-## Working on Cockpit using Vagrant
-
-It is recommended to use a Vagrant virtual machine to develop Cockpit.
-
-Most of Cockpit is written in javascript. Almost all of this code is found
-in the packages in the pkg/ subdirectory of the Cockpit git checkout.
-
-To use Vagrant to develop Cockpit, run in its top level git checkout.
-In some cases you may need to use `sudo` with vagrant commands:
-
-    $ vagrant up
-
-Now you can edit files in the `pkg/` subdirectory of the Cockpit sources.
-Use the `webpack` command to build those sources. The changes should
-take effect after syncing them to the Vagrant VM. For example:
-
-    $ webpack
-    $ vagrant rsync
-
-Now log into Cockpit on the vagrant VM to see your changes. Use the
-user name 'admin' and the password 'foobar' to log in. The Cockpit
-instance in vagrant should be available at the following URL:
-
-http://localhost:9090
-
-If you want to setup automatic syncing as you edit javascript files
-you can:
-
-    $ vagrant rsync-auto &
-    $ webpack --progress --colors --watch
-
 ## Working on your local machine
 
 It's easy to set up your local Linux machine for rapid development of Cockpit's
-javascript code. First install Cockpit on your local machine as described in:
+JavaScript code. First install Cockpit on your local machine as described in:
 
 https://cockpit-project.org/running.html
 
@@ -114,26 +123,65 @@ sure to run it as the same user that you'll use to log into Cockpit below.
     $ mkdir -p ~/.local/share/
     $ ln -s $(pwd)/dist ~/.local/share/cockpit
 
-This will cause cockpit to read javascript and HTML files directly from the built
+This will cause cockpit to read JavaScript and HTML files directly from the built
 package output directory instead of using the installed Cockpit UI files.
-
-Next run Webpack to build the javascript code:
-
-    $ webpack
 
 Now you can log into Cockpit on your local Linux machine at the following address.
 Use the same user and password that you used to log into your Linux desktop.
 
 http://localhost:9090
 
-If you want to setup automatic syncing as you edit javascript files you can:
-
-    $ webpack --progress --colors --watch
+After every change to your sources, run `make` to update all the webpacks, and
+reload cockpit in your browser.
 
 To make Cockpit again use the installed code, rather than that from your
 git checkout directory, run the following, and log into Cockpit again:
 
     $ rm ~/.local/share/cockpit
+
+## Working on Cockpit using Vagrant
+
+It is also possible to use a Vagrant virtual machine to develop Cockpit.
+
+Most of Cockpit is written in JavaScript. Almost all of this code is found
+in the packages in the pkg/ subdirectory of the Cockpit git checkout.
+
+To use Vagrant to develop Cockpit, run in its top level git checkout.
+In some cases you may need to use `sudo` with vagrant commands:
+
+    $ vagrant up
+
+Now you can edit files in the `pkg/` subdirectory of the Cockpit sources.  Use
+`make` to build those sources. The changes should take effect after syncing
+them to the Vagrant VM. For example:
+
+    $ make && vagrant rsync
+
+Now log into Cockpit on the vagrant VM to see your changes. Use the
+user name 'admin' and the password 'foobar' to log in. The Cockpit
+instance in vagrant should be available at the following URL:
+
+http://localhost:9090
+
+If you want to setup automatic syncing as you edit JavaScript files
+you can run:
+
+    $ vagrant rsync-auto &
+
+## Installation from upstream sources
+
+    $ make
+    $ sudo make install
+    $ sudo cp src/bridge/cockpit.pam.insecure /etc/pam.d/cockpit
+
+This will install Cockpit and all support files, and will install a
+simplistic PAM configuration.
+
+If you prefer to install to a different `--prefix` and would prefer
+that `make install` not write outside that prefix, then specify the
+`--enable-prefix-only` option to `autogen.sh`. This will result in an
+installation of Cockpit that does not work without further tweaking.
+For advanced users only.
 
 ## Contributing a change
 
@@ -202,72 +250,6 @@ To revert the above logging changes:
     $ sudo rm /etc/systemd/system/cockpit.service.d/debug.conf
     $ sudo systemctl daemon-reload
     $ sudo systemctl restart cockpit
-
-## Building Cockpit binaries
-
-For more complex hacking on Cockpit beyond the user interface, you need to
-build the Cockpit binaries locally and install the relevant dependencies.
-Currently, recent x86_64 architectures of Fedora are most often used for
-development.
-
-Before attempting to build anything, first make sure the relevant
-dependencies are installed as described in "Getting the development
-dependencies" above.
-
-Cockpit uses the autotools and thus there are the familiar `./configure`
-script and the familar Makefile targets.
-
-But after a fresh clone of the Cockpit sources, you need to prepare
-them by running `autogen.sh` like this:
-
-    $ mkdir build
-    $ cd build
-    $ ../autogen.sh --prefix=/usr --enable-debug
-
-As shown, `autogen.sh` runs 'configure' with the given options, and it
-also prepares the build tree by downloading various nodejs dependencies.
-
-When working with a Git clone, it is therefore best to simply always
-run `../autogen.sh` instead of `../configure`.
-
-Creating a build directory puts the output of the build in a separate
-directory, rather than mixing it in with the sources, which is confusing.
-
-Then you can build the sources and install them, as usual:
-
-    $ make
-    $ sudo make install
-    $ sudo cp ../src/bridge/cockpit.pam.insecure /etc/pam.d/cockpit
-
-This will install Cockpit and all support files, and will install a
-simplistic PAM configuration.
-
-Cockpit has a single non-recursive Makefile.  You can only run `make`
-from the top-level and it will always rebuild the whole project.
-
-If you prefer to install to a different `--prefix` and would prefer
-that `make install` not write outside that prefix, then specify the
-`--enable-prefix-only` option to `autogen.sh`. This will result in an
-installation of Cockpit that does not work without further tweaking.
-For advanced users only.
-
-You can run unit tests of the current checkout:
-
-    $ make check
-
-These should finish very quickly and it is good practice to do it
-often.
-
-For debugging individual tests, there are compiled binaries in the
-build directory. For QUnit tests (javascript), you can run
-
-    $ ./test-server
-
-which will output a URL to connect to with a browser, such as
-`http://localhost:8765/dist/base1/test-dbus.html`. Adjust the path
-for different tests and inspect the results there.
-
-To run the integration tests, see `test/README`.
 
 ## Running Cockpit processes under a debugger
 


### PR DESCRIPTION
 - Stop describing direct `webpack` invocation. This is guaranteed not
   to work initially You always need to configure and `make` first --
   there is just too much work happening in the `Makefile`s that isn't
   or can't be built with webpack. And even afterwards this doesn't
   guarantee success, so it's best to stick with `make`.

 - Move "Building" and "Working on your local machine" further up, as
   these are the most common workflows.

 - Stop building in a separate build dir. It's inconsistent with how we
   document running from the local checkout, and also a bit confusing.
   People familiar with autotools will know this standard technique and
   know what they are doing.

 - Fix reference to integration test README.md.

Fixes #9607