### PR TITLE
Add missing jsonify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jquery-flot": "0.8.3",
     "js-sha1": "0.6.0",
     "json-stable-stringify": "1.0.1",
+    "jsonify": "0.0.0",
     "kubernetes-container-terminal": "1.0.3",
     "kubernetes-object-describer": "1.1.4",
     "kubernetes-topology-graph": "0.0.24",


### PR DESCRIPTION
Unfortunatily #9465 adds new dependencies but doesn't include the
dependency jsonify. This leads to build errors when you have a
clean node_modules:

    ERROR in ../~/json-stable-stringify/index.js
    Module not found: Error: Cannot resolve module 'jsonify'
        in /data/src/cockpit/node_modules/json-stable-stringify