### PR TITLE
bots: Close issue when all tasks done by bots

### DIFF
--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -220,8 +220,8 @@ def finish(publishing, ret, name, context, issue):
             "data": { "title": issue["title"], "body": checklist.body }
         } ]
 
-        # Close the issue if it's not a pull request, successful, and only one task to do
-        if "pull_request" not in issue and not ret and len(checklist.items) == 1:
+        # Close the issue if it's not a pull request, successful, and all tasks done
+        if "pull_request" not in issue and not ret and len(checklist.items) == len(checklist.checked()):
             requests[0]["data"]["state"] = "closed"
 
         # Comment if there was a failure

--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -370,3 +370,10 @@ class Checklist(object):
 
     def add(self, item):
         self.process(self.body, { item: False })
+
+    def checked(self):
+        result = { }
+        for item, check in self.items.items():
+            if check:
+                result[item] = check
+        return result

--- a/bots/task/test-checklist
+++ b/bots/task/test-checklist
@@ -82,5 +82,14 @@ class TestChecklist(unittest.TestCase):
         self.assertEqual(checklist.body, "This is a description\n- [ ] item1\n * [x] Item two\n\nMore lines\n * [ ] Item three")
         self.assertEqual(checklist.items, { "item1": False, "Item two": True, "Item three": False })
 
+    def testChecked(self):
+        body = "This is a description\n- [ ] item1\n * [x] Item two\n * [X] Item three\n\nMore lines"
+        checklist = github.Checklist(body)
+        checklist.check("item1", True)
+        checklist.check("Item three", False)
+        checked = checklist.checked()
+        self.assertEqual(checklist.items, { "item1": True, "Item two": True, "Item three": False })
+        self.assertEqual(checked, { "item1": True, "Item two": True })
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If an issue has a list of tasks, and they're all done, then close
the issue when the last issue is done by bots. This previously worked
when there was only one task in the checklist, but now we make this
work for any number of tasks in the checklist.

Obviously if there are tasks in the checklist that bots cannot do,
then the issue will not be closed.

Pull requests are not affected at all.