### PR TITLE
lib/onoff: Don't write boolean attribute values into DOM

### DIFF
--- a/pkg/lib/cockpit-components-onoff.jsx
+++ b/pkg/lib/cockpit-components-onoff.jsx
@@ -62,7 +62,7 @@ var OnOffSwitch = React.createClass({
         }
         var clickHandler = this.handleOnOffClick.bind(this, !this.props.state);
         return (
-            <div className="btn-group btn-onoff-ct" enabled={this.props.enabled}>
+            <div className="btn-group btn-onoff-ct">
                 <label className={ onClasses.join(" ") }>
                     <input type="radio" />
                     <span onClick={clickHandler}>{this.props.captionOn}</span>


### PR DESCRIPTION
They must be strings.  The "enabled" attribute does not seem to have
any effect anyway, the actual disabling happens with the <label>
elements.