### PR TITLE
common: Fix off by one error in flow control

### DIFF
--- a/src/common/cockpitchannel.c
+++ b/src/common/cockpitchannel.c
@@ -234,7 +234,7 @@ process_pong (CockpitChannel *self,
                  self->priv->id, sequence);
     }
 
-  if (sequence > self->priv->out_window)
+  if (sequence >= self->priv->out_window)
     {
       /* Up to this point has been confirmed received */
       self->priv->out_window = sequence + CHANNEL_FLOW_WINDOW;


### PR DESCRIPTION
This led to hangs when the ping sequence number replied to
was exactly equal to the throttling window. We would only
consider unthrottling when the sequence was greater than
the throttling window.