### PR TITLE
bots: Run rhel-7-6-distropkg tests on master commits

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -46,8 +46,8 @@ DEFAULT_VERIFY = {
 REDHAT_VERIFY = {
     "verify/rhel-7-5": [ 'rhel-7.5' ],
     "verify/rhel-7-5-distropkg": [ 'master' ],
-    "verify/rhel-7-6": [ 'master', 'rhel-7.6' ],
-    "verify/rhel-7-6-distropkg": [ ],
+    "verify/rhel-7-6": [ 'rhel-7.6' ],
+    "verify/rhel-7-6-distropkg": [ 'master' ],
     "verify/rhel-x": [ 'master', 'rhel-8.0' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/edge': [ 'master' ],


### PR DESCRIPTION
Instead of rhel-7-6. This is more appropriate from now on, as we won't
rebase Cockpit in RHEL 7.6 Base any more.