### PR TITLE
bots: Rename RHEL branch to development version

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -20,7 +20,7 @@
 
 BASELINE_PRIORITY = 10
 
-BRANCHES = [ 'master', 'rhel-7.5', 'rhel-7.6', 'rhel-8.0' ]
+BRANCHES = [ 'master', 'rhel-7.5', 'rhel-7.6', 'rhel-x' ]
 
 DEFAULT_VERIFY = {
     'avocado/fedora': BRANCHES,
@@ -47,7 +47,7 @@ REDHAT_VERIFY = {
     "verify/rhel-7-5-distropkg": [ 'master' ],
     "verify/rhel-7-6": [ 'rhel-7.6' ],
     "verify/rhel-7-6-distropkg": [ 'master' ],
-    "verify/rhel-x": [ 'master', 'rhel-8.0' ],
+    "verify/rhel-x": [ 'master', 'rhel-x' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/edge': [ 'master' ],
 }


### PR DESCRIPTION
Rename branch to match the name of our rhel-x image.