### PR TITLE
ws: Return a 403 in a HTTP channel response if access-denied

### DIFF
--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -228,6 +228,11 @@ cockpit_channel_response_close (CockpitChannel *channel,
           g_debug ("%s: not found", self->logname);
           cockpit_web_response_error (self->response, 404, NULL, NULL);
         }
+      else if (g_str_equal (problem, "access-denied"))
+        {
+          g_debug ("%s: forbidden", self->logname);
+          cockpit_web_response_error (self->response, 403, NULL, NULL);
+        }
       else if (g_str_equal (problem, "no-host") ||
                g_str_equal (problem, "no-cockpit") ||
                g_str_equal (problem, "unknown-hostkey") ||


### PR DESCRIPTION
When we use a HTTP channel response (ie: either a resource, or
a /cockpit/channel GET request) and find a channel that cannot
be accessed due to access-denied, return a 403. This is similar
to how we return 404 in the case of not-found.