### PR TITLE
tools: Declare bundled JavaScript libraries which are available as packages

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -463,6 +463,14 @@ Provides: cockpit-sosreport = %{version}-%{release}
 Provides: cockpit-subscriptions = %{version}-%{release}
 Requires: subscription-manager >= 1.13
 %endif
+# NPM modules which are also available as packages
+Provides: bundled(js-jquery) = %{npm-version:jquery}
+Provides: bundled(js-moment) = %{npm-version:moment}
+Provides: bundled(nodejs-flot) = %{npm-version:jquery-flot}
+Provides: bundled(nodejs-promise) = %{npm-version:promise}
+Provides: bundled(nodejs-requirejs) = %{npm-version:requirejs}
+Provides: bundled(xstatic-bootstrap-datepicker-common) = %{npm-version:bootstrap-datepicker}
+Provides: bundled(xstatic-patternfly-common) = %{npm-version:patternfly}
 
 %description system
 This package contains the Cockpit shell and system configuration interfaces.

--- a/tools/gen-spec-dependencies
+++ b/tools/gen-spec-dependencies
@@ -21,19 +21,35 @@
 
 import sys
 import os
+import re
 import fileinput
 import subprocess
+import json
 
-min_base_version_path = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "min-base-version")
+tools_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
+min_base_version_path = os.path.join(tools_dir, "min-base-version")
+package_json = os.path.join(os.path.dirname(tools_dir), "package.json")
 
 if len(sys.argv) != 2:
     sys.stderr.write("Usage: %s <specfile>\n" % sys.argv[0])
     sys.exit(1)
 
+# for resolving %{npm-version:*}
+with open(package_json) as f:
+    dependencies = json.load(f)["dependencies"]
+
 curpkg = None
 pkg_base_dep = None
+npm_version_re = re.compile(r"%{npm-version:(.*?)}")
+
 for line in fileinput.input(sys.argv[1], inplace=True):
-    if line.startswith("%package"):
+    npm_version_match = npm_version_re.search(line)
+    if npm_version_match:
+        # translate %{npm-version:*} to version from package.json
+        module = dependencies[npm_version_match.group(1)]
+        sys.stderr.write('NPM version of %s: %s\n' % (npm_version_match.group(1), module))
+        line = npm_version_re.sub(module, line)
+    elif line.startswith("%package"):
         # translate package name into pkg/<page> name
         curpkg = line.split()[-1]
         if curpkg.startswith('cockpit-'):


### PR DESCRIPTION
As per Fedora policy [1], a package that bundles third-party code should
declare them with the `Provides: bundled(pkgname) = version` syntax.

Teach gen-spec-dependencies to replace `%{npm-version-MODULE}` with the
version of `MODULE` in package.json's `dependencies`, and add the
ones which are also packaged in Fedora to the spec file.

Fixes #9986

[1] https://fedoraproject.org/wiki/Bundled_Libraries#Requirement_if_you_bundle