### PR TITLE
Fix crash when using %00 in a URL

### DIFF
--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1300,7 +1300,7 @@ web_response_file (CockpitWebResponse *response,
 
   /* Someone is trying to escape the root directory, or access hidden files? */
   unescaped = g_uri_unescape_string (escaped, NULL);
-  if (strstr (unescaped, "/.") || strstr (unescaped, "../") || strstr (unescaped, "//"))
+  if (!unescaped || strstr (unescaped, "/.") || strstr (unescaped, "../") || strstr (unescaped, "//"))
     {
       g_debug ("%s: invalid path request", escaped);
       cockpit_web_response_error (response, 404, NULL, "Not Found");

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1299,7 +1299,7 @@ web_response_file (CockpitWebResponse *response,
   g_return_if_fail (escaped != NULL);
 
   /* Someone is trying to escape the root directory, or access hidden files? */
-  unescaped = g_uri_unescape_string (escaped, NULL);
+  unescaped = g_uri_unescape_string (escaped, "/");
   if (!unescaped || strstr (unescaped, "/.") || strstr (unescaped, "../") || strstr (unescaped, "//"))
     {
       g_debug ("%s: invalid path request", escaped);

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -310,6 +310,22 @@ test_file_encoding_denied (TestCase *tc,
 }
 
 static void
+test_file_slash_denied (TestCase *tc,
+                        gconstpointer user_data)
+{
+  gchar *root = realpath ( SRCDIR "/src", NULL);
+  const gchar *roots[] = { root, NULL };
+  const gchar *breakout = "/common%2fMakefile-common.am";
+  gchar *check = g_build_filename (roots[0], "common", "Makefile-common.am", NULL);
+  g_assert (root);
+  g_assert (g_file_test (check, G_FILE_TEST_EXISTS));
+  g_free (check);
+  cockpit_web_response_file (tc->response, breakout, roots);
+  cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 404*");
+  free (root);
+}
+
+static void
 test_file_breakout_non_existant (TestCase *tc,
                                  gconstpointer user_data)
 {
@@ -1440,6 +1456,8 @@ main (int argc,
               setup, test_file_breakout_denied, teardown);
   g_test_add ("/web-response/file/invalid-encoding-denied", TestCase, NULL,
               setup, test_file_encoding_denied, teardown);
+  g_test_add ("/web-response/file/file-slash-denied", TestCase, NULL,
+              setup, test_file_slash_denied, teardown);
   g_test_add ("/web-response/file/breakout-non-existant", TestCase, NULL,
               setup, test_file_breakout_non_existant, teardown);
   g_test_add ("/web-reponse/file/template", TestCase, &template_fixture,

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -294,6 +294,22 @@ test_file_breakout_denied (TestCase *tc,
 }
 
 static void
+test_file_encoding_denied (TestCase *tc,
+                           gconstpointer user_data)
+{
+  gchar *root = realpath ( SRCDIR "/src", NULL);
+  const gchar *roots[] = { root, NULL };
+  const gchar *breakout = "/common/Makefile-common.am%00";
+  gchar *check = g_build_filename (roots[0], "common", "Makefile-common.am", NULL);
+  g_assert (root);
+  g_assert (g_file_test (check, G_FILE_TEST_EXISTS));
+  g_free (check);
+  cockpit_web_response_file (tc->response, breakout, roots);
+  cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 404*");
+  free (root);
+}
+
+static void
 test_file_breakout_non_existant (TestCase *tc,
                                  gconstpointer user_data)
 {
@@ -1422,6 +1438,8 @@ main (int argc,
               setup, test_file_access_denied, teardown);
   g_test_add ("/web-response/file/breakout-denied", TestCase, NULL,
               setup, test_file_breakout_denied, teardown);
+  g_test_add ("/web-response/file/invalid-encoding-denied", TestCase, NULL,
+              setup, test_file_encoding_denied, teardown);
   g_test_add ("/web-response/file/breakout-non-existant", TestCase, NULL,
               setup, test_file_breakout_non_existant, teardown);
   g_test_add ("/web-reponse/file/template", TestCase, &template_fixture,


### PR DESCRIPTION
This fixes a crash when using %00 in a HTTP Cockpit resource URL. In addition we hanlde the %2F case appropriately (second commit).