### PR TITLE
test: Deal with iptable rules moving around

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -62,11 +62,11 @@ class TestConnection(MachineCase):
         b.set_val("#login-password-input", "foobar")
 
         # sever the connection on the login page
-        m.execute("iptables -w -I INPUT 1 -p tcp --dport 9090 -j REJECT --reject-with tcp-reset")
+        m.execute("iptables -w -I INPUT -p tcp --dport 9090 -j REJECT --reject-with tcp-reset")
         b.click('#login-button')
         with b.wait_timeout(20):
             b.wait_text_not('#login-fatal-message', "")
-        m.execute("iptables -w -D INPUT 1")
+        m.execute("iptables -w -D INPUT -p tcp --dport 9090 -j REJECT --reject-with tcp-reset")
         b.reload()
         b.wait_visible("#login")
         b.set_val("#login-user-input", "admin")
@@ -76,14 +76,14 @@ class TestConnection(MachineCase):
         b.enter_page("/system")
 
         # sever the connection on the server page
-        m.execute("iptables -w -I INPUT 1 -p tcp --dport 9090 -j REJECT")
+        m.execute("iptables -w -I INPUT -p tcp --dport 9090 -j REJECT")
         b.switch_to_top()
         with b.wait_timeout(60):
             b.wait_visible(".curtains-ct")
 
         b.wait_in_text(".curtains-ct h1", "Disconnected")
         b.wait_in_text('.curtains-ct p', "Connection has timed out.")
-        m.execute("iptables -w -D INPUT 1")
+        m.execute("iptables -w -D INPUT -p tcp --dport 9090 -j REJECT")
         b.click("#machine-reconnect")
         b.expect_load()
         b.enter_page("/system")


### PR DESCRIPTION
A rule that is added as number 1 will not stay number 1 if some other
rules are added in the background.  This happens on ubuntu-1604 at
least.

To deal with this, we delete rules based on their specification, not
their position.