### PR TITLE
storage: Avoid jsonify npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "jquery": "3.3.1",
     "jquery-flot": "0.8.3",
     "js-sha1": "0.6.0",
-    "json-stable-stringify": "1.0.1",
+    "json-stable-stringify-without-jsonify": "1.0.1",
     "kubernetes-container-terminal": "1.0.3",
     "kubernetes-object-describer": "1.1.4",
     "kubernetes-topology-graph": "0.0.24",

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -20,7 +20,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import sha1 from "js-sha1";
-import stable_stringify from "json-stable-stringify";
+import stable_stringify from "json-stable-stringify-without-jsonify";
 
 import {
     dialog_open,


### PR DESCRIPTION
Simply because json-stable-stringify-without-jsonify exists and works
for us.