### PR TITLE
ws: Remove any Hop-by-Hop headers when relaying HTTP connection

### DIFF
--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -773,8 +773,6 @@ append_header (GString *string,
     return HEADER_DNS_PREFETCH_CONTROL;
   if (g_ascii_strcasecmp ("Referrer-Policy", name) == 0)
     return HEADER_REFERRER_POLICY;
-  else if (g_ascii_strcasecmp ("Content-Length", name) == 0)
-    g_critical ("Don't set Content-Length manually. This is a programmer error.");
   else if (g_ascii_strcasecmp ("Connection", name) == 0)
     g_critical ("Don't set Connection header manually. This is a programmer error.");
   return 0;

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -265,8 +265,13 @@ object_to_headers (JsonObject *object,
 
   g_return_if_fail (value != NULL);
 
-  if (g_ascii_strcasecmp (header, "Content-Length") == 0 ||
-      g_ascii_strcasecmp (header, "Connection") == 0)
+  /* Remove hop-by-hop headers. See RFC 2068 */
+  if (g_ascii_strcasecmp (header, "Connection") == 0 ||
+      g_ascii_strcasecmp (header, "Keep-Alive") == 0 ||
+      g_ascii_strcasecmp (header, "Public") == 0 ||
+      g_ascii_strcasecmp (header, "Proxy-Authenticate") == 0 ||
+      g_ascii_strcasecmp (header, "Transfer-Encoding") == 0 ||
+      g_ascii_strcasecmp (header, "Upgrade") == 0)
     return;
 
   g_hash_table_insert (headers, g_strdup (header), g_strdup (value));


### PR DESCRIPTION
When we relay an HTTP connection to the bridge, from cockpit-ws lets only remove Hop-by-Hop headers. In particular, we now continue to relay Content-Length, which is not hop by hop.

Clients are expected to ignore Content-Length when we do chunked transfer encoding.

See RFC 2068

https://www.freesoft.org/CIE/RFC/2068/143.htm