### PR TITLE
common: Print a clearer message when capability not present

### DIFF
--- a/src/common/cockpitchannel.c
+++ b/src/common/cockpitchannel.c
@@ -456,7 +456,7 @@ cockpit_channel_ensure_capable (CockpitChannel *channel,
       if (channel->priv->capabilities == NULL ||
           !strv_contains(channel->priv->capabilities, capabilities[i]))
         {
-          g_message ("unsupported capability required: %s", capabilities[i]);
+          g_message ("%s: unsupported capability required: %s", channel->priv->id, capabilities[i]);
           missing = TRUE;
         }
     }

--- a/src/common/test-channel.c
+++ b/src/common/test-channel.c
@@ -413,10 +413,10 @@ test_close_not_capable (void)
   CockpitChannel *channel2;
   const gchar *cap[] = { "supported", NULL };
 
-  cockpit_expect_message ("unsupported capability required: unsupported1");
-  cockpit_expect_message ("unsupported capability required: unsupported2");
-  cockpit_expect_message ("unsupported capability required: unsupported1");
-  cockpit_expect_message ("unsupported capability required: unsupported2");
+  cockpit_expect_message ("55: unsupported capability required: unsupported1");
+  cockpit_expect_message ("55: unsupported capability required: unsupported2");
+  cockpit_expect_message ("55: unsupported capability required: unsupported1");
+  cockpit_expect_message ("55: unsupported capability required: unsupported2");
 
   options = json_object_new ();
   capabilities = json_array_new ();


### PR DESCRIPTION
The previous message did not include the channel id, and this
makes it harder to use the message in debugging.