### PR TITLE
common: Handle use of NULL string in web_response_file

### DIFF
--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1302,7 +1302,7 @@ web_response_file (CockpitWebResponse *response,
 
   /* Someone is trying to escape the root directory, or access hidden files? */
   unescaped = g_uri_unescape_string (escaped, NULL);
-  if (strstr (unescaped, "/.") || strstr (unescaped, "../") || strstr (unescaped, "//"))
+  if (!unescaped || strstr (unescaped, "/.") || strstr (unescaped, "../") || strstr (unescaped, "//"))
     {
       g_debug ("%s: invalid path request", escaped);
       cockpit_web_response_error (response, 404, NULL, "Not Found");

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -294,6 +294,22 @@ test_file_breakout_denied (TestCase *tc,
 }
 
 static void
+test_file_encoding_denied (TestCase *tc,
+                           gconstpointer user_data)
+{
+  gchar *root = realpath ( SRCDIR "/src", NULL);
+  const gchar *roots[] = { root, NULL };
+  const gchar *breakout = "/common/Makefile-common.am%00";
+  gchar *check = g_build_filename (roots[0], "common", "Makefile-common.am", NULL);
+  g_assert (root);
+  g_assert (g_file_test (check, G_FILE_TEST_EXISTS));
+  g_free (check);
+  cockpit_web_response_file (tc->response, breakout, roots);
+  cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 404*");
+  free (root);
+}
+
+static void
 test_file_breakout_non_existant (TestCase *tc,
                                  gconstpointer user_data)
 {
@@ -1422,6 +1438,8 @@ main (int argc,
               setup, test_file_access_denied, teardown);
   g_test_add ("/web-response/file/breakout-denied", TestCase, NULL,
               setup, test_file_breakout_denied, teardown);
+  g_test_add ("/web-response/file/invalid-encoding-denied", TestCase, NULL,
+              setup, test_file_encoding_denied, teardown);
   g_test_add ("/web-response/file/breakout-non-existant", TestCase, NULL,
               setup, test_file_breakout_non_existant, teardown);
   g_test_add ("/web-reponse/file/template", TestCase, &template_fixture,


### PR DESCRIPTION
The function g_uri_unescape_string can return a NULL response
if the escaped string is invalid.

Closes #10047 

 - [x] fix build/tests: PR #10053