### PR TITLE
lib/select: Allow any type for entry data

### DIFF
--- a/pkg/lib/cockpit-components-select.jsx
+++ b/pkg/lib/cockpit-components-select.jsx
@@ -133,7 +133,7 @@ export class StatelessSelect extends React.Component {
 }
 
 StatelessSelect.propTypes = {
-    selected: PropTypes.string,
+    selected: PropTypes.any,
     onChange: PropTypes.func,
     id: PropTypes.string,
     enabled: PropTypes.bool,
@@ -174,7 +174,7 @@ export class Select extends React.Component {
 }
 
 Select.propTypes = {
-    initial: PropTypes.string,
+    initial: PropTypes.any,
     onChange: PropTypes.func,
     id: PropTypes.string,
     enabled: PropTypes.bool,
@@ -216,5 +216,5 @@ export const SelectHeader = ({ children }) => {
 };
 
 SelectEntry.propTypes = {
-    data: PropTypes.string.isRequired,
+    data: PropTypes.any.isRequired,
 };


### PR DESCRIPTION
There is no reason to restrict this to strings only and the Storage
page does in fact puts arbitrary objects there.