### PR TITLE
po: Don't mark JavaScript strings as c-format

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -85,13 +85,14 @@ po/cockpit.html.pot: po/POTFILES.html.in
 
 # Extract cockpit style javascript translations
 po/cockpit.js.pot: po/POTFILES.js.in
-	$(XGETTEXT) --default-domain=cockpit --output=$@ --language=C --keyword= \
+	$(XGETTEXT) --default-domain=cockpit --output=- --language=C --keyword= \
 		--keyword=_:1,1t --keyword=_:1c,2,1t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
 		--keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
-		--from-code=UTF-8 --directory=$(srcdir) --files-from=$^
+		--from-code=UTF-8 --directory=$(srcdir) --files-from=$^ | \
+		sed '/^#/ s/, c-format//' > $@
 
 po/cockpit.manifest.pot: po/POTFILES.manifest.in
 	$(srcdir)/tools/missing $(srcdir)/po/manifest2po -d $(srcdir) -f $^ -o $@

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-05-03 04:56+0000\n"
 "Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
 "Language-Team: Catalan\n"
 "Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -79,7 +79,7 @@ msgid_plural "$0 bytes"
 msgstr[0] "$0 byte"
 msgstr[1] "$0 bytes"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -196,7 +196,7 @@ msgid_plural "$0 updates"
 msgstr[0] "$0 actualització"
 msgstr[1] "$0 actualitzacions"
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 utilitzats de $1 ($2 estalviat)"
 
@@ -222,7 +222,6 @@ msgstr[0] "$0 any"
 msgstr[1] "$0 anys"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% lliure"
@@ -575,7 +574,7 @@ msgid "Access"
 msgstr "Accés"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "Modes d'accés"
 
@@ -639,7 +638,7 @@ msgid "Active Pages"
 msgstr "Pàgines actives"
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -660,11 +659,11 @@ msgstr "Balanceig de càrrega de transmissió adaptativa"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Afegeix"
 
@@ -824,7 +823,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adreça"
 
@@ -941,8 +940,8 @@ msgstr "Serveis permesos"
 msgid "Always"
 msgstr "Sempre"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Anotacions"
@@ -951,8 +950,8 @@ msgstr "Anotacions"
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr "Anònim: permet que tots els usuaris no autenticats recuperin imatges"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "Aplicacions"
 
@@ -960,11 +959,11 @@ msgstr "Aplicacions"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Aplica"
 
@@ -1013,8 +1012,8 @@ msgstr "Etiqueta de recurs"
 msgid "At least $0 disks are needed."
 msgstr "Com a mínim es necessiten $0 discs."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Com a mínim es necessita un disc."
 
@@ -1034,9 +1033,9 @@ msgstr "Registre d'auditoria"
 msgid "Authenticating"
 msgstr "S'està autenticant"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Autenticació"
 
@@ -1052,13 +1051,13 @@ msgstr "Ha fallat l'autenticació: el servidor ha tancat la connexió"
 msgid "Authentication failed"
 msgstr "Ha fallat l'autenticació"
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "Autenticació requerida"
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Autor"
 
@@ -1115,7 +1114,7 @@ msgstr "Disponible"
 msgid "Available Updates"
 msgstr "Actualitzacions disponibles"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr "Objectius disponibles en $0"
 
@@ -1143,7 +1142,7 @@ msgstr "Versió del BIOS"
 msgid "Back to Accounts"
 msgstr "Torna als comptes"
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1266,10 +1265,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr "Ha fallat l'acció CHANGE NETWORK STATE"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1334,7 +1333,6 @@ msgstr "No es pot carregar la imatge"
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1346,27 +1344,27 @@ msgstr "No es pot carregar la imatge"
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Cancel·la"
 
@@ -1387,7 +1385,7 @@ msgid "Cannot schedule event in the past"
 msgstr "No es pot planificar un esdeveniment del passat"
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "Capacitat"
@@ -1405,11 +1403,11 @@ msgid "Ceph Monitors"
 msgstr ""
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "Canvia"
 
@@ -1437,7 +1435,7 @@ msgstr "Canvia l'hora del sistema"
 msgid "Change User"
 msgstr "Canvia l'usuari"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr "Canvia el nom d'iniciador iSCSI"
 
@@ -1548,16 +1546,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr "Certificat de client"
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Tanca"
 
@@ -1565,7 +1564,7 @@ msgstr "Tanca"
 msgid "Close Selected Pages"
 msgstr "Tanca les pàgines seleccionades"
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr "Clúster"
@@ -1656,10 +1655,10 @@ msgstr "Cockpit no ha pogut contactar amb {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1699,7 +1698,7 @@ msgstr[1] "Ús combinat de $0 nuclis de CPU"
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Ordre"
 
@@ -1744,8 +1743,8 @@ msgstr "Compatible amb els sistemes moderns i els discs durs > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Comprimeix els estavellaments per estalviar espai"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "Compressió"
 
@@ -1957,10 +1956,11 @@ msgid "Container:"
 msgstr "Contenidor:"
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Contenidors"
 
@@ -2075,10 +2075,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Crea"
 
@@ -2180,12 +2180,13 @@ msgstr "Crea una partició a $0"
 msgid "Create partition table"
 msgstr "Crea la taula de particions"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "Creat"
 
@@ -2305,7 +2306,7 @@ msgstr "Dominis de cerca DNS $val"
 msgid "Dashboard"
 msgstr "Tauler de control"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr "Dades utilitzades"
 
@@ -2325,7 +2326,7 @@ msgstr "S'està desactivant $target"
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr "Deduplicació"
 
@@ -2350,12 +2351,11 @@ msgstr "Retard"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2431,7 +2431,7 @@ msgstr "La supressió d'un dispositiu RAID n'esborrarà totes les dades."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Si suprimiu un dispositiu VDO, s'esborraran totes les dades."
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "La supressió d'un contenidor n'esborrarà totes les dades."
 
@@ -2478,14 +2478,14 @@ msgstr "Configuracions de desplegaments"
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "Descripció"
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "Descripció:"
 
@@ -2498,10 +2498,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "Detalls"
 
@@ -2510,7 +2510,7 @@ msgstr "Detalls"
 msgid "Device"
 msgstr "Dispositiu"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr "Fitxer de dispositiu"
 
@@ -2591,9 +2591,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Discs"
 
@@ -2645,8 +2645,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 "Voleu suprimir el rol '{{ fields.displayRole }}' del membre {{ fields.member."
 "metadata.name }}?"
@@ -2761,7 +2761,7 @@ msgstr "Àlies duplicat"
 msgid "Duplicate port"
 msgstr "Port duplicat"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr "Edita"
 
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Entry"
 msgstr "Entrada"
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 #, fuzzy
 msgid "Entrypoint"
 msgstr "Extrem"
@@ -2947,9 +2947,9 @@ msgid "Errata:"
 msgstr "Fe d'errates:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Error"
 
@@ -3037,7 +3037,7 @@ msgstr "Ha fallat"
 msgid "Failed to add machine: $0"
 msgstr "No s'ha pogut afegir la màquina: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "Ha fallat el canvi de contrasenya"
 
@@ -3102,7 +3102,6 @@ msgstr "Muntatge del sistema de fitxers"
 msgid "Filesystem Name"
 msgstr "Nom del sistema de fitxers"
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3110,6 +3109,7 @@ msgstr "Nom del sistema de fitxers"
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr "Tipus de sistema de fitxers"
 
@@ -3125,7 +3125,7 @@ msgstr "Sistemes de fitxers"
 msgid "Filter Services"
 msgstr "Filtra els serveis"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Empremta"
 
@@ -3248,7 +3248,7 @@ msgstr "General"
 msgid "Generating report"
 msgstr "S'està generant l'informe"
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr "Obtén una imatge nova"
 
@@ -3311,9 +3311,9 @@ msgstr "Grup o projecte"
 msgid "Groups"
 msgstr "Grups"
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr "Fes créixer"
 
@@ -3374,9 +3374,9 @@ msgstr "Hello time $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Amfitrió"
 
@@ -3416,8 +3416,8 @@ msgstr "Espera d'E/S"
 msgid "INSTALL VM action failed"
 msgstr "Ha fallat l'acció INSTALL VM"
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr "IP"
 
@@ -3457,7 +3457,7 @@ msgstr "Ajusts d'IPv6"
 msgid "ISCSI"
 msgstr "ISCSI"
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr "Id"
@@ -3546,11 +3546,10 @@ msgstr "Flux d'imatges"
 msgid "Image:"
 msgstr "Imatge:"
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr "Imatges"
 
@@ -3580,8 +3579,7 @@ msgstr "Les imatges poden ser recuperades per usuaris o grups autenticats"
 #: node_modules/registry-image-widgets/views/imagestream-body.html:25
 #: node_modules/registry-image-widgets/views/imagestream-body.html:26
 msgid "Images may only be pulled by specific users or groups"
-msgstr ""
-"Les imatges només poden ser recuperades per usuaris o grups específics"
+msgstr "Les imatges només poden ser recuperades per usuaris o grups específics"
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:54
 msgid "Images pushed recently"
@@ -3611,8 +3609,8 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Per sincronitzar els usuaris, cal que inicieu la sessió a "
-"{{#strong}}{{host}}{{/strong}}."
+"Per sincronitzar els usuaris, cal que inicieu la sessió a {{#strong}}{{host}}"
+"{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:822 pkg/networkmanager/interfaces.js:1418
 #: pkg/networkmanager/interfaces.js:1425 pkg/networkmanager/interfaces.js:2594
@@ -3627,7 +3625,7 @@ msgstr "Volum inactiu"
 msgid "Incorrect Host Key"
 msgstr "Clau d'amfitrió incorrecta"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3643,9 +3641,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr "S'està inicialitzant..."
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr "Instal·la"
 
@@ -3694,7 +3692,7 @@ msgstr "Instal·lat"
 msgid "Installed products"
 msgstr "Productes instal·lats"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "S'està instal·lant"
@@ -3707,8 +3705,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr "Instancia"
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr "Interfície"
 
@@ -3732,11 +3730,11 @@ msgstr "Adreça no vàlida $0"
 msgid "Invalid credentials"
 msgstr "Credencials no vàlides"
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "Format de data no vàlid"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "Format no vàlid de la data i l'hora"
 
@@ -3784,7 +3782,7 @@ msgstr "Prefix no vàlid $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "Prefix o màscara de xarxa no vàlid $0"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "Format d'hora no vàlid"
 
@@ -3792,7 +3790,7 @@ msgstr "Format d'hora no vàlid"
 msgid "Invalid time zone"
 msgstr "Zona horària no vàlida"
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr "El nom d'usuari o la contrasenya no són vàlids"
@@ -3912,11 +3910,12 @@ msgstr "Clúster Kubernetes"
 msgid "LACP Key"
 msgstr "Clau LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Etiquetes"
@@ -3961,8 +3960,8 @@ msgstr "Últim cop actualitzat"
 msgid "Last checked: $0 ago"
 msgstr "Última comprovació: fa $0"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr "Última versió"
 
@@ -3993,7 +3992,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Deixeu-ho en blanc per connectar a aquesta màquina amb "
 "l'usuari{{#default_user}} ({{default_user}}){{/default_user}}, que ha "
@@ -4060,8 +4058,8 @@ msgstr "S'estan carregant les actualitzacions disponibles, espereu..."
 msgid "Loading data ..."
 msgstr "S'estan carregant les dades..."
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "S'està carregant..."
 
@@ -4137,17 +4135,17 @@ msgstr "Missatges del registre"
 msgid "Logged In"
 msgstr "Autenticat"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr "Lògica"
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr "Mida lògica"
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr "Número de la unitat lògica"
 
@@ -4343,9 +4341,10 @@ msgstr "Pertinença"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4377,8 +4376,8 @@ msgstr "Ús de la memòria: "
 msgid "Memory:"
 msgstr "Memòria:"
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "Missatge"
 
@@ -4393,7 +4392,7 @@ msgstr "Missatge per als usuaris que hagin iniciat la sessió"
 msgid "Metadata"
 msgstr "Metadades"
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr "Metadades utilitzades"
 
@@ -4473,8 +4472,8 @@ msgstr "Més informació"
 msgid "More details"
 msgstr "Més detalls"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "Munta"
 
@@ -4482,17 +4481,17 @@ msgstr "Munta"
 msgid "Mount Location"
 msgstr "Ubicació del muntatge"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "Opcions de muntatge"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Punt de muntatge"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr "Munta a l'arrencada"
 
@@ -4516,7 +4515,7 @@ msgstr "El punt de muntatge no pot estar en blanc."
 msgid "Mount point must start with \"/\"."
 msgstr "El punt de muntatge ha de començar amb «/»."
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr "Munta només de lectura"
 
@@ -4580,37 +4579,38 @@ msgstr "Servidor NTP"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Nom"
 
@@ -4644,7 +4644,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4655,6 +4654,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "Espai de noms"
@@ -4668,8 +4668,8 @@ msgid "Need at least one NTP server"
 msgstr "Com a mínim es necessita un servidor NTP"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Xarxa"
 
@@ -4735,8 +4735,8 @@ msgstr "Projecte nou"
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr "Flux d'imatges nou"
 
@@ -4744,7 +4744,7 @@ msgstr "Flux d'imatges nou"
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "No s'ha acceptat la nova contrasenya"
 
@@ -4754,7 +4754,7 @@ msgstr "No s'ha acceptat la nova contrasenya"
 msgid "New project"
 msgstr "Projecte nou"
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Següent"
 
@@ -4869,9 +4869,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "No s'ha proporcionat cap descripció."
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr "No hi ha disponible cap disc."
 
@@ -4899,7 +4899,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr "Cap destinació iSCSI preparada"
 
@@ -4907,7 +4907,7 @@ msgstr "Cap destinació iSCSI preparada"
 msgid "No image streams are present."
 msgstr "No hi ha present cap flux d'imatges."
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr "Sense imatges"
 
@@ -4915,7 +4915,7 @@ msgstr "Sense imatges"
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5068,9 +5068,9 @@ msgstr "Node"
 msgid "Node:"
 msgstr "Node:"
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr "Nodes"
 
@@ -5081,7 +5081,7 @@ msgstr "Els nodes són les màquines que executen els vostres contenidors."
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Cap"
 
@@ -5123,8 +5123,8 @@ msgstr "No disponible"
 msgid "Not connected"
 msgstr "No connectat"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr "No desplegat"
 
@@ -5140,7 +5140,7 @@ msgstr "No muntat"
 msgid "Not permitted to perform this action."
 msgstr "No es permet realitzar aquesta acció."
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "No s'està executant"
 
@@ -5168,8 +5168,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5201,8 +5201,8 @@ msgstr "S'ha produït entre $0 i $1"
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Off"
 
@@ -5218,14 +5218,14 @@ msgstr "Contrasenya antiga"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "Contrasenya antiga no acceptada"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "On"
 
@@ -5408,11 +5408,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Les contrasenyes no coincideixen"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5451,10 +5452,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Enganxeu aquí el contingut del fitxer de la vostra clau SSH pública"
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "Camí"
 
@@ -5518,7 +5519,7 @@ msgstr "Volums persistents"
 msgid "Phase"
 msgstr "Fase"
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5550,8 +5551,8 @@ msgstr "Objectiu de ping"
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5642,7 +5643,6 @@ msgid ""
 "Please provide fully qualified domain name and port of the oVirt engine."
 msgstr ""
 "Proporcioneu el nom de domini plenament qualificat i el port del motor oVirt."
-""
 
 #: pkg/ovirt/components/InstallationDialog.jsx:137
 msgid ""
@@ -5772,9 +5772,8 @@ msgstr "Pobla"
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr "Port"
 
@@ -5790,7 +5789,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Ports"
 
@@ -5873,7 +5872,7 @@ msgstr "Informació del problema"
 msgid "Problems"
 msgstr "Problemes"
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr "Procés"
 
@@ -5887,7 +5886,6 @@ msgstr "Nom del producte"
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5899,6 +5897,7 @@ msgstr "Nom del producte"
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Projecte"
@@ -5931,10 +5930,10 @@ msgstr "Lloc web del projecte"
 msgid "Project:"
 msgstr "Projecte:"
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr "Projectes"
 
@@ -5966,7 +5965,7 @@ msgstr "Servidor intermediari"
 msgid "Proxy Version"
 msgstr "Versió del servidor intermediari"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Clau pública"
 
@@ -5994,8 +5993,8 @@ msgstr "Propòsit"
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr "Nom qualificat"
 
@@ -6059,7 +6058,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "Dispositiu RAID"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "Dispositiu RAID $0"
 
@@ -6095,7 +6094,6 @@ msgstr "Aleatòria"
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6107,6 +6105,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr "Tan sols lectura"
 
@@ -6173,7 +6172,7 @@ msgstr "El nom d'amfitrió real pot tenir com a molt 64 caràcters"
 msgid "Reason"
 msgstr "Motiu"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "Rearrencada"
 
@@ -6229,8 +6228,8 @@ msgstr "Es nega a connectar. La clau d'amfitrió no coincideix"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Es nega a connectar. La clau d'amfitrió és desconeguda"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr "Registra"
 
@@ -6258,8 +6257,8 @@ msgstr "Registrament d'oVirt a Cockpit"
 msgid "Register…"
 msgstr "Registra..."
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "Recarrega"
 
@@ -6300,9 +6299,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "Suprimeix"
 
@@ -6354,7 +6353,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6422,10 +6421,10 @@ msgstr "Repeteix cada any"
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "Rèpliques"
 
@@ -6537,8 +6536,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Reinicia"
 
@@ -6587,8 +6586,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Reutilitza la meva contrasenya per a les tasques privilegiades"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Reutilitza la meva contrasenya per a les tasques privilegiades i per "
 "connectar a altres màquines"
@@ -6644,7 +6642,7 @@ msgstr "Executa com"
 msgid "Runner"
 msgstr "Runner"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "En execució"
 
@@ -6732,8 +6730,8 @@ msgstr "Ha fallat l'acció SUSPEND"
 msgid "Saturday"
 msgstr "Dissabte"
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "Desa"
 
@@ -6786,7 +6784,7 @@ msgstr "Claus de shell segures"
 msgid "Securely erasing $target"
 msgstr "S'està eliminant de forma segura $target"
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr "Seguretat"
 
@@ -6818,8 +6816,8 @@ msgstr "Seleccioneu un objecte per veure'n més detalls. "
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 "Seleccioneu els usuaris que vulgueu que estiguin sincronitzats amb "
 "{{#strong}}{{host}}{{/strong}}"
@@ -6842,15 +6840,14 @@ msgstr "Enviament"
 msgid "Serial Console"
 msgstr "Consola sèrie"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "Servidor"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr "Adreça del servidor"
 
@@ -6858,7 +6855,7 @@ msgstr "Adreça del servidor"
 msgid "Server Administrator"
 msgstr "Administrador del servidor"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr "L'adreça del servidor no pot estar en blanc."
 
@@ -6877,7 +6874,7 @@ msgstr "Servidors"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "Servei"
 
@@ -6926,7 +6923,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr "Sessió"
 
@@ -7062,7 +7059,7 @@ msgstr "Mostra totes les imatges"
 msgid "Show fingerprints"
 msgstr "Mostra les empremtes"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7083,34 +7080,34 @@ msgstr "Des de"
 msgid "Since $0"
 msgstr "Des de $0"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Mida"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "La mida no pot ser negativa"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "La mida no pot ser zero"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr "La mida és massa gran"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "La mida ha de ser un número"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr "La mida com a mínim ha de ser $0"
 
@@ -7204,7 +7201,7 @@ msgid "Stable"
 msgstr "Estable"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Inicia"
@@ -7245,10 +7242,10 @@ msgstr "Comença"
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "Estat"
 
@@ -7270,10 +7267,11 @@ msgid "Static"
 msgstr "Estàtic"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7296,7 +7294,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7529,7 +7527,7 @@ msgstr "Etiqueta"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr "Etiquetes"
 
@@ -7551,7 +7549,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr "Objectius"
 
@@ -7684,8 +7682,8 @@ msgstr "L'adreça conté caràcters no vàlids"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7722,11 +7720,11 @@ msgstr "La configuració del desplegament '{{ target }}' no existeix."
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7738,9 +7736,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7749,14 +7746,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7859,11 +7855,11 @@ msgstr "El controlador de replicació '{{ target }}' no existeix."
 msgid "The route '{{ target }}' does not exist."
 msgstr "L'encaminament '{{ target }}' no existeix."
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7955,8 +7951,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "La configuració del navegador web impedeix que s'executi Cockpit "
 "(inaccessible $0)"
@@ -8022,13 +8017,13 @@ msgstr ""
 "Aquest dispositiu té sistemes de fitxers actualment en ús. El procediment "
 "desmuntarà tots els sistemes de fitxers que conté."
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr "Aquest dispositiu s'utilitza actualment amb dispositius RAID."
 
@@ -8041,17 +8036,17 @@ msgstr ""
 "Si continueu, s'eliminarà dels dispositius\n"
 " RAID."
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr "Aquest dispositiu s'utilitza actualment per als dispositiu VDO."
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr "Aquest dispositiu s'utilitza actualment amb grups de volums."
 
@@ -8063,7 +8058,7 @@ msgstr ""
 "Aquest dispositiu s'utilitza actualment amb grups de volums.                "
 "Si continueu, s'eliminarà dels grups de volums."
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8083,7 +8078,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr "No existeix aquesta image."
 
@@ -8158,9 +8153,9 @@ msgstr "Aquesta màquina virtual no està gestionada per oVirt"
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8330,11 +8325,11 @@ msgstr "Tuned no s'està executant"
 msgid "Tuned is off"
 msgstr "Tuned no està aturat"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Tipus"
@@ -8397,7 +8392,7 @@ msgstr "No es poden obtenir els detalls de l'alerta."
 msgid "Unable to get alert: $0"
 msgstr "No es pot obtenir l'alerta: $0"
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "No es pot arribar al servidor"
 
@@ -8443,23 +8438,23 @@ msgstr "Error inesperat"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Desconegut"
 
@@ -8483,7 +8478,7 @@ msgstr "Clau desconeguda d'amfitrió"
 msgid "Unknown configuration"
 msgstr "Configuració desconeguda"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr "Nom d'amfitrió desconegut"
 
@@ -8528,7 +8523,7 @@ msgstr "Interfícies sense gestionar"
 msgid "Unmask"
 msgstr "Desemmascara"
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Desmunta"
 
@@ -8619,7 +8614,7 @@ msgstr "Actualitzacions disponibles"
 msgid "Updates are disabled."
 msgstr "Les actualitzacions estan inhabilitades."
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr "S'està actualitzant"
 
@@ -8670,13 +8665,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr "Utilitza l'ajust de /etc/kdump.conf"
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Utilitzat"
 
@@ -8686,10 +8681,10 @@ msgstr "Utilitzat pels contenidors"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8708,7 +8703,7 @@ msgstr "Contrasenya d'usuari"
 msgid "User interface for Linux servers"
 msgstr "Interfície d'usuari per als servidors GNU/Linux"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nom d'usuari"
@@ -8721,8 +8716,8 @@ msgstr "El nom d'usuari no pot estar en blanc"
 msgid "User or Group"
 msgstr "Usuari o grup"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "Nom d'usuari"
 
@@ -8882,9 +8877,9 @@ msgid "Verifying"
 msgstr "S'està verificant"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Versió"
 
@@ -8946,8 +8941,8 @@ msgstr "Grups de volums"
 msgid "Volume ID"
 msgstr "Id. del volum"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "Nom del volum"
 
@@ -8955,9 +8950,8 @@ msgstr "Nom del volum"
 msgid "Volume Type"
 msgstr "Tipus del volum"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volums"
@@ -9259,7 +9253,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr "iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr "Destinacions iSCSI"
 
@@ -9334,10 +9328,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9512,7 +9506,7 @@ msgstr "udp"
 msgid "unassigned"
 msgstr "sense assignar"
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "indefinit"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-02-27 04:55+0000\n"
 "Last-Translator: Zdenek <chmelarz@gmail.com>\n"
 "Language-Team: Czech\n"
 "Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
 
@@ -86,7 +86,7 @@ msgstr[0] "$0 bajt"
 msgstr[1] "$0 bajty"
 msgstr[2] "$0 bajtů"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr[0] "$0 aktualizace"
 msgstr[1] "$0 aktualizace"
 msgstr[2] "$0 aktualizací"
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -239,7 +239,6 @@ msgstr[1] "$0 roky"
 msgstr[2] "$0 roků"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% volný"
@@ -596,7 +595,7 @@ msgid "Access"
 msgstr "Přístup"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "Režimy přístupu"
 
@@ -662,7 +661,7 @@ msgid "Active Pages"
 msgstr "Aktivní stránky"
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -685,11 +684,11 @@ msgstr "Adaptivní přenos rozložení zátěže"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Přidat"
 
@@ -853,7 +852,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adresa"
 
@@ -975,8 +974,8 @@ msgstr ""
 msgid "Always"
 msgstr "Vždy"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Anotace"
@@ -985,8 +984,8 @@ msgstr "Anotace"
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr "Anonymní: Povolit všem neověřeným uživatelům nahrát obrazy"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "Aplikace"
 
@@ -995,11 +994,11 @@ msgstr "Aplikace"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Použít"
 
@@ -1050,8 +1049,8 @@ msgstr "Tag zařízení"
 msgid "At least $0 disks are needed."
 msgstr "Je vyžadováno alespoň $0 disků."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Je vyžadován alespoň 1 disk."
 
@@ -1071,9 +1070,9 @@ msgstr "Záznam auditu"
 msgid "Authenticating"
 msgstr "Ověřuji"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Ověření"
 
@@ -1090,14 +1089,14 @@ msgid "Authentication failed"
 msgstr "Ověření selhalo"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "Nutné ověření"
 
 # auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Autor"
 
@@ -1157,7 +1156,7 @@ msgstr "Dostupný"
 msgid "Available Updates"
 msgstr "Dostupné aktualizace"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr "Dostupné cíle na $0"
 
@@ -1185,7 +1184,7 @@ msgstr "Verze BIOSu"
 msgid "Back to Accounts"
 msgstr "Zpět k účtům"
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr "Zálohovací zařízení"
 
@@ -1312,10 +1311,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr "CHANGE NETWORK STATE akce selhala"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1380,7 +1379,6 @@ msgstr "Nelze načíst obraz"
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1392,27 +1390,27 @@ msgstr "Nelze načíst obraz"
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Zrušit"
 
@@ -1434,7 +1432,7 @@ msgstr "Nelze naplánovat událost v minulosti"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "Kapacita"
@@ -1453,11 +1451,11 @@ msgid "Ceph Monitors"
 msgstr "Ceph monitory"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "Změna"
 
@@ -1485,7 +1483,7 @@ msgstr "Změnit systémový čas"
 msgid "Change User"
 msgstr "Změnit uživatele"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr "Změnit název iSCSI iniciátoru"
 
@@ -1602,16 +1600,17 @@ msgid "Client Certificate"
 msgstr "Klientský certifikát"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Zavřít"
 
@@ -1620,7 +1619,7 @@ msgid "Close Selected Pages"
 msgstr "Zavřít vybrané stránky"
 
 # auto translated by TM merge from project: Fedora Release Notes, version: f23, DocId: pot/Cluster
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr "Cluster"
@@ -1714,10 +1713,10 @@ msgstr "Cockpit se nemohl spojit s {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1759,7 +1758,7 @@ msgstr[2] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Příkaz"
 
@@ -1805,8 +1804,8 @@ msgstr "Kompatibilní s moderním systémem a pevnými disky > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Komprimovat výpisy paměti z havárií pro úsporu místa"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "Komprese"
 
@@ -2023,10 +2022,11 @@ msgstr ""
 
 # auto translated by TM merge from project: Fedora Release Notes, version: f24, DocId: pot/Containers
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Kontejnery"
 
@@ -2143,10 +2143,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr ""
 
@@ -2249,12 +2249,13 @@ msgstr ""
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2376,7 +2377,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2396,7 +2397,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2423,12 +2424,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2504,7 +2504,7 @@ msgstr ""
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 
@@ -2552,15 +2552,15 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "Popis"
 
 # auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "Popis:"
 
@@ -2575,10 +2575,10 @@ msgstr ""
 
 # auto translated by TM merge from project: blivet-gui, version: master, DocId: po/blivet-gui
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "Podrobnosti"
 
@@ -2588,7 +2588,7 @@ msgstr "Podrobnosti"
 msgid "Device"
 msgstr "Zařízení"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2674,9 +2674,9 @@ msgstr ""
 # auto translated by TM merge from project: blivet-gui, version: master, DocId: po/blivet-gui
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Disky"
 
@@ -2724,8 +2724,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2845,7 +2845,7 @@ msgid "Duplicate port"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr "Upravit"
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "Entry"
 msgstr "Položka"
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -3035,9 +3035,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Chyba"
 
@@ -3128,7 +3128,7 @@ msgstr "Neúspěšný"
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
@@ -3195,7 +3195,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3203,6 +3202,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3220,7 +3220,7 @@ msgid "Filter Services"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Otisk"
 
@@ -3348,7 +3348,7 @@ msgstr "Obecné"
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3413,9 +3413,9 @@ msgstr ""
 msgid "Groups"
 msgstr "Skupiny"
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3480,9 +3480,9 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Počítač"
 
@@ -3524,8 +3524,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3570,7 +3570,7 @@ msgid "ISCSI"
 msgstr ""
 
 # auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr "Id"
@@ -3662,11 +3662,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3741,7 +3740,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3758,9 +3757,9 @@ msgid "Initializing..."
 msgstr ""
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr "Instalovat"
 
@@ -3811,7 +3810,7 @@ msgid "Installed products"
 msgstr ""
 
 # auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "Instalování"
@@ -3825,8 +3824,8 @@ msgid "Instantiate"
 msgstr ""
 
 # auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr "Rozhraní"
 
@@ -3852,11 +3851,11 @@ msgstr ""
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3904,7 +3903,7 @@ msgstr ""
 msgid "Invalid prefix or netmask $0"
 msgstr ""
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3912,7 +3911,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -4036,11 +4035,12 @@ msgid "LACP Key"
 msgstr ""
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Štítky"
@@ -4085,8 +4085,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -4114,7 +4114,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4177,8 +4176,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -4259,17 +4258,17 @@ msgid "Logged In"
 msgstr ""
 
 # auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr "logický"
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4470,9 +4469,10 @@ msgstr ""
 # auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4507,8 +4507,8 @@ msgid "Memory:"
 msgstr "Paměť:"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "Zpráva"
 
@@ -4523,7 +4523,7 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4610,8 +4610,8 @@ msgstr ""
 msgid "More details"
 msgstr "Více podrobností"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4619,18 +4619,18 @@ msgstr ""
 msgid "Mount Location"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr ""
 
 # auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Připojit do"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4654,7 +4654,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4721,37 +4721,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Název"
 
@@ -4785,7 +4786,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4796,6 +4796,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
@@ -4810,8 +4811,8 @@ msgstr ""
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Síť"
 
@@ -4880,8 +4881,8 @@ msgstr "Nový projekt"
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4889,7 +4890,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4900,7 +4901,7 @@ msgid "New project"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Další"
 
@@ -5015,9 +5016,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -5046,7 +5047,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -5054,7 +5055,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -5062,7 +5063,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5211,9 +5212,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5224,7 +5225,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Žádný"
 
@@ -5266,8 +5267,8 @@ msgstr ""
 msgid "Not connected"
 msgstr "Nepřipojeno"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5284,7 +5285,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5314,8 +5315,8 @@ msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr "Budiž"
 
@@ -5348,8 +5349,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr ""
 
@@ -5365,14 +5366,14 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr ""
 
@@ -5563,11 +5564,12 @@ msgid "Passphrases do not match"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5607,10 +5609,10 @@ msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
 # auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "Cesta"
 
@@ -5677,7 +5679,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5709,8 +5711,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5929,9 +5931,8 @@ msgstr ""
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr "Port"
 
@@ -5949,7 +5950,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Porty"
 
@@ -6036,7 +6037,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -6051,7 +6052,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -6063,6 +6063,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr ""
@@ -6091,10 +6092,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -6128,7 +6129,7 @@ msgstr "Proxy"
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -6156,8 +6157,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -6222,7 +6223,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "RAID zařízení"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr ""
 
@@ -6260,7 +6261,6 @@ msgid "Raw to a device"
 msgstr ""
 
 # auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6272,6 +6272,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr "Pouze pro čtení"
 
@@ -6337,7 +6338,7 @@ msgid "Reason"
 msgstr ""
 
 # auto translated by TM merge from project: system-config-kdump, version: master, DocId: system-config-kdump
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "Restartovat"
 
@@ -6393,8 +6394,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6422,8 +6423,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "Obnovit"
 
@@ -6465,9 +6466,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "Odstranit"
 
@@ -6520,7 +6521,7 @@ msgid "Remove passphrase in $0?"
 msgstr ""
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr "K odstranění"
 
@@ -6588,10 +6589,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
@@ -6707,8 +6708,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Restartovat"
 
@@ -6757,8 +6758,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 # auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
@@ -6816,7 +6816,7 @@ msgid "Runner"
 msgstr ""
 
 # auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "Běží"
 
@@ -6906,8 +6906,8 @@ msgid "Saturday"
 msgstr "sobota"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "Uložit"
 
@@ -6962,7 +6962,7 @@ msgid "Securely erasing $target"
 msgstr ""
 
 # auto translated by TM merge from project: Fedora OpenSSH Guide, version: master, DocId: Security
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr "Bezpečnost"
 
@@ -6994,8 +6994,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -7017,15 +7017,14 @@ msgid "Serial Console"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "Server"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -7033,7 +7032,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr "Administrátor serveru"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -7054,7 +7053,7 @@ msgstr "Servery"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "Služba"
 
@@ -7104,7 +7103,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr ""
 
@@ -7245,7 +7244,7 @@ msgid "Show fingerprints"
 msgstr ""
 
 # auto translated by TM merge from project: anaconda, version: master, DocId: main
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr "Zmenšit"
 
@@ -7268,34 +7267,34 @@ msgid "Since $0"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Velikost"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr ""
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7390,7 +7389,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Start"
@@ -7432,10 +7431,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "Stav"
 
@@ -7459,10 +7458,11 @@ msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7486,7 +7486,7 @@ msgstr ""
 
 # auto translated by TM merge from project: Fedora Media Writer, version: master, DocId: mediawriter
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7727,7 +7727,7 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr "Tagy"
 
@@ -7750,7 +7750,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7882,8 +7882,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7918,11 +7918,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7934,9 +7934,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7945,14 +7944,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -8053,11 +8051,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -8143,8 +8141,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -8200,13 +8197,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -8216,17 +8213,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -8236,7 +8233,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8256,7 +8253,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8325,9 +8322,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8491,11 +8488,11 @@ msgid "Tuned is off"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Typ"
@@ -8561,7 +8558,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8608,24 +8605,24 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Neznámý"
 
@@ -8649,7 +8646,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8695,7 +8692,7 @@ msgid "Unmask"
 msgstr ""
 
 # auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Odpojit"
 
@@ -8787,7 +8784,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8838,13 +8835,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
@@ -8855,10 +8852,10 @@ msgstr ""
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8879,7 +8876,7 @@ msgid "User interface for Linux servers"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Uživatelské jméno"
@@ -8893,8 +8890,8 @@ msgid "User or Group"
 msgstr ""
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "Jméno uživatele"
 
@@ -9060,9 +9057,9 @@ msgstr "Ověřuji"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Verze"
 
@@ -9126,8 +9123,8 @@ msgstr ""
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr ""
 
@@ -9135,9 +9132,8 @@ msgstr ""
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9438,7 +9434,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9516,10 +9512,10 @@ msgid "non responsive"
 msgstr ""
 
 # auto translated by TM merge from project: anaconda, version: rhel8-alpha-branch, DocId: anaconda
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9698,7 +9694,7 @@ msgstr "udp"
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-02 13:53+0200\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,24 +25,35 @@ msgstr ""
 msgid " 1\"Do you want to delete the following Nodes?"
 msgstr ""
 
-#: pkg/storaged/overview.js:256
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:220
+msgid " or drag & drop."
+msgstr ""
+
+#: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr ""
 
-#: pkg/storaged/details.js:361
+#: pkg/storaged/mdraid-details.jsx:193
 msgid "$0 Chunk Size"
 msgstr ""
 
-#: pkg/storaged/details.js:359
+#: pkg/storaged/mdraid-details.jsx:191
 msgid "$0 Disks"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:290
+#: pkg/storaged/content-views.jsx:320
 msgctxt "storage-id-desc"
 msgid "$0 File System"
 msgstr ""
 
-#: pkg/systemd/init.js:376 pkg/systemd/init.js:659
+#: pkg/realmd/operation.js:112
+msgid ""
+"$0 Only users with local credentials will be able to log into this machine. "
+"This may also effect other services as DNS resolution settings and the list "
+"of trusted CAs may change."
+msgstr ""
+
+#: pkg/systemd/init.js:377 pkg/systemd/init.js:711
 msgid "$0 Template"
 msgstr ""
 
@@ -67,7 +78,11 @@ msgid_plural "$0 bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/lib/plot.js:890
+#: pkg/storaged/vdo-details.jsx:279
+msgid "$0 data + $1 overhead used of $2 ($3)"
+msgstr ""
+
+#: pkg/lib/plot.js:897
 msgid "$0 day"
 msgid_plural "$0 days"
 msgstr[0] ""
@@ -75,7 +90,7 @@ msgstr[1] ""
 
 #: src/base1/test-locale.js:64 src/base1/test-locale.js:65
 #: src/base1/test-locale.js:66 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/details.js:372
+#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:213
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] ""
@@ -90,39 +105,65 @@ msgid_plural "$0 disks are missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ws/login.js:279 src/ws/login.js:601
+#: src/ws/login.js:306 src/ws/login.js:644
 msgid "$0 error"
 msgstr ""
 
-#: src/base1/cockpit.js:2662
+#: src/base1/cockpit.js:2739
 msgid "$0 exited with code $1"
 msgstr ""
 
-#: src/base1/cockpit.js:2664
+#: src/base1/cockpit.js:2741
 msgid "$0 failed"
 msgstr ""
 
-#: pkg/lib/plot.js:893
+#: pkg/storaged/lvol-tabs.jsx:306
+msgid "$0 filesystems can not be made larger."
+msgstr ""
+
+#: pkg/storaged/lvol-tabs.jsx:303
+msgid "$0 filesystems can not be made smaller."
+msgstr ""
+
+#: pkg/storaged/lvol-tabs.jsx:299
+msgid "$0 filesystems can not be resized here."
+msgstr ""
+
+#: pkg/lib/plot.js:900
 msgid "$0 hour"
 msgid_plural "$0 hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/ostree/client.js:484
-msgid "$0 key ID"
+#: pkg/machines/components/desktopConsole.jsx:44
+msgid ""
+"$0 is available for most operating systems. To install it, search for it in "
+"GNOME Software or run the following:"
 msgstr ""
 
-#: src/base1/cockpit.js:2660
+#: pkg/storaged/content-views.jsx:274 pkg/storaged/content-views.jsx:487
+#: pkg/storaged/format-dialog.jsx:253 pkg/storaged/lvol-tabs.jsx:153
+#: pkg/storaged/lvol-tabs.jsx:202 pkg/storaged/mdraid-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:291 pkg/storaged/vdo-details.jsx:135
+#: pkg/storaged/vdo-details.jsx:166 pkg/storaged/vgroup-details.jsx:202
+msgid "$0 is in active use"
+msgstr ""
+
+#: pkg/lib/cockpit-components-install-dialog.jsx:150
+msgid "$0 is not available from any repository."
+msgstr ""
+
+#: src/base1/cockpit.js:2737
 msgid "$0 killed with signal $1"
 msgstr ""
 
-#: pkg/lib/plot.js:896
+#: pkg/lib/plot.js:903
 msgid "$0 minute"
 msgid_plural "$0 minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/lib/plot.js:884
+#: pkg/lib/plot.js:891
 msgid "$0 month"
 msgid_plural "$0 months"
 msgstr[0] ""
@@ -134,61 +175,85 @@ msgid_plural "$1 occurrences"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/fsys-tab.jsx:58
+#: pkg/storaged/fsys-tab.jsx:57
 msgid "$0 of $1"
 msgstr ""
 
-#: pkg/ostree/app.js:471
-msgid "$0 package"
-msgstr ""
-
-#: pkg/ostree/app.js:471
-msgid "$0 packages"
-msgstr ""
-
-#: pkg/docker/util.js:123
+#: pkg/docker/util.js:128
 msgid "$0 shares"
 msgstr ""
 
-#: pkg/lib/plot.js:887
+#: pkg/storaged/crypto-keyslots.jsx:548
+msgid "$0 slots remain"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:158
+msgid "$0 update"
+msgid_plural "$0 updates"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/storaged/vdo-details.jsx:292
+msgid "$0 used of $1 ($2 saved)"
+msgstr ""
+
+#: pkg/machines/components/vcpuModal.jsx:217
+#: pkg/ovirt/components/vcpuModal.jsx:91
+msgid "$0 vCPU Details"
+msgstr ""
+
+#: pkg/lib/plot.js:894
 msgid "$0 week"
 msgid_plural "$0 weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/lib/plot.js:881
+#: pkg/lib/cockpit-components-install-dialog.jsx:106
+msgid "$0 will be installed."
+msgstr ""
+
+#: pkg/lib/plot.js:888
 msgid "$0 year"
 msgid_plural "$0 years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/kubernetes/scripts/nodes.js:870
-#, c-format
+#: pkg/kubernetes/scripts/nodes.js:874
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/kubernetes/scripts/nodes.js:872
+#: pkg/kubernetes/scripts/nodes.js:876
 msgid "$0% Used"
 msgid_plural "$0% Used"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/details.js:503
+#: pkg/storaged/vgroup-details.jsx:116
 msgid "$0, $1 free"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2579
+#: pkg/packagekit/updates.jsx:156
+msgid "$1 security fix"
+msgid_plural "$1 security fixes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/networkmanager/interfaces.js:2745
 msgid "$mtu"
 msgstr ""
 
-#: pkg/storaged/utils.js:157
+#: pkg/storaged/utils.js:154
 msgid "$name (from $host)"
 msgstr ""
 
-#: pkg/docker/details.js:143
+#: pkg/docker/details.js:145
 msgid "${hip}:${hport} -> $cport"
+msgstr ""
+
+#: pkg/storaged/utils.js:118
+msgid "${size} ${desc}"
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-client.js:198
@@ -199,274 +264,260 @@ msgstr ""
 msgid "'Organization' required when using activation keys."
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:185
+#: pkg/storaged/fsys-tab.jsx:162
 msgid "(default)"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:138
+#: pkg/storaged/crypto-tab.jsx:139
 msgid "(none)"
 msgstr ""
 
-#: pkg/ostree/index.html:92
-msgid "- Add New Repository"
+#: pkg/packagekit/updates.jsx:160
+msgid ", including $1 security fix"
+msgid_plural ", including $1 security fixes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/storaged/nfs-details.jsx:310
+msgid "--"
 msgstr ""
 
-#: pkg/storaged/overview.js:443
+#: pkg/storaged/mdraids-panel.jsx:64
 msgid "1 MiB"
 msgstr ""
 
-#: pkg/systemd/index.html:443 pkg/systemd/index.html:447
+#: pkg/systemd/index.html:473 pkg/systemd/index.html:477
 msgid "1 Minute"
 msgstr ""
 
-#: pkg/networkmanager/index.html:56 pkg/networkmanager/index.html:543
-#: pkg/storaged/index.html:310 pkg/systemd/index.html:181
-#: pkg/dashboard/index.html:55
+#: pkg/dashboard/index.html:55 pkg/networkmanager/index.html:68
+#: pkg/networkmanager/index.html:575 pkg/systemd/index.html:210
+#: pkg/storaged/plot.jsx:85
 msgid "1 day"
 msgstr ""
 
-#: pkg/networkmanager/index.html:54 pkg/networkmanager/index.html:541
-#: pkg/storaged/index.html:308 pkg/systemd/index.html:177
-#: pkg/dashboard/index.html:51
+#: pkg/dashboard/index.html:51 pkg/networkmanager/index.html:66
+#: pkg/networkmanager/index.html:573 pkg/systemd/index.html:206
+#: pkg/storaged/plot.jsx:79
 msgid "1 hour"
 msgstr ""
 
-#: pkg/systemd/host.js:1424
+#: pkg/systemd/host.js:1532
 msgid "1 min"
 msgstr ""
 
-#: pkg/networkmanager/index.html:57 pkg/networkmanager/index.html:544
-#: pkg/storaged/index.html:311 pkg/systemd/index.html:183
-#: pkg/dashboard/index.html:57
+#: pkg/dashboard/index.html:57 pkg/networkmanager/index.html:69
+#: pkg/networkmanager/index.html:576 pkg/systemd/index.html:212
+#: pkg/storaged/plot.jsx:88
 msgid "1 week"
 msgstr ""
 
-#: pkg/systemd/services.html:215
+#: pkg/systemd/services.html:257
 msgid "10th"
 msgstr ""
 
-#: pkg/systemd/services.html:216
+#: pkg/systemd/services.html:258
 msgid "11th"
 msgstr ""
 
-#: pkg/storaged/overview.js:441
+#: pkg/storaged/mdraids-panel.jsx:62
 msgid "128 KiB"
 msgstr ""
 
-#: pkg/systemd/services.html:217
+#: pkg/systemd/services.html:259
 msgid "12th"
 msgstr ""
 
-#: pkg/systemd/services.html:218
+#: pkg/systemd/services.html:260
 msgid "13th"
 msgstr ""
 
-#: pkg/systemd/services.html:219
+#: pkg/systemd/services.html:261
 msgid "14th"
 msgstr ""
 
-#: pkg/systemd/services.html:220
+#: pkg/systemd/services.html:262
 msgid "15th"
 msgstr ""
 
-#: pkg/storaged/overview.js:438
+#: pkg/storaged/mdraids-panel.jsx:59
 msgid "16 KiB"
 msgstr ""
 
-#: pkg/systemd/services.html:221
+#: pkg/systemd/services.html:263
 msgid "16th"
 msgstr ""
 
-#: pkg/systemd/services.html:222
+#: pkg/systemd/services.html:264
 msgid "17th"
 msgstr ""
 
-#: pkg/systemd/services.html:223
+#: pkg/systemd/services.html:265
 msgid "18th"
 msgstr ""
 
-#: pkg/systemd/services.html:224
+#: pkg/systemd/services.html:266
 msgid "19th"
 msgstr ""
 
-#: pkg/systemd/services.html:206
+#: pkg/systemd/services.html:248
 msgid "1st"
 msgstr ""
 
-#: pkg/storaged/overview.js:444
+#: pkg/storaged/mdraids-panel.jsx:65
 msgid "2 MiB"
 msgstr ""
 
-#: pkg/systemd/host.js:1423
+#: pkg/systemd/host.js:1531
 msgid "2 min"
 msgstr ""
 
-#: pkg/systemd/index.html:449
+#: pkg/systemd/index.html:479
 msgid "20 Minutes"
 msgstr ""
 
-#: pkg/systemd/services.html:225
+#: pkg/systemd/services.html:267
 msgid "20th"
 msgstr ""
 
-#: pkg/systemd/services.html:226
+#: pkg/systemd/services.html:268
 msgid "21st"
 msgstr ""
 
-#: pkg/systemd/services.html:227
+#: pkg/systemd/services.html:269
 msgid "22nd"
 msgstr ""
 
-#: pkg/systemd/services.html:228
+#: pkg/systemd/services.html:270
 msgid "23rd"
 msgstr ""
 
-#: pkg/systemd/services.html:229
+#: pkg/systemd/services.html:271
 msgid "24th"
 msgstr ""
 
-#: pkg/systemd/services.html:230
+#: pkg/systemd/services.html:272
 msgid "25th"
 msgstr ""
 
-#: pkg/systemd/services.html:231
+#: pkg/systemd/services.html:273
 msgid "26th"
 msgstr ""
 
-#: pkg/systemd/services.html:232
+#: pkg/systemd/services.html:274
 msgid "27th"
 msgstr ""
 
-#: pkg/systemd/services.html:233
+#: pkg/systemd/services.html:275
 msgid "28th"
 msgstr ""
 
-#: pkg/systemd/services.html:234
+#: pkg/systemd/services.html:276
 msgid "29th"
 msgstr ""
 
-#: pkg/systemd/services.html:207
+#: pkg/systemd/services.html:249
 msgid "2nd"
 msgstr ""
 
-#: pkg/systemd/host.js:1422
+#: pkg/systemd/host.js:1530
 msgid "3 min"
 msgstr ""
 
-#: pkg/systemd/services.html:235
+#: pkg/systemd/services.html:277
 msgid "30th"
 msgstr ""
 
-#: pkg/systemd/services.html:236
+#: pkg/systemd/services.html:278
 msgid "31st"
 msgstr ""
 
-#: pkg/storaged/overview.js:439
+#: pkg/storaged/mdraids-panel.jsx:60
 msgid "32 KiB"
 msgstr ""
 
-#: pkg/systemd/services.html:208
+#: pkg/systemd/services.html:250
 msgid "3rd"
 msgstr ""
 
-#: pkg/storaged/overview.js:436
+#: pkg/storaged/mdraids-panel.jsx:57
 msgid "4 KiB"
 msgstr ""
 
-#: pkg/systemd/host.js:1421
+#: pkg/systemd/host.js:1529
 msgid "4 min"
 msgstr ""
 
-#: pkg/systemd/index.html:450
+#: pkg/systemd/index.html:480
 msgid "40 Minutes"
 msgstr ""
 
-#: pkg/systemd/services.html:209
+#: pkg/systemd/services.html:251
 msgid "4th"
 msgstr ""
 
-#: pkg/systemd/index.html:448
+#: pkg/systemd/index.html:478
 msgid "5 Minutes"
 msgstr ""
 
-#: pkg/systemd/host.js:1420
+#: pkg/systemd/host.js:1528
 msgid "5 min"
 msgstr ""
 
-#: pkg/networkmanager/index.html:53 pkg/networkmanager/index.html:540
-#: pkg/storaged/index.html:307 pkg/systemd/index.html:175
-#: pkg/dashboard/index.html:49
+#: pkg/dashboard/index.html:49 pkg/networkmanager/index.html:65
+#: pkg/networkmanager/index.html:572 pkg/systemd/index.html:204
+#: pkg/storaged/plot.jsx:76
 msgid "5 minutes"
 msgstr ""
 
-#: pkg/storaged/overview.js:442
+#: pkg/storaged/mdraids-panel.jsx:63
 msgid "512 KiB"
 msgstr ""
 
-#: pkg/systemd/services.html:210
+#: pkg/systemd/services.html:252
 msgid "5th"
 msgstr ""
 
-#: pkg/networkmanager/index.html:55 pkg/networkmanager/index.html:542
-#: pkg/storaged/index.html:309 pkg/systemd/index.html:179
-#: pkg/dashboard/index.html:53
+#: pkg/dashboard/index.html:53 pkg/networkmanager/index.html:67
+#: pkg/networkmanager/index.html:574 pkg/systemd/index.html:208
+#: pkg/storaged/plot.jsx:82
 msgid "6 hours"
 msgstr ""
 
-#: pkg/systemd/index.html:451
+#: pkg/systemd/index.html:481
 msgid "60 Minutes"
 msgstr ""
 
-#: pkg/storaged/overview.js:440
+#: pkg/storaged/mdraids-panel.jsx:61
 msgid "64 KiB"
 msgstr ""
 
-#: pkg/systemd/services.html:211
+#: pkg/systemd/services.html:253
 msgid "6th"
 msgstr ""
 
-#: pkg/systemd/services.html:212
+#: pkg/systemd/services.html:254
 msgid "7th"
 msgstr ""
 
-#: pkg/storaged/overview.js:437
+#: pkg/storaged/mdraids-panel.jsx:58
 msgid "8 KiB"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1845
+#: pkg/networkmanager/interfaces.js:1976
 msgid "802.3ad"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1862
+#: pkg/networkmanager/interfaces.js:1993
 msgid "802.3ad LACP"
 msgstr ""
 
-#: pkg/systemd/services.html:213
+#: pkg/systemd/services.html:255
 msgid "8th"
 msgstr ""
 
-#: pkg/systemd/services.html:214
+#: pkg/systemd/services.html:256
 msgid "9th"
-msgstr ""
-
-#: pkg/storaged/utils.js:220
-msgid "<span>Encrypted $0</span>"
-msgstr ""
-
-#: pkg/storaged/utils.js:212
-msgid "<span>Encrypted Logical Volume of $0</span>"
-msgstr ""
-
-#: pkg/storaged/utils.js:214
-msgid "<span>Encrypted Partition of $0</span>"
-msgstr ""
-
-#: pkg/storaged/utils.js:216
-msgid "<span>Logical Volume of $0</span>"
-msgstr ""
-
-#: pkg/storaged/utils.js:218
-msgid "<span>Partition of $0</span>"
 msgstr ""
 
 #: pkg/lib/machine-not-supported.html:5
@@ -475,19 +526,32 @@ msgid ""
 "strong}}."
 msgstr ""
 
+#: pkg/storaged/vdos-panel.jsx:64
+msgid "A disk is needed."
+msgstr ""
+
+#: src/ws/login.html:115
+msgid ""
+"A modern browser is required for security, reliability, and performance."
+msgstr ""
+
+#: pkg/storaged/mdraid-details.jsx:119
+msgid "A spare disk needs to be added first before this disk can be removed."
+msgstr ""
+
 #: cockpit.desktop.in.h:2
 msgid "A user interface for GNU/Linux servers"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1853
+#: pkg/networkmanager/interfaces.js:1984
 msgid "ARP"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2608
+#: pkg/networkmanager/interfaces.js:2774
 msgid "ARP Monitoring"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1874
+#: pkg/networkmanager/interfaces.js:2005
 msgid "ARP Ping"
 msgstr ""
 
@@ -495,22 +559,22 @@ msgstr ""
 msgid "AWS Elastic Block Store"
 msgstr ""
 
-#: pkg/shell/simple.html:41 pkg/shell/simple.html:68 pkg/shell/index.html:41
-#: pkg/shell/index.html:80 pkg/shell/stub.html:41 pkg/shell/stub.html:73
+#: pkg/shell/index.html:56 pkg/shell/index.html:82 pkg/shell/simple.html:42
+#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
 msgid "About Cockpit"
 msgstr ""
 
-#: pkg/users/index.html:103 pkg/users/index.html:197
+#: pkg/users/index.html:105 pkg/users/index.html:212
 msgid "Access"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-claim.html:9 pkg/kubernetes/views/pvc-body.html:18
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-modify.html:69
+#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr ""
 
 #: pkg/kubernetes/views/project-modify.html:49
-#: bower_components/registry-image-widgets/views/imagestream-body.html:12
+#: node_modules/registry-image-widgets/views/imagestream-body.html:12
 msgid "Access Policy"
 msgstr ""
 
@@ -518,28 +582,39 @@ msgstr ""
 msgid "Access denied"
 msgstr ""
 
-#: pkg/shell/index.html:45
+#: pkg/users/index.html:301
+#, fuzzy
+msgid "Account Expiration"
+msgstr "Indstillinger"
+
+#: pkg/shell/index.html:63
 msgid "Account Settings"
 msgstr ""
 
-#: pkg/users/index.html:61
+#: pkg/users/index.html:63
 msgid "Account not available or cannot be edited."
 msgstr ""
 
-#: pkg/users/index.html:69
+#: pkg/users/index.html:71
 msgid "Accounts"
 msgstr ""
 
-#: pkg/users/local.js:308 pkg/users/local.js:610
+#: pkg/users/local.js:310 pkg/users/local.js:612
 msgctxt "page-title"
 msgid "Accounts"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:227
+#: pkg/ovirt/components/ClusterTemplates.jsx:136
+#: pkg/ovirt/components/ClusterVms.jsx:183
+#, fuzzy
+msgid "Action"
+msgstr "Indstillinger"
+
+#: pkg/storaged/content-views.jsx:247
 msgid "Activate"
 msgstr ""
 
-#: pkg/storaged/jobs.js:145
+#: pkg/storaged/jobs-panel.jsx:68
 msgid "Activating $target"
 msgstr ""
 
@@ -547,54 +622,61 @@ msgstr ""
 msgid "Activation Key"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:745 pkg/networkmanager/interfaces.js:1868
+#: pkg/networkmanager/interfaces.js:836 pkg/networkmanager/interfaces.js:1999
 msgid "Active"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1842 pkg/networkmanager/interfaces.js:1859
+#: pkg/networkmanager/interfaces.js:1973 pkg/networkmanager/interfaces.js:1990
 msgid "Active Backup"
+msgstr ""
+
+#: pkg/shell/index.html:59 pkg/shell/stub.html:49 pkg/shell/active-pages.js:94
+msgid "Active Pages"
+msgstr ""
+
+#: pkg/storaged/index.html:377 pkg/storaged/index.html:397
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
+msgid "Active since"
 msgstr ""
 
 #: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
 msgid "Actual"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1847
+#: pkg/networkmanager/interfaces.js:1978
 msgid "Adaptive load balancing"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1846
+#: pkg/networkmanager/interfaces.js:1977
 msgid "Adaptive transmit load balancing"
 msgstr ""
 
-#: pkg/ostree/index.html:90 pkg/kubernetes/views/node-add.html:50
-#: pkg/kubernetes/views/user-add-membership.html:49
+#: pkg/kubernetes/views/add-member-role-dialog.html:61
 #: pkg/kubernetes/views/add-role-dialog.html:8
 #: pkg/kubernetes/views/add-user-dialog.html:27
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/storaged/details.js:86 pkg/storaged/details.js:222
-#: pkg/storaged/overview.js:632 pkg/storaged/overview.js:660
+#: pkg/kubernetes/views/node-add.html:50
+#: pkg/kubernetes/views/user-add-membership.html:49
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2923
+#: pkg/networkmanager/interfaces.js:3090
 msgid "Add $0"
 msgstr ""
 
-#: pkg/docker/storage.jsx:365
+#: pkg/docker/storage.jsx:351
 msgid "Add Additional Storage"
 msgstr ""
 
-#: pkg/ostree/index.html:75
-msgid "Add Another Key"
-msgstr ""
-
-#: pkg/networkmanager/index.html:87
+#: pkg/networkmanager/index.html:118
 msgid "Add Bond"
 msgstr ""
 
-#: pkg/networkmanager/index.html:89
+#: pkg/networkmanager/index.html:120
 msgid "Add Bridge"
 msgstr ""
 
@@ -602,12 +684,22 @@ msgstr ""
 msgid "Add Cluster Node"
 msgstr ""
 
-#: pkg/storaged/details.js:66 pkg/storaged/details.js:199
+#: pkg/machines/components/diskAdd.jsx:390
+#: pkg/machines/components/diskAdd.jsx:466
+#, fuzzy
+msgid "Add Disk"
+msgstr "Disk I/O"
+
+#: pkg/storaged/mdraid-details.jsx:44 pkg/storaged/vgroup-details.jsx:48
 msgid "Add Disks"
 msgstr ""
 
 #: pkg/kubernetes/views/add-group-dialog.html:3
 msgid "Add Group"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:173
+msgid "Add Key"
 msgstr ""
 
 #: pkg/kubernetes/views/nodes-page.html:34
@@ -618,16 +710,16 @@ msgstr ""
 msgid "Add Machine to Dashboard"
 msgstr ""
 
-#: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/project-body.html:108
 #: pkg/kubernetes/views/add-member-role-dialog.html:4
+#: pkg/kubernetes/views/group-page.html:38
 #: pkg/kubernetes/views/group-panel.html:29
+#: pkg/kubernetes/views/project-body.html:108
 #: pkg/kubernetes/views/user-group-add.html:3
 msgid "Add Member"
 msgstr ""
 
-#: pkg/kubernetes/views/user-panel.html:76
 #: pkg/kubernetes/views/user-body.html:67
+#: pkg/kubernetes/views/user-panel.html:76
 msgid "Add Membership"
 msgstr ""
 
@@ -645,28 +737,36 @@ msgstr ""
 msgid "Add Role"
 msgstr ""
 
+#: pkg/networkmanager/firewall.jsx:254 pkg/networkmanager/firewall.jsx:261
+msgid "Add Services"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:301 pkg/networkmanager/firewall.jsx:305
+msgid "Add Services…"
+msgstr ""
+
 #: pkg/docker/storage.jsx:207
 msgid "Add Storage"
 msgstr ""
 
-#: pkg/networkmanager/index.html:88
+#: pkg/networkmanager/index.html:119
 msgid "Add Team"
 msgstr ""
 
-#: pkg/kubernetes/views/project-listing.html:83
 #: pkg/kubernetes/views/add-user-dialog.html:3
+#: pkg/kubernetes/views/project-listing.html:83
 msgid "Add User"
 msgstr ""
 
-#: pkg/networkmanager/index.html:90
+#: pkg/networkmanager/index.html:121
 msgid "Add VLAN"
 msgstr ""
 
-#: pkg/storaged/overview.js:518
+#: pkg/storaged/iscsi-panel.jsx:41
 msgid "Add iSCSI Portal"
 msgstr ""
 
-#: pkg/users/index.html:353
+#: pkg/shell/index.html:172 pkg/users/index.html:466
 msgid "Add key"
 msgstr ""
 
@@ -674,11 +774,11 @@ msgstr ""
 msgid "Add membership"
 msgstr ""
 
-#: pkg/users/index.html:345
+#: pkg/users/index.html:458
 msgid "Add public key"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2922
+#: pkg/networkmanager/interfaces.js:3089
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -688,45 +788,58 @@ msgstr ""
 msgid "Adding key"
 msgstr ""
 
-#: pkg/storaged/jobs.js:150
+#: pkg/storaged/jobs-panel.jsx:73
 msgid "Adding physical volume to $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2478
+#: pkg/machines/vmnetworktab.jsx:87
+msgid "Additional"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2644
 msgid "Additional DNS $val"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2481
+#: pkg/networkmanager/interfaces.js:2647
 msgid "Additional DNS Search Domains $val"
 msgstr ""
 
-#: pkg/docker/index.html:297
+#: pkg/docker/index.html:305
 msgid "Additional Storage"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2473
+#: pkg/networkmanager/interfaces.js:2639
 msgid "Additional address $val"
 msgstr ""
 
-#: pkg/ostree/index.html:313 pkg/ostree/index.html:331
-msgid "Additions"
+#: pkg/lib/cockpit-components-install-dialog.jsx:73
+msgid "Additional packages:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/nodes-page.html:43
 #: pkg/kubernetes/views/auth-form.html:29
+#: pkg/kubernetes/views/dashboard-page.html:157
 #: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/dashboard-page.html:157 pkg/lib/machine-add.html:11
-#: pkg/storaged/overview.js:627
+#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
+#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2473
+#: pkg/networkmanager/interfaces.js:2639
 msgid "Address $val"
 msgstr ""
 
+#: pkg/storaged/crypto-keyslots.jsx:197 pkg/storaged/crypto-keyslots.jsx:243
+msgid "Address cannot be empty"
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:154
+#: pkg/ovirt/components/VmOverviewColumn.jsx:53
+msgid "Address:"
+msgstr ""
+
 #: pkg/kubernetes/views/details-page.html:37
-#: pkg/networkmanager/interfaces.js:3114
+#: pkg/networkmanager/interfaces.js:3283
 msgid "Addresses"
 msgstr ""
 
@@ -754,20 +867,29 @@ msgstr ""
 msgid "Admin"
 msgstr ""
 
-#: pkg/realmd/operation.js:272
+#: pkg/realmd/operation.js:289
 msgid "Administrator Password"
 msgstr ""
 
-#: pkg/systemd/services.html:397
+#: pkg/lib/machine-info.es6:86
+msgid "Advanced TCA"
+msgstr ""
+
+#: pkg/systemd/services.html:439 pkg/systemd/init.js:692
 msgid "After"
 msgstr ""
 
-#: pkg/systemd/services.html:388 pkg/systemd/services.html:392
+#: pkg/systemd/services.html:430 pkg/systemd/services.html:434
+#: pkg/systemd/init.js:1017
 msgid "After system boot"
 msgstr ""
 
-#: pkg/systemd/logs.html:51
-msgid "All"
+#: pkg/systemd/logs.html:56
+msgid "Alert and above"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:72
+msgid "All In One"
 msgstr ""
 
 #: pkg/kubernetes/views/filter-project.html:4
@@ -778,7 +900,11 @@ msgstr ""
 msgid "All Types"
 msgstr ""
 
-#: pkg/docker/storage.jsx:368
+#: pkg/machines/components/vcpuModal.jsx:159
+msgid "All changes will take effect only after stopping and starting the VM."
+msgstr ""
+
+#: pkg/docker/storage.jsx:354
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
@@ -800,30 +926,52 @@ msgstr ""
 msgid "All running"
 msgstr ""
 
-#: pkg/docker/index.html:537 pkg/docker/util.js:106
+#: pkg/ovirt/components/HostToMaintenance.jsx:36
+msgid "All running virtual machines will be turned off."
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:325
+msgid "Allowed Services"
+msgstr ""
+
+#: pkg/docker/index.html:545 pkg/docker/util.js:111
 msgid "Always"
 msgstr ""
 
 #: pkg/kubernetes/views/route-body.html:27
 #: pkg/kubernetes/views/node-body.html:57
-#: bower_components/registry-image-widgets/views/imagestream-meta.html:2
-#: bower_components/registry-image-widgets/views/image-meta.html:9
+#: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
 
-#: pkg/kubernetes/scripts/projects.js:1020
+#: pkg/kubernetes/scripts/projects.js:1028
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/networkmanager/index.html:620 pkg/networkmanager/index.html:644
-#: pkg/networkmanager/index.html:668 pkg/networkmanager/index.html:692
-#: pkg/networkmanager/index.html:716 pkg/networkmanager/index.html:740
-#: pkg/networkmanager/index.html:764 pkg/networkmanager/index.html:788
-#: pkg/networkmanager/index.html:812 pkg/ostree/index.html:39
-#: pkg/storaged/fsys-tab.jsx:76 pkg/storaged/fsys-tab.jsx:145
-#: pkg/storaged/crypto-tab.jsx:73 pkg/storaged/crypto-tab.jsx:107
-#: pkg/kdump/kdump-view.jsx:356
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
+#, fuzzy
+msgid "Applications"
+msgstr "Indstillinger"
+
+#: pkg/networkmanager/index.html:652 pkg/networkmanager/index.html:676
+#: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
+#: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
+#: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
+#: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:303
+msgid "Apply all updates"
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:304
+msgid "Apply security updates"
 msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:107
@@ -834,47 +982,58 @@ msgstr ""
 msgid "Applying solution..."
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-config.html:16
+#: pkg/packagekit/updates.jsx:42
+msgid "Applying updates"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:44
+msgid "Applying updates failed"
+msgstr ""
+
+#: node_modules/registry-image-widgets/views/image-config.html:16
 #: pkg/subscriptions/subscriptions-view.jsx:35
 msgid "Architecture"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:453
-msgid "Are you sure you want to delete this image?"
+#: pkg/realmd/operation.js:109
+msgid "Are you sure you want to leave the '$0' domain?"
 msgstr ""
 
-#: pkg/storaged/index.html:449
-msgctxt "storage"
-msgid "Assessment"
+#: pkg/realmd/operation.js:107
+msgid "Are you sure you want to leave this domain?"
 msgstr ""
 
-#: pkg/systemd/index.html:81
+#: pkg/systemd/index.html:92
 msgid "Asset Tag"
 msgstr ""
 
-#: pkg/storaged/overview.js:458
+#: pkg/storaged/mdraids-panel.jsx:78
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/details.js:81 pkg/storaged/details.js:217
-#: pkg/storaged/overview.js:504
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr ""
 
-#: pkg/systemd/services.html:393
+#: pkg/systemd/services.html:435
 msgid "At specific time"
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:114
+msgid "Attach permanently"
 msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:395
 msgid "Audit log"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:737
+#: pkg/networkmanager/interfaces.js:828
 msgid "Authenticating"
 msgstr ""
 
-#: pkg/realmd/operation.html:34 pkg/shell/index.html:48
-#: pkg/shell/index.html:147 pkg/kubernetes/views/auth-form.html:85
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
 #: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr ""
@@ -883,61 +1042,78 @@ msgstr ""
 msgid "Authentication Failed"
 msgstr ""
 
-#: src/ws/login.js:581
+#: src/ws/login.js:624
 msgid "Authentication Failed: Server closed connection"
 msgstr ""
 
-#: src/ws/login.js:591
+#: src/ws/login.js:634
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/overview.js:648
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
-#: pkg/docker/index.html:686 pkg/kubernetes/views/image-listing.html:15
-#: bower_components/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:312
+#: pkg/docker/index.html:694
+#: node_modules/registry-image-widgets/views/image-body.html:12
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr ""
 
-#: pkg/users/index.html:136
+#: pkg/users/index.html:149
 msgid "Authorized Public SSH Keys"
 msgstr ""
 
-#: pkg/networkmanager/index.html:166 pkg/networkmanager/interfaces.js:1832
-#: pkg/networkmanager/interfaces.js:2581 pkg/networkmanager/interfaces.js:3122
-#: pkg/networkmanager/interfaces.js:3126 pkg/networkmanager/interfaces.js:3132
-#: pkg/realmd/operation.js:275
+#: pkg/networkmanager/index.html:198 pkg/networkmanager/interfaces.js:1963
+#: pkg/networkmanager/interfaces.js:2747 pkg/networkmanager/interfaces.js:3291
+#: pkg/networkmanager/interfaces.js:3295 pkg/networkmanager/interfaces.js:3301
+#: pkg/realmd/operation.js:292
 msgid "Automatic"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1833
+#: pkg/networkmanager/interfaces.js:1964
 msgid "Automatic (DHCP only)"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1823
+#: pkg/networkmanager/interfaces.js:1954
 msgid "Automatic (DHCP)"
 msgstr ""
 
-#: pkg/systemd/index.html:388
+#: pkg/packagekit/autoupdates.jsx:341
+msgid "Automatic Updates"
+msgstr ""
+
+#: pkg/ovirt/components/OVirtTab.jsx:81
+msgid "Automatically selected host"
+msgstr ""
+
+#: pkg/machines/components/libvirtSlate.jsx:110
+msgid "Automatically start libvirt on boot"
+msgstr ""
+
+#: pkg/systemd/index.html:418
 msgid "Automatically using NTP"
 msgstr ""
 
-#: pkg/systemd/index.html:389
+#: pkg/systemd/index.html:419
 msgid "Automatically using specific NTP servers"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:220
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:61
 msgid "Autostart:"
 msgstr ""
 
-#: pkg/ostree/index.html:255 pkg/lib/machine-change-auth.html:66
-#: pkg/machines/hostvmslist.jsx:252 pkg/machines/hostvmslist.jsx:263
+#: pkg/lib/machine-change-auth.html:66
+#: pkg/machines/components/vm/vmUsageTab.jsx:64
+#: pkg/machines/components/vm/vmUsageTab.jsx:75
 msgid "Available"
 msgstr ""
 
-#: pkg/storaged/overview.js:622
+#: pkg/packagekit/updates.jsx:842
+msgid "Available Updates"
+msgstr ""
+
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -949,45 +1125,80 @@ msgstr ""
 msgid "Azure"
 msgstr ""
 
-#: pkg/users/index.html:63
+#: pkg/systemd/hwinfo.jsx:50
+msgid "BIOS"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:58
+msgid "BIOS date"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:54
+msgid "BIOS version"
+msgstr ""
+
+#: pkg/users/index.html:65
 msgid "Back to Accounts"
+msgstr ""
+
+#: pkg/storaged/vdo-details.jsx:267
+msgid "Backing Device"
 msgstr ""
 
 #: src/bridge/cockpitdbussetup.c:367 src/bridge/cockpitdbussetup.c:631
 msgid "Bad data passed for passwd1 mechanism"
 msgstr ""
 
-#: pkg/networkmanager/index.html:431
+#: pkg/networkmanager/index.html:463
 msgid "Balancer"
 msgstr ""
 
-#: pkg/ostree/index.html:68
-msgid "Begins with '-----BEGIN PGP PUBLIC KEY BLOCK-----'"
+#: pkg/ovirt/components/ClusterTemplates.jsx:135
+msgid "Base Template"
 msgstr ""
 
-#: pkg/storaged/index.html:558
-msgctxt "storage"
-msgid "Bitmap"
+#: pkg/ovirt/components/ClusterVms.jsx:83
+msgid "Base template"
 msgstr ""
 
-#: pkg/storaged/index.html:412
-msgid "Block Device"
+#: pkg/ovirt/components/OVirtTab.jsx:106 pkg/ovirt/components/OVirtTab.jsx:113
+msgid "Base template:"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:683
+#: pkg/systemd/init.js:691
+msgid "Before"
+msgstr ""
+
+#: pkg/systemd/init.js:682
+msgid "Binds To"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:87
+msgid "Blade"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:88
+msgid "Blade enclosure"
+msgstr ""
+
+#: pkg/storaged/block-details.jsx:34
+msgid "Block"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:631
 msgid "Block device for filesystems"
 msgstr ""
 
-#: pkg/storaged/details.js:411
+#: pkg/storaged/mdraid-details.jsx:103
 msgid "Blocked"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2340 pkg/networkmanager/interfaces.js:2352
-#: pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:2503 pkg/networkmanager/interfaces.js:2515
+#: pkg/networkmanager/interfaces.js:2779
 msgid "Bond"
 msgstr ""
 
-#: pkg/networkmanager/index.html:632
+#: pkg/networkmanager/index.html:664
 msgid "Bond Settings"
 msgstr ""
 
@@ -995,60 +1206,97 @@ msgstr ""
 msgid "Boot ID"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2346 pkg/networkmanager/interfaces.js:2358
-#: pkg/networkmanager/interfaces.js:2690
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:59
+msgid "Boot Order:"
+msgstr ""
+
+#: pkg/systemd/init.js:687
+msgid "Bound By"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2509 pkg/networkmanager/interfaces.js:2521
+#: pkg/networkmanager/interfaces.js:2856
 msgid "Bridge"
 msgstr ""
 
-#: pkg/networkmanager/index.html:728
+#: pkg/networkmanager/index.html:760
 msgid "Bridge Port Settings"
 msgstr ""
 
-#: pkg/networkmanager/index.html:704
+#: pkg/networkmanager/index.html:736
 msgid "Bridge Settings"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2711
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Bridge port"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1844 pkg/networkmanager/interfaces.js:1861
+#: pkg/networkmanager/interfaces.js:1975 pkg/networkmanager/interfaces.js:1992
 msgid "Broadcast"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2626 pkg/networkmanager/interfaces.js:2660
+#: pkg/networkmanager/interfaces.js:2792 pkg/networkmanager/interfaces.js:2826
 msgid "Broken configuration"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-body.html:16
+#: pkg/systemd/host.js:451
+msgid "Bug Fix Updates Available"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:309
+msgid "Bugs:"
+msgstr ""
+
+#: node_modules/registry-image-widgets/views/image-body.html:18
 msgid "Built"
 msgstr ""
 
-#: pkg/docker/index.html:260 pkg/systemd/index.html:196
-#: pkg/dashboard/index.html:70 pkg/docker/containers-view.jsx:267
-#: pkg/kubernetes/scripts/nodes.js:711 pkg/kubernetes/scripts/nodes.js:817
-#: pkg/kubernetes/scripts/graphs.js:599
+#: pkg/machines/components/vmDisksTab.jsx:70
+msgid "Bus"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:79
+msgid "Bus Expansion Chassis"
+msgstr ""
+
+#: pkg/machines/libvirt.es6:358
+msgid "CHANGE NETWORK STATE action failed"
+msgstr ""
+
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:268
+#: pkg/docker/containers-view.jsx:351
+#: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr ""
 
-#: pkg/systemd/host.js:1318
+#: pkg/systemd/host.js:1418
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Tilstand"
 
-#: pkg/kubernetes/scripts/nodes.js:712
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:60
+msgid "CPU Type:"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:716
 msgid "CPU Utilization: $0%"
 msgstr ""
 
-#: pkg/docker/index.html:458 pkg/docker/index.html:629
+#: pkg/docker/index.html:466 pkg/docker/index.html:637
 msgid "CPU priority"
 msgstr ""
 
-#: pkg/docker/index.html:208
+#: pkg/docker/index.html:216
 msgid "CPU usage:"
 msgstr ""
 
-#: pkg/systemd/index.html:247 pkg/systemd/host.js:1437
+#: pkg/ovirt/provider.es6:227
+msgid "CREATE VM action failed"
+msgstr ""
+
+#: pkg/systemd/index.html:277 pkg/systemd/host.js:1545
 msgid "Cached"
 msgstr ""
 
@@ -1056,90 +1304,92 @@ msgstr ""
 msgid "Can&rsquo;t connect to Docker"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:274
+#: pkg/storaged/content-views.jsx:304
 msgid "Can't delete while unlocked"
 msgstr ""
 
-#: pkg/playground/translate.html:39 pkg/networkmanager/index.html:619
-#: pkg/networkmanager/index.html:643 pkg/networkmanager/index.html:667
-#: pkg/networkmanager/index.html:691 pkg/networkmanager/index.html:715
-#: pkg/networkmanager/index.html:739 pkg/networkmanager/index.html:763
-#: pkg/networkmanager/index.html:787 pkg/networkmanager/index.html:811
-#: pkg/storaged/index.html:287 pkg/storaged/index.html:858
-#: pkg/users/index.html:210 pkg/users/index.html:271 pkg/users/index.html:295
-#: pkg/users/index.html:352 pkg/docker/index.html:552 pkg/docker/index.html:586
-#: pkg/docker/index.html:648 pkg/docker/index.html:700
-#: pkg/docker/index.html:740 pkg/systemd/services.html:464
-#: pkg/systemd/index.html:331 pkg/systemd/index.html:418
-#: pkg/systemd/index.html:470 pkg/systemd/index.html:486
-#: pkg/realmd/operation.html:90 pkg/ostree/index.html:164
-#: pkg/shell/simple.html:100 pkg/shell/index.html:120 pkg/shell/stub.html:113
-#: pkg/dashboard/index.html:173 pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/image-delete.html:7 pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/add-role-dialog.html:7
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/dashboard/list.js:203
+msgid "Can't load image"
+msgstr ""
+
+#: pkg/dashboard/index.html:173 pkg/docker/index.html:560
+#: pkg/docker/index.html:594 pkg/docker/index.html:656
+#: pkg/docker/index.html:708 pkg/docker/index.html:748
+#: pkg/docker/index.html:777 pkg/kubernetes/views/add-group-dialog.html:18
 #: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:202
+#: pkg/kubernetes/views/add-role-dialog.html:7
+#: pkg/kubernetes/views/add-user-dialog.html:26
+#: pkg/kubernetes/views/auth-form.html:128
+#: pkg/kubernetes/views/auth-rejected-cert.html:31
+#: pkg/kubernetes/views/deploy.html:61
 #: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/user-group-add.html:29 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-change-auth.html:79 pkg/sosreport/index.js:54
-#: pkg/lib/cockpit-components-dialog.jsx:136
+#: pkg/kubernetes/views/image-delete.html:7
+#: pkg/kubernetes/views/imagestream-delete.html:7
+#: pkg/kubernetes/views/imagestream-modify.html:96
+#: pkg/kubernetes/views/item-delete.html:10
+#: pkg/kubernetes/views/node-add.html:49
+#: pkg/kubernetes/views/node-delete.html:14
+#: pkg/kubernetes/views/project-delete.html:8
+#: pkg/kubernetes/views/project-modify.html:71
+#: pkg/kubernetes/views/pv-delete.html:10
+#: pkg/kubernetes/views/pvc-delete.html:14
+#: pkg/kubernetes/views/remove-role-dialog.html:7
+#: pkg/kubernetes/views/replicationcontroller-modify.html:16
+#: pkg/kubernetes/views/route-modify.html:16
+#: pkg/kubernetes/views/service-modify.html:24
+#: pkg/kubernetes/views/user-add-membership.html:48
+#: pkg/kubernetes/views/user-delete.html:24
+#: pkg/kubernetes/views/user-group-add.html:29
+#: pkg/kubernetes/views/user-group-remove.html:9
+#: pkg/kubernetes/views/user-modify.html:26
+#: pkg/kubernetes/views/user-remove-membership.html:9
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
+#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
+#: pkg/ovirt/components/ClusterTemplates.jsx:75
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Annullér"
 
-#: pkg/shell/indexes.js:322
+#: pkg/shell/indexes.js:413
 msgid "Cannot connect to an unknown machine"
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:359
+#: src/ws/cockpitcertificate.c:483
 msgid "Cannot decrypt PEM-encoded private key"
 msgstr ""
 
-#: src/base1/cockpit.js:3933
+#: src/base1/cockpit.js:4012
 msgid "Cannot forward login credentials"
-msgstr ""
-
-#: pkg/realmd/operation.js:418
-msgid "Cannot join a domain because realmd is not available on this system"
 msgstr ""
 
 #: pkg/systemd/shutdown.js:163
 msgid "Cannot schedule event in the past"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pvc-body.html:32
-#: pkg/kubernetes/views/pv-body.html:13 pkg/kubernetes/views/pv-modify.html:44
+#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
+#: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr ""
 
-#: pkg/storaged/index.html:441 pkg/storaged/index.html:517
-#: pkg/storaged/index.html:549 pkg/storaged/index.html:628
-msgctxt "storage"
-msgid "Capacity"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2412
+#: pkg/networkmanager/interfaces.js:2578
 msgid "Carrier"
 msgstr ""
 
@@ -1151,37 +1401,33 @@ msgstr ""
 msgid "Ceph Monitors"
 msgstr ""
 
-#: pkg/docker/index.html:649 pkg/systemd/index.html:332
-#: pkg/systemd/index.html:419 pkg/kubernetes/views/project-modify.html:74
+#: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
 #: pkg/kubernetes/views/route-modify.html:17
-#: pkg/kubernetes/views/pv-modify.html:204 pkg/storaged/overview.js:710
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
+#: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
-#: pkg/systemd/index.html:288
+#: pkg/systemd/index.html:318
 #, fuzzy
 msgid "Change Host Name"
 msgstr "Værtsnavn"
 
-#: pkg/shell/index.html:264
+#: pkg/shell/index.html:332
 msgid "Change Password"
 msgstr ""
 
-#: pkg/tuned/dialog.js:189
+#: pkg/tuned/dialog.js:191
 msgid "Change Performance Profile"
 msgstr ""
 
-#: pkg/tuned/dialog.js:198
+#: pkg/tuned/dialog.js:200
 msgid "Change Profile"
 msgstr ""
 
-#: pkg/ostree/index.html:134
-#, fuzzy
-msgid "Change Repository"
-msgstr "Værtsnavn"
-
-#: pkg/systemd/index.html:357
+#: pkg/systemd/index.html:387
 msgid "Change System Time"
 msgstr ""
 
@@ -1189,7 +1435,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/overview.js:702
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1197,57 +1443,74 @@ msgstr ""
 msgid "Change image stream"
 msgstr ""
 
+#: pkg/storaged/crypto-keyslots.jsx:219
+#, fuzzy
+msgid "Change passphrase"
+msgstr "Værtsnavn"
+
 #: pkg/kubernetes/views/project-modify.html:10
 msgid "Change project"
 msgstr ""
 
-#: pkg/docker/index.html:219
+#: pkg/docker/index.html:227
 msgid "Change resource limits"
 msgstr ""
 
-#: pkg/docker/index.html:601
+#: pkg/docker/index.html:609
 msgid "Change resources limits"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2960
+#: pkg/networkmanager/interfaces.js:3129
 msgid "Change the settings"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2959
+#: pkg/networkmanager/interfaces.js:3128
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/ostree/index.html:210
+#: pkg/packagekit/updates.jsx:174
 msgid "Check for Updates"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:741
+#: pkg/storaged/jobs-panel.jsx:47
+msgid "Checking $target"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:832
 msgid "Checking IP"
 msgstr ""
 
-#: pkg/storaged/jobs.js:140
+#: pkg/storaged/jobs-panel.jsx:63
 msgid "Checking RAID Device $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:141
+#: pkg/storaged/jobs-panel.jsx:64
 msgid "Checking and Repairing RAID Device $target"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:70
+#: pkg/apps/application-list.jsx:127
+msgid "Checking for new applications"
+msgstr ""
+
+#: pkg/lib/machine-change-auth.html:71
 msgid "Checking for public keys"
 msgstr ""
 
-#: pkg/ostree/app.js:315
-msgid "Checking for updates"
+#: pkg/systemd/host.js:469
+msgid "Checking for updates…"
 msgstr ""
 
-#: pkg/shell/simple.html:95 pkg/shell/index.html:115 pkg/shell/stub.html:108
+#: pkg/lib/cockpit-components-install-dialog.jsx:142
+msgid "Checking installed software"
+msgstr ""
+
+#: pkg/shell/index.html:117 pkg/shell/simple.html:85 pkg/shell/stub.html:100
 msgid "Choose the language to be used in the application"
 msgstr ""
 
-#: pkg/storaged/overview.js:434
+#: pkg/storaged/mdraids-panel.jsx:55
 msgid "Chunk Size"
 msgstr ""
 
@@ -1263,56 +1526,84 @@ msgstr ""
 msgid "Claim Name"
 msgstr ""
 
-#: pkg/storaged/jobs.js:132
+#: pkg/systemd/hwinfo.jsx:84
+msgid "Class"
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:55
 msgid "Cleaning up for $target"
+msgstr ""
+
+#: pkg/systemd/host.js:653
+msgid "Click to see system hardware information"
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:41
+msgid ""
+"Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr ""
 
 #: pkg/kubernetes/views/auth-form.html:88
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/networkmanager/index.html:830 pkg/storaged/index.html:704
-#: pkg/users/index.html:45 pkg/docker/index.html:721
-#: pkg/systemd/services.html:305 pkg/systemd/services.html:323
-#: pkg/systemd/index.html:277 pkg/shell/simple.html:82 pkg/shell/index.html:94
-#: pkg/shell/index.html:137 pkg/shell/index.html:275 pkg/shell/stub.html:130
-#: pkg/lib/machine-unknown-hostkey.html:19 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-change-port.html:45
-#: pkg/lib/machine-invalid-hostkey.html:19 pkg/sosreport/index.js:48
-#: pkg/sosreport/index.js:112
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:5
+#: pkg/shell/active-pages.js:102
+msgid "Close Selected Pages"
+msgstr ""
+
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
+#: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterTemplates.jsx:128
+msgid "Cluster Templates"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterVms.jsx:174
+msgid "Cluster Virtual Machines"
 msgstr ""
 
 #: cockpit.desktop.in.h:1
 msgid "Cockpit"
 msgstr ""
 
-#: src/ws/login.js:298
+#: src/ws/login.js:325
 msgid "Cockpit authentication is configured incorrectly."
 msgstr ""
 
-#: pkg/lib/machine-dialogs.js:431
+#: pkg/lib/machine-dialogs.js:428
 msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
 msgstr ""
 
-#: src/base1/cockpit.js:3939
+#: src/base1/cockpit.js:4018
 msgid "Cockpit could not contact the given host."
 msgstr ""
 
-#: pkg/shell/base_index.js:680
+#: pkg/shell/base_index.js:744
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
 "details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
 
-#: cockpit.appdata.xml.in.h:1
+#: cockpit.appdata.xml.in.h:2
 msgid ""
 "Cockpit is a server manager that makes it easy to administer your Linux "
 "servers via a web browser. Jumping between the terminal and the web tool is "
@@ -1321,15 +1612,11 @@ msgid ""
 "journal interface."
 msgstr ""
 
-#: pkg/shell/index.html:83
+#: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr ""
 
-#: pkg/shell/simple.html:71
-msgid "Cockpit is an interactive Linux server admin interface. "
-msgstr ""
-
-#: src/base1/cockpit.js:3937
+#: src/base1/cockpit.js:4016
 msgid "Cockpit is not compatible with the software on the system."
 msgstr ""
 
@@ -1337,11 +1624,11 @@ msgstr ""
 msgid "Cockpit is not installed"
 msgstr ""
 
-#: src/base1/cockpit.js:3931
+#: src/base1/cockpit.js:4010
 msgid "Cockpit is not installed on the system."
 msgstr ""
 
-#: cockpit.appdata.xml.in.h:2
+#: cockpit.appdata.xml.in.h:3
 msgid ""
 "Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
 "tasks such as storage administration, inspecting journals and starting and "
@@ -1384,18 +1671,21 @@ msgstr ""
 msgid "Color"
 msgstr ""
 
-#: pkg/docker/index.html:95
-msgid "Combined CPU usage"
-msgstr ""
-
-#: pkg/docker/index.html:101
+#: pkg/docker/index.html:102
 msgid "Combined memory usage"
 msgstr ""
 
-#: pkg/docker/index.html:259 pkg/docker/index.html:434
-#: pkg/docker/index.html:692 pkg/systemd/services.html:369
-#: pkg/docker/containers-view.jsx:124 pkg/docker/containers-view.jsx:267
-#: pkg/docker/containers-view.jsx:310
+#: pkg/docker/overview.js:89
+msgid "Combined usage of $0 CPU core"
+msgid_plural "Combined usage of $0 CPU cores"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/docker/index.html:267 pkg/docker/index.html:442
+#: pkg/docker/index.html:700 pkg/systemd/services.html:411
+#: node_modules/registry-image-widgets/views/image-config.html:2
+#: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr ""
 
@@ -1403,53 +1693,65 @@ msgstr ""
 msgid "Command can't be empty"
 msgstr ""
 
-#: pkg/docker/index.html:158
-#: bower_components/registry-image-widgets/views/image-config.html:2
+#: pkg/docker/index.html:162
 msgid "Command:"
 msgstr ""
 
-#: pkg/shell/index.html:216
+#: pkg/shell/index.html:281
 msgid "Comment"
 msgstr ""
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:701
-#: pkg/docker/containers-view.jsx:247
+#: pkg/docker/index.html:137 pkg/docker/index.html:709
+#: pkg/docker/containers-view.jsx:321
 msgid "Commit"
 msgstr ""
 
-#: pkg/docker/index.html:663
+#: pkg/docker/index.html:671
 msgid "Commit Image"
 msgstr ""
 
-#: pkg/tuned/dialog.js:114
+#: pkg/tuned/dialog.js:116
 msgid "Communication with tuned has failed"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:511
+#: pkg/lib/machine-info.es6:85
+msgid "Compact PCI"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:504
 msgid "Compatible with all systems and devices (MBR)"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:512
+#: pkg/storaged/content-views.jsx:506
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:198
+#: pkg/kdump/kdump-view.jsx:199
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:189
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
-#: pkg/realmd/operation.html:28
+#: pkg/realmd/operation.html:29
 msgid "Computer OU"
+msgstr ""
+
+#: pkg/systemd/init.js:663
+msgid "Condition $0=$1 was not met"
+msgstr ""
+
+#: pkg/systemd/services.html:136
+msgid "Condition failed"
 msgstr ""
 
 #: pkg/kubernetes/views/node-add.html:24
 msgid "Configuration"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2547
+#: pkg/networkmanager/interfaces.js:2713
 msgid "Configure"
 msgstr ""
 
@@ -1461,28 +1763,56 @@ msgstr ""
 msgid "Configure Kubelet and Proxy"
 msgstr ""
 
-#: pkg/docker/storage.jsx:307
+#: pkg/docker/storage.jsx:306
 msgid "Configure storage..."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:735
+#: pkg/networkmanager/interfaces.js:826
 msgid "Configuring"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:739
+#: pkg/networkmanager/interfaces.js:830
 msgid "Configuring IP"
 msgstr ""
 
-#: pkg/users/index.html:177 pkg/shell/index.html:250
+#: pkg/shell/index.html:317 pkg/users/index.html:192
 msgid "Confirm"
 msgstr ""
 
-#: pkg/users/index.html:249
+#: pkg/users/index.html:264
 msgid "Confirm New Password"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:155
+#: pkg/machines/components/deleteDialog.jsx:88
+msgid "Confirm deletion of $0"
+msgstr ""
+
+#: pkg/ovirt/components/OVirtTab.jsx:65
+msgid "Confirm migration"
+msgstr ""
+
+#: pkg/storaged/format-dialog.jsx:291
 msgid "Confirm passphrase"
+msgstr ""
+
+#: pkg/ovirt/components/VdsmView.jsx:95
+msgid "Confirm reload:"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:335
+msgid "Confirm removal with passphrase"
+msgstr ""
+
+#: pkg/ovirt/components/VdsmView.jsx:108
+msgid "Confirm save:"
+msgstr ""
+
+#: pkg/systemd/init.js:690
+msgid "Conflicted By"
+msgstr ""
+
+#: pkg/systemd/init.js:689
+msgid "Conflicts"
 msgstr ""
 
 #: pkg/kubernetes/views/auth-form.html:130
@@ -1491,12 +1821,24 @@ msgstr ""
 msgid "Connect"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2534
+#: pkg/networkmanager/interfaces.js:2700
 msgid "Connect automatically"
 msgstr ""
 
-#: src/ws/login.html:75
+#: src/ws/login.html:74
 msgid "Connect to"
+msgstr ""
+
+#: pkg/ovirt/components/InstallationDialog.jsx:102
+msgid "Connect to oVirt Engine"
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:189
+msgid "Connect with any $0 viewer application."
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:186
+msgid "Connect with any SPICE or VNC viewer application."
 msgstr ""
 
 #: pkg/lib/machine-add.html:39
@@ -1508,27 +1850,27 @@ msgstr ""
 msgid "Connecting to Docker"
 msgstr ""
 
-#: pkg/ostree/index.html:418
-msgid "Connecting to OSTree"
-msgstr ""
-
 #: pkg/selinux/setroubleshoot-view.jsx:352
 msgid "Connecting to SETroubleshoot daemon..."
 msgstr ""
 
-#: pkg/shell/indexes.js:317
+#: pkg/machines/components/libvirtSlate.jsx:97
+msgid "Connecting to Virtualization Service"
+msgstr ""
+
+#: pkg/shell/indexes.js:408
 msgid "Connecting to the machine"
 msgstr ""
 
-#: pkg/kubernetes/index.html:101 pkg/kubernetes/registry.html:71
+#: pkg/kubernetes/index.html:110 pkg/kubernetes/registry.html:71
 msgid "Connecting..."
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:349
+#: pkg/machines/hostvmslist.jsx:92
 msgid "Connection"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-dialog.html:4
+#: pkg/kubernetes/views/auth-dialog.html:4 pkg/dashboard/list.js:397
 msgid "Connection Error"
 msgstr ""
 
@@ -1540,23 +1882,35 @@ msgstr ""
 msgid "Connection Settings"
 msgstr ""
 
-#: src/base1/cockpit.js:3929
+#: src/base1/cockpit.js:4008
 msgid "Connection has timed out."
 msgstr ""
 
-#: pkg/networkmanager/index.html:842
+#: pkg/networkmanager/index.html:874
 msgid "Connection will be lost"
 msgstr ""
 
-#: pkg/docker/console.html:4 pkg/kubernetes/views/image-panel.html:12
-#: pkg/kubernetes/views/image-page.html:24
+#: pkg/systemd/init.js:688
+msgid "Consists Of"
+msgstr ""
+
+#: pkg/machines/components/consoles.jsx:78
+msgid "Console Type"
+msgstr ""
+
+#: pkg/machines/components/vm/vm.jsx:47
+msgid "Consoles"
+msgstr ""
+
+#: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
 #: pkg/kubernetes/views/container-page-inline.html:2
 #: pkg/kubernetes/views/container-panel.html:4
-#: pkg/kubernetes/views/container-body.html:4
+#: pkg/kubernetes/views/image-page.html:23
+#: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr ""
 
-#: pkg/users/local.js:700
+#: pkg/users/local.js:718
 msgid "Container Administrator"
 msgstr ""
 
@@ -1564,8 +1918,8 @@ msgstr ""
 msgid "Container ID"
 msgstr ""
 
-#: pkg/docker/index.html:427 pkg/docker/index.html:606
-#: pkg/docker/index.html:668
+#: pkg/docker/index.html:435 pkg/docker/index.html:614
+#: pkg/docker/index.html:676
 msgid "Container Name"
 msgstr ""
 
@@ -1573,34 +1927,34 @@ msgstr ""
 msgid "Container Runtime Version"
 msgstr ""
 
-#: pkg/docker/util.js:488
+#: pkg/docker/util.js:498
 msgid ""
 "Container is currently marked as not running, but regular stopping failed."
 msgstr ""
 
-#: pkg/docker/util.js:486
+#: pkg/docker/util.js:496
 msgid "Container is currently running."
 msgstr ""
 
-#: pkg/docker/index.html:140
+#: pkg/docker/index.html:141
 msgid "Container:"
 msgstr ""
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:277
-#: pkg/kubernetes/views/pod-page.html:36
+#: pkg/docker/index.html:23 pkg/docker/index.html:285
 #: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
-#: pkg/kubernetes/views/dashboard-page.html:199 pkg/kubernetes/index.html:52
-#: pkg/docker/containers-view.jsx:283
+#: pkg/kubernetes/views/dashboard-page.html:199
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr ""
 
-#: pkg/docker/details.js:46
+#: pkg/docker/details.js:48
 msgctxt "page-title"
 msgid "Containers"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:542
+#: pkg/storaged/content-views.jsx:539
 msgid "Content"
 msgstr ""
 
@@ -1615,7 +1969,16 @@ msgctxt "key"
 msgid "Control"
 msgstr ""
 
-#: pkg/docker/storage.jsx:407
+#: pkg/lib/machine-info.es6:90
+msgid "Convertible"
+msgstr ""
+
+#: pkg/machines/components/vcpuModal.jsx:186
+#: pkg/ovirt/components/vcpuModal.jsx:62
+msgid "Cores per socket"
+msgstr ""
+
+#: pkg/docker/storage.jsx:399
 msgid "Could not add all disks"
 msgstr ""
 
@@ -1627,15 +1990,15 @@ msgstr ""
 msgid "Could not list services"
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:407
+#: src/ws/cockpitcertificate.c:531
 msgid "Could not parse PEM-encoded certificate"
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:374
+#: src/ws/cockpitcertificate.c:498
 msgid "Could not parse PEM-encoded private key"
 msgstr ""
 
-#: pkg/docker/storage.jsx:448
+#: pkg/docker/storage.jsx:439
 msgid "Could not reset the storage pool"
 msgstr ""
 
@@ -1647,11 +2010,11 @@ msgstr ""
 msgid "Couldn't change user password"
 msgstr ""
 
-#: pkg/kubernetes/index.html:102 pkg/kubernetes/registry.html:72
+#: pkg/kubernetes/index.html:111 pkg/kubernetes/registry.html:72
 msgid "Couldn't connect to server"
 msgstr ""
 
-#: pkg/shell/indexes.js:320
+#: pkg/shell/indexes.js:411
 msgid "Couldn't connect to the machine"
 msgstr ""
 
@@ -1660,7 +2023,7 @@ msgid "Couldn't create new users"
 msgstr ""
 
 #: pkg/kubernetes/scripts/connection.js:512
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:925
+#: pkg/kubernetes/scripts/kube-client-cockpit.js:978
 msgid "Couldn't find running API server"
 msgstr ""
 
@@ -1678,63 +2041,93 @@ msgstr ""
 msgid "Couldn't list users"
 msgstr ""
 
-#: pkg/ostree/remotes.js:175
-msgid "Couldn't load settings for '$0': $1"
-msgstr ""
-
 #: src/bridge/cockpitdbussetup.c:382
 msgid "Couldn't load user data"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:340 pkg/kdump/kdump-view.jsx:508
+#: pkg/kdump/kdump-view.jsx:342 pkg/kdump/kdump-view.jsx:511
 msgid "Crash dump location"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:311
+#: pkg/kdump/kdump-view.jsx:313
 msgid "Crash system"
 msgstr ""
 
-#: pkg/users/index.html:211 pkg/kubernetes/views/add-group-dialog.html:19
-#: pkg/kubernetes/views/project-modify.html:72 pkg/storaged/details.js:159
-#: pkg/storaged/lvol-tabs.jsx:132 pkg/storaged/overview.js:464
-#: pkg/storaged/overview.js:509 pkg/storaged/content-views.jsx:120
-#: pkg/storaged/content-views.jsx:727
+#: pkg/kubernetes/views/add-group-dialog.html:19
+#: pkg/kubernetes/views/project-modify.html:72 pkg/users/index.html:226
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
+#: pkg/ovirt/components/ClusterTemplates.jsx:76
 msgid "Create"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:673
+#: pkg/storaged/content-views.jsx:621
 msgid "Create Logical Volume"
 msgstr ""
 
-#: pkg/users/index.html:52 pkg/users/index.html:149
+#: pkg/machines/components/diskAdd.jsx:336
+msgid "Create New"
+msgstr ""
+
+#: pkg/users/index.html:52 pkg/users/index.html:164
 msgid "Create New Account"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:404
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:427
+#: pkg/ovirt/components/App.jsx:155
+msgid "Create New VM"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:386
+msgid "Create New Virtual Machine"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:416
 msgid "Create Partition"
 msgstr ""
 
-#: pkg/storaged/overview.js:417
+#: pkg/storaged/mdraids-panel.jsx:38
 msgid "Create RAID Device"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:115 pkg/storaged/lvol-tabs.jsx:151
+#: pkg/sosreport/index.html:36
+#, fuzzy
+msgid "Create Report"
+msgstr "Værtsnavn"
+
+#: pkg/storaged/lvol-tabs.jsx:250 pkg/storaged/lvol-tabs.jsx:352
 msgid "Create Snapshot"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:104 pkg/storaged/content-views.jsx:131
+#: pkg/storaged/content-views.jsx:100 pkg/storaged/content-views.jsx:125
 msgid "Create Thin Volume"
 msgstr ""
 
-#: pkg/systemd/services.html:58
+#: pkg/systemd/services.html:59
 msgid "Create Timer"
 msgstr ""
 
-#: pkg/systemd/services.html:335
+#: pkg/systemd/services.html:377
 msgid "Create Timers"
 msgstr ""
 
-#: pkg/storaged/overview.js:490
+#: pkg/storaged/vdos-panel.jsx:48
+msgid "Create VDO Device"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterTemplates.jsx:81
+msgid "Create VM"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:42
+msgid "Create Virtual Machine"
+msgstr ""
+
+#: pkg/storaged/vgroups-panel.jsx:53
 msgid "Create Volume Group"
 msgstr ""
 
@@ -1742,7 +2135,7 @@ msgstr ""
 msgid "Create diagnostic report"
 msgstr ""
 
-#: pkg/kubernetes/scripts/images.js:634
+#: pkg/kubernetes/scripts/images.js:631
 msgid "Create empty image stream"
 msgstr ""
 
@@ -1750,106 +2143,106 @@ msgstr ""
 msgid "Create image stream"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3632 pkg/networkmanager/interfaces.js:3825
-#: pkg/networkmanager/interfaces.js:4064 pkg/networkmanager/interfaces.js:4270
+#: pkg/networkmanager/interfaces.js:3793 pkg/networkmanager/interfaces.js:3986
+#: pkg/networkmanager/interfaces.js:4225 pkg/networkmanager/interfaces.js:4431
 msgid "Create it"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:746
+#: pkg/storaged/content-views.jsx:690
 msgid "Create new Logical Volume"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:192
+#: pkg/storaged/format-dialog.jsx:303
 msgid "Create partition"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:39
+#: pkg/storaged/format-dialog.jsx:174
 msgid "Create partition on $0"
 msgstr ""
 
-#: pkg/storaged/index.html:379 pkg/storaged/content-views.jsx:537
+#: pkg/storaged/content-views.jsx:534
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/sosreport/index.html:36
-msgid "Create report"
-msgstr ""
-
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
 #: pkg/kubernetes/views/service-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/docker/containers-view.jsx:122 pkg/docker/containers-view.jsx:311
-#: pkg/docker/containers-view.jsx:583
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
-#: pkg/docker/index.html:150
+#: pkg/docker/index.html:151
 msgid "Created:"
 msgstr ""
 
-#: pkg/storaged/jobs.js:139
+#: pkg/storaged/jobs-panel.jsx:62
 msgid "Creating RAID Device $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:127
+#: pkg/storaged/jobs-panel.jsx:50
 msgid "Creating filesystem on $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:153
+#: pkg/storaged/jobs-panel.jsx:76
 msgid "Creating logical volume $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:131
+#: pkg/storaged/jobs-panel.jsx:54
 msgid "Creating partition $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:147
+#: pkg/storaged/jobs-panel.jsx:70
 msgid "Creating snapshot of $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4269
+#: pkg/networkmanager/interfaces.js:4430
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3631
+#: pkg/networkmanager/interfaces.js:3792
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4063
+#: pkg/networkmanager/interfaces.js:4224
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3824
+#: pkg/networkmanager/interfaces.js:3985
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/storaged/jobs.js:148
+#: pkg/storaged/jobs-panel.jsx:71
 msgid "Creating volume group $target"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:408
+msgid "Creation of vm $0 failed"
+msgstr ""
+
+#: pkg/systemd/logs.html:57
+msgid "Critical and above"
 msgstr ""
 
 #: pkg/systemd/logs.html:42
 msgid "Current boot"
 msgstr ""
 
-#: pkg/ostree/index.html:184
-msgid "Currently using:"
-msgstr ""
-
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/format-dialog.jsx:174
+#: pkg/storaged/format-dialog.jsx:75
 msgid "Custom"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:112
+#: pkg/storaged/format-dialog.jsx:248
 msgid "Custom (Enter filesystem type)"
 msgstr ""
 
@@ -1857,15 +2250,29 @@ msgstr ""
 msgid "Custom URL"
 msgstr ""
 
-#: pkg/storaged/index.html:452
+#: pkg/storaged/format-dialog.jsx:148
+msgid "Custom encryption options"
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:172
+#, fuzzy
+msgid "Custom mount option"
+msgstr "Indstillinger"
+
+#: pkg/storaged/format-dialog.jsx:112
+#, fuzzy
+msgid "Custom mount options"
+msgstr "Indstillinger"
+
+#: pkg/storaged/drive-details.jsx:49
 msgid "DISK IS FAILING"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3121
+#: pkg/networkmanager/interfaces.js:3290
 msgid "DNS"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2478
+#: pkg/networkmanager/interfaces.js:2644
 msgid "DNS $val"
 msgstr ""
 
@@ -1873,11 +2280,11 @@ msgstr ""
 msgid "DNS Policy"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3125
+#: pkg/networkmanager/interfaces.js:3294
 msgid "DNS Search Domains"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2481
+#: pkg/networkmanager/interfaces.js:2647
 msgid "DNS Search Domains $val"
 msgstr ""
 
@@ -1885,54 +2292,64 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:204
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:225
+#: pkg/storaged/content-views.jsx:245
 msgid "Deactivate"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:747
+#: pkg/networkmanager/interfaces.js:838
 msgid "Deactivating"
 msgstr ""
 
-#: pkg/storaged/jobs.js:146
+#: pkg/storaged/jobs-panel.jsx:69
 msgid "Deactivating $target"
 msgstr ""
 
-#: pkg/docker/index.html:347 pkg/docker/index.html:351
-#: pkg/ostree/index.html:253
-#: bower_components/registry-image-widgets/views/image-config.html:10
-#: pkg/storaged/fsys-tab.jsx:125 pkg/storaged/format-dialog.jsx:173
+#: pkg/systemd/logs.html:62
+msgid "Debug and above"
+msgstr ""
+
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
+msgid "Deduplication"
+msgstr ""
+
+#: pkg/docker/index.html:355 pkg/docker/index.html:359
+#: node_modules/registry-image-widgets/views/image-config.html:10
+#: pkg/storaged/format-dialog.jsx:74
 #: pkg/subscriptions/subscriptions-register.jsx:101
 msgid "Default"
 msgstr ""
 
-#: pkg/systemd/index.html:437
+#: pkg/systemd/index.html:467
 msgid "Delay"
 msgstr ""
 
-#: pkg/networkmanager/index.html:575 pkg/users/index.html:77
-#: pkg/users/index.html:296 pkg/docker/index.html:135 pkg/docker/index.html:236
-#: pkg/ostree/index.html:38 pkg/kubernetes/views/item-delete.html:11
-#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/docker/index.html:136 pkg/docker/index.html:244
 #: pkg/kubernetes/views/image-delete.html:8
 #: pkg/kubernetes/views/imagestream-delete.html:8
+#: pkg/kubernetes/views/item-delete.html:11
+#: pkg/kubernetes/views/node-delete.html:15
+#: pkg/kubernetes/views/project-delete.html:9
+#: pkg/kubernetes/views/pv-delete.html:11
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
-#: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/pv-delete.html:11 pkg/storaged/details.js:132
-#: pkg/storaged/details.js:182 pkg/storaged/details.js:431
-#: pkg/storaged/details.js:514 pkg/storaged/content-views.jsx:257
-#: pkg/storaged/content-views.jsx:275 pkg/docker/details.js:272
-#: pkg/docker/containers-view.jsx:169 pkg/docker/containers-view.jsx:453
-#: pkg/docker/image.js:140 pkg/kubernetes/scripts/volumes.js:218
+#: pkg/networkmanager/index.html:607 pkg/users/index.html:79
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
+#: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
+#: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
+#: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
+#: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
+#: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
+#: pkg/storaged/vgroup-details.jsx:215 pkg/storaged/vgroup-details.jsx:238
 msgid "Delete"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2265 pkg/users/local.js:1033
-#: pkg/docker/containers-view.jsx:452
+#: pkg/networkmanager/interfaces.js:2428 pkg/users/local.js:1123
 msgid "Delete $0"
 msgstr ""
 
@@ -1940,7 +2357,7 @@ msgstr ""
 msgid "Delete '{{ name }}'"
 msgstr ""
 
-#: pkg/users/index.html:290
+#: pkg/users/index.html:403
 msgid "Delete Files"
 msgstr ""
 
@@ -1964,6 +2381,10 @@ msgstr ""
 msgid "Delete Selected"
 msgstr ""
 
+#: pkg/machines/components/deleteDialog.jsx:54
+msgid "Delete associated storage files:"
+msgstr ""
+
 #: pkg/kubernetes/views/imagestream-delete.html:3
 msgid "Delete image stream"
 msgstr ""
@@ -1972,11 +2393,11 @@ msgstr ""
 msgid "Delete {{ item.kind }}"
 msgstr ""
 
-#: pkg/storaged/jobs.js:130 pkg/storaged/jobs.js:144
+#: pkg/storaged/jobs-panel.jsx:53 pkg/storaged/jobs-panel.jsx:67
 msgid "Deleting $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2264
+#: pkg/networkmanager/interfaces.js:2427
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1988,39 +2409,36 @@ msgid ""
 "automatically created again in some cases."
 msgstr ""
 
-#: pkg/storaged/details.js:133
+#: pkg/storaged/mdraid-details.jsx:304
 msgid "Deleting a RAID device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/details.js:271 pkg/docker/containers-view.jsx:168
+#: pkg/storaged/vdo-details.jsx:193
+msgid "Deleting a VDO device will erase all data on it."
+msgstr ""
+
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:244
+#: pkg/storaged/content-views.jsx:264
 msgid "Deleting a logical volume will delete all data in it."
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:247
+#: pkg/storaged/content-views.jsx:267
 msgid "Deleting a partition will delete all data in it."
 msgstr ""
 
-#: pkg/storaged/details.js:181
+#: pkg/storaged/vgroup-details.jsx:214
 msgid "Deleting a volume group will erase all data on it."
 msgstr ""
 
-#: pkg/docker/image.js:139
-msgid ""
-"Deleting an image will delete it, but you can probably download it again if "
-"you need it later.  Unless this image has never been pushed to a repository, "
-"that is, in which case you probably can't download it again."
-msgstr ""
-
-#: pkg/storaged/jobs.js:149
+#: pkg/storaged/jobs-panel.jsx:72
 msgid "Deleting volume group $target"
 msgstr ""
 
-#: pkg/kubernetes/views/deploy.html:62
 #: pkg/kubernetes/views/dashboard-page.html:131
+#: pkg/kubernetes/views/deploy.html:62
 msgid "Deploy"
 msgstr ""
 
@@ -2038,50 +2456,53 @@ msgid "Deployment Config"
 msgstr ""
 
 #: pkg/kubernetes/views/details-page.html:98
-#: pkg/kubernetes/scripts/details.js:221
+#: pkg/kubernetes/scripts/details.js:222
 msgid "Deployment Configs"
 msgstr ""
 
-#: pkg/systemd/services.html:355 pkg/kubernetes/views/project-modify.html:40
 #: pkg/kubernetes/views/project-listing.html:15
 #: pkg/kubernetes/views/project-listing.html:54
-#: bower_components/registry-image-widgets/views/image-body.html:6
-#: pkg/systemd/init.js:270
+#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
+#: node_modules/registry-image-widgets/views/image-body.html:6
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/ovirt/components/ClusterVms.jsx:83
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/shell/index.html:185 pkg/kubernetes/index.html:64
-#: pkg/subscriptions/subscriptions-view.jsx:209
-#: pkg/docker/containers-view.jsx:254 pkg/docker/containers-view.jsx:402
-#: pkg/docker/containers-view.jsx:412
+#: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
+msgid "Description:"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:62
+msgid "Desktop"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:91
+msgid "Detachable"
+msgstr ""
+
+#: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
-#: pkg/storaged/index.html:541
-msgctxt "storage"
-msgid "Device"
-msgstr ""
-
-#: pkg/storaged/utils.js:407
-msgid "Device $0 is a member of RAID Array $1"
-msgstr ""
-
-#: pkg/storaged/utils.js:413
-msgid "Device $0 is a physical volume of $1"
-msgstr ""
-
-#: pkg/storaged/utils.js:401
-msgid "Device $0 is mounted on $1"
-msgstr ""
-
-#: pkg/storaged/index.html:465 pkg/storaged/index.html:471
-#: pkg/storaged/index.html:513
+#: pkg/machines/components/vmDiskSourceCell.jsx:37
+#: pkg/machines/components/vmDisksTab.jsx:57
 #, fuzzy
-msgctxt "storage"
+msgid "Device"
+msgstr "Værtsnavn"
+
+#: pkg/storaged/vdo-details.jsx:263
+#, fuzzy
 msgid "Device File"
 msgstr "Værtsnavn"
 
-#: pkg/storaged/content-views.jsx:536 pkg/storaged/format-dialog.jsx:264
+#: pkg/storaged/content-views.jsx:533 pkg/storaged/format-dialog.jsx:387
 msgid "Device is read-only"
 msgstr ""
 
@@ -2089,63 +2510,86 @@ msgstr ""
 msgid "Diagnostic reports"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-body.html:20
+#: node_modules/registry-image-widgets/views/image-body.html:22
 msgid "Digest"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:28
-#: bower_components/registry-image-widgets/views/image-config.html:11
+#: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:85
 msgid "Directory"
 msgstr ""
 
-#: pkg/kdump/kdump-client.es6:114
+#: pkg/kdump/kdump-client.es6:115
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr ""
 
-#: pkg/systemd/init.js:541
+#: pkg/systemd/init.js:543
 msgid "Disable"
 msgstr ""
 
-#: pkg/tuned/dialog.js:232
+#: pkg/tuned/dialog.js:234
 msgid "Disable tuned"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1827 pkg/systemd/init.js:303
+#: pkg/networkmanager/interfaces.js:1958 pkg/systemd/init.js:304
 msgid "Disabled"
 msgstr ""
 
-#: pkg/shell/simple.html:111 pkg/shell/indexes.js:126 pkg/shell/indexes.js:497
+#: pkg/machines/components/serialConsole.jsx:133
+msgid "Disconnect"
+msgstr ""
+
+#: pkg/shell/simple.html:101 pkg/shell/indexes.js:152 pkg/shell/indexes.js:600
 msgid "Disconnected"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:835
+#: pkg/machines/components/serialConsole.jsx:134
+msgid "Disconnected from serial console. Click the Reconnect button."
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:723 pkg/kubernetes/scripts/nodes.js:839
+#: pkg/storaged/vdos-panel.jsx:59
 #, fuzzy
 msgid "Disk"
 msgstr "Disk I/O"
 
-#: pkg/systemd/index.html:206 pkg/dashboard/index.html:73
+#: pkg/dashboard/index.html:73 pkg/systemd/index.html:235
 #, fuzzy
 msgid "Disk I/O"
 msgstr "Disk I/O"
 
-#: pkg/kubernetes/scripts/nodes.js:720
+#: pkg/kubernetes/scripts/nodes.js:724
 msgid "Disk Utilization: $0%"
 msgstr ""
 
-#: pkg/storaged/index.html:455
+#: pkg/machines/components/diskAdd.jsx:435
+msgid "Disk failed to be attached with following error: "
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:422
+msgid "Disk failed to be created with following error: "
+msgstr ""
+
+#: pkg/storaged/drive-details.jsx:50
 msgid "Disk is OK"
 msgstr ""
 
-#: pkg/storaged/index.html:582 pkg/storaged/details.js:69
-#: pkg/storaged/details.js:202 pkg/storaged/overview.js:451
-#: pkg/storaged/overview.js:498
+#: pkg/storaged/crypto-keyslots.jsx:152
+msgid "Disk passphrase"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 #, fuzzy
 msgid "Disks"
 msgstr "Disk I/O"
 
-#: pkg/shell/simple.html:37 pkg/shell/simple.html:92 pkg/shell/index.html:37
-#: pkg/shell/index.html:112 pkg/shell/stub.html:37 pkg/shell/stub.html:105
+#: pkg/shell/index.html:52 pkg/shell/index.html:114 pkg/shell/simple.html:38
+#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
 msgid "Display Language"
 msgstr ""
 
@@ -2192,7 +2636,7 @@ msgid ""
 "{{ fields.member.metadata.name }}?"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-meta.html:11
+#: node_modules/registry-image-widgets/views/image-meta.html:10
 #, fuzzy
 msgid "Docker Version"
 msgstr "Version"
@@ -2201,39 +2645,45 @@ msgstr "Version"
 msgid "Docker is not installed or activated on the system"
 msgstr ""
 
-#: pkg/systemd/index.html:107
+#: pkg/lib/machine-info.es6:71
+#, fuzzy
+msgid "Docking Station"
+msgstr "Indstillinger"
+
+#: pkg/systemd/index.html:124
 msgid "Domain"
 msgstr ""
 
-#: pkg/realmd/operation.js:148
+#: pkg/realmd/operation.js:162
 msgid "Domain $0 could not be contacted"
 msgstr ""
 
-#: pkg/realmd/operation.js:219
+#: pkg/realmd/operation.js:236
 msgid "Domain $0 is not supported"
 msgstr ""
 
-#: pkg/realmd/operation.html:11
+#: pkg/realmd/operation.html:12
 msgid "Domain Address"
 msgstr ""
 
-#: pkg/realmd/operation.html:59
+#: pkg/realmd/operation.html:60
 msgid "Domain Administrator Name"
 msgstr ""
 
-#: pkg/realmd/operation.html:65
+#: pkg/realmd/operation.html:66
 msgid "Domain Administrator Password"
 msgstr ""
 
-#: pkg/systemd/services.html:425 pkg/systemd/services.html:429
+#: pkg/systemd/services.html:467 pkg/systemd/services.html:471
+#: pkg/systemd/init.js:1168
 msgid "Don't Repeat"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:504 pkg/storaged/format-dialog.jsx:128
+#: pkg/storaged/content-views.jsx:498 pkg/storaged/format-dialog.jsx:271
 msgid "Don't overwrite existing data"
 msgstr ""
 
-#: pkg/kubernetes/scripts/images.js:624
+#: pkg/kubernetes/scripts/images.js:621
 msgid "Don't pull images automatically"
 msgstr ""
 
@@ -2241,23 +2691,39 @@ msgstr ""
 msgid "Done!"
 msgstr ""
 
-#: pkg/ostree/index.html:319 pkg/ostree/index.html:349
-msgid "Downgrades"
+#: pkg/docker/index.html:595
+msgid "Download"
 msgstr ""
 
-#: pkg/docker/index.html:587
-msgid "Download"
+#: src/ws/login.html:118
+msgid "Download a new browser for free"
 msgstr ""
 
 #: pkg/sosreport/index.html:64
 msgid "Download report"
 msgstr ""
 
-#: pkg/storaged/index.html:409 pkg/docker/storage.jsx:160
+#: pkg/machines/components/desktopConsole.jsx:47
+msgid "Download the MSI from $0"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:57
+msgid "Downloaded"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:49
+msgid "Downloading"
+msgstr ""
+
+#: pkg/lib/cockpit-components-install-dialog.jsx:179
+msgid "Downloading $0"
+msgstr ""
+
+#: pkg/docker/storage.jsx:160 pkg/storaged/drive-details.jsx:63
 msgid "Drive"
 msgstr ""
 
-#: pkg/storaged/overview.js:194 pkg/storaged/overview.js:196
+#: pkg/storaged/drives-panel.jsx:97 pkg/storaged/drives-panel.jsx:99
 msgctxt "storage"
 msgid "Drive"
 msgstr ""
@@ -2266,8 +2732,12 @@ msgstr ""
 msgid "Driver"
 msgstr ""
 
-#: pkg/storaged/index.html:164
+#: pkg/storaged/drives-panel.jsx:119
 msgid "Drives"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:192
+msgid "Drop file here to upload."
 msgstr ""
 
 #: pkg/docker/run.js:348
@@ -2278,7 +2748,7 @@ msgstr ""
 msgid "Duplicate port"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:132
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2286,12 +2756,28 @@ msgstr ""
 msgid "Edit Server"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/imagestream-body.html:7
+#: pkg/storaged/crypto-keyslots.jsx:240
+msgid "Edit Tang keyserver"
+msgstr ""
+
+#: node_modules/registry-image-widgets/views/imagestream-body.html:7
 msgid "Edit image stream"
 msgstr ""
 
-#: pkg/storaged/jobs.js:117
+#: pkg/ovirt/components/VdsmView.jsx:125
+msgid "Edit the vdsm.conf"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:507
+msgid "Editing a key requires a free slot"
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:36
 msgid "Ejecting $target"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:93
+msgid "Embedded PC"
 msgstr ""
 
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:46
@@ -2309,40 +2795,72 @@ msgstr ""
 msgid "Empty Directory"
 msgstr ""
 
-#: pkg/storaged/jobs.js:152
+#: pkg/storaged/jobs-panel.jsx:75
 msgid "Emptying $target"
 msgstr ""
 
-#: pkg/systemd/init.js:539
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:57
+msgid "Emulated Machine:"
+msgstr ""
+
+#: pkg/systemd/init.js:541
 msgid "Enable"
 msgstr ""
 
-#: pkg/systemd/init.js:540
+#: pkg/systemd/init.js:542
 msgid "Enable Forcefully"
 msgstr ""
 
-#: pkg/systemd/init.js:302
+#: pkg/networkmanager/index.html:50
+msgid "Enable Service"
+msgstr ""
+
+#: pkg/systemd/index.html:187
+msgid "Enable persistent metrics…"
+msgstr ""
+
+#: pkg/systemd/init.js:303
 msgid "Enabled"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:106
+#: pkg/storaged/utils.js:245
+msgid "Encrypted $0"
+msgstr ""
+
+#: pkg/storaged/format-dialog.jsx:241
 msgid "Encrypted EXT4 (LUKS)"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:105
+#: pkg/storaged/utils.js:237
+msgid "Encrypted Logical Volume of $0"
+msgstr ""
+
+#: pkg/storaged/utils.js:239
+msgid "Encrypted Partition of $0"
+msgstr ""
+
+#: pkg/storaged/format-dialog.jsx:240
 msgid "Encrypted XFS (LUKS)"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:304
+#: pkg/storaged/content-views.jsx:334
 msgctxt "storage-id-desc"
 msgid "Encrypted data"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:144
+#: pkg/storaged/lvol-tabs.jsx:287
+msgid "Encrypted volumes can not be resized here."
+msgstr ""
+
+#: pkg/storaged/lvol-tabs.jsx:290
+msgid "Encrypted volumes need to be unlocked before they can be resized."
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:138
 msgid "Encryption"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:99 pkg/storaged/format-dialog.jsx:167
+#: pkg/storaged/crypto-tab.jsx:104 pkg/storaged/format-dialog.jsx:140
 msgid "Encryption Options"
 msgstr ""
 
@@ -2354,8 +2872,8 @@ msgstr ""
 msgid "Endpoint Name"
 msgstr ""
 
-#: pkg/kubernetes/views/service-panel.html:9
 #: pkg/kubernetes/views/service-page.html:14
+#: pkg/kubernetes/views/service-panel.html:9
 msgid "Endpoints"
 msgstr ""
 
@@ -2367,8 +2885,16 @@ msgstr ""
 msgid "Enforce policy:"
 msgstr ""
 
-#: pkg/lib/machine-dialogs.js:449
+#: pkg/systemd/host.js:453
+msgid "Enhancement Updates Available"
+msgstr ""
+
+#: pkg/lib/machine-dialogs.js:446
 msgid "Enter IP address or host name"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterTemplates.jsx:74
+msgid "Enter New VM name"
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:57
@@ -2377,55 +2903,55 @@ msgid ""
 "time you reconnect to this machine"
 msgstr ""
 
-#: pkg/systemd/logs.html:61
+#: pkg/systemd/logs.html:73
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:309
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
-#: pkg/docker/index.html:515 pkg/kubernetes/views/container-body.html:26
-#: bower_components/registry-image-widgets/views/image-config.html:21
+#: pkg/docker/index.html:523 pkg/kubernetes/views/container-body.html:26
+#: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:502 pkg/storaged/format-dialog.jsx:126
+#: pkg/storaged/content-views.jsx:496 pkg/storaged/format-dialog.jsx:269
 msgid "Erase"
 msgstr ""
 
-#: pkg/docker/storage.jsx:426
+#: pkg/docker/storage.jsx:418
 msgid "Erase containers and reset storage pool"
 msgstr ""
 
-#: pkg/docker/storage.jsx:362
-msgid "Erase containers, reformat disks, and add them"
-msgstr ""
-
-#: pkg/storaged/jobs.js:126
+#: pkg/storaged/jobs-panel.jsx:49
 msgid "Erasing $target"
 msgstr ""
 
+#: pkg/packagekit/updates.jsx:307
+msgid "Errata:"
+msgstr ""
+
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:317 pkg/storaged/devices.js:118
-#: pkg/storaged/storage-controls.jsx:68 pkg/storaged/details.js:268
-#: pkg/storaged/overview.js:692 pkg/users/local.js:1169
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
+msgstr ""
+
+#: pkg/systemd/logs.html:58
+msgid "Error and above"
 msgstr ""
 
 #: pkg/kubernetes/scripts/connection.js:648
 msgid "Error getting certificate details: $0"
 msgstr ""
 
-#: pkg/ostree/remotes.js:321
-msgid "Error loading remotes: $0"
-msgstr ""
-
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
 msgstr ""
 
-#: pkg/docker/util.js:489
+#: pkg/docker/util.js:499
 msgid "Error message from Docker:"
 msgstr ""
 
@@ -2433,11 +2959,11 @@ msgstr ""
 msgid "Error saving authorized keys: "
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:192
+#: pkg/selinux/setroubleshoot-client.js:193
 msgid "Error while deleting alert: $0"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot.js:65
+#: pkg/selinux/setroubleshoot.js:66
 msgid "Error while setting SELinux mode: '$0'"
 msgstr ""
 
@@ -2445,91 +2971,83 @@ msgstr ""
 msgid "Error writing kubectl config"
 msgstr ""
 
-#: pkg/systemd/logs.html:48
-msgid "Errors"
-msgstr ""
-
-#: pkg/networkmanager/index.html:800
+#: pkg/networkmanager/index.html:832
 msgid "Ethernet MAC"
 msgstr ""
 
-#: pkg/networkmanager/index.html:776
+#: pkg/networkmanager/index.html:808
 msgid "Ethernet MTU"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1873
+#: pkg/networkmanager/interfaces.js:2004
 msgid "Ethtool"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:101
+#: pkg/systemd/logs.html:54 pkg/docker/containers-view.jsx:103
 msgid "Everything"
 msgstr ""
 
-#: pkg/users/local.js:445 pkg/users/local.js:1118
+#: pkg/users/local.js:447 pkg/users/local.js:1349
 msgid "Excellent password"
 msgstr ""
 
-#: pkg/docker/util.js:95
+#: pkg/docker/util.js:100
 msgid "Exited $ExitCode"
 msgstr ""
 
-#: pkg/ostree/index.html:290
-msgid "Expired Signature"
+#: pkg/lib/machine-info.es6:77
+msgid "Expansion Chassis"
 msgstr ""
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:505
 msgid "Expose container ports"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:423 pkg/storaged/format-dialog.jsx:109
+#: pkg/storaged/content-views.jsx:436 pkg/storaged/format-dialog.jsx:245
 msgid "Extended Partition"
 msgstr ""
 
-#: pkg/storaged/details.js:407
+#: pkg/storaged/mdraid-details.jsx:99
 msgid "FAILED"
 msgstr ""
 
-#: pkg/machines/libvirt.es6:174
-msgid "FORCEOFF_VM action failed"
+#: pkg/ovirt/components/InstallationDialog.jsx:47
+msgid "FQDN"
 msgstr ""
 
-#: pkg/machines/libvirt.es6:194
-msgid "FORCEREBOOT_VM action failed"
-msgstr ""
-
-#: pkg/ostree/index.html:258 pkg/networkmanager/interfaces.js:749
+#: pkg/networkmanager/interfaces.js:840
 msgid "Failed"
 msgstr ""
 
-#: pkg/lib/machine-dialogs.js:414
+#: pkg/lib/machine-dialogs.js:411
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/users/local.js:112 pkg/users/local.js:143 pkg/lib/credentials.js:224
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:187
+#: pkg/selinux/setroubleshoot-client.js:188
 msgid "Failed to delete alert: $0"
 msgstr ""
 
-#: pkg/tuned/dialog.js:169
+#: pkg/tuned/dialog.js:171
 msgid "Failed to disable tuned"
 msgstr ""
 
-#: pkg/tuned/dialog.js:133
+#: pkg/tuned/dialog.js:135
 msgid "Failed to disable tuned profile"
 msgstr ""
 
-#: pkg/lib/machine-dialogs.js:496
+#: pkg/lib/machine-dialogs.js:493
 msgid "Failed to edit machine: $0"
 msgstr ""
 
-#: pkg/tuned/dialog.js:167
+#: pkg/tuned/dialog.js:169
 msgid "Failed to enable tuned"
 msgstr ""
 
-#: pkg/users/index.html:332
+#: pkg/users/index.html:445
 msgid "Failed to load authorized keys."
 msgstr ""
 
@@ -2537,27 +3055,36 @@ msgstr ""
 msgid "Failed to start Docker: $0"
 msgstr ""
 
-#: pkg/docker/util.js:542
+#: pkg/docker/util.js:552
 msgid "Failed to stop Docker scope: $0"
 msgstr ""
 
-#: pkg/tuned/dialog.js:145
+#: pkg/tuned/dialog.js:147
 msgid "Failed to switch profile"
+msgstr ""
+
+#: pkg/machines/components/vcpuModal.jsx:171
+msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:204
 msgid "Fibre Channel"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:142
+#: pkg/machines/components/vmDiskSourceCell.jsx:36
+msgid "File"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:227
+#: pkg/storaged/content-views.jsx:136
 msgid "Filesystem"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:120
+#: pkg/storaged/fsys-tab.jsx:117
 msgid "Filesystem Mounting"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:68
+#: pkg/storaged/fsys-tab.jsx:67
 msgid "Filesystem Name"
 msgstr ""
 
@@ -2568,27 +3095,34 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
-#: pkg/kubernetes/views/pv-modify.html:180
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:141
+#: pkg/storaged/format-dialog.jsx:279
 msgid "Filesystem type"
 msgstr ""
 
-#: pkg/storaged/index.html:223
+#: pkg/storaged/fsys-panel.jsx:103
 msgid "Filesystems"
 msgstr ""
 
-#: pkg/shell/index.html:224 pkg/lib/machine-unknown-hostkey.html:10
+#: pkg/networkmanager/firewall.jsx:182
+msgid "Filter Services"
+msgstr ""
+
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
-#: pkg/storaged/index.html:424
-#, fuzzy
-msgctxt "storage"
-msgid "Firmware Version"
-msgstr "Version"
+#: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:96
+#: pkg/networkmanager/firewall.jsx:317 pkg/networkmanager/firewall.jsx:320
+msgid "Firewall"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:291
+msgid "Firewall is not available"
+msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:206
 msgid "Flex"
@@ -2602,58 +3136,79 @@ msgstr ""
 msgid "Flocker Dataset Name"
 msgstr ""
 
-#: pkg/docker/util.js:501
+#: node_modules/registry-image-widgets/views/imagestream-body.html:35
+msgid "Follows docker repo"
+msgstr ""
+
+#: pkg/users/index.html:123
+msgid "Force Change"
+msgstr ""
+
+#: pkg/docker/util.js:511
 msgid "Force Delete"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:47
+#: pkg/machines/components/vm/vmActions.jsx:45
 msgid "Force Restart"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:59
+#: pkg/machines/components/vm/vmActions.jsx:59
 msgid "Force Shut Down"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:520 pkg/storaged/format-dialog.jsx:192
-#: pkg/storaged/format-dialog.jsx:265
+#: pkg/users/index.html:378
+msgid "Force password change"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:344
+msgid "Force remove passphrase in $0"
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:175 pkg/storaged/content-views.jsx:512
+#: pkg/storaged/format-dialog.jsx:303 pkg/storaged/format-dialog.jsx:388
 msgid "Format"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:41
+#: pkg/storaged/format-dialog.jsx:176
 msgid "Format $0"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:498
+#: pkg/storaged/content-views.jsx:493
 msgid "Format Disk $0"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:521
+#: pkg/storaged/content-views.jsx:513
 msgid "Formatting a disk will erase all data on it."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:194
+#: pkg/storaged/format-dialog.jsx:305
 msgid "Formatting a storage device will erase all data on it."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2683
+#: pkg/networkmanager/interfaces.js:2849
 msgid "Forward delay $forward_delay"
 msgstr ""
 
-#: pkg/systemd/index.html:255 pkg/storaged/pvol-tabs.jsx:48
-#: pkg/docker/storage.jsx:300 pkg/docker/storage.jsx:322
-#: pkg/systemd/host.js:1439
+#: pkg/systemd/index.html:285 pkg/docker/storage.jsx:300
+#: pkg/docker/storage.jsx:321
+#: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
+#: pkg/storaged/pvol-tabs.jsx:54 pkg/systemd/host.js:1547
 msgid "Free"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:409
+#: pkg/storaged/content-views.jsx:422
 msgid "Free Space"
 msgstr ""
 
-#: pkg/systemd/services.html:181
+#: pkg/systemd/services.html:223
 msgid "Friday"
 msgstr ""
 
-#: pkg/users/index.html:84 pkg/users/index.html:154
+#: node_modules/registry-image-widgets/views/image-listing.html:6
+msgid "From"
+msgstr ""
+
+#: pkg/users/index.html:86 pkg/users/index.html:169
 msgid "Full Name"
 msgstr ""
 
@@ -2661,11 +3216,15 @@ msgstr ""
 msgid "GCE Persistent Disk"
 msgstr ""
 
-#: pkg/docker/index.html:178
+#: pkg/machines/libvirt.es6:393
+msgid "GET HYPERVISOR MAX VCPU action failed"
+msgstr ""
+
+#: pkg/docker/index.html:182
 msgid "Gateway:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2525
+#: pkg/networkmanager/interfaces.js:2691 pkg/systemd/logs.js:411
 msgid "General"
 msgstr ""
 
@@ -2673,8 +3232,14 @@ msgstr ""
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:580
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:168
+#: pkg/machines/components/memorySelectRow.jsx:57
+#: pkg/machines/components/vmDisksTab.jsx:42
+msgid "GiB"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:194
@@ -2689,23 +3254,31 @@ msgstr ""
 msgid "GlusterFS"
 msgstr ""
 
-#: pkg/systemd/logs.js:130
+#: pkg/systemd/logs.js:195
 msgid "Go to"
 msgstr ""
 
-#: pkg/networkmanager/index.html:51 pkg/networkmanager/index.html:538
-#: pkg/storaged/index.html:305 pkg/systemd/index.html:172
-#: pkg/dashboard/index.html:46
-msgid "Go to now"
+#: pkg/apps/application.jsx:108
+msgid "Go to Application"
 msgstr ""
 
-#: pkg/ostree/index.html:289
-msgid "Good Signature"
+#: pkg/dashboard/index.html:46 pkg/networkmanager/index.html:63
+#: pkg/networkmanager/index.html:570 pkg/systemd/index.html:201
+#: pkg/storaged/plot.jsx:72
+msgid "Go to now"
 msgstr ""
 
 #: pkg/kubernetes/views/project-body.html:3
 #: pkg/kubernetes/views/project-body.html:8
 msgid "Grant additional push or admin access to specific members below."
+msgstr ""
+
+#: pkg/machines/components/consoles.jsx:50
+msgid "Graphics Console (VNC)"
+msgstr ""
+
+#: pkg/machines/components/consoles.jsx:59
+msgid "Graphics Console in Desktop Viewer"
 msgstr ""
 
 #: pkg/kubernetes/views/group-page.html:21
@@ -2722,12 +3295,43 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/networkmanager/index.html:292
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
+msgid "Grow"
+msgstr ""
+
+#: pkg/storaged/lvol-tabs.jsx:161
+msgid "Grow Logical Volume"
+msgstr ""
+
+#: pkg/storaged/vdo-details.jsx:211
+msgid "Grow logical size of $0"
+msgstr ""
+
+#: pkg/storaged/vdo-details.jsx:119
+msgid "Grow to take all space"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterTemplates.jsx:136
+#: pkg/ovirt/components/ClusterVms.jsx:182
+msgid "HA"
+msgstr ""
+
+#: pkg/ovirt/components/OVirtTab.jsx:128
+msgid "HA:"
+msgstr ""
+
+#: pkg/networkmanager/index.html:324
 msgid "Hair Pin mode"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2709
+#: pkg/networkmanager/interfaces.js:2875
 msgid "Hairpin mode"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:70
+msgid "Hand Held"
 msgstr ""
 
 #: pkg/docker/storage.jsx:159
@@ -2735,26 +3339,33 @@ msgstr ""
 msgid "Hard Disk"
 msgstr "Disk I/O"
 
-#: pkg/storaged/overview.js:182
+#: pkg/storaged/drives-panel.jsx:85
 msgctxt "storage"
 msgid "Hard Disk"
 msgstr ""
 
-#: pkg/systemd/index.html:77
+#: pkg/systemd/index.html:88
 msgid "Hardware"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2685
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:95
+msgid "Hardware Information"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2851
 msgid "Hello time $hello_time"
 msgstr ""
 
+#: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/kubernetes/views/details-page.html:73
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr ""
 
-#: pkg/systemd/index.html:102 pkg/dashboard/index.html:135
+#: pkg/dashboard/index.html:135 pkg/systemd/index.html:119
 msgid "Host Name"
 msgstr ""
 
@@ -2762,28 +3373,32 @@ msgstr ""
 msgid "Host Path"
 msgstr ""
 
-#: src/base1/cockpit.js:3925
+#: src/base1/cockpit.js:4004
 msgid "Host key is incorrect"
 msgstr ""
 
-#: pkg/systemd/services.html:441
+#: pkg/ovirt/components/HostToMaintenance.jsx:75
+msgid "Host to Maintenance"
+msgstr ""
+
+#: pkg/systemd/services.html:483
 msgid "Hour : Minute"
 msgstr ""
 
-#: pkg/systemd/init.js:1180 pkg/systemd/init.js:1209
+#: pkg/systemd/init.js:1232 pkg/systemd/init.js:1261
 msgid "Hour needs to be a number between 0-23"
 msgstr ""
 
-#: pkg/systemd/services.html:407
+#: pkg/systemd/services.html:449
 msgid "Hours"
 msgstr ""
 
-#: pkg/systemd/index.html:221 pkg/systemd/host.js:1350
+#: pkg/systemd/index.html:251 pkg/systemd/host.js:1452
 msgid "I/O Wait"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:218
-msgid "ID:"
+#: pkg/machines/libvirt-common.es6:700
+msgid "INSTALL VM action failed"
 msgstr ""
 
 #: pkg/kubernetes/views/service-body.html:9
@@ -2791,35 +3406,35 @@ msgstr ""
 msgid "IP"
 msgstr ""
 
-#: pkg/networkmanager/index.html:97 pkg/networkmanager/index.html:115
+#: pkg/networkmanager/index.html:128 pkg/networkmanager/index.html:146
 msgid "IP Address"
 msgstr ""
 
-#: pkg/docker/index.html:170
+#: pkg/docker/index.html:174
 msgid "IP Address:"
 msgstr ""
 
-#: pkg/docker/index.html:174
+#: pkg/docker/index.html:178
 msgid "IP Prefix Length:"
 msgstr ""
 
-#: pkg/networkmanager/index.html:608
+#: pkg/networkmanager/index.html:640
 msgid "IP Settings"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2734
+#: pkg/networkmanager/interfaces.js:2900
 msgid "IPv4"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3164
+#: pkg/networkmanager/interfaces.js:3333
 msgid "IPv4 Settings"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2735
+#: pkg/networkmanager/interfaces.js:2901
 msgid "IPv6"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3164
+#: pkg/networkmanager/interfaces.js:3333
 msgid "IPv6 Settings"
 msgstr ""
 
@@ -2827,49 +3442,59 @@ msgstr ""
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:121 pkg/docker/containers-view.jsx:307
-#: pkg/systemd/init.js:271
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
+#: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2726
+#: pkg/networkmanager/interfaces.js:2892
 msgid "Id $id"
 msgstr ""
 
-#: pkg/docker/index.html:146
+#: pkg/docker/index.html:147
 msgid "Id:"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-body.html:22
+#: node_modules/registry-image-widgets/views/image-listing.html:7
+#: node_modules/registry-image-widgets/views/image-body.html:24
 msgid "Identifier"
 msgstr ""
 
+#: pkg/kubernetes/views/user-page.html:22
 #: pkg/kubernetes/views/user-panel.html:18
-#: pkg/kubernetes/views/user-page.html:23
 msgid "Identities"
 msgstr ""
 
+#: pkg/kubernetes/views/add-user-dialog.html:17
 #: pkg/kubernetes/views/project-listing.html:91
 #: pkg/kubernetes/views/user-modify.html:17
-#: pkg/kubernetes/views/add-user-dialog.html:17
 msgid "Identity"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1836
+#: pkg/storaged/crypto-keyslots.jsx:296
+msgid "If tang-show-keys is not available, run the following:"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1967 pkg/packagekit/updates.jsx:519
 msgid "Ignore"
 msgstr ""
 
-#: pkg/docker/index.html:258 pkg/docker/index.html:420
-#: pkg/kubernetes/views/image-panel.html:9
-#: pkg/kubernetes/views/image-page.html:16
+#: pkg/docker/index.html:266 pkg/docker/index.html:428
 #: pkg/kubernetes/views/container-body.html:6
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:267
+#: pkg/kubernetes/views/image-page.html:15
+#: node_modules/registry-image-widgets/views/image-panel.html:9
+#: pkg/docker/containers-view.jsx:126 pkg/docker/containers-view.jsx:351
 msgid "Image"
 msgstr ""
 
-#: pkg/docker/image.js:76
+#: pkg/docker/image.js:77
 msgid "Image $0"
 msgstr ""
+
+#: pkg/users/local.js:719
+#, fuzzy
+msgid "Image Builder"
+msgstr "Værtsnavn"
 
 #: pkg/kubernetes/views/container-body.html:8
 msgid "Image ID"
@@ -2884,7 +3509,7 @@ msgstr "Værtsnavn"
 msgid "Image Registry"
 msgstr ""
 
-#: pkg/docker/index.html:567
+#: pkg/docker/index.html:575
 #, fuzzy
 msgid "Image Search"
 msgstr "Værtsnavn"
@@ -2897,30 +3522,35 @@ msgstr ""
 msgid "Image commands"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/imagestream-body.html:34
+#: node_modules/registry-image-widgets/views/imagestream-body.html:41
 #, fuzzy
 msgid "Image count"
 msgstr "Værtsnavn"
 
-#: pkg/docker/index.html:154
+#: node_modules/registry-image-widgets/views/imagestream-panel.html:12
+#, fuzzy
+msgid "Image stream"
+msgstr "Værtsnavn"
+
+#: pkg/docker/index.html:155
 #, fuzzy
 msgid "Image:"
 msgstr "Værtsnavn"
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/kubernetes/views/image-listing.html:9
-#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:78
-#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:611
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
-#: pkg/docker/image.js:42
+#: pkg/docker/image.js:43
 #, fuzzy
 msgctxt "page-title"
 msgid "Images"
 msgstr "Værtsnavn"
 
-#: pkg/docker/containers-view.jsx:102
+#: pkg/docker/containers-view.jsx:104
 msgid "Images and running containers"
 msgstr ""
 
@@ -2928,15 +3558,18 @@ msgstr ""
 msgid "Images by project"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/imagestream-body.html:15
+#: node_modules/registry-image-widgets/views/imagestream-body.html:15
+#: node_modules/registry-image-widgets/views/imagestream-body.html:16
 msgid "Images may be pulled by anonymous users"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/imagestream-body.html:19
+#: node_modules/registry-image-widgets/views/imagestream-body.html:20
+#: node_modules/registry-image-widgets/views/imagestream-body.html:21
 msgid "Images may be pulled by any authenticated user or group"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/imagestream-body.html:23
+#: node_modules/registry-image-widgets/views/imagestream-body.html:25
+#: node_modules/registry-image-widgets/views/imagestream-body.html:26
 msgid "Images may only be pulled by specific users or groups"
 msgstr ""
 
@@ -2944,7 +3577,11 @@ msgstr ""
 msgid "Images pushed recently"
 msgstr ""
 
-#: pkg/storaged/details.js:408
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:285
+msgid "Immediately Start VM"
+msgstr ""
+
+#: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr ""
 
@@ -2965,12 +3602,12 @@ msgid ""
 "strong}}."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:731 pkg/networkmanager/interfaces.js:1314
-#: pkg/networkmanager/interfaces.js:1321 pkg/networkmanager/interfaces.js:2428
+#: pkg/networkmanager/interfaces.js:822 pkg/networkmanager/interfaces.js:1418
+#: pkg/networkmanager/interfaces.js:1425 pkg/networkmanager/interfaces.js:2594
 msgid "Inactive"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:630
+#: pkg/storaged/content-views.jsx:595
 msgid "Inactive volume"
 msgstr ""
 
@@ -2978,41 +3615,101 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
+#, fuzzy
+msgid "Index Memory"
+msgstr "Hukommelse"
+
+#: pkg/systemd/logs.html:61
+msgid "Info and above"
+msgstr ""
+
 #: pkg/docker/storage.jsx:284
 msgid "Information about the Docker storage pool is not available."
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:478
+msgid "Initializing..."
+msgstr ""
+
+#: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
+msgid "Install"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:826
+msgid "Install All Updates"
+msgstr ""
+
+#: pkg/storaged/nfs-panel.jsx:96
+msgid "Install NFS Support"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:826 pkg/packagekit/updates.jsx:832
+msgid "Install Security Updates"
+msgstr ""
+
+#: pkg/lib/cockpit-components-install-dialog.jsx:103
+msgid "Install Software"
+msgstr ""
+
+#: pkg/storaged/vdos-panel.jsx:174
+msgid "Install VDO support"
 msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:360
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr ""
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:235
+msgid "Installation Source"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
+msgid "Installation Source Type"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:346
+msgid "Installation Source should not be empty"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:58
+msgid "Installed"
+msgstr ""
+
 #: pkg/subscriptions/subscriptions-view.jsx:222
 msgid "Installed products"
 msgstr ""
 
-#: pkg/systemd/services.html:135
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
+#: pkg/packagekit/updates.jsx:50
+msgid "Installing"
+msgstr ""
+
+#: pkg/lib/cockpit-components-install-dialog.jsx:183
+msgid "Installing $0"
+msgstr ""
+
+#: pkg/systemd/services.html:177
 msgid "Instantiate"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:81
-#: pkg/kubernetes/views/pv-modify.html:169
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr ""
 
-#: pkg/networkmanager/index.html:85
+#: pkg/networkmanager/index.html:116
 msgid "Interfaces"
 msgstr ""
 
-#: src/ws/login.js:573
+#: src/ws/login.js:616
 msgid "Internal Error: Invalid challenge header"
 msgstr ""
 
-#: src/base1/cockpit.js:3927
+#: src/base1/cockpit.js:4006
 msgid "Internal error"
-msgstr ""
-
-#: pkg/ostree/index.html:291
-msgid "Invalid Signature"
 msgstr ""
 
 #: pkg/networkmanager/utils.js:89 pkg/networkmanager/utils.js:172
@@ -3023,23 +3720,31 @@ msgstr ""
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1228
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1224
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
-#: pkg/systemd/init.js:1215
+#: pkg/systemd/init.js:1267
 msgid "Invalid date format."
 msgstr ""
 
-#: pkg/lib/credentials.js:276
+#: pkg/users/local.js:1180
+msgid "Invalid expiration date"
+msgstr ""
+
+#: pkg/lib/credentials.js:285
 msgid "Invalid file permissions"
 msgstr ""
 
-#: pkg/users/index.html:316
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:328
+msgid "Invalid filename"
+msgstr ""
+
+#: pkg/users/index.html:429
 msgid "Invalid key"
 msgstr ""
 
@@ -3047,7 +3752,11 @@ msgstr ""
 msgid "Invalid metric $0"
 msgstr ""
 
-#: pkg/systemd/init.js:1166
+#: pkg/users/local.js:1253
+msgid "Invalid number of days"
+msgstr ""
+
+#: pkg/systemd/init.js:1218
 msgid "Invalid number."
 msgstr ""
 
@@ -3063,65 +3772,69 @@ msgstr ""
 msgid "Invalid prefix or netmask $0"
 msgstr ""
 
-#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1226
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
-#: pkg/systemd/index.html:373
+#: pkg/systemd/index.html:403
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/overview.js:580 pkg/storaged/overview.js:671
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:92
+msgid "IoT Gateway"
 msgstr ""
 
 #: pkg/lib/machine-change-port.html:15
 msgid "Is sshd running on a different port?"
 msgstr ""
 
-#: pkg/systemd/init.js:520
-msgid "Isolate"
-msgstr ""
-
-#: pkg/storaged/index.html:278
+#: pkg/storaged/job-views.jsx:51 pkg/storaged/jobs-panel.jsx:172
 msgid "Jobs"
 msgstr ""
 
-#: pkg/realmd/operation.js:96
+#: pkg/realmd/operation.js:100
 msgid "Join"
 msgstr ""
 
-#: pkg/realmd/operation.js:454
+#: pkg/realmd/operation.js:544
 msgid "Join Domain"
 msgstr ""
 
-#: pkg/realmd/operation.js:95
+#: pkg/realmd/operation.js:99
 msgid "Join a Domain"
 msgstr ""
 
-#: pkg/realmd/operation.js:346
+#: pkg/realmd/operation.js:455
 msgid "Joining this domain is not supported"
+msgstr ""
+
+#: pkg/systemd/init.js:698
+msgid "Joins Namespace Of"
 msgstr ""
 
 #: pkg/systemd/logs.html:23
 msgid "Journal"
 msgstr ""
 
-#: pkg/systemd/logs.js:257
+#: pkg/systemd/logs.js:334
 msgid "Journal entry"
 msgstr ""
 
-#: pkg/systemd/logs.js:284
+#: pkg/systemd/logs.js:365
 msgid "Journal entry not found"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:461
+#: pkg/kdump/kdump-view.jsx:463
 msgid ""
 "Kdump service not installed. Please ensure package kexec-tools is installed."
 msgstr ""
 
-#: pkg/networkmanager/index.html:850
+#: pkg/networkmanager/index.html:882
 msgid "Keep connection"
 msgstr ""
 
@@ -3133,8 +3846,12 @@ msgstr ""
 msgid "Kerberos Ticket"
 msgstr ""
 
-#: pkg/systemd/index.html:225 pkg/systemd/host.js:1351
+#: pkg/systemd/index.html:255 pkg/systemd/host.js:1453
 msgid "Kernel"
+msgstr ""
+
+#: pkg/kdump/index.html:23
+msgid "Kernel Dump"
 msgstr ""
 
 #: pkg/kubernetes/views/node-body.html:19
@@ -3142,12 +3859,32 @@ msgstr ""
 msgid "Kernel Version"
 msgstr "Version"
 
-#: pkg/kdump/index.html:23
-msgid "Kernel dump configuration"
-msgstr ""
-
 #: pkg/kubernetes/views/volume-body.html:67
 msgid "Key Ring Path"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:535
+msgid "Key slots with unknown types can not be edited here"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:175
+msgid "Key source"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:558
+msgid "Keys"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:529
+msgid "Keyserver"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:195 pkg/storaged/crypto-keyslots.jsx:242
+msgid "Keyserver address"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:386
+msgid "Keyserver removal may prevent unlocking $0."
 msgstr ""
 
 #: pkg/kubernetes/views/node-body.html:23
@@ -3158,17 +3895,26 @@ msgstr ""
 msgid "Kubernetes Cluster"
 msgstr ""
 
-#: pkg/networkmanager/index.html:515
+#: pkg/networkmanager/index.html:547
 msgid "LACP Key"
 msgstr ""
 
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: bower_components/registry-image-widgets/views/image-meta.html:3
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
+#: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:80
+msgid "Labels:"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:68
+msgid "Laptop"
 msgstr ""
 
 #: pkg/systemd/logs.html:43
@@ -3183,7 +3929,7 @@ msgstr ""
 msgid "Last Heartbeat"
 msgstr ""
 
-#: pkg/users/index.html:98
+#: pkg/users/index.html:100
 msgid "Last Login"
 msgstr ""
 
@@ -3191,24 +3937,32 @@ msgstr ""
 msgid "Last Status Change"
 msgstr ""
 
-#: pkg/systemd/init.js:274
+#: pkg/systemd/init.js:275
 msgid "Last Trigger"
 msgstr ""
 
-#: pkg/kubernetes/views/image-listing.html:16
+#: node_modules/registry-image-widgets/views/image-listing.html:8
 msgid "Last Updated"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
+#: pkg/packagekit/updates.jsx:178
+msgid "Last checked: $0 ago"
+msgstr ""
+
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
-#: pkg/realmd/operation.js:101
+#: pkg/machines/components/desktopConsole.jsx:129
+msgid "Launch Remote Viewer"
+msgstr ""
+
+#: pkg/realmd/operation.js:106
 msgid "Leave"
 msgstr ""
 
-#: pkg/realmd/operation.js:100
+#: pkg/realmd/operation.js:105
 msgid "Leave Domain"
 msgstr ""
 
@@ -3222,56 +3976,72 @@ msgstr ""
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
-"user{{#user}} ({{user}}){{/user}}. If you enter a different username, that "
-"user will always be used connecting to this machine."
+"user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
+"different username, that user will always be used connecting to this machine."
 msgstr ""
 
-#: pkg/shell/simple.html:76 pkg/shell/index.html:88 pkg/shell/stub.html:81
+#: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
 msgid "Licensed under:"
 msgstr ""
 
-#: pkg/networkmanager/index.html:357
+#: pkg/networkmanager/index.html:389
 msgid "Link Monitoring"
 msgstr ""
 
-#: pkg/networkmanager/index.html:439
+#: pkg/networkmanager/index.html:471
 msgid "Link Watch"
 msgstr ""
 
-#: pkg/networkmanager/index.html:392 pkg/networkmanager/index.html:474
+#: pkg/networkmanager/index.html:424 pkg/networkmanager/index.html:506
 msgid "Link down delay"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1824 pkg/networkmanager/interfaces.js:1834
+#: pkg/networkmanager/interfaces.js:1955 pkg/networkmanager/interfaces.js:1965
 msgid "Link local"
 msgstr ""
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:494
 msgid "Link to another container"
 msgstr ""
 
-#: pkg/networkmanager/index.html:383 pkg/networkmanager/index.html:465
+#: pkg/networkmanager/index.html:415 pkg/networkmanager/index.html:497
 msgid "Link up delay"
 msgstr ""
 
-#: pkg/docker/index.html:482
+#: pkg/docker/index.html:490
 msgid "Links"
 msgstr ""
 
-#: pkg/docker/index.html:190
+#: pkg/docker/index.html:194
 msgid "Links:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1860
+#: pkg/networkmanager/interfaces.js:1991
 msgid "Load Balancing"
 msgstr ""
 
-#: pkg/systemd/logs.js:69
+#: pkg/systemd/logs.js:134
 msgid "Load earlier entries"
 msgstr ""
 
-#: pkg/systemd/logs.js:75 pkg/systemd/logs.js:90 pkg/systemd/logs.js:134
-#: pkg/systemd/logs.js:175 pkg/kdump/kdump-view.jsx:370
+#: pkg/machines/components/serialConsole.jsx:136
+msgid "Loading ..."
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:45
+msgid "Loading available updates failed"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:38
+msgid "Loading available updates, please wait..."
+msgstr ""
+
+#: pkg/ovirt/components/VdsmView.jsx:34
+msgid "Loading data ..."
+msgstr ""
+
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -3289,33 +4059,49 @@ msgstr "Disk I/O"
 msgid "Local Filesystem"
 msgstr "Disk I/O"
 
-#: pkg/kdump/kdump-view.jsx:174
+#: pkg/storaged/nfs-details.jsx:152
+msgid "Local Mount Point"
+msgstr ""
+
+#: pkg/kdump/kdump-view.jsx:175
 #, fuzzy
 msgid "Location"
 msgstr "Indstillinger"
 
-#: pkg/storaged/content-views.jsx:209
+#: pkg/storaged/content-views.jsx:229
 msgid "Lock"
 msgstr ""
 
-#: pkg/users/index.html:107 pkg/users/index.html:202
+#: pkg/users/index.html:110 pkg/users/index.html:217
 msgid "Lock Account"
 msgstr ""
 
-#: pkg/storaged/jobs.js:119
+#: pkg/users/local.js:851 pkg/users/local.js:1162
+msgid "Lock account on $0"
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:38
 msgid "Locking $target"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:80 src/ws/login.html:86
+#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:85 src/ws/login.js:466
 msgid "Log In"
 msgstr ""
 
-#: pkg/shell/simple.html:118
+#: pkg/shell/index.html:70 pkg/shell/simple.html:46 pkg/shell/stub.html:53
+msgid "Log Out"
+msgstr ""
+
+#: pkg/shell/simple.html:108
 msgid "Log in again"
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:4
 msgid "Log in to {{host}}"
+msgstr ""
+
+#: src/ws/login.js:492
+msgid "Log in with your server user account."
 msgstr ""
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:116
@@ -3326,37 +4112,46 @@ msgstr ""
 msgid "Log into the registry:"
 msgstr ""
 
-#: pkg/systemd/index.html:64
+#: pkg/systemd/index.html:65
 msgid "Log messages"
 msgstr ""
 
-#: pkg/shell/simple.html:45 pkg/shell/index.html:52 pkg/shell/stub.html:45
-msgid "Log out"
-msgstr ""
-
-#: pkg/users/local.js:855
+#: pkg/users/local.js:932
 msgid "Logged In"
 msgstr ""
 
+#: pkg/storaged/vdo-details.jsx:289
+msgid "Logical"
+msgstr ""
+
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
+#, fuzzy
+msgid "Logical Size"
+msgstr "Disk I/O"
+
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
-#: pkg/kubernetes/views/pv-modify.html:158
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
-#: pkg/storaged/utils.js:172
+#: pkg/storaged/utils.js:169
 msgid "Logical Volume"
 msgstr ""
 
-#: pkg/storaged/utils.js:170
+#: pkg/storaged/utils.js:167
 msgid "Logical Volume (Snapshot)"
+msgstr ""
+
+#: pkg/storaged/utils.js:241
+msgid "Logical Volume of $0"
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-register.jsx:140
 msgid "Login"
 msgstr ""
 
-#: src/ws/login.js:252
+#: src/ws/login.js:279
 msgid "Login Again"
 msgstr ""
 
@@ -3368,20 +4163,24 @@ msgstr ""
 msgid "Login commands"
 msgstr ""
 
-#: src/base1/cockpit.js:3919
+#: src/base1/cockpit.js:3996
 msgid "Login failed"
+msgstr ""
+
+#: pkg/shell/index.html:36
+msgid "Login has escalated admin privileges"
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-client.js:200
 msgid "Login/password or activation key required to register."
 msgstr ""
 
-#: src/ws/login.js:253
+#: src/ws/login.js:280
 msgid "Logout Successful"
 msgstr ""
 
-#: pkg/systemd/logs.html:60 pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6
+#: pkg/kubernetes/views/container-page-inline.html:8
+#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:72
 msgid "Logs"
 msgstr ""
 
@@ -3389,69 +4188,110 @@ msgstr ""
 msgid "Lost connection. Trying to reconnect"
 msgstr ""
 
-#: pkg/networkmanager/index.html:184 pkg/networkmanager/index.html:323
+#: pkg/lib/machine-info.es6:63
+msgid "Low Profile Desktop"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:75
+msgid "Lunch Box"
+msgstr ""
+
+#: pkg/networkmanager/index.html:216 pkg/networkmanager/index.html:355
 msgid "MAC"
 msgstr ""
 
-#: pkg/docker/index.html:182
+#: pkg/machines/vmnetworktab.jsx:68
+msgid "MAC Address"
+msgstr ""
+
+#: pkg/docker/index.html:186
 msgid "MAC Address:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1852
+#: pkg/ovirt/provider.es6:254
+msgid "MIGRATE action failed"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1983
 msgid "MII (Recommended)"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2583
+#: pkg/machines/vmnetworktab.jsx:89 pkg/networkmanager/interfaces.js:2749
 msgid "MTU"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4335
+#: pkg/networkmanager/interfaces.js:4496
 msgid "MTU must be a positive number"
 msgstr ""
 
-#: pkg/systemd/index.html:85 pkg/kubernetes/views/node-body.html:15
+#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:96
 msgid "Machine ID"
 msgstr ""
 
-#: pkg/systemd/index.html:266
+#: pkg/systemd/index.html:296
 msgid "Machine SSH Key Fingerprints"
 msgstr ""
 
-#: pkg/shell/simple.html:56 pkg/shell/index.html:66 pkg/shell/stub.html:59
-#: pkg/shell/indexes.js:253
+#: pkg/shell/indexes.js:297
 msgid "Machines"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:76
+msgid "Main Server Chassis"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:290
+msgid "Make sure the key hash from the Tang server matches:"
+msgstr ""
+
+#: pkg/machines/vmnetworktab.jsx:91
+msgid "Managed"
 msgstr ""
 
 #: pkg/kubernetes/scripts/dashboard.js:459
 msgid "Manifest"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1825 pkg/networkmanager/interfaces.js:1835
+#: pkg/networkmanager/interfaces.js:1956 pkg/networkmanager/interfaces.js:1966
 msgid "Manual"
 msgstr ""
 
-#: pkg/systemd/index.html:383 pkg/systemd/index.html:387
+#: pkg/machines/components/desktopConsole.jsx:194
+msgid "Manual Connection"
+msgstr ""
+
+#: pkg/systemd/index.html:413 pkg/systemd/index.html:417
 msgid "Manually"
 msgstr ""
 
-#: pkg/storaged/jobs.js:137
+#: pkg/storaged/crypto-keyslots.jsx:293
+msgid "Manually check with SSH: "
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:60
 msgid "Marking $target as faulty"
 msgstr ""
 
-#: pkg/systemd/init.js:544
+#: pkg/systemd/init.js:546
 msgid "Mask"
 msgstr ""
 
-#: pkg/systemd/init.js:545
+#: pkg/systemd/init.js:547
 msgid "Mask Forcefully"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2589
+#: pkg/networkmanager/interfaces.js:2755
 msgid "Master"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2687
+#: pkg/networkmanager/interfaces.js:2853
 msgid "Maximum message age $max_age"
+msgstr ""
+
+#: pkg/machines/components/vcpuModal.jsx:176
+msgid ""
+"Maximum number of virtual CPUs allocated for the guest OS, which must be "
+"between 1 and $0"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:34
@@ -3459,63 +4299,72 @@ msgid "Medium"
 msgstr ""
 
 #: pkg/kubernetes/views/project-listing.html:92
+#: pkg/kubernetes/views/user-body.html:4
+#: pkg/kubernetes/views/user-panel.html:27
 msgid "Member of"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:301
+#: pkg/storaged/content-views.jsx:331
 msgid "Member of RAID Device"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:297
+#: pkg/storaged/content-views.jsx:327
 msgid "Member of RAID Device $0"
 msgstr ""
 
-#: pkg/networkmanager/index.html:315
 #: pkg/kubernetes/views/project-listing.html:16
 #: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/interfaces.js:2807
+#: pkg/networkmanager/index.html:347 pkg/networkmanager/interfaces.js:2974
 msgid "Members"
 msgstr ""
 
-#: pkg/kubernetes/views/user-panel.html:11
-#: pkg/kubernetes/views/user-panel.html:27
 #: pkg/kubernetes/views/project-page.html:29
-#: pkg/kubernetes/views/user-body.html:4
+#: pkg/kubernetes/views/user-page.html:25
+#: pkg/kubernetes/views/user-panel.html:11
 msgid "Membership"
 msgstr ""
 
-#: pkg/playground/translate.html:90 pkg/docker/index.html:261
-#: pkg/systemd/index.html:201 pkg/dashboard/index.html:71
-#: pkg/docker/containers-view.jsx:267 pkg/kubernetes/scripts/nodes.js:715
-#: pkg/kubernetes/scripts/nodes.js:826 pkg/kubernetes/scripts/graphs.js:604
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:269
+#: pkg/playground/translate.html:90 pkg/systemd/index.html:230
+#: pkg/docker/containers-view.jsx:351
+#: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
+#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Memory"
 msgstr ""
 
-#: pkg/systemd/host.js:1403
+#: pkg/systemd/host.js:1511
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Hukommelse"
 
-#: pkg/kubernetes/scripts/nodes.js:716
+#: pkg/kubernetes/scripts/nodes.js:720
 msgid "Memory Utilization: $0%"
 msgstr ""
 
-#: pkg/docker/index.html:441 pkg/docker/index.html:612
+#: pkg/docker/index.html:449 pkg/docker/index.html:620
 msgid "Memory limit"
 msgstr ""
 
-#: pkg/docker/index.html:201
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:350
+msgid "Memory should be positive number"
+msgstr ""
+
+#: pkg/docker/index.html:209
 #, fuzzy
 msgid "Memory usage:"
 msgstr "Hukommelse"
 
-#: pkg/machines/hostvmslist.jsx:210
+#: pkg/machines/components/vmOverviewTab.jsx:79
 #, fuzzy
 msgid "Memory:"
 msgstr "Hukommelse"
 
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
-#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/node-body.html:47
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -3523,54 +4372,73 @@ msgstr ""
 msgid "Message to logged in users"
 msgstr ""
 
-#: pkg/kubernetes/views/image-panel.html:15
-#: pkg/kubernetes/views/image-page.html:30
-#: pkg/kubernetes/views/imagestream-page.html:27
+#: pkg/kubernetes/views/image-page.html:29
+#: pkg/kubernetes/views/imagestream-page.html:30
+#: node_modules/registry-image-widgets/views/image-panel.html:15
+#: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:208
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
-#: pkg/docker/index.html:455 pkg/docker/index.html:626
+#: pkg/docker/index.html:463 pkg/docker/index.html:634
+#: pkg/machines/components/diskAdd.jsx:165
+#: pkg/machines/components/memorySelectRow.jsx:54
 msgid "MiB"
 msgstr ""
 
-#: pkg/systemd/init.js:1186 pkg/systemd/init.js:1195 pkg/systemd/init.js:1204
+#: pkg/ovirt/components/OVirtTab.jsx:70
+msgid "Migrate To:"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:94
+msgid "Mini PC"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:65
+msgid "Mini Tower"
+msgstr ""
+
+#: pkg/systemd/init.js:1238 pkg/systemd/init.js:1247 pkg/systemd/init.js:1256
 msgid "Minute needs to be a number between 0-59"
 msgstr ""
 
-#: pkg/systemd/services.html:406
+#: pkg/systemd/services.html:448
 msgid "Minutes"
 msgstr ""
 
-#: pkg/networkmanager/index.html:341
+#: pkg/networkmanager/index.html:373
 msgid "Mode"
 msgstr ""
 
-#: pkg/storaged/index.html:419
-msgctxt "storage"
+#: pkg/systemd/hwinfo.jsx:84
 msgid "Model"
+msgstr ""
+
+#: pkg/machines/vmnetworktab.jsx:67
+msgid "Model type"
 msgstr ""
 
 #: pkg/kubernetes/views/user-modify.html:27
 msgid "Modify"
 msgstr ""
 
-#: pkg/storaged/jobs.js:120 pkg/storaged/jobs.js:125 pkg/storaged/jobs.js:129
+#: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:45
+#: pkg/storaged/jobs-panel.jsx:52
 msgid "Modifying $target"
 msgstr ""
 
-#: pkg/systemd/services.html:177
+#: pkg/systemd/services.html:219
 msgid "Monday"
 msgstr ""
 
-#: pkg/networkmanager/index.html:365
+#: pkg/networkmanager/index.html:397
 msgid "Monitoring Interval"
 msgstr ""
 
-#: pkg/networkmanager/index.html:374
+#: pkg/networkmanager/index.html:406
 msgid "Monitoring Targets"
 msgstr ""
 
@@ -3578,16 +4446,22 @@ msgstr ""
 msgid "Monitors"
 msgstr ""
 
-#: pkg/realmd/operation.js:367
+#: pkg/realmd/operation.js:478
 msgid "More"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:447
+#: pkg/machines/components/desktopConsole.jsx:103
+#: pkg/machines/components/desktopConsole.jsx:111
+#, fuzzy
+msgid "More Information"
+msgstr "Indstillinger"
+
+#: pkg/kdump/kdump-view.jsx:449
 msgid "More details"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:188 pkg/storaged/fsys-tab.jsx:217
-#: pkg/kdump/kdump-view.jsx:104
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -3596,130 +4470,187 @@ msgstr ""
 msgid "Mount Location"
 msgstr "Indstillinger"
 
-#: pkg/storaged/fsys-tab.jsx:137 pkg/storaged/fsys-tab.jsx:199
-#: pkg/storaged/format-dialog.jsx:185
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 #, fuzzy
 msgid "Mount Options"
 msgstr "Indstillinger"
 
-#: pkg/storaged/index.html:229 pkg/storaged/fsys-tab.jsx:130
-#: pkg/storaged/fsys-tab.jsx:182 pkg/storaged/format-dialog.jsx:179
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr ""
 
-#: pkg/docker/index.html:508
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
+#, fuzzy
+msgid "Mount at boot"
+msgstr "Indstillinger"
+
+#: pkg/docker/index.html:516
 msgid "Mount container volumes"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:212
+#: pkg/storaged/format-dialog.jsx:88
+#, fuzzy
+msgid "Mount options"
+msgstr "Indstillinger"
+
+#: pkg/storaged/format-dialog.jsx:84
+msgid "Mount point can not be empty"
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:156
+msgid "Mount point cannot be empty."
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:158
+msgid "Mount point must start with \"/\"."
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
+#, fuzzy
+msgid "Mount read only"
+msgstr "Indstillinger"
+
+#: pkg/storaged/fsys-tab.jsx:191
 #, fuzzy
 msgid "Mounted At"
 msgstr "Indstillinger"
 
-#: pkg/storaged/fsys-tab.jsx:123 pkg/storaged/format-dialog.jsx:171
+#: pkg/storaged/format-dialog.jsx:69
 msgid "Mounting"
 msgstr ""
 
-#: pkg/storaged/jobs.js:123
+#: pkg/storaged/jobs-panel.jsx:43
 msgid "Mounting $target"
 msgstr ""
 
-#: pkg/storaged/index.html:506
-msgctxt "storage"
-msgid "Multipathed Devices"
+#: pkg/lib/machine-info.es6:84
+msgid "Multi-system Chassis"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/VmDisksTabKubevirt.jsx:65
+msgid "N/A"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:858
 msgid "NFS"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:199
+#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-details.jsx:127
 msgid "NFS Mount"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1875
+#: pkg/storaged/nfs-panel.jsx:92
+msgid "NFS Mounts"
+msgstr ""
+
+#: pkg/storaged/nfs-panel.jsx:95
+msgid "NFS Support not installed"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2006
 msgid "NSNA Ping"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:108
+#: pkg/storaged/format-dialog.jsx:243
 msgid "NTFS - Compatible with most systems"
 msgstr ""
 
-#: pkg/systemd/host.js:1284
+#: pkg/systemd/host.js:1384
 msgid "NTP Server"
 msgstr ""
 
-#: pkg/networkmanager/index.html:96 pkg/networkmanager/index.html:114
-#: pkg/networkmanager/index.html:151 pkg/networkmanager/index.html:207
-#: pkg/networkmanager/index.html:306 pkg/networkmanager/index.html:406
-#: pkg/storaged/index.html:228 pkg/docker/index.html:257
-#: pkg/ostree/index.html:99 pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41 pkg/kubernetes/views/pv-claim.html:4
-#: pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/service-modify.html:9
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/volume-body.html:31
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/docker/index.html:265 pkg/kubernetes/views/add-group-dialog.html:9
 #: pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/containers-listing.html:11
+#: pkg/kubernetes/views/dashboard-page.html:156
+#: pkg/kubernetes/views/dashboard-page.html:198
 #: pkg/kubernetes/views/details-page.html:34
 #: pkg/kubernetes/views/details-page.html:70
 #: pkg/kubernetes/views/details-page.html:103
 #: pkg/kubernetes/views/details-page.html:137
 #: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/containers-listing.html:11
-#: pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/dashboard-page.html:156
-#: pkg/kubernetes/views/dashboard-page.html:198
-#: bower_components/registry-image-widgets/views/image-body.html:2
-#: pkg/storaged/fsys-tab.jsx:71 pkg/storaged/fsys-tab.jsx:172
-#: pkg/storaged/details.js:153 pkg/storaged/lvol-tabs.jsx:39
-#: pkg/storaged/lvol-tabs.jsx:118 pkg/storaged/lvol-tabs.jsx:155
-#: pkg/storaged/lvol-tabs.jsx:192 pkg/storaged/part-tab.jsx:37
-#: pkg/storaged/overview.js:420 pkg/storaged/overview.js:493
-#: pkg/storaged/overview.js:627 pkg/storaged/overview.js:705
-#: pkg/storaged/content-views.jsx:107 pkg/storaged/content-views.jsx:676
-#: pkg/storaged/format-dialog.jsx:137 pkg/docker/containers-view.jsx:267
-#: pkg/docker/containers-view.jsx:583 pkg/machines/hostvmslist.jsx:349
+#: pkg/kubernetes/views/imagestream-modify.html:10
+#: pkg/kubernetes/views/node-add.html:16
+#: pkg/kubernetes/views/project-listing.html:14
+#: pkg/kubernetes/views/project-listing.html:53
+#: pkg/kubernetes/views/project-listing.html:90
+#: pkg/kubernetes/views/project-modify.html:16
+#: pkg/kubernetes/views/pv-claim.html:4
+#: pkg/kubernetes/views/service-modify.html:9
+#: pkg/kubernetes/views/user-modify.html:9
+#: pkg/kubernetes/views/volume-body.html:31
+#: pkg/kubernetes/views/volumes-page.html:19
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
+#: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
+#: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
+#: pkg/networkmanager/index.html:438
+#: node_modules/registry-image-widgets/views/image-body.html:2
+#: node_modules/registry-image-widgets/views/imagestream-listing.html:5
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
+#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
 #, fuzzy
 msgid "Name"
 msgstr "Værtsnavn"
 
-#: pkg/storaged/utils.js:129
+#: pkg/storaged/vdos-panel.jsx:55
+msgid "Name can not be empty."
+msgstr ""
+
+#: pkg/storaged/utils.js:123
 msgid "Name cannot be empty."
 msgstr ""
 
-#: pkg/storaged/utils.js:131
+#: pkg/storaged/utils.js:125
 msgid "Name cannot be longer than 127 characters."
 msgstr ""
 
-#: pkg/storaged/utils.js:135
+#: pkg/storaged/utils.js:129
 msgid "Name cannot contain the character '$0'."
 msgstr ""
 
-#: pkg/storaged/utils.js:137
+#: pkg/storaged/utils.js:131
 msgid "Name cannot contain whitespace."
 msgstr ""
 
-#: pkg/kubernetes/views/pv-claim.html:6
-#: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
-#: pkg/kubernetes/views/service-body.html:5
-#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:311
+msgid "Name should not be empty"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:316
+msgid "Name should not consist of empty characters only"
+msgstr ""
+
+#: pkg/kubernetes/views/containers-listing.html:14
+#: pkg/kubernetes/views/dashboard-page.html:160
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
 #: pkg/kubernetes/views/details-page.html:139
 #: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/pod-body.html:5
+#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
+#: pkg/kubernetes/views/replicationcontroller-body.html:5
+#: pkg/kubernetes/views/route-body.html:5
+#: pkg/kubernetes/views/service-body.html:5
+#: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
 
@@ -3727,43 +4658,71 @@ msgstr ""
 msgid "Namespace cannot be empty."
 msgstr ""
 
-#: pkg/systemd/host.js:1147
+#: pkg/systemd/host.js:1247
 msgid "Need at least one NTP server"
 msgstr ""
 
-#: pkg/playground/translate.html:95 pkg/dashboard/index.html:72
+#: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
+#: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
 #: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr ""
 
-#: pkg/systemd/index.html:211
+#: pkg/systemd/index.html:240
 #, fuzzy
 msgid "Network Traffic"
 msgstr "Netværks Traffik"
 
-#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:527
+#: pkg/networkmanager/index.html:52
+msgid "Network devices and graphs require NetworkManager."
+msgstr ""
+
+#: pkg/networkmanager/index.html:46
+msgid "NetworkManager is not running."
+msgstr ""
+
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:559
+#: pkg/networkmanager/firewall.jsx:316
 msgid "Networking"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1499 pkg/networkmanager/interfaces.js:2071
+#: pkg/networkmanager/interfaces.js:1626 pkg/networkmanager/interfaces.js:2200
 #, fuzzy
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Netværks Traffik"
 
-#: pkg/networkmanager/index.html:125
+#: pkg/networkmanager/index.html:157
 msgid "Networking Logs"
 msgstr ""
 
-#: pkg/users/local.js:857
+#: pkg/machines/components/vm/vm.jsx:46
+#, fuzzy
+msgid "Networks"
+msgstr "Netværks Traffik"
+
+#: pkg/users/local.js:934
 msgid "Never"
+msgstr ""
+
+#: pkg/users/index.html:349 pkg/users/local.js:840
+#, fuzzy
+msgid "Never expire password"
+msgstr "Indtast adgangskode"
+
+#: pkg/users/index.html:310 pkg/users/local.js:848
+msgid "Never lock account"
 msgstr ""
 
 #: pkg/kubernetes/views/project-listing.html:46
 msgid "New Group"
 msgstr ""
 
-#: pkg/users/index.html:238 pkg/shell/index.html:243
+#: pkg/storaged/nfs-details.jsx:127
+msgid "New NFS Mount"
+msgstr ""
+
+#: pkg/shell/index.html:309 pkg/users/index.html:253
 #, fuzzy
 msgid "New Password"
 msgstr "Indtast adgangskode"
@@ -3772,12 +4731,22 @@ msgstr "Indtast adgangskode"
 msgid "New Project"
 msgstr ""
 
+#: pkg/machines/components/diskAdd.jsx:134
+#, fuzzy
+msgid "New Volume Name"
+msgstr "Værtsnavn"
+
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
-#: pkg/kubernetes/views/image-listing.html:7
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
-#: pkg/users/local.js:120 pkg/lib/credentials.js:232
+#: pkg/storaged/crypto-keyslots.jsx:183 pkg/storaged/crypto-keyslots.jsx:225
+#, fuzzy
+msgid "New passphrase"
+msgstr "Indtast adgangskode"
+
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -3787,49 +4756,45 @@ msgstr ""
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:91 pkg/storaged/overview.js:536
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr ""
 
-#: pkg/systemd/init.js:273
+#: pkg/systemd/init.js:274
 msgid "Next Run"
 msgstr ""
 
-#: pkg/systemd/index.html:233 pkg/systemd/host.js:1353
+#: pkg/systemd/index.html:263 pkg/systemd/host.js:1455
 msgid "Nice"
 msgstr ""
 
-#: pkg/docker/index.html:531 pkg/docker/index.html:535
-#: pkg/networkmanager/interfaces.js:2416 pkg/docker/util.js:101
-#: pkg/docker/run.js:241 pkg/kubernetes/scripts/volumes.js:990
+#: pkg/docker/index.html:539 pkg/docker/index.html:543 pkg/docker/run.js:241
+#: pkg/docker/util.js:106 pkg/kubernetes/scripts/volumes.js:990
+#: pkg/networkmanager/interfaces.js:2582
 msgid "No"
 msgstr ""
 
-#: pkg/systemd/index.html:453
+#: pkg/systemd/index.html:483
 msgid "No Delay"
 msgstr ""
 
-#: pkg/ostree/index.html:420
-msgid "No Deployments"
-msgstr ""
-
-#: pkg/storaged/format-dialog.jsx:111
+#: pkg/storaged/format-dialog.jsx:247
 msgid "No Filesystem"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:753
+#: pkg/storaged/content-views.jsx:697
 msgid "No Logical Volumes"
 msgstr ""
 
-#: pkg/ostree/app.js:108
-msgid "No OSTree deployments found"
+#: pkg/storaged/nfs-panel.jsx:111
+msgid "No NFS mounts set up"
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:398
+#: src/ws/cockpitcertificate.c:522
 msgid "No PEM-encoded certificate found"
 msgstr ""
 
-#: src/ws/cockpitcertificate.c:364
+#: src/ws/cockpitcertificate.c:488
 msgid "No PEM-encoded private key found"
 msgstr ""
 
@@ -3841,7 +4806,12 @@ msgstr ""
 msgid "No SELinux alerts."
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:34
+#: pkg/ovirt/components/ClusterTemplates.jsx:29
+#: pkg/ovirt/components/ClusterVms.jsx:36
+msgid "No VM found in oVirt."
+msgstr ""
+
+#: pkg/machines/hostvmslist.jsx:94
 msgid "No VM is running or defined on this host"
 msgstr ""
 
@@ -3857,39 +4827,69 @@ msgstr ""
 msgid "No alias specified"
 msgstr ""
 
-#: pkg/sosreport/index.js:114
+#: pkg/apps/application-list.jsx:137
+msgid "No applications installed or available"
+msgstr ""
+
+#: pkg/sosreport/index.js:112
 msgid "No archive has been created."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1316
+#: pkg/storaged/crypto-keyslots.jsx:548
+msgid "No available slots"
+msgstr ""
+
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:30
+msgid "No boot device found"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1420
 msgid "No carrier"
 msgstr ""
 
-#: pkg/ostree/remotes.js:106
-msgid "No configuration data found"
+#: pkg/kdump/kdump-view.jsx:397
+msgid "No configuration found"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:395
-msgid "No configuration found"
+#: pkg/machines/components/consoles.jsx:97
+msgid "No console defined for this virtual machine."
 msgstr ""
 
 #: pkg/docker/run.js:371
 msgid "No container specified"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:277
+#: pkg/docker/containers-view.jsx:361
 msgid "No containers"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:279
+#: pkg/docker/containers-view.jsx:363
 msgid "No containers that match the current filter"
 msgstr ""
 
-#: pkg/storaged/index.html:191
+#: pkg/apps/application.jsx:79
+msgid "No description provided."
+msgstr ""
+
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
+msgid "No disks are available."
+msgstr ""
+
+#: pkg/machines/components/vmDisksTab.jsx:85
+msgid "No disks defined for this VM"
+msgstr ""
+
+#: pkg/storaged/drives-panel.jsx:120
 msgid "No drives attached"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:738
+#: pkg/storaged/crypto-keyslots.jsx:553
+msgid "No free key slots"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:682 pkg/storaged/lvol-tabs.jsx:338
 msgid "No free space"
 msgstr ""
 
@@ -3897,19 +4897,19 @@ msgstr ""
 msgid "No groups are present."
 msgstr ""
 
-#: pkg/systemd/index.html:28
+#: pkg/systemd/index.html:29
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/index.html:156
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
-#: pkg/kubernetes/views/image-listing.html:70
+#: node_modules/registry-image-widgets/views/imagestream-listing.html:43
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:605
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -3917,19 +4917,31 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:607
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
+msgstr ""
+
+#: pkg/apps/utils.jsx:95
+msgid "No installation package found for this application."
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-view.jsx:223
 msgid "No installed products on the system."
 msgstr ""
 
-#: pkg/storaged/index.html:444
+#: pkg/storaged/crypto-keyslots.jsx:492
+msgid "No keys added"
+msgstr ""
+
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:204
+msgid "No matching files found"
+msgstr ""
+
+#: pkg/storaged/drive-details.jsx:71
 msgid "No media inserted"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:451
+#: pkg/kdump/kdump-view.jsx:453
 msgid ""
 "No memory reserved. Append a crashkernel option to the kernel command line "
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
@@ -3941,11 +4953,23 @@ msgid ""
 "No metadata file was selected. Please select a Kubernetes metadata file."
 msgstr ""
 
+#: pkg/machines/vmnetworktab.jsx:31
+msgid "No network interfaces defined for this VM"
+msgstr ""
+
 #: pkg/kubernetes/views/dashboard-page.html:117
 msgid "No nodes in cluster"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:515
+#: pkg/ovirt/components/App.jsx:59
+msgid "No oVirt connection"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:327
+msgid "No open ports"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:508
 msgid "No partitioning"
 msgstr ""
 
@@ -3969,7 +4993,7 @@ msgstr ""
 msgid "No projects are present."
 msgstr ""
 
-#: pkg/users/local.js:421
+#: pkg/users/local.js:423
 msgid "No real name specified"
 msgstr ""
 
@@ -3977,27 +5001,35 @@ msgstr ""
 msgid "No results for $0"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:272
+#: pkg/docker/containers-view.jsx:356
 msgid "No running containers"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:274
+#: pkg/docker/containers-view.jsx:358
 msgid "No running containers that match the current filter"
 msgstr ""
 
-#: pkg/ostree/index.html:294
-msgid "No signature avaliable"
-msgstr ""
-
-#: pkg/storaged/index.html:85
+#: pkg/storaged/mdraids-panel.jsx:128
 msgid "No storage set up as RAID"
 msgstr ""
 
-#: pkg/lib/credentials.js:182
+#: pkg/storaged/vdos-panel.jsx:170
+msgid "No storage set up as VDO"
+msgstr ""
+
+#: pkg/lib/credentials.js:188
 msgid "No such file or directory"
 msgstr ""
 
-#: pkg/users/local.js:416
+#: node_modules/registry-image-widgets/views/image-listing.html:73
+msgid "No tags are present."
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:41
+msgid "No updates pending"
+msgstr ""
+
+#: pkg/users/local.js:418
 msgid "No user name specified"
 msgstr ""
 
@@ -4005,7 +5037,11 @@ msgstr ""
 msgid "No users are present."
 msgstr ""
 
-#: pkg/storaged/index.html:118
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:54
+msgid "No virtual machines"
+msgstr ""
+
+#: pkg/storaged/vgroups-panel.jsx:116
 msgid "No volume groups created"
 msgstr ""
 
@@ -4017,17 +5053,21 @@ msgstr ""
 msgid "No volumes in use"
 msgstr ""
 
-#: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7
-#: pkg/kubernetes/views/topology-page.html:38
 #: pkg/kubernetes/views/containers-listing.html:15
-#: pkg/kubernetes/views/pod-body.html:18
+#: pkg/kubernetes/views/node-page.html:14
+#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
+#: pkg/kubernetes/views/topology-page.html:38
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 msgid "Node"
 msgstr ""
 
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:79
+msgid "Node:"
+msgstr ""
+
 #: pkg/kubernetes/views/dashboard-page.html:90
-#: pkg/kubernetes/views/dashboard-page.html:192 pkg/kubernetes/index.html:46
+#: pkg/kubernetes/views/dashboard-page.html:192
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -4037,26 +5077,30 @@ msgstr ""
 
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
-#: bower_components/registry-image-widgets/views/imagestream-body.html:33
-#: bower_components/registry-image-widgets/views/image-config.html:29
-#: pkg/tuned/dialog.js:231 pkg/kdump/kdump-view.jsx:418
+#: node_modules/registry-image-widgets/views/image-config.html:29
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr ""
 
-#: pkg/playground/translate.html:29 pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/kubernetes/scripts/nodes.js:319
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:56
+msgid "Not Available"
+msgstr ""
+
+#: pkg/kubernetes/views/details-page.html:53
+#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
+#: pkg/kubernetes/scripts/nodes.js:319
 msgid "Not Ready"
 msgstr ""
 
-#: pkg/kubernetes/scripts/details.js:498 pkg/kubernetes/scripts/details.js:621
+#: pkg/kubernetes/scripts/details.js:499 pkg/kubernetes/scripts/details.js:622
 msgid "Not a valid number of replicas"
 msgstr ""
 
-#: pkg/lib/credentials.js:249
+#: pkg/lib/credentials.js:255
 msgid "Not a valid private key"
 msgstr ""
 
-#: pkg/kubernetes/scripts/details.js:549
+#: pkg/kubernetes/scripts/details.js:550
 msgid "Not a valid value for Host"
 msgstr ""
 
@@ -4064,65 +5108,84 @@ msgstr ""
 msgid "Not authorized to access Docker on this system"
 msgstr ""
 
-#: pkg/ostree/app.js:87
-msgid "Not authorized to update software on this system"
+#: pkg/systemd/logs.js:452
+msgid "Not authorized to upload-report"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:729
+#: pkg/networkmanager/interfaces.js:820
 msgid "Not available"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot.js:238
+#: pkg/selinux/setroubleshoot.js:239
 msgid "Not connected"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
-#: pkg/storaged/details.js:555 pkg/docker/details.js:176
+#: pkg/docker/details.js:179 pkg/storaged/details.jsx:135
 msgid "Not found"
 msgstr ""
 
-#: src/base1/cockpit.js:3917
+#: pkg/storaged/nfs-panel.jsx:55
+msgid "Not mounted"
+msgstr ""
+
+#: src/base1/cockpit.js:3994
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/details.js:389
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
-#: pkg/systemd/index.html:62
+#: pkg/systemd/index.html:63
 msgid "Not synchronized"
 msgstr ""
 
-#: pkg/systemd/services.html:299
+#: node_modules/registry-image-widgets/views/image-listing.html:44
+msgid "Not yet synced"
+msgstr ""
+
+#: pkg/systemd/services.html:341
 msgid "Note"
 msgstr ""
 
-#: pkg/systemd/logs.html:50
-msgid "Notices"
+#: pkg/lib/machine-info.es6:69
+msgid "Notebook"
+msgstr ""
+
+#: pkg/systemd/logs.html:60
+msgid "Notice and above"
+msgstr ""
+
+#: pkg/ovirt/components/vcpuModal.jsx:52
+msgid "Number of virtual CPUs that gonna be used."
+msgstr ""
+
+#: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
+msgid "OK"
 msgstr ""
 
 #: pkg/kubernetes/views/node-body.html:13
+#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "OS"
 msgstr ""
 
-#: pkg/ostree/client.js:585 pkg/ostree/client.js:662
-msgid "OS $0 not found"
+#: pkg/ovirt/components/OVirtTab.jsx:148
+msgid "OS Type:"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:219
-msgid "OS Type:"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
+msgid "OS Vendor"
 msgstr ""
 
 #: pkg/kubernetes/views/nodes-page.html:19
 msgid "OS Versions"
-msgstr ""
-
-#: pkg/ostree/app.js:89
-msgid "OSTree is not available on this system"
 msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:375
@@ -4133,115 +5196,142 @@ msgstr ""
 msgid "Occurred between $0 and $1"
 msgstr ""
 
-#: pkg/playground/jquery-patterns.html:95
-#: pkg/playground/jquery-patterns.html:108 pkg/storaged/index.html:563
-#: pkg/systemd/index.html:157 pkg/shell/index.html:177
-#: pkg/lib/cockpit-components-onoff.jsx:38 pkg/lib/patterns.js:244
+#: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
+#: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr ""
 
-#: pkg/lib/cockpit-components-dialog.jsx:155
+#: pkg/lib/cockpit-components-dialog.jsx:188
 msgid "Ok"
 msgstr ""
 
-#: pkg/users/index.html:228 pkg/shell/index.html:236
+#: pkg/shell/index.html:301 pkg/users/index.html:243
 #, fuzzy
 msgid "Old Password"
 msgstr "Indtast adgangskode"
 
-#: pkg/users/local.js:77 pkg/lib/credentials.js:214
+#: pkg/storaged/crypto-keyslots.jsx:221
+#, fuzzy
+msgid "Old passphrase"
+msgstr "Indtast adgangskode"
+
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
-#: pkg/playground/jquery-patterns.html:91
-#: pkg/playground/jquery-patterns.html:104 pkg/storaged/index.html:562
-#: pkg/systemd/index.html:153 pkg/shell/index.html:173
-#: pkg/lib/cockpit-components-onoff.jsx:39 pkg/lib/patterns.js:244
+#: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
+#: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-meta.html:7
+#: node_modules/registry-image-widgets/views/image-meta.html:7
 msgid "On Build"
 msgstr ""
 
-#: pkg/docker/index.html:536
+#: pkg/docker/index.html:544 pkg/systemd/init.js:693
 msgid "On Failure"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:393
+#: pkg/kdump/kdump-view.jsx:395
 msgid "On a mounted device"
 msgstr ""
 
-#: pkg/docker/util.js:103
+#: pkg/docker/util.js:108
 msgid "On failure, retry $0 time"
 msgid_plural "On failure, retry $0 times"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/realmd/operation.html:71 pkg/realmd/operation.js:274
+#: pkg/realmd/operation.html:72 pkg/realmd/operation.js:291
 msgid "One Time Password"
 msgstr ""
 
-#: pkg/systemd/init.js:1144
+#: pkg/storaged/vdo-details.jsx:123
+msgid "Only $0 of $1 are used."
+msgstr ""
+
+#: pkg/systemd/logs.html:55
+msgid "Only Emergency"
+msgstr ""
+
+#: pkg/systemd/init.js:1196
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr ""
 
-#: pkg/shell/simple.html:28 pkg/shell/index.html:28 pkg/shell/stub.html:28
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:118
+msgid "Only files of size $0 MiB and less are supported"
+msgstr ""
+
+#: pkg/shell/index.html:43 pkg/shell/simple.html:29 pkg/shell/stub.html:33
 msgid "Ooops!"
 msgstr ""
 
-#: pkg/systemd/index.html:89 pkg/ostree/index.html:301
-#: pkg/kubernetes/views/nodes-page.html:42
+#: pkg/kubernetes/views/nodes-page.html:42 pkg/systemd/index.html:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:259
 msgid "Operating System"
 msgstr ""
 
-#: pkg/ostree/index.html:375
-msgid "Operating System Updates"
-msgstr ""
-
-#: pkg/storaged/jobs.js:163
+#: pkg/storaged/jobs-panel.jsx:84
 msgid "Operation '$operation' on $target"
 msgstr ""
 
-#: pkg/storaged/overview.js:191
+#: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr ""
 
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:102
-#: pkg/storaged/crypto-tab.jsx:137
+#: pkg/ovirt/components/OVirtTab.jsx:157
+msgid "Optimized for:"
+msgstr ""
+
+#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:138
+#: pkg/storaged/vdos-panel.jsx:96
 msgid "Options"
 msgstr "Indstillinger"
+
+#: src/ws/login.html:125
+msgid "Or use a bundled browser"
+msgstr ""
 
 #: pkg/subscriptions/subscriptions-register.jsx:176
 msgid "Organization"
 msgstr ""
 
-#: pkg/ostree/index.html:307
-msgid "Origin"
+#: pkg/lib/machine-info.es6:60
+msgid "Other"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:309
+#: pkg/storaged/content-views.jsx:339
 msgctxt "storage-id-desc"
 msgid "Other Data"
 msgstr ""
 
-#: pkg/storaged/index.html:200
+#: pkg/storaged/others-panel.jsx:71
 msgid "Other Devices"
 msgstr ""
 
-#: src/ws/login.html:70
+#: src/ws/login.html:69
 #, fuzzy
 msgid "Other Options"
 msgstr "Indstillinger"
 
-#: pkg/docker/index.html:287 pkg/kubernetes/index.html:40
-#: pkg/kubernetes/registry.html:43 pkg/machines/hostvmslist.jsx:304
+#: pkg/docker/index.html:295 pkg/kubernetes/index.html:43
+#: pkg/kubernetes/registry.html:43
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:47
+#: pkg/machines/components/vm/vm.jsx:50
 msgid "Overview"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:505 pkg/storaged/format-dialog.jsx:129
+#: pkg/storaged/content-views.jsx:499 pkg/storaged/format-dialog.jsx:272
 msgid "Overwrite existing data with zeros"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:84
+msgid "PCI"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:4
@@ -4249,70 +5339,117 @@ msgstr ""
 msgid "PD Name"
 msgstr "Værtsnavn"
 
-#: pkg/ostree/index.html:266
-msgid "Packages"
+#: pkg/packagekit/updates.jsx:524
+msgid "Package information"
 msgstr ""
 
-#: pkg/networkmanager/index.html:134
+#: pkg/lib/packagekit.es6:115
+msgid "PackageKit crashed"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:584
+msgid "PackageKit is not installed"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:738
+msgid "PackageKit reported error code $0"
+msgstr ""
+
+#: pkg/networkmanager/index.html:166
 msgid "Parent"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2725
+#: pkg/networkmanager/interfaces.js:2891
 msgid "Parent $parent"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1362
+#: pkg/systemd/init.js:683
+msgid "Part Of"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:1466
 msgid "Part of "
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:138
+#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:132
 msgid "Partition"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:509
+#: pkg/storaged/utils.js:243
+msgid "Partition of $0"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:501
 msgid "Partitioning"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1867
+#: pkg/networkmanager/interfaces.js:1998
 msgid "Passive"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:194 pkg/storaged/format-dialog.jsx:147
+#: pkg/storaged/content-views.jsx:215 pkg/storaged/crypto-keyslots.jsx:179
+#: pkg/storaged/crypto-keyslots.jsx:524 pkg/storaged/format-dialog.jsx:284
+#: pkg/storaged/lvol-tabs.jsx:176 pkg/storaged/lvol-tabs.jsx:221
 msgid "Passphrase"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:150
+#: pkg/storaged/crypto-keyslots.jsx:154 pkg/storaged/crypto-keyslots.jsx:185
+#: pkg/storaged/crypto-keyslots.jsx:222 pkg/storaged/crypto-keyslots.jsx:226
+#: pkg/storaged/format-dialog.jsx:287
 msgid "Passphrase cannot be empty"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:158
+#: pkg/storaged/crypto-keyslots.jsx:327
+msgid "Passphrase removal may prevent unlocking $0."
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:192 pkg/storaged/crypto-keyslots.jsx:229
+#: pkg/storaged/format-dialog.jsx:294
 msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/users/index.html:113 pkg/users/index.html:166 pkg/shell/index.html:187
-#: pkg/shell/index.html:200 pkg/kubernetes/views/auth-form.html:105
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
-#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:51
-#: pkg/storaged/overview.js:532 pkg/storaged/overview.js:655
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
 msgstr ""
 
-#: pkg/users/local.js:258
+#: pkg/users/index.html:340
+msgid "Password Expiration"
+msgstr ""
+
+#: pkg/users/local.js:260
 msgid "Password is not acceptable"
 msgstr ""
 
-#: pkg/users/local.js:246
+#: pkg/users/local.js:248
 msgid "Password is too weak"
 msgstr ""
 
-#: pkg/lib/credentials.js:280
+#: pkg/users/local.js:842
+msgid "Password must be changed"
+msgstr ""
+
+#: pkg/lib/credentials.js:289
 msgid "Password not accepted"
 msgstr ""
 
-#: pkg/users/index.html:348
+#: pkg/shell/index.html:155
+msgid ""
+"Password not usable for privileged tasks or to connect to other machines"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:211
+msgid "Paste JSON below, "
+msgstr ""
+
+#: pkg/users/index.html:461
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
@@ -4323,15 +5460,35 @@ msgstr ""
 msgid "Path"
 msgstr ""
 
-#: pkg/networkmanager/index.html:283
+#: pkg/networkmanager/index.html:315
 msgid "Path cost"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2707
+#: pkg/networkmanager/interfaces.js:2873
 msgid "Path cost $path_cost"
 msgstr ""
 
-#: pkg/systemd/services.html:56
+#: pkg/storaged/nfs-details.jsx:140
+msgid "Path on Server"
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:145
+msgid "Path on server cannot be empty."
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:147
+msgid "Path on server must start with \"/\"."
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:181
+msgid "Path to ISO file on host's file system"
+msgstr ""
+
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:264
+msgid "Path to file"
+msgstr ""
+
+#: pkg/systemd/services.html:57
 msgid "Paths"
 msgstr ""
 
@@ -4339,15 +5496,19 @@ msgstr ""
 msgid "Pending Volume Claims"
 msgstr ""
 
-#: pkg/systemd/index.html:143
+#: pkg/systemd/index.html:163
 msgid "Performance Profile"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3444
+#: pkg/lib/machine-info.es6:80
+msgid "Peripheral Chassis"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3605
 msgid "Permanent"
 msgstr ""
 
-#: src/ws/login.js:597
+#: src/ws/login.js:640
 msgid "Permission denied"
 msgstr ""
 
@@ -4359,38 +5520,71 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:147 pkg/storaged/content-views.jsx:299
+#: pkg/storaged/vdo-details.jsx:276
+msgid "Physical"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:141 pkg/storaged/content-views.jsx:329
 msgid "Physical Volume"
 msgstr ""
 
-#: pkg/storaged/index.html:639
+#: pkg/storaged/vgroup-details.jsx:132
 msgid "Physical Volumes"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:294
+#: pkg/storaged/content-views.jsx:324
 msgid "Physical volume of $0"
 msgstr ""
 
-#: pkg/networkmanager/index.html:447
+#: pkg/storaged/lvol-tabs.jsx:311
+msgid "Physical volumes can not be resized here."
+msgstr ""
+
+#: pkg/networkmanager/index.html:479
 msgid "Ping Interval"
 msgstr ""
 
-#: pkg/networkmanager/index.html:456
+#: pkg/networkmanager/index.html:488
 msgid "Ping Target"
 msgstr ""
 
-#: pkg/storaged/details.js:127 pkg/storaged/details.js:176
-#: pkg/storaged/content-views.jsx:251 pkg/docker/details.js:270
-#: pkg/docker/containers-view.jsx:167 pkg/docker/image.js:138
+#: pkg/lib/machine-info.es6:64
+msgid "Pizza Box"
+msgstr ""
+
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
+#: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr ""
 
-#: pkg/docker/util.js:499
+#: pkg/docker/util.js:509
 msgid "Please confirm forced deletion of $0"
+msgstr ""
+
+#: pkg/storaged/mdraid-details.jsx:245 pkg/storaged/vdo-details.jsx:143
+msgid "Please confirm stopping of $0"
+msgstr ""
+
+#: pkg/ovirt/components/HostToMaintenance.jsx:34
+msgid "Please confirm, the host shall be switched to maintenance mode."
 msgstr ""
 
 #: pkg/kubernetes/scripts/dashboard.js:440
 msgid "Please create another namespace for $0 \"$1\""
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:406
+msgid "Please enter new volume name"
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:409
+msgid "Please enter new volume size"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:292
+msgid "Please install the {0} package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574
@@ -4403,10 +5597,6 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:632
 msgid "Please provide a valid NFS server"
-msgstr ""
-
-#: pkg/ostree/remotes.js:255
-msgid "Please provide a valid URL"
 msgstr ""
 
 #: pkg/kubernetes/scripts/connection.js:537
@@ -4425,7 +5615,7 @@ msgstr ""
 msgid "Please provide a valid logical unit number"
 msgstr ""
 
-#: pkg/ostree/remotes.js:248 pkg/kubernetes/scripts/volumes.js:477
+#: pkg/kubernetes/scripts/volumes.js:477
 msgid "Please provide a valid name"
 msgstr ""
 
@@ -4449,6 +5639,22 @@ msgstr ""
 msgid "Please provide a valid target"
 msgstr ""
 
+#: pkg/ovirt/components/InstallationDialog.jsx:83
+msgid ""
+"Please provide fully qualified domain name and port of the oVirt engine."
+msgstr ""
+
+#: pkg/ovirt/components/InstallationDialog.jsx:137
+msgid ""
+"Please provide valid oVirt engine fully qualified domain name (FQDN) and "
+"port (443 by default)"
+msgstr ""
+
+#: pkg/ovirt/components/ConsoleClientResources.jsx:32
+msgid ""
+"Please refer to oVirt's $0 for more information about Remote Viewer setup."
+msgstr ""
+
 #: pkg/kubernetes/scripts/volumes.js:469
 msgid "Please select a valid access mode"
 msgstr ""
@@ -4461,17 +5667,41 @@ msgstr ""
 msgid "Please select a valid policy option."
 msgstr ""
 
+#: pkg/users/local.js:1175
+msgid "Please specify an expiration date"
+msgstr ""
+
+#: src/ws/login.js:427
+msgid "Please specify the host to connect to"
+msgstr ""
+
+#: pkg/machines/components/consoles.jsx:37
+msgid "Please start the virtual machine to access its console."
+msgstr ""
+
 #: pkg/docker/search.js:150
 msgid "Please try another term"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:397
+#: pkg/kubernetes/scripts/nodes.js:401
 msgid "Please type an address"
 msgstr ""
 
+#: pkg/ovirt/components/ClusterVms.jsx:37
+msgid "Please wait till VMs list is loaded from the server."
+msgstr ""
+
+#: pkg/ovirt/components/ClusterTemplates.jsx:30
+msgid "Please wait till list of templates is loaded from the server."
+msgstr ""
+
+#: pkg/machines/vmnetworktab.jsx:123
+msgid "Plug"
+msgstr ""
+
+#: pkg/kubernetes/views/containers-listing.html:12
 #: pkg/kubernetes/views/pod-page.html:12
 #: pkg/kubernetes/views/topology-page.html:14
-#: pkg/kubernetes/views/containers-listing.html:12
 msgid "Pod"
 msgstr ""
 
@@ -4493,12 +5723,16 @@ msgstr ""
 msgid "Pod Selector"
 msgstr ""
 
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:78
+msgid "Pod:"
+msgstr ""
+
+#: pkg/kubernetes/views/dashboard-page.html:18
+#: pkg/kubernetes/views/details-page.html:166
 #: pkg/kubernetes/views/pv-claim.html:37
 #: pkg/kubernetes/views/replicationcontroller-page.html:17
-#: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/dashboard-page.html:18
 #: pkg/kubernetes/views/replicationcontroller-panel.html:12
-#: pkg/kubernetes/scripts/details.js:228
+#: pkg/kubernetes/scripts/details.js:229
 msgid "Pods"
 msgstr ""
 
@@ -4508,7 +5742,9 @@ msgid ""
 "your application code."
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:130
+#: pkg/machines/components/diskAdd.jsx:200
+#: pkg/machines/components/vmDiskSourceCell.jsx:39
+#: pkg/storaged/content-views.jsx:124
 #, fuzzy
 msgid "Pool"
 msgstr "Værtsnavn"
@@ -4518,15 +5754,15 @@ msgstr "Værtsnavn"
 msgid "Pool Name"
 msgstr "Værtsnavn"
 
-#: pkg/storaged/utils.js:166
+#: pkg/storaged/utils.js:163
 msgid "Pool for Thin Logical Volumes"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:611
+#: pkg/storaged/content-views.jsx:576
 msgid "Pool for Thin Volumes"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:686
+#: pkg/storaged/content-views.jsx:633
 msgid "Pool for thinly provisioned volumes"
 msgstr ""
 
@@ -4534,69 +5770,109 @@ msgstr ""
 msgid "Populate"
 msgstr ""
 
-#: pkg/lib/machine-change-port.html:23 pkg/storaged/overview.js:627
+#: pkg/lib/machine-change-port.html:23
+#: pkg/machines/components/vmDiskSourceCell.jsx:42
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
+#: pkg/ovirt/components/InstallationDialog.jsx:65
 msgid "Port"
 msgstr ""
 
-#: pkg/networkmanager/index.html:216 pkg/networkmanager/index.html:415
-#: pkg/docker/index.html:493 pkg/kubernetes/views/service-body.html:13
-#: pkg/kubernetes/views/container-body.html:12
-#: bower_components/registry-image-widgets/views/image-config.html:27
-#: pkg/networkmanager/interfaces.js:2807 pkg/docker/containers-view.jsx:313
+#: pkg/lib/machine-info.es6:67
+msgid "Portable"
+msgstr ""
+
+#: pkg/machines/vmnetworktab.jsx:92
+msgid "Portgroup"
+msgstr ""
+
+#: pkg/docker/index.html:501 pkg/kubernetes/views/container-body.html:12
+#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
+#: pkg/networkmanager/index.html:447
+#: node_modules/registry-image-widgets/views/image-config.html:27
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr ""
 
-#: pkg/docker/index.html:186
+#: pkg/docker/index.html:190
 msgid "Ports:"
 msgstr ""
 
-#: pkg/systemd/index.html:123
+#: pkg/systemd/index.html:140
 msgid "Power Options"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3111
+#: pkg/machines/components/vcpuModal.jsx:183
+#: pkg/ovirt/components/vcpuModal.jsx:59
+msgid "Preferred number of sockets to expose to the guest."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3280
 msgid "Prefix length"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3111
+#: pkg/networkmanager/interfaces.js:3280
 msgid "Prefix length or Netmask"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:733
+#: pkg/networkmanager/interfaces.js:824
 msgid "Preparing"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3445
+#: pkg/ovirt/rephraseUI.es6:25
+msgid "Preparing for Maintenance"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3606
 msgid "Preserve"
 msgstr ""
 
-#: pkg/systemd/init.js:542
+#: pkg/systemd/init.js:544
 msgid "Preset"
 msgstr ""
 
-#: pkg/systemd/init.js:543
+#: pkg/systemd/init.js:545
 msgid "Preset Forcefully"
 msgstr ""
 
-#: pkg/systemd/index.html:294
+#: pkg/systemd/index.html:324
 msgid "Pretty Host Name"
 msgstr ""
 
-#: pkg/networkmanager/index.html:349
+#: pkg/networkmanager/index.html:381
 msgid "Primary"
 msgstr ""
 
-#: pkg/networkmanager/index.html:274 pkg/networkmanager/index.html:488
-#: pkg/networkmanager/index.html:506
+#: pkg/networkmanager/index.html:306 pkg/networkmanager/index.html:520
+#: pkg/networkmanager/index.html:538
 msgid "Priority"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2681 pkg/networkmanager/interfaces.js:2705
+#: pkg/networkmanager/interfaces.js:2847 pkg/networkmanager/interfaces.js:2871
 msgid "Priority $priority"
 msgstr ""
 
-#: pkg/kubernetes/scripts/projects.js:1018
+#: pkg/kubernetes/scripts/projects.js:1026
 msgid "Private: Allow only specific users or groups to pull images"
+msgstr ""
+
+#: pkg/shell/index.html:39
+msgid "Privileged"
+msgstr ""
+
+#: pkg/systemd/logs.js:413
+msgid "Problem details"
+msgstr ""
+
+#: pkg/systemd/logs.js:412
+msgid "Problem info"
+msgstr ""
+
+#: pkg/docker/containers-view.jsx:337
+msgid "Problems"
+msgstr ""
+
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
+msgid "Process"
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-view.jsx:33
@@ -4607,20 +5883,21 @@ msgstr ""
 msgid "Product name"
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/route-body.html:4
-#: pkg/kubernetes/views/service-body.html:4
-#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/containers-listing.html:13
+#: pkg/kubernetes/views/dashboard-page.html:159
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
 #: pkg/kubernetes/views/details-page.html:138
 #: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
+#: pkg/kubernetes/views/imagestream-modify.html:21
 #: pkg/kubernetes/views/pod-body.html:4
+#: pkg/kubernetes/views/replicationcontroller-body.html:4
+#: pkg/kubernetes/views/route-body.html:4
+#: pkg/kubernetes/views/service-body.html:4
+#: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr ""
 
@@ -4640,7 +5917,7 @@ msgstr ""
 msgid "Project access policy only allows specific members to access images."
 msgstr ""
 
-#: pkg/shell/simple.html:72 pkg/shell/index.html:84 pkg/shell/stub.html:77
+#: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
 msgid "Project website"
 msgstr ""
 
@@ -4648,23 +5925,31 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
+#: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
-#: pkg/kubernetes/views/group-delete.html:10 pkg/kubernetes/index.html:85
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
 #: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
-#: pkg/users/local.js:82
+#: pkg/users/local.js:84
 msgid "Prompting via passwd timed out"
 msgstr ""
 
-#: pkg/lib/credentials.js:253
+#: pkg/lib/credentials.js:260
 msgid "Prompting via ssh-add timed out"
 msgstr ""
 
-#: pkg/lib/credentials.js:192
+#: pkg/lib/credentials.js:198
 msgid "Prompting via ssh-keygen timed out"
+msgstr ""
+
+#: pkg/systemd/init.js:696
+msgid "Propagates Reload To"
+msgstr ""
+
+#: pkg/machines/components/vmDiskSourceCell.jsx:38
+msgid "Protocol"
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-register.jsx:125
@@ -4675,11 +5960,15 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/shell/index.html:186 pkg/lib/machine-auth-failed.html:9
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:150
+#: node_modules/registry-image-widgets/views/imagestream-body.html:39
+msgid "Public pulling repo"
+msgstr ""
+
+#: pkg/kubernetes/views/registry-dashboard-page.html:152
 msgid "Pull an image:"
 msgstr ""
 
@@ -4687,117 +5976,116 @@ msgstr ""
 msgid "Pull from"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/imagestream-body.html:31
-msgid "Pull repository"
-msgstr ""
-
-#: pkg/kubernetes/scripts/images.js:626
+#: pkg/kubernetes/scripts/images.js:623
 msgid "Pull specific tags from another image repository"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:681
+#: pkg/storaged/content-views.jsx:627
 msgid "Purpose"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:140
+#: pkg/kubernetes/views/registry-dashboard-page.html:141
 msgid "Push an image:"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:77
-#: pkg/kubernetes/views/pv-modify.html:147
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
-#: pkg/storaged/details.js:354
+#: pkg/storaged/mdraid-details.jsx:186
 msgid "RAID ($0)"
 msgstr ""
 
-#: pkg/storaged/details.js:348
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 0"
 msgstr ""
 
-#: pkg/storaged/overview.js:425
+#: pkg/storaged/mdraids-panel.jsx:46
 msgid "RAID 0 (Stripe)"
 msgstr ""
 
-#: pkg/storaged/details.js:349
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 1"
 msgstr ""
 
-#: pkg/storaged/overview.js:426
+#: pkg/storaged/mdraids-panel.jsx:47
 msgid "RAID 1 (Mirror)"
 msgstr ""
 
-#: pkg/storaged/details.js:353
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID 10"
 msgstr ""
 
-#: pkg/storaged/overview.js:430
+#: pkg/storaged/mdraids-panel.jsx:51
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr ""
 
-#: pkg/storaged/details.js:350
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 4"
 msgstr ""
 
-#: pkg/storaged/overview.js:427
+#: pkg/storaged/mdraids-panel.jsx:48
 msgid "RAID 4 (Dedicated Parity)"
 msgstr ""
 
-#: pkg/storaged/details.js:351
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 5"
 msgstr ""
 
-#: pkg/storaged/overview.js:428
+#: pkg/storaged/mdraids-panel.jsx:49
 msgid "RAID 5 (Distributed Parity)"
 msgstr ""
 
-#: pkg/storaged/details.js:352
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 6"
 msgstr ""
 
-#: pkg/storaged/overview.js:429
+#: pkg/storaged/mdraids-panel.jsx:50
 msgid "RAID 6 (Double Distributed Parity)"
 msgstr ""
 
-#: pkg/storaged/index.html:535 pkg/storaged/pvol-tabs.jsx:68
+#: pkg/lib/machine-info.es6:81
+msgid "RAID Chassis"
+msgstr ""
+
+#: pkg/storaged/pvol-tabs.jsx:74
 msgid "RAID Device"
 msgstr ""
 
-#: pkg/storaged/utils.js:233
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr ""
 
-#: pkg/storaged/index.html:63
+#: pkg/storaged/mdraids-panel.jsx:127
 msgid "RAID Devices"
 msgstr ""
 
-#: pkg/storaged/overview.js:423
+#: pkg/storaged/mdraids-panel.jsx:44
 msgid "RAID Level"
 msgstr ""
 
-#: pkg/storaged/index.html:553
-msgctxt "storage"
-msgid "RAID Level"
-msgstr ""
-
-#: pkg/storaged/content-views.jsx:150
+#: pkg/storaged/content-views.jsx:144
 msgid "RAID Member"
 msgstr ""
 
-#: pkg/machines/libvirt.es6:184
-msgid "REBOOT_VM action failed"
+#: pkg/ovirt/provider.es6:160
+msgid "REBOOT action failed"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:82
+msgid "Rack Mount Chassis"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:200
 msgid "Rados Block Device"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3446
+#: pkg/networkmanager/interfaces.js:3607
 msgid "Random"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:391
+#: pkg/kdump/kdump-view.jsx:393
 msgid "Raw to a device"
 msgstr ""
 
@@ -4812,7 +6100,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
-#: pkg/kubernetes/views/pv-modify.html:194
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr ""
 
@@ -4828,25 +6116,29 @@ msgstr ""
 msgid "Read only from multiple nodes"
 msgstr ""
 
-#: pkg/docker/index.html:353
+#: pkg/docker/index.html:361
 msgid "ReadOnly"
 msgstr ""
 
-#: pkg/docker/index.html:352
+#: pkg/docker/index.html:360
 msgid "ReadWrite"
 msgstr ""
 
-#: pkg/storaged/index.html:325
+#: pkg/storaged/plot.jsx:265
 msgid "Reading"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:412
+#: pkg/kdump/kdump-view.jsx:414
 msgid "Reading..."
 msgstr ""
 
-#: pkg/playground/translate.html:19 pkg/playground/translate.html:179
+#: pkg/machines/components/vmDisksTab.jsx:72
+msgid "Readonly"
+msgstr ""
+
 #: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
+#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
 msgid "Ready"
 msgstr ""
 
@@ -4855,17 +6147,17 @@ msgctxt "verb"
 msgid "Ready"
 msgstr ""
 
-#: pkg/systemd/index.html:303
+#: pkg/systemd/index.html:333
 msgid "Real Host Name"
 msgstr ""
 
-#: pkg/systemd/host.js:820
+#: pkg/systemd/host.js:920
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
 msgstr ""
 
-#: pkg/systemd/host.js:821
+#: pkg/systemd/host.js:921
 msgid "Real host name must be 64 characters or less"
 msgstr ""
 
@@ -4873,30 +6165,14 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/ostree/index.html:241
-msgid "Rebase and Reboot"
-msgstr ""
-
-#: pkg/lib/journal.js:238
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr ""
 
-#: pkg/networkmanager/index.html:76 pkg/networkmanager/index.html:99
-#: pkg/networkmanager/index.html:117 pkg/networkmanager/index.html:563
-#: pkg/networkmanager/index.html:591
+#: pkg/networkmanager/index.html:88 pkg/networkmanager/index.html:130
+#: pkg/networkmanager/index.html:148 pkg/networkmanager/index.html:595
+#: pkg/networkmanager/index.html:623
 msgid "Receiving"
-msgstr ""
-
-#: pkg/ostree/client.js:56
-msgid "Receiving delta parts"
-msgstr ""
-
-#: pkg/ostree/client.js:58
-msgid "Receiving metadata objects"
-msgstr ""
-
-#: pkg/ostree/client.js:61
-msgid "Receiving objects: $0%"
 msgstr ""
 
 #: pkg/systemd/logs.html:41
@@ -4907,17 +6183,17 @@ msgstr ""
 msgid "Reclaim Policy"
 msgstr ""
 
-#: pkg/ostree/index.html:423 pkg/shell/simple.html:131 pkg/shell/index.html:311
-#: pkg/shell/stub.html:166 pkg/kubernetes/index.html:105
-#: pkg/kubernetes/registry.html:75
+#: pkg/kubernetes/index.html:114 pkg/kubernetes/registry.html:75
+#: pkg/shell/index.html:406 pkg/shell/simple.html:138 pkg/shell/stub.html:180
+#: pkg/machines/components/serialConsole.jsx:135
 msgid "Reconnect"
 msgstr ""
 
-#: pkg/storaged/details.js:409
+#: pkg/storaged/mdraid-details.jsx:101
 msgid "Recovering"
 msgstr ""
 
-#: pkg/storaged/jobs.js:142
+#: pkg/storaged/jobs-panel.jsx:65
 msgid "Recovering RAID Device $target"
 msgstr ""
 
@@ -4925,24 +6201,28 @@ msgstr ""
 msgid "Recycle"
 msgstr ""
 
-#: pkg/docker/storage.jsx:350
+#: pkg/docker/storage.jsx:360
 msgid "Reformat and add disks"
 msgstr ""
 
-#: src/ws/login.js:587
+#: pkg/packagekit/updates.jsx:40
+msgid "Refreshing package information"
+msgstr ""
+
+#: src/ws/login.js:630
 msgid "Refusing to connect. Host is unknown"
 msgstr ""
 
-#: src/ws/login.js:589
+#: src/ws/login.js:632
 msgid "Refusing to connect. Hostkey does not match"
 msgstr ""
 
-#: src/ws/login.js:585
+#: src/ws/login.js:628
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:205 pkg/subscriptions/main.js:45
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -4954,31 +6234,40 @@ msgstr ""
 msgid "Register Persistent Volume"
 msgstr ""
 
-#: pkg/subscriptions/main.js:74
+#: pkg/ovirt/components/InstallationDialog.jsx:108
+msgid "Register oVirt"
+msgstr ""
+
+#: pkg/subscriptions/main.js:75
 msgid "Register system"
 msgstr ""
 
-#: pkg/ostree/index.html:305
-msgid "Released"
+#: pkg/ovirt/components/InstallationDialog.jsx:128
+msgid "Registering oVirt to Cockpit"
 msgstr ""
 
-#: pkg/systemd/init.js:516
+#: pkg/packagekit/updates.jsx:904
+msgid "Register…"
+msgstr ""
+
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
-#: pkg/systemd/init.js:517
-msgid "Reload or Restart"
+#: pkg/systemd/init.js:697
+msgid "Reload Propagated From"
 msgstr ""
 
-#: pkg/systemd/init.js:519
-msgid "Reload or Try Restart"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:192
+msgid "Remote URL"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:160 pkg/kdump/kdump-view.jsx:389
+#: pkg/kdump/kdump-view.jsx:160 pkg/kdump/kdump-view.jsx:391
 msgid "Remote over NFS"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:161 pkg/kdump/kdump-view.jsx:387
+#: pkg/kdump/kdump-view.jsx:161 pkg/kdump/kdump-view.jsx:389
 msgid "Remote over SSH"
 msgstr ""
 
@@ -4990,24 +6279,31 @@ msgstr ""
 msgid "Remote;Administration;"
 msgstr ""
 
-#: pkg/storaged/overview.js:187 pkg/storaged/overview.js:189
+#: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
 msgctxt "storage"
 msgid "Removable Drive"
 msgstr ""
 
-#: pkg/ostree/index.html:315 pkg/ostree/index.html:337
-msgid "Removals"
+#: pkg/lib/cockpit-components-install-dialog.jsx:81
+msgid "Removals:"
 msgstr ""
 
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/group-delete.html:21
+#: pkg/kubernetes/views/remove-role-dialog.html:8
+#: pkg/kubernetes/views/user-delete.html:25
+#: pkg/kubernetes/views/user-group-remove.html:10
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2876
+#: pkg/networkmanager/interfaces.js:3043
 msgid "Remove $0"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:385
+msgid "Remove $0?"
 msgstr ""
 
 #: pkg/kubernetes/views/group-delete.html:3
@@ -5022,8 +6318,16 @@ msgstr ""
 msgid "Remove Role"
 msgstr ""
 
+#: pkg/storaged/crypto-keyslots.jsx:394
+msgid "Remove Tang keyserver"
+msgstr ""
+
 #: pkg/kubernetes/views/user-delete.html:3
 msgid "Remove User"
+msgstr ""
+
+#: pkg/storaged/vdo-details.jsx:103
+msgid "Remove device"
 msgstr ""
 
 #: pkg/kubernetes/views/image-delete.html:3
@@ -5034,71 +6338,97 @@ msgstr ""
 msgid "Remove membership"
 msgstr ""
 
-#: pkg/storaged/jobs.js:138
+#: pkg/storaged/crypto-keyslots.jsx:358
+msgid "Remove passphrase"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:325
+msgid "Remove passphrase in $0?"
+msgstr ""
+
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
+msgid "Removing"
+msgstr ""
+
+#: pkg/lib/cockpit-components-install-dialog.jsx:181
+msgid "Removing $0"
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:61
 msgid "Removing $target from RAID Device"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2875
+#: pkg/networkmanager/interfaces.js:3042
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/storaged/jobs.js:151
+#: pkg/storaged/jobs-panel.jsx:74
 msgid "Removing physical volume from $target"
 msgstr ""
 
-#: pkg/storaged/details.js:513 pkg/storaged/lvol-tabs.jsx:44
+#: pkg/storaged/lvol-tabs.jsx:45 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:236
 msgid "Rename"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:36
+#: pkg/storaged/lvol-tabs.jsx:37
 msgid "Rename Logical Volume"
 msgstr ""
 
-#: pkg/storaged/details.js:150
+#: pkg/storaged/vgroup-details.jsx:177
 msgid "Rename Volume Group"
 msgstr ""
 
-#: pkg/storaged/jobs.js:154
+#: pkg/storaged/jobs-panel.jsx:77
 msgid "Renaming $target"
 msgstr ""
 
-#: pkg/systemd/services.html:431
+#: pkg/storaged/jobs-panel.jsx:48
+msgid "Repairing $target"
+msgstr ""
+
+#: pkg/systemd/services.html:473
 msgid "Repeat Daily"
 msgstr ""
 
-#: pkg/systemd/services.html:430
+#: pkg/systemd/services.html:472
 msgid "Repeat Hourly"
 msgstr ""
 
-#: pkg/systemd/services.html:433
+#: pkg/systemd/services.html:475
 msgid "Repeat Monthly"
 msgstr ""
 
-#: pkg/systemd/services.html:432
+#: pkg/systemd/services.html:474
 msgid "Repeat Weekly"
 msgstr ""
 
-#: pkg/systemd/services.html:434
+#: pkg/systemd/services.html:476
 msgid "Repeat Yearly"
 msgstr ""
 
-#: pkg/kubernetes/views/replicationcontroller-body.html:9
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
-#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/storaged/crypto-keyslots.jsx:177 pkg/storaged/crypto-keyslots.jsx:187
+#: pkg/storaged/crypto-keyslots.jsx:228
+msgid "Repeat passphrase"
+msgstr ""
+
 #: pkg/kubernetes/views/details-page.html:141
+#: pkg/kubernetes/views/replicationcontroller-body.html:9
+#: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
 #: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/topology-page.html:22
 #: pkg/kubernetes/views/replicationcontroller-panel.html:10
+#: pkg/kubernetes/views/topology-page.html:22
 msgid "Replication Controller"
 msgstr ""
 
 #: pkg/kubernetes/views/details-page.html:132
-#: pkg/kubernetes/scripts/details.js:225
+#: pkg/kubernetes/scripts/details.js:226
 msgid "Replication Controllers"
 msgstr ""
 
@@ -5108,7 +6438,24 @@ msgid ""
 "and remove pods when necessary."
 msgstr ""
 
-#: pkg/docker/index.html:674
+#: pkg/systemd/logs.js:437
+msgid "Report"
+msgstr ""
+
+#: pkg/systemd/logs.js:430
+msgid "Reported"
+msgstr ""
+
+#: pkg/systemd/logs.js:454
+msgid "Reporter 'reporter-ureport' not found."
+msgstr ""
+
+#: pkg/systemd/logs.js:456
+msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
+msgstr ""
+
+#: pkg/docker/index.html:682
+#: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr ""
 
@@ -5124,48 +6471,66 @@ msgstr ""
 msgid "Requests"
 msgstr ""
 
+#: pkg/users/local.js:1239
+msgid "Require password change every $0 days"
+msgstr ""
+
+#: pkg/users/local.js:844
+msgid "Require password change on $0"
+msgstr ""
+
+#: pkg/systemd/init.js:684
+msgid "Required By"
+msgstr ""
+
+#: pkg/systemd/init.js:679
+msgid "Requires"
+msgstr ""
+
 #: pkg/kubernetes/views/auth-form.html:54
 msgid "Requires Authentication"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:502
+#: pkg/systemd/init.js:680
+msgid "Requisite"
+msgstr ""
+
+#: pkg/systemd/init.js:685
+msgid "Requisite Of"
+msgstr ""
+
+#: pkg/kdump/kdump-view.jsx:505
 msgid "Reserved memory"
 msgstr ""
 
-#: pkg/docker/index.html:291 pkg/systemd/terminal.jsx:80
+#: pkg/docker/index.html:299 pkg/users/index.html:385
+#: pkg/systemd/terminal.jsx:81
 msgid "Reset"
 msgstr ""
 
-#: pkg/docker/storage.jsx:420
+#: pkg/docker/storage.jsx:412
 msgid "Reset Storage Pool"
 msgstr ""
 
-#: pkg/docker/storage.jsx:423
+#: pkg/docker/storage.jsx:415
 msgid ""
 "Resetting the storage pool will erase all containers and release disks in "
 "the pool."
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:87
-msgid "Resize"
-msgstr ""
-
-#: pkg/storaged/lvol-tabs.jsx:79
-msgid "Resize Filesystem"
-msgstr ""
-
-#: pkg/storaged/lvol-tabs.jsx:67
-msgid "Resize Logical Volume"
-msgstr ""
-
-#: pkg/storaged/jobs.js:155
+#: pkg/storaged/jobs-panel.jsx:40 pkg/storaged/jobs-panel.jsx:46
+#: pkg/storaged/jobs-panel.jsx:78
 msgid "Resizing $target"
 msgstr ""
 
-#: pkg/docker/index.html:134 pkg/systemd/index.html:126
-#: pkg/systemd/index.html:133 pkg/docker/containers-view.jsx:235
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
-#: pkg/systemd/init.js:515 pkg/machines/hostvmslist.jsx:43
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:59
+msgid "Resolve above errors to continue"
+msgstr ""
+
+#: pkg/docker/index.html:135 pkg/systemd/index.html:143
+#: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr ""
 
@@ -5173,12 +6538,24 @@ msgstr ""
 msgid "Restart Count"
 msgstr ""
 
-#: pkg/docker/index.html:526 pkg/kubernetes/views/pod-body.html:10
+#: pkg/packagekit/updates.jsx:521
+msgid "Restart Now"
+msgstr ""
+
+#: pkg/docker/index.html:534 pkg/kubernetes/views/pod-body.html:10
 msgid "Restart Policy"
 msgstr ""
 
-#: pkg/docker/index.html:166
+#: pkg/docker/index.html:170
 msgid "Restart Policy:"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:516
+msgid "Restart Recommended"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:888
+msgid "Restarting"
 msgstr ""
 
 #: pkg/networkmanager/index.html:39
@@ -5189,7 +6566,7 @@ msgstr ""
 msgid "Retain"
 msgstr ""
 
-#: pkg/docker/index.html:542
+#: pkg/docker/index.html:550
 msgid "Retries:"
 msgstr ""
 
@@ -5197,56 +6574,71 @@ msgstr ""
 msgid "Retrieving subscription status..."
 msgstr ""
 
+#: src/ws/login.html:57
+msgid "Reuse my password for privileged tasks"
+msgstr ""
+
+#: pkg/shell/index.html:159
+msgid "Reuse my password for privileged tasks and to connect to other machines"
+msgstr ""
+
 #: pkg/kubernetes/views/volume-body.html:26
 msgid "Revision"
 msgstr ""
 
 #: pkg/kubernetes/views/user-add-membership.html:28
+#: pkg/kubernetes/views/user-body.html:5
+#: pkg/kubernetes/views/user-panel.html:28
 msgid "Role"
 msgstr ""
 
-#: pkg/users/index.html:92 pkg/kubernetes/views/project-body.html:21
 #: pkg/kubernetes/views/add-member-role-dialog.html:39
+#: pkg/kubernetes/views/project-body.html:21 pkg/users/index.html:94
 msgid "Roles"
 msgstr ""
 
-#: pkg/ostree/index.html:237
-msgid "Roll Back and Reboot"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:1841 pkg/networkmanager/interfaces.js:1858
+#: pkg/networkmanager/interfaces.js:1972 pkg/networkmanager/interfaces.js:1989
 msgid "Round Robin"
 msgstr ""
 
-#: pkg/kubernetes/views/route-panel.html:9
 #: pkg/kubernetes/views/route-page.html:14
+#: pkg/kubernetes/views/route-panel.html:9
 msgid "Route"
 msgstr ""
 
 #: pkg/kubernetes/views/details-page.html:65
-#: pkg/networkmanager/interfaces.js:3130 pkg/kubernetes/scripts/details.js:217
+#: pkg/kubernetes/scripts/details.js:218 pkg/networkmanager/interfaces.js:3299
 msgid "Routes"
 msgstr ""
 
-#: pkg/docker/index.html:234 pkg/docker/index.html:553
-#: pkg/systemd/services.html:383 pkg/machines/hostvmslist.jsx:65
+#: pkg/docker/index.html:242 pkg/docker/index.html:561
+#: pkg/systemd/services.html:425 pkg/machines/components/vm/vmActions.jsx:76
+#: pkg/ovirt/components/ClusterVms.jsx:92
 msgid "Run"
 msgstr ""
 
-#: pkg/docker/index.html:415
+#: pkg/ovirt/components/ClusterVms.jsx:97
+msgid "Run Here"
+msgstr ""
+
+#: pkg/docker/index.html:423
 msgid "Run Image"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-config.html:8
+#: node_modules/registry-image-widgets/views/image-config.html:8
 msgid "Run as"
 msgstr ""
 
-#: pkg/networkmanager/index.html:423
+#: pkg/networkmanager/index.html:455
 msgid "Runner"
 msgstr ""
 
-#: pkg/ostree/index.html:251 pkg/storaged/details.js:389
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
+msgstr ""
+
+#: pkg/ovirt/components/VmOverviewColumn.jsx:54
+msgid "Running Since:"
 msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:345
@@ -5273,44 +6665,71 @@ msgstr ""
 msgid "SELinux system status is unknown."
 msgstr ""
 
-#: pkg/machines/libvirt.es6:164
-msgid "SHUTDOWN_VM action failed"
+#: pkg/machines/libvirt.es6:316 pkg/ovirt/provider.es6:411
+msgid "SET VCPU SETTINGS action failed"
 msgstr ""
 
-#: pkg/storaged/jobs.js:116
+#: pkg/ovirt/provider.es6:112 pkg/ovirt/provider.es6:136
+msgid "SHUTDOWN action failed"
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:35
 msgid "SMART self-test of $target"
 msgstr ""
 
-#: pkg/machines/libvirt.es6:204
-msgid "START_VM action failed"
+#: pkg/machines/components/desktopConsole.jsx:188
+msgid "SPICE"
 msgstr ""
 
-#: pkg/networkmanager/index.html:242
+#: pkg/machines/components/desktopConsole.jsx:157
+msgid "SPICE Address:"
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:163
+msgid "SPICE Port:"
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:166
+msgid "SPICE TLS Port:"
+msgstr ""
+
+#: pkg/ovirt/provider.es6:196
+msgid "START action failed"
+msgstr ""
+
+#: pkg/networkmanager/index.html:274
 msgid "STP Forward delay"
 msgstr ""
 
-#: pkg/networkmanager/index.html:251
+#: pkg/networkmanager/index.html:283
 msgid "STP Hello time"
 msgstr ""
 
-#: pkg/networkmanager/index.html:260
+#: pkg/networkmanager/index.html:292
 msgid "STP Maximum message age"
 msgstr ""
 
-#: pkg/networkmanager/index.html:233
+#: pkg/networkmanager/index.html:265
 msgid "STP Priority"
 msgstr ""
 
-#: pkg/systemd/services.html:182
+#: pkg/ovirt/provider.es6:274
+msgid "SUSPEND action failed"
+msgstr ""
+
+#: pkg/systemd/services.html:224
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:465
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
-#: pkg/ostree/client.js:66
-msgid "Scanning metadata"
+#: pkg/storaged/crypto-keyslots.jsx:155
+msgid ""
+"Saving a new passphrase requires unlocking the disk. Please provide a "
+"current disk passphrase."
 msgstr ""
 
 #: pkg/kubernetes/views/node-capacity.html:9
@@ -5321,7 +6740,12 @@ msgstr ""
 msgid "Scheduling Disabled"
 msgstr ""
 
-#: pkg/systemd/services.html:401 pkg/systemd/services.html:405
+#: pkg/lib/machine-info.es6:83
+msgid "Sealed-case PC"
+msgstr ""
+
+#: pkg/systemd/services.html:443 pkg/systemd/services.html:447
+#: pkg/systemd/init.js:1018
 msgid "Seconds"
 msgstr ""
 
@@ -5344,24 +6768,38 @@ msgstr "Værtsnavn"
 msgid "Secret Volume"
 msgstr ""
 
-#: pkg/systemd/index.html:93
+#: pkg/systemd/index.html:110
 msgid "Secure Shell Keys"
 msgstr ""
 
-#: pkg/storaged/jobs.js:133
+#: pkg/storaged/jobs-panel.jsx:56
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:404
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
-#: pkg/shell/simple.html:101 pkg/shell/index.html:121 pkg/shell/stub.html:114
+#: pkg/systemd/host.js:449
+msgid "Security Updates Available"
+msgstr ""
+
+#: pkg/shell/index.html:123 pkg/shell/simple.html:91 pkg/shell/stub.html:106
 msgid "Select"
 msgstr ""
 
 #: pkg/kubernetes/views/file-button.html:4
 msgid "Select Manifest File..."
+msgstr ""
+
+#: pkg/kubernetes/scripts/projects.js:885
+#: pkg/kubernetes/scripts/projects.js:1187
+msgid "Select Member"
+msgstr ""
+
+#: pkg/kubernetes/scripts/projects.js:887
+#: pkg/kubernetes/scripts/projects.js:1190
+msgid "Select Role"
 msgstr ""
 
 #: pkg/kubernetes/views/topology-page.html:7
@@ -5374,36 +6812,48 @@ msgid ""
 "{{host}}{{/strong}}"
 msgstr ""
 
-#: pkg/networkmanager/index.html:70 pkg/networkmanager/index.html:98
-#: pkg/networkmanager/index.html:116 pkg/networkmanager/index.html:557
-#: pkg/networkmanager/index.html:590
+#: pkg/machines/components/vm/vmActions.jsx:65
+msgid "Send Non-Maskable Interrupt"
+msgstr ""
+
+#: pkg/machines/components/vnc.jsx:44
+msgid "Send shortcut"
+msgstr ""
+
+#: pkg/networkmanager/index.html:82 pkg/networkmanager/index.html:129
+#: pkg/networkmanager/index.html:147 pkg/networkmanager/index.html:589
+#: pkg/networkmanager/index.html:622
 msgid "Sending"
 msgstr ""
 
-#: pkg/storaged/index.html:430
-msgctxt "storage"
-msgid "Serial Number"
+#: pkg/machines/components/consoles.jsx:68
+msgid "Serial Console"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:47
-#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:95
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
 #: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/overview.js:521
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
-#: pkg/users/local.js:698 pkg/users/local.js:699
+#: pkg/users/local.js:716 pkg/users/local.js:717
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/storaged/overview.js:524
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
-#: src/base1/cockpit.js:3935
+#: pkg/storaged/nfs-details.jsx:135
+msgid "Server cannot be empty."
+msgstr ""
+
+#: src/base1/cockpit.js:4014
 msgid "Server has closed the connection."
 msgstr ""
 
@@ -5411,9 +6861,10 @@ msgstr ""
 msgid "Servers"
 msgstr ""
 
-#: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/topology-page.html:30
+#: pkg/kubernetes/views/service-panel.html:8
+#: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -5421,42 +6872,41 @@ msgstr ""
 msgid "Service Account"
 msgstr ""
 
-#: pkg/systemd/services.html:279
+#: pkg/systemd/services.html:321
 msgid "Service Logs"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:441
+#: pkg/kdump/kdump-view.jsx:443
 #, fuzzy
 msgid "Service has an error"
 msgstr "Værtsnavn"
 
-#: pkg/kdump/kdump-view.jsx:437
+#: pkg/kdump/kdump-view.jsx:439
 #, fuzzy
 msgid "Service is running"
 msgstr "Værtsnavn"
 
-#: pkg/kdump/kdump-view.jsx:443
+#: pkg/kdump/kdump-view.jsx:445
 msgid "Service is starting"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:439
+#: pkg/kdump/kdump-view.jsx:441
 #, fuzzy
 msgid "Service is stopped"
 msgstr "Værtsnavn"
 
-#: pkg/kdump/kdump-view.jsx:445
+#: pkg/kdump/kdump-view.jsx:447
 msgid "Service is stopping"
 msgstr ""
 
-#: pkg/systemd/services.html:341
+#: pkg/systemd/services.html:383
 #, fuzzy
 msgid "Service name"
 msgstr "Værtsnavn"
 
-#: pkg/systemd/services.html:4 pkg/systemd/services.html:272
-#: pkg/kubernetes/views/details-page.html:29
 #: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/scripts/details.js:214
+#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
+#: pkg/systemd/services.html:314 pkg/kubernetes/scripts/details.js:215
 msgid "Services"
 msgstr ""
 
@@ -5466,7 +6916,8 @@ msgid ""
 "balanced IP address to access them."
 msgstr ""
 
-#: pkg/machines/helpers.es6:100
+#: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr ""
 
@@ -5474,28 +6925,32 @@ msgstr ""
 msgid "Session Affinity"
 msgstr ""
 
-#: pkg/users/index.html:272 pkg/dashboard/index.html:174
+#: pkg/dashboard/index.html:174 pkg/users/index.html:290
 msgid "Set"
 msgstr ""
 
-#: pkg/systemd/host.js:579
+#: pkg/systemd/host.js:678
 msgid "Set Host name"
 msgstr ""
 
-#: pkg/users/index.html:115 pkg/users/index.html:223
+#: pkg/users/index.html:122 pkg/users/index.html:238
 msgid "Set Password"
 msgstr ""
 
-#: pkg/systemd/index.html:377
+#: pkg/systemd/index.html:407
 msgid "Set Time"
 msgstr ""
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:527
 msgid "Set container environment variables"
 msgstr ""
 
-#: pkg/networkmanager/index.html:173
+#: pkg/networkmanager/index.html:205
 msgid "Set to"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:60
+msgid "Set up"
 msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:282
@@ -5503,8 +6958,20 @@ msgid ""
 "Setting deviates from the configured state and will revert on the next boot."
 msgstr ""
 
-#: pkg/storaged/jobs.js:128
+#: pkg/packagekit/updates.jsx:52
+msgid "Setting up"
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:51
 msgid "Setting up loop device $target"
+msgstr ""
+
+#: pkg/systemd/logs.html:47 pkg/packagekit/updates.jsx:377
+msgid "Severity"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:305
+msgid "Severity:"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:139
@@ -5512,11 +6979,11 @@ msgstr ""
 msgid "Share Name"
 msgstr "Værtsnavn"
 
-#: pkg/networkmanager/interfaces.js:1826
+#: pkg/networkmanager/interfaces.js:1957
 msgid "Shared"
 msgstr ""
 
-#: pkg/kubernetes/scripts/projects.js:1019
+#: pkg/kubernetes/scripts/projects.js:1027
 msgid "Shared: Allow any authenticated user to pull images"
 msgstr ""
 
@@ -5567,7 +7034,11 @@ msgstr ""
 msgid "Show all Services"
 msgstr ""
 
-#: pkg/docker/index.html:127
+#: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:45
+msgid "Show all VMs"
+msgstr ""
+
+#: pkg/docker/index.html:128
 msgid "Show all containers"
 msgstr ""
 
@@ -5575,58 +7046,64 @@ msgstr ""
 msgid "Show all image streams"
 msgstr ""
 
-#: pkg/docker/index.html:244 pkg/kubernetes/views/image-page.html:11
+#: pkg/docker/index.html:252 pkg/kubernetes/views/image-page.html:10
 msgid "Show all images"
 msgstr ""
 
-#: pkg/systemd/index.html:94
+#: pkg/systemd/index.html:111
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/systemd/index.html:136 pkg/systemd/shutdown.js:93
-#: pkg/systemd/shutdown.js:94 pkg/machines/hostvmslist.jsx:55
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
+msgid "Shrink"
+msgstr ""
+
+#: pkg/storaged/lvol-tabs.jsx:210
+msgid "Shrink Logical Volume"
+msgstr ""
+
+#: pkg/systemd/index.html:156 pkg/machines/components/vm/vmActions.jsx:55
+#: pkg/systemd/shutdown.js:93 pkg/systemd/shutdown.js:94
 msgid "Shut Down"
-msgstr ""
-
-#: pkg/ostree/index.html:267
-msgid "Signature"
-msgstr ""
-
-#: pkg/ostree/index.html:279
-msgid "Signed by"
 msgstr ""
 
 #: pkg/kubernetes/views/container-body.html:18
 msgid "Since"
 msgstr ""
 
-#: pkg/systemd/init.js:619
+#: pkg/systemd/init.js:636
 msgid "Since $0"
 msgstr ""
 
-#: pkg/storaged/index.html:230 pkg/kubernetes/views/volumes-page.html:60
-#: pkg/storaged/lvol-tabs.jsx:70 pkg/storaged/lvol-tabs.jsx:122
-#: pkg/storaged/lvol-tabs.jsx:161 pkg/storaged/lvol-tabs.jsx:198
-#: pkg/storaged/part-tab.jsx:41 pkg/storaged/content-views.jsx:112
-#: pkg/storaged/content-views.jsx:721 pkg/storaged/format-dialog.jsx:118
-#: pkg/docker/containers-view.jsx:583
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
+#: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr ""
 
-#: pkg/storaged/dialog.js:270
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:268
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:272
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:266
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
+msgstr ""
+
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
+msgid "Size must be at least $0"
 msgstr ""
 
 #: pkg/kubernetes/views/auth-form.html:43
@@ -5634,11 +7111,20 @@ msgstr ""
 msgid "Skip Certificate Verification"
 msgstr ""
 
-#: pkg/systemd/services.html:54
+#: pkg/systemd/hwinfo.jsx:84
+msgid "Slot"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:503
+msgid "Slot $0"
+msgstr ""
+
+#: pkg/systemd/services.html:55 pkg/machines/components/vcpuModal.jsx:183
+#: pkg/ovirt/components/vcpuModal.jsx:59
 msgid "Sockets"
 msgstr ""
 
-#: pkg/ostree/index.html:23
+#: pkg/packagekit/index.html:23
 msgid "Software Updates"
 msgstr ""
 
@@ -5646,7 +7132,7 @@ msgstr ""
 msgid "Solid-State Disk"
 msgstr ""
 
-#: pkg/storaged/overview.js:184
+#: pkg/storaged/drives-panel.jsx:87
 msgctxt "storage"
 msgid "Solid-State Disk"
 msgstr ""
@@ -5664,37 +7150,55 @@ msgstr ""
 msgid "Solutions"
 msgstr "Indstillinger"
 
+#: pkg/packagekit/updates.jsx:39
+msgid ""
+"Some other program is currently using the package manager, please wait..."
+msgstr ""
+
 #: pkg/kubernetes/scripts/volumes.js:906
 msgid "Sorry, I don't know how to modify this volume"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-body.html:8
+#: pkg/machines/components/diskAdd.jsx:324
+#: pkg/machines/components/vmDisksTab.jsx:74 pkg/machines/vmnetworktab.jsx:70
+msgid "Source"
+msgstr ""
+
+#: node_modules/registry-image-widgets/views/image-body.html:8
 msgid "Source URL"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2679
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:336
+msgid "Source should start with http, ftp or nfs protocol"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:74
+msgid "Space-saving Computer"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2845
 msgid "Spanning Tree Protocol"
 msgstr ""
 
-#: pkg/networkmanager/index.html:224
+#: pkg/networkmanager/index.html:256
 msgid "Spanning Tree Protocol (STP)"
 msgstr ""
 
-#: pkg/storaged/details.js:409
+#: pkg/storaged/mdraid-details.jsx:101
 msgid "Spare"
 msgstr ""
 
-#: pkg/systemd/index.html:454
+#: pkg/systemd/index.html:484
 msgid "Specific Time"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3447
+#: pkg/networkmanager/interfaces.js:3608
 msgid "Stable"
 msgstr ""
 
-#: pkg/docker/index.html:132 pkg/storaged/details.js:427
-#: pkg/storaged/swap-tab.jsx:76 pkg/docker/containers-view.jsx:232
-#: pkg/systemd/init.js:513
+#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
+#: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr ""
 
@@ -5706,15 +7210,23 @@ msgstr ""
 msgid "Start Multipath"
 msgstr ""
 
-#: pkg/storaged/details.js:429
-msgid "Start Scrubbing"
+#: pkg/networkmanager/index.html:44
+msgid "Start Service"
 msgstr ""
 
-#: pkg/storaged/jobs.js:136
+#: pkg/machines/components/libvirtSlate.jsx:125
+msgid "Start libvirt"
+msgstr ""
+
+#: pkg/machines/components/vmDisksTabLibvirt.jsx:71
+msgid "Start the VM to see disk statistics."
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:59
 msgid "Starting RAID Device $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:121
+#: pkg/storaged/jobs-panel.jsx:41
 msgid "Starting swapspace $target"
 msgstr ""
 
@@ -5725,33 +7237,41 @@ msgstr ""
 #: pkg/kubernetes/views/container-body.html:16
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
-#: pkg/docker/containers-view.jsx:125 pkg/docker/containers-view.jsx:267
-#: pkg/systemd/init.js:275 pkg/machines/hostvmslist.jsx:349
+#: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
+#: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
-#: pkg/storaged/index.html:569
-#, fuzzy
-msgctxt "storage"
-msgid "State"
-msgstr "Tilstand"
-
-#: pkg/docker/index.html:162 pkg/machines/hostvmslist.jsx:209
+#: pkg/docker/index.html:166
 #, fuzzy
 msgid "State:"
 msgstr "Tilstand"
 
-#: pkg/systemd/init.js:304
+#: pkg/ovirt/components/ClusterTemplates.jsx:136
+#: pkg/ovirt/components/ClusterVms.jsx:182
+#, fuzzy
+msgid "Stateless"
+msgstr "Tilstand"
+
+#: pkg/ovirt/components/OVirtTab.jsx:156
+#, fuzzy
+msgid "Stateless:"
+msgstr "Tilstand"
+
+#: pkg/systemd/init.js:305
 msgid "Static"
 msgstr ""
 
-#: pkg/ostree/index.html:288 pkg/kubernetes/views/nodes-page.html:44
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/pv-body.html:24
+#: pkg/kubernetes/views/containers-listing.html:16
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
 #: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/networkmanager/interfaces.js:2435
+#: pkg/kubernetes/views/nodes-page.html:44
+#: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
 msgstr "Tilstand"
@@ -5765,66 +7285,87 @@ msgstr "Tilstand"
 msgid "Status: System isn't registered"
 msgstr ""
 
-#: pkg/networkmanager/index.html:497
+#: pkg/lib/machine-info.es6:95
+msgid "Stick PC"
+msgstr ""
+
+#: pkg/networkmanager/index.html:529
 msgid "Sticky"
 msgstr ""
 
-#: pkg/docker/index.html:133 pkg/storaged/details.js:428
-#: pkg/storaged/swap-tab.jsx:75 pkg/docker/containers-view.jsx:230
-#: pkg/systemd/init.js:514
+#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
+#: pkg/systemd/init.js:515
 msgid "Stop"
 msgstr ""
 
-#: pkg/storaged/details.js:430
-msgid "Stop Scrubbing"
+#: pkg/storaged/mdraid-details.jsx:250
+msgid "Stop Device"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-config.html:14
+#: pkg/storaged/nfs-details.jsx:241
+msgid "Stop and Unmount"
+msgstr ""
+
+#: pkg/docker/util.js:632
+msgid "Stop and delete"
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:266
+msgid "Stop and remove"
+msgstr ""
+
+#: node_modules/registry-image-widgets/views/image-config.html:14
 msgid "Stop with"
 msgstr ""
 
-#: pkg/docker/util.js:229
+#: pkg/docker/util.js:234
 msgid "Stopped"
 msgstr ""
 
-#: pkg/storaged/jobs.js:135
+#: pkg/storaged/jobs-panel.jsx:58
 msgid "Stopping RAID Device $target"
 msgstr ""
 
-#: pkg/storaged/jobs.js:122
+#: pkg/storaged/jobs-panel.jsx:42
 msgid "Stopping swapspace $target"
 msgstr ""
 
-#: pkg/storaged/index.html:23 pkg/storaged/index.html:670
-#: pkg/docker/index.html:278
+#: pkg/docker/index.html:286 pkg/storaged/index.html:23
+#: pkg/storaged/details.jsx:141
 msgid "Storage"
 msgstr ""
 
-#: pkg/storaged/index.html:684
-msgid "Storage Log"
-msgstr ""
-
-#: pkg/storaged/index.html:340
+#: pkg/storaged/logs-panel.jsx:37
 msgid "Storage Logs"
 msgstr ""
 
-#: pkg/docker/index.html:292
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:276
+msgid "Storage Size"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:354
+msgid "Storage Size should not be negative number"
+msgstr ""
+
+#: pkg/docker/index.html:300
 msgid "Storage pool"
 msgstr ""
 
-#: pkg/systemd/index.html:148
+#: pkg/systemd/index.html:168
 msgid "Store Performance Data"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:163
+#: pkg/storaged/format-dialog.jsx:298
 msgid "Store passphrase"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:63 pkg/storaged/crypto-tab.jsx:66
+#: pkg/storaged/crypto-tab.jsx:69 pkg/storaged/crypto-tab.jsx:71
 msgid "Stored Passphrase"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:131
+#: pkg/storaged/crypto-tab.jsx:132
 msgid "Stored passphrase"
 msgstr ""
 
@@ -5832,58 +7373,86 @@ msgstr ""
 msgid "Strategy"
 msgstr ""
 
+#: pkg/lib/machine-info.es6:78
+msgid "Sub Chassis"
+msgstr ""
+
+#: pkg/lib/machine-info.es6:73
+msgid "Sub Notebook"
+msgstr ""
+
 #: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:161
 msgid "Subscriptions"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-body.html:4
+#: node_modules/registry-image-widgets/views/image-body.html:4
 msgid "Summary"
 msgstr ""
 
-#: pkg/systemd/services.html:183
+#: pkg/systemd/services.html:225
 msgid "Sunday"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:152
+#: pkg/storaged/optional-panel.jsx:95
+msgid "Support is installed."
+msgstr ""
+
+#: pkg/ovirt/components/VmActions.jsx:40
+msgid "Suspend"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:148
 msgid "Swap"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:307
+#: pkg/storaged/content-views.jsx:337
 msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr ""
 
-#: pkg/systemd/index.html:243 pkg/systemd/host.js:1436
+#: pkg/systemd/index.html:273 pkg/systemd/host.js:1544
 msgid "Swap Used"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2322 pkg/networkmanager/interfaces.js:2860
+#: pkg/ovirt/components/HostToMaintenance.jsx:40
+msgid "Switch Host to Maintenance"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2485 pkg/networkmanager/interfaces.js:3027
 msgid "Switch off $0"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2297 pkg/networkmanager/interfaces.js:2848
+#: pkg/networkmanager/interfaces.js:2460 pkg/networkmanager/interfaces.js:3015
 msgid "Switch on $0"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2321
+#: pkg/ovirt/provider.es6:385
+msgid "Switching host to maintenance mode failed. Received error: "
+msgstr ""
+
+#: pkg/ovirt/provider.es6:379
+msgid "Switching host to maintenance mode in progress ..."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2484
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2859
+#: pkg/networkmanager/interfaces.js:3026
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2296 pkg/networkmanager/interfaces.js:2847
+#: pkg/networkmanager/interfaces.js:2459 pkg/networkmanager/interfaces.js:3014
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr ""
 
-#: pkg/kubernetes/scripts/images.js:625
+#: pkg/kubernetes/scripts/images.js:622
 msgid "Sync all tags from a remote image repository"
 msgstr ""
 
@@ -5895,31 +7464,49 @@ msgstr ""
 msgid "Synchronize users"
 msgstr ""
 
-#: pkg/systemd/index.html:54
+#: pkg/systemd/index.html:55
 msgid "Synchronized"
 msgstr ""
 
-#: pkg/systemd/index.html:51
+#: pkg/systemd/index.html:52
 msgid "Synchronized with {{Server}}"
 msgstr ""
 
-#: pkg/storaged/jobs.js:143
+#: pkg/storaged/jobs-panel.jsx:66
 msgid "Synchronizing RAID Device $target"
 msgstr ""
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.es6:99
+#: pkg/systemd/index.html:4 pkg/machines/helpers.es6:177
+#: pkg/systemd/hwinfo.jsx:94
 msgid "System"
 msgstr ""
 
-#: pkg/systemd/services.html:53
+#: pkg/systemd/hwinfo.jsx:98
+msgid "System Information"
+msgstr ""
+
+#: pkg/systemd/host.js:433
+msgid "System Not Registered"
+msgstr ""
+
+#: pkg/systemd/services.html:54
 msgid "System Services"
 msgstr ""
 
-#: pkg/systemd/index.html:112
+#: pkg/systemd/index.html:129
 msgid "System Time"
 msgstr ""
 
-#: pkg/docker/index.html:317 pkg/docker/index.html:321
+#: pkg/systemd/host.js:439
+msgid "System Up To Date"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:917
+msgid "System is up to date"
+msgstr ""
+
+#: pkg/docker/index.html:325 pkg/docker/index.html:329
+#: pkg/networkmanager/firewall.jsx:326
 msgid "TCP"
 msgstr ""
 
@@ -5927,18 +7514,30 @@ msgstr ""
 msgid "TLS Termination"
 msgstr ""
 
-#: pkg/docker/index.html:680
+#: pkg/lib/machine-info.es6:89
+msgid "Tablet"
+msgstr ""
+
+#: pkg/docker/index.html:688
+#: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr ""
 
 #: pkg/kubernetes/views/imagestream-modify.html:76
-#: pkg/kubernetes/views/image-listing.html:14
-#: bower_components/registry-image-widgets/views/image-body.html:27
-#: pkg/docker/containers-view.jsx:308
+#: node_modules/registry-image-widgets/views/image-body.html:29
+#: node_modules/registry-image-widgets/views/imagestream-listing.html:6
+#: node_modules/registry-image-widgets/views/imagestream-panel.html:16
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:136
+#: pkg/storaged/crypto-keyslots.jsx:180
+msgid "Tang keyserver"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-modify.html:137
+#: pkg/machines/components/diskAdd.jsx:222
+#: pkg/machines/components/vmDisksTab.jsx:57 pkg/machines/vmnetworktab.jsx:69
 msgid "Target"
 msgstr ""
 
@@ -5950,51 +7549,60 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:52 pkg/storaged/overview.js:626
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2342 pkg/networkmanager/interfaces.js:2354
-#: pkg/networkmanager/interfaces.js:2636
+#: pkg/networkmanager/interfaces.js:2505 pkg/networkmanager/interfaces.js:2517
+#: pkg/networkmanager/interfaces.js:2802
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2664
+#: pkg/networkmanager/interfaces.js:2830
 msgid "Team Port"
 msgstr ""
 
-#: pkg/networkmanager/index.html:680
+#: pkg/networkmanager/index.html:712
 msgid "Team Port Settings"
 msgstr ""
 
-#: pkg/networkmanager/index.html:656
+#: pkg/networkmanager/index.html:688
 msgid "Team Settings"
 msgstr ""
 
 #: pkg/kubernetes/views/deploymentconfig-page.html:15
-#: pkg/kubernetes/views/replicationcontroller-page.html:20
 #: pkg/kubernetes/views/deploymentconfig-panel.html:10
+#: pkg/kubernetes/views/replicationcontroller-page.html:20
 #: pkg/kubernetes/views/replicationcontroller-panel.html:14
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Template"
+msgstr ""
+
+#: pkg/ovirt/components/App.jsx:109
+msgid "Templates"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterTemplates.jsx:130
+msgid "Templates of $0 cluster"
 msgstr ""
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
 msgstr ""
 
-#: pkg/users/index.html:76
+#: pkg/users/index.html:78
 msgid "Terminate Session"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:475 pkg/kdump/kdump-view.jsx:482
+#: pkg/kdump/kdump-view.jsx:477 pkg/kdump/kdump-view.jsx:484
 msgid "Test Configuration"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:480
+#: pkg/kdump/kdump-view.jsx:482
 msgid "Test is only available while the kdump service is running."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:300
+#: pkg/kdump/kdump-view.jsx:302
 msgid "Test kdump settings"
 msgstr ""
 
@@ -6006,51 +7614,67 @@ msgstr ""
 msgid "The \"storaged\" API is not available on this system."
 msgstr ""
 
-#: pkg/docker/storage.jsx:487
+#: pkg/docker/storage.jsx:478
 msgid "The Docker storage pool cannot be managed on this system."
 msgstr ""
 
-#: pkg/lib/machine-dialogs.js:388
+#: pkg/lib/machine-dialogs.js:385
 msgid "The IP address or host name cannot contain whitespace."
 msgstr ""
 
-#: pkg/storaged/index.html:530
+#: pkg/storaged/mdraid-details.jsx:219
 msgid "The RAID Array is in a degraded state"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:107
+#: pkg/storaged/mdraid-details.jsx:149
+msgid "The RAID device must be running in order to add spare disks."
+msgstr ""
+
+#: pkg/storaged/mdraid-details.jsx:115
+msgid "The RAID device must be running in order to remove disks."
+msgstr ""
+
+#: pkg/machines/components/vm/stateIcon.jsx:38
 msgid "The VM crashed."
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:106
+#: pkg/machines/components/vm/stateIcon.jsx:37
 msgid "The VM is down."
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:105
+#: pkg/machines/components/vm/stateIcon.jsx:36
 msgid "The VM is going down."
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:103
+#: pkg/machines/components/vm/stateIcon.jsx:34
 msgid "The VM is idle."
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:109
+#: pkg/machines/components/vm/stateIcon.jsx:41
 msgid "The VM is in process of dying (shut down or crash is not completed)."
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:104
+#: pkg/machines/components/vm/stateIcon.jsx:35
 msgid "The VM is paused."
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:102
+#: pkg/machines/components/deleteDialog.jsx:48
+msgid "The VM is running and will be forced off before deletion."
+msgstr ""
+
+#: pkg/machines/components/vm/stateIcon.jsx:33
 msgid "The VM is running."
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110
+#: pkg/machines/components/vm/stateIcon.jsx:45
 msgid "The VM is suspended by guest power management."
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:399
+#: pkg/users/local.js:1278
+msgid "The account '$0' will be forced to change their password on next login"
+msgstr ""
+
+#: pkg/kubernetes/scripts/nodes.js:403
 msgid "The address contains invalid characters"
 msgstr ""
 
@@ -6072,12 +7696,67 @@ msgstr ""
 msgid "The container '{{ target }}' does not exist."
 msgstr ""
 
+#: pkg/storaged/vdo-details.jsx:106
+msgid ""
+"The creation of this VDO device did not finish and the device can't be used."
+msgstr ""
+
 #: pkg/subscriptions/subscriptions-view.jsx:192
 msgid "The current user isn't allowed to access system subscription status."
 msgstr ""
 
+#: pkg/storaged/crypto-keyslots.jsx:488
+msgid ""
+"The currently logged in user is not permitted to see information about keys."
+msgstr ""
+
 #: pkg/kubernetes/views/deploymentconfig-page.html:25
 msgid "The deployment config '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/storaged/index.html:357
+msgid ""
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
+msgstr ""
+
+#: pkg/storaged/dialogx.jsx:757
+msgid ""
+"The filesystem is in use by login sessions and system services. Proceeding "
+"will stop these."
+msgstr ""
+
+#: pkg/storaged/index.html:361
+msgid ""
+"The filesystem is in use by login sessions.                Proceeding will "
+"stop these."
+msgstr ""
+
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
+msgstr ""
+
+#: pkg/storaged/index.html:367
+msgid ""
+"The filesystem is in use by system services.                Proceeding will "
+"stop these."
+msgstr ""
+
+#: pkg/storaged/dialogx.jsx:761
+msgid ""
+"The filesystem is in use by system services. Proceeding will stop these."
+msgstr ""
+
+#: pkg/docker/util.js:624
+msgid "The following containers depend on this image and will become unusable."
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:393
+msgid "The following packages were recently updated:"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:392
+msgid "The following packages were updated $0:"
 msgstr ""
 
 #: pkg/sosreport/index.html:51
@@ -6102,19 +7781,27 @@ msgstr ""
 msgid "The key you provided was not valid."
 msgstr ""
 
-#: pkg/storaged/details.js:489
+#: pkg/storaged/mdraid-details.jsx:121
+msgid "The last disk of a RAID device cannot be removed."
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:513
+msgid "The last key slot can not be removed"
+msgstr ""
+
+#: pkg/storaged/vgroup-details.jsx:94
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr ""
 
-#: pkg/shell/indexes.js:314
+#: pkg/shell/indexes.js:405
 msgid "The machine is restarting"
 msgstr ""
 
-#: pkg/kubernetes/scripts/details.js:500 pkg/kubernetes/scripts/details.js:623
+#: pkg/kubernetes/scripts/details.js:501 pkg/kubernetes/scripts/details.js:624
 msgid "The maximum number of replicas is 128"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:407
+#: pkg/kubernetes/scripts/nodes.js:411
 msgid "The name contains invalid characters"
 msgstr ""
 
@@ -6130,11 +7817,11 @@ msgstr ""
 msgid "The node doesn't have enough free memory"
 msgstr ""
 
-#: pkg/users/local.js:411 pkg/users/local.js:1096
+#: pkg/users/local.js:413 pkg/users/local.js:1327
 msgid "The passwords do not match"
 msgstr ""
 
-#: pkg/lib/credentials.js:186
+#: pkg/lib/credentials.js:192
 msgid "The passwords do not match."
 msgstr ""
 
@@ -6144,6 +7831,10 @@ msgstr ""
 
 #: pkg/kubernetes/views/pod-page.html:40
 msgid "The pod '{{ target }}' does not exist."
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:72
+msgid "The pool is empty"
 msgstr ""
 
 #: pkg/kubernetes/views/project-page.html:34
@@ -6158,17 +7849,25 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
+#: pkg/docker/containers-view.jsx:419
+msgid "The scan from $time ($type) found no vulnerabilities."
+msgstr ""
+
+#: pkg/docker/containers-view.jsx:417
+msgid "The scan from $time ($type) was not successful."
+msgstr ""
+
 #: pkg/kubernetes/scripts/dashboard.js:386
 msgid "The selected file is not a valid Kubernetes application manifest."
 msgstr ""
 
-#: src/ws/login.js:579
+#: src/ws/login.js:622
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
 "no other supported authentication methods are available."
 msgstr ""
 
-#: src/base1/cockpit.js:3921
+#: src/base1/cockpit.js:3998
 msgid "The server refused to authenticate using any supported methods."
 msgstr ""
 
@@ -6180,53 +7879,71 @@ msgstr ""
 msgid "The service '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/storage.jsx:357
-msgid ""
-"The storage pool will be reset to optimize its layout.  All containers will "
-"be erased."
-msgstr ""
-
 #: pkg/kubernetes/views/user-page.html:29
 msgid "The user '{{ userName }}' does not exist."
 msgstr ""
 
-#: pkg/systemd/init.js:832
+#: pkg/systemd/init.js:883
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr ""
 
-#: pkg/dashboard/list.js:208
+#: pkg/tuned/dialog.js:99
+msgid "The user <b>$0</b> is not permitted to change profiles"
+msgstr ""
+
+#: pkg/systemd/host.js:67
+msgid "The user <b>$0</b> is not permitted to change the system time"
+msgstr ""
+
+#: pkg/systemd/init.js:585
+msgid "The user <b>$0</b> is not permitted to enable or disable services"
+msgstr ""
+
+#: pkg/dashboard/list.js:213
 msgid "The user <b>$0</b> is not permitted to manage servers"
 msgstr ""
 
-#: pkg/storaged/permissions.js:60 pkg/storaged/storage-controls.jsx:78
+#: pkg/storaged/storage-controls.jsx:65
 msgid "The user <b>$0</b> is not permitted to manage storage"
 msgstr ""
 
-#: pkg/users/local.js:40
+#: pkg/users/local.js:42
 msgid "The user <b>$0</b> is not permitted to modify accounts"
 msgstr ""
 
-#: pkg/systemd/host.js:45
+#: pkg/systemd/host.js:51
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1410
+#: pkg/networkmanager/interfaces.js:1517
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
 
-#: pkg/realmd/operation.js:437
+#: pkg/realmd/operation.js:586
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr ""
 
-#: pkg/users/local.js:517
+#: pkg/systemd/host.js:59
+msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
+msgstr ""
+
+#: pkg/systemd/init.js:577 pkg/systemd/init.js:581
+msgid "The user <b>$0</b> is not permitted to start or stop services"
+msgstr ""
+
+#: pkg/users/local.js:519
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
 msgstr ""
 
-#: src/ws/login.js:124
+#: src/ws/login.js:135
 msgid ""
 "The web browser configuration prevents Cockpit from running (inaccessible $0)"
+msgstr ""
+
+#: pkg/shell/active-pages-dialog.jsx:59
+msgid "There are currently no active pages"
 msgstr ""
 
 #: pkg/storaged/index.html:51
@@ -6235,18 +7952,26 @@ msgid ""
 "service is not running."
 msgstr ""
 
-#: pkg/users/index.html:326
+#: pkg/users/index.html:439
 msgid "There are no authorized public keys for this account."
 msgstr ""
 
-#: pkg/storaged/details.js:494
+#: pkg/storaged/vgroup-details.jsx:100
 msgid ""
-"There is not enough free space elsewhere to remove this physical volume.  At "
+"There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
 msgstr ""
 
-#: pkg/storaged/utils.js:168
+#: pkg/storaged/utils.js:165
 msgid "Thin Logical Volume"
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:128
+msgid "This NFS mount is in use and only its options can be changed."
+msgstr ""
+
+#: pkg/storaged/vdo-details.jsx:122
+msgid "This VDO device does not use all of its backing device."
 msgstr ""
 
 #: pkg/kubernetes/views/pvc-delete.html:8
@@ -6254,38 +7979,87 @@ msgid ""
 "This claim is in use. Deleting it may cause issues with the following pod:"
 msgstr ""
 
-#: pkg/systemd/init.js:1219
+#: pkg/systemd/init.js:1271
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
 msgstr ""
 
-#: pkg/ostree/index.html:327
-msgid ""
-"This deployment contains the same packages as your currently booted system"
-msgstr ""
-
-#: pkg/networkmanager/interfaces.js:2446
+#: pkg/networkmanager/interfaces.js:2612
 msgid "This device cannot be managed here."
 msgstr ""
 
-#: pkg/systemd/init.js:1139 pkg/systemd/init.js:1151 pkg/systemd/init.js:1158
+#: pkg/storaged/index.html:329
+msgid ""
+"This device has filesystems that are currently in use.                "
+"Proceeding will unmount all filesystems on it."
+msgstr ""
+
+#: pkg/storaged/dialogx.jsx:742
+msgid ""
+"This device has filesystems that are currently in use. Proceeding will "
+"unmount all filesystems on it."
+msgstr ""
+
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
+msgid "This device is currently used for RAID devices."
+msgstr ""
+
+#: pkg/storaged/index.html:347
+msgid ""
+"This device is currently used for RAID devices.                Proceeding "
+"will remove it from its RAID devices."
+msgstr ""
+
+#: pkg/storaged/dialogx.jsx:750
+msgid ""
+"This device is currently used for RAID devices. Proceeding will remove it "
+"from its RAID devices."
+msgstr ""
+
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
+msgid "This device is currently used for VDO devices."
+msgstr ""
+
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
+msgid "This device is currently used for volume groups."
+msgstr ""
+
+#: pkg/storaged/index.html:338
+msgid ""
+"This device is currently used for volume groups.                Proceeding "
+"will remove it from its volume groups."
+msgstr ""
+
+#: pkg/storaged/dialogx.jsx:746
+msgid ""
+"This device is currently used for volume groups. Proceeding will remove it "
+"from its volume groups."
+msgstr ""
+
+#: pkg/storaged/mdraid-details.jsx:117
+msgid "This disk cannot be removed while the device is recovering."
+msgstr ""
+
+#: pkg/systemd/init.js:1191 pkg/systemd/init.js:1203 pkg/systemd/init.js:1210
 msgid "This field cannot be empty."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:392
+#: pkg/ovirt/components/App.jsx:148
+msgid ""
+"This host is managed by a virtualization manager, so creation of new VMs "
+"from the host is not possible."
+msgstr ""
+
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:96
-msgid "This logical volume cannot be made smaller."
-msgstr ""
-
-#: pkg/lib/machine-dialogs.js:366
+#: pkg/lib/machine-dialogs.js:363
 msgid "This machine has already been added."
 msgstr ""
 
-#: pkg/realmd/operation.html:89
+#: pkg/realmd/operation.html:91
 msgid "This may take a while"
 msgstr ""
 
@@ -6295,20 +8069,24 @@ msgid ""
 "a multi-node cluster"
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:492
+#: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
 msgstr ""
 
-#: src/bridge/cockpitpackages.c:481
+#: src/bridge/cockpitpackages.c:495
 #, c-format
 msgid "This package requires Cockpit version %s or later"
 msgstr ""
 
-#: pkg/tuned/dialog.js:102
+#: pkg/packagekit/updates.jsx:899
+msgid "This system is not registered"
+msgstr ""
+
+#: pkg/tuned/dialog.js:104
 msgid "This system is using a custom profile"
 msgstr ""
 
-#: pkg/tuned/dialog.js:100
+#: pkg/tuned/dialog.js:102
 msgid "This system is using the recommended profile"
 msgstr ""
 
@@ -6318,22 +8096,26 @@ msgid ""
 "this system for use with diagnosing problems with the system."
 msgstr ""
 
-#: pkg/systemd/init.js:637
+#: pkg/systemd/init.js:656
 msgid "This unit is an instance of the $0 template."
 msgstr ""
 
-#: pkg/systemd/services.html:302
+#: pkg/systemd/services.html:344
 msgid "This unit is not designed to be enabled explicitly."
 msgstr ""
 
-#: pkg/users/local.js:525
+#: pkg/users/local.js:527
 msgid "This user name already exists"
 msgstr ""
 
-#: pkg/lib/machine-dialogs.js:382
+#: pkg/lib/machine-dialogs.js:379
 msgid ""
 "This version of cockpit-ws does not support connecting to a host with an "
 "alternate user or port"
+msgstr ""
+
+#: pkg/ovirt/components/OVirtTab.jsx:134
+msgid "This virtual machine is not managed by oVirt"
 msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
@@ -6347,45 +8129,64 @@ msgstr ""
 msgid "This volume has not been claimed"
 msgstr ""
 
-#: src/ws/login.js:129
+#: pkg/storaged/lvol-tabs.jsx:329
+msgid "This volume needs to be activated before it can be resized."
+msgstr ""
+
+#: src/ws/login.js:141
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:303
+#: pkg/packagekit/updates.jsx:852
+msgid "This web console will be updated."
+msgstr ""
+
+#: pkg/kdump/kdump-view.jsx:305
 msgid ""
 "This will test kdump settings by crashing the kernel and thereby the system. "
 "Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:516
+#: pkg/kdump/kdump-view.jsx:519
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr ""
 
-#: pkg/systemd/services.html:180
+#: pkg/machines/components/vcpuModal.jsx:189
+#: pkg/ovirt/components/vcpuModal.jsx:65
+msgid "Threads per cores"
+msgstr ""
+
+#: pkg/systemd/services.html:222
 msgid "Thursday"
 msgstr ""
 
-#: pkg/systemd/index.html:363
+#: pkg/systemd/index.html:393
 msgid "Time Zone"
 msgstr ""
 
-#: pkg/systemd/services.html:55
+#: pkg/systemd/services.html:56
 msgid "Timers"
 msgstr ""
 
-#: pkg/shell/index.html:257
+#: pkg/shell/index.html:325
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/image-pull.html:4
+#: pkg/packagekit/updates.jsx:900
+msgid ""
+"To get software updates, this system needs to be registered with Red Hat, "
+"either using the Red Hat Customer Portal or a local subscription server."
+msgstr ""
+
+#: node_modules/registry-image-widgets/views/image-pull.html:4
 msgid "To pull this image:"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/imagestream-push.html:4
-msgid "To push to an image to this image stream:"
+#: node_modules/registry-image-widgets/views/imagestream-push.html:4
+msgid "To push an image to this image stream:"
 msgstr ""
 
 #: pkg/lib/machine-change-port.html:11
@@ -6398,84 +8199,94 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: src/base1/cockpit.js:3941
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:150
+msgid "Too many files found"
+msgstr ""
+
+#: src/base1/cockpit.js:4020
 msgid "Too much data"
 msgstr ""
 
-#: pkg/shell/index.html:290 pkg/shell/stub.html:145
-msgid "Tools"
-msgstr ""
-
-#: pkg/kubernetes/index.html:58
+#: pkg/kubernetes/index.html:67
 msgid "Topology"
 msgstr ""
 
-#: pkg/docker/storage.jsx:316
+#: pkg/docker/storage.jsx:315
 msgid "Total"
 msgstr ""
 
-#: pkg/ostree/index.html:265
-msgid "Tree"
+#: pkg/lib/cockpit-components-install-dialog.jsx:96
+msgid "Total size: $0"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:32
+#: pkg/lib/machine-info.es6:66
+msgid "Tower"
+msgstr ""
+
+#: pkg/systemd/init.js:695
+msgid "Triggered By"
+msgstr ""
+
+#: pkg/kubernetes/views/deploymentconfig-body.html:32 pkg/systemd/init.js:694
 msgid "Triggers"
 msgstr ""
 
-#: pkg/shell/index.html:312 pkg/shell/stub.html:167
-#: pkg/kubernetes/index.html:106
+#: pkg/kubernetes/index.html:115 pkg/shell/index.html:407
+#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/machines/components/libvirtSlate.jsx:119
 msgid "Troubleshoot"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:302
+msgid "Trust key"
 msgstr ""
 
 #: pkg/kubernetes/views/auth-rejected-cert.html:21
 msgid "Trust this certificate for this connection"
 msgstr ""
 
-#: src/ws/login.html:112
+#: src/ws/login.html:111
 msgid "Try Again"
-msgstr ""
-
-#: pkg/systemd/init.js:518
-msgid "Try Restart"
 msgstr ""
 
 #: pkg/docker/index.html:71 pkg/docker/index.html:74
 msgid "Try again"
 msgstr ""
 
-#: pkg/shell/simple.html:117
+#: pkg/shell/simple.html:107
 msgid "Try to reconnect"
 msgstr ""
 
-#: pkg/systemd/index.html:59
+#: pkg/systemd/index.html:60
 msgid "Trying to synchronize with {{Server}}"
 msgstr ""
 
-#: pkg/systemd/services.html:178
+#: pkg/systemd/services.html:220
 msgid "Tuesday"
 msgstr ""
 
-#: pkg/tuned/dialog.js:260
+#: pkg/tuned/dialog.js:262
 msgid "Tuned has failed to start"
 msgstr ""
 
-#: pkg/tuned/dialog.js:94
+#: pkg/tuned/dialog.js:92
 msgid "Tuned is not available"
 msgstr ""
 
-#: pkg/tuned/dialog.js:96
+#: pkg/tuned/dialog.js:94
 msgid "Tuned is not running"
 msgstr ""
 
-#: pkg/tuned/dialog.js:98
+#: pkg/tuned/dialog.js:96
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/shell/index.html:220 pkg/kubernetes/views/deploy.html:9
-#: pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
 #: pkg/kubernetes/views/volumes-page.html:20
-#: pkg/kubernetes/views/pv-modify.html:10 pkg/storaged/unrecognized-tab.jsx:44
-#: pkg/storaged/part-tab.jsx:49 pkg/storaged/format-dialog.jsx:133
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
+#: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr ""
 
@@ -6484,7 +8295,7 @@ msgstr ""
 msgid "Type a password"
 msgstr "Indtast adgangskode"
 
-#: pkg/docker/containers-view.jsx:108
+#: pkg/docker/containers-view.jsx:110
 msgid "Type to filter…"
 msgstr ""
 
@@ -6492,25 +8303,20 @@ msgstr ""
 msgid "Type:"
 msgstr ""
 
-#: pkg/docker/index.html:322
+#: pkg/docker/index.html:330 pkg/networkmanager/firewall.jsx:326
 msgid "UDP"
 msgstr ""
 
-#: pkg/ostree/index.html:48 pkg/ostree/index.html:109
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:228
 #: pkg/subscriptions/subscriptions-register.jsx:110
 msgid "URL"
 msgstr ""
 
-#: pkg/storaged/part-tab.jsx:45
+#: pkg/storaged/part-tab.jsx:46
 msgid "UUID"
 msgstr ""
 
-#: pkg/storaged/index.html:545 pkg/storaged/index.html:624
-msgctxt "storage"
-msgid "UUID"
-msgstr ""
-
-#: pkg/kdump/kdump-view.jsx:288
+#: pkg/kdump/kdump-view.jsx:290
 msgid "Unable to apply settings: $0"
 msgstr ""
 
@@ -6518,15 +8324,11 @@ msgstr ""
 msgid "Unable to apply this solution automatically"
 msgstr ""
 
-#: pkg/ostree/index.html:419
-msgid "Unable to communicate with OSTree"
-msgstr ""
-
 #: pkg/subscriptions/subscriptions-view.jsx:195
 msgid "Unable to connect"
 msgstr ""
 
-#: src/ws/login.js:583
+#: src/ws/login.js:626
 msgid "Unable to connect to that address"
 msgstr ""
 
@@ -6534,7 +8336,7 @@ msgstr ""
 msgid "Unable to decode Kubernetes application manifest."
 msgstr ""
 
-#: pkg/users/local.js:56
+#: pkg/users/local.js:57
 msgid "Unable to delete root account"
 msgstr ""
 
@@ -6543,11 +8345,11 @@ msgstr ""
 msgid "Unable to get alert details."
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:157
+#: pkg/selinux/setroubleshoot-client.js:158
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/overview.js:589
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -6555,16 +8357,28 @@ msgstr ""
 msgid "Unable to read the Kubernetes application manifest. Code $0."
 msgstr ""
 
-#: pkg/users/local.js:58
+#: pkg/storaged/nfs-details.jsx:264
+msgid "Unable to remove mount"
+msgstr ""
+
+#: pkg/users/local.js:59
 msgid "Unable to rename root account"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:172
+#: node_modules/registry-image-widgets/views/image-listing.html:41
+msgid "Unable to resolve"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-client.js:173
 msgid "Unable to run fix: %0"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-client.js:52
+#: pkg/selinux/setroubleshoot-client.js:53
 msgid "Unable to start setroubleshootd"
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:239
+msgid "Unable to unmount filesystem"
 msgstr ""
 
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
@@ -6572,97 +8386,144 @@ msgstr ""
 msgid "Unavailable"
 msgstr ""
 
-#: pkg/networkmanager/index.html:824 pkg/docker/index.html:715
-#: pkg/users/local.js:1178 pkg/shell/base_index.js:679
+#: pkg/docker/index.html:723 pkg/networkmanager/index.html:856
+#: pkg/shell/base_index.js:743 pkg/users/local.js:1409
 msgid "Unexpected error"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-claim.html:31 pkg/kubernetes/views/pv-body.html:26
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:212
+#, fuzzy
+msgid "Unique name"
+msgstr "Værtsnavn"
+
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
+msgid "Unit"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
 #: pkg/kubernetes/views/node-body.html:12
 #: pkg/kubernetes/views/node-body.html:43
-#: bower_components/registry-image-widgets/views/imagestream-body.html:27
-#: bower_components/registry-image-widgets/views/image-body.html:15
-#: pkg/networkmanager/interfaces.js:506 pkg/networkmanager/interfaces.js:986
-#: pkg/networkmanager/interfaces.js:2362 pkg/networkmanager/interfaces.js:2364
-#: pkg/storaged/fsys-tab.jsx:62 pkg/storaged/swap-tab.jsx:56
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:753 pkg/kubernetes/scripts/volumes.js:266
+#: node_modules/registry-image-widgets/views/image-body.html:16
+#: node_modules/registry-image-widgets/views/imagestream-body.html:30
+#: node_modules/registry-image-widgets/views/imagestream-body.html:31
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2348 pkg/networkmanager/interfaces.js:2360
+#: pkg/networkmanager/interfaces.js:2511 pkg/networkmanager/interfaces.js:2523
 msgid "Unknown \"$0\""
 msgstr ""
 
-#: pkg/storaged/details.js:412
+#: pkg/storaged/mdraid-details.jsx:104
 msgid "Unknown ($0)"
+msgstr ""
+
+#: pkg/apps/application.jsx:98
+msgid "Unknown Application"
 msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:2
 msgid "Unknown Host Key"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2462
+#: pkg/networkmanager/interfaces.js:2628
 msgid "Unknown configuration"
 msgstr ""
 
-#: pkg/storaged/overview.js:585
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
-#: pkg/docker/index.html:538 pkg/docker/util.js:108
+#: pkg/storaged/crypto-keyslots.jsx:534
+msgid "Unknown type"
+msgstr ""
+
+#: pkg/docker/index.html:546 pkg/docker/util.js:113
 msgid "Unless Stopped"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:191 pkg/storaged/content-views.jsx:198
-#: pkg/storaged/content-views.jsx:211
+#: pkg/storaged/content-views.jsx:213 pkg/storaged/content-views.jsx:218
+#: pkg/storaged/content-views.jsx:231
 msgid "Unlock"
 msgstr ""
 
-#: pkg/shell/index.html:208
+#: pkg/shell/index.html:221 pkg/shell/index.html:273
 msgid "Unlock Key"
 msgstr ""
 
-#: pkg/storaged/jobs.js:118
+#: pkg/storaged/format-dialog.jsx:139
+msgid "Unlock at boot"
+msgstr ""
+
+#: pkg/storaged/format-dialog.jsx:144
+msgid "Unlock read only"
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:37
 msgid "Unlocking $target"
 msgstr ""
 
-#: pkg/networkmanager/index.html:109
+#: pkg/storaged/crypto-keyslots.jsx:161
+msgid "Unlocking disk..."
+msgstr ""
+
+#: pkg/networkmanager/index.html:140
 msgid "Unmanaged Interfaces"
 msgstr ""
 
-#: pkg/systemd/init.js:546
+#: pkg/systemd/init.js:548
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:216
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr ""
 
-#: pkg/storaged/jobs.js:124
+#: pkg/storaged/jobs-panel.jsx:44
 msgid "Unmounting $target"
 msgstr ""
 
-#: pkg/users/index.html:309
+#: pkg/users/index.html:422
 msgid "Unnamed"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:154
+#: pkg/machines/vmnetworktab.jsx:123
+msgid "Unplug"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:150
 msgid "Unrecognized Data"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:312
+#: pkg/storaged/content-views.jsx:344
 msgctxt "storage-id-desc"
 msgid "Unrecognized Data"
+msgstr ""
+
+#: pkg/storaged/lvol-tabs.jsx:325
+msgid "Unrecognized data can not be made smaller here."
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-view.jsx:148
 msgid "Unregister"
 msgstr ""
 
+#: pkg/packagekit/updates.jsx:805
+msgid "Unregistered System"
+msgstr ""
+
 #: pkg/subscriptions/subscriptions-view.jsx:154
 msgid "Unregistering system..."
+msgstr ""
+
+#: node_modules/registry-image-widgets/views/image-listing.html:46
+msgid "Unresolved"
 msgstr ""
 
 #: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
@@ -6670,51 +8531,87 @@ msgstr ""
 msgid "Unsupported setup mechanism"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:630
+#: pkg/storaged/content-views.jsx:595
 msgid "Unsupported volume"
 msgstr ""
 
-#: src/base1/cockpit.js:3923
+#: src/base1/cockpit.js:4000 src/base1/cockpit.js:4002
 msgid "Untrusted host"
 msgstr ""
 
-#: pkg/docker/util.js:93
-msgid "Up since $StartedAt"
+#: pkg/docker/util.js:97
+msgid "Up since $0"
 msgstr ""
 
 #: pkg/lib/machine-change-port.html:41
 msgid "Update"
 msgstr ""
 
-#: pkg/ostree/index.html:233
-msgid "Update and Reboot"
+#: pkg/packagekit/updates.jsx:864
+msgid "Update History"
 msgstr ""
 
-#: pkg/ostree/index.html:317 pkg/ostree/index.html:343
-msgid "Updates"
+#: pkg/packagekit/updates.jsx:496
+msgid "Update Log"
 msgstr ""
 
-#: pkg/ostree/index.html:262 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/packagekit/updates.jsx:59
+msgid "Updated"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:517
+msgid "Updated packages may require a restart to take effect."
+msgstr ""
+
+#: pkg/systemd/host.js:455
+msgid "Updates Available"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:809
+msgid "Updates are disabled."
+msgstr ""
+
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
-#: pkg/kubernetes/scripts/details.js:657
+#: pkg/kubernetes/scripts/details.js:658
 msgid "Updating $0..."
 msgstr ""
 
-#: pkg/storaged/unrecognized-tab.jsx:40 pkg/machines/hostvmslist.jsx:305
+#: pkg/machines/components/vmDisksTabLibvirt.jsx:68
+msgid "Upgrade to a more recent version of libvirt to view disk statistics"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:71
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:54
+#: pkg/machines/components/vm/vm.jsx:44 pkg/storaged/unrecognized-tab.jsx:41
 msgid "Usage"
 msgstr ""
 
-#: pkg/shell/index.html:153
-msgid "Use my password for privileged tasks and to connect to other machines"
+#: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:134
+msgid "Usage metrics are available after the pod starts"
+msgstr ""
+
+#: pkg/systemd/host.js:1483
+msgid "Usage of $0 CPU core"
+msgid_plural "Usage of $0 CPU cores"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/storaged/vdos-panel.jsx:103
+msgid "Use 512 Byte emulation"
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:348
+msgid "Use Existing"
 msgstr ""
 
 #: pkg/subscriptions/subscriptions-register.jsx:132
 msgid "Use proxy server"
 msgstr ""
 
-#: pkg/shell/index.html:160
+#: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
 msgstr ""
 
@@ -6722,49 +8619,52 @@ msgstr ""
 msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
-#: pkg/ostree/index.html:59 pkg/ostree/index.html:121
-msgid "Use trusted GPG key"
-msgstr ""
-
-#: pkg/systemd/index.html:251 pkg/storaged/fsys-tab.jsx:225
-#: pkg/storaged/swap-tab.jsx:82 pkg/docker/storage.jsx:315
-#: pkg/systemd/host.js:1438 pkg/machines/hostvmslist.jsx:251
-#: pkg/machines/hostvmslist.jsx:262 pkg/kubernetes/scripts/nodes.js:828
-#: pkg/kubernetes/scripts/nodes.js:837
+#: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
+#: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
+#: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
+#: pkg/machines/components/vm/vmUsageTab.jsx:63
+#: pkg/machines/components/vm/vmUsageTab.jsx:74
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
-#: pkg/docker/index.html:252
+#: pkg/docker/index.html:260
 msgid "Used by Containers"
 msgstr ""
 
-#: pkg/playground/translate.html:85 pkg/playground/translate.html:105
-#: pkg/systemd/index.html:229 pkg/dashboard/index.html:142
-#: pkg/kubernetes/views/user-panel.html:9
-#: pkg/kubernetes/views/auth-form.html:61
+#: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
+#: pkg/kubernetes/views/user-group-add.html:9
 #: pkg/kubernetes/views/volume-body.html:64
 #: pkg/kubernetes/views/volume-body.html:103
-#: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1352
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
+#: pkg/playground/translate.html:105 pkg/systemd/index.html:259
+#: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
 msgstr ""
 
-#: pkg/users/index.html:88 pkg/users/index.html:160
-#: pkg/realmd/operation.html:47
+#: pkg/realmd/operation.html:48 pkg/users/index.html:90
+#: pkg/users/index.html:175
 #, fuzzy
 msgid "User Name"
 msgstr "Værtsnavn"
 
-#: pkg/realmd/operation.html:53 pkg/realmd/operation.js:273
+#: pkg/realmd/operation.html:54 pkg/realmd/operation.js:290
 msgid "User Password"
 msgstr ""
 
+#: cockpit.appdata.xml.in.h:1
+msgid "User interface for Linux servers"
+msgstr ""
+
 #: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
-#: src/ws/login.html:44
+#: src/ws/login.html:43
 msgid "User name"
 msgstr ""
 
-#: src/ws/login.js:393
+#: src/ws/login.js:425
 msgid "User name cannot be empty"
 msgstr ""
 
@@ -6772,8 +8672,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/overview.js:528
-#: pkg/storaged/overview.js:651
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 #, fuzzy
 msgid "Username"
 msgstr "Værtsnavn"
@@ -6786,24 +8686,131 @@ msgstr ""
 msgid "Using available credentials"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:107
+#: pkg/storaged/content-views.jsx:146
+msgid "VDO Backing"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:342
+msgctxt "storage-id-desc"
+msgid "VDO Backing"
+msgstr ""
+
+#: pkg/storaged/pvol-tabs.jsx:100
+msgid "VDO Device"
+msgstr ""
+
+#: pkg/storaged/utils.js:224 pkg/storaged/vdo-details.jsx:249
+msgid "VDO Device $0"
+msgstr ""
+
+#: pkg/storaged/vdos-panel.jsx:169
+msgid "VDO Devices"
+msgstr ""
+
+#: pkg/storaged/lvol-tabs.jsx:318
+msgid "VDO backing devices can not be made smaller"
+msgstr ""
+
+#: pkg/storaged/vdos-panel.jsx:175
+msgid "VDO support not installed"
+msgstr ""
+
+#: pkg/ovirt/components/App.jsx:113
+msgid "VDSM"
+msgstr ""
+
+#: pkg/ovirt/components/VdsmView.jsx:128
+#, fuzzy
+msgid "VDSM Service Management"
+msgstr "Værtsnavn"
+
+#: pkg/storaged/format-dialog.jsx:242
 msgid "VFAT - Compatible with all systems and devices"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2344 pkg/networkmanager/interfaces.js:2356
-#: pkg/networkmanager/interfaces.js:2728
+#: pkg/networkmanager/interfaces.js:2507 pkg/networkmanager/interfaces.js:2519
+#: pkg/networkmanager/interfaces.js:2894
 msgid "VLAN"
 msgstr ""
 
-#: pkg/networkmanager/index.html:142
+#: pkg/networkmanager/index.html:174
 msgid "VLAN Id"
 msgstr ""
 
-#: pkg/networkmanager/index.html:752
+#: pkg/networkmanager/index.html:784
 msgid "VLAN Settings"
 msgstr ""
 
-#: src/ws/login.html:102
+#: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:68
+msgid "VM"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:56
+msgid "VM $0:$1 does not exist."
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:41
+msgid "VM DELETE failed."
+msgstr ""
+
+#: pkg/machines/libvirt.es6:267
+msgid "VM FORCE OFF action failed"
+msgstr ""
+
+#: pkg/machines/libvirt.es6:287
+msgid "VM FORCE REBOOT action failed"
+msgstr ""
+
+#: pkg/machines/libvirt.es6:278
+msgid "VM REBOOT action failed"
+msgstr ""
+
+#: pkg/machines/libvirt.es6:383
+msgid "VM SEND Non-Maskable Interrrupt action failed"
+msgstr ""
+
+#: pkg/machines/libvirt.es6:258
+msgid "VM SHUT DOWN action failed"
+msgstr ""
+
+#: pkg/machines/libvirt.es6:296
+msgid "VM START action failed"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:86
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:93
+msgid "VM definition is not a valid JSON."
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:81
+msgid "VM definition is required."
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:88
+msgid "VM definition must be an object."
+msgstr ""
+
+#: pkg/ovirt/components/VmOverviewColumn.jsx:37
+msgid "VM icon"
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:188
+msgid "VNC"
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:160
+msgid "VNC Address:"
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:169
+msgid "VNC Port:"
+msgstr ""
+
+#: pkg/machines/components/desktopConsole.jsx:172
+msgid "VNC TLS Port:"
+msgstr ""
+
+#: src/ws/login.html:101
 msgid "Validating authentication token"
 msgstr ""
 
@@ -6811,34 +8818,79 @@ msgstr ""
 msgid "Validating key"
 msgstr ""
 
-#: pkg/systemd/index.html:98 pkg/ostree/index.html:303 pkg/shell/simple.html:74
-#: pkg/shell/index.html:86 pkg/shell/stub.html:79
-#: pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:84
+msgid "Vendor"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:61
+msgid "Verified"
+msgstr ""
+
+#: pkg/storaged/crypto-keyslots.jsx:287
+msgid "Verify key"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:53
+msgid "Verifying"
+msgstr ""
+
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
 msgid "Version"
 msgstr ""
 
-#: pkg/storaged/jobs.js:134
+#: pkg/ovirt/components/ClusterVms.jsx:83
+msgid "Version num"
+msgstr ""
+
+#: pkg/storaged/jobs-panel.jsx:57
 msgid "Very securely erasing $target"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:349
+#: pkg/packagekit/updates.jsx:815
+msgid "View Registration Details"
+msgstr ""
+
+#: pkg/kubernetes/index.html:61
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:53
+#: pkg/machines/hostvmslist.jsx:91
 msgid "Virtual Machines"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pvc-body.html:6
-#: pkg/kubernetes/views/pv-panel.html:10 pkg/storaged/content-views.jsx:133
+#: pkg/ovirt/components/ClusterVms.jsx:176
+msgid "Virtual Machines of $0 cluster"
+msgstr ""
+
+#: pkg/machines/components/libvirtSlate.jsx:100
+msgid "Virtualization Service (libvirt) is Not Active"
+msgstr ""
+
+#: pkg/machines/components/libvirtSlate.jsx:94
+msgid "Virtualization Service is Available"
+msgstr ""
+
+#: pkg/machines/vmnetworktab.jsx:90
+msgid "Virtualport"
+msgstr ""
+
+#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
+#: pkg/kubernetes/views/pvc-body.html:6 pkg/machines/components/diskAdd.jsx:82
+#: pkg/machines/components/vmDiskSourceCell.jsx:40
+#: pkg/storaged/content-views.jsx:127
 msgid "Volume"
 msgstr ""
 
-#: pkg/storaged/index.html:618 pkg/storaged/pvol-tabs.jsx:44
+#: pkg/storaged/pvol-tabs.jsx:44
 msgid "Volume Group"
 msgstr ""
 
-#: pkg/storaged/utils.js:239
+#: pkg/storaged/utils.js:219 pkg/storaged/vgroup-details.jsx:234
 msgid "Volume Group $0"
 msgstr ""
 
-#: pkg/storaged/index.html:96
+#: pkg/storaged/vgroups-panel.jsx:115
 msgid "Volume Groups"
 msgstr ""
 
@@ -6853,17 +8905,22 @@ msgstr ""
 msgid "Volume Name"
 msgstr "Værtsnavn"
 
-#: pkg/kubernetes/views/volume-body.html:1 pkg/kubernetes/views/pvc-body.html:2
+#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:504 pkg/kubernetes/views/pod-page.html:18
-#: pkg/kubernetes/views/dashboard-page.html:47 pkg/kubernetes/index.html:71
-#: bower_components/registry-image-widgets/views/image-config.html:32
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
+#: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:743
+#: pkg/docker/index.html:198
+#, fuzzy
+msgid "Volumes:"
+msgstr "Værtsnavn"
+
+#: pkg/networkmanager/interfaces.js:834
 msgid "Waiting"
 msgstr ""
 
@@ -6872,19 +8929,36 @@ msgstr ""
 msgid "Waiting for details..."
 msgstr ""
 
+#: pkg/apps/utils.jsx:62
+msgid "Waiting for other programs to finish using the package manager..."
+msgstr ""
+
+#: pkg/lib/cockpit-components-install-dialog.jsx:140
+#: pkg/lib/cockpit-components-install-dialog.jsx:175
+msgid "Waiting for other software management operations to finish"
+msgstr ""
+
+#: pkg/systemd/init.js:686
+msgid "Wanted By"
+msgstr ""
+
+#: pkg/systemd/init.js:681
+msgid "Wants"
+msgstr ""
+
+#: pkg/systemd/logs.html:59
+msgid "Warning and above"
+msgstr ""
+
 #: pkg/kubernetes/views/pv-modify.html:24
 msgid "Warning:"
 msgstr ""
 
-#: pkg/systemd/logs.html:49
-msgid "Warnings"
-msgstr ""
-
-#: pkg/systemd/services.html:179
+#: pkg/systemd/services.html:221
 msgid "Wednesday"
 msgstr ""
 
-#: pkg/systemd/services.html:408
+#: pkg/systemd/services.html:450
 msgid "Weeks"
 msgstr ""
 
@@ -6892,45 +8966,39 @@ msgstr ""
 msgid "Welcome to the Image Registry"
 msgstr ""
 
-#: pkg/ostree/index.html:282 pkg/kubernetes/views/volumes-page.html:61
+#: pkg/storaged/crypto-keyslots.jsx:295
+msgid "What if tang-show-keys is not available?"
+msgstr ""
+
+#: pkg/kubernetes/views/volumes-page.html:61
 msgid "When"
 msgstr ""
 
-#: pkg/docker/index.html:475
+#: pkg/docker/index.html:483
 msgid "With terminal"
 msgstr ""
 
-#: pkg/storaged/index.html:436
-#, fuzzy
-msgctxt "storage"
-msgid "World Wide Name"
-msgstr "Værtsnavn"
-
-#: pkg/storaged/details.js:410
+#: pkg/storaged/mdraid-details.jsx:102
 msgid "Write-mostly"
 msgstr ""
 
-#: pkg/storaged/index.html:331
+#: pkg/storaged/plot.jsx:268
 msgid "Writing"
 msgstr ""
 
-#: pkg/ostree/client.js:64
-msgid "Writing objects"
-msgstr ""
-
-#: src/ws/login.js:593
+#: src/ws/login.js:636
 msgid "Wrong user name or password"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:103
+#: pkg/storaged/format-dialog.jsx:238
 msgid "XFS - Red Hat Enterprise Linux 7 default"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1843
+#: pkg/networkmanager/interfaces.js:1974
 msgid "XOR"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2415 pkg/kubernetes/scripts/volumes.js:988
+#: pkg/kubernetes/scripts/volumes.js:988 pkg/networkmanager/interfaces.js:2581
 msgid "Yes"
 msgstr ""
 
@@ -6940,9 +9008,13 @@ msgid ""
 "synchronize users, a user with superuser privileges is required."
 msgstr ""
 
-#: pkg/dashboard/list.js:393
+#: pkg/dashboard/list.js:431
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:65 pkg/networkmanager/firewall.jsx:300
+msgid "You are not authorized to modify the firewall."
 msgstr ""
 
 #: pkg/kubernetes/views/auth-rejected-cert.html:3
@@ -6960,14 +9032,28 @@ msgid ""
 "You can remove the previously stored key by running the following command"
 msgstr ""
 
-#: pkg/users/index.html:329
+#: pkg/users/index.html:442
 msgid ""
 "You do not have permission to view the authorized public keys for this "
 "account."
 msgstr ""
 
-#: pkg/docker/storage.jsx:484
+#: pkg/docker/storage.jsx:475
 msgid "You don't have permission to manage the Docker storage pool."
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:811
+msgid "You need to re-subscribe this system."
+msgstr ""
+
+#: pkg/machines/components/vnc.jsx:31
+msgid "Your browser does not support iframes."
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:854
+msgid ""
+"Your browser will disconnect, but this does not affect the update process. "
+"You can reconnect in a few moments to continue watching the progress."
 msgstr ""
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:112
@@ -6976,11 +9062,17 @@ msgid ""
 "from the command line."
 msgstr ""
 
-#: src/base1/cockpit.js:3913
+#: pkg/packagekit/updates.jsx:889
+msgid ""
+"Your server will close the connection soon. You can reconnect after it has "
+"restarted."
+msgstr ""
+
+#: src/base1/cockpit.js:3990
 msgid "Your session has been terminated."
 msgstr ""
 
-#: src/base1/cockpit.js:3915
+#: src/base1/cockpit.js:3992
 msgid "Your session has expired. Please log in again."
 msgstr ""
 
@@ -6996,105 +9088,299 @@ msgstr ""
 msgid "[no data]"
 msgstr ""
 
-#: pkg/docker/run.js:574
+#: pkg/shell/active-pages-dialog.jsx:40
+msgid "active"
+msgstr ""
+
+#: pkg/docker/run.js:572
 msgid "alias"
 msgstr ""
 
-#: pkg/ostree/index.html:186
+#: pkg/packagekit/autoupdates.jsx:331
+msgid "and restart the machine automatically."
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:323
 msgid "at"
 msgstr ""
 
-#: pkg/storaged/utils.js:88
+#: pkg/machines/helpers.es6:203
+msgid "bridge"
+msgstr ""
+
+#: pkg/storaged/utils.js:89
 msgctxt "format-bytes"
 msgid "bytes"
 msgstr ""
 
-#: pkg/machines/helpers.es6:108
+#: pkg/machines/helpers.es6:192
+msgid "cdrom"
+msgstr ""
+
+#: pkg/ovirt/rephraseUI.es6:35
+msgid "connecting"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterVms.jsx:46
+msgid "cores"
+msgstr ""
+
+#: pkg/machines/helpers.es6:186
 msgid "crashed"
 msgstr ""
 
-#: pkg/docker/util.js:122
+#: pkg/machines/helpers.es6:197
+msgid "custom"
+msgstr ""
+
+#: pkg/docker/util.js:127
 msgid "default"
 msgstr ""
 
-#: pkg/machines/helpers.es6:95
+#: pkg/machines/helpers.es6:201
+msgid "direct"
+msgstr ""
+
+#: pkg/machines/helpers.es6:173 pkg/ovirt/components/OVirtTab.jsx:123
 msgid "disabled"
 msgstr ""
 
-#: pkg/machines/helpers.es6:109
+#: pkg/machines/helpers.es6:191 pkg/machines/helpers.es6:194
+msgid "disk"
+msgstr ""
+
+#: pkg/machines/helpers.es6:218 pkg/ovirt/rephraseUI.es6:27
+msgid "down"
+msgstr ""
+
+#: pkg/machines/helpers.es6:187
 msgid "dying"
 msgstr ""
 
-#: pkg/realmd/operation.js:237 pkg/realmd/operation.js:243
+#: pkg/realmd/operation.js:254 pkg/realmd/operation.js:260
 msgid "e.g. \"$0\""
 msgstr ""
 
-#: pkg/kubernetes/scripts/images.js:630
+#: pkg/kubernetes/scripts/images.js:627
 msgid "eg: my-image-stream"
 msgstr ""
 
-#: pkg/machines/helpers.es6:96
+#: pkg/machines/helpers.es6:174 pkg/ovirt/components/OVirtTab.jsx:125
 msgid "enabled"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:104
+#: pkg/ovirt/rephraseUI.es6:28
+msgid "error"
+msgstr ""
+
+#: pkg/machines/helpers.es6:205
+msgid "ethernet"
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:311
+msgid "every day"
+msgstr ""
+
+#: pkg/storaged/format-dialog.jsx:239
 msgid "ext4 - Red Hat Enterprise Linux 6 default"
 msgstr ""
 
-#: pkg/systemd/host.js:694
+#: pkg/systemd/host.js:794
 msgid "failed to list ssh host keys: $0"
 msgstr ""
 
-#: pkg/storaged/index.html:133
+#: pkg/machines/helpers.es6:198
+msgid "host"
+msgstr ""
+
+#: pkg/machines/helpers.es6:206
+msgid "hostdev"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/VmDisksTabKubevirt.jsx:67
+msgid "iSCSI"
+msgstr ""
+
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
-#: pkg/machines/helpers.es6:104
+#: pkg/machines/helpers.es6:182
 msgid "idle"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:379
+#: pkg/ovirt/rephraseUI.es6:29
+msgid "initializing"
+msgstr ""
+
+#: pkg/ovirt/rephraseUI.es6:30
+msgid "installation failed"
+msgstr ""
+
+#: pkg/ovirt/rephraseUI.es6:38
+msgid "installing OS"
+msgstr ""
+
+#: pkg/kdump/kdump-view.jsx:381
 msgid "invalid: multiple targets defined"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:491
+#: pkg/kdump/kdump-view.jsx:494
 msgid "kdump status"
+msgstr ""
+
+#: pkg/ovirt/rephraseUI.es6:39
+msgid "kdumping"
 msgstr ""
 
 #: pkg/docker/run.js:526
 msgid "key"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:383 pkg/kdump/kdump-view.jsx:385
+#: pkg/storaged/crypto-keyslots.jsx:321
+msgid "key slot $0"
+msgstr ""
+
+#: pkg/kdump/kdump-view.jsx:385 pkg/kdump/kdump-view.jsx:387
 msgid "locally in $0"
 msgstr ""
 
+#: pkg/ovirt/rephraseUI.es6:31
+msgid "maintenance"
+msgstr ""
+
+#: pkg/machines/helpers.es6:207
+msgid "mcast"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
+#: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:43
+msgid "n/a"
+msgstr ""
+
+#: pkg/machines/helpers.es6:193 pkg/machines/helpers.es6:202
+#, fuzzy
+msgid "network"
+msgstr "Netværks Traffik"
+
 #: pkg/kubernetes/views/route-body.html:14
+#: pkg/machines/components/vmDisksTab.jsx:103 pkg/machines/helpers.es6:214
+#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.es6:43
 msgid "no"
+msgstr ""
+
+#: pkg/ovirt/rephraseUI.es6:32
+#, fuzzy
+msgid "non operational"
+msgstr "Indstillinger"
+
+#: pkg/ovirt/rephraseUI.es6:33
+msgid "non responsive"
 msgstr ""
 
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
 #: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59 pkg/tuned/dialog.js:104
+#: pkg/kubernetes/views/node-body.html:59
+#: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
-#: pkg/docker/run.js:575
+#: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
 msgid "none"
 msgstr ""
 
-#: pkg/machines/helpers.es6:105
+#: pkg/ovirt/provider.es6:63
+msgid "oVirt"
+msgstr ""
+
+#: pkg/ovirt/components/HostStatus.jsx:37
+msgid "oVirt Host State:"
+msgstr ""
+
+#: pkg/ovirt/components/InstallationDialog.jsx:35
+msgid "oVirt Provider installation script failed due to missing arguments."
+msgstr ""
+
+#: pkg/ovirt/components/InstallationDialog.jsx:36
+msgid ""
+"oVirt Provider installation script failed: Can't write to /etc/cockpit/"
+"machines-ovirt.config, try as root."
+msgstr ""
+
+#: pkg/ovirt/components/InstallationDialog.jsx:164
+msgid "oVirt installation script failed with following output: "
+msgstr ""
+
+#: pkg/ovirt/components/App.jsx:49
+msgid "oVirt login in progress"
+msgstr ""
+
+#: pkg/systemd/host.js:632
+msgid "of $0 CPU core"
+msgid_plural "of $0 CPU cores"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/packagekit/autoupdates.jsx:316
+msgid "on Fridays"
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:312
+msgid "on Mondays"
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:317
+msgid "on Saturdays"
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:318
+msgid "on Sundays"
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:315
+msgid "on Thursdays"
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:313
+msgid "on Tuesdays"
+msgstr ""
+
+#: pkg/packagekit/autoupdates.jsx:314
+msgid "on Wednesdays"
+msgstr ""
+
+#: pkg/machines/libvirt-common.es6:112
+msgid "other"
+msgstr ""
+
+#: pkg/machines/helpers.es6:183
 msgid "paused"
+msgstr ""
+
+#: pkg/ovirt/rephraseUI.es6:34
+msgid "pending approval"
 msgstr ""
 
 #: pkg/kubernetes/views/dashboard-page.html:83
 msgid "pending volume claims"
 msgstr ""
 
-#: pkg/tuned/change-profile.jsx:52
+#: pkg/machines/components/diskAdd.jsx:182
+msgid "qcow2"
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:185
+msgid "raw"
+msgstr ""
+
+#: pkg/ovirt/rephraseUI.es6:36
+msgid "reboot"
+msgstr ""
+
+#: pkg/tuned/change-profile.jsx:49
 msgid "recommended"
 msgstr ""
 
-#: pkg/machines/helpers.es6:103
+#: pkg/machines/helpers.es6:181
 msgid "running"
 msgstr ""
 
@@ -7102,20 +9388,36 @@ msgstr ""
 msgid "search by name, namespace or description"
 msgstr ""
 
-#: pkg/docker/index.html:394
+#: pkg/docker/index.html:402
 msgid "select container"
 msgstr ""
 
-#: pkg/docker/index.html:472 pkg/docker/index.html:643
+#: pkg/machines/helpers.es6:208
+msgid "server"
+msgstr ""
+
+#: pkg/docker/index.html:480 pkg/docker/index.html:651
 msgid "shares"
 msgstr ""
 
-#: pkg/machines/helpers.es6:107
+#: pkg/machines/components/notification/inlineNotification.jsx:50
+msgid "show less"
+msgstr ""
+
+#: pkg/machines/components/notification/inlineNotification.jsx:48
+msgid "show more"
+msgstr ""
+
+#: pkg/machines/helpers.es6:185
 msgid "shut off"
 msgstr ""
 
-#: pkg/machines/helpers.es6:106
+#: pkg/machines/helpers.es6:184
 msgid "shutdown"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterVms.jsx:46
+msgid "sockets"
 msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:118
@@ -7126,8 +9428,12 @@ msgstr ""
 msgid "ssh key"
 msgstr ""
 
-#: pkg/machines/helpers.es6:110
+#: pkg/machines/helpers.es6:188
 msgid "suspended (PM)"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterVms.jsx:46
+msgid "threads"
 msgstr ""
 
 #: pkg/docker/run.js:473
@@ -7138,19 +9444,62 @@ msgstr ""
 msgid "to host port"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:30
+#: pkg/users/index.html:486
+msgid "translatable"
+msgstr ""
+
+#: pkg/machines/helpers.es6:209
+msgid "udp"
+msgstr ""
+
+#: pkg/ovirt/rephraseUI.es6:37
+msgid "unassigned"
+msgstr ""
+
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 
-#: pkg/systemd/init.js:243 pkg/systemd/init.js:257
+#: node_modules/registry-image-widgets/views/imagestream-listing.html:31
+#: pkg/systemd/init.js:244 pkg/systemd/init.js:258
 msgid "unknown"
 msgstr ""
 
-#: pkg/storaged/jobs.js:177
+#: pkg/storaged/jobs-panel.jsx:96
 msgid "unknown target"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:212
+#: pkg/storaged/utils.js:397
+msgid "unpartitioned space on $0"
+msgstr ""
+
+#: pkg/machines/helpers.es6:217 pkg/ovirt/rephraseUI.es6:26
+msgid "up"
+msgstr ""
+
+#: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:214
+msgid "upload a JSON file"
+msgstr ""
+
+#: pkg/machines/helpers.es6:204
+msgid "user"
+msgstr ""
+
+#: pkg/machines/components/vcpuModal.jsx:170
+#: pkg/ovirt/components/vcpuModal.jsx:51
+msgid "vCPU Count"
+msgstr ""
+
+#: pkg/machines/components/vcpuModal.jsx:175
+msgid "vCPU Maximum"
+msgstr ""
+
+#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/ovirt/components/ClusterVms.jsx:181
+msgid "vCPUs"
+msgstr ""
+
+#: pkg/machines/components/vmOverviewTab.jsx:80
 msgid "vCPUs:"
 msgstr ""
 
@@ -7158,15 +9507,31 @@ msgstr ""
 msgid "value"
 msgstr ""
 
+#: pkg/machines/helpers.es6:210
+msgid "vhostuser"
+msgstr ""
+
 #: pkg/kubernetes/views/route-body.html:13
+#: pkg/machines/components/vmDisksTab.jsx:103 pkg/machines/helpers.es6:213
+#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.es6:42
 msgid "yes"
 msgstr ""
 
-#: bower_components/registry-image-widgets/views/imagestream-body.html:6
+#: node_modules/registry-image-widgets/views/imagestream-body.html:6
 msgid ""
 "{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
 "count: {{ condition.generation }}"
 msgstr ""
+
+#, fuzzy
+#~ msgctxt "storage"
+#~ msgid "Firmware Version"
+#~ msgstr "Version"
+
+#, fuzzy
+#~ msgctxt "storage"
+#~ msgid "World Wide Name"
+#~ msgstr "Værtsnavn"
 
 #, fuzzy
 #~ msgid "Image Layers Example"

--- a/po/de.po
+++ b/po/de.po
@@ -13,14 +13,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-08-17 06:14+0000\n"
 "Last-Translator: Fabian Affolter <fab@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Zanata 4.6.2\n"
 
@@ -85,7 +85,7 @@ msgid_plural "$0 bytes"
 msgstr[0] "$0 byte"
 msgstr[1] "$0 bytes"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -200,7 +200,7 @@ msgid_plural "$0 updates"
 msgstr[0] "$0 Aktualisierung"
 msgstr[1] "$0 Aktualisierungen"
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 verwendet von $1 ($2 gespeichert)"
 
@@ -226,7 +226,6 @@ msgstr[0] "$0 Jahr"
 msgstr[1] "$0 Jahre"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% verfügbar"
@@ -579,7 +578,7 @@ msgid "Access"
 msgstr "Zugriff"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "Zugriffsmodi"
 
@@ -643,7 +642,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -664,11 +663,11 @@ msgstr "Adaptives Transmit Load Balancing (tlb)"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -830,7 +829,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adresse"
 
@@ -949,8 +948,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -959,8 +958,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "Anwendungen"
 
@@ -968,11 +967,11 @@ msgstr "Anwendungen"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Anwenden"
 
@@ -1021,8 +1020,8 @@ msgstr "Kennzeichen"
 msgid "At least $0 disks are needed."
 msgstr "Mindestens $0 Datenträger sind nötig."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Mindestens ein Datenträger ist nötig."
 
@@ -1042,9 +1041,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr "Authentifiziere"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Authentifizierung"
 
@@ -1060,13 +1059,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "Authentifikation erforderlich"
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Autor"
 
@@ -1123,7 +1122,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1151,7 +1150,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1274,10 +1273,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1342,7 +1341,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1354,27 +1352,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -1395,7 +1393,7 @@ msgid "Cannot schedule event in the past"
 msgstr "Vorgang kann nicht für die Vergangenheit geplant werden"
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "Kapazität"
@@ -1413,11 +1411,11 @@ msgid "Ceph Monitors"
 msgstr ""
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1445,7 +1443,7 @@ msgstr "Systemzeit ändern"
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1559,16 +1557,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr "Client-Zertifikat"
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Schließen"
 
@@ -1576,7 +1575,7 @@ msgstr "Schließen"
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr ""
@@ -1674,10 +1673,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1717,7 +1716,7 @@ msgstr[1] "Kombinierte Verwendung von $0 CPU-Kernen"
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Befehl"
 
@@ -1763,8 +1762,8 @@ msgstr "Kompatibel mit modernen Systemen und Festplatten > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Absturzberichte komprimieren um Speicherplatz zu sparen"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "Komprimierung"
 
@@ -1978,10 +1977,11 @@ msgid "Container:"
 msgstr "Container:"
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Container"
 
@@ -2095,10 +2095,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Erstellen"
 
@@ -2201,12 +2201,13 @@ msgstr "Partition auf $0 erzeugen"
 msgid "Create partition table"
 msgstr "Partitionstabelle erzeugen"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "Erstellt"
 
@@ -2332,7 +2333,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2352,7 +2353,7 @@ msgstr "Deaktiviere $target"
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2377,12 +2378,11 @@ msgstr "Verzögerung"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2458,7 +2458,7 @@ msgstr "Das Löschen eines RAID-Gerätes löscht alle darauf vorhandenen Daten."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 "Das Löschen eines Containers entfernt alle sich darin befindlichen Daten."
@@ -2508,14 +2508,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2528,10 +2528,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2621,9 +2621,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Datenträger"
 
@@ -2671,8 +2671,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2786,7 +2786,7 @@ msgstr "Alias duplizieren"
 msgid "Duplicate port"
 msgstr "Port duplizieren"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2971,9 +2971,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Fehler"
 
@@ -3061,7 +3061,7 @@ msgstr "Fehlgeschlagen"
 msgid "Failed to add machine: $0"
 msgstr "Maschine konnte nicht hinzugefügt werden: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "Passwort konnte nicht geändert werden"
 
@@ -3126,7 +3126,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3134,6 +3133,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3149,7 +3149,7 @@ msgstr ""
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3272,7 +3272,7 @@ msgstr "Allgemein"
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3335,9 +3335,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3398,9 +3398,9 @@ msgstr "Hello-Zeit $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Host"
 
@@ -3440,8 +3440,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3481,7 +3481,7 @@ msgstr "IPv6 Einstellungen"
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3571,11 +3571,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3650,7 +3649,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3666,9 +3665,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3716,7 +3715,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3729,8 +3728,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr "Instanzieren"
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr ""
 
@@ -3756,11 +3755,11 @@ msgstr "Ungültiger Schlüssel"
 msgid "Invalid credentials"
 msgstr "Ungültiger Port"
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3813,7 +3812,7 @@ msgstr "Ungültiger Port"
 msgid "Invalid prefix or netmask $0"
 msgstr "Ungültiger Port"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3821,7 +3820,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3940,11 +3939,12 @@ msgstr "Kubernetes Cluster"
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3989,8 +3989,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -4019,7 +4019,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4084,8 +4083,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "Lade..."
 
@@ -4163,17 +4162,17 @@ msgstr ""
 msgid "Logged In"
 msgstr "Angemeldet"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4368,9 +4367,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4402,8 +4402,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4418,7 +4418,7 @@ msgstr "Nachricht an angemeldete Benutzer"
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4499,8 +4499,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "Einhängen"
 
@@ -4508,17 +4508,17 @@ msgstr "Einhängen"
 msgid "Mount Location"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "Einhängoptionen"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Einhängestelle"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4542,7 +4542,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4606,37 +4606,38 @@ msgstr "NTP Server"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Name"
 
@@ -4674,7 +4675,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4685,6 +4685,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "Namespace"
@@ -4698,8 +4699,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Netzwerk"
 
@@ -4765,8 +4766,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4774,7 +4775,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "Das neue Passwort wurde nicht akzeptiert"
 
@@ -4784,7 +4785,7 @@ msgstr "Das neue Passwort wurde nicht akzeptiert"
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Weiter"
 
@@ -4900,9 +4901,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4930,7 +4931,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4938,7 +4939,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4946,7 +4947,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5098,9 +5099,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5111,7 +5112,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Kein"
 
@@ -5153,8 +5154,8 @@ msgstr "Nicht verfügbar"
 msgid "Not connected"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5170,7 +5171,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "Läuft nicht"
 
@@ -5198,8 +5199,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5231,8 +5232,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Aus"
 
@@ -5248,14 +5249,14 @@ msgstr "Altes Passwort"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "Altes Passwort wurde nicht akzeptiert"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Ein"
 
@@ -5440,11 +5441,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Passphrasen stimmen nicht überein."
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5483,10 +5485,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr ""
 
@@ -5550,7 +5552,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5584,8 +5586,8 @@ msgstr "$target wird gelöscht"
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5802,9 +5804,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5820,7 +5821,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Ports"
 
@@ -5903,7 +5904,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5917,7 +5918,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5929,6 +5929,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Projekt"
@@ -5957,10 +5958,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5992,7 +5993,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -6020,8 +6021,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -6085,7 +6086,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "RAID-Gerät $0"
 
@@ -6121,7 +6122,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6133,6 +6133,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr ""
 
@@ -6198,7 +6199,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "Neustart"
 
@@ -6255,8 +6256,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6284,8 +6285,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "Neu Laden"
 
@@ -6326,9 +6327,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "Entfernen"
 
@@ -6381,7 +6382,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6451,10 +6452,10 @@ msgstr "Jährlich wiederholen"
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "Repliken"
 
@@ -6568,8 +6569,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Neustarten"
 
@@ -6619,8 +6620,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Mein Passwort für Administrator-Aufgaben verwenden"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Mein Passwort für Administrator-Aufgaben und zum Verbinden zu anderen "
 "Maschinen verwenden"
@@ -6678,7 +6678,7 @@ msgstr "Ausführen als"
 msgid "Runner"
 msgstr "Läuft"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "Läuft"
 
@@ -6766,8 +6766,8 @@ msgstr ""
 msgid "Saturday"
 msgstr "Samstag"
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "Speichern"
 
@@ -6820,7 +6820,7 @@ msgstr "Secure Shell-Schlüssel"
 msgid "Securely erasing $target"
 msgstr "$target wird sicher gelöscht"
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr "Sicherheit"
 
@@ -6852,8 +6852,8 @@ msgstr "Wählen Sie ein Objekt aus, um weitere Details anzuzeigen."
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 "Wählen Sie die Nutzer aus, die mit {{#strong}}{{host}}{{/strong}} "
 "synchronisiert werden sollen"
@@ -6876,15 +6876,14 @@ msgstr "Sende"
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "Server"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr "Serveradresse"
 
@@ -6892,7 +6891,7 @@ msgstr "Serveradresse"
 msgid "Server Administrator"
 msgstr "Server Administrator"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr "Serveradresse darf nicht leer sein."
 
@@ -6911,7 +6910,7 @@ msgstr "Server"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "Dienst"
 
@@ -6961,7 +6960,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr "Sitzung"
 
@@ -7100,7 +7099,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr "Fingerabdrücke anzeigen"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7122,35 +7121,35 @@ msgstr "Seit"
 msgid "Since $0"
 msgstr "Seit $0"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Größe"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "Größe darf nicht negativ sein"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "Größe darf nicht Null sein"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 #, fuzzy
 msgid "Size is too large"
 msgstr "Größe zu groß"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "Größe muss eine Zahl sein"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7246,7 +7245,7 @@ msgid "Stable"
 msgstr "Stabil"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Starten"
@@ -7287,10 +7286,10 @@ msgstr "Startet"
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "Status"
 
@@ -7312,10 +7311,11 @@ msgid "Static"
 msgstr "Statisch"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7338,7 +7338,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7578,7 +7578,7 @@ msgstr "Tag"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7600,7 +7600,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr "Ziele"
 
@@ -7669,8 +7669,7 @@ msgstr "Die \"storaged\" API ist auf diesem System nicht verfügbar."
 
 #: pkg/docker/storage.jsx:478
 msgid "The Docker storage pool cannot be managed on this system."
-msgstr ""
-"Der Docker Storage Pool kann auf diesem System nicht verwaltet werden."
+msgstr "Der Docker Storage Pool kann auf diesem System nicht verwaltet werden."
 
 #: pkg/lib/machine-dialogs.js:385
 msgid "The IP address or host name cannot contain whitespace."
@@ -7734,16 +7733,15 @@ msgstr "Das Adressfeld enthält ungültige Zeichen"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Die Authentizität von Host {{#strong}}{{host}}{{/strong}} kann nicht "
 "bestätigt werden. Sind Sie sicher, dass Sie fortfahren wollen?"
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
-msgstr ""
-"Die gesammelten Informationen werden lokal auf dem System gespeichert."
+msgstr "Die gesammelten Informationen werden lokal auf dem System gespeichert."
 
 #: pkg/selinux/setroubleshoot-view.jsx:280
 msgid "The configured state is unknown, it might change on the next boot."
@@ -7777,11 +7775,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7793,9 +7791,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7804,14 +7801,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7918,11 +7914,11 @@ msgstr "Der Replication Controller '{{ target }}' existiert nicht."
 msgid "The route '{{ target }}' does not exist."
 msgstr "Die Route '{{ target }}' existiert nicht."
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -8016,8 +8012,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -8032,8 +8027,7 @@ msgstr ""
 
 #: pkg/users/index.html:439
 msgid "There are no authorized public keys for this account."
-msgstr ""
-"Für dieses Konto existieren keine autorisierten öffentlichen Schlüssel"
+msgstr "Für dieses Konto existieren keine autorisierten öffentlichen Schlüssel"
 
 #: pkg/storaged/vgroup-details.jsx:100
 msgid ""
@@ -8076,13 +8070,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -8092,17 +8086,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -8112,7 +8106,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8132,7 +8126,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr "Dieses Image existiert nicht."
 
@@ -8203,9 +8197,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8281,8 +8275,7 @@ msgstr ""
 msgid ""
 "To try a different port you will need to upgrade cockpit-ws to a newer "
 "version."
-msgstr ""
-"Um einen anderen Port zu benutzen müssen Sie cockpit-ws aktualisieren."
+msgstr "Um einen anderen Port zu benutzen müssen Sie cockpit-ws aktualisieren."
 
 #: pkg/kubernetes/views/auth-form.html:116
 msgid "Token"
@@ -8370,11 +8363,11 @@ msgstr "Tuned läuft nicht"
 msgid "Tuned is off"
 msgstr "Tuned ist ausgeschaltet"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Typ"
@@ -8437,7 +8430,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Kann Server nicht erreichen"
 
@@ -8484,23 +8477,23 @@ msgstr "Unerwarteter Fehler"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -8524,7 +8517,7 @@ msgstr "Unbekannter Host-Schlüssel"
 msgid "Unknown configuration"
 msgstr "Unbekannte Konfiguration"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr "Unbekannter Host-Name"
 
@@ -8569,7 +8562,7 @@ msgstr "Unverwaltete Schnittstellen"
 msgid "Unmask"
 msgstr "Freigeben"
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Aushängen"
 
@@ -8659,7 +8652,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr "Aktualisiere"
 
@@ -8709,13 +8702,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr "Benutze die Einstellungen in /etc/kdump.conf"
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Benutzt"
 
@@ -8725,10 +8718,10 @@ msgstr "Genutzt von Containern"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8747,7 +8740,7 @@ msgstr "Benutzerpasswort"
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Benutzername"
@@ -8760,8 +8753,8 @@ msgstr ""
 msgid "User or Group"
 msgstr "Benutzer oder Gruppe"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "Benutzername"
 
@@ -8921,9 +8914,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Version"
 
@@ -8985,8 +8978,8 @@ msgstr "Datenträgerverbünde"
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr ""
 
@@ -8994,9 +8987,8 @@ msgstr ""
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9300,7 +9292,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr "iSCSI Targets"
 
@@ -9376,10 +9368,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9555,7 +9547,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "nicht definiert"
 

--- a/po/es.po
+++ b/po/es.po
@@ -17,14 +17,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-05-18 07:33+0000\n"
 "Last-Translator: Emilio Herrera <ehespinosa57@gmail.com>\n"
 "Language-Team: Spanish\n"
 "Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -92,7 +92,7 @@ msgid_plural "$0 bytes"
 msgstr[0] "$0 byte"
 msgstr[1] "$0 bytes"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 datos + $1 geneal utilizado de $2 ($3)"
 
@@ -209,7 +209,7 @@ msgid_plural "$0 updates"
 msgstr[0] "$0 actualización."
 msgstr[1] "$0 actualizaciones."
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 usado de $1 ($2 guardado)"
 
@@ -235,7 +235,6 @@ msgstr[0] "$0 año"
 msgstr[1] "$0 años"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0 % disponible"
@@ -542,8 +541,8 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"No se ha instalado una versión compatible de Cockpit en "
-"{{#strong}}{{host}}{{/strong}}."
+"No se ha instalado una versión compatible de Cockpit en {{#strong}}{{host}}"
+"{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:64
 msgid "A disk is needed."
@@ -590,7 +589,7 @@ msgid "Access"
 msgstr "Acceder"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "Modos de acceso"
 
@@ -654,7 +653,7 @@ msgid "Active Pages"
 msgstr "Páginas Activas"
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr "Activo desde"
 
@@ -675,11 +674,11 @@ msgstr "Equilibrio de carga de transmisión adaptativa"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Añadir"
 
@@ -841,7 +840,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Dirección"
 
@@ -960,8 +959,8 @@ msgstr "Servicios Permitidos"
 msgid "Always"
 msgstr "Siempre"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Anotaciones"
@@ -969,11 +968,10 @@ msgstr "Anotaciones"
 #: pkg/kubernetes/scripts/projects.js:1028
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
-"Anónimo: Permite a todos los usuarios no autentificados tirar de las "
-"imágenes"
+"Anónimo: Permite a todos los usuarios no autentificados tirar de las imágenes"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "Aplicaciones"
 
@@ -981,11 +979,11 @@ msgstr "Aplicaciones"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -1034,8 +1032,8 @@ msgstr "Etiqueta de Propiedad"
 msgid "At least $0 disks are needed."
 msgstr "Se necesitan al menos $0 discos."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Se necesita al menos un disco."
 
@@ -1055,9 +1053,9 @@ msgstr "Registro de auditoria"
 msgid "Authenticating"
 msgstr "Autenticando "
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Autenticación"
 
@@ -1073,13 +1071,13 @@ msgstr "Falló la autenticación: Conexión con el servidor cerrada."
 msgid "Authentication failed"
 msgstr "Autenticación Fallida"
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "Autentificación requerida"
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Autor"
 
@@ -1136,7 +1134,7 @@ msgstr "Disponible"
 msgid "Available Updates"
 msgstr "Actualizaciones Disponibles"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr "Objetivos disponibles en $0"
 
@@ -1164,7 +1162,7 @@ msgstr "Versión de la BIOS"
 msgid "Back to Accounts"
 msgstr "Regreso a las Cuentas"
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr "Dispositivo de Respaldo"
 
@@ -1287,10 +1285,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr "Fallo en la acción CHANGE NETWORK STATE"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1355,7 +1353,6 @@ msgstr "No puede cargar imagen"
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1367,27 +1364,27 @@ msgstr "No puede cargar imagen"
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1408,7 +1405,7 @@ msgid "Cannot schedule event in the past"
 msgstr "No puede planificar un evento en el pasado"
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "Capacidad"
@@ -1426,11 +1423,11 @@ msgid "Ceph Monitors"
 msgstr "Monitores Ceph"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "Cambiar"
 
@@ -1458,7 +1455,7 @@ msgstr "Cambiar la Hora del Sistema"
 msgid "Change User"
 msgstr "Cambiar Usuario"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr "Cambiar Nombre Iniciador de iSCSI "
 
@@ -1573,16 +1570,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr "Certificado de Cliente"
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Cerrar"
 
@@ -1590,7 +1588,7 @@ msgstr "Cerrar"
 msgid "Close Selected Pages"
 msgstr "Cerrar Paginas Seleccionas"
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr "Cluster"
@@ -1685,16 +1683,15 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit no pudo ingresar en {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}Puede que desee probar a {{#sync_link}}sincronizar usuarios{{/"
-"sync_link}}.{{/can_sync}} Para obtener más opciones de autenticación y "
-"asistencia para solucionar problemas, actualice cockpit-ws a una versión más "
-"reciente."
+"Cockpit no pudo ingresar en {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"Puede que desee probar a {{#sync_link}}sincronizar usuarios{{/sync_link}}.{{/"
+"can_sync}} Para obtener más opciones de autenticación y asistencia para "
+"solucionar problemas, actualice cockpit-ws a una versión más reciente."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1738,7 +1735,7 @@ msgstr[1] "Uo combinado de núcleos de CPU $0"
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Orden"
 
@@ -1783,8 +1780,8 @@ msgstr "Compatible con los sistemas modernos y discos duros > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Comprimir volcado de errores para ahorrar espacio"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "Compresión"
 
@@ -1997,10 +1994,11 @@ msgid "Container:"
 msgstr "Contenedor:"
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Contenedores"
 
@@ -2115,10 +2113,10 @@ msgstr "Error del sistema"
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Crear"
 
@@ -2220,12 +2218,13 @@ msgstr "Crear partición en $0"
 msgid "Create partition table"
 msgstr "Crear tabla de particiones"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "Creado"
 
@@ -2353,7 +2352,7 @@ msgstr "Buscar Dominios DNS $val"
 msgid "Dashboard"
 msgstr "Tablero"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr "Datos Usados"
 
@@ -2373,7 +2372,7 @@ msgstr "Desactivando $target"
 msgid "Debug and above"
 msgstr "Depurar y arriba"
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr "Deduplicación"
 
@@ -2398,12 +2397,11 @@ msgstr "Retraso"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2483,7 +2481,7 @@ msgstr "Eliminar un dispositivo RAID borrará toda la información en el."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Al borrar un dispositivo VDO borrará todos los datos en él."
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "Eliminar un contenedor eliminara toda la información en él."
 
@@ -2530,14 +2528,14 @@ msgstr "Configuración de despliegue"
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "Descripción "
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "Descripción:"
 
@@ -2550,10 +2548,10 @@ msgid "Detachable"
 msgstr "Desmontable"
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "Detalles"
 
@@ -2562,7 +2560,7 @@ msgstr "Detalles"
 msgid "Device"
 msgstr "Dispositivo"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr "Fichero de Dispositivo"
 
@@ -2643,9 +2641,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Discos"
 
@@ -2699,8 +2697,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 "¿Desea borrar el rol '{{ fields.displayRole }}' del miembro {{ fields.member."
 "metadata.name }}?"
@@ -2815,7 +2813,7 @@ msgstr "Alias duplicado"
 msgid "Duplicate port"
 msgstr "Puerto duplicado"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr "Editar"
 
@@ -2978,7 +2976,7 @@ msgstr ""
 msgid "Entry"
 msgstr "Entrada"
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr "Punto de entrada"
 
@@ -3004,9 +3002,9 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Error"
 
@@ -3094,7 +3092,7 @@ msgstr "Falló"
 msgid "Failed to add machine: $0"
 msgstr "Fallo al agregar maquina: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "Error al cambiar contraseña"
 
@@ -3159,7 +3157,6 @@ msgstr "Montando Sistema de archivos"
 msgid "Filesystem Name"
 msgstr "Nombre de Sistema de archivos"
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3167,6 +3164,7 @@ msgstr "Nombre de Sistema de archivos"
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr "Tipo de Sistema de archivos"
 
@@ -3182,7 +3180,7 @@ msgstr "Archivos del sistema"
 msgid "Filter Services"
 msgstr "Filtrar Servicios"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Fingerprint"
 
@@ -3304,7 +3302,7 @@ msgstr "General"
 msgid "Generating report"
 msgstr "Generando reporte"
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr "Obtener nueva imagen"
 
@@ -3369,9 +3367,9 @@ msgstr "Grupo o Proyecto"
 msgid "Groups"
 msgstr "Grupos"
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr "Crecer"
 
@@ -3432,9 +3430,9 @@ msgstr "Tiempo de saludo $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Anfitrión"
 
@@ -3474,8 +3472,8 @@ msgstr "Espera de E/S"
 msgid "INSTALL VM action failed"
 msgstr "INSTALL VM acción fallada"
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr "IP"
 
@@ -3515,7 +3513,7 @@ msgstr "Configuración IPv6"
 msgid "ISCSI"
 msgstr "ISCSI"
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr "Id"
@@ -3604,11 +3602,10 @@ msgstr "Imagen Stream"
 msgid "Image:"
 msgstr "Imagen:"
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr "Imágenes"
 
@@ -3675,8 +3672,8 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Con el objetivo de sincronizar usuarios, necesita acceder a "
-"{{#strong}}{{host}}{{/strong}}."
+"Con el objetivo de sincronizar usuarios, necesita acceder a {{#strong}}"
+"{{host}}{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:822 pkg/networkmanager/interfaces.js:1418
 #: pkg/networkmanager/interfaces.js:1425 pkg/networkmanager/interfaces.js:2594
@@ -3691,7 +3688,7 @@ msgstr "Volumen inactivo"
 msgid "Incorrect Host Key"
 msgstr "Llave de Host Incorrecta"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr "Índice de Memoria"
 
@@ -3708,9 +3705,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr "Inicializando..."
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr "Instalar"
 
@@ -3760,7 +3757,7 @@ msgstr "Instalado"
 msgid "Installed products"
 msgstr "Productos instalados"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "Instalando"
@@ -3773,8 +3770,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr "Instanciar"
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr "Interfaz"
 
@@ -3798,11 +3795,11 @@ msgstr "La dirección $0 no es válida"
 msgid "Invalid credentials"
 msgstr "Las credenciales no son válidas"
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "Formato de fecha inválido"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "Formato de fecha y formato de hora inválidos "
 
@@ -3850,7 +3847,7 @@ msgstr "El prefijo $0 no es válido"
 msgid "Invalid prefix or netmask $0"
 msgstr "El prefijo o la máscara de red $0 no es válido"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "Formato de hora inválido"
 
@@ -3858,7 +3855,7 @@ msgstr "Formato de hora inválido"
 msgid "Invalid time zone"
 msgstr "El huso horario no es válido"
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr "Nombre de usuario o contraseña invalidos"
@@ -3978,11 +3975,12 @@ msgstr "Cluster de Kubernetes"
 msgid "LACP Key"
 msgstr "Clave de LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Viñetas"
@@ -4027,8 +4025,8 @@ msgstr "Última Actualización"
 msgid "Last checked: $0 ago"
 msgstr "Ultima revisión: $0 atrás"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr "Última Versión"
 
@@ -4059,7 +4057,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Déjelo en blanco para conectarse a esta máquina como el usuario actualmente "
 "conectado {{#default_user}} ({{default_user}}){{/default_user}}. Si usted "
@@ -4126,8 +4123,8 @@ msgstr "Leyendo actualizaciones disponibles, por favor espere..."
 msgid "Loading data ..."
 msgstr "Cargando datos ..."
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "Cargando..."
 
@@ -4203,17 +4200,17 @@ msgstr "Mensajes de registro"
 msgid "Logged In"
 msgstr "Sesión iniciada"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr "Logico"
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr "Tamaño Lógico"
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr "Número de unidad lógica"
 
@@ -4410,9 +4407,10 @@ msgstr "Afiliación"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4444,8 +4442,8 @@ msgstr "Uso de memoria:"
 msgid "Memory:"
 msgstr "Memoria:"
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "Mensaje"
 
@@ -4460,7 +4458,7 @@ msgstr "Mensaje para usuarios activos "
 msgid "Metadata"
 msgstr "Metadatos"
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr "Metadatos en uso"
 
@@ -4540,8 +4538,8 @@ msgstr "Mas información"
 msgid "More details"
 msgstr "Más detalles"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "Montar"
 
@@ -4549,17 +4547,17 @@ msgstr "Montar"
 msgid "Mount Location"
 msgstr "Ubicación de montaje"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "Opciones de Montaje"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Punto de Montaje"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr "Montar en el arranque"
 
@@ -4583,7 +4581,7 @@ msgstr "El punto de montaje no puede estar vacío."
 msgid "Mount point must start with \"/\"."
 msgstr "El punto de montaje debe empezar con \"/\"."
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr "Montar en sólo lectura"
 
@@ -4647,37 +4645,38 @@ msgstr "Servidor NTP"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Nombre"
 
@@ -4711,7 +4710,6 @@ msgstr "El nombre no debería constar solo de caracteres vacíos"
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4722,6 +4720,7 @@ msgstr "El nombre no debería constar solo de caracteres vacíos"
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "Espacio de Nombres"
@@ -4735,8 +4734,8 @@ msgid "Need at least one NTP server"
 msgstr "Se requiere al menos un servidor NTP"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Red"
 
@@ -4802,8 +4801,8 @@ msgstr "Proyecto nuevo"
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr "Flujo de imágenes nuevo"
 
@@ -4811,7 +4810,7 @@ msgstr "Flujo de imágenes nuevo"
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "Nueva contraseña no fue aceptada"
 
@@ -4821,7 +4820,7 @@ msgstr "Nueva contraseña no fue aceptada"
 msgid "New project"
 msgstr "Nuevo proyecto"
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Siguiente"
 
@@ -4936,9 +4935,9 @@ msgstr "Ningún contenedor corresponde al filtro actual"
 msgid "No description provided."
 msgstr "No se ha suministrado descripción."
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr "No hay discos disponibles."
 
@@ -4966,7 +4965,7 @@ msgstr "No hay ningún grupo presente."
 msgid "No host keys found."
 msgstr "No se encontró ninguna clave de anfitrión."
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr "Sin objetivos iSCSI ajustados"
 
@@ -4974,7 +4973,7 @@ msgstr "Sin objetivos iSCSI ajustados"
 msgid "No image streams are present."
 msgstr "No hay ningún flujo de imágenes presente."
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr "No hay imágenes"
 
@@ -4982,7 +4981,7 @@ msgstr "No hay imágenes"
 msgid "No images pushed"
 msgstr "Sin imágenes empujadas"
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr "No hay imágenes que correspondan al filtro actual"
 
@@ -5135,9 +5134,9 @@ msgstr "Nodo"
 msgid "Node:"
 msgstr "Nodo:"
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr "Nodos"
 
@@ -5148,7 +5147,7 @@ msgstr "Nodos son las computadoras que ejecutan sus contenedores"
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Ninguno"
 
@@ -5190,8 +5189,8 @@ msgstr "No disponible"
 msgid "Not connected"
 msgstr "No conectado"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr "No distribuido"
 
@@ -5207,7 +5206,7 @@ msgstr "No montado"
 msgid "Not permitted to perform this action."
 msgstr "No esta permitido ejecutar esta acción."
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "No esta corriendo"
 
@@ -5235,8 +5234,8 @@ msgstr "Aviso y arriba"
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr "OK"
 
@@ -5268,8 +5267,8 @@ msgstr "Ocurrió entre $0 y $1"
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Apagado"
 
@@ -5285,14 +5284,14 @@ msgstr "Contraseña vieja"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "Contraseña antigua no aceptada"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Encencido"
 
@@ -5475,11 +5474,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Palabra de paso no coincide"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5520,10 +5520,10 @@ msgstr "Pegar JSON abajo,"
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Pegue aquí el contenido de su archivo de clave SSH pública"
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "Trayecto"
 
@@ -5587,7 +5587,7 @@ msgstr "Volúmenes persistentes"
 msgid "Phase"
 msgstr "Fase"
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr "Físico"
 
@@ -5619,8 +5619,8 @@ msgstr "Hacer Ping al Objetivo"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5768,7 +5768,6 @@ msgstr "Por favor espere hasta que la lista VMs se cargue desde el servidor."
 msgid "Please wait till list of templates is loaded from the server."
 msgstr ""
 "Por favor espere hasta que la lista de plantilla se cargue desde el servidor."
-""
 
 #: pkg/machines/vmnetworktab.jsx:123
 msgid "Plug"
@@ -5847,9 +5846,8 @@ msgstr "Rellenar"
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr "Puerto"
 
@@ -5865,7 +5863,7 @@ msgstr "Grupo de puertos"
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Puertos"
 
@@ -5947,7 +5945,7 @@ msgstr "Información de problema"
 msgid "Problems"
 msgstr "Problemas"
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr "Proceso"
 
@@ -5961,7 +5959,6 @@ msgstr "Nombre del Producto"
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5973,6 +5970,7 @@ msgstr "Nombre del Producto"
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Proyecto"
@@ -6007,10 +6005,10 @@ msgstr "Sitio web del proyecto"
 msgid "Project:"
 msgstr "Proyecto:"
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr "Proyectos"
 
@@ -6042,7 +6040,7 @@ msgstr "Proxy"
 msgid "Proxy Version"
 msgstr "Versión de Proxy"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Llave pública"
 
@@ -6070,8 +6068,8 @@ msgstr "Proposito"
 msgid "Push an image:"
 msgstr "Empujar una imagen:"
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr "Nombre Cualificado"
 
@@ -6135,7 +6133,7 @@ msgstr "Chasis RAID"
 msgid "RAID Device"
 msgstr "Dispositivo RAID"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "Dispositivo RAID $0"
 
@@ -6171,7 +6169,6 @@ msgstr "Al azar"
 msgid "Raw to a device"
 msgstr "Sin procesar a un dispositivo"
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6183,6 +6180,7 @@ msgstr "Sin procesar a un dispositivo"
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr "Solo lectura"
 
@@ -6249,7 +6247,7 @@ msgstr "El nombre real de anfitrión debe tener 64 caracteres o menos"
 msgid "Reason"
 msgstr "Razón"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "Reiniciar"
 
@@ -6305,8 +6303,8 @@ msgstr "Rechazando conexión. La clave de host no coincide"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Rechazando la conexión. La clave de host es desconocida"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr "Registrar"
 
@@ -6334,8 +6332,8 @@ msgstr "Registrando oVirt a Cockpit"
 msgid "Register…"
 msgstr "Registro…"
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "Recargar"
 
@@ -6376,9 +6374,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "Eliminar"
 
@@ -6430,7 +6428,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr "Quitando"
 
@@ -6500,10 +6498,10 @@ msgstr "Repetir cada año"
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "Réplicas"
 
@@ -6619,8 +6617,8 @@ msgstr "Resuelva los errores de arriba para continuar"
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -6669,8 +6667,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Reutilizar mi contraseña para tareas privilegiadas"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Reutilizar mi contraseña para tareas con privilegios y para conectar con "
 "otras máquinas"
@@ -6726,7 +6723,7 @@ msgstr "Ejecutar como"
 msgid "Runner"
 msgstr "Ejecutor"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "Corriendo"
 
@@ -6814,8 +6811,8 @@ msgstr "SUSPEND acción fallada"
 msgid "Saturday"
 msgstr "Sábado"
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "Guardar"
 
@@ -6868,7 +6865,7 @@ msgstr "Claves de Shell Seguras"
 msgid "Securely erasing $target"
 msgstr "Borrando de forma segura $target"
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr "Seguridad"
 
@@ -6900,11 +6897,11 @@ msgstr "Selecciona un objeto para ver mas detalles"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Seleccione el usuario con el que le gustaría sincronizar  "
-"{{#strong}}{{host}}{{/strong}}"
+"Seleccione el usuario con el que le gustaría sincronizar  {{#strong}}{{host}}"
+"{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:65
 msgid "Send Non-Maskable Interrupt"
@@ -6924,15 +6921,14 @@ msgstr "Enviando"
 msgid "Serial Console"
 msgstr "Consola Serie"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "Servidor"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr "Dirección del Servidor"
 
@@ -6940,7 +6936,7 @@ msgstr "Dirección del Servidor"
 msgid "Server Administrator"
 msgstr "Administrador del Servidor"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr "La dirección del servidor no puede estar vacía."
 
@@ -6959,7 +6955,7 @@ msgstr "Servidores"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "Servicio"
 
@@ -7010,7 +7006,7 @@ msgstr ""
 "IP opcional con balance de carga para acceder a ellos"
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr "Sesión"
 
@@ -7148,7 +7144,7 @@ msgstr "Mostrar todas las imágenes"
 msgid "Show fingerprints"
 msgstr "Mostrar huellas dactilares"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr "Encogimiento"
 
@@ -7169,34 +7165,34 @@ msgstr "Desde"
 msgid "Since $0"
 msgstr "Desde $0"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Tamaño"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "El tamaño no puede ser negativo"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "El tamaño no puede ser cero"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr "Tamaño es muy grande"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "Tamaña debe ser un número"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr "El tamaño debe ser al menos $0"
 
@@ -7292,7 +7288,7 @@ msgid "Stable"
 msgstr "Estable"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Iniciar"
@@ -7333,10 +7329,10 @@ msgstr "Inicios"
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "Estado"
 
@@ -7358,10 +7354,11 @@ msgid "Static"
 msgstr "Estático"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7384,7 +7381,7 @@ msgid "Sticky"
 msgstr "Pegajoso"
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7626,7 +7623,7 @@ msgstr "Etiquetas"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr "Etiquetas"
 
@@ -7648,7 +7645,7 @@ msgstr "Portal Objetivo"
 msgid "Target World Wide Names"
 msgstr "Nombres Objetivo en todo el Mundo"
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr "Objetivos"
 
@@ -7787,8 +7784,8 @@ msgstr "La dirección contiene caracteres inválidos"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "La autenticidad del host {{#strong}}{{host}}{{/strong}} no se ha podido "
 "establecer.¿Está seguro que desea continuar con la conexión?"
@@ -7830,13 +7827,13 @@ msgstr "La configuración de despliegue '{{ target }}' no existe."
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 "El sistema de archivos está en uso por inicios de sesiones y servicios del "
 "sistema.                Si se sigue se parará eso."
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7850,9 +7847,8 @@ msgstr ""
 "El sistema de archivos está en uso por inicio de sesiones.                Si "
 "se sigue se pararán."
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7863,14 +7859,13 @@ msgstr ""
 "El sistema de archivos está en uso por servicios del sistema.                "
 "Si se sigue se pararán."
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7978,11 +7973,11 @@ msgstr "El controlador de replica '{{ target }}' no existe."
 msgid "The route '{{ target }}' does not exist."
 msgstr "La ruta '{{ target }}' no existe."
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "El escaneo desde $time ($type) no encontró vulnerabilidades."
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr "El escaneo desde $time ($type) no tuvo éxito."
 
@@ -8038,8 +8033,7 @@ msgstr "El usuario <b>$0</b> no está autorizado para administrar servidores"
 
 #: pkg/storaged/storage-controls.jsx:65
 msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr ""
-"Al usuario <b>$0</b> no le es permitido administrar el almacenamiento "
+msgstr "Al usuario <b>$0</b> no le es permitido administrar el almacenamiento "
 
 #: pkg/users/local.js:42
 msgid "The user <b>$0</b> is not permitted to modify accounts"
@@ -8078,8 +8072,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "La configuración del navegador evita que se ejecute Cockpit (inaccesible $0)"
 
@@ -8113,8 +8106,7 @@ msgstr "Volumen Lógico Delgado"
 
 #: pkg/storaged/nfs-details.jsx:128
 msgid "This NFS mount is in use and only its options can be changed."
-msgstr ""
-"Este montaje NFS está en uso y solo pueden ser cambiadas sus opciones."
+msgstr "Este montaje NFS está en uso y solo pueden ser cambiadas sus opciones."
 
 #: pkg/storaged/vdo-details.jsx:122
 msgid "This VDO device does not use all of its backing device."
@@ -8144,16 +8136,16 @@ msgid ""
 "This device has filesystems that are currently in use.                "
 "Proceeding will unmount all filesystems on it."
 msgstr ""
-"Este dispositivo tiene sistemas de archivos que están actualmente en uso.    "
-"            Procede desmontar todos los sistemas de archivos en él."
+"Este dispositivo tiene sistemas de archivos que están actualmente en "
+"uso.                Procede desmontar todos los sistemas de archivos en él."
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr "Este dispositivo está usado actualmente por dispositivos RAID."
 
@@ -8162,20 +8154,20 @@ msgid ""
 "This device is currently used for RAID devices.                Proceeding "
 "will remove it from its RAID devices."
 msgstr ""
-"Este dispositivo está usado actualmente por dispositivos RAID.               "
-" Procediendo lo quitará de sus dispositivos RAID."
+"Este dispositivo está usado actualmente por dispositivos "
+"RAID.                Procediendo lo quitará de sus dispositivos RAID."
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr "Este dispositivo está actualmente usado por dispositivos VDO."
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 "Este dispositivo está siendo utilizado actualmente por grupos de volumen."
@@ -8185,10 +8177,10 @@ msgid ""
 "This device is currently used for volume groups.                Proceeding "
 "will remove it from its volume groups."
 msgstr ""
-"Este dispositivo está usado actualmente por grupos de volumen.               "
-" Procediendo lo quitará de sus grupos de volumen."
+"Este dispositivo está usado actualmente por grupos de "
+"volumen.                Procediendo lo quitará de sus grupos de volumen."
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8211,7 +8203,7 @@ msgstr ""
 "Este host está gestionado por un gestor de virtualización de modo que la "
 "creación de nuevas VMs desde este host no es posible."
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr "Esta imagen no existe."
 
@@ -8287,9 +8279,9 @@ msgstr "Esta máquina virtual no está gestionada por oVirt"
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 "Este volumen ha sido reclamado por {{ item.item.spec.claimRef.namespace }} / "
 "{{ item.item.spec.claimRef.name }}. Eliminarlo romperá el reclamo y puede "
@@ -8301,14 +8293,12 @@ msgstr "Este volumen ni ha sido reclamado"
 
 #: pkg/storaged/lvol-tabs.jsx:329
 msgid "This volume needs to be activated before it can be resized."
-msgstr ""
-"Este volumen necesita ser activado antes de poder modificar el tamaño."
+msgstr "Este volumen necesita ser activado antes de poder modificar el tamaño."
 
 #: src/ws/login.js:141
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr ""
-"Este navegador web es demasiado viejo para ejecutar Cockpit (desaparecido "
-"$0)"
+"Este navegador web es demasiado viejo para ejecutar Cockpit (desaparecido $0)"
 
 #: pkg/packagekit/updates.jsx:852
 msgid "This web console will be updated."
@@ -8464,11 +8454,11 @@ msgstr "Tuned no se esta ejecutando"
 msgid "Tuned is off"
 msgstr "Tuned esta apagado"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Tipo"
@@ -8533,7 +8523,7 @@ msgstr "Incapaz de obtener detalles de la alerta."
 msgid "Unable to get alert: $0"
 msgstr "Incapaz de obtener alerta: $0"
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Imposible conectar al servidor"
 
@@ -8580,23 +8570,23 @@ msgstr "Error inesperado"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr "Unidad"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -8620,7 +8610,7 @@ msgstr "Host Key desconocido"
 msgid "Unknown configuration"
 msgstr "Configuración desconocida"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr "Nombre de host desconocido "
 
@@ -8665,7 +8655,7 @@ msgstr "Interfaces No Manejadas"
 msgid "Unmask"
 msgstr "Desenmascarar"
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Desmontar"
 
@@ -8756,7 +8746,7 @@ msgstr "Actualizaciones Disponibles"
 msgid "Updates are disabled."
 msgstr "Las actualizaciones están deshabilitadas."
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr "Actualizando"
 
@@ -8807,13 +8797,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr "Usar los ajustes de /etc/kdump.conf"
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Usado"
 
@@ -8823,10 +8813,10 @@ msgstr "Utilizado por contenedores"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8845,7 +8835,7 @@ msgstr "Contraseña de usuario"
 msgid "User interface for Linux servers"
 msgstr "Interfaz de usuario para servidores Linux"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nombre de usuario"
@@ -8858,8 +8848,8 @@ msgstr "El nombre de usuario no puede estar vacío"
 msgid "User or Group"
 msgstr "Usuario o Grupo"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "Nombre de Usuario"
 
@@ -9019,9 +9009,9 @@ msgid "Verifying"
 msgstr "Verificando"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Versión"
 
@@ -9083,8 +9073,8 @@ msgstr "Grupos de Volumen"
 msgid "Volume ID"
 msgstr "ID de Volumen"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "Nombre de Volumen"
 
@@ -9092,9 +9082,8 @@ msgstr "Nombre de Volumen"
 msgid "Volume Type"
 msgstr "Tipo de Volumen"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volúmenes"
@@ -9401,7 +9390,7 @@ msgstr "hostdev"
 msgid "iSCSI"
 msgstr "iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr "Objetivos iSCSI"
 
@@ -9476,10 +9465,10 @@ msgstr "no operativo"
 msgid "non responsive"
 msgstr "sin respuesta"
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9657,7 +9646,7 @@ msgstr "udp"
 msgid "unassigned"
 msgstr "no asignado"
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "sin definir"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -3,14 +3,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-07-11 09:54+0000\n"
 "Last-Translator: Mikel Olasagasti Uranga <mikel@olasagasti.info>\n"
 "Language-Team: Basque\n"
 "Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -75,7 +75,7 @@ msgid_plural "$0 bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -190,7 +190,7 @@ msgid_plural "$0 updates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -216,7 +216,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] ""
@@ -567,7 +566,7 @@ msgid "Access"
 msgstr ""
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr ""
 
@@ -631,7 +630,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -652,11 +651,11 @@ msgstr ""
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Gehitu"
 
@@ -816,7 +815,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr ""
 
@@ -933,8 +932,8 @@ msgstr ""
 msgid "Always"
 msgstr "Beti"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -943,8 +942,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "Aplikazioak"
 
@@ -952,11 +951,11 @@ msgstr "Aplikazioak"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Aplikatu"
 
@@ -1005,8 +1004,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr ""
 
@@ -1026,9 +1025,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr ""
 
@@ -1044,13 +1043,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Egilea"
 
@@ -1107,7 +1106,7 @@ msgstr "Eskuragarri"
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1135,7 +1134,7 @@ msgstr "BIOS bertsioa"
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1258,10 +1257,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPUa"
 
@@ -1326,7 +1325,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1338,27 +1336,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr ""
 
@@ -1379,7 +1377,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "Edukiera"
@@ -1397,11 +1395,11 @@ msgid "Ceph Monitors"
 msgstr ""
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "Aldatu"
 
@@ -1429,7 +1427,7 @@ msgstr ""
 msgid "Change User"
 msgstr "Aldatu erabiltzailea"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1540,16 +1538,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr ""
 
@@ -1557,7 +1556,7 @@ msgstr ""
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr ""
@@ -1635,10 +1634,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1677,7 +1676,7 @@ msgstr[1] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Komandoa"
 
@@ -1722,8 +1721,8 @@ msgstr ""
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1933,10 +1932,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr ""
 
@@ -2049,10 +2049,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr ""
 
@@ -2154,12 +2154,13 @@ msgstr ""
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "Sortua"
 
@@ -2279,7 +2280,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2299,7 +2300,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2324,12 +2325,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2405,7 +2405,7 @@ msgstr ""
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 
@@ -2452,14 +2452,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "Deskribapena"
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "Deskribapena:"
 
@@ -2472,10 +2472,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "Xehetasunak"
 
@@ -2484,7 +2484,7 @@ msgstr "Xehetasunak"
 msgid "Device"
 msgstr "Gailua"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr "Gailu fitxategia"
 
@@ -2565,9 +2565,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr ""
 
@@ -2615,8 +2615,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2729,7 +2729,7 @@ msgstr ""
 msgid "Duplicate port"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2888,7 +2888,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2914,9 +2914,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr ""
 
@@ -3004,7 +3004,7 @@ msgstr ""
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
@@ -3069,7 +3069,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3077,6 +3076,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3213,7 +3213,7 @@ msgstr ""
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3276,9 +3276,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3339,9 +3339,9 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr ""
 
@@ -3381,8 +3381,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3422,7 +3422,7 @@ msgstr ""
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3511,11 +3511,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3589,7 +3588,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3605,9 +3604,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3655,7 +3654,7 @@ msgstr "Instalatua"
 msgid "Installed products"
 msgstr "Instalatutako produktuak"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "Instalatzen"
@@ -3668,8 +3667,8 @@ msgstr "$0 instalatzen"
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr ""
 
@@ -3693,11 +3692,11 @@ msgstr ""
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3745,7 +3744,7 @@ msgstr ""
 msgid "Invalid prefix or netmask $0"
 msgstr ""
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3753,7 +3752,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3871,11 +3870,12 @@ msgstr ""
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Etiketak"
@@ -3920,8 +3920,8 @@ msgstr "Azken eguneraketa"
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -3949,7 +3949,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4012,8 +4011,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -4089,17 +4088,17 @@ msgstr ""
 msgid "Logged In"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4294,9 +4293,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4328,8 +4328,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4344,7 +4344,7 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4424,8 +4424,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4433,17 +4433,17 @@ msgstr ""
 msgid "Mount Location"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4467,7 +4467,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4531,37 +4531,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr ""
 
@@ -4595,7 +4596,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4606,6 +4606,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
@@ -4619,8 +4620,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr ""
 
@@ -4686,8 +4687,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4695,7 +4696,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4705,7 +4706,7 @@ msgstr ""
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr ""
 
@@ -4820,9 +4821,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4850,7 +4851,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4858,7 +4859,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4866,7 +4867,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5014,9 +5015,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5027,7 +5028,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr ""
 
@@ -5069,8 +5070,8 @@ msgstr ""
 msgid "Not connected"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5086,7 +5087,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5114,8 +5115,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5147,8 +5148,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr ""
 
@@ -5164,14 +5165,14 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr ""
 
@@ -5354,11 +5355,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5397,10 +5399,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr ""
 
@@ -5464,7 +5466,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5496,8 +5498,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5714,9 +5716,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5732,7 +5733,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr ""
 
@@ -5814,7 +5815,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5828,7 +5829,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5840,6 +5840,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr ""
@@ -5868,10 +5869,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5903,7 +5904,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -5931,8 +5932,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -5996,7 +5997,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr ""
 
@@ -6032,7 +6033,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6044,6 +6044,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr ""
 
@@ -6108,7 +6109,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr ""
 
@@ -6164,8 +6165,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6193,8 +6194,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
@@ -6235,9 +6236,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
@@ -6289,7 +6290,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6357,10 +6358,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
@@ -6472,8 +6473,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr ""
 
@@ -6522,8 +6523,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6577,7 +6577,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr ""
 
@@ -6665,8 +6665,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6719,7 +6719,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6751,8 +6751,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6773,15 +6773,14 @@ msgstr ""
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6789,7 +6788,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6808,7 +6807,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -6857,7 +6856,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr ""
 
@@ -6993,7 +6992,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7014,34 +7013,34 @@ msgstr ""
 msgid "Since $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr ""
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr ""
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7135,7 +7134,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr ""
@@ -7176,10 +7175,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
@@ -7201,10 +7200,11 @@ msgid "Static"
 msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7227,7 +7227,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7460,7 +7460,7 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7482,7 +7482,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7613,8 +7613,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7649,11 +7649,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7665,9 +7665,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7676,14 +7675,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7784,11 +7782,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7874,8 +7872,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -7931,13 +7928,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -7947,17 +7944,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -7967,7 +7964,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -7987,7 +7984,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8056,9 +8053,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8217,11 +8214,11 @@ msgstr ""
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr ""
@@ -8284,7 +8281,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8330,23 +8327,23 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr ""
 
@@ -8370,7 +8367,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8415,7 +8412,7 @@ msgstr ""
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr ""
 
@@ -8505,7 +8502,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8554,13 +8551,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
@@ -8570,10 +8567,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8592,7 +8589,7 @@ msgstr ""
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr ""
@@ -8605,8 +8602,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr ""
 
@@ -8766,9 +8763,9 @@ msgid "Verifying"
 msgstr "Egiaztatzen"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Bertsioa"
 
@@ -8830,8 +8827,8 @@ msgstr ""
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr ""
 
@@ -8839,9 +8836,8 @@ msgstr ""
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9131,7 +9127,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr "iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9206,10 +9202,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9384,7 +9380,7 @@ msgstr "udp"
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-05-12 02:24+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish\n"
 "Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -82,7 +82,7 @@ msgid_plural "$0 bytes"
 msgstr[0] "$0 tavu"
 msgstr[1] "$0 tavua"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgid_plural "$0 updates"
 msgstr[0] "$0 päivitys"
 msgstr[1] "$0 päivitystä"
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 käytetty kohteesta $1 ($2 tallennettu)"
 
@@ -225,7 +225,6 @@ msgstr[0] "$0 vuosi"
 msgstr[1] "$0 vuotta"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% Vapaana"
@@ -532,8 +531,8 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Yhteensopivaa versiota Cockpitistä ei ole asennettu kohteessa "
-"{{#strong}}{{host}}{{/strong}}."
+"Yhteensopivaa versiota Cockpitistä ei ole asennettu kohteessa {{#strong}}"
+"{{host}}{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:64
 msgid "A disk is needed."
@@ -578,7 +577,7 @@ msgid "Access"
 msgstr "Pääsy"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr ""
 
@@ -642,7 +641,7 @@ msgid "Active Pages"
 msgstr "Aktiiviset sivut"
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr "Aktiivinen lähtien"
 
@@ -663,11 +662,11 @@ msgstr "Mukautuva lähtevän kuorman tasapainottaja (balance-tlb)"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Lisää"
 
@@ -829,7 +828,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Osoite"
 
@@ -948,8 +947,8 @@ msgstr "Sallitut palvelut"
 msgid "Always"
 msgstr "Aina"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Annotaatiot"
@@ -959,8 +958,8 @@ msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 "Anonyymi: Salli kaikkien tunnistautumattomien käyttäjien ottaa levykuvia"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "Sovellukset"
 
@@ -968,11 +967,11 @@ msgstr "Sovellukset"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Toteuta"
 
@@ -1021,8 +1020,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr "Vähintään $0 levyä tarvitaan."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Vähintään yksi levy tarvitaan."
 
@@ -1042,9 +1041,9 @@ msgstr "Audit-loki"
 msgid "Authenticating"
 msgstr "Tunnistaudutaan"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Tunnistautuminen"
 
@@ -1060,13 +1059,13 @@ msgstr "Tunnistautuminen epäonnistui: palvelin sulki yhteyden."
 msgid "Authentication failed"
 msgstr "Tunnistautuminen epäonnistui"
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "Tunnistautuminen vaaditaan"
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Tekijä"
 
@@ -1123,7 +1122,7 @@ msgstr "Saatavilla"
 msgid "Available Updates"
 msgstr "Saatavilla olevat päivitykset"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr "Käytettävät kohteet $0"
 
@@ -1151,7 +1150,7 @@ msgstr "BIOS-versio"
 msgid "Back to Accounts"
 msgstr "Takaisin käyttäjätileihin"
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1274,10 +1273,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr "CHANGE NETWORK STATE -toiminto epäonnistui"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "Prosessori"
 
@@ -1342,7 +1341,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1354,27 +1352,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Peru"
 
@@ -1395,7 +1393,7 @@ msgid "Cannot schedule event in the past"
 msgstr "Tapahtumaa ei voi aikatauluttaa menneisyyteen"
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "Koko"
@@ -1413,11 +1411,11 @@ msgid "Ceph Monitors"
 msgstr "Ceph-monitorit"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "Vaihda"
 
@@ -1445,7 +1443,7 @@ msgstr "Vaihda järjestelmän aika"
 msgid "Change User"
 msgstr "Vaihda käyttäjä"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr "Vaihda iSCSI-asiakaslaitteen nimi"
 
@@ -1558,16 +1556,17 @@ msgstr "Painamalla \"Launch Remote Viewer\" lataat .vv-tiedoston ja avaat $0."
 msgid "Client Certificate"
 msgstr "Asiakasvarmenne"
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Sulje"
 
@@ -1575,7 +1574,7 @@ msgstr "Sulje"
 msgid "Close Selected Pages"
 msgstr "Sulje valitut sivut"
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr "Klusteri"
@@ -1669,10 +1668,10 @@ msgstr "Cockpit ei saanut yhteyttä kohteeseen {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit ei pystynyt kirjautumaan kohteeseen {{#strong}}{{host}}{{/strong}}. "
 "{{#can_sync}}Haluat ehkä kokeilla {{#sync_link}}käyttäjien synkronointia{{/"
@@ -1692,8 +1691,8 @@ msgid ""
 msgstr ""
 "Cockpit ei pystynyt kirjautumaan kohteeseen {{#strong}}{{host}}{{/strong}}. "
 "Käyttääksesi tätä konetta Cockpitin kanssa sinun tulee ottaa käyttöön jokin "
-"seuraavista todentamismetodeista sshd-konfiguraatiossa kohteessa "
-"{{#strong}}{{host}}{{/strong}}:"
+"seuraavista todentamismetodeista sshd-konfiguraatiossa kohteessa {{#strong}}"
+"{{host}}{{/strong}}:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1724,7 +1723,7 @@ msgstr[1] "Yhdistetty $0 CPU-ydinten käyttö"
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Komento"
 
@@ -1763,15 +1762,14 @@ msgstr "Yhteensopiva kaikkien järjestelmien ja laitteiden kanssa (MBR)"
 
 #: pkg/storaged/content-views.jsx:506
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr ""
-"Yhteensopiva modernien järjestelmien ja kovalevyjen kanssa > 2TB (GPT)"
+msgstr "Yhteensopiva modernien järjestelmien ja kovalevyjen kanssa > 2TB (GPT)"
 
 #: pkg/kdump/kdump-view.jsx:199
 msgid "Compress crash dumps to save space"
 msgstr "Tiivistä crash dump säästääksesi tilaa"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "Pakkaus"
 
@@ -1985,10 +1983,11 @@ msgid "Container:"
 msgstr "Kontti:"
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Kontit"
 
@@ -2103,10 +2102,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Luo"
 
@@ -2208,12 +2207,13 @@ msgstr "Luo osio kohteessa $0"
 msgid "Create partition table"
 msgstr "Luo osiotaulu"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "Luotu"
 
@@ -2337,7 +2337,7 @@ msgstr "DNS Search Domainit $val"
 msgid "Dashboard"
 msgstr "Kojelauta"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr "Dataa käytetty"
 
@@ -2357,7 +2357,7 @@ msgstr "Deaktivoidaan $target"
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2382,12 +2382,11 @@ msgstr "Viive"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2467,7 +2466,7 @@ msgstr "RAID-laitteen poistaminen tuhoaa kaiken sillä olevan datan."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "VDO-laitteen poistaminen tuhoaa kaiken sillä olevan datan."
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "Kontin poistaminen tuhoaa kaiken sillä olevan datan."
 
@@ -2514,14 +2513,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "Kuvaus"
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "Kuvaus:"
 
@@ -2534,10 +2533,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "Yksityiskohdat"
 
@@ -2546,7 +2545,7 @@ msgstr "Yksityiskohdat"
 msgid "Device"
 msgstr "Laite"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr "Laitetiedosto"
 
@@ -2627,9 +2626,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Levyt"
 
@@ -2681,8 +2680,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 "Haluatko poistaa roolin '{{ fields.displayRole }}' jäseneltä {{ fields."
 "member.metadata.name }}?"
@@ -2797,7 +2796,7 @@ msgstr "Aliaksen duplikaatti"
 msgid "Duplicate port"
 msgstr "Portin duplikaatti"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr "Muokkaa"
 
@@ -2960,7 +2959,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2986,9 +2985,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Virhe"
 
@@ -3076,7 +3075,7 @@ msgstr "Epäonnistui"
 msgid "Failed to add machine: $0"
 msgstr "Ei voitu lisätä konetta: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "Ei voitu vaihtaa salasanaa"
 
@@ -3141,7 +3140,6 @@ msgstr "Tiedostojärjestelmän liittäminen"
 msgid "Filesystem Name"
 msgstr "Tiedostojärjestelmän nimi"
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3149,6 +3147,7 @@ msgstr "Tiedostojärjestelmän nimi"
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr "Tiedostojärjestelmän tyyppi"
 
@@ -3164,7 +3163,7 @@ msgstr "Tiedostojärjestelmät"
 msgid "Filter Services"
 msgstr "Suodata palveluja"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Sormenjälki"
 
@@ -3285,7 +3284,7 @@ msgstr "Yleiset"
 msgid "Generating report"
 msgstr "Luodaan raporttia"
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr "Hae uusi levykuva"
 
@@ -3348,9 +3347,9 @@ msgstr "Ryhmä tai projekti"
 msgid "Groups"
 msgstr "Ryhmät"
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr "Kasvata"
 
@@ -3411,9 +3410,9 @@ msgstr "Hello time $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Kone"
 
@@ -3453,8 +3452,8 @@ msgstr "I/O Odottaa"
 msgid "INSTALL VM action failed"
 msgstr "INSTALL VM -toiminto epäonnistui"
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr "IP"
 
@@ -3494,7 +3493,7 @@ msgstr "IPv6-asetukset"
 msgid "ISCSI"
 msgstr "ISCSI"
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr "Id"
@@ -3583,11 +3582,10 @@ msgstr ""
 msgid "Image:"
 msgstr "Levykuva:"
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr "Levykuvat"
 
@@ -3665,7 +3663,7 @@ msgstr "Epäaktiivinen taltio"
 msgid "Incorrect Host Key"
 msgstr "Väärä Host Avain"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3681,9 +3679,9 @@ msgstr "Tieto Dockering tallentovarannosta ei ole saatavilla."
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr "Asenna"
 
@@ -3732,7 +3730,7 @@ msgstr "Asennettu"
 msgid "Installed products"
 msgstr "Asennetut tuotteet"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "Asennetaan"
@@ -3745,8 +3743,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr "Instansoi"
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr "Liitäntä"
 
@@ -3770,11 +3768,11 @@ msgstr "Virheellinen osoite $0"
 msgid "Invalid credentials"
 msgstr "Virheelliset tunnistautumistiedot"
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "Virheellinen päivämuoto"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "Virheellinen päivämuoto ja aikamuoto"
 
@@ -3822,7 +3820,7 @@ msgstr "Virheellinen etuliite $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "Virheellinen etuliite tai verkkopeite $0"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "Virheellinen aikamuoto"
 
@@ -3830,7 +3828,7 @@ msgstr "Virheellinen aikamuoto"
 msgid "Invalid time zone"
 msgstr "Virheellinen aikavyöhyke"
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr "Virheellinen käyttäjätunnus tai salasana"
@@ -3950,11 +3948,12 @@ msgstr "Kubernetes-klusteri"
 msgid "LACP Key"
 msgstr "LACP-avain"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3999,8 +3998,8 @@ msgstr "Viimeksi päivitetty"
 msgid "Last checked: $0 ago"
 msgstr "Viimeksi tarkistettu: $0 sitten"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr "Viimeisin versio"
 
@@ -4031,7 +4030,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4094,8 +4092,8 @@ msgstr "Ladataan saatavilla olevat päivitykset, odota hetki..."
 msgid "Loading data ..."
 msgstr "Ladataan tietoja..."
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "Ladataan..."
 
@@ -4171,17 +4169,17 @@ msgstr "Kirjaa viestit"
 msgid "Logged In"
 msgstr "Kirjautunut sisään"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr "Looginen"
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr "Looginen koko"
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr "Looginen yksikön numero"
 
@@ -4376,9 +4374,10 @@ msgstr "Jäsenyys"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4410,8 +4409,8 @@ msgstr "Muistin käyttö:"
 msgid "Memory:"
 msgstr "Muisti:"
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "Viesti"
 
@@ -4426,7 +4425,7 @@ msgstr "Viesti sisäänkirjautuneille käyttäjille"
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4506,8 +4505,8 @@ msgstr "Lisää tietoja"
 msgid "More details"
 msgstr "Lisätietoja"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4515,17 +4514,17 @@ msgstr ""
 msgid "Mount Location"
 msgstr "Liitossijainti"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "Liitosvalinnat"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Liitospiste"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr "Liitä käynnistyksen yhteydessä"
 
@@ -4549,7 +4548,7 @@ msgstr "Liitospiste ei voi olla tyhjä."
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4613,37 +4612,38 @@ msgstr "NTP-palvelin"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Nimi"
 
@@ -4677,7 +4677,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4688,6 +4687,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "Nimiavaruus"
@@ -4701,8 +4701,8 @@ msgid "Need at least one NTP server"
 msgstr "Tarvitaan vähintään yksi NTP-palvelin"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Verkko"
 
@@ -4768,8 +4768,8 @@ msgstr "Uusi projekti"
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4777,7 +4777,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "Uutta salasanaa ei hyväksytty"
 
@@ -4787,7 +4787,7 @@ msgstr "Uutta salasanaa ei hyväksytty"
 msgid "New project"
 msgstr "Uusi projekti"
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Seuraava"
 
@@ -4902,9 +4902,9 @@ msgstr "Ei nykyistä suodatusta vastaavia kontteja"
 msgid "No description provided."
 msgstr "Kuvausta ei annettu."
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr "Levyjä ei ole saatavilla."
 
@@ -4932,7 +4932,7 @@ msgstr "Ryhmiä ei ole läsnä."
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4940,7 +4940,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4948,7 +4948,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5096,9 +5096,9 @@ msgstr "Node"
 msgid "Node:"
 msgstr "Node:"
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr "Noodit"
 
@@ -5109,7 +5109,7 @@ msgstr "Noodit ovat konttejasi suorittavia koneita."
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr ""
 
@@ -5151,8 +5151,8 @@ msgstr ""
 msgid "Not connected"
 msgstr "Ei yhdistetty"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5168,7 +5168,7 @@ msgstr "Ei liitetty"
 msgid "Not permitted to perform this action."
 msgstr "Ei oikeutta suorittaa tätä toimintoa."
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "Ei käynnissä"
 
@@ -5196,8 +5196,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr "OK"
 
@@ -5229,8 +5229,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Pois"
 
@@ -5246,14 +5246,14 @@ msgstr "Vanha salasana"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "Vanhaa salasanaa ei hyväksytty"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Päällä"
 
@@ -5436,11 +5436,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Tunnuslauseet eivät täsmää"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5479,10 +5480,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Liitä julkisen SSH-avaintiedostosi sisältö tähän"
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "Polku"
 
@@ -5546,7 +5547,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr "Fyysinen"
 
@@ -5578,8 +5579,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5798,9 +5799,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr "Portti"
 
@@ -5816,7 +5816,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Portit"
 
@@ -5898,7 +5898,7 @@ msgstr ""
 msgid "Problems"
 msgstr "Ongelmat"
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5912,7 +5912,6 @@ msgstr "Tuotteen nimi"
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5924,6 +5923,7 @@ msgstr "Tuotteen nimi"
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Projekti"
@@ -5952,10 +5952,10 @@ msgstr "Projektin verkkosivusto"
 msgid "Project:"
 msgstr "Projekti:"
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr "Projektit"
 
@@ -5987,7 +5987,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Julkinen avain"
 
@@ -6015,8 +6015,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -6080,7 +6080,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "RAID-laite"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "RAID-laite $0"
 
@@ -6116,7 +6116,6 @@ msgstr "Satunnainen"
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6128,6 +6127,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr "Vain luku"
 
@@ -6192,7 +6192,7 @@ msgstr ""
 msgid "Reason"
 msgstr "Syy"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "Käynnistä uudelleen"
 
@@ -6248,8 +6248,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr "Rekisteröi"
 
@@ -6277,8 +6277,8 @@ msgstr "Rekisteröidän oVirt Cockpitiin"
 msgid "Register…"
 msgstr "Rekisteröi…"
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "Lataa uudelleen"
 
@@ -6319,9 +6319,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "Poista"
 
@@ -6373,7 +6373,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr "Poistetaan"
 
@@ -6441,10 +6441,10 @@ msgstr "Toista joka vuosi"
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
@@ -6556,8 +6556,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Käynnistä uudelleen"
 
@@ -6606,8 +6606,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6661,7 +6660,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr ""
 
@@ -6749,8 +6748,8 @@ msgstr "SUSPEND-toiminto epäonnistui"
 msgid "Saturday"
 msgstr "Lauantai"
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "Tallenna"
 
@@ -6803,7 +6802,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6835,8 +6834,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6857,15 +6856,14 @@ msgstr "Lähetetään"
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "Palvelin"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr "Palvelimen osoite"
 
@@ -6873,7 +6871,7 @@ msgstr "Palvelimen osoite"
 msgid "Server Administrator"
 msgstr "Palvelimen ylläpitäjä"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr "Palvelimen osoite ei voi olla tyhjä."
 
@@ -6892,7 +6890,7 @@ msgstr "Palvelimet"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "Palvelu"
 
@@ -6941,7 +6939,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr "Istunto"
 
@@ -7077,7 +7075,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr "Näytä sormenjäljet"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7098,34 +7096,34 @@ msgstr ""
 msgid "Since $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Koko"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "Koko ei  voi olla negatiivinen"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "Koko ei voi olla nolla"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr "Koko on liian suuri"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "Koon tulee olla numero"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr "Koon tulee olla vähintään $0"
 
@@ -7219,7 +7217,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Käynnistä"
@@ -7260,10 +7258,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "Tila"
 
@@ -7285,10 +7283,11 @@ msgid "Static"
 msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7311,7 +7310,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7544,7 +7543,7 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7566,7 +7565,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7699,8 +7698,8 @@ msgstr "Osoite sisltää virheellisiä merkkejä"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7735,11 +7734,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7751,9 +7750,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7762,14 +7760,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7870,11 +7867,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr "Reittiä '{{ target }}' ei ole olemassa."
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7963,8 +7960,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -8023,13 +8019,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr "Tätä laitetta käytetään parhaillaan RAID-laitteille."
 
@@ -8039,17 +8035,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr "Tätä laitetta käytetään parhaillaan VDO-laitteille."
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr "Tätä laitetta käytetään parhaillaan taltioryhmille."
 
@@ -8059,7 +8055,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8079,7 +8075,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr "Tätä kuvaa ei ole olemassa."
 
@@ -8148,9 +8144,9 @@ msgstr "Tämä virtuaalikone ei ole oVirtin hallinnassa"
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8313,11 +8309,11 @@ msgstr "Tuned ei ole käynnissä"
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Tyyppi"
@@ -8380,7 +8376,7 @@ msgstr "Virheen lisätietojen hakeminen epäonnistui."
 msgid "Unable to get alert: $0"
 msgstr "Ei voitu hakea virhettä: $0"
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Palvelimeen ei saada yhteyttä"
 
@@ -8426,23 +8422,23 @@ msgstr "Odottamaton virhe"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr "Yksikkö"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Tuntematon"
 
@@ -8466,7 +8462,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr "Tuntematon konfiguraatio"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8511,7 +8507,7 @@ msgstr "Hallitsemattomat liitännät"
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Irroita"
 
@@ -8603,7 +8599,7 @@ msgstr "Päivityksiä saatavilla"
 msgid "Updates are disabled."
 msgstr "Päivitykset on poistettu käytöstä."
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr "Päivitetään"
 
@@ -8652,13 +8648,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr "Käytä asetusta sijainnissa /etc/kdump.conf"
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Käytetty"
 
@@ -8668,10 +8664,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8690,7 +8686,7 @@ msgstr "Salasana"
 msgid "User interface for Linux servers"
 msgstr "Käyttöliittymä Linux-palvelimille"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Käyttäjätunnus"
@@ -8703,8 +8699,8 @@ msgstr "Käyttäjätunnus ei voi olla tyhjä"
 msgid "User or Group"
 msgstr "Käyttäjä tai ryhmä"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "Käyttäjätunnus"
 
@@ -8864,9 +8860,9 @@ msgid "Verifying"
 msgstr "Vahvistetaan"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Versio"
 
@@ -8928,8 +8924,8 @@ msgstr "Taltioryhmät"
 msgid "Volume ID"
 msgstr "Taltio-ID"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "Taltion nimi"
 
@@ -8937,9 +8933,8 @@ msgstr "Taltion nimi"
 msgid "Volume Type"
 msgstr "Taltion tyyppi"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Taltiot"
@@ -9236,7 +9231,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr "iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr "iSCSI-kohteet"
 
@@ -9311,10 +9306,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9489,7 +9484,7 @@ msgstr "udp"
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "määrittämätön"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -9,14 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2017-08-30 02:07+0000\n"
 "Last-Translator: Jean-Baptiste Holcroft <jean-baptiste@holcroft.fr>\n"
 "Language-Team: French\n"
 "Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
 
@@ -81,7 +81,7 @@ msgid_plural "$0 bytes"
 msgstr[0] "$0 octet"
 msgstr[1] "$0 octets"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -196,7 +196,7 @@ msgid_plural "$0 updates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -222,7 +222,6 @@ msgstr[0] "$0 an"
 msgstr[1] "$0 ans"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% disponible"
@@ -530,8 +529,8 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Une version compatible de Cockpit n''est pas installée sur "
-"{{#strong}}{{host}}{{/strong}}."
+"Une version compatible de Cockpit n''est pas installée sur {{#strong}}"
+"{{host}}{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:64
 msgid "A disk is needed."
@@ -577,7 +576,7 @@ msgid "Access"
 msgstr "Accès"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "Modes d'accès"
 
@@ -641,7 +640,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -662,11 +661,11 @@ msgstr "Adaptive transmit load balancing"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Ajouter"
 
@@ -826,7 +825,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adresse"
 
@@ -945,8 +944,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -955,8 +954,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr ""
 
@@ -964,11 +963,11 @@ msgstr ""
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Appliquer"
 
@@ -1017,8 +1016,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Au moins un disque est nécessaire."
 
@@ -1038,9 +1037,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr "Authentification"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Authentification"
 
@@ -1056,13 +1055,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Auteur"
 
@@ -1119,7 +1118,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1147,7 +1146,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1270,10 +1269,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1338,7 +1337,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1350,27 +1348,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -1391,7 +1389,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr ""
@@ -1409,11 +1407,11 @@ msgid "Ceph Monitors"
 msgstr ""
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1441,7 +1439,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1552,16 +1550,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Fermer"
 
@@ -1569,7 +1568,7 @@ msgstr "Fermer"
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr ""
@@ -1649,10 +1648,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1691,7 +1690,7 @@ msgstr[1] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Commande"
 
@@ -1731,15 +1730,14 @@ msgstr "Compatible avec tous les systèmes et périphériques (MBR)"
 #: pkg/storaged/content-views.jsx:506
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
 msgstr ""
-"Compatible avec les systèmes modernes et disques durs de taille > 2 Tio "
-"(GPT)"
+"Compatible avec les systèmes modernes et disques durs de taille > 2 Tio (GPT)"
 
 #: pkg/kdump/kdump-view.jsx:199
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1950,10 +1948,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Conteneurs"
 
@@ -2066,10 +2065,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Créer"
 
@@ -2171,12 +2170,13 @@ msgstr "Créer une partition sur $0"
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr "Tableau de bord"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2316,7 +2316,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2341,12 +2341,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2418,13 +2417,12 @@ msgstr ""
 msgid "Deleting a RAID device will erase all data on it."
 msgstr ""
 "Supprimer un périphérique RAID en effacera toutes les données qu'il contient."
-""
 
 #: pkg/storaged/vdo-details.jsx:193
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "Supprimer un conteneur en supprimera toutes les données"
 
@@ -2442,7 +2440,6 @@ msgstr ""
 msgid "Deleting a volume group will erase all data on it."
 msgstr ""
 "Supprimer un groupe de volumes en effacera toutes les données qu'il contient."
-""
 
 #: pkg/storaged/jobs-panel.jsx:72
 msgid "Deleting volume group $target"
@@ -2475,14 +2472,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2495,10 +2492,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2507,7 +2504,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2588,9 +2585,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Disques"
 
@@ -2638,8 +2635,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2753,7 +2750,7 @@ msgstr "Alias dupliqué"
 msgid "Duplicate port"
 msgstr "Port dupliqué"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2912,7 +2909,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2938,9 +2935,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Erreur"
 
@@ -3028,7 +3025,7 @@ msgstr "Échec"
 msgid "Failed to add machine: $0"
 msgstr "Échec lors de l'ajout de la machine : $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "Échec du changement de mot de passe"
 
@@ -3093,7 +3090,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3101,6 +3097,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3116,7 +3113,7 @@ msgstr "Systèmes de fichiers"
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3240,7 +3237,7 @@ msgstr "Général"
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3303,9 +3300,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3366,9 +3363,9 @@ msgstr "Hello time $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Hôte"
 
@@ -3408,8 +3405,8 @@ msgstr "Attente sur E/S"
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3449,7 +3446,7 @@ msgstr "Réglages IPv6"
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3539,11 +3536,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3618,7 +3614,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3634,9 +3630,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3684,7 +3680,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3697,8 +3693,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr ""
 
@@ -3723,11 +3719,11 @@ msgstr "Port invalide"
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "Format de date invalide"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "Formats de date et d'heure invalides"
 
@@ -3778,7 +3774,7 @@ msgstr "Port invalide"
 msgid "Invalid prefix or netmask $0"
 msgstr "Port invalide"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "Format d'heure invalide"
 
@@ -3786,7 +3782,7 @@ msgstr "Format d'heure invalide"
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3905,11 +3901,12 @@ msgstr "Grappe Kubernetes"
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3954,8 +3951,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -3984,7 +3981,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4047,8 +4043,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "Chargement..."
 
@@ -4125,17 +4121,17 @@ msgstr ""
 msgid "Logged In"
 msgstr "Connecté"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4330,9 +4326,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4364,8 +4361,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4380,7 +4377,7 @@ msgstr "Message aux utilisateurs connectés"
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4460,8 +4457,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "Monter"
 
@@ -4469,17 +4466,17 @@ msgstr "Monter"
 msgid "Mount Location"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "Options de montage"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Point de montage"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4503,7 +4500,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4567,37 +4564,38 @@ msgstr "Serveur NTP"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Nom"
 
@@ -4631,7 +4629,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4642,6 +4639,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "Espace de nommage"
@@ -4655,8 +4653,8 @@ msgid "Need at least one NTP server"
 msgstr "Au moins un serveur NTP est nécessaire"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Réseau"
 
@@ -4722,8 +4720,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4731,7 +4729,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "Refus du nouveau mot de passe"
 
@@ -4741,7 +4739,7 @@ msgstr "Refus du nouveau mot de passe"
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Suivant"
 
@@ -4857,9 +4855,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4887,7 +4885,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4895,7 +4893,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4903,7 +4901,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5053,9 +5051,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5066,7 +5064,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Aucun(e)"
 
@@ -5108,8 +5106,8 @@ msgstr "Indisponible"
 msgid "Not connected"
 msgstr "Non connecté"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5125,7 +5123,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5153,8 +5151,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5186,8 +5184,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Éteint"
 
@@ -5203,14 +5201,14 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "Refus de l'ancien mot de passe "
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Allumé"
 
@@ -5393,11 +5391,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Les phrases de passe ne correspondent pas."
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5436,10 +5435,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr ""
 
@@ -5503,7 +5502,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5535,8 +5534,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5753,9 +5752,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5771,7 +5769,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Ports"
 
@@ -5854,7 +5852,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5868,7 +5866,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5880,6 +5877,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Projet"
@@ -5908,10 +5906,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5943,7 +5941,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -5971,8 +5969,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -6036,7 +6034,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "Périphérique RAID"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "Périphérique RAID $0"
 
@@ -6072,7 +6070,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6084,6 +6081,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr ""
 
@@ -6149,7 +6147,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "Redémarrer"
 
@@ -6205,8 +6203,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6234,8 +6232,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "Recharger"
 
@@ -6276,9 +6274,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
@@ -6330,7 +6328,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6398,10 +6396,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "Répliques"
 
@@ -6513,8 +6511,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Redémarrer"
 
@@ -6564,8 +6562,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6619,7 +6616,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "En fonctionnement"
 
@@ -6707,8 +6704,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6761,7 +6758,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6793,8 +6790,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6815,15 +6812,14 @@ msgstr "Envoi"
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6831,7 +6827,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr "Administrateur de serveurs"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6850,7 +6846,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -6901,7 +6897,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 #, fuzzy
 msgid "Session"
 msgstr "Version"
@@ -7038,7 +7034,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7059,34 +7055,34 @@ msgstr ""
 msgid "Since $0"
 msgstr "Depuis $0"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Taille"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr ""
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7181,7 +7177,7 @@ msgid "Stable"
 msgstr "Activer"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Démarrer"
@@ -7222,10 +7218,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
@@ -7247,10 +7243,11 @@ msgid "Static"
 msgstr "Statique"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7273,7 +7270,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7507,7 +7504,7 @@ msgstr "Balise"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7529,7 +7526,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7661,8 +7658,8 @@ msgstr "L'adresse contient des caractères invalides"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7697,11 +7694,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7713,9 +7710,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7724,14 +7720,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7832,11 +7827,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7925,8 +7920,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -7982,13 +7976,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -7998,17 +7992,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -8018,7 +8012,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8038,7 +8032,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8109,9 +8103,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8270,11 +8264,11 @@ msgstr "Tuned n'est pas en cours d'exécution"
 msgid "Tuned is off"
 msgstr "Tuned est désactivé"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Type"
@@ -8337,7 +8331,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8383,23 +8377,23 @@ msgstr "Erreur inattendue"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -8423,7 +8417,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr "Configuration inconnue"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8468,7 +8462,7 @@ msgstr ""
 msgid "Unmask"
 msgstr "Démasquer"
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Démonter"
 
@@ -8558,7 +8552,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8607,13 +8601,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Utilisé(e)"
 
@@ -8624,10 +8618,10 @@ msgstr "Conteneurs"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8646,7 +8640,7 @@ msgstr "Mot de passe utilisateur"
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr ""
@@ -8659,8 +8653,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr ""
 
@@ -8820,9 +8814,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Version"
 
@@ -8884,8 +8878,8 @@ msgstr "Groupes de volumes"
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr ""
 
@@ -8893,9 +8887,8 @@ msgstr ""
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9189,7 +9182,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9264,10 +9257,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9443,7 +9436,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -5,17 +5,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2017-02-24 04:55+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Croatian\n"
 "Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
 #: pkg/docker/storage.jsx:244
 msgid " (shared with the OS)"
@@ -81,7 +81,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -232,7 +232,6 @@ msgstr[1] ""
 msgstr[2] ""
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] ""
@@ -587,7 +586,7 @@ msgid "Access"
 msgstr ""
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr ""
 
@@ -651,7 +650,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -672,11 +671,11 @@ msgstr ""
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Dodaj"
 
@@ -838,7 +837,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adresa"
 
@@ -957,8 +956,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -967,8 +966,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr ""
 
@@ -976,11 +975,11 @@ msgstr ""
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr ""
 
@@ -1029,8 +1028,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr "Najmanje $0 diskova  je potrebno."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr ""
 
@@ -1050,9 +1049,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr "Autoriziranje"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Autentifikacija"
 
@@ -1068,13 +1067,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Autor"
 
@@ -1131,7 +1130,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1159,7 +1158,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1282,10 +1281,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1351,7 +1350,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1363,27 +1361,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Odustani"
 
@@ -1404,7 +1402,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr ""
@@ -1423,11 +1421,11 @@ msgid "Ceph Monitors"
 msgstr "Repozitorij"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1455,7 +1453,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1567,16 +1565,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Zatvori"
 
@@ -1584,7 +1583,7 @@ msgstr "Zatvori"
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 #, fuzzy
 msgid "Cluster"
@@ -1663,10 +1662,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1706,7 +1705,7 @@ msgstr[2] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Naredba"
 
@@ -1751,8 +1750,8 @@ msgstr ""
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1967,10 +1966,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Spremnici"
 
@@ -2083,10 +2083,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Izradi"
 
@@ -2188,12 +2188,13 @@ msgstr ""
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2313,7 +2314,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2333,7 +2334,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2358,12 +2359,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2441,7 +2441,7 @@ msgstr ""
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "Brisanjem svih spremnika ćete izbrisati sve podatke u njima."
 
@@ -2488,14 +2488,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2508,10 +2508,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2520,7 +2520,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2602,9 +2602,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr ""
 
@@ -2652,8 +2652,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2768,7 +2768,7 @@ msgstr ""
 msgid "Duplicate port"
 msgstr "Dupliciran port"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2927,7 +2927,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2953,9 +2953,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr ""
 
@@ -3043,7 +3043,7 @@ msgstr "Neuspjelo"
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
@@ -3111,7 +3111,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3119,6 +3118,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3134,7 +3134,7 @@ msgstr ""
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3255,7 +3255,7 @@ msgstr "Općenito"
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3320,9 +3320,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3383,9 +3383,9 @@ msgstr "Hello vrijeme $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr ""
 
@@ -3425,8 +3425,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3468,7 +3468,7 @@ msgstr "IPv6 Postavke"
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3559,11 +3559,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3638,7 +3637,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3654,9 +3653,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3704,7 +3703,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3717,8 +3716,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 #, fuzzy
 msgid "Interface"
 msgstr "Sučelja"
@@ -3744,11 +3743,11 @@ msgstr "Nepravilan port"
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3799,7 +3798,7 @@ msgstr "Nepravilan port"
 msgid "Invalid prefix or netmask $0"
 msgstr "Nepravilan port"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3807,7 +3806,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3927,11 +3926,12 @@ msgstr ""
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3976,8 +3976,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -4006,7 +4006,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4069,8 +4068,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -4147,17 +4146,17 @@ msgstr ""
 msgid "Logged In"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4355,9 +4354,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4389,8 +4389,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4405,7 +4405,7 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4486,8 +4486,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4496,17 +4496,17 @@ msgstr ""
 msgid "Mount Location"
 msgstr "Točka pristupa"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Točka pristupa"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4595,37 +4595,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Naziv"
 
@@ -4659,7 +4660,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4670,6 +4670,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
@@ -4683,8 +4684,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Mreža"
 
@@ -4750,8 +4751,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4759,7 +4760,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4769,7 +4770,7 @@ msgstr ""
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Sljedeće"
 
@@ -4886,9 +4887,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4917,7 +4918,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr "Nije pronađeno"
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4925,7 +4926,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4933,7 +4934,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5081,9 +5082,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5094,7 +5095,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr ""
 
@@ -5137,8 +5138,8 @@ msgstr "Nije dostupno"
 msgid "Not connected"
 msgstr "Nepovezan"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5154,7 +5155,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5182,8 +5183,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5216,8 +5217,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Isključi"
 
@@ -5233,14 +5234,14 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Uključi"
 
@@ -5426,11 +5427,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Lozinke(fraze) se ne podudaraju"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5469,10 +5471,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 #, fuzzy
 msgid "Path"
 msgstr "Trošak putanje"
@@ -5537,7 +5539,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5569,8 +5571,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5791,9 +5793,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5809,7 +5810,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Portovi"
 
@@ -5891,7 +5892,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5905,7 +5906,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5917,6 +5917,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Projekt"
@@ -5945,10 +5946,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5980,7 +5981,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -6008,8 +6009,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -6073,7 +6074,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "RAID uređaj $0"
 
@@ -6111,7 +6112,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr "$0 Blok uređaj"
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6123,6 +6123,7 @@ msgstr "$0 Blok uređaj"
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 #, fuzzy
 msgid "Read Only"
 msgstr "Spreman"
@@ -6189,7 +6190,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr ""
 
@@ -6245,8 +6246,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6274,8 +6275,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
@@ -6316,9 +6317,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
@@ -6371,7 +6372,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6439,10 +6440,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "Replike"
 
@@ -6556,8 +6557,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr ""
 
@@ -6607,8 +6608,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6664,7 +6664,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "Pokrenuto"
 
@@ -6752,8 +6752,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6807,7 +6807,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6839,8 +6839,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6861,15 +6861,14 @@ msgstr "Slanje"
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6877,7 +6876,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6896,7 +6895,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -6946,7 +6945,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 #, fuzzy
 msgid "Session"
 msgstr "Inačica"
@@ -7086,7 +7085,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7107,35 +7106,35 @@ msgstr ""
 msgid "Since $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Veličina"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 #, fuzzy
 msgid "Size must be a number"
 msgstr "Veličina mora biti specificirana."
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7229,7 +7228,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr ""
@@ -7270,10 +7269,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
@@ -7295,10 +7294,11 @@ msgid "Static"
 msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7321,7 +7321,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7554,7 +7554,7 @@ msgstr "Oznaka"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7576,7 +7576,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7708,8 +7708,8 @@ msgstr "Adresa sadrži neispravne znakove"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7744,11 +7744,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7760,9 +7760,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7771,14 +7770,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7879,11 +7877,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7969,8 +7967,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -8026,13 +8023,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -8042,17 +8039,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -8062,7 +8059,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8082,7 +8079,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8151,9 +8148,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8312,11 +8309,11 @@ msgstr ""
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Tip"
@@ -8380,7 +8377,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8427,23 +8424,23 @@ msgstr "Neočekivana pogreška"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Nepoznato"
 
@@ -8467,7 +8464,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr "Nepoznata konfiguracija"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8513,7 +8510,7 @@ msgstr ""
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr ""
 
@@ -8603,7 +8600,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8653,13 +8650,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
@@ -8670,10 +8667,10 @@ msgstr "Spremnici"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8692,7 +8689,7 @@ msgstr "Korisnička Lozinka"
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr ""
@@ -8705,8 +8702,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 #, fuzzy
 msgid "Username"
 msgstr "Korisničko ime"
@@ -8867,9 +8864,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Inačica"
 
@@ -8931,8 +8928,8 @@ msgstr ""
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 #, fuzzy
 msgid "Volume Name"
 msgstr "Korisničko ime"
@@ -8941,9 +8938,8 @@ msgstr "Korisničko ime"
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9237,7 +9233,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9312,10 +9308,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9494,7 +9490,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,14 +4,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-05-25 06:59+0000\n"
 "Last-Translator: Zoltan Hoppar <zoltanh721@fedoraproject.org>\n"
 "Language-Team: Hungarian\n"
 "Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -76,7 +76,7 @@ msgid_plural "$0 bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgid_plural "$0 updates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -217,7 +217,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] ""
@@ -568,7 +567,7 @@ msgid "Access"
 msgstr ""
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr ""
 
@@ -632,7 +631,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -653,11 +652,11 @@ msgstr ""
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr ""
 
@@ -817,7 +816,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr ""
 
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -944,8 +943,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr ""
 
@@ -953,11 +952,11 @@ msgstr ""
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr ""
 
@@ -1006,8 +1005,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr ""
 
@@ -1027,9 +1026,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr ""
 
@@ -1045,13 +1044,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr ""
 
@@ -1108,7 +1107,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1136,7 +1135,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1259,10 +1258,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr ""
 
@@ -1327,7 +1326,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1339,27 +1337,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr ""
 
@@ -1380,7 +1378,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr ""
@@ -1398,11 +1396,11 @@ msgid "Ceph Monitors"
 msgstr ""
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1430,7 +1428,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1541,16 +1539,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr ""
 
@@ -1558,7 +1557,7 @@ msgstr ""
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr ""
@@ -1641,10 +1640,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1683,7 +1682,7 @@ msgstr[1] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr ""
 
@@ -1728,8 +1727,8 @@ msgstr ""
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1939,10 +1938,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr ""
 
@@ -2055,10 +2055,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr ""
 
@@ -2160,12 +2160,13 @@ msgstr ""
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2285,7 +2286,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2305,7 +2306,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2330,12 +2331,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2411,7 +2411,7 @@ msgstr ""
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 
@@ -2458,14 +2458,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2478,10 +2478,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2490,7 +2490,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2571,9 +2571,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr ""
 
@@ -2621,8 +2621,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2735,7 +2735,7 @@ msgstr ""
 msgid "Duplicate port"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2894,7 +2894,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2920,9 +2920,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr ""
 
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
@@ -3075,7 +3075,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3083,6 +3082,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3098,7 +3098,7 @@ msgstr ""
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3219,7 +3219,7 @@ msgstr ""
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3282,9 +3282,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3345,9 +3345,9 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr ""
 
@@ -3387,8 +3387,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3428,7 +3428,7 @@ msgstr ""
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3517,11 +3517,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3595,7 +3594,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3611,9 +3610,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3661,7 +3660,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3674,8 +3673,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr ""
 
@@ -3699,11 +3698,11 @@ msgstr ""
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3751,7 +3750,7 @@ msgstr ""
 msgid "Invalid prefix or netmask $0"
 msgstr ""
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3759,7 +3758,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3877,11 +3876,12 @@ msgstr ""
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3926,8 +3926,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -3955,7 +3955,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4018,8 +4017,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -4095,17 +4094,17 @@ msgstr ""
 msgid "Logged In"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4300,9 +4299,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4334,8 +4334,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4350,7 +4350,7 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4430,8 +4430,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4439,17 +4439,17 @@ msgstr ""
 msgid "Mount Location"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4473,7 +4473,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4537,37 +4537,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr ""
 
@@ -4601,7 +4602,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4612,6 +4612,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
@@ -4625,8 +4626,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr ""
 
@@ -4692,8 +4693,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4701,7 +4702,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4711,7 +4712,7 @@ msgstr ""
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr ""
 
@@ -4826,9 +4827,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4856,7 +4857,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4864,7 +4865,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4872,7 +4873,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5020,9 +5021,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5033,7 +5034,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Nincs"
 
@@ -5075,8 +5076,8 @@ msgstr ""
 msgid "Not connected"
 msgstr "Nincs kapcsolódva"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5092,7 +5093,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5120,8 +5121,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5153,8 +5154,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Kikapcsolva"
 
@@ -5170,14 +5171,14 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Bekapcsolva"
 
@@ -5360,11 +5361,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5403,10 +5405,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr ""
 
@@ -5470,7 +5472,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5502,8 +5504,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5720,9 +5722,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5738,7 +5739,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr ""
 
@@ -5820,7 +5821,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5834,7 +5835,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5846,6 +5846,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr ""
@@ -5874,10 +5875,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5909,7 +5910,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -5937,8 +5938,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -6002,7 +6003,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr ""
 
@@ -6038,7 +6039,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6050,6 +6050,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr ""
 
@@ -6114,7 +6115,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr ""
 
@@ -6170,8 +6171,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6199,8 +6200,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
@@ -6241,9 +6242,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
@@ -6295,7 +6296,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6363,10 +6364,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
@@ -6478,8 +6479,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr ""
 
@@ -6528,8 +6529,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6583,7 +6583,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr ""
 
@@ -6671,8 +6671,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6725,7 +6725,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6757,8 +6757,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6779,15 +6779,14 @@ msgstr ""
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6795,7 +6794,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6814,7 +6813,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -6863,7 +6862,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr ""
 
@@ -6999,7 +6998,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7020,34 +7019,34 @@ msgstr ""
 msgid "Since $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr ""
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr ""
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7141,7 +7140,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr ""
@@ -7182,10 +7181,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
@@ -7207,10 +7206,11 @@ msgid "Static"
 msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7233,7 +7233,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7466,7 +7466,7 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7488,7 +7488,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7619,8 +7619,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7655,11 +7655,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7671,9 +7671,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7682,14 +7681,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7790,11 +7788,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7880,8 +7878,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -7937,13 +7934,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -7953,17 +7950,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -7973,7 +7970,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -7993,7 +7990,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8064,9 +8061,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8225,11 +8222,11 @@ msgstr "Tuned alkalmazás nem működik"
 msgid "Tuned is off"
 msgstr "Tuned alkalmazás kikapcsolva"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr ""
@@ -8292,7 +8289,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8338,23 +8335,23 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr ""
 
@@ -8378,7 +8375,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8423,7 +8420,7 @@ msgstr ""
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr ""
 
@@ -8513,7 +8510,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8562,13 +8559,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
@@ -8578,10 +8575,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8600,7 +8597,7 @@ msgstr ""
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr ""
@@ -8613,8 +8610,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr ""
 
@@ -8774,9 +8771,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr ""
 
@@ -8838,8 +8835,8 @@ msgstr ""
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr ""
 
@@ -8847,9 +8844,8 @@ msgstr ""
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9139,7 +9135,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9214,10 +9210,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9392,7 +9388,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -5,14 +5,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-07-12 09:17+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Japanese\n"
 "Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
@@ -51,8 +51,9 @@ msgid ""
 "This may also effect other services as DNS resolution settings and the list "
 "of trusted CAs may change."
 msgstr ""
-"$0 ローカル認証情報を持つユーザーだけが、このマシンにログインできます。DNS 解決設定と、信頼される CA "
-"の一覧が変更する場合があるため、他のサービスにもこれが当てはまることもあります。"
+"$0 ローカル認証情報を持つユーザーだけが、このマシンにログインできます。DNS 解"
+"決設定と、信頼される CA の一覧が変更する場合があるため、他のサービスにもこれ"
+"が当てはまることもあります。"
 
 #: pkg/systemd/init.js:377 pkg/systemd/init.js:711
 msgid "$0 Template"
@@ -76,7 +77,7 @@ msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "$0 バイト"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 データ + $1 オーバーヘッドが $2 ($3) を使用しています"
 
@@ -133,7 +134,9 @@ msgstr[0] "$0 時間"
 msgid ""
 "$0 is available for most operating systems. To install it, search for it in "
 "GNOME Software or run the following:"
-msgstr "$0 は、多数のオペレーティングシステムで利用できます。インストールするには、GNOME ソフトウェアで検索するか、以下を実行します:"
+msgstr ""
+"$0 は、多数のオペレーティングシステムで利用できます。インストールするには、"
+"GNOME ソフトウェアで検索するか、以下を実行します:"
 
 #: pkg/storaged/content-views.jsx:274 pkg/storaged/content-views.jsx:487
 #: pkg/storaged/format-dialog.jsx:253 pkg/storaged/lvol-tabs.jsx:153
@@ -183,7 +186,7 @@ msgid "$0 update"
 msgid_plural "$0 updates"
 msgstr[0] "$0 更新"
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 が $1  ($2 が保存) を使用しています"
 
@@ -207,7 +210,6 @@ msgid_plural "$0 years"
 msgstr[0] "$0 年"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% 空き"
@@ -509,7 +511,9 @@ msgstr "9 日"
 msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
-msgstr "Cockpit の互換バージョンが {{#strong}}{{host}}{{/strong}} にインストールされていません。"
+msgstr ""
+"Cockpit の互換バージョンが {{#strong}}{{host}}{{/strong}} にインストールされ"
+"ていません。"
 
 #: pkg/storaged/vdos-panel.jsx:64
 msgid "A disk is needed."
@@ -554,7 +558,7 @@ msgid "Access"
 msgstr "アクセス"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "アクセスモード"
 
@@ -618,7 +622,7 @@ msgid "Active Pages"
 msgstr "アクティブページ"
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr "以降有効"
 
@@ -639,11 +643,11 @@ msgstr "適応送信のロードバランス"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "追加する"
 
@@ -764,7 +768,9 @@ msgstr "公開鍵の追加"
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
-msgstr "<b>$0</b> を追加すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"<b>$0</b> を追加すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/users/authorized-keys.js:109
 msgid "Adding key"
@@ -803,7 +809,7 @@ msgstr "追加のパッケージ:"
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "アドレス:"
 
@@ -890,7 +896,9 @@ msgstr "すべての変更は、仮想マシンの停止および開始後にの
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
-msgstr "選択されたディスク上のすべてのデータが削除され、ストレージプールにディスクが追加されます。"
+msgstr ""
+"選択されたディスク上のすべてのデータが削除され、ストレージプールにディスクが"
+"追加されます。"
 
 #: pkg/kubernetes/views/dashboard-page.html:112
 msgid "All healthy"
@@ -920,8 +928,8 @@ msgstr "許可されたサービス"
 msgid "Always"
 msgstr "常時"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "アノテーション"
@@ -930,8 +938,8 @@ msgstr "アノテーション"
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr "匿名: 認証されていないすべてのユーザーがイメージをプルできます"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "アプリケーション"
 
@@ -939,11 +947,11 @@ msgstr "アプリケーション"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "適用"
 
@@ -992,8 +1000,8 @@ msgstr "アセットタグ"
 msgid "At least $0 disks are needed."
 msgstr "少なくとも $0 ディスクが必要です。"
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "少なくとも 1 つのディスクが必要です。"
 
@@ -1013,9 +1021,9 @@ msgstr "監査ログ"
 msgid "Authenticating"
 msgstr "認証"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "認証"
 
@@ -1031,13 +1039,13 @@ msgstr "認証に失敗しました: サーバーの接続が切断されまし�
 msgid "Authentication failed"
 msgstr "認証に失敗しました"
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "認証が必要です"
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "作成者"
 
@@ -1094,7 +1102,7 @@ msgstr "利用可能"
 msgid "Available Updates"
 msgstr "利用可能なアップデート"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr "$0 で利用可能なターゲット"
 
@@ -1122,7 +1130,7 @@ msgstr "BIOS のバージョン"
 msgid "Back to Accounts"
 msgstr "アカウントに戻る"
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr "バッキングデバイス"
 
@@ -1245,10 +1253,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr "CHANGE NETWORK STATE アクションに失敗しました"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1313,7 +1321,6 @@ msgstr "画像を読み込めません。"
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1325,27 +1332,27 @@ msgstr "画像を読み込めません。"
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "取り消し"
 
@@ -1366,7 +1373,7 @@ msgid "Cannot schedule event in the past"
 msgstr "過去のイベントはスケジュールできません"
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "容量"
@@ -1384,11 +1391,11 @@ msgid "Ceph Monitors"
 msgstr "Ceph モニター"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "変更"
 
@@ -1416,7 +1423,7 @@ msgstr "システム時間の変更"
 msgid "Change User"
 msgstr "ユーザーの変更"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr "iSCSI イニシエーター名の変更"
 
@@ -1448,7 +1455,9 @@ msgstr "設定の変更"
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "設定を変更すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"設定を変更すると、サーバーへの接続が切断され、管理 UI が利用できなくなりま"
+"す。"
 
 #: pkg/packagekit/updates.jsx:174
 msgid "Check for Updates"
@@ -1521,22 +1530,25 @@ msgstr "クリックしてシステムハードウェア情報を確認"
 #: pkg/machines/components/desktopConsole.jsx:41
 msgid ""
 "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
-msgstr "\"リモートビューアーの起動\" をクリックすると、.vv ファイルをダウンロードし、$0 を起動します。"
+msgstr ""
+"\"リモートビューアーの起動\" をクリックすると、.vv ファイルをダウンロード"
+"し、$0 を起動します。"
 
 #: pkg/kubernetes/views/auth-form.html:88
 msgid "Client Certificate"
 msgstr "クライアント証明書"
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "閉じる"
 
@@ -1544,7 +1556,7 @@ msgstr "閉じる"
 msgid "Close Selected Pages"
 msgstr "選択されたページを閉じる"
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr "クラスター"
@@ -1570,8 +1582,8 @@ msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
 msgstr ""
-"Cockpit は該当するホスト $0 に接続できませんでした。そのホストのポート $1 で ssh "
-"が実行されていることを確認するか、アドレスで別のポートを指定します。"
+"Cockpit は該当するホスト $0 に接続できませんでした。そのホストのポート $1 で "
+"ssh が実行されていることを確認するか、アドレスで別のポートを指定します。"
 
 #: src/base1/cockpit.js:4018
 msgid "Cockpit could not contact the given host."
@@ -1583,9 +1595,9 @@ msgid ""
 "Cockpit by pressing refresh in your browser. The javascript console contains "
 "details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
-"Cockpit で予期しない内部エラーが発生しました。<br/><br/>ブラウザーで更新を押して Cockpit "
-"の再起動を試行できます。javascript コンソールにはこのエラーに関する詳細が含まれます (ほとんどのブラウザーでは <b>Ctrl-Shift-"
-"J</b>)。"
+"Cockpit で予期しない内部エラーが発生しました。<br/><br/>ブラウザーで更新を押"
+"して Cockpit の再起動を試行できます。javascript コンソールにはこのエラーに関"
+"する詳細が含まれます (ほとんどのブラウザーでは <b>Ctrl-Shift-J</b>)。"
 
 #: cockpit.appdata.xml.in.h:2
 msgid ""
@@ -1595,9 +1607,10 @@ msgid ""
 "Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
 "journal interface."
 msgstr ""
-"Cockpit は、Web ブラウザーで Linux サーバーを簡単に管理できるサーバーマネージャーです。端末と Web "
-"ツールを区別せずに使用できます。Cockpit で起動されたサービスは端末で停止できます。同様に、端末でエラーが発生した場合は、そのエラーを "
-"Cockpit ジャーナルインターフェースで確認できます。"
+"Cockpit は、Web ブラウザーで Linux サーバーを簡単に管理できるサーバーマネー"
+"ジャーです。端末と Web ツールを区別せずに使用できます。Cockpit で起動された"
+"サービスは端末で停止できます。同様に、端末でエラーが発生した場合は、そのエ"
+"ラーを Cockpit ジャーナルインターフェースで確認できます。"
 
 #: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
 msgid "Cockpit is an interactive Linux server admin interface."
@@ -1623,8 +1636,11 @@ msgid ""
 "same time. Just add them with a single click and your machines will look "
 "after its buddies."
 msgstr ""
-"Cockpit "
-"は経験が少ないシステム管理者に最適です。これらのシステム管理者はストレージの管理、ジャーナルの検査、サービスの起動および停止などの単純なタスクを簡単に実行できるようになります。また、複数のサーバーを同時に監視および管理できます。これらのサーバーはクリックするだけで追加できます。追加後に、ご使用のマシンは他のマシンを管理するようになります。"
+"Cockpit は経験が少ないシステム管理者に最適です。これらのシステム管理者はスト"
+"レージの管理、ジャーナルの検査、サービスの起動および停止などの単純なタスクを"
+"簡単に実行できるようになります。また、複数のサーバーを同時に監視および管理で"
+"きます。これらのサーバーはクリックするだけで追加できます。追加後に、ご使用の"
+"マシンは他のマシンを管理するようになります。"
 
 #: pkg/lib/machine-change-port.html:9
 msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
@@ -1632,15 +1648,15 @@ msgstr "Cockpit は {{#strong}}{{host}}{{/strong}} に接続できませんで�
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit は {{#strong}}{{host}}{{/strong}} "
-"にログインできませんでした。{{#can_sync}}{{#sync_link}}ユーザーの同期{{/sync_link}}を行ってください。{{/"
-"can_sync}}他の認証オプションとトラブルシューティングのサポートが必要な場合は、cockpit-ws "
-"を新しいバージョンにアップグレードしてください。"
+"Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。"
+"{{#can_sync}}{{#sync_link}}ユーザーの同期{{/sync_link}}を行ってください。{{/"
+"can_sync}}他の認証オプションとトラブルシューティングのサポートが必要な場合"
+"は、cockpit-ws を新しいバージョンにアップグレードしてください。"
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1652,8 +1668,9 @@ msgid ""
 "machine with cockpit you will need to enable one of the following "
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
-"Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。このマシンを Cockpit "
-"で使用するには、{{#strong}}{{host}}{{/strong}} 上の sshd 設定で次の認証方法のいずれかを有効にする必要があります。"
+"Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。このマ"
+"シンを Cockpit で使用するには、{{#strong}}{{host}}{{/strong}} 上の sshd 設定"
+"で次の認証方法のいずれかを有効にする必要があります。"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1661,9 +1678,9 @@ msgid ""
 "change your authentication credentials below. {{#can_sync}}You may prefer to "
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
-"Cockpit は {{#strong}}{{host}}{{/strong}} "
-"にログインできませんでした。認証情報は以下で変更できます。{{#can_sync}}{{#sync_link}}アカウントとパスワードの同期{{/"
-"sync_link}}を実行できます。{{/can_sync}}"
+"Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。認証情"
+"報は以下で変更できます。{{#can_sync}}{{#sync_link}}アカウントとパスワードの同"
+"期{{/sync_link}}を実行できます。{{/can_sync}}"
 
 #: pkg/dashboard/index.html:155 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1682,7 +1699,7 @@ msgstr[0] "$0 CPU コアの合計使用率"
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "コマンド"
 
@@ -1721,14 +1738,15 @@ msgstr "すべてのシステムおよびデバイスとの互換性あり (MBR)
 
 #: pkg/storaged/content-views.jsx:506
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "最新のシステムとの互換性があり、ハードディスクが 2TB よりも大きい (GPT)"
+msgstr ""
+"最新のシステムとの互換性があり、ハードディスクが 2TB よりも大きい (GPT)"
 
 #: pkg/kdump/kdump-view.jsx:199
 msgid "Compress crash dumps to save space"
 msgstr "クラッシュダンプを圧縮し容量を節約する"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "圧縮"
 
@@ -1927,7 +1945,8 @@ msgstr "コンテナーランタイムバージョン"
 #: pkg/docker/util.js:498
 msgid ""
 "Container is currently marked as not running, but regular stopping failed."
-msgstr "コンテナーは現在実行中でないと示されていますが、正常な停止に失敗しました。"
+msgstr ""
+"コンテナーは現在実行中でないと示されていますが、正常な停止に失敗しました。"
 
 #: pkg/docker/util.js:496
 msgid "Container is currently running."
@@ -1938,10 +1957,11 @@ msgid "Container:"
 msgstr "コンテナー:"
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "コンテナー"
 
@@ -2028,7 +2048,8 @@ msgid ""
 "Couldn't get system subscription status. Please ensure subscription-manager "
 "is installed."
 msgstr ""
-"システムサブスクリプションステータスを取得できませんでした。subscription-manager がインストールされていることを確認してください。"
+"システムサブスクリプションステータスを取得できませんでした。subscription-"
+"manager がインストールされていることを確認してください。"
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -2055,10 +2076,10 @@ msgstr "クラッシュシステム"
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "作成"
 
@@ -2160,12 +2181,13 @@ msgstr "$0 上でのパーティションの作成"
 msgid "Create partition table"
 msgstr "パーティションテーブルの作成"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "作成済み"
 
@@ -2197,25 +2219,33 @@ msgstr "$target のスナップショットの作成"
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "この VLAN を作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"この VLAN を作成すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/networkmanager/interfaces.js:3792
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "このボンドを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"このボンドを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/networkmanager/interfaces.js:4224
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "このブリッジを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"このブリッジを作成すると、サーバーへの接続が切断され、管理 UI が利用できなく"
+"なります。"
 
 #: pkg/networkmanager/interfaces.js:3985
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "このチームを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"このチームを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/storaged/jobs-panel.jsx:71
 msgid "Creating volume group $target"
@@ -2285,7 +2315,7 @@ msgstr "DNS 検索ドメイン $val"
 msgid "Dashboard"
 msgstr "ダッシュボード"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr "使用済みデータ"
 
@@ -2305,7 +2335,7 @@ msgstr "$target の非アクティブ化"
 msgid "Debug and above"
 msgstr "デバッグ以上のレベル"
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr "重複"
 
@@ -2330,12 +2360,11 @@ msgstr "遅延"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2395,37 +2424,46 @@ msgstr "$target の削除中"
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "<b>$0</b> を削除すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"<b>$0</b> を削除すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/kubernetes/views/item-delete.html:7
 msgid ""
 "Deleting a Pod will kill all associated containers. Pods may be "
 "automatically created again in some cases."
-msgstr "ポッドを削除すると、関連するすべてのコンテナーが終了します。ポッドは自動的に再び作成されることもあります。"
+msgstr ""
+"ポッドを削除すると、関連するすべてのコンテナーが終了します。ポッドは自動的に"
+"再び作成されることもあります。"
 
 #: pkg/storaged/mdraid-details.jsx:304
 msgid "Deleting a RAID device will erase all data on it."
-msgstr "RAID デバイスを削除すると、そのデバイス上のすべてのデータが削除されます。"
+msgstr ""
+"RAID デバイスを削除すると、そのデバイス上のすべてのデータが削除されます。"
 
 #: pkg/storaged/vdo-details.jsx:193
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "VDO デバイスを削除すると、そのデバイスのデータはすべて削除されます。"
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "コンテナーを削除すると、コンテナー内のすべてのデータが削除されます。"
 
 #: pkg/storaged/content-views.jsx:264
 msgid "Deleting a logical volume will delete all data in it."
-msgstr "論理ボリュームを削除すると、論理ボリューム内のすべてのデータが削除されます。"
+msgstr ""
+"論理ボリュームを削除すると、論理ボリューム内のすべてのデータが削除されます。"
 
 #: pkg/storaged/content-views.jsx:267
 msgid "Deleting a partition will delete all data in it."
-msgstr "パーティションを削除すると、パーティション内のすべてのデータが削除されます。"
+msgstr ""
+"パーティションを削除すると、パーティション内のすべてのデータが削除されます。"
 
 #: pkg/storaged/vgroup-details.jsx:214
 msgid "Deleting a volume group will erase all data on it."
-msgstr "ボリュームグループを削除すると、ボリュームグループ上のすべてのデータが削除されます。"
+msgstr ""
+"ボリュームグループを削除すると、ボリュームグループ上のすべてのデータが削除さ"
+"れます。"
 
 #: pkg/storaged/jobs-panel.jsx:72
 msgid "Deleting volume group $target"
@@ -2458,14 +2496,14 @@ msgstr "デプロイメント設定"
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "説明"
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "詳細:"
 
@@ -2478,10 +2516,10 @@ msgid "Detachable"
 msgstr "割り当て解除可能"
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "詳細"
 
@@ -2490,7 +2528,7 @@ msgstr "詳細"
 msgid "Device"
 msgstr "デバイス"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr "デバイスファイル"
 
@@ -2538,7 +2576,8 @@ msgstr "切断されています"
 
 #: pkg/machines/components/serialConsole.jsx:134
 msgid "Disconnected from serial console. Click the Reconnect button."
-msgstr "シリアルコンソールから切断されました。「再接続」ボタンをクリックします。"
+msgstr ""
+"シリアルコンソールから切断されました。「再接続」ボタンをクリックします。"
 
 #: pkg/kubernetes/scripts/nodes.js:723 pkg/kubernetes/scripts/nodes.js:839
 #: pkg/storaged/vdos-panel.jsx:59
@@ -2571,9 +2610,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "ディスク"
 
@@ -2595,7 +2634,8 @@ msgid ""
 "Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
 "name}}' image stream?"
 msgstr ""
-"'{{stream.metadata.namespace}}/{{stream.metadata.name}}' イメージストリームを削除しますか?"
+"'{{stream.metadata.namespace}}/{{stream.metadata.name}}' イメージストリームを"
+"削除しますか?"
 
 #: pkg/kubernetes/views/pv-delete.html:6
 msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
@@ -2619,16 +2659,16 @@ msgid ""
 "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
 "{{stream.metadata.name}}:{{tag.tag}}'?"
 msgstr ""
-"'{{stream.metadata.namespace}}/{{stream.metadata.name}}:{{tag.tag}}' "
-"というタグが付けられたイメージを削除しますか?"
+"'{{stream.metadata.namespace}}/{{stream.metadata.name}}:{{tag.tag}}' というタ"
+"グが付けられたイメージを削除しますか?"
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
-"ロール '{{ fields.displayRole }}' をメンバー {{ fields.member.metadata.name }} "
-"から削除しますか?"
+"ロール '{{ fields.displayRole }}' をメンバー {{ fields.member.metadata."
+"name }} から削除しますか?"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2636,7 +2676,8 @@ msgstr "Docker バージョン"
 
 #: pkg/docker/index.html:60
 msgid "Docker is not installed or activated on the system"
-msgstr "Docker はインストールされていないか、システムでアクティベートされていません"
+msgstr ""
+"Docker はインストールされていないか、システムでアクティベートされていません"
 
 #: pkg/lib/machine-info.es6:71
 msgid "Docking Station"
@@ -2740,7 +2781,7 @@ msgstr "重複するエイリアス"
 msgid "Duplicate port"
 msgstr "重複するポート"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr "編集"
 
@@ -2846,7 +2887,8 @@ msgstr "ここでは、暗号化したボリュームのサイズを変更する
 
 #: pkg/storaged/lvol-tabs.jsx:290
 msgid "Encrypted volumes need to be unlocked before they can be resized."
-msgstr "暗号化したボリュームは、サイズを変更する前にロックを解除する必要があります。"
+msgstr ""
+"暗号化したボリュームは、サイズを変更する前にロックを解除する必要があります。"
 
 #: pkg/storaged/content-views.jsx:138
 msgid "Encryption"
@@ -2893,13 +2935,15 @@ msgstr "新規仮想マシン名を入力します"
 msgid ""
 "Entering a different password here means you will need to retype it every "
 "time you reconnect to this machine"
-msgstr "ここで別のパスワードを入力すると、このマシンに接続するときに毎回そのパスワードを再入力する必要があります"
+msgstr ""
+"ここで別のパスワードを入力すると、このマシンに接続するときに毎回そのパスワー"
+"ドを再入力する必要があります"
 
 #: pkg/systemd/logs.html:73
 msgid "Entry"
 msgstr "エントリー"
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr "Entrypoint"
 
@@ -2925,9 +2969,9 @@ msgid "Errata:"
 msgstr "エラータ:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "エラー"
 
@@ -3015,7 +3059,7 @@ msgstr "失敗"
 msgid "Failed to add machine: $0"
 msgstr "マシンの追加に失敗しました: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "パスワードの変更に失敗しました"
 
@@ -3080,7 +3124,6 @@ msgstr "ファイルシステムのマウント"
 msgid "Filesystem Name"
 msgstr "ファイルシステム名"
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3088,6 +3131,7 @@ msgstr "ファイルシステム名"
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr "ファイルシステムタイプ"
 
@@ -3103,7 +3147,7 @@ msgstr "ファイルシステム"
 msgid "Filter Services"
 msgstr "フィルターサービス"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "フィンガープリント"
 
@@ -3171,11 +3215,14 @@ msgstr "ディスク $0 のフォーマット"
 
 #: pkg/storaged/content-views.jsx:513
 msgid "Formatting a disk will erase all data on it."
-msgstr "ディスクをフォーマットすると、ディスク上のすべてのデータが削除されます。"
+msgstr ""
+"ディスクをフォーマットすると、ディスク上のすべてのデータが削除されます。"
 
 #: pkg/storaged/format-dialog.jsx:305
 msgid "Formatting a storage device will erase all data on it."
-msgstr "ストレージデバイスをフォーマットすると、そのデバイス上のすべてのデータが削除されます。"
+msgstr ""
+"ストレージデバイスをフォーマットすると、そのデバイス上のすべてのデータが削除"
+"されます。"
 
 #: pkg/networkmanager/interfaces.js:2849
 msgid "Forward delay $forward_delay"
@@ -3224,7 +3271,7 @@ msgstr "全般"
 msgid "Generating report"
 msgstr "レポートの生成"
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr "新規イメージの取得"
 
@@ -3287,9 +3334,9 @@ msgstr "グループまたはプロジェクト"
 msgid "Groups"
 msgstr "グループ"
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr "増加"
 
@@ -3350,9 +3397,9 @@ msgstr "Hello タイム $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "ホスト"
 
@@ -3392,8 +3439,8 @@ msgstr "I/O 待機"
 msgid "INSTALL VM action failed"
 msgstr "INSTALL VM アクションに失敗しました"
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr "IP"
 
@@ -3433,7 +3480,7 @@ msgstr "IPv6 のセッティング"
 msgid "ISCSI"
 msgstr "ISCSI"
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr "ID"
@@ -3522,11 +3569,10 @@ msgstr "イメージストリーム"
 msgid "Image:"
 msgstr "イメージ:"
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr "イメージ"
 
@@ -3573,19 +3619,24 @@ msgstr "同期"
 #: pkg/kubernetes/views/registry-dashboard-page.html:81
 msgid ""
 "In order to begin pushing images to the registry, use the commands below."
-msgstr "レジストリーへのイメージのプッシュを開始するには、次のコマンドを使用します。"
+msgstr ""
+"レジストリーへのイメージのプッシュを開始するには、次のコマンドを使用します。"
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:6
 msgid ""
 "In order to begin pushing images to the registry, you need to create a "
 "project."
-msgstr "レジストリーへのイメージのプッシュを開始するには、プロジェクトを作成する必要があります。"
+msgstr ""
+"レジストリーへのイメージのプッシュを開始するには、プロジェクトを作成する必要"
+"があります。"
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
-msgstr "ユーザーを同期するには、{{#strong}}{{host}}{{/strong}} にログインする必要があります。"
+msgstr ""
+"ユーザーを同期するには、{{#strong}}{{host}}{{/strong}} にログインする必要があ"
+"ります。"
 
 #: pkg/networkmanager/interfaces.js:822 pkg/networkmanager/interfaces.js:1418
 #: pkg/networkmanager/interfaces.js:1425 pkg/networkmanager/interfaces.js:2594
@@ -3600,7 +3651,7 @@ msgstr "非アクティブなボリューム"
 msgid "Incorrect Host Key"
 msgstr "正しくないホストキー"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr "インデックスメモリー"
 
@@ -3616,9 +3667,9 @@ msgstr "Docker ストレージプールに関する情報は利用できませ�
 msgid "Initializing..."
 msgstr "初期化中..."
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr "インストール"
 
@@ -3644,7 +3695,9 @@ msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:360
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
-msgstr "setroubleshoot-server をインストールして SELinux イベントをトラブルシュートします。"
+msgstr ""
+"setroubleshoot-server をインストールして SELinux イベントをトラブルシュートし"
+"ます。"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:235
 msgid "Installation Source"
@@ -3666,7 +3719,7 @@ msgstr "インストール済み"
 msgid "Installed products"
 msgstr "インストールされた製品"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "インストール中"
@@ -3679,8 +3732,8 @@ msgstr "$0 をインストール中"
 msgid "Instantiate"
 msgstr "インスタンス化"
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr "インターフェース"
 
@@ -3704,11 +3757,11 @@ msgstr "無効なアドレス $0"
 msgid "Invalid credentials"
 msgstr "無効な資格情報"
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "無効な日付形式"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "無効な日付形式と無効な時間形式"
 
@@ -3756,7 +3809,7 @@ msgstr "無効なプレフィックス $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "無効なプレフィックスまたはネットマスク $0"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "無効な時間形式"
 
@@ -3764,7 +3817,7 @@ msgstr "無効な時間形式"
 msgid "Invalid time zone"
 msgstr "無効なタイムゾーン"
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr "無効なユーザー名またはパスワード"
@@ -3816,7 +3869,9 @@ msgstr "ジャーナルエントリーが見つかりません"
 #: pkg/kdump/kdump-view.jsx:463
 msgid ""
 "Kdump service not installed. Please ensure package kexec-tools is installed."
-msgstr "Kdump サービスがインストールされていません。パッケージ kexec-tools がインストールされていることを確認してください。"
+msgstr ""
+"Kdump サービスがインストールされていません。パッケージ kexec-tools がインス"
+"トールされていることを確認してください。"
 
 #: pkg/networkmanager/index.html:882
 msgid "Keep connection"
@@ -3882,11 +3937,12 @@ msgstr "Kubernetes クラスター"
 msgid "LACP Key"
 msgstr "LACP キー"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "ラベル"
@@ -3931,8 +3987,8 @@ msgstr "最終更新日"
 msgid "Last checked: $0 ago"
 msgstr "最終確認: $0 前"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr "最新バージョン"
 
@@ -3954,17 +4010,19 @@ msgid ""
 "you enter a different username, that user will always be used when "
 "connecting to this machine."
 msgstr ""
-"現在ログインしているユーザーとしてこのマシンに接続する場合は空白のままにします。異なるユーザー名を入力した場合は、このマシンへの接続時にそのユーザーが常に使用されます。"
+"現在ログインしているユーザーとしてこのマシンに接続する場合は空白のままにしま"
+"す。異なるユーザー名を入力した場合は、このマシンへの接続時にそのユーザーが常"
+"に使用されます。"
 
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
-"現在ログインしているユーザー {{#default_user}} ({{default_user}}){{/default_user}} "
-"としてこのマシンに接続する場合は空白のままにします。別のユーザー名を入力すると、このマシンへの接続時にそのユーザーが常に使用されます。"
+"現在ログインしているユーザー {{#default_user}} ({{default_user}}){{/"
+"default_user}} としてこのマシンに接続する場合は空白のままにします。別のユー"
+"ザー名を入力すると、このマシンへの接続時にそのユーザーが常に使用されます。"
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
 msgid "Licensed under:"
@@ -4026,8 +4084,8 @@ msgstr "利用可能なアップデートをロード中です。しばらくお
 msgid "Loading data ..."
 msgstr "データのロード中..."
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "読み込み中..."
 
@@ -4103,17 +4161,17 @@ msgstr "ログメッセージ"
 msgid "Logged In"
 msgstr "すでにログインしています"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr "論理"
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr "論理サイズ"
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr "論理ユニット番号"
 
@@ -4155,7 +4213,8 @@ msgstr "ログインで、管理者の権限をエスカレートさせました
 
 #: pkg/subscriptions/subscriptions-client.js:200
 msgid "Login/password or activation key required to register."
-msgstr "ログイン/パスワードまたはアクティベーションキーを登録する必要があります。"
+msgstr ""
+"ログイン/パスワードまたはアクティベーションキーを登録する必要があります。"
 
 #: src/ws/login.js:280
 msgid "Logout Successful"
@@ -4274,7 +4333,9 @@ msgstr "メッセージ最大期間 $max_age"
 msgid ""
 "Maximum number of virtual CPUs allocated for the guest OS, which must be "
 "between 1 and $0"
-msgstr "ゲスト OS に割り当てられる仮想 CPU の最大数で、これは 1 から $0 の間でなければなりません"
+msgstr ""
+"ゲスト OS に割り当てられる仮想 CPU の最大数で、これは 1 から $0 の間でなけれ"
+"ばなりません"
 
 #: pkg/kubernetes/views/volume-body.html:34
 msgid "Medium"
@@ -4308,9 +4369,10 @@ msgstr "メンバーシップ"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4342,8 +4404,8 @@ msgstr "メモリー使用状況:"
 msgid "Memory:"
 msgstr "メモリー:"
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "メッセージ"
 
@@ -4358,7 +4420,7 @@ msgstr "ログインしているユーザーへのメッセージ"
 msgid "Metadata"
 msgstr "メタデータ"
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr "使用済みメタデータ"
 
@@ -4438,8 +4500,8 @@ msgstr "詳細情報"
 msgid "More details"
 msgstr "詳細"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "マウント"
 
@@ -4447,17 +4509,17 @@ msgstr "マウント"
 msgid "Mount Location"
 msgstr "マウント場所"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "マウントオプション"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "マウントポイント"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr "起動時にマウント"
 
@@ -4481,7 +4543,7 @@ msgstr "マウントポイントは空欄にできません。"
 msgid "Mount point must start with \"/\"."
 msgstr "マウントポイントは \"/\" で開始してください。"
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr "読み取り専用でマウント"
 
@@ -4545,37 +4607,38 @@ msgstr "NTP サーバー"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "名前"
 
@@ -4609,7 +4672,6 @@ msgstr "名前は空欄にできません"
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4620,6 +4682,7 @@ msgstr "名前は空欄にできません"
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "名前空間"
@@ -4633,8 +4696,8 @@ msgid "Need at least one NTP server"
 msgstr "少なくとも 1 つの NTP サーバーが必要です"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "ネットワーク"
 
@@ -4700,8 +4763,8 @@ msgstr "新規プロジェクト"
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr "新規イメージストリーム"
 
@@ -4709,7 +4772,7 @@ msgstr "新規イメージストリーム"
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "新規パスワードは受け入れられませんでした"
 
@@ -4719,7 +4782,7 @@ msgstr "新規パスワードは受け入れられませんでした"
 msgid "New project"
 msgstr "新規プロジェクト"
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "次へ"
 
@@ -4834,9 +4897,9 @@ msgstr "現在のフィルターに一致するコンテナーがありません
 msgid "No description provided."
 msgstr "説明が入力されていません。"
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr "ディスクが利用できません。"
 
@@ -4864,7 +4927,7 @@ msgstr "グループが存在しません。"
 msgid "No host keys found."
 msgstr "ホストキーが見つかりません。"
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr "iSCSI ターゲットが設定されていません"
 
@@ -4872,7 +4935,7 @@ msgstr "iSCSI ターゲットが設定されていません"
 msgid "No image streams are present."
 msgstr "イメージストリームが存在しません。"
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr "イメージなし"
 
@@ -4880,7 +4943,7 @@ msgstr "イメージなし"
 msgid "No images pushed"
 msgstr "イメージがプッシュされていません"
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr "現在のフィルターに一致するイメージがありません"
 
@@ -4910,13 +4973,16 @@ msgid ""
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
 "crashkernel=512M"
 msgstr ""
-"メモリーが予約されていません。crashkernel オプションをカーネルコマンドラインに追加して (例: /etc/default/"
-"grub)、起動時にメモリーを予約します。例: crashkernel=512M"
+"メモリーが予約されていません。crashkernel オプションをカーネルコマンドライン"
+"に追加して (例: /etc/default/grub)、起動時にメモリーを予約します。例: "
+"crashkernel=512M"
 
 #: pkg/kubernetes/scripts/dashboard.js:384
 msgid ""
 "No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr "メタデータファイルが選択されていません。Kubernetes メタデータファイルを選択してください。"
+msgstr ""
+"メタデータファイルが選択されていません。Kubernetes メタデータファイルを選択し"
+"てください。"
 
 #: pkg/machines/vmnetworktab.jsx:31
 msgid "No network interfaces defined for this VM"
@@ -5030,9 +5096,9 @@ msgstr "ノード"
 msgid "Node:"
 msgstr "ノード:"
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr "ノード"
 
@@ -5043,7 +5109,7 @@ msgstr "ノードはコンテナーを実行するマシンです。"
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "なし"
 
@@ -5085,8 +5151,8 @@ msgstr "利用できません"
 msgid "Not connected"
 msgstr "接続していません"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr "デプロイされていません"
 
@@ -5102,7 +5168,7 @@ msgstr "マウントされていません"
 msgid "Not permitted to perform this action."
 msgstr "このアクションを実行する権限がありません。"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "実行中ではありません"
 
@@ -5130,8 +5196,8 @@ msgstr "注意以上のレベル"
 msgid "Number of virtual CPUs that gonna be used."
 msgstr "使用予定の仮想 CPU の数。"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr "OK"
 
@@ -5163,8 +5229,8 @@ msgstr "$0〜$1 の発生件数"
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "オフ"
 
@@ -5180,14 +5246,14 @@ msgstr "古いパスワード"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "古いパスワードは受け入れられません"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "オン"
 
@@ -5369,11 +5435,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "パスフレーズが一致しません"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5402,7 +5469,8 @@ msgstr "パスワードは受け入れられません"
 #: pkg/shell/index.html:155
 msgid ""
 "Password not usable for privileged tasks or to connect to other machines"
-msgstr "特権タスクの実行または他のマシンへの接続のためにパスワードを使用できません"
+msgstr ""
+"特権タスクの実行または他のマシンへの接続のためにパスワードを使用できません"
 
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:211
 msgid "Paste JSON below, "
@@ -5412,10 +5480,10 @@ msgstr "以下に JSON を貼り付けます、"
 msgid "Paste the contents of your public SSH key file here"
 msgstr "公開 SSH 鍵ファイルの内容をここに貼り付けます"
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "パス"
 
@@ -5479,7 +5547,7 @@ msgstr "永続ボリューム"
 msgid "Phase"
 msgstr "フェーズ"
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr "物理"
 
@@ -5511,8 +5579,8 @@ msgstr "Ping ターゲット"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5607,7 +5675,9 @@ msgstr "完全修飾ドメイン名と、oVirt エンジンのポートを提供
 msgid ""
 "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
 "port (443 by default)"
-msgstr "有効な oVirt エンジンの完全修飾ドメイン名 (FQDN) と、ポート (デフォルトでは 443) を提供してください"
+msgstr ""
+"有効な oVirt エンジンの完全修飾ドメイン名 (FQDN) と、ポート (デフォルトでは "
+"443) を提供してください"
 
 #: pkg/ovirt/components/ConsoleClientResources.jsx:32
 msgid ""
@@ -5699,7 +5769,9 @@ msgstr "ポッド"
 msgid ""
 "Pods contain one or more containers that run together on a node, containing "
 "your application code."
-msgstr "ポッドには、ノードで一緒に実行される 1 つ以上のコンテナーが含まれます (アプリケーションコードを含む)"
+msgstr ""
+"ポッドには、ノードで一緒に実行される 1 つ以上のコンテナーが含まれます (アプリ"
+"ケーションコードを含む)"
 
 #: pkg/machines/components/diskAdd.jsx:200
 #: pkg/machines/components/vmDiskSourceCell.jsx:39
@@ -5729,9 +5801,8 @@ msgstr "入力"
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr "ポート"
 
@@ -5747,7 +5818,7 @@ msgstr "ポートグループ"
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "ポート"
 
@@ -5811,7 +5882,9 @@ msgstr "優先度 $priority"
 
 #: pkg/kubernetes/scripts/projects.js:1026
 msgid "Private: Allow only specific users or groups to pull images"
-msgstr "プライベート: 特定のユーザーまたはグループのみがイメージをプルすることを許可する"
+msgstr ""
+"プライベート: 特定のユーザーまたはグループのみがイメージをプルすることを許可"
+"する"
 
 #: pkg/shell/index.html:39
 msgid "Privileged"
@@ -5829,7 +5902,7 @@ msgstr "問題の情報"
 msgid "Problems"
 msgstr "問題"
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr "プロセス"
 
@@ -5843,7 +5916,6 @@ msgstr "製品名"
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5855,6 +5927,7 @@ msgstr "製品名"
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "プロジェクト"
@@ -5865,15 +5938,21 @@ msgstr "プロジェクトメンバー"
 
 #: pkg/kubernetes/views/project-body.html:3
 msgid "Project access policy allows anonymous users to pull images."
-msgstr "プロジェクトアクセスポリシーにより、匿名ユーザーはイメージをプルすることができます。"
+msgstr ""
+"プロジェクトアクセスポリシーにより、匿名ユーザーはイメージをプルすることがで"
+"きます。"
 
 #: pkg/kubernetes/views/project-body.html:8
 msgid "Project access policy allows any authenticated user to pull images."
-msgstr "プロジェクトアクセスポリシーにより、認証されたユーザーはイメージをプルすることができます。"
+msgstr ""
+"プロジェクトアクセスポリシーにより、認証されたユーザーはイメージをプルするこ"
+"とができます。"
 
 #: pkg/kubernetes/views/project-body.html:13
 msgid "Project access policy only allows specific members to access images."
-msgstr "プロジェクトアクセスポリシーにより、特定のメンバーのみがイメージにアクセスできます。"
+msgstr ""
+"プロジェクトアクセスポリシーにより、特定のメンバーのみがイメージにアクセスで"
+"きます。"
 
 #: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
 msgid "Project website"
@@ -5883,10 +5962,10 @@ msgstr "プロジェクト Web サイト"
 msgid "Project:"
 msgstr "プロジェクト:"
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr "プロジェクト"
 
@@ -5918,7 +5997,7 @@ msgstr "プロキシ"
 msgid "Proxy Version"
 msgstr "プロキシーバージョン"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "公開鍵"
 
@@ -5946,8 +6025,8 @@ msgstr "目的"
 msgid "Push an image:"
 msgstr "イメージのプッシュ:"
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr "修飾名"
 
@@ -6011,7 +6090,7 @@ msgstr "RAID シャーシ"
 msgid "RAID Device"
 msgstr "RAID デバイス"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "RAID デバイス $0"
 
@@ -6047,7 +6126,6 @@ msgstr "ランダム"
 msgid "Raw to a device"
 msgstr "デバイスに対する Raw"
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6059,6 +6137,7 @@ msgstr "デバイスに対する Raw"
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr "読み込み専用"
 
@@ -6113,7 +6192,9 @@ msgstr "実際のホスト名"
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
-msgstr "実際のホスト名には小文字、数字、ダッシュ、およびピリオドのみを使用できます (入力されたサブドメインを含む)。"
+msgstr ""
+"実際のホスト名には小文字、数字、ダッシュ、およびピリオドのみを使用できます "
+"(入力されたサブドメインを含む)。"
 
 #: pkg/systemd/host.js:921
 msgid "Real host name must be 64 characters or less"
@@ -6123,7 +6204,7 @@ msgstr "実際のホスト名は 64 文字以下である必要があります"
 msgid "Reason"
 msgstr "理由"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "再起動"
 
@@ -6179,8 +6260,8 @@ msgstr "接続を拒否しています。ホストキーが一致しません"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "接続を拒否しています。ホストキーが不明です"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr "登録"
 
@@ -6208,8 +6289,8 @@ msgstr "oVirt を Cockpit に登録中"
 msgid "Register…"
 msgstr "登録中…"
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "再読み込み"
 
@@ -6250,9 +6331,9 @@ msgstr "削除:"
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "削除"
 
@@ -6304,7 +6385,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr "削除中"
 
@@ -6320,7 +6401,9 @@ msgstr "$target を RAID デバイスから削除"
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "<b>$0</b> を削除すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"<b>$0</b> を削除すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/storaged/jobs-panel.jsx:74
 msgid "Removing physical volume from $target"
@@ -6372,10 +6455,10 @@ msgstr "毎年繰り返す"
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "レプリカ"
 
@@ -6394,7 +6477,9 @@ msgstr "レプリケーションコントローラー"
 msgid ""
 "Replication controllers dynamically create instances of pods from templates, "
 "and remove pods when necessary."
-msgstr "レプリケーションコントローラーにより、テンプレートからポッドのインスタンスが動的に作成され、必要に応じてポッドが削除されます。"
+msgstr ""
+"レプリケーションコントローラーにより、テンプレートからポッドのインスタンスが"
+"動的に作成され、必要に応じてポッドが削除されます。"
 
 #: pkg/systemd/logs.js:437
 msgid "Report"
@@ -6474,7 +6559,9 @@ msgstr "ストレージプールのリセット"
 msgid ""
 "Resetting the storage pool will erase all containers and release disks in "
 "the pool."
-msgstr "ストレージプールをリセットすると、すべてのコンテナーが削除され、プール内のディスクが解放されます。"
+msgstr ""
+"ストレージプールをリセットすると、すべてのコンテナーが削除され、プール内の"
+"ディスクが解放されます。"
 
 #: pkg/storaged/jobs-panel.jsx:40 pkg/storaged/jobs-panel.jsx:46
 #: pkg/storaged/jobs-panel.jsx:78
@@ -6487,8 +6574,8 @@ msgstr "上記のエラーを解決して続行"
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "再起動"
 
@@ -6537,9 +6624,9 @@ msgid "Reuse my password for privileged tasks"
 msgstr "特権タスクにパスワードを再使用する"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
-msgstr "特権タスクの実行または他のマシンへの接続のためにパスワードを再使用します"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
+msgstr ""
+"特権タスクの実行または他のマシンへの接続のためにパスワードを再使用します"
 
 #: pkg/kubernetes/views/volume-body.html:26
 msgid "Revision"
@@ -6592,7 +6679,7 @@ msgstr "次で実行"
 msgid "Runner"
 msgstr "ランナー"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "実行中"
 
@@ -6680,8 +6767,8 @@ msgstr "SUSPEND アクションに失敗しました"
 msgid "Saturday"
 msgstr "土曜日"
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "保存"
 
@@ -6734,7 +6821,7 @@ msgstr "セキュアシェルキー"
 msgid "Securely erasing $target"
 msgstr "$target を安全に削除"
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr "Security"
 
@@ -6766,8 +6853,8 @@ msgstr "オブジェクトを選択して詳細を参照します。"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr "{{#strong}}{{host}}{{/strong}} と同期するユーザーを選択します"
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6788,15 +6875,14 @@ msgstr "送信:"
 msgid "Serial Console"
 msgstr "シリアルコンソール"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "サーバー"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr "サーバーアドレス"
 
@@ -6804,7 +6890,7 @@ msgstr "サーバーアドレス"
 msgid "Server Administrator"
 msgstr "サーバー管理者"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr "サーバーアドレスは空欄にできません。"
 
@@ -6823,7 +6909,7 @@ msgstr "サーバー"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "サービス"
 
@@ -6869,10 +6955,12 @@ msgstr "サービス"
 msgid ""
 "Services group pods and provide a common DNS name and an optional, load-"
 "balanced IP address to access them."
-msgstr "サービスはポッドをグループ化し、ポッドにアクセスするために共通の DNS 名とオプションのロードバランス IP アドレスを提供します。"
+msgstr ""
+"サービスはポッドをグループ化し、ポッドにアクセスするために共通の DNS 名とオプ"
+"ションのロードバランス IP アドレスを提供します。"
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr "セッション"
 
@@ -7008,7 +7096,7 @@ msgstr "すべてのイメージの表示"
 msgid "Show fingerprints"
 msgstr "フィンガープリントの表示"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr "縮小"
 
@@ -7029,34 +7117,34 @@ msgstr "以降"
 msgid "Since $0"
 msgstr "$0 以降"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Size"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "サイズはマイナスにすることができません"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "サイズはゼロにすることができません"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr "サイズが大きすぎます"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "サイズは数値である必要があります"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr "サイズは $0 以上にする必要があります"
 
@@ -7106,7 +7194,8 @@ msgstr "ソリューション"
 #: pkg/packagekit/updates.jsx:39
 msgid ""
 "Some other program is currently using the package manager, please wait..."
-msgstr "別のプログラムがパッケージマネージャーを使用中です。しばらくお待ちください..."
+msgstr ""
+"別のプログラムがパッケージマネージャーを使用中です。しばらくお待ちください..."
 
 #: pkg/kubernetes/scripts/volumes.js:906
 msgid "Sorry, I don't know how to modify this volume"
@@ -7150,7 +7239,7 @@ msgid "Stable"
 msgstr "安定"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "開始日"
@@ -7191,10 +7280,10 @@ msgstr "開始"
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "状態"
 
@@ -7216,10 +7305,11 @@ msgid "Static"
 msgstr "静的"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7242,7 +7332,7 @@ msgid "Sticky"
 msgstr "スティッキー"
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7376,7 +7466,9 @@ msgstr "$0 をオンにする"
 
 #: pkg/ovirt/provider.es6:385
 msgid "Switching host to maintenance mode failed. Received error: "
-msgstr "ホストをメンテナンスモードに切り替えることができませんでした。受け取ったエラー: "
+msgstr ""
+"ホストをメンテナンスモードに切り替えることができませんでした。受け取ったエ"
+"ラー: "
 
 #: pkg/ovirt/provider.es6:379
 msgid "Switching host to maintenance mode in progress ..."
@@ -7386,19 +7478,25 @@ msgstr "ホストをメンテナンスモードに切り替え中..."
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
-msgstr "<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなく"
+"なります。"
 
 #: pkg/networkmanager/interfaces.js:3026
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
-msgstr "<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなくなります。1"
+msgstr ""
+"<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなく"
+"なります。1"
 
 #: pkg/networkmanager/interfaces.js:2459 pkg/networkmanager/interfaces.js:3014
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
-msgstr "<b>$0</b> をオンにすると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"<b>$0</b> をオンにすると、サーバーへの接続が切断され、管理 UI が利用できなく"
+"なります。"
 
 #: pkg/kubernetes/scripts/images.js:622
 msgid "Sync all tags from a remote image repository"
@@ -7475,7 +7573,7 @@ msgstr "タグ"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr "タグ"
 
@@ -7497,7 +7595,7 @@ msgstr "ターゲットポータル"
 msgid "Target World Wide Names"
 msgstr "ターゲットワールドワイド名"
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr "ターゲット"
 
@@ -7576,7 +7674,8 @@ msgstr "RAID アレイは劣化状態にあります"
 
 #: pkg/storaged/mdraid-details.jsx:149
 msgid "The RAID device must be running in order to add spare disks."
-msgstr "スペアディスクを追加する場合は、RAID デバイスが実行中である必要があります。"
+msgstr ""
+"スペアディスクを追加する場合は、RAID デバイスが実行中である必要があります。"
 
 #: pkg/storaged/mdraid-details.jsx:115
 msgid "The RAID device must be running in order to remove disks."
@@ -7600,7 +7699,9 @@ msgstr "仮想マシンがアイドル状態です。"
 
 #: pkg/machines/components/vm/stateIcon.jsx:41
 msgid "The VM is in process of dying (shut down or crash is not completed)."
-msgstr "仮想マシンが終了中の状態です (シャットダウンまたはクラッシュが完了していません)。"
+msgstr ""
+"仮想マシンが終了中の状態です (シャットダウンまたはクラッシュが完了していませ"
+"ん)。"
 
 #: pkg/machines/components/vm/stateIcon.jsx:35
 msgid "The VM is paused."
@@ -7628,9 +7729,11 @@ msgstr "アドレスに無効な文字が含まれています。"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
-msgstr "ホスト {{#strong}}{{host}}{{/strong}} の認証を確立できません。本当に接続を維持しますか?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+"ホスト {{#strong}}{{host}}{{/strong}} の認証を確立できません。本当に接続を維"
+"持しますか?"
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
@@ -7651,7 +7754,9 @@ msgstr "この VDO デバイスの作成は終了していないため、使用�
 
 #: pkg/subscriptions/subscriptions-view.jsx:192
 msgid "The current user isn't allowed to access system subscription status."
-msgstr "現在のユーザーにはシステムサブスクリプションステータスへのアクセスが許可されていません。"
+msgstr ""
+"現在のユーザーにはシステムサブスクリプションステータスへのアクセスが許可され"
+"ていません。"
 
 #: pkg/storaged/crypto-keyslots.jsx:488
 msgid ""
@@ -7664,11 +7769,13 @@ msgstr "デプロイメント設定 '{{ target }}' が存在しません。"
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
-msgstr "このファイルシステムは、ログインセッションおよびシステムサービスで使用中です。               続行するとこれらを停止します。"
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
+msgstr ""
+"このファイルシステムは、ログインセッションおよびシステムサービスで使用中で"
+"す。               続行するとこれらを停止します。"
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7678,27 +7785,29 @@ msgstr ""
 msgid ""
 "The filesystem is in use by login sessions.                Proceeding will "
 "stop these."
-msgstr "このファイルシステムは、ログインセッションで使用中です。                続行するとこれらを停止します。"
+msgstr ""
+"このファイルシステムは、ログインセッションで使用中です。                続行"
+"するとこれらを停止します。"
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
 msgid ""
 "The filesystem is in use by system services.                Proceeding will "
 "stop these."
-msgstr "このファイルシステムは、システムサービスで使用中です。                続行するとこれらを停止します。"
+msgstr ""
+"このファイルシステムは、システムサービスで使用中です。                続行す"
+"るとこれらを停止します。"
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7714,7 +7823,9 @@ msgid ""
 "The generated archive contains data considered sensitive and its content "
 "should be reviewed by the originating organization before being passed to "
 "any third party."
-msgstr "生成されたアーカイブには、機密データと見なされるデータが含まれます。その内容はサードパーティーに渡す前に元の組織が確認する必要があります。"
+msgstr ""
+"生成されたアーカイブには、機密データと見なされるデータが含まれます。その内容"
+"はサードパーティーに渡す前に元の組織が確認する必要があります。"
 
 #: pkg/kubernetes/views/group-page.html:47
 msgid "The group '{{ groupName }}' does not exist."
@@ -7726,8 +7837,9 @@ msgid ""
 "in use. Unless this machine was recently replaced, it is likely that someone "
 "is trying to attack your connection to this machine."
 msgstr ""
-"{{#strong}}{{host}}{{/strong}} "
-"の鍵が、以前に使用された鍵と一致しません。このマシンが最近置き換えられたものでない限り、誰かがこのマシンへの接続を攻撃しようとしている可能性があります。"
+"{{#strong}}{{host}}{{/strong}} の鍵が、以前に使用された鍵と一致しません。この"
+"マシンが最近置き換えられたものでない限り、誰かがこのマシンへの接続を攻撃しよ"
+"うとしている可能性があります。"
 
 #: pkg/users/authorized-keys.js:119
 msgid "The key you provided was not valid."
@@ -7801,23 +7913,27 @@ msgstr "レプリケーションコントローラー '{{ target }}' が存在�
 msgid "The route '{{ target }}' does not exist."
 msgstr "ルート '{{ target }}' が存在しません。"
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "$time ($type) のスキャンでは、脆弱性は見つかりませんでした。"
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr "$time ($type) のスキャンは成功しませんでした。"
 
 #: pkg/kubernetes/scripts/dashboard.js:386
 msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "選択されたファイルは有効な Kubernetes アプリケーションマニフェストではありません。"
+msgstr ""
+"選択されたファイルは有効な Kubernetes アプリケーションマニフェストではありま"
+"せん。"
 
 #: src/ws/login.js:622
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
 "no other supported authentication methods are available."
-msgstr "サーバーはパスワード認証を使用した '$0' の認証を拒否しました。サポートされた他の認証方法は利用できません。"
+msgstr ""
+"サーバーはパスワード認証を使用した '$0' の認証を拒否しました。サポートされた"
+"他の認証方法は利用できません。"
 
 #: src/base1/cockpit.js:3998
 msgid "The server refused to authenticate using any supported methods."
@@ -7849,7 +7965,8 @@ msgstr "ユーザー <b>$0</b> は、システムの時間の変更を許可さ�
 
 #: pkg/systemd/init.js:585
 msgid "The user <b>$0</b> is not permitted to enable or disable services"
-msgstr "ユーザー <b>$0</b> は、サービスを有効または無効にすることを許可されていません"
+msgstr ""
+"ユーザー <b>$0</b> は、サービスを有効または無効にすることを許可されていません"
 
 #: pkg/dashboard/list.js:213
 msgid "The user <b>$0</b> is not permitted to manage servers"
@@ -7869,7 +7986,8 @@ msgstr "ユーザー <b>$0</b> はホスト名を変更することを許可さ�
 
 #: pkg/networkmanager/interfaces.js:1517
 msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr "ユーザー <b>$0</b> はネットワーク設定を変更することを許可されていません"
+msgstr ""
+"ユーザー <b>$0</b> はネットワーク設定を変更することを許可されていません"
 
 #: pkg/realmd/operation.js:586
 msgid "The user <b>$0</b> is not permitted to modify realms"
@@ -7877,23 +7995,28 @@ msgstr "ユーザー <b>$0</b> はレルムを変更することを許可され�
 
 #: pkg/systemd/host.js:59
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
-msgstr "ユーザー <b>$0</b> は、このサーバーをシャットダウンまたは再起動することを許可されていません"
+msgstr ""
+"ユーザー <b>$0</b> は、このサーバーをシャットダウンまたは再起動することを許可"
+"されていません"
 
 #: pkg/systemd/init.js:577 pkg/systemd/init.js:581
 msgid "The user <b>$0</b> is not permitted to start or stop services"
-msgstr "ユーザー <b>$0</b> は、サービスを開始または停止することを許可されていません"
+msgstr ""
+"ユーザー <b>$0</b> は、サービスを開始または停止することを許可されていません"
 
 #: pkg/users/local.js:519
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
-msgstr "ユーザー名は a〜z の文字、数字、ドット、ダッシュ、およびアンダースコアだけで構成されます。"
+msgstr ""
+"ユーザー名は a〜z の文字、数字、ドット、ダッシュ、およびアンダースコアだけで"
+"構成されます。"
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
-msgstr "Web ブラウザーの設定により、Cockpit の実行は防がれます (アクセスできない $0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
+msgstr ""
+"Web ブラウザーの設定により、Cockpit の実行は防がれます (アクセスできない $0)"
 
 #: pkg/shell/active-pages-dialog.jsx:59
 msgid "There are currently no active pages"
@@ -7903,7 +8026,9 @@ msgstr "現在アクティブなページはありません"
 msgid ""
 "There are devices with multiple paths on the system, but the multipath "
 "service is not running."
-msgstr "システムに複数のパスを持つデバイスがありますが、マルチパスサービスが実行されていません。"
+msgstr ""
+"システムに複数のパスを持つデバイスがありますが、マルチパスサービスが実行され"
+"ていません。"
 
 #: pkg/users/index.html:439
 msgid "There are no authorized public keys for this account."
@@ -7913,7 +8038,9 @@ msgstr "このアカウントに承認された公開鍵がありません。"
 msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
-msgstr "この物理ボリュームを削除するのに十分な空き領域がありません。少なくとも $0 の空き領域が必要です。"
+msgstr ""
+"この物理ボリュームを削除するのに十分な空き領域がありません。少なくとも $0 の"
+"空き領域が必要です。"
 
 #: pkg/storaged/utils.js:165
 msgid "Thin Logical Volume"
@@ -7930,13 +8057,17 @@ msgstr "この VDO デバイスは、そのバッキングデバイスをすべ�
 #: pkg/kubernetes/views/pvc-delete.html:8
 msgid ""
 "This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr "このクレームは使用中です。クレームを削除すると、次のポッドで問題が発生することがあります。"
+msgstr ""
+"このクレームは使用中です。クレームを削除すると、次のポッドで問題が発生するこ"
+"とがあります。"
 
 #: pkg/systemd/init.js:1271
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
-msgstr "この日はすべての月で存在しません。<br> タイマーは 31 日がある月でのみ実行されます。"
+msgstr ""
+"この日はすべての月で存在しません。<br> タイマーは 31 日がある月でのみ実行され"
+"ます。"
 
 #: pkg/networkmanager/interfaces.js:2612
 msgid "This device cannot be managed here."
@@ -7947,16 +8078,16 @@ msgid ""
 "This device has filesystems that are currently in use.                "
 "Proceeding will unmount all filesystems on it."
 msgstr ""
-"このデバイスには、現在使用中のファイルシステムがあります。                "
-"続行すると、このデバイスのファイルシステムをすべてアンマウントします。"
+"このデバイスには、現在使用中のファイルシステムがあります。                続"
+"行すると、このデバイスのファイルシステムをすべてアンマウントします。"
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr "このデバイスは、現在 RAID デバイスに使用されています。"
 
@@ -7965,20 +8096,20 @@ msgid ""
 "This device is currently used for RAID devices.                Proceeding "
 "will remove it from its RAID devices."
 msgstr ""
-"このデバイスは、現在 RAID デバイスに使用されています。                続行すると、RAID "
-"デバイスからこのデバイスが削除されます。"
+"このデバイスは、現在 RAID デバイスに使用されています。                続行す"
+"ると、RAID デバイスからこのデバイスが削除されます。"
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr "このデバイスは、現在 VDO デバイスに使用されています。"
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr "このデバイスは、現在ボリュームグループに使用されています。"
 
@@ -7987,10 +8118,10 @@ msgid ""
 "This device is currently used for volume groups.                Proceeding "
 "will remove it from its volume groups."
 msgstr ""
-"このデバイスは現在ボリュームグループに使用されています。                "
-"続行すると、そのボリュームグループからこのデバイスが削除されます。"
+"このデバイスは現在ボリュームグループに使用されています。                続行"
+"すると、そのボリュームグループからこのデバイスが削除されます。"
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8008,9 +8139,11 @@ msgstr "このフィールドは空にできません。"
 msgid ""
 "This host is managed by a virtualization manager, so creation of new VMs "
 "from the host is not possible."
-msgstr "このホストは仮想化マネージャーによって管理されているため、ホストからの新規の仮想マシンの作成は不可能です。"
+msgstr ""
+"このホストは仮想化マネージャーによって管理されているため、ホストからの新規の"
+"仮想マシンの作成は不可能です。"
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr "このイメージは存在しません。"
 
@@ -8026,7 +8159,9 @@ msgstr "これにはしばらく時間がかかることがあります"
 msgid ""
 "This option is for single node testing only – local storage will not work in "
 "a multi-node cluster"
-msgstr "このオプションは単一ノードのテストにのみ使用できます – ローカルストレージはマルチノードクラスターで動作しません"
+msgstr ""
+"このオプションは単一ノードのテストにのみ使用できます – ローカルストレージはマ"
+"ルチノードクラスターで動作しません"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
@@ -8053,7 +8188,9 @@ msgstr "このシステムは推奨プロファイルを使用しています"
 msgid ""
 "This tool will collect system configuration and diagnostic information from "
 "this system for use with diagnosing problems with the system."
-msgstr "このツールは、システムの問題の診断で使用するためにシステムからシステム設定と診断情報を収集します。"
+msgstr ""
+"このツールは、システムの問題の診断で使用するためにシステムからシステム設定と"
+"診断情報を収集します。"
 
 #: pkg/systemd/init.js:656
 msgid "This unit is an instance of the $0 template."
@@ -8071,7 +8208,9 @@ msgstr "このユーザー名はすでに存在します"
 msgid ""
 "This version of cockpit-ws does not support connecting to a host with an "
 "alternate user or port"
-msgstr "cockpit-ws のこのバージョンでは、別のユーザーまたはポートによるホストへの接続がサポートされません"
+msgstr ""
+"cockpit-ws のこのバージョンでは、別のユーザーまたはポートによるホストへの接続"
+"がサポートされません"
 
 #: pkg/ovirt/components/OVirtTab.jsx:134
 msgid "This virtual machine is not managed by oVirt"
@@ -8079,13 +8218,13 @@ msgstr "この仮想マシンは、oVirt で管理されていません"
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 "このボリュームは {{ item.item.spec.claimRef.namespace }} / {{ item.item.spec."
-"claimRef.name }} "
-"によってクレームされました。このボリュームを削除すると、そのクレームが破損して、依存するすべてのポッドで問題が発生することがあります。"
+"claimRef.name }} によってクレームされました。このボリュームを削除すると、その"
+"クレームが破損して、依存するすべてのポッドで問題が発生することがあります。"
 
 #: pkg/kubernetes/views/pv-claim.html:23
 msgid "This volume has not been claimed"
@@ -8093,7 +8232,8 @@ msgstr "このボリュームはクレームされていません"
 
 #: pkg/storaged/lvol-tabs.jsx:329
 msgid "This volume needs to be activated before it can be resized."
-msgstr "このボリュームは、サイズを変更する前にアクティベートする必要があります。"
+msgstr ""
+"このボリュームは、サイズを変更する前にアクティベートする必要があります。"
 
 #: src/ws/login.js:141
 msgid "This web browser is too old to run Cockpit (missing $0)"
@@ -8109,12 +8249,14 @@ msgid ""
 "Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
 msgstr ""
-"このため、kdump 設定は、カーネル (つまり、システム) "
-"をクラッシュすることによりテストされます。設定に応じて、再起動が自動的に行われず、処理にしばらく時間がかかることがあります。"
+"このため、kdump 設定は、カーネル (つまり、システム) をクラッシュすることによ"
+"りテストされます。設定に応じて、再起動が自動的に行われず、処理にしばらく時間"
+"がかかることがあります。"
 
 #: pkg/kdump/kdump-view.jsx:519
 msgid "This will test the kdump configuration by crashing the kernel."
-msgstr "このため、kdump 設定はカーネルをクラッシュすることによりテストされます。"
+msgstr ""
+"このため、kdump 設定はカーネルをクラッシュすることによりテストされます。"
 
 #: pkg/machines/components/vcpuModal.jsx:189
 #: pkg/ovirt/components/vcpuModal.jsx:65
@@ -8137,15 +8279,18 @@ msgstr "タイマー"
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
-msgstr "ヒント: 他のシステムに対して自動的に認証する場合は、鍵のパスワードをログインパスワードに一致させます。"
+msgstr ""
+"ヒント: 他のシステムに対して自動的に認証する場合は、鍵のパスワードをログイン"
+"パスワードに一致させます。"
 
 #: pkg/packagekit/updates.jsx:900
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
 msgstr ""
-"ソフトウェアアップデートを取得するには、このシステムを Red Hat に登録する必要があります。登録には、Red Hat "
-"カスタマーポータルまたはローカルのサブスクリプションサーバーを使用します。"
+"ソフトウェアアップデートを取得するには、このシステムを Red Hat に登録する必要"
+"があります。登録には、Red Hat カスタマーポータルまたはローカルのサブスクリプ"
+"ションサーバーを使用します。"
 
 #: node_modules/registry-image-widgets/views/image-pull.html:4
 msgid "To pull this image:"
@@ -8159,7 +8304,9 @@ msgstr "このイメージストリームにイメージをプッシュするに
 msgid ""
 "To try a different port you will need to upgrade cockpit-ws to a newer "
 "version."
-msgstr "別のポートを試すには、cockpit-ws を新しいバージョンにアップグレードする必要があります。"
+msgstr ""
+"別のポートを試すには、cockpit-ws を新しいバージョンにアップグレードする必要が"
+"あります。"
 
 #: pkg/kubernetes/views/auth-form.html:116
 msgid "Token"
@@ -8247,11 +8394,11 @@ msgstr "Tuned が実行中ではありません"
 msgid "Tuned is off"
 msgstr "Tuned がオフです"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "タイプ"
@@ -8314,13 +8461,15 @@ msgstr "アラート詳細を取得できません"
 msgid "Unable to get alert: $0"
 msgstr "アラートを取得できません: $0"
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "サーバーに到達できません"
 
 #: pkg/kubernetes/scripts/dashboard.js:401
 msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Kubernetes アプリケーションマニフェストを読み取ることができません。コード $0。"
+msgstr ""
+"Kubernetes アプリケーションマニフェストを読み取ることができません。コード "
+"$0。"
 
 #: pkg/storaged/nfs-details.jsx:264
 msgid "Unable to remove mount"
@@ -8360,23 +8509,23 @@ msgstr "予期しないエラー"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr "単位"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "不明"
 
@@ -8400,7 +8549,7 @@ msgstr "不明なホストキー"
 msgid "Unknown configuration"
 msgstr "不明な設定"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr "不明なホスト名"
 
@@ -8445,7 +8594,7 @@ msgstr "未管理のインターフェース"
 msgid "Unmask"
 msgstr "マスク解除"
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "アンマウント"
 
@@ -8535,7 +8684,7 @@ msgstr "更新を利用できます"
 msgid "Updates are disabled."
 msgstr "更新が無効です。"
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr "更新中"
 
@@ -8545,7 +8694,9 @@ msgstr "$0 の更新中 ..."
 
 #: pkg/machines/components/vmDisksTabLibvirt.jsx:68
 msgid "Upgrade to a more recent version of libvirt to view disk statistics"
-msgstr "ディスクの統計情報を表示するには、libvirt を新しいバージョンにアップグレードしてください"
+msgstr ""
+"ディスクの統計情報を表示するには、libvirt を新しいバージョンにアップグレード"
+"してください"
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:71
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:54
@@ -8583,13 +8734,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr "/etc/kdump.conf の設定を使用します"
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Used"
 
@@ -8599,10 +8750,10 @@ msgstr "コンテナーにより使用済み"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8621,7 +8772,7 @@ msgstr "ユーザーパスワード"
 msgid "User interface for Linux servers"
 msgstr "Linux サーバーのユーザーインターフェース"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "ユーザー名"
@@ -8634,8 +8785,8 @@ msgstr "ユーザー名は空にできません"
 msgid "User or Group"
 msgstr "ユーザーまたはグループ"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "ユーザー名"
 
@@ -8795,9 +8946,9 @@ msgid "Verifying"
 msgstr "検証中"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "バージョン"
 
@@ -8859,8 +9010,8 @@ msgstr "ボリュームグループ"
 msgid "Volume ID"
 msgstr "ボリューム ID"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "ボリューム名"
 
@@ -8868,9 +9019,8 @@ msgstr "ボリューム名"
 msgid "Volume Type"
 msgstr "ボリュームタイプ"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "ボリューム"
@@ -8890,7 +9040,8 @@ msgstr "詳細を待機中 ..."
 
 #: pkg/apps/utils.jsx:62
 msgid "Waiting for other programs to finish using the package manager..."
-msgstr "パッケージマネージャーを使用して、その他のプログラムを終了するのを待機中..."
+msgstr ""
+"パッケージマネージャーを使用して、その他のプログラムを終了するのを待機中..."
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:140
 #: pkg/lib/cockpit-components-install-dialog.jsx:175
@@ -8966,8 +9117,8 @@ msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
 msgstr ""
-"{{#strong}}{{host}}{{/strong}} "
-"に接続されていますが、ユーザーを同期するには、スーパーユーザー権限を持つユーザーが必要です。"
+"{{#strong}}{{host}}{{/strong}} に接続されていますが、ユーザーを同期するには、"
+"スーパーユーザー権限を持つユーザーが必要です。"
 
 #: pkg/dashboard/list.js:431
 msgid ""
@@ -8982,7 +9133,9 @@ msgstr "ファイアウォールを修正する権限がありません。"
 msgid ""
 "You can bypass the certificate check, but any data you send to the server "
 "could be intercepted by others."
-msgstr "証明書チェックを省略できますが、サーバーに送信したデータは他者によって取得されることがあります。"
+msgstr ""
+"証明書チェックを省略できますが、サーバーに送信したデータは他者によって取得さ"
+"れることがあります。"
 
 #: pkg/kubernetes/views/dashboard-page.html:150
 msgid "You can deploy an application to your cluster."
@@ -9015,13 +9168,17 @@ msgstr "ブラウザーが、iframe をサポートしません。"
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
-msgstr "ブラウザーが切断されますが、更新プロセスへの影響はありません。すぐに再接続して進捗確認を継続できます。"
+msgstr ""
+"ブラウザーが切断されますが、更新プロセスへの影響はありません。すぐに再接続し"
+"て進捗確認を継続できます。"
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:112
 msgid ""
 "Your login credentials do not give you access to use the docker registry "
 "from the command line."
-msgstr "ログイン資格情報は、コマンドラインから docker レジストリーを使用するアクセスを提供しません。"
+msgstr ""
+"ログイン資格情報は、コマンドラインから docker レジストリーを使用するアクセス"
+"を提供しません。"
 
 #: pkg/packagekit/updates.jsx:889
 msgid ""
@@ -9162,7 +9319,7 @@ msgstr "hostdev"
 msgid "iSCSI"
 msgstr "iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr "iSCSI ターゲット"
 
@@ -9237,10 +9394,10 @@ msgstr "稼動していません"
 msgid "non responsive"
 msgstr "応答しません"
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9257,15 +9414,16 @@ msgstr "oVirt ホストの状態:"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:35
 msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr "引数がないため、oVirt プロバイダーのインストールスクリプトに失敗しました。"
+msgstr ""
+"引数がないため、oVirt プロバイダーのインストールスクリプトに失敗しました。"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:36
 msgid ""
 "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
 "machines-ovirt.config, try as root."
 msgstr ""
-"oVirt プロバイダーのインストールスクリプトに失敗しました。/etc/cockpit/machines-ovirt.config "
-"に書き込めません。root で試行してください。"
+"oVirt プロバイダーのインストールスクリプトに失敗しました。/etc/cockpit/"
+"machines-ovirt.config に書き込めません。root で試行してください。"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:164
 msgid "oVirt installation script failed with following output: "
@@ -9416,7 +9574,7 @@ msgstr "udp"
 msgid "unassigned"
 msgstr "未割り当て"
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "未定義"
 
@@ -9482,5 +9640,5 @@ msgid ""
 "{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
 "count: {{ condition.generation }}"
 msgstr ""
-"{{ condition.message }}。タイムスタンプ: {{ condition.lastTransitionTime }} エラー数: {{ "
-"condition.generation }}"
+"{{ condition.message }}。タイムスタンプ: {{ condition.lastTransitionTime }} "
+"エラー数: {{ condition.generation }}"

--- a/po/ko.po
+++ b/po/ko.po
@@ -6,14 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2017-02-24 04:55+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Korean\n"
 "Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
@@ -75,7 +75,7 @@ msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] ""
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -182,7 +182,7 @@ msgid "$0 update"
 msgid_plural "$0 updates"
 msgstr[0] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -206,7 +206,6 @@ msgid_plural "$0 years"
 msgstr[0] ""
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] ""
@@ -553,7 +552,7 @@ msgid "Access"
 msgstr ""
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr ""
 
@@ -617,7 +616,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -638,11 +637,11 @@ msgstr "적응형 전송 로드 밸런싱"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "추가"
 
@@ -805,7 +804,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "주소"
 
@@ -923,8 +922,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -933,8 +932,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr ""
 
@@ -942,11 +941,11 @@ msgstr ""
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "적용"
 
@@ -995,8 +994,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr "최소 $0 개의 디스크가 필요합니다."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "최소 1개의 디스크가 필요합니다."
 
@@ -1016,9 +1015,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr "인증 중입니다"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr ""
 
@@ -1034,13 +1033,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "작성자"
 
@@ -1097,7 +1096,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1125,7 +1124,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1248,10 +1247,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1317,7 +1316,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1329,27 +1327,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "취소"
 
@@ -1370,7 +1368,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr ""
@@ -1390,11 +1388,11 @@ msgid "Ceph Monitors"
 msgstr "리포지터리 "
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1422,7 +1420,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1534,16 +1532,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "닫기"
 
@@ -1551,7 +1550,7 @@ msgstr "닫기"
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 #, fuzzy
 msgid "Cluster"
@@ -1630,10 +1629,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1671,7 +1670,7 @@ msgstr[0] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "명령"
 
@@ -1716,8 +1715,8 @@ msgstr "최신 시스템과 2TB 이상의 하드 디스크와 호환됩니다 (G
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1920,7 +1919,9 @@ msgstr ""
 #: pkg/docker/util.js:498
 msgid ""
 "Container is currently marked as not running, but regular stopping failed."
-msgstr "컨테이너는 현재 실행중이지 않은 것으로 보이지만, 정상적인 종료가 되지 않았습니다."
+msgstr ""
+"컨테이너는 현재 실행중이지 않은 것으로 보이지만, 정상적인 종료가 되지 않았습"
+"니다."
 
 #: pkg/docker/util.js:496
 msgid "Container is currently running."
@@ -1931,10 +1932,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "컨테이너들"
 
@@ -2047,10 +2049,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "생성"
 
@@ -2153,12 +2155,13 @@ msgstr "$0에 파티션 만들기"
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2278,7 +2281,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2298,7 +2301,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2323,12 +2326,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2406,7 +2408,7 @@ msgstr "RAID 장치를 제거하면 내부의 모든 데이터를 지우게 됩�
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "컨테이너를 삭제하시면, 내부의 모든 데이터도 함께 삭제됩니다. "
 
@@ -2453,14 +2455,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2473,10 +2475,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2567,9 +2569,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr ""
 
@@ -2617,8 +2619,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2732,7 +2734,7 @@ msgstr "alias 복제"
 msgid "Duplicate port"
 msgstr "포트 복제"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2891,7 +2893,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2917,9 +2919,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr ""
 
@@ -3007,7 +3009,7 @@ msgstr "실패하였습니다"
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
@@ -3075,7 +3077,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3083,6 +3084,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 #, fuzzy
 msgid "Filesystem Type"
 msgstr "파일 시스템 옵션"
@@ -3099,7 +3101,7 @@ msgstr ""
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3221,7 +3223,7 @@ msgstr "일반"
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3286,9 +3288,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3349,9 +3351,9 @@ msgstr "Hello 시간 $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "호스트"
 
@@ -3392,8 +3394,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3435,7 +3437,7 @@ msgstr ""
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3526,11 +3528,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3605,7 +3606,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3621,9 +3622,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3671,7 +3672,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3684,8 +3685,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 #, fuzzy
 msgid "Interface"
 msgstr "인터페이스"
@@ -3711,11 +3712,11 @@ msgstr "잘못된 포트"
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3766,7 +3767,7 @@ msgstr "잘못된 포트"
 msgid "Invalid prefix or netmask $0"
 msgstr "잘못된 포트"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3774,7 +3775,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3893,11 +3894,12 @@ msgstr "Kubernetes 클러스터"
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3942,8 +3944,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -3971,7 +3973,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4034,8 +4035,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -4113,17 +4114,17 @@ msgstr ""
 msgid "Logged In"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 #, fuzzy
 msgid "Logical Unit Number"
 msgstr "논리 볼륨"
@@ -4321,9 +4322,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4355,8 +4357,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4371,7 +4373,7 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4452,8 +4454,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4462,17 +4464,17 @@ msgstr ""
 msgid "Mount Location"
 msgstr "마운트 옵션"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "마운트 옵션"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "마운트 포인트"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4496,7 +4498,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4560,37 +4562,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "이름"
 
@@ -4624,7 +4627,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4635,6 +4637,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "네임스페이스"
@@ -4648,8 +4651,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "네트워크"
 
@@ -4715,8 +4718,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4724,7 +4727,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4734,7 +4737,7 @@ msgstr ""
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "다음"
 
@@ -4852,9 +4855,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4883,7 +4886,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr "찾을 수 없습니다."
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4891,7 +4894,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4899,7 +4902,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -4933,7 +4936,9 @@ msgstr ""
 #: pkg/kubernetes/scripts/dashboard.js:384
 msgid ""
 "No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr "메타데이터 파일이 선택되지 않았습니다. Kubernetes 메타데이터 파일을 선택하세요."
+msgstr ""
+"메타데이터 파일이 선택되지 않았습니다. Kubernetes 메타데이터 파일을 선택하세"
+"요."
 
 #: pkg/machines/vmnetworktab.jsx:31
 msgid "No network interfaces defined for this VM"
@@ -5047,9 +5052,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5060,7 +5065,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr ""
 
@@ -5103,8 +5108,8 @@ msgstr "사용할 수 없습니다"
 msgid "Not connected"
 msgstr "연결 해제됨"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5120,7 +5125,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5148,8 +5153,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5182,8 +5187,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "비활성"
 
@@ -5199,14 +5204,14 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "활성"
 
@@ -5390,11 +5395,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5433,10 +5439,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 #, fuzzy
 msgid "Path"
 msgstr "Path cost"
@@ -5501,7 +5507,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5533,8 +5539,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5767,9 +5773,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5785,7 +5790,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "포트"
 
@@ -5867,7 +5872,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5881,7 +5886,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5893,6 +5897,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "프로젝트"
@@ -5921,10 +5926,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5956,7 +5961,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -5984,8 +5989,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -6049,7 +6054,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "RAID 장치 $0"
 
@@ -6085,7 +6090,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6097,6 +6101,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 #, fuzzy
 msgid "Read Only"
 msgstr "준비됨"
@@ -6163,7 +6168,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr ""
 
@@ -6219,8 +6224,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6249,8 +6254,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
@@ -6291,9 +6296,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
@@ -6346,7 +6351,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6414,10 +6419,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "Replicas"
 
@@ -6531,8 +6536,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr ""
 
@@ -6582,8 +6587,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6638,7 +6642,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "작동중"
 
@@ -6726,8 +6730,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6782,7 +6786,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6814,8 +6818,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6836,15 +6840,14 @@ msgstr "전송 중입니다"
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6852,7 +6855,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6871,7 +6874,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -6921,7 +6924,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 #, fuzzy
 msgid "Session"
 msgstr "버전"
@@ -7061,7 +7064,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7082,34 +7085,34 @@ msgstr ""
 msgid "Since $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr ""
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr ""
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7203,7 +7206,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr ""
@@ -7244,10 +7247,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
@@ -7269,10 +7272,11 @@ msgid "Static"
 msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7295,7 +7299,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7528,7 +7532,7 @@ msgstr "태그"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7550,7 +7554,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7682,8 +7686,8 @@ msgstr "주소에 잘못된 문자가 있습니다 "
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7718,11 +7722,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7734,9 +7738,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7745,14 +7748,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7853,11 +7855,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7943,8 +7945,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -8000,13 +8001,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -8016,17 +8017,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -8036,7 +8037,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8056,7 +8057,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8125,9 +8126,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8286,11 +8287,11 @@ msgstr ""
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr ""
@@ -8353,7 +8354,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8400,23 +8401,23 @@ msgstr "예상치 못한 오류"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "알 수 없음"
 
@@ -8440,7 +8441,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr "알 수 없는 설정"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8486,7 +8487,7 @@ msgstr ""
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr ""
 
@@ -8576,7 +8577,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8624,13 +8625,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
@@ -8641,10 +8642,10 @@ msgstr "컨테이너들"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8663,7 +8664,7 @@ msgstr ""
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr ""
@@ -8676,8 +8677,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 #, fuzzy
 msgid "Username"
 msgstr "사용자 이름"
@@ -8838,9 +8839,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "버전"
 
@@ -8903,8 +8904,8 @@ msgstr ""
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 #, fuzzy
 msgid "Volume Name"
 msgstr "사용자 이름"
@@ -8914,9 +8915,8 @@ msgstr "사용자 이름"
 msgid "Volume Type"
 msgstr "볼륨 그룹 $0"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9211,7 +9211,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9286,10 +9286,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9466,7 +9466,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 

--- a/po/my.po
+++ b/po/my.po
@@ -5,14 +5,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2017-06-03 01:04+0000\n"
 "Last-Translator: cockpit <cockpituous@gmail.com>\n"
 "Language-Team: Burmese\n"
 "Language: my\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
@@ -74,7 +74,7 @@ msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] ""
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -181,7 +181,7 @@ msgid "$0 update"
 msgid_plural "$0 updates"
 msgstr[0] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -205,7 +205,6 @@ msgid_plural "$0 years"
 msgstr[0] ""
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] ""
@@ -552,7 +551,7 @@ msgid "Access"
 msgstr ""
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr ""
 
@@ -616,7 +615,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -637,11 +636,11 @@ msgstr ""
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr ""
 
@@ -801,7 +800,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr ""
 
@@ -918,8 +917,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -928,8 +927,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr ""
 
@@ -937,11 +936,11 @@ msgstr ""
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr ""
 
@@ -990,8 +989,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr ""
 
@@ -1011,9 +1010,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr ""
 
@@ -1029,13 +1028,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "ေရးသူ"
 
@@ -1092,7 +1091,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1120,7 +1119,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1243,10 +1242,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1311,7 +1310,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1323,27 +1321,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr ""
 
@@ -1364,7 +1362,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr ""
@@ -1382,11 +1380,11 @@ msgid "Ceph Monitors"
 msgstr ""
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1414,7 +1412,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1525,16 +1523,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "ပိတ္ပါ။"
 
@@ -1542,7 +1541,7 @@ msgstr "ပိတ္ပါ။"
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr ""
@@ -1620,10 +1619,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1661,7 +1660,7 @@ msgstr[0] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr ""
 
@@ -1706,8 +1705,8 @@ msgstr ""
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1917,10 +1916,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr ""
 
@@ -2033,10 +2033,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr ""
 
@@ -2138,12 +2138,13 @@ msgstr ""
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2263,7 +2264,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2283,7 +2284,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2308,12 +2309,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2389,11 +2389,9 @@ msgstr ""
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
-msgstr ""
-"Container ကို ဖျက်ဆီးခြင်းသည် ၄င်းထဲတွင်ရှိသော အချက်အလက်များအားလုံးကိုပါ "
-"ဖျက်ဆီးပစ်လိမ့်မည်။"
+msgstr "Container ကို ဖျက်ဆီးခြင်းသည် ၄င်းထဲတွင်ရှိသော အချက်အလက်များအားလုံးကိုပါ ဖျက်ဆီးပစ်လိမ့်မည်။"
 
 #: pkg/storaged/content-views.jsx:264
 msgid "Deleting a logical volume will delete all data in it."
@@ -2438,14 +2436,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2458,10 +2456,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2470,7 +2468,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2551,9 +2549,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr ""
 
@@ -2601,8 +2599,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2715,7 +2713,7 @@ msgstr ""
 msgid "Duplicate port"
 msgstr "Port ထပ်နေသည်။"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2874,7 +2872,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2900,9 +2898,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr ""
 
@@ -2990,7 +2988,7 @@ msgstr ""
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
@@ -3055,7 +3053,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3063,6 +3060,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3078,7 +3076,7 @@ msgstr ""
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3199,7 +3197,7 @@ msgstr ""
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3262,9 +3260,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3325,9 +3323,9 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Host"
 
@@ -3367,8 +3365,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3408,7 +3406,7 @@ msgstr ""
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3497,11 +3495,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3575,7 +3572,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3591,9 +3588,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3641,7 +3638,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3654,8 +3651,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr ""
 
@@ -3679,11 +3676,11 @@ msgstr ""
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3731,7 +3728,7 @@ msgstr ""
 msgid "Invalid prefix or netmask $0"
 msgstr ""
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3739,7 +3736,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3857,11 +3854,12 @@ msgstr ""
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3906,8 +3904,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -3935,7 +3933,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -3998,8 +3995,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -4075,17 +4072,17 @@ msgstr ""
 msgid "Logged In"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4280,9 +4277,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4314,8 +4312,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4330,7 +4328,7 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4410,8 +4408,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4419,17 +4417,17 @@ msgstr ""
 msgid "Mount Location"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4453,7 +4451,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4517,37 +4515,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "အမည်"
 
@@ -4581,7 +4580,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4592,6 +4590,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
@@ -4605,8 +4604,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "ကွန်ယက်"
 
@@ -4672,8 +4671,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4681,7 +4680,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4691,7 +4690,7 @@ msgstr ""
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr ""
 
@@ -4806,9 +4805,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4836,7 +4835,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4844,7 +4843,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4852,7 +4851,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5000,9 +4999,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5013,7 +5012,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr ""
 
@@ -5055,8 +5054,8 @@ msgstr "မရနိင်"
 msgid "Not connected"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5072,7 +5071,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5100,8 +5099,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5133,8 +5132,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "ဖွင့်"
 
@@ -5150,14 +5149,14 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "ပိတ်"
 
@@ -5339,11 +5338,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5382,10 +5382,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr ""
 
@@ -5449,7 +5449,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5481,8 +5481,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5699,9 +5699,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5717,7 +5716,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Ports"
 
@@ -5799,7 +5798,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5813,7 +5812,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5825,6 +5823,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Project"
@@ -5853,10 +5852,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5888,7 +5887,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -5916,8 +5915,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -5981,7 +5980,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr ""
 
@@ -6017,7 +6016,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6029,6 +6027,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr ""
 
@@ -6093,7 +6092,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr ""
 
@@ -6149,8 +6148,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6178,8 +6177,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
@@ -6220,9 +6219,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
@@ -6274,7 +6273,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6342,10 +6341,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
@@ -6457,8 +6456,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr ""
 
@@ -6507,8 +6506,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6562,7 +6560,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "Running"
 
@@ -6650,8 +6648,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6704,7 +6702,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6736,8 +6734,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6758,15 +6756,14 @@ msgstr "ပို့နေသည်"
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6774,7 +6771,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6793,7 +6790,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -6842,7 +6839,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr ""
 
@@ -6978,7 +6975,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -6999,34 +6996,34 @@ msgstr ""
 msgid "Since $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr ""
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr ""
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7120,7 +7117,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr ""
@@ -7161,10 +7158,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
@@ -7186,10 +7183,11 @@ msgid "Static"
 msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7212,7 +7210,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7445,7 +7443,7 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7467,7 +7465,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7598,8 +7596,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7634,11 +7632,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7650,9 +7648,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7661,14 +7658,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7769,11 +7765,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7821,9 +7817,7 @@ msgstr ""
 
 #: pkg/dashboard/list.js:213
 msgid "The user <b>$0</b> is not permitted to manage servers"
-msgstr ""
-"<b>$0</b> ဟူသော အသုံးပြုသူသည် Server များကိုစီမံကွပ်ကဲရန် "
-"ခွင့်ထားခြင်းမရှိပါ။"
+msgstr "<b>$0</b> ဟူသော အသုံးပြုသူသည် Server များကိုစီမံကွပ်ကဲရန် ခွင့်ထားခြင်းမရှိပါ။"
 
 #: pkg/storaged/storage-controls.jsx:65
 msgid "The user <b>$0</b> is not permitted to manage storage"
@@ -7861,8 +7855,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -7918,13 +7911,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -7934,17 +7927,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -7954,7 +7947,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -7974,7 +7967,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8043,9 +8036,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8204,11 +8197,11 @@ msgstr "လုပ်ဆောင်ခြင်းမရှိပါ။"
 msgid "Tuned is off"
 msgstr "ပိတ်ထားသည်"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr ""
@@ -8271,7 +8264,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8317,23 +8310,23 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr ""
 
@@ -8357,7 +8350,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8402,7 +8395,7 @@ msgstr ""
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr ""
 
@@ -8492,7 +8485,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8540,13 +8533,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
@@ -8556,10 +8549,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8578,7 +8571,7 @@ msgstr ""
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr ""
@@ -8591,8 +8584,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr ""
 
@@ -8752,9 +8745,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr ""
 
@@ -8816,8 +8809,8 @@ msgstr ""
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr ""
 
@@ -8825,9 +8818,8 @@ msgstr ""
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -8927,8 +8919,7 @@ msgstr ""
 #: pkg/dashboard/list.js:431
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
-msgstr ""
-"သင်သည် ယခု Server သို့ တိုက်ရိုက်ချိတ်ဆက်ထားသောကြောင့် ၄င်းအား ဖျက်ပစ်၍မရပါ။"
+msgstr "သင်သည် ယခု Server သို့ တိုက်ရိုက်ချိတ်ဆက်ထားသောကြောင့် ၄င်းအား ဖျက်ပစ်၍မရပါ။"
 
 #: pkg/networkmanager/firewall.jsx:65 pkg/networkmanager/firewall.jsx:300
 msgid "You are not authorized to modify the firewall."
@@ -9118,7 +9109,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9193,10 +9184,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9370,7 +9361,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -3,14 +3,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2017-08-23 04:21+0000\n"
 "Last-Translator: Toon van Gerwen <translation@vgerwen.nl>\n"
 "Language-Team: Dutch\n"
 "Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -49,8 +49,8 @@ msgid ""
 "This may also effect other services as DNS resolution settings and the list "
 "of trusted CAs may change."
 msgstr ""
-"$ 0 Alleen gebruikers met lokale referenties kunnen inloggen op deze machine."
-" Dit kan ook invloed hebben op andere diensten als DNS-resolutie "
+"$ 0 Alleen gebruikers met lokale referenties kunnen inloggen op deze "
+"machine. Dit kan ook invloed hebben op andere diensten als DNS-resolutie "
 "instellingen en de lijst met vertrouwde CA's kan veranderen."
 
 #: pkg/systemd/init.js:377 pkg/systemd/init.js:711
@@ -78,7 +78,7 @@ msgid_plural "$0 bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -193,7 +193,7 @@ msgid_plural "$0 updates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -219,7 +219,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] ""
@@ -572,7 +571,7 @@ msgid "Access"
 msgstr ""
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr ""
 
@@ -636,7 +635,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -657,11 +656,11 @@ msgstr ""
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr ""
 
@@ -821,7 +820,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr ""
 
@@ -940,8 +939,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -950,8 +949,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr ""
 
@@ -959,11 +958,11 @@ msgstr ""
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr ""
 
@@ -1012,8 +1011,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr "Minimaal $0 schijven zijn noodzakelijk."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Minimaal een schijf is noodzakelijk."
 
@@ -1033,9 +1032,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr ""
 
@@ -1051,13 +1050,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr ""
 
@@ -1114,7 +1113,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1142,7 +1141,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1265,10 +1264,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr ""
 
@@ -1333,7 +1332,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1345,27 +1343,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr ""
 
@@ -1386,7 +1384,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr ""
@@ -1404,11 +1402,11 @@ msgid "Ceph Monitors"
 msgstr ""
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1436,7 +1434,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1547,16 +1545,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr ""
 
@@ -1564,7 +1563,7 @@ msgstr ""
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr ""
@@ -1642,10 +1641,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1684,7 +1683,7 @@ msgstr[1] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr ""
 
@@ -1729,8 +1728,8 @@ msgstr "Verenigbaar met moderne systemen en harde schijven > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1940,10 +1939,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr ""
 
@@ -2056,10 +2056,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr ""
 
@@ -2161,12 +2161,13 @@ msgstr ""
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2286,7 +2287,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2306,7 +2307,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2331,12 +2332,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2412,7 +2412,7 @@ msgstr ""
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 
@@ -2459,14 +2459,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2479,10 +2479,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2491,7 +2491,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2572,9 +2572,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Schijven"
 
@@ -2627,8 +2627,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 "Wil je de role '{{ fields.displayRole }}' van lid {{ fields.member.metadata."
 "name }} verwijderen?"
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "Duplicate port"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2902,7 +2902,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2928,9 +2928,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr ""
 
@@ -3018,7 +3018,7 @@ msgstr ""
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
@@ -3083,7 +3083,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3091,6 +3090,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3106,7 +3106,7 @@ msgstr ""
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3227,7 +3227,7 @@ msgstr ""
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3290,9 +3290,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3353,9 +3353,9 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr ""
 
@@ -3395,8 +3395,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3436,7 +3436,7 @@ msgstr ""
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3525,11 +3525,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3603,7 +3602,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3619,9 +3618,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3669,7 +3668,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3682,8 +3681,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr ""
 
@@ -3707,11 +3706,11 @@ msgstr ""
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3759,7 +3758,7 @@ msgstr ""
 msgid "Invalid prefix or netmask $0"
 msgstr ""
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3767,7 +3766,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3885,11 +3884,12 @@ msgstr ""
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3934,8 +3934,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -3963,7 +3963,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4026,8 +4025,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -4103,17 +4102,17 @@ msgstr ""
 msgid "Logged In"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4308,9 +4307,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4342,8 +4342,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4358,7 +4358,7 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4438,8 +4438,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4447,17 +4447,17 @@ msgstr ""
 msgid "Mount Location"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4481,7 +4481,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4545,37 +4545,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr ""
 
@@ -4609,7 +4610,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4620,6 +4620,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
@@ -4633,8 +4634,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr ""
 
@@ -4700,8 +4701,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4709,7 +4710,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4719,7 +4720,7 @@ msgstr ""
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr ""
 
@@ -4834,9 +4835,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr "Geen schijven beschikbaar."
 
@@ -4864,7 +4865,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4872,7 +4873,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4880,7 +4881,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5028,9 +5029,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5041,7 +5042,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr ""
 
@@ -5083,8 +5084,8 @@ msgstr ""
 msgid "Not connected"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5100,7 +5101,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5128,8 +5129,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5161,8 +5162,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr ""
 
@@ -5178,14 +5179,14 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr ""
 
@@ -5368,11 +5369,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5411,10 +5413,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr ""
 
@@ -5478,7 +5480,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5510,8 +5512,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5728,9 +5730,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5746,7 +5747,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr ""
 
@@ -5828,7 +5829,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5842,7 +5843,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5854,6 +5854,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr ""
@@ -5882,10 +5883,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5917,7 +5918,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -5945,8 +5946,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -6010,7 +6011,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr ""
 
@@ -6046,7 +6047,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6058,6 +6058,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr ""
 
@@ -6122,7 +6123,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr ""
 
@@ -6178,8 +6179,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6207,8 +6208,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
@@ -6249,9 +6250,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
@@ -6303,7 +6304,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6371,10 +6372,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
@@ -6486,8 +6487,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr ""
 
@@ -6536,8 +6537,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr ""
 
@@ -6679,8 +6679,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6733,7 +6733,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6765,8 +6765,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6787,15 +6787,14 @@ msgstr ""
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6803,7 +6802,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6822,7 +6821,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -6871,7 +6870,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr ""
 
@@ -7007,7 +7006,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7028,34 +7027,34 @@ msgstr ""
 msgid "Since $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr ""
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr ""
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7149,7 +7148,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr ""
@@ -7190,10 +7189,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
@@ -7215,10 +7214,11 @@ msgid "Static"
 msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7241,7 +7241,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7474,7 +7474,7 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7496,7 +7496,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7630,8 +7630,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7666,11 +7666,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7682,9 +7682,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7693,14 +7692,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7801,11 +7799,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7891,8 +7889,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -7948,13 +7945,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -7964,17 +7961,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -7984,7 +7981,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8004,7 +8001,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8073,9 +8070,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8234,11 +8231,11 @@ msgstr ""
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr ""
@@ -8301,7 +8298,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8347,23 +8344,23 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr ""
 
@@ -8387,7 +8384,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8432,7 +8429,7 @@ msgstr ""
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr ""
 
@@ -8522,7 +8519,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8573,13 +8570,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
@@ -8589,10 +8586,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8611,7 +8608,7 @@ msgstr ""
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr ""
@@ -8624,8 +8621,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr ""
 
@@ -8785,9 +8782,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr ""
 
@@ -8849,8 +8846,8 @@ msgstr ""
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr ""
 
@@ -8858,9 +8855,8 @@ msgstr ""
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9150,7 +9146,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9225,10 +9221,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9403,7 +9399,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -4,14 +4,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2017-05-12 11:11+0000\n"
 "Last-Translator: A S Alam <aalam@fedoraproject.org>\n"
 "Language-Team: Punjabi\n"
 "Language: pa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -76,7 +76,7 @@ msgid_plural "$0 bytes"
 msgstr[0] "$0 ਬਾਈਟ"
 msgstr[1] "$0 ਬਾਈਟ"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -191,7 +191,7 @@ msgid_plural "$0 updates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -217,7 +217,6 @@ msgstr[0] "$0 ਸਾਲ"
 msgstr[1] "$0 ਸਾਲ"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% ਖਾਲੀ"
@@ -568,7 +567,7 @@ msgid "Access"
 msgstr "ਪਹੁੰਚ"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "ਪਹੁੰਚ ਢੰਗ"
 
@@ -632,7 +631,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -653,11 +652,11 @@ msgstr ""
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "ਜੋੜੋ"
 
@@ -817,7 +816,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr ""
 
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -944,8 +943,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr ""
 
@@ -953,11 +952,11 @@ msgstr ""
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr ""
 
@@ -1006,8 +1005,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr ""
 
@@ -1027,9 +1026,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr ""
 
@@ -1045,13 +1044,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr ""
 
@@ -1108,7 +1107,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1136,7 +1135,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1259,10 +1258,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr ""
 
@@ -1327,7 +1326,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1339,27 +1337,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr ""
 
@@ -1380,7 +1378,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr ""
@@ -1398,11 +1396,11 @@ msgid "Ceph Monitors"
 msgstr ""
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1430,7 +1428,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1541,16 +1539,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr ""
 
@@ -1558,7 +1557,7 @@ msgstr ""
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr ""
@@ -1636,10 +1635,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1678,7 +1677,7 @@ msgstr[1] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr ""
 
@@ -1723,8 +1722,8 @@ msgstr ""
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1934,10 +1933,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr ""
 
@@ -2050,10 +2050,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr ""
 
@@ -2155,12 +2155,13 @@ msgstr ""
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2280,7 +2281,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2300,7 +2301,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2325,12 +2326,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2406,7 +2406,7 @@ msgstr ""
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 
@@ -2453,14 +2453,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2473,10 +2473,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2566,9 +2566,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr ""
 
@@ -2616,8 +2616,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2730,7 +2730,7 @@ msgstr ""
 msgid "Duplicate port"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2889,7 +2889,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2915,9 +2915,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr ""
 
@@ -3005,7 +3005,7 @@ msgstr ""
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
@@ -3070,7 +3070,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3078,6 +3077,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3093,7 +3093,7 @@ msgstr "ਫਾਇਲ-ਸਿਸਟਮ"
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3277,9 +3277,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3340,9 +3340,9 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr ""
 
@@ -3382,8 +3382,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgstr ""
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3512,11 +3512,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3590,7 +3589,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3606,9 +3605,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3656,7 +3655,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3669,8 +3668,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr ""
 
@@ -3694,11 +3693,11 @@ msgstr ""
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3746,7 +3745,7 @@ msgstr ""
 msgid "Invalid prefix or netmask $0"
 msgstr ""
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3754,7 +3753,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3872,11 +3871,12 @@ msgstr ""
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3921,8 +3921,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -3950,7 +3950,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4013,8 +4012,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "...ਲੋਡ ਕਰ ਰਿਹਾ ਹੈ"
 
@@ -4090,17 +4089,17 @@ msgstr ""
 msgid "Logged In"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4295,9 +4294,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4329,8 +4329,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4345,7 +4345,7 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4425,8 +4425,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4434,17 +4434,17 @@ msgstr ""
 msgid "Mount Location"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "ਮਾਊਸ ਪੁਆਇੰਟ"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4468,7 +4468,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4532,37 +4532,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "ਨਾਂ"
 
@@ -4596,7 +4597,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4607,6 +4607,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
@@ -4620,8 +4621,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr ""
 
@@ -4687,8 +4688,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4696,7 +4697,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4706,7 +4707,7 @@ msgstr ""
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr ""
 
@@ -4821,9 +4822,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4851,7 +4852,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4859,7 +4860,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4867,7 +4868,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5015,9 +5016,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5028,7 +5029,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr ""
 
@@ -5070,8 +5071,8 @@ msgstr ""
 msgid "Not connected"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5087,7 +5088,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5115,8 +5116,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5148,8 +5149,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr ""
 
@@ -5165,14 +5166,14 @@ msgstr "ਪੁਰਾਣਾ ਪਾਸਵਰਡ"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr ""
 
@@ -5355,11 +5356,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5398,10 +5400,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr ""
 
@@ -5465,7 +5467,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5497,8 +5499,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5715,9 +5717,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5733,7 +5734,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr ""
 
@@ -5815,7 +5816,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5829,7 +5830,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5841,6 +5841,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr ""
@@ -5869,10 +5870,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5904,7 +5905,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -5932,8 +5933,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -5997,7 +5998,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "ਰੇਡ ਡਿਵਾਇਸ"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr ""
 
@@ -6033,7 +6034,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6045,6 +6045,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr ""
 
@@ -6109,7 +6110,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "ਮੁਡ਼ ਚਾਲੂ ਕਰੋ"
 
@@ -6165,8 +6166,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6194,8 +6195,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
@@ -6236,9 +6237,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
@@ -6290,7 +6291,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6358,10 +6359,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
@@ -6473,8 +6474,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr ""
 
@@ -6523,8 +6524,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6578,7 +6578,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr ""
 
@@ -6666,8 +6666,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6720,7 +6720,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6752,8 +6752,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6774,15 +6774,14 @@ msgstr ""
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6790,7 +6789,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6809,7 +6808,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -6858,7 +6857,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr ""
 
@@ -6994,7 +6993,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr "ਫਿੰਗਰਪਰਿੰਟ ਵੇਖੋ"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7015,34 +7014,34 @@ msgstr "ਇਸ ਤੋਂ"
 msgid "Since $0"
 msgstr "$0 ਤੋਂ"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "ਆਕਾਰ"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "ਆਕਾਰ ਸਿਫ਼ਰ ਤੋਂ ਘੱਟ ਨਹੀਂ ਹੋ ਸਕਦਾ"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "ਆਕਾਰ ਸਿਫ਼ਰ ਨਹੀਂ ਹੋ ਸਕਦਾ"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr "ਆਕਾਰ ਬਹੁਤ ਵੱਡਾ ਹੈ"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "ਆਕਾਰ ਨੰਬਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7136,7 +7135,7 @@ msgid "Stable"
 msgstr "ਸਥਿਰ"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "ਸ਼ੁਰੂ ਕਰੋ"
@@ -7177,10 +7176,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "ਹਾਲਤ"
 
@@ -7202,10 +7201,11 @@ msgid "Static"
 msgstr "ਸਥਿਰ"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7228,7 +7228,7 @@ msgid "Sticky"
 msgstr "ਸਟਿੱਕੀ"
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7461,7 +7461,7 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7483,7 +7483,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7614,8 +7614,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7650,11 +7650,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7666,9 +7666,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7677,14 +7676,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7785,11 +7783,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7875,8 +7873,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -7932,13 +7929,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -7948,17 +7945,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -7968,7 +7965,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -7988,7 +7985,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8057,9 +8054,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8218,11 +8215,11 @@ msgstr ""
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "ਕਿਸਮ"
@@ -8285,7 +8282,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8331,23 +8328,23 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr ""
 
@@ -8371,7 +8368,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8416,7 +8413,7 @@ msgstr ""
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr ""
 
@@ -8506,7 +8503,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8555,13 +8552,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
@@ -8571,10 +8568,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8593,7 +8590,7 @@ msgstr "ਵਰਤੋਂਕਾਰ ਪਾਸਵਰਡ"
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ"
@@ -8606,8 +8603,8 @@ msgstr ""
 msgid "User or Group"
 msgstr "ਵਰਤੋਂਕਾਰ ਜਾਂ ਗਰੁੱਪ"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "ਵਰਤੋਂਕਾਰ ਨਾਂ"
 
@@ -8767,9 +8764,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "ਵਰਜ਼ਨ"
 
@@ -8831,8 +8828,8 @@ msgstr "ਵਾਲੀਅਮ ਗਰੁੱਪ"
 msgid "Volume ID"
 msgstr "ਵਾਲੀਅਮ ID"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "ਵਾਲੀਅਮ ਕਿਸਮ"
 
@@ -8840,9 +8837,8 @@ msgstr "ਵਾਲੀਅਮ ਕਿਸਮ"
 msgid "Volume Type"
 msgstr "ਵਾਲੀਅਮ ਕਿਸਮ"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "ਵਾਲੀਅਮ"
@@ -9132,7 +9128,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9207,10 +9203,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9385,7 +9381,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "ਨਾ-ਪ੍ਰਭਾਸ਼ਿਤ"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -11,14 +11,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-08-24 01:26+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Zanata 4.6.2\n"
@@ -61,7 +61,6 @@ msgstr ""
 "$0 Tylko użytkownicy z lokalnymi danymi uwierzytelniania będą mogli "
 "zalogować się do tego komputera. Może to mieć wpływ także na inne usługi, "
 "ponieważ ustawienia rozwiązywania DNS i listy zaufanych CA mogą ulec zmianie."
-""
 
 #: pkg/systemd/init.js:377 pkg/systemd/init.js:711
 msgid "$0 Template"
@@ -91,7 +90,7 @@ msgstr[0] "$0 bajt"
 msgstr[1] "$0 bajty"
 msgstr[2] "$0 bajtów"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 danych + $1 nadwyżki użyto z $2 ($3)"
 
@@ -216,7 +215,7 @@ msgstr[0] "$0 aktualizacja"
 msgstr[1] "$0 aktualizacje"
 msgstr[2] "$0 aktualizacji"
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 używanych z $1 ($2 zapisano)"
 
@@ -244,7 +243,6 @@ msgstr[1] "$0 lata"
 msgstr[2] "$0 lat"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% wolny"
@@ -602,7 +600,7 @@ msgid "Access"
 msgstr "Dostęp"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "Tryby dostępu"
 
@@ -666,7 +664,7 @@ msgid "Active Pages"
 msgstr "Aktywne strony"
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr "Aktywne od"
 
@@ -687,11 +685,11 @@ msgstr "Adaptacyjne równoważenie obciążenia przesyłu"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Dodaj"
 
@@ -853,7 +851,7 @@ msgstr "Dodatkowe pakiety:"
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adres"
 
@@ -974,8 +972,8 @@ msgstr "Dozwolone usługi"
 msgid "Always"
 msgstr "Zawsze"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Adnotacje"
@@ -986,8 +984,8 @@ msgstr ""
 "Anonimowo: umożliwia pobieranie obrazów wszystkim nieuwierzytelnionym "
 "użytkownikom"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "Aplikacje"
 
@@ -995,11 +993,11 @@ msgstr "Aplikacje"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Zastosuj"
 
@@ -1048,8 +1046,8 @@ msgstr "Etykieta zasobu"
 msgid "At least $0 disks are needed."
 msgstr "Wymagane są co najmniej $0 dyski."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Wymagany jest co najmniej jeden dysk."
 
@@ -1069,9 +1067,9 @@ msgstr "Dziennik audytu"
 msgid "Authenticating"
 msgstr "Uwierzytelnianie"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Uwierzytelnienie"
 
@@ -1087,13 +1085,13 @@ msgstr "Uwierzytelnienie się nie powiodło: serwer zamknął połączenie"
 msgid "Authentication failed"
 msgstr "Uwierzytelnienie się nie powiodło"
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "Wymagane jest uwierzytelnienie"
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Autor"
 
@@ -1150,7 +1148,7 @@ msgstr "Dostępne"
 msgid "Available Updates"
 msgstr "Dostępne aktualizacje"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr "Dostępne cele w $0"
 
@@ -1178,7 +1176,7 @@ msgstr "Wersja BIOS-u"
 msgid "Back to Accounts"
 msgstr "Wróć do kont"
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr "Urządzenie podstawowe"
 
@@ -1301,10 +1299,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr "Działanie CHANGE NETWORK STATE się nie powiodło"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "Procesor"
 
@@ -1369,7 +1367,6 @@ msgstr "Nie można wczytać obrazu"
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1381,27 +1378,27 @@ msgstr "Nie można wczytać obrazu"
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -1422,7 +1419,7 @@ msgid "Cannot schedule event in the past"
 msgstr "Nie można planować zdarzeń w przeszłości"
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "Pojemność"
@@ -1440,11 +1437,11 @@ msgid "Ceph Monitors"
 msgstr "Monitory Ceph"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "Zmień"
 
@@ -1472,7 +1469,7 @@ msgstr "Zmień czas systemu"
 msgid "Change User"
 msgstr "Zmień użytkownika"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr "Zmień nazwę inicjatora iSCSI"
 
@@ -1586,16 +1583,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr "Certyfikat klienta"
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Zamknij"
 
@@ -1603,7 +1601,7 @@ msgstr "Zamknij"
 msgid "Close Selected Pages"
 msgstr "Zamknij zaznaczone strony"
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr "Klaster"
@@ -1698,15 +1696,15 @@ msgstr "Cockpit nie może skontaktować się z {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit nie może zalogować do {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}Można spróbować {{#sync_link}}synchronizować użytkowników{{/"
-"sync_link}}.{{/can_sync}} Zaktualizowanie cockpit-ws do nowszej wersji "
-"udostępni więcej opcji uwierzytelniania i pomocy w rozwiązywaniu problemów."
+"Cockpit nie może zalogować do {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"Można spróbować {{#sync_link}}synchronizować użytkowników{{/sync_link}}.{{/"
+"can_sync}} Zaktualizowanie cockpit-ws do nowszej wersji udostępni więcej "
+"opcji uwierzytelniania i pomocy w rozwiązywaniu problemów."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1730,8 +1728,8 @@ msgid ""
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
 "Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}. Poniżej "
-"można zmienić dane uwierzytelniające. {{#can_sync}}Można też "
-"{{#sync_link}}synchronizować konta i hasła{{/sync_link}}.{{/can_sync}}"
+"można zmienić dane uwierzytelniające. {{#can_sync}}Można też {{#sync_link}}"
+"synchronizować konta i hasła{{/sync_link}}.{{/can_sync}}"
 
 #: pkg/dashboard/index.html:155 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1752,7 +1750,7 @@ msgstr[2] "Łączne użycie $0 rdzeni procesora"
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Polecenie"
 
@@ -1797,8 +1795,8 @@ msgstr "Zgodne z nowoczesnymi systemami i dyskami twardymi > 2 TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Kompresowanie zrzutów awarii, aby oszczędzać miejsce"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "Kompresja"
 
@@ -2012,10 +2010,11 @@ msgid "Container:"
 msgstr "Kontener:"
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Kontenery"
 
@@ -2130,10 +2129,10 @@ msgstr "System awarii"
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Utwórz"
 
@@ -2235,12 +2234,13 @@ msgstr "Utwórz partycję w $0"
 msgid "Create partition table"
 msgstr "Utwórz tablicę partycji"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "Utworzono"
 
@@ -2368,7 +2368,7 @@ msgstr "Domeny wyszukiwania DNS $val"
 msgid "Dashboard"
 msgstr "Panel kontrolny"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr "Użyte dane"
 
@@ -2388,7 +2388,7 @@ msgstr "Dezaktywowanie $target"
 msgid "Debug and above"
 msgstr "Debugowania i powyżej"
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr "Deduplikacja"
 
@@ -2413,12 +2413,11 @@ msgstr "Opóźnienie"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2492,14 +2491,13 @@ msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:304
 msgid "Deleting a RAID device will erase all data on it."
-msgstr ""
-"Usunięcie urządzenia RAID usunie wszystkie znajdujące się na nim dane."
+msgstr "Usunięcie urządzenia RAID usunie wszystkie znajdujące się na nim dane."
 
 #: pkg/storaged/vdo-details.jsx:193
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Usunięcie urządzenia VDO usunie wszystkie znajdujące się na nim dane."
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "Usunięcie kontenera usunie wszystkie znajdujące się w nim dane."
 
@@ -2514,8 +2512,7 @@ msgstr "Usunięcie partycji usunie wszystkie znajdujące się na niej dane."
 
 #: pkg/storaged/vgroup-details.jsx:214
 msgid "Deleting a volume group will erase all data on it."
-msgstr ""
-"Usunięcie grupy woluminów usunie wszystkie znajdujące się w niej dane."
+msgstr "Usunięcie grupy woluminów usunie wszystkie znajdujące się w niej dane."
 
 #: pkg/storaged/jobs-panel.jsx:72
 msgid "Deleting volume group $target"
@@ -2548,14 +2545,14 @@ msgstr "Konfiguracje wdrożeń"
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "Opis"
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "Opis:"
 
@@ -2568,10 +2565,10 @@ msgid "Detachable"
 msgstr "Odłączalny"
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "Szczegóły"
 
@@ -2580,7 +2577,7 @@ msgstr "Szczegóły"
 msgid "Device"
 msgstr "Urządzenie"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr "Plik urządzenia"
 
@@ -2662,9 +2659,9 @@ msgstr "Hasło dysku"
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Dyski"
 
@@ -2716,8 +2713,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 "Usunąć rolę „{{ fields.displayRole }}” z elementu {{ fields.member.metadata."
 "name }}?"
@@ -2832,7 +2829,7 @@ msgstr "Podwójny alias"
 msgid "Duplicate port"
 msgstr "Podwójny port"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr "Modyfikuj"
 
@@ -2993,7 +2990,7 @@ msgstr ""
 msgid "Entry"
 msgstr "Wpis"
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr "Punkt wejścia"
 
@@ -3019,9 +3016,9 @@ msgid "Errata:"
 msgstr "Poprawka:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Błąd"
 
@@ -3109,7 +3106,7 @@ msgstr "Niepowodzenie"
 msgid "Failed to add machine: $0"
 msgstr "Dodanie komputera się nie powiodło: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "Zmiana hasła się nie powiodła"
 
@@ -3175,7 +3172,6 @@ msgstr "Montowanie systemu plików"
 msgid "Filesystem Name"
 msgstr "Nazwa systemu plików"
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3183,6 +3179,7 @@ msgstr "Nazwa systemu plików"
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr "Typ systemu plików"
 
@@ -3198,7 +3195,7 @@ msgstr "Systemy plików"
 msgid "Filter Services"
 msgstr "Filtrowanie usług"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Odcisk"
 
@@ -3321,7 +3318,7 @@ msgstr "Ogólne"
 msgid "Generating report"
 msgstr "Tworzenie raportu"
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr "Pobierz nowy obraz"
 
@@ -3386,9 +3383,9 @@ msgstr "Grupa lub projekt"
 msgid "Groups"
 msgstr "Grupy"
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr "Powiększ"
 
@@ -3449,9 +3446,9 @@ msgstr "Czas powitania $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Gospodarz"
 
@@ -3491,8 +3488,8 @@ msgstr "Oczekiwanie wejścia/wyjścia"
 msgid "INSTALL VM action failed"
 msgstr "Działanie INSTALL VM się nie powiodło"
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr "IP"
 
@@ -3532,7 +3529,7 @@ msgstr "Ustawienia IPv6"
 msgid "ISCSI"
 msgstr "iSCSI"
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr "Identyfikator"
@@ -3621,11 +3618,10 @@ msgstr "Strumień obrazu"
 msgid "Image:"
 msgstr "Obraz:"
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr "Obrazy"
 
@@ -3674,8 +3670,7 @@ msgstr "Zsynchronizowane"
 #: pkg/kubernetes/views/registry-dashboard-page.html:81
 msgid ""
 "In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-"Aby zacząć wysyłać obrazy do rejestru, należy użyć poniższych poleceń."
+msgstr "Aby zacząć wysyłać obrazy do rejestru, należy użyć poniższych poleceń."
 
 #: pkg/kubernetes/views/registry-dashboard-page.html:6
 msgid ""
@@ -3688,8 +3683,8 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Aby synchronizować użytkowników, należy się zalogować "
-"w {{#strong}}{{host}}{{/strong}}."
+"Aby synchronizować użytkowników, należy się zalogować w {{#strong}}{{host}}"
+"{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:822 pkg/networkmanager/interfaces.js:1418
 #: pkg/networkmanager/interfaces.js:1425 pkg/networkmanager/interfaces.js:2594
@@ -3704,7 +3699,7 @@ msgstr "Nieaktywny wolumin"
 msgid "Incorrect Host Key"
 msgstr "Niepoprawny klucz komputera"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr "Pamięć indeksu"
 
@@ -3721,9 +3716,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr "Inicjowanie…"
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr "Zainstaluj"
 
@@ -3773,7 +3768,7 @@ msgstr "Zainstalowano"
 msgid "Installed products"
 msgstr "Zainstalowane produkty"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "Instalowanie"
@@ -3786,8 +3781,8 @@ msgstr "Instalowanie $0"
 msgid "Instantiate"
 msgstr "Wystąpienie"
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr "Interfejs"
 
@@ -3811,11 +3806,11 @@ msgstr "Nieprawidłowy adres $0"
 msgid "Invalid credentials"
 msgstr "Nieprawidłowe dane uwierzytelniania"
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "Nieprawidłowy format daty"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "Nieprawidłowy format daty i nieprawidłowy format czasu"
 
@@ -3863,7 +3858,7 @@ msgstr "Nieprawidłowy przedrostek $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "Nieprawidłowy przedrostek lub maska sieci $0"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "Nieprawidłowy format czasu"
 
@@ -3871,7 +3866,7 @@ msgstr "Nieprawidłowy format czasu"
 msgid "Invalid time zone"
 msgstr "Nieprawidłowa strefa czasowa"
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr "Nieprawidłowa nazwa użytkownika lub hasło"
@@ -3957,8 +3952,7 @@ msgstr "Ścieżka do bazy kluczy"
 
 #: pkg/storaged/crypto-keyslots.jsx:535
 msgid "Key slots with unknown types can not be edited here"
-msgstr ""
-"Nie można modyfikować gniazd na klucze o nieznanym typie w tym miejscu"
+msgstr "Nie można modyfikować gniazd na klucze o nieznanym typie w tym miejscu"
 
 #: pkg/storaged/crypto-keyslots.jsx:175
 msgid "Key source"
@@ -3992,11 +3986,12 @@ msgstr "Klaster Kubernetes"
 msgid "LACP Key"
 msgstr "Klucz LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Etykiety"
@@ -4041,8 +4036,8 @@ msgstr "Ostatnio zaktualizowano"
 msgid "Last checked: $0 ago"
 msgstr "Ostatnio wyszukano: $0 temu"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr "Najnowsza wersja"
 
@@ -4073,7 +4068,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Pozostawienie pustego pola spowoduje łączenie z tą maszyną jako obecnie "
 "zalogowany użytkownik {{#default_user}}({{default_user}}){{/default_user}}. "
@@ -4140,8 +4134,8 @@ msgstr "Wczytywanie dostępnych aktualizacji, proszę czekać…"
 msgid "Loading data ..."
 msgstr "Wczytywanie danych…"
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "Wczytywanie…"
 
@@ -4217,17 +4211,17 @@ msgstr "Komunikaty dziennika"
 msgid "Logged In"
 msgstr "Zalogowano"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr "Logiczny"
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr "Rozmiar logiczny"
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr "Numer jednostki logicznej"
 
@@ -4425,9 +4419,10 @@ msgstr "Członkostwo"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4459,8 +4454,8 @@ msgstr "Użycie pamięci:"
 msgid "Memory:"
 msgstr "Pamięć:"
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "Komunikat"
 
@@ -4475,7 +4470,7 @@ msgstr "Wiadomość do zalogowanych użytkowników"
 msgid "Metadata"
 msgstr "Metadane"
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr "Użyte metadane"
 
@@ -4555,8 +4550,8 @@ msgstr "Więcej informacji"
 msgid "More details"
 msgstr "Więcej informacji"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "Zamontuj"
 
@@ -4564,17 +4559,17 @@ msgstr "Zamontuj"
 msgid "Mount Location"
 msgstr "Położenie punktu montowania"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "Opcje montowania"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Punkt montowania"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr "Montowanie podczas uruchamiania"
 
@@ -4598,7 +4593,7 @@ msgstr "Punkt montowania nie może być pusty."
 msgid "Mount point must start with \"/\"."
 msgstr "Punkt montowania musi zaczynać się od „/”."
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr "Montowanie tylko do odczytu"
 
@@ -4662,37 +4657,38 @@ msgstr "Serwer NTP"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Nazwa"
 
@@ -4726,7 +4722,6 @@ msgstr "Nazwa nie może składać się tylko z pustych znaków"
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4737,6 +4732,7 @@ msgstr "Nazwa nie może składać się tylko z pustych znaków"
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "Przestrzeń nazw"
@@ -4750,8 +4746,8 @@ msgid "Need at least one NTP server"
 msgstr "Wymagany jest co najmniej jeden serwer NTP"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Sieć"
 
@@ -4817,8 +4813,8 @@ msgstr "Nowy projekt"
 msgid "New Volume Name"
 msgstr "Nazwa nowego woluminu"
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr "Nowy strumień obrazu"
 
@@ -4826,7 +4822,7 @@ msgstr "Nowy strumień obrazu"
 msgid "New passphrase"
 msgstr "Nowe hasło"
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "Nie przyjęto nowego hasła"
 
@@ -4836,7 +4832,7 @@ msgstr "Nie przyjęto nowego hasła"
 msgid "New project"
 msgstr "Nowy projekt"
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Dalej"
 
@@ -4953,9 +4949,9 @@ msgstr "Brak kontenerów pasujących do obecnego filtru"
 msgid "No description provided."
 msgstr "Nie podano opisu."
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr "Brak dostępnych dysków."
 
@@ -4983,7 +4979,7 @@ msgstr "Brak grup."
 msgid "No host keys found."
 msgstr "Nie odnaleziono kluczy komputera."
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr "Nie ustawiono żadnych celów iSCSI"
 
@@ -4991,7 +4987,7 @@ msgstr "Nie ustawiono żadnych celów iSCSI"
 msgid "No image streams are present."
 msgstr "Żadne strumienie obrazów nie są obecne."
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr "Brak obrazów"
 
@@ -4999,7 +4995,7 @@ msgstr "Brak obrazów"
 msgid "No images pushed"
 msgstr "Nie wysłano obrazów"
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr "Brak obrazów pasujących do obecnego filtru"
 
@@ -5152,9 +5148,9 @@ msgstr "Węzeł"
 msgid "Node:"
 msgstr "Węzeł:"
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr "Węzły"
 
@@ -5165,7 +5161,7 @@ msgstr "Węzły to komputery, na których działają kontenery."
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Brak"
 
@@ -5207,8 +5203,8 @@ msgstr "Niedostępne"
 msgid "Not connected"
 msgstr "Nie połączono"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr "Nie wdrożono"
 
@@ -5224,7 +5220,7 @@ msgstr "Niezamontowane"
 msgid "Not permitted to perform this action."
 msgstr "Brak uprawnień do wykonania tego działania."
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "Niedziałające"
 
@@ -5252,8 +5248,8 @@ msgstr "Uwagi i powyżej"
 msgid "Number of virtual CPUs that gonna be used."
 msgstr "Liczba wirtualnych procesorów, które będą używane."
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr "OK"
 
@@ -5285,8 +5281,8 @@ msgstr "Wystąpiło między $0 a $1"
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Wyłączone"
 
@@ -5302,14 +5298,14 @@ msgstr "Poprzednie hasło"
 msgid "Old passphrase"
 msgstr "Poprzednie hasło"
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "Nie przyjęto poprzedniego hasła"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Włączone"
 
@@ -5493,11 +5489,12 @@ msgstr "Usunięcie hasła może uniemożliwić odblokowanie $0."
 msgid "Passphrases do not match"
 msgstr "Hasła się nie zgadzają"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5538,10 +5535,10 @@ msgstr "Proszę wkleić plik JSON poniżej "
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Proszę tutaj wkleić zawartość pliku publicznego klucza SSH"
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "Ścieżka"
 
@@ -5605,7 +5602,7 @@ msgstr "Trwałe woluminy"
 msgid "Phase"
 msgstr "Faza"
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr "Fizyczny"
 
@@ -5637,8 +5634,8 @@ msgstr "Cel pingu"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5719,8 +5716,7 @@ msgstr "Proszę podać prawidłową nazwę kwalifikowaną"
 
 #: pkg/kubernetes/scripts/volumes.js:485
 msgid "Please provide a valid storage capacity."
-msgstr ""
-"Proszę podać prawidłową pojemność urządzenia do przechowywania danych."
+msgstr "Proszę podać prawidłową pojemność urządzenia do przechowywania danych."
 
 #: pkg/kubernetes/scripts/volumes.js:779
 msgid "Please provide a valid target"
@@ -5769,8 +5765,7 @@ msgstr "Proszę podać komputer, z którym się połączyć"
 
 #: pkg/machines/components/consoles.jsx:37
 msgid "Please start the virtual machine to access its console."
-msgstr ""
-"Proszę uruchomić maszynę wirtualną, aby uzyskać dostęp do jej konsoli."
+msgstr "Proszę uruchomić maszynę wirtualną, aby uzyskać dostęp do jej konsoli."
 
 #: pkg/docker/search.js:150
 msgid "Please try another term"
@@ -5865,9 +5860,8 @@ msgstr "Wypełnij"
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr "Port"
 
@@ -5883,7 +5877,7 @@ msgstr "Grupa portów"
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Porty"
 
@@ -5965,7 +5959,7 @@ msgstr "Informacje o problemie"
 msgid "Problems"
 msgstr "Problemy"
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr "Proces"
 
@@ -5979,7 +5973,6 @@ msgstr "Nazwa produktu"
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5991,6 +5984,7 @@ msgstr "Nazwa produktu"
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Projekt"
@@ -6025,10 +6019,10 @@ msgstr "Strona projektu"
 msgid "Project:"
 msgstr "Projekt:"
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr "Projekty"
 
@@ -6060,7 +6054,7 @@ msgstr "Pośrednik"
 msgid "Proxy Version"
 msgstr "Wersja pośrednika"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Klucz publiczny"
 
@@ -6088,8 +6082,8 @@ msgstr "Zastosowanie"
 msgid "Push an image:"
 msgstr "Wysłanie obrazu:"
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr "Nazwa kwalifikowana"
 
@@ -6153,7 +6147,7 @@ msgstr "Obudowa RAID"
 msgid "RAID Device"
 msgstr "Urządzenie RAID"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "Urządzenie RAID $0"
 
@@ -6189,7 +6183,6 @@ msgstr "Losowo"
 msgid "Raw to a device"
 msgstr "Surowe do urządzenia"
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6201,6 +6194,7 @@ msgstr "Surowe do urządzenia"
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr "Tylko do odczytu"
 
@@ -6267,7 +6261,7 @@ msgstr "Prawdziwa nazwa komputera może mieć co najwyżej 64 znaki"
 msgid "Reason"
 msgstr "Przyczyna"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "Uruchom ponownie"
 
@@ -6323,8 +6317,8 @@ msgstr "Odmowa połączenia. Klucze komputera się nie zgadzają"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Odmowa połączenia. Klucz komputera jest nieznany"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr "Zarejestruj"
 
@@ -6352,8 +6346,8 @@ msgstr "Rejestrowanie oprogramowania oVirt w programie Cockpit"
 msgid "Register…"
 msgstr "Zarejestruj…"
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "Wczytaj ponownie"
 
@@ -6394,9 +6388,9 @@ msgstr "Usuwane:"
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "Usuń"
 
@@ -6448,7 +6442,7 @@ msgstr "Usuń hasło"
 msgid "Remove passphrase in $0?"
 msgstr "Usunąć hasło w $0?"
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr "Usuwanie"
 
@@ -6518,10 +6512,10 @@ msgstr "Powtarzanie co roku"
 msgid "Repeat passphrase"
 msgstr "Powtórzenie hasła"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "Repliki"
 
@@ -6637,8 +6631,8 @@ msgstr "Należy rozwiązać powyższe błędy, aby kontynuować"
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Uruchom ponownie"
 
@@ -6687,8 +6681,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Użycie istniejącego hasła do zadań wymagających uprawnień"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Użycie istniejącego hasła do zadań wymagających uprawnień i łączenia "
 "z innymi komputerami"
@@ -6744,7 +6737,7 @@ msgstr "Działanie jako"
 msgid "Runner"
 msgstr "Uruchamianie"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "Działające"
 
@@ -6832,8 +6825,8 @@ msgstr "Działanie SUSPEND się nie powiodło"
 msgid "Saturday"
 msgstr "sobota"
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "Zapisz"
 
@@ -6888,7 +6881,7 @@ msgstr "Klucze SSH"
 msgid "Securely erasing $target"
 msgstr "Bezpieczne usuwanie zawartości $target"
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr "Zabezpieczenia"
 
@@ -6920,11 +6913,10 @@ msgstr "Wybranie obiektu wyświetli więcej informacji."
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Proszę wybrać użytkowników do synchronizacji z {{#strong}}{{host}}{{/"
-"strong}}"
+"Proszę wybrać użytkowników do synchronizacji z {{#strong}}{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:65
 msgid "Send Non-Maskable Interrupt"
@@ -6944,15 +6936,14 @@ msgstr "Wysyłanie"
 msgid "Serial Console"
 msgstr "Konsola szeregowa"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "Serwer"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr "Adres serwera"
 
@@ -6960,7 +6951,7 @@ msgstr "Adres serwera"
 msgid "Server Administrator"
 msgstr "Administrator serwera"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr "Adres serwera nie może być pusty."
 
@@ -6979,7 +6970,7 @@ msgstr "Serwery"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "Usługa"
 
@@ -7030,7 +7021,7 @@ msgstr ""
 "zrównoważony adres IP do uzyskiwania do nich dostępu."
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr "Sesja"
 
@@ -7170,7 +7161,7 @@ msgstr "Wyświetl wszystkie obrazy"
 msgid "Show fingerprints"
 msgstr "Wyświetl odciski"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr "Zmniejsz"
 
@@ -7191,34 +7182,34 @@ msgstr "Od"
 msgid "Since $0"
 msgstr "Od $0"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Rozmiar"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "Rozmiar nie może być ujemny"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "Rozmiar nie może wynosić zero"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr "Rozmiar jest za duży"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "Rozmiar musi być liczbą"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr "Rozmiar musi wynosić co najmniej $0"
 
@@ -7312,7 +7303,7 @@ msgid "Stable"
 msgstr "Stabilna"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Rozpocznij"
@@ -7353,10 +7344,10 @@ msgstr "Zaczyna się"
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "Stan"
 
@@ -7378,10 +7369,11 @@ msgid "Static"
 msgstr "Statyczne"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7404,7 +7396,7 @@ msgid "Sticky"
 msgstr "Lepkie"
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7457,8 +7449,7 @@ msgstr "Rozmiar urządzenia do przechowywania danych"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:354
 msgid "Storage Size should not be negative number"
-msgstr ""
-"Rozmiar urządzenia do przechowywania danych nie może być liczbą ujemną"
+msgstr "Rozmiar urządzenia do przechowywania danych nie może być liczbą ujemną"
 
 #: pkg/docker/index.html:300
 msgid "Storage pool"
@@ -7646,7 +7637,7 @@ msgstr "Etykieta"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr "Etykiety"
 
@@ -7668,7 +7659,7 @@ msgstr "Portal docelowy"
 msgid "Target World Wide Names"
 msgstr "Docelowe WWN"
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr "Cele"
 
@@ -7806,8 +7797,8 @@ msgstr "Adres zawiera nieprawidłowe znaki"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Nie można ustalić autentyczności komputera {{#strong}}{{host}}{{/strong}}. "
 "Na pewno kontynuować łączenie?"
@@ -7820,7 +7811,6 @@ msgstr "Zebrane informacje będą przechowywane lokalnie w systemie."
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 "Nieznany stan konfiguracji, może zostać zmieniony po następnych uruchomieniu."
-""
 
 #: pkg/kubernetes/views/container-page-inline.html:22
 msgid "The container '{{ target }}' does not exist."
@@ -7850,13 +7840,13 @@ msgstr "Konfiguracja wdrożenia „{{ target }}” nie istnieje."
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
-"System plików jest używany przez sesje logowania i usługi systemowe.         "
-"       Kontynuacja je zatrzyma."
+"System plików jest używany przez sesje logowania i usługi "
+"systemowe.                Kontynuacja je zatrzyma."
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7870,9 +7860,8 @@ msgstr ""
 "System plików jest używany przez sesje logowania.                Kontynuacja "
 "je zatrzyma."
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7883,14 +7872,13 @@ msgstr ""
 "System plików jest używany przez usługi systemowe.                "
 "Kontynuacja je zatrzyma."
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "Poniższe kontenery zależą od tego obrazu i nie będzie już można ich używać."
 
@@ -7998,11 +7986,11 @@ msgstr "Kontroler replikacji „{{ target }}” nie istnieje."
 msgid "The route '{{ target }}' does not exist."
 msgstr "Trasa „{{ target }}” nie istnieje."
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "Wyszukiwanie z $time ($type) nie zwróciło żadnych zagrożeń."
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr "Wyszukiwanie z $time ($type) się nie powiodło."
 
@@ -8073,8 +8061,7 @@ msgstr ""
 
 #: pkg/networkmanager/interfaces.js:1517
 msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr ""
-"Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie ustawień sieci"
+msgstr "Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie ustawień sieci"
 
 #: pkg/realmd/operation.js:586
 msgid "The user <b>$0</b> is not permitted to modify realms"
@@ -8101,8 +8088,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "Konfiguracja przeglądarki uniemożliwia działanie programu Cockpit ($0 jest "
 "niedostępne)"
@@ -8171,13 +8157,13 @@ msgstr ""
 "To urządzenie ma obecnie używane systemy plików.                Kontynuacja "
 "odmontuje wszystkie jego systemy plików."
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr "To urządzenie jest obecnie używane dla urządzeń RAID."
 
@@ -8189,17 +8175,17 @@ msgstr ""
 "To urządzenie jest obecnie używane dla urządzeń RAID.                "
 "Kontynuacja usunie je z jego urządzeń RAID."
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr "To urządzenie jest obecnie używane dla urządzeń VDO."
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr "To urządzenie jest obecnie używane dla grup woluminów."
 
@@ -8211,7 +8197,7 @@ msgstr ""
 "To urządzenie jest obecnie używane dla grup woluminów.                "
 "Kontynuacja usunie je z jego grup woluminów."
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8233,7 +8219,7 @@ msgstr ""
 "Ten gospodarz jest zarządzany przez menedżera wirtualizacji, więc tworzenie "
 "nowych maszyn wirtualnych z gospodarza nie jest możliwe."
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr "Ten obraz nie istnieje."
 
@@ -8308,13 +8294,13 @@ msgstr "Ta maszyna wirtualna nie jest zarządzana przez oprogramowanie oVirt"
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
-"Ten wolumin został zadeklarowany przez {{ item.item.spec.claimRef.namespace "
-"}}/{{ item.item.spec.claimRef.name }}. Usunięcie uszkodzi tę deklarację "
-"i może spowodować problemy z pojemnikami od niej zależnymi."
+"Ten wolumin został zadeklarowany przez {{ item.item.spec.claimRef."
+"namespace }}/{{ item.item.spec.claimRef.name }}. Usunięcie uszkodzi tę "
+"deklarację i może spowodować problemy z pojemnikami od niej zależnymi."
 
 #: pkg/kubernetes/views/pv-claim.html:23
 msgid "This volume has not been claimed"
@@ -8482,11 +8468,11 @@ msgstr "tuned nie jest uruchomione"
 msgid "Tuned is off"
 msgstr "tuned jest wyłączone"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Typ"
@@ -8549,7 +8535,7 @@ msgstr "Nie można pobrać informacji o alarmie."
 msgid "Unable to get alert: $0"
 msgstr "Nie można pobrać alarmu: $0"
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Nie można połączyć się z serwerem"
 
@@ -8595,23 +8581,23 @@ msgstr "Nieoczekiwany błąd"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr "Jednostka"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Nieznane"
 
@@ -8635,7 +8621,7 @@ msgstr "Nieznany klucz komputera"
 msgid "Unknown configuration"
 msgstr "Nieznana konfiguracja"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr "Nieznana nazwa komputera"
 
@@ -8680,7 +8666,7 @@ msgstr "Niezarządzane interfejsy"
 msgid "Unmask"
 msgstr "Anuluj maskowanie"
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Odmontuj"
 
@@ -8770,7 +8756,7 @@ msgstr "Dostępne są aktualizacje"
 msgid "Updates are disabled."
 msgstr "Aktualizacje są wyłączone."
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr "Aktualizowanie"
 
@@ -8822,13 +8808,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr "Użycie ustawień z /etc/kdump.conf"
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Używane"
 
@@ -8838,10 +8824,10 @@ msgstr "Używane przez kontenery"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8860,7 +8846,7 @@ msgstr "Hasło użytkownika"
 msgid "User interface for Linux servers"
 msgstr "Interfejs użytkownika dla serwerów Linux"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nazwa użytkownika"
@@ -8873,8 +8859,8 @@ msgstr "Nazwa użytkownika nie może być pusta"
 msgid "User or Group"
 msgstr "Użytkownik lub grupa"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
@@ -9034,9 +9020,9 @@ msgid "Verifying"
 msgstr "Sprawdzanie poprawności"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Wersja"
 
@@ -9098,8 +9084,8 @@ msgstr "Grupy woluminów"
 msgid "Volume ID"
 msgstr "Identyfikator woluminu"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "Nazwa woluminu"
 
@@ -9107,9 +9093,8 @@ msgstr "Nazwa woluminu"
 msgid "Volume Type"
 msgstr "Typ woluminu"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Woluminy"
@@ -9414,7 +9399,7 @@ msgstr "urządzenie gospodarza"
 msgid "iSCSI"
 msgstr "iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr "Cele iSCSI"
 
@@ -9489,10 +9474,10 @@ msgstr "nie działa"
 msgid "non responsive"
 msgstr "nie odpowiada"
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9518,8 +9503,8 @@ msgid ""
 "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
 "machines-ovirt.config, try as root."
 msgstr ""
-"Skrypt instalacji dostawcy oVirt się nie powiódł: nie można zapisać do pliku "
-"/etc/cockpit/machines-ovirt.config, próbowanie jako root."
+"Skrypt instalacji dostawcy oVirt się nie powiódł: nie można zapisać do "
+"pliku /etc/cockpit/machines-ovirt.config, próbowanie jako root."
 
 #: pkg/ovirt/components/InstallationDialog.jsx:164
 msgid "oVirt installation script failed with following output: "
@@ -9672,7 +9657,7 @@ msgstr "UDP"
 msgid "unassigned"
 msgstr "nieprzydzielone"
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "nieokreślone"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -3,14 +3,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2016-12-01 09:09+0000\n"
 "Last-Translator: Eduardo Ramalho <eduardo.ramalho@gmail.com>\n"
 "Language-Team: Portuguese\n"
 "Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -75,7 +75,7 @@ msgid_plural "$0 bytes"
 msgstr[0] "$0 byte"
 msgstr[1] "$0 bytes"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -190,7 +190,7 @@ msgid_plural "$0 updates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -216,7 +216,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] ""
@@ -567,7 +566,7 @@ msgid "Access"
 msgstr ""
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr ""
 
@@ -631,7 +630,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -652,11 +651,11 @@ msgstr ""
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr ""
 
@@ -816,7 +815,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr ""
 
@@ -933,8 +932,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -943,8 +942,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr ""
 
@@ -952,11 +951,11 @@ msgstr ""
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr ""
 
@@ -1005,8 +1004,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr ""
 
@@ -1026,9 +1025,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr ""
 
@@ -1044,13 +1043,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr ""
 
@@ -1107,7 +1106,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1135,7 +1134,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1258,10 +1257,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr ""
 
@@ -1326,7 +1325,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1338,27 +1336,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr ""
 
@@ -1379,7 +1377,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr ""
@@ -1397,11 +1395,11 @@ msgid "Ceph Monitors"
 msgstr ""
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1429,7 +1427,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1540,16 +1538,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr ""
 
@@ -1557,7 +1556,7 @@ msgstr ""
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr ""
@@ -1635,10 +1634,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1677,7 +1676,7 @@ msgstr[1] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr ""
 
@@ -1722,8 +1721,8 @@ msgstr ""
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1933,10 +1932,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr ""
 
@@ -2049,10 +2049,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr ""
 
@@ -2154,12 +2154,13 @@ msgstr ""
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2279,7 +2280,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2299,7 +2300,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2324,12 +2325,11 @@ msgstr ""
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2405,7 +2405,7 @@ msgstr ""
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 
@@ -2452,14 +2452,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2472,10 +2472,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2484,7 +2484,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2565,9 +2565,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr ""
 
@@ -2615,8 +2615,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2729,7 +2729,7 @@ msgstr ""
 msgid "Duplicate port"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2888,7 +2888,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2914,9 +2914,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr ""
 
@@ -3004,7 +3004,7 @@ msgstr ""
 msgid "Failed to add machine: $0"
 msgstr ""
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr ""
 
@@ -3069,7 +3069,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3077,6 +3076,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3213,7 +3213,7 @@ msgstr ""
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3276,9 +3276,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3339,9 +3339,9 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr ""
 
@@ -3381,8 +3381,8 @@ msgstr ""
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3422,7 +3422,7 @@ msgstr ""
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3511,11 +3511,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3589,7 +3588,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3605,9 +3604,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3655,7 +3654,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3668,8 +3667,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr ""
 
@@ -3693,11 +3692,11 @@ msgstr ""
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3745,7 +3744,7 @@ msgstr ""
 msgid "Invalid prefix or netmask $0"
 msgstr ""
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr ""
 
@@ -3753,7 +3752,7 @@ msgstr ""
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3871,11 +3870,12 @@ msgstr ""
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3920,8 +3920,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -3949,7 +3949,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4012,8 +4011,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -4089,17 +4088,17 @@ msgstr ""
 msgid "Logged In"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr ""
 
@@ -4294,9 +4293,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4328,8 +4328,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4344,7 +4344,7 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4424,8 +4424,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr ""
 
@@ -4433,17 +4433,17 @@ msgstr ""
 msgid "Mount Location"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4467,7 +4467,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4531,37 +4531,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr ""
 
@@ -4595,7 +4596,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4606,6 +4606,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
@@ -4619,8 +4620,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr ""
 
@@ -4686,8 +4687,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4695,7 +4696,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4705,7 +4706,7 @@ msgstr ""
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr ""
 
@@ -4820,9 +4821,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4850,7 +4851,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4858,7 +4859,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4866,7 +4867,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5014,9 +5015,9 @@ msgstr ""
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr ""
 
@@ -5027,7 +5028,7 @@ msgstr ""
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr ""
 
@@ -5069,8 +5070,8 @@ msgstr ""
 msgid "Not connected"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5086,7 +5087,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr ""
 
@@ -5114,8 +5115,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5147,8 +5148,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr ""
 
@@ -5164,14 +5165,14 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr ""
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr ""
 
@@ -5354,11 +5355,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5397,10 +5399,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr ""
 
@@ -5464,7 +5466,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5496,8 +5498,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5714,9 +5716,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5732,7 +5733,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr ""
 
@@ -5814,7 +5815,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5828,7 +5829,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5840,6 +5840,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr ""
@@ -5868,10 +5869,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5903,7 +5904,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -5931,8 +5932,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr ""
 
@@ -5996,7 +5997,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr ""
 
@@ -6032,7 +6033,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6044,6 +6044,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr ""
 
@@ -6108,7 +6109,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr ""
 
@@ -6164,8 +6165,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6193,8 +6194,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
@@ -6235,9 +6236,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr ""
 
@@ -6289,7 +6290,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6357,10 +6358,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
@@ -6472,8 +6473,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr ""
 
@@ -6522,8 +6523,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6577,7 +6577,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr ""
 
@@ -6665,8 +6665,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6719,7 +6719,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6751,8 +6751,8 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6773,15 +6773,14 @@ msgstr ""
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6789,7 +6788,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6808,7 +6807,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr ""
 
@@ -6857,7 +6856,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr ""
 
@@ -6993,7 +6992,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7014,34 +7013,34 @@ msgstr ""
 msgid "Since $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr ""
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr ""
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7135,7 +7134,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr ""
@@ -7176,10 +7175,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
@@ -7201,10 +7200,11 @@ msgid "Static"
 msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7227,7 +7227,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7460,7 +7460,7 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7482,7 +7482,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7613,8 +7613,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7649,11 +7649,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7665,9 +7665,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7676,14 +7675,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7784,11 +7782,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7874,8 +7872,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -7931,13 +7928,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -7947,17 +7944,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -7967,7 +7964,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -7987,7 +7984,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8056,9 +8053,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8217,11 +8214,11 @@ msgstr ""
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr ""
@@ -8284,7 +8281,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8330,23 +8327,23 @@ msgstr ""
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr ""
 
@@ -8370,7 +8367,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8415,7 +8412,7 @@ msgstr ""
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr ""
 
@@ -8505,7 +8502,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8554,13 +8551,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr ""
 
@@ -8570,10 +8567,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8592,7 +8589,7 @@ msgstr ""
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr ""
@@ -8605,8 +8602,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr ""
 
@@ -8766,9 +8763,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr ""
 
@@ -8830,8 +8827,8 @@ msgstr ""
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr ""
 
@@ -8839,9 +8836,8 @@ msgstr ""
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9131,7 +9127,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9206,10 +9202,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9384,7 +9380,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "indefinido"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -12,14 +12,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-08-17 12:13+0000\n"
 "Last-Translator: Luiz Fernando Pereira <luizfernandopereira@outlook.com.br>\n"
 "Language-Team: Portuguese (Brazil)\n"
 "Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -33,7 +33,8 @@ msgstr "1 \"Deseja excluir os seguintes nós?"
 
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmDialog.jsx:220
 msgid " or drag & drop."
-msgstr " ou arrastar & soltar\n"
+msgstr ""
+" ou arrastar & soltar\n"
 "."
 
 #: pkg/storaged/others-panel.jsx:57
@@ -88,7 +89,7 @@ msgid_plural "$0 bytes"
 msgstr[0] "$0 byte"
 msgstr[1] "$0 bytes"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 dados + $1 sobrecarga usada de $2 ($3)"
 
@@ -205,7 +206,7 @@ msgid_plural "$0 updates"
 msgstr[0] "$0 atualizar"
 msgstr[1] "$0 atualizações"
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 usados of $1 ($2 salvos)"
 
@@ -231,7 +232,6 @@ msgstr[0] "$0 ano"
 msgstr[1] "$0 anos"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% Livre"
@@ -586,7 +586,7 @@ msgid "Access"
 msgstr "Acesso"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "Modos de Acesso"
 
@@ -650,7 +650,7 @@ msgid "Active Pages"
 msgstr "Páginas Ativas"
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr "Ativo desde"
 
@@ -671,11 +671,11 @@ msgstr "Transmissão dinâmica de balanceamento de carga"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Adicionar"
 
@@ -837,7 +837,7 @@ msgstr "Pacotes adicionais:"
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Endereço"
 
@@ -957,8 +957,8 @@ msgstr "Serviços Permitidos"
 msgid "Always"
 msgstr "Sempre"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Anotações"
@@ -968,8 +968,8 @@ msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 "Anônimo: permitir que todos os usuários não autenticados baixem imagens"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "Aplicações"
 
@@ -977,11 +977,11 @@ msgstr "Aplicações"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -1030,8 +1030,8 @@ msgstr "Tag do Recurso"
 msgid "At least $0 disks are needed."
 msgstr "Pelo menos $0 discos são necessários."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Pelo menos um disco é necessário."
 
@@ -1051,9 +1051,9 @@ msgstr "Log de auditoria"
 msgid "Authenticating"
 msgstr "Autenticando"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Autenticação"
 
@@ -1069,13 +1069,13 @@ msgstr "Falha na Autenticação: Conexão encerrada com servidor"
 msgid "Authentication failed"
 msgstr "Falha na Autenticação"
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "Autenticação requerida"
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Autor"
 
@@ -1132,7 +1132,7 @@ msgstr "Disponível"
 msgid "Available Updates"
 msgstr "Atualizações Disponíveis"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr "Alvos disponíveis em $0"
 
@@ -1160,7 +1160,7 @@ msgstr "BIOS versão"
 msgid "Back to Accounts"
 msgstr "Voltar para Contas"
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr "Dispositivo de apoio"
 
@@ -1283,10 +1283,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr "A ação MUDAR DE ESTADO DE REDE falhou"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1351,7 +1351,6 @@ msgstr "Não é possível carregar a imagem"
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1363,27 +1362,27 @@ msgstr "Não é possível carregar a imagem"
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1404,7 +1403,7 @@ msgid "Cannot schedule event in the past"
 msgstr "Não é possível agendar eventos no passado"
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "Capacidade"
@@ -1422,11 +1421,11 @@ msgid "Ceph Monitors"
 msgstr "Monitores Ceph"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "Alterar"
 
@@ -1454,7 +1453,7 @@ msgstr "Alterar Horário do Sistema"
 msgid "Change User"
 msgstr "Alterar Usuário"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr "Alterar Nome do Iniciador iSCSI"
 
@@ -1569,16 +1568,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr "Certificado de Cliente"
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Fechar"
 
@@ -1586,7 +1586,7 @@ msgstr "Fechar"
 msgid "Close Selected Pages"
 msgstr "Fechar Páginas Selecionadas"
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr "Cluster"
@@ -1646,8 +1646,7 @@ msgstr ""
 
 #: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
 msgid "Cockpit is an interactive Linux server admin interface."
-msgstr ""
-"Cockpit é uma interface interativa de administração de servidor Linux."
+msgstr "Cockpit é uma interface interativa de administração de servidor Linux."
 
 #: src/base1/cockpit.js:4016
 msgid "Cockpit is not compatible with the software on the system."
@@ -1682,10 +1681,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 "O Cockpit não pôde fazer login no {{#strong}}{{host}}{{/strong}}. "
 "{{#can_sync}}Talvez você queira tentar {{#sync_link}}sincronizar usuários{{/"
@@ -1736,7 +1735,7 @@ msgstr[1] "Uso combinado de núcleos de CPU de $0 CPU"
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Comando"
 
@@ -1781,8 +1780,8 @@ msgstr "Compatível com sistema moderno e discos rígidos > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Comprimir despejos de travamento para economizar espaço"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "Compressão"
 
@@ -1995,10 +1994,11 @@ msgid "Container:"
 msgstr "Contêiner:"
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Containers"
 
@@ -2113,10 +2113,10 @@ msgstr "Sistema de travamento"
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Criar"
 
@@ -2218,12 +2218,13 @@ msgstr "Criar partição em $0"
 msgid "Create partition table"
 msgstr "Criar tabela de partições"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "Criado"
 
@@ -2351,7 +2352,7 @@ msgstr "Domínios de Pesquisa DNS $val"
 msgid "Dashboard"
 msgstr "Painel"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr "Dados Usados"
 
@@ -2371,7 +2372,7 @@ msgstr "Desativando $target"
 msgid "Debug and above"
 msgstr "Depurar e acima"
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr "Desduplicação"
 
@@ -2396,12 +2397,11 @@ msgstr "Atraso"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2481,7 +2481,7 @@ msgstr "A exclusão de um dispositivo RAID apagará todos os dados nele."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "A exclusão de um dispositivo VDO apagará todos os dados nele."
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "A exclusão de um container irá apagar todos os dados nele."
 
@@ -2528,14 +2528,14 @@ msgstr "Configs de Implantação"
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "Descrição"
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "Descrição:"
 
@@ -2548,10 +2548,10 @@ msgid "Detachable"
 msgstr "Destacável"
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "Detalhes"
 
@@ -2560,7 +2560,7 @@ msgstr "Detalhes"
 msgid "Device"
 msgstr "Dispositivo"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr "Arquivo do dispositivo"
 
@@ -2641,9 +2641,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Discos"
 
@@ -2696,8 +2696,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 "Deseja remover a função '{{ fields.displayRole }}' from member {{ fields."
 "member.metadata.name }}?"
@@ -2812,7 +2812,7 @@ msgstr "Apelido duplicado"
 msgid "Duplicate port"
 msgstr "Porta duplicada"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr "Editar"
 
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Entry"
 msgstr "Entrada"
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr "Ponto de entrada"
 
@@ -3001,9 +3001,9 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Erro"
 
@@ -3091,7 +3091,7 @@ msgstr "Falhou"
 msgid "Failed to add machine: $0"
 msgstr "Falha ao adicionar a máquina: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "Falha ao mudar senha"
 
@@ -3156,7 +3156,6 @@ msgstr "Montagem do Sistema de Arquivos"
 msgid "Filesystem Name"
 msgstr "Nome do Sistema de Arquivos"
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3164,6 +3163,7 @@ msgstr "Nome do Sistema de Arquivos"
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr "Tipo do Sistema de Arquivos"
 
@@ -3179,7 +3179,7 @@ msgstr "Sistema de Arquivos"
 msgid "Filter Services"
 msgstr "Serviços de filtro"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Digital"
 
@@ -3300,7 +3300,7 @@ msgstr "Geral"
 msgid "Generating report"
 msgstr "Gerando relatório"
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr "Obter nova imagem"
 
@@ -3364,9 +3364,9 @@ msgstr "Grupo ou Projeto"
 msgid "Groups"
 msgstr "Grupos"
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr "Crescer"
 
@@ -3427,9 +3427,9 @@ msgstr "Hello time $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Máquina"
 
@@ -3469,8 +3469,8 @@ msgstr "E/S Espera"
 msgid "INSTALL VM action failed"
 msgstr "A ação de instalação da VM falhou"
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr "IP"
 
@@ -3510,7 +3510,7 @@ msgstr "IPv6 Ajustes"
 msgid "ISCSI"
 msgstr "ISCSI"
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr "Id"
@@ -3599,11 +3599,10 @@ msgstr "Fluxo de imagem"
 msgid "Image:"
 msgstr "Imagem:"
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr "Imagens"
 
@@ -3667,8 +3666,8 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Para sincronizar os usuários, você precisa fazer login em "
-"{{#strong}}{{host}}{{/strong}}."
+"Para sincronizar os usuários, você precisa fazer login em {{#strong}}{{host}}"
+"{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:822 pkg/networkmanager/interfaces.js:1418
 #: pkg/networkmanager/interfaces.js:1425 pkg/networkmanager/interfaces.js:2594
@@ -3683,7 +3682,7 @@ msgstr "Volume inativo"
 msgid "Incorrect Host Key"
 msgstr "Chave de Host Incorreta"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr "Memória de índice"
 
@@ -3695,15 +3694,14 @@ msgstr "Info e acima"
 msgid "Information about the Docker storage pool is not available."
 msgstr ""
 "As informações sobre o pool de armazenamento do Docker não estão disponíveis."
-""
 
 #: pkg/packagekit/updates.jsx:478
 msgid "Initializing..."
 msgstr "Inicializando ..."
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr "Instale"
 
@@ -3731,7 +3729,6 @@ msgstr ""
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr ""
 "Instale o setroubleshoot-server para solucionar problemas de eventos SELinux."
-""
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:235
 msgid "Installation Source"
@@ -3753,7 +3750,7 @@ msgstr "Instalado"
 msgid "Installed products"
 msgstr "Produtos instalados"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "Instalando"
@@ -3766,8 +3763,8 @@ msgstr "Instalando $0"
 msgid "Instantiate"
 msgstr "Instanciar"
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr "Interface"
 
@@ -3791,11 +3788,11 @@ msgstr "Endereço inválido $0"
 msgid "Invalid credentials"
 msgstr "Credenciais Inválidas"
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "Formato de data inválido"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "Formato de data inválido e formato de tempo inválido"
 
@@ -3843,7 +3840,7 @@ msgstr "Prefixo inválido $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "Prefixo ou máscara de rede inválidos $0"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "Formato de tempo inválido"
 
@@ -3851,7 +3848,7 @@ msgstr "Formato de tempo inválido"
 msgid "Invalid time zone"
 msgstr "Fuso Horário inválido"
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr "Nome de usuário ou senha inválidos"
@@ -3971,11 +3968,12 @@ msgstr "Kubernetes Cluster"
 msgid "LACP Key"
 msgstr "Chave LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Rótulos"
@@ -4020,8 +4018,8 @@ msgstr "Ultima Atualização"
 msgid "Last checked: $0 ago"
 msgstr "Última verificação: $0 atrás"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr "Versão Mais Recente"
 
@@ -4052,7 +4050,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Deixe em branco para se conectar a esta máquina como a conexão atualmente "
 "efetuada como user{{#default_user}} ({{default_user}}){{/default_user}}. Se "
@@ -4119,8 +4116,8 @@ msgstr "Carregando as atualizações disponíveis, por favor aguarde ..."
 msgid "Loading data ..."
 msgstr "Carregando dados ..."
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "Carregando..."
 
@@ -4196,17 +4193,17 @@ msgstr "Mensagens de Log"
 msgid "Logged In"
 msgstr "Logado"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr "Logical"
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr "Tamanho Lógico"
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr "Número da Unidade Lógica"
 
@@ -4403,9 +4400,10 @@ msgstr "Associação"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4437,8 +4435,8 @@ msgstr "Uso de memória:"
 msgid "Memory:"
 msgstr "Memória:"
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "Mensagem"
 
@@ -4453,7 +4451,7 @@ msgstr "Mensagem para usuários logados"
 msgid "Metadata"
 msgstr "Metadados"
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr "Metadados Usados"
 
@@ -4533,8 +4531,8 @@ msgstr "Mais Informações"
 msgid "More details"
 msgstr "Mais detalhes"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "Montar"
 
@@ -4542,17 +4540,17 @@ msgstr "Montar"
 msgid "Mount Location"
 msgstr "Montar Locação"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "Opções de Montagem"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Ponto de Montagem"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr "Monte na Inicialização"
 
@@ -4576,7 +4574,7 @@ msgstr "O ponto de montagem não pode estar vazio"
 msgid "Mount point must start with \"/\"."
 msgstr "O ponto de montagem deve começar com \"/\"."
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr "Monte só de leitura"
 
@@ -4640,37 +4638,38 @@ msgstr "Servidor NTP"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Nome"
 
@@ -4704,7 +4703,6 @@ msgstr "O nome não deve conter apenas caracteres vazios"
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4715,6 +4713,7 @@ msgstr "O nome não deve conter apenas caracteres vazios"
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "Namespace"
@@ -4728,8 +4727,8 @@ msgid "Need at least one NTP server"
 msgstr "Precisa de pelo menos um servidor NTP"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Rede"
 
@@ -4795,8 +4794,8 @@ msgstr "Novo Projeto"
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr "Novo stream de imagem"
 
@@ -4804,7 +4803,7 @@ msgstr "Novo stream de imagem"
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "Nova senha não foi aceita"
 
@@ -4814,7 +4813,7 @@ msgstr "Nova senha não foi aceita"
 msgid "New project"
 msgstr "Novo projeto"
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Próximo"
 
@@ -4929,9 +4928,9 @@ msgstr "Nenhum contêiner que corresponda ao filtro atual"
 msgid "No description provided."
 msgstr "Nenhuma descrição fornecida."
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr "Sem discos disponíveis."
 
@@ -4959,7 +4958,7 @@ msgstr "Nenhum grupo presente."
 msgid "No host keys found."
 msgstr "Nenhuma chave de host encontrada."
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr "Nenhum destino iSCSI configurado"
 
@@ -4967,7 +4966,7 @@ msgstr "Nenhum destino iSCSI configurado"
 msgid "No image streams are present."
 msgstr "Nenhum stream de imagem está presente."
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr "Nenhuma imagem"
 
@@ -4975,7 +4974,7 @@ msgstr "Nenhuma imagem"
 msgid "No images pushed"
 msgstr "Nenhuma imagem inserida"
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr "Sem imagens que correspondam ao filtro atual"
 
@@ -5128,9 +5127,9 @@ msgstr "Nó"
 msgid "Node:"
 msgstr "Node:"
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr "Nós"
 
@@ -5141,7 +5140,7 @@ msgstr "Nós são as máquinas que executam seus contêineres."
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Nenhum"
 
@@ -5183,8 +5182,8 @@ msgstr "Indisponível"
 msgid "Not connected"
 msgstr "Não conectado"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr "Não Implantado"
 
@@ -5200,7 +5199,7 @@ msgstr "Não montado"
 msgid "Not permitted to perform this action."
 msgstr "Não é permitido executar esta ação."
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "Não está rodando"
 
@@ -5228,8 +5227,8 @@ msgstr "Observe e acima"
 msgid "Number of virtual CPUs that gonna be used."
 msgstr "Número de CPUs virtuais que serão usadas."
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr "OK"
 
@@ -5261,8 +5260,8 @@ msgstr "Ocorreu entre $0 e $1"
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Desligado"
 
@@ -5278,14 +5277,14 @@ msgstr "Senha Atual"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "Senha antiga não aceita"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Ligado"
 
@@ -5468,11 +5467,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "As senhas não correspondem"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5513,10 +5513,10 @@ msgstr "Cole JSON abaixo, "
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Cole o conteúdo do seu arquivo de chave pública SSH aqui"
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "Caminho"
 
@@ -5580,7 +5580,7 @@ msgstr "Volumes Persistentes"
 msgid "Phase"
 msgstr "Fase"
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr "Fisica"
 
@@ -5612,8 +5612,8 @@ msgstr "Alvo do Ping"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5839,9 +5839,8 @@ msgstr "Preencher"
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr "Porta"
 
@@ -5857,7 +5856,7 @@ msgstr "Portgroup"
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Portas"
 
@@ -5940,7 +5939,7 @@ msgstr "Informação do Problema"
 msgid "Problems"
 msgstr "Problemas"
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr "Processo"
 
@@ -5954,7 +5953,6 @@ msgstr "Nome do produto"
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5966,6 +5964,7 @@ msgstr "Nome do produto"
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Projeto"
@@ -5978,7 +5977,6 @@ msgstr "Membros do Projeto"
 msgid "Project access policy allows anonymous users to pull images."
 msgstr ""
 "A diretiva de acesso ao projeto permite que usuários anônimos baixem imagens."
-""
 
 #: pkg/kubernetes/views/project-body.html:8
 msgid "Project access policy allows any authenticated user to pull images."
@@ -6000,10 +5998,10 @@ msgstr "Site do projeto"
 msgid "Project:"
 msgstr "Projeto:"
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr "Projetos"
 
@@ -6035,7 +6033,7 @@ msgstr "Proxy"
 msgid "Proxy Version"
 msgstr "Versão do Proxy"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Chave Pública"
 
@@ -6063,8 +6061,8 @@ msgstr "Propósito"
 msgid "Push an image:"
 msgstr "Enviar uma imagem:"
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr "Nome Qualificado"
 
@@ -6128,7 +6126,7 @@ msgstr "RAID Chassis"
 msgid "RAID Device"
 msgstr "Dispositivo RAID"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "Dispositivo RAID $0"
 
@@ -6164,7 +6162,6 @@ msgstr "Aleatório(a)"
 msgid "Raw to a device"
 msgstr "Raw para um dispositivo"
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6176,6 +6173,7 @@ msgstr "Raw para um dispositivo"
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr "Somente leitura"
 
@@ -6242,7 +6240,7 @@ msgstr "Nome de host real deve conter 64 caracteres ou menos"
 msgid "Reason"
 msgstr "Razão"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "Reiniciar"
 
@@ -6298,8 +6296,8 @@ msgstr "Recusando-se a se conectar. A chave não coincide"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Recusando-se a se conectar. A chave é desconhecida"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr "Registrar"
 
@@ -6327,8 +6325,8 @@ msgstr "Registrando oVirt no Cockpit"
 msgid "Register…"
 msgstr "Registro…"
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "Recarregar"
 
@@ -6369,9 +6367,9 @@ msgstr "Remoções:"
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "Remover"
 
@@ -6423,7 +6421,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr "Removendo"
 
@@ -6493,10 +6491,10 @@ msgstr "Repita Anualmente"
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "Réplicas"
 
@@ -6533,8 +6531,7 @@ msgstr "Repórter 'reporter-ureport' não encontrado."
 
 #: pkg/systemd/logs.js:456
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
-msgstr ""
-"Os relatórios não tiveram sucesso. Tente executar `reporter-ureport -d"
+msgstr "Os relatórios não tiveram sucesso. Tente executar `reporter-ureport -d"
 
 #: pkg/docker/index.html:682
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
@@ -6613,8 +6610,8 @@ msgstr "Resolva os erros acima para continuar"
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -6663,8 +6660,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Reutilize minha senha para tarefas privilegiadas"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Reutilizar minha senha para tarefas privilegiadas e conectar-se a outras "
 "máquinas"
@@ -6720,7 +6716,7 @@ msgstr "Executar como"
 msgid "Runner"
 msgstr "Executor"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "Executando"
 
@@ -6808,8 +6804,8 @@ msgstr "SUSPEND Ação: falhou"
 msgid "Saturday"
 msgstr "Sábado"
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "Salvar"
 
@@ -6862,7 +6858,7 @@ msgstr "Chaves de Shell Seguras"
 msgid "Securely erasing $target"
 msgstr "Apagando com segurança $target"
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr "Segurança"
 
@@ -6894,11 +6890,11 @@ msgstr "Selecione um objeto para ver mais detalhes."
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Selecione os usuários que você gostaria de ser sincronizado com "
-"{{#strong}}{{host}}{{/strong}}"
+"Selecione os usuários que você gostaria de ser sincronizado com {{#strong}}"
+"{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:65
 msgid "Send Non-Maskable Interrupt"
@@ -6918,15 +6914,14 @@ msgstr "Enviando"
 msgid "Serial Console"
 msgstr "Console Serial"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "Servidor"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr "Endereço do Servidor"
 
@@ -6934,7 +6929,7 @@ msgstr "Endereço do Servidor"
 msgid "Server Administrator"
 msgstr "Administrador do servidor"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr "O endereço do servidor não pode estar vazio."
 
@@ -6953,7 +6948,7 @@ msgstr "Servidores"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "Serviço"
 
@@ -7004,7 +6999,7 @@ msgstr ""
 "opcional, balanceado por carga para acessá-los."
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr "Sessão"
 
@@ -7073,8 +7068,7 @@ msgstr "Compartilhado"
 
 #: pkg/kubernetes/scripts/projects.js:1027
 msgid "Shared: Allow any authenticated user to pull images"
-msgstr ""
-"Compartilhado: permitir que qualquer usuário autenticado baixe imagens"
+msgstr "Compartilhado: permitir que qualquer usuário autenticado baixe imagens"
 
 #: pkg/kubernetes/views/container-page-inline.html:14
 #: pkg/kubernetes/views/container-panel.html:9
@@ -7143,7 +7137,7 @@ msgstr "Exibir todas as imagens"
 msgid "Show fingerprints"
 msgstr "Exibir digitais"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr "Compactar"
 
@@ -7164,34 +7158,34 @@ msgstr "Desde"
 msgid "Since $0"
 msgstr "Desde $0"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Tamanho"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "O tamanho não pode ser negativo"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "O tamanho não pode ser zero"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr "O tamanho é muito extenso"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "O tamanho deve ser um número"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr "O tamanho deve ser pelo menos $0"
 
@@ -7287,7 +7281,7 @@ msgid "Stable"
 msgstr "Estável"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Iniciar"
@@ -7328,10 +7322,10 @@ msgstr "Começa"
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "Estado"
 
@@ -7353,10 +7347,11 @@ msgid "Static"
 msgstr "Estático"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7379,7 +7374,7 @@ msgid "Sticky"
 msgstr "Sticky"
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7618,7 +7613,7 @@ msgstr "Marca"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr "Tags"
 
@@ -7640,7 +7635,7 @@ msgstr "Portal Alvo"
 msgid "Target World Wide Names"
 msgstr "Nomes de Alvos Mundiais"
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr "Alvos"
 
@@ -7775,8 +7770,8 @@ msgstr "O endereço contém caracteres inválidos"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "A autenticidade do host {{#strong}}{{host}}{{/strong}} não pode ser "
 "estabelecida. Tem certeza de que deseja continuar conectando?"
@@ -7818,13 +7813,13 @@ msgstr "O Deployment config '{{target}}' não existe."
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
-"O sistema de arquivos está em uso por sessões de login e serviços do sistema."
-"                 Prosseguir interromperá isso."
+"O sistema de arquivos está em uso por sessões de login e serviços do "
+"sistema.                 Prosseguir interromperá isso."
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7838,9 +7833,8 @@ msgstr ""
 "O sistema de arquivos está em uso por sessões de login.                "
 "Prosseguir interromperá isso."
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7848,17 +7842,16 @@ msgid ""
 "The filesystem is in use by system services.                Proceeding will "
 "stop these."
 msgstr ""
-"O sistema de arquivos está sendo usado pelos serviços do sistema.            "
-"    Proseguir interromperá isso."
+"O sistema de arquivos está sendo usado pelos serviços do "
+"sistema.                Proseguir interromperá isso."
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7965,11 +7958,11 @@ msgstr "O controlador de replicação '{{ target }}' não existe."
 msgid "The route '{{ target }}' does not exist."
 msgstr "A rota '{{ target }}' não existe."
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "O scanner de  $time ($type) não detectou vulnerabilidades."
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr "O scanner de $time ($type) não funcionou."
 
@@ -8039,8 +8032,7 @@ msgstr "O usuário <b>$0</b> não tem permissão para modificar os hostnames"
 #: pkg/networkmanager/interfaces.js:1517
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
-"O usuário <b>$0</b> não tem permissão para modificar as configurações de "
-"rede"
+"O usuário <b>$0</b> não tem permissão para modificar as configurações de rede"
 
 #: pkg/realmd/operation.js:586
 msgid "The user <b>$0</b> is not permitted to modify realms"
@@ -8064,8 +8056,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "A configuração do navegador da Web impede que o Cockpit seja executado "
 "(inacessível $0)"
@@ -8134,13 +8125,13 @@ msgstr ""
 "Não há sistemas de arquivos que você possa montar ou desmontar.\n"
 "Contate seu administrador de sistemas."
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr "Este dispositivo é atualmente usado por dispositivos RAID."
 
@@ -8152,17 +8143,17 @@ msgstr ""
 "Este dispositivo é usado atualmente para dispositivos RAID.                "
 "Proceder o removerá dos seus dispositivos RAID."
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr "Este dispositivo é usado atualmente para dispositivos VDO."
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr "Este dispositivo é usado atualmente para grupos de volumes."
 
@@ -8174,7 +8165,7 @@ msgstr ""
 "Este dispositivo é usado atualmente para grupos de volumes.                "
 "Proceder irá removê-lo dos seus grupos de volumes."
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8197,7 +8188,7 @@ msgstr ""
 "Esse host é gerenciado por um gerenciador de virtualização, portanto, a "
 "criação de novas VMs a partir do host não é possível."
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr "Esta imagem não existe."
 
@@ -8272,9 +8263,9 @@ msgstr "Esta máquina virtual não é gerenciada pelo oVirt"
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 "Este volume foi reivindicado por {{ item.item.spec.claimRef.namespace }} / "
 "{{ item.item.spec.claimRef.name }}. Excluí-lo vai parar essa reivindicação e "
@@ -8446,11 +8437,11 @@ msgstr "Tuned não está em execução"
 msgid "Tuned is off"
 msgstr "Tuned está fora"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Tipo"
@@ -8513,7 +8504,7 @@ msgstr "Não é possível obter detalhes de alerta."
 msgid "Unable to get alert: $0"
 msgstr "Não é possível obter alerta: $0"
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Não é possível acessar o servidor"
 
@@ -8559,23 +8550,23 @@ msgstr "Erro inesperado"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr "Unidade"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -8599,7 +8590,7 @@ msgstr "Chave de Host Desconhecida"
 msgid "Unknown configuration"
 msgstr "Configuração desconhecida"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr "Nome de host desconhecido"
 
@@ -8644,7 +8635,7 @@ msgstr "Interfaces Não Gerenciadas"
 msgid "Unmask"
 msgstr "Sem Máscara"
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Desmontar"
 
@@ -8735,7 +8726,7 @@ msgstr "Atualizações disponíveis"
 msgid "Updates are disabled."
 msgstr "Atualizações estão desativadas."
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr "Atualizando"
 
@@ -8786,13 +8777,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr "Use a configuração em /etc/kdump.conf"
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Usado"
 
@@ -8802,10 +8793,10 @@ msgstr "Usado pelos Contêineres"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8824,7 +8815,7 @@ msgstr "Senha de Usuário"
 msgid "User interface for Linux servers"
 msgstr "Interface de usuário para servidores Linux"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nome de usuário"
@@ -8837,8 +8828,8 @@ msgstr "O nome de usuário não pode estar vazio"
 msgid "User or Group"
 msgstr "Usuário ou Grupo"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "Nome de Usuário"
 
@@ -8998,9 +8989,9 @@ msgid "Verifying"
 msgstr "Verificando"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Versão"
 
@@ -9062,8 +9053,8 @@ msgstr "Grupos do Volume"
 msgid "Volume ID"
 msgstr "ID do Volume"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "Nome do Volume"
 
@@ -9071,9 +9062,8 @@ msgstr "Nome do Volume"
 msgid "Volume Type"
 msgstr "Tipo do Volume"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volumes"
@@ -9382,7 +9372,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr "Alvos iSCSI"
 
@@ -9457,10 +9447,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9635,7 +9625,7 @@ msgstr "udp"
 msgid "unassigned"
 msgstr "não assinado"
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "indefinido"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,14 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2017-02-24 04:55+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Turkish\n"
 "Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n>1)\n"
 
@@ -78,7 +78,7 @@ msgid_plural "$0 bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -193,7 +193,7 @@ msgid_plural "$0 updates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, fuzzy, c-format
+#, fuzzy
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "Boş"
@@ -571,7 +571,7 @@ msgid "Access"
 msgstr "Erişim"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 #, fuzzy
 msgid "Access Modes"
 msgstr "Erişim"
@@ -636,7 +636,7 @@ msgid "Active Pages"
 msgstr ""
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -657,11 +657,11 @@ msgstr ""
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Ekle"
 
@@ -824,7 +824,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adres"
 
@@ -943,8 +943,8 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr ""
@@ -953,8 +953,8 @@ msgstr ""
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr ""
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr ""
 
@@ -962,11 +962,11 @@ msgstr ""
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Uygula"
 
@@ -1015,8 +1015,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "En azından bir disk gerekli"
 
@@ -1036,9 +1036,9 @@ msgstr ""
 msgid "Authenticating"
 msgstr "Yetkilendiriliyor"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Yetkilendirme"
 
@@ -1054,13 +1054,13 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr ""
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Yazar"
 
@@ -1117,7 +1117,7 @@ msgstr ""
 msgid "Available Updates"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr ""
 
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1268,10 +1268,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1337,7 +1337,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1349,27 +1348,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "İptal"
 
@@ -1390,7 +1389,7 @@ msgid "Cannot schedule event in the past"
 msgstr ""
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 #, fuzzy
 msgid "Capacity"
@@ -1411,11 +1410,11 @@ msgid "Ceph Monitors"
 msgstr "Depo"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr ""
 
@@ -1443,7 +1442,7 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr ""
 
@@ -1555,16 +1554,17 @@ msgstr ""
 msgid "Client Certificate"
 msgstr ""
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Kapat"
 
@@ -1572,7 +1572,7 @@ msgstr "Kapat"
 msgid "Close Selected Pages"
 msgstr ""
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 #, fuzzy
 msgid "Cluster"
@@ -1651,10 +1651,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1693,7 +1693,7 @@ msgstr[1] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Komut"
 
@@ -1738,8 +1738,8 @@ msgstr ""
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr ""
 
@@ -1953,10 +1953,11 @@ msgid "Container:"
 msgstr ""
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Konteynerler"
 
@@ -2069,10 +2070,10 @@ msgstr ""
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Yarat"
 
@@ -2175,12 +2176,13 @@ msgstr ""
 msgid "Create partition table"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr ""
 
@@ -2300,7 +2302,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr ""
 
@@ -2320,7 +2322,7 @@ msgstr ""
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2345,12 +2347,11 @@ msgstr "Gecikme"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2429,7 +2430,7 @@ msgstr "Bir RAID cihazını silmek üstündeki tüm veriyi silecektir."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "Bir konteyneri silmek içindeki veriyi de silecektir."
 
@@ -2476,14 +2477,14 @@ msgstr ""
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr ""
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr ""
 
@@ -2496,10 +2497,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr ""
 
@@ -2508,7 +2509,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2590,9 +2591,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Diskler"
 
@@ -2640,8 +2641,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
@@ -2756,7 +2757,7 @@ msgstr ""
 msgid "Duplicate port"
 msgstr ""
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr ""
 
@@ -2915,7 +2916,7 @@ msgstr ""
 msgid "Entry"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr ""
 
@@ -2941,9 +2942,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Hata"
 
@@ -3031,7 +3032,7 @@ msgstr ""
 msgid "Failed to add machine: $0"
 msgstr "Makine ekleme başarısız: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "Parola değişimi başarısız oldu"
 
@@ -3096,7 +3097,6 @@ msgstr ""
 msgid "Filesystem Name"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3104,6 +3104,7 @@ msgstr ""
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 #, fuzzy
 msgid "Filesystem Type"
 msgstr "Dosya sistemi tipi"
@@ -3120,7 +3121,7 @@ msgstr "Dosya Sistemleri"
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr ""
 
@@ -3242,7 +3243,7 @@ msgstr "Genel"
 msgid "Generating report"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr ""
 
@@ -3307,9 +3308,9 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3370,9 +3371,9 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Host"
 
@@ -3413,8 +3414,8 @@ msgstr "I/O Beklemesi"
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr ""
 
@@ -3456,7 +3457,7 @@ msgstr "IPv6 Ayarları"
 msgid "ISCSI"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr ""
@@ -3547,11 +3548,10 @@ msgstr ""
 msgid "Image:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr ""
 
@@ -3626,7 +3626,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3642,9 +3642,9 @@ msgstr ""
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr ""
 
@@ -3692,7 +3692,7 @@ msgstr ""
 msgid "Installed products"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr ""
@@ -3705,8 +3705,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 #, fuzzy
 msgid "Interface"
 msgstr "Arayüzler"
@@ -3732,11 +3732,11 @@ msgstr "Geçersiz anahtar"
 msgid "Invalid credentials"
 msgstr ""
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "Geçersiz tarih biçimi"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "Geçersiz tarih ve geçersiz zaman biçimi"
 
@@ -3787,7 +3787,7 @@ msgstr "Geçersiz port"
 msgid "Invalid prefix or netmask $0"
 msgstr "Geçersiz port"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "Geçersiz zaman biçimi"
 
@@ -3795,7 +3795,7 @@ msgstr "Geçersiz zaman biçimi"
 msgid "Invalid time zone"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr ""
@@ -3914,11 +3914,12 @@ msgstr "Kubernetes kümesi"
 msgid "LACP Key"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Etiketler"
@@ -3963,8 +3964,8 @@ msgstr ""
 msgid "Last checked: $0 ago"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr ""
 
@@ -3993,7 +3994,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
@@ -4056,8 +4056,8 @@ msgstr ""
 msgid "Loading data ..."
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr ""
 
@@ -4135,17 +4135,17 @@ msgstr ""
 msgid "Logged In"
 msgstr "Giriş Yapıldı"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 #, fuzzy
 msgid "Logical Unit Number"
 msgstr "Mantıksal Bölüm"
@@ -4344,9 +4344,10 @@ msgstr ""
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4378,8 +4379,8 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr ""
 
@@ -4394,7 +4395,7 @@ msgstr "Giriş yapmış kullanıcılara mesaj"
 msgid "Metadata"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr ""
 
@@ -4475,8 +4476,8 @@ msgstr ""
 msgid "More details"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "Bağla"
 
@@ -4485,17 +4486,17 @@ msgstr "Bağla"
 msgid "Mount Location"
 msgstr "Bağlama Seçenekleri"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "Bağlama Seçenekleri"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Bağlama Noktası"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4519,7 +4520,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4585,37 +4586,38 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "İsim"
 
@@ -4649,7 +4651,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4660,6 +4661,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr ""
@@ -4673,8 +4675,8 @@ msgid "Need at least one NTP server"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Ağ"
 
@@ -4740,8 +4742,8 @@ msgstr ""
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr ""
 
@@ -4749,7 +4751,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "Yeni parola kabul edilmedi"
 
@@ -4759,7 +4761,7 @@ msgstr "Yeni parola kabul edilmedi"
 msgid "New project"
 msgstr ""
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Sonraki"
 
@@ -4876,9 +4878,9 @@ msgstr ""
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr ""
 
@@ -4907,7 +4909,7 @@ msgstr ""
 msgid "No host keys found."
 msgstr "Bulunamadı"
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr ""
 
@@ -4915,7 +4917,7 @@ msgstr ""
 msgid "No image streams are present."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr ""
 
@@ -4923,7 +4925,7 @@ msgstr ""
 msgid "No images pushed"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr ""
 
@@ -5072,9 +5074,9 @@ msgstr "Düğüm"
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr "Düğümler"
 
@@ -5085,7 +5087,7 @@ msgstr "Düğümler, konteynerlerinizi çalıştıran makinelerdir."
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Hiçbiri"
 
@@ -5127,8 +5129,8 @@ msgstr ""
 msgid "Not connected"
 msgstr "Bağlı değil"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr ""
 
@@ -5144,7 +5146,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "Çalışmıyor"
 
@@ -5172,8 +5174,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr ""
 
@@ -5206,8 +5208,8 @@ msgstr ""
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Kapalı"
 
@@ -5223,14 +5225,14 @@ msgstr "Eski Parola"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "Eski parola kabul edilmedi"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Açık"
 
@@ -5415,11 +5417,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Parolalar eşleşmiyor"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5458,10 +5461,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr ""
 
@@ -5525,7 +5528,7 @@ msgstr ""
 msgid "Phase"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5557,8 +5560,8 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5779,9 +5782,8 @@ msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr ""
 
@@ -5797,7 +5799,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Portlar"
 
@@ -5879,7 +5881,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5893,7 +5895,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5905,6 +5906,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr ""
@@ -5933,10 +5935,10 @@ msgstr ""
 msgid "Project:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr ""
 
@@ -5968,7 +5970,7 @@ msgstr ""
 msgid "Proxy Version"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr ""
 
@@ -5996,8 +5998,8 @@ msgstr ""
 msgid "Push an image:"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 #, fuzzy
 msgid "Qualified Name"
 msgstr "Tam İsim"
@@ -6062,7 +6064,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "RAID Aygıtı"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr ""
 
@@ -6100,7 +6102,6 @@ msgstr ""
 msgid "Raw to a device"
 msgstr "Blok Aygıtı"
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6112,6 +6113,7 @@ msgstr "Blok Aygıtı"
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 #, fuzzy
 msgid "Read Only"
 msgstr "Hazır"
@@ -6180,7 +6182,7 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr ""
 
@@ -6236,8 +6238,8 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr ""
 
@@ -6266,8 +6268,8 @@ msgstr ""
 msgid "Register…"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr ""
 
@@ -6310,9 +6312,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "Kaldır"
 
@@ -6368,7 +6370,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr ""
 
@@ -6436,10 +6438,10 @@ msgstr ""
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr ""
 
@@ -6553,8 +6555,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Yeniden başlat"
 
@@ -6604,8 +6606,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6661,7 +6662,7 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "Çalışıyor"
 
@@ -6749,8 +6750,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr ""
 
@@ -6806,7 +6807,7 @@ msgstr ""
 msgid "Securely erasing $target"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr ""
 
@@ -6838,8 +6839,8 @@ msgstr "Daha fazla ayrıntı için bir obje seçin."
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6860,16 +6861,15 @@ msgstr ""
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 #, fuzzy
 msgid "Server"
 msgstr "Servis"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr ""
 
@@ -6877,7 +6877,7 @@ msgstr ""
 msgid "Server Administrator"
 msgstr "Sunucu Yöneticisi"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr ""
 
@@ -6896,7 +6896,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "Servis"
 
@@ -6948,7 +6948,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 #, fuzzy
 msgid "Session"
 msgstr "Sürüm"
@@ -7092,7 +7092,7 @@ msgstr ""
 msgid "Show fingerprints"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7113,35 +7113,35 @@ msgstr ""
 msgid "Since $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Boyut"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr ""
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr ""
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr ""
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 #, fuzzy
 msgid "Size must be a number"
 msgstr "Boyut belirtilmeli"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7235,7 +7235,7 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Başlat"
@@ -7276,10 +7276,10 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr ""
 
@@ -7301,10 +7301,11 @@ msgid "Static"
 msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7327,7 +7328,7 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7562,7 +7563,7 @@ msgstr "Etiket"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr ""
 
@@ -7584,7 +7585,7 @@ msgstr ""
 msgid "Target World Wide Names"
 msgstr ""
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr ""
 
@@ -7716,8 +7717,8 @@ msgstr "Adres geçersiz karakterler içeriyor"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -7752,11 +7753,11 @@ msgstr ""
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7768,9 +7769,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7779,14 +7779,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7887,11 +7886,11 @@ msgstr ""
 msgid "The route '{{ target }}' does not exist."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
@@ -7977,8 +7976,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -8034,13 +8032,13 @@ msgid ""
 "Proceeding will unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr ""
 
@@ -8050,17 +8048,17 @@ msgid ""
 "will remove it from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr ""
 
@@ -8070,7 +8068,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8090,7 +8088,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr ""
 
@@ -8159,9 +8157,9 @@ msgstr ""
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8320,11 +8318,11 @@ msgstr "Tuned çalışmıyor"
 msgid "Tuned is off"
 msgstr "Tuned kapalı"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Tip"
@@ -8388,7 +8386,7 @@ msgstr ""
 msgid "Unable to get alert: $0"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr ""
 
@@ -8434,23 +8432,23 @@ msgstr "Beklenmeyen hata"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
@@ -8474,7 +8472,7 @@ msgstr ""
 msgid "Unknown configuration"
 msgstr "Bilinmeyen konfigrasyon"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr ""
 
@@ -8520,7 +8518,7 @@ msgstr ""
 msgid "Unmask"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Çöz"
 
@@ -8610,7 +8608,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr ""
 
@@ -8659,13 +8657,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr ""
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Kullanılmış"
 
@@ -8676,10 +8674,10 @@ msgstr "Konteynerler"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8698,7 +8696,7 @@ msgstr "Kullanıcı Parolası"
 msgid "User interface for Linux servers"
 msgstr ""
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr ""
@@ -8711,8 +8709,8 @@ msgstr ""
 msgid "User or Group"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 #, fuzzy
 msgid "Username"
 msgstr "Kullanıcı Adı"
@@ -8873,9 +8871,9 @@ msgid "Verifying"
 msgstr ""
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Sürüm"
 
@@ -8938,8 +8936,8 @@ msgstr ""
 msgid "Volume ID"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 #, fuzzy
 msgid "Volume Name"
 msgstr "Tam İsim"
@@ -8948,9 +8946,8 @@ msgstr "Tam İsim"
 msgid "Volume Type"
 msgstr ""
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr ""
@@ -9243,7 +9240,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr ""
 
@@ -9318,10 +9315,10 @@ msgstr ""
 msgid "non responsive"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9499,7 +9496,7 @@ msgstr ""
 msgid "unassigned"
 msgstr ""
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,17 +7,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2018-08-24 03:51+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
 "Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
 #: pkg/docker/storage.jsx:244
 msgid " (shared with the OS)"
@@ -87,7 +87,7 @@ msgstr[0] "$0 байт"
 msgstr[1] "$0 байти"
 msgstr[2] "$0 байтів"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 даних + $1 додатково використано з $2 ($3)"
 
@@ -213,7 +213,7 @@ msgstr[0] "$0 оновлення"
 msgstr[1] "$0 оновлення"
 msgstr[2] "$0 оновлень"
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 використано з $1 ($2 заощаджено)"
 
@@ -241,7 +241,6 @@ msgstr[1] "$0 роки"
 msgstr[2] "$0 років"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "Вільно $0%"
@@ -600,7 +599,7 @@ msgid "Access"
 msgstr "Доступ"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "Режими доступу"
 
@@ -664,7 +663,7 @@ msgid "Active Pages"
 msgstr "Активні сторінки"
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr "Активний з"
 
@@ -685,11 +684,11 @@ msgstr "Адаптивне урівноваження навантаження �
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Додати"
 
@@ -851,7 +850,7 @@ msgstr "Додаткові пакунки:"
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Адреса"
 
@@ -932,8 +931,7 @@ msgstr "Всі типи"
 
 #: pkg/machines/components/vcpuModal.jsx:159
 msgid "All changes will take effect only after stopping and starting the VM."
-msgstr ""
-"Усі зміни набудуть чинності лише після перезапуску віртуальної машини."
+msgstr "Усі зміни набудуть чинності лише після перезапуску віртуальної машини."
 
 #: pkg/docker/storage.jsx:354
 msgid ""
@@ -971,19 +969,18 @@ msgstr "Дозволені служби"
 msgid "Always"
 msgstr "Завжди"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Анотації"
 
 #: pkg/kubernetes/scripts/projects.js:1028
 msgid "Anonymous: Allow all unauthenticated users to pull images"
-msgstr ""
-"Анонімний: дозволити усім нерозпізнаним користувачам отримувати образи"
+msgstr "Анонімний: дозволити усім нерозпізнаним користувачам отримувати образи"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "Програми"
 
@@ -991,11 +988,11 @@ msgstr "Програми"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "Застосувати"
 
@@ -1044,8 +1041,8 @@ msgstr "Мітка активу"
 msgid "At least $0 disks are needed."
 msgstr "Потрібно принаймні $0 дисків."
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "Потрібен принаймні один диск."
 
@@ -1065,9 +1062,9 @@ msgstr "Журнал інспектування"
 msgid "Authenticating"
 msgstr "Автентифікація"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Розпізнавання"
 
@@ -1083,13 +1080,13 @@ msgstr "Не вдалося пройти розпізнавання: з’єдн
 msgid "Authentication failed"
 msgstr "Помилка розпізнавання"
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "Слід пройти розпізнавання"
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "Автор"
 
@@ -1146,7 +1143,7 @@ msgstr "Доступні"
 msgid "Available Updates"
 msgstr "Доступні оновлення"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr "Доступні призначення на $0"
 
@@ -1174,7 +1171,7 @@ msgstr "Версія BIOS"
 msgid "Back to Accounts"
 msgstr "Назад до облікових записів"
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr "Резервний пристрій"
 
@@ -1297,10 +1294,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr "Не вдалося виконати дію зі зміни стану мережі"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "Процесор"
 
@@ -1365,7 +1362,6 @@ msgstr "Не вдалося завантажити образ"
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1377,27 +1373,27 @@ msgstr "Не вдалося завантажити образ"
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -1418,7 +1414,7 @@ msgid "Cannot schedule event in the past"
 msgstr "Не можна планувати подію на минуле"
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "Місткість"
@@ -1436,11 +1432,11 @@ msgid "Ceph Monitors"
 msgstr "Монітори Ceph"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "Змінити"
 
@@ -1468,7 +1464,7 @@ msgstr "Змінити системний час"
 msgid "Change User"
 msgstr "Змінити користувача"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr "Змінити назву ініціатора iSCSI"
 
@@ -1576,23 +1572,24 @@ msgstr "Натисніть, щоб побачити дані щодо облад
 msgid ""
 "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr ""
-"У результаті натискання «Запустити віддалений переглядач» буде отримано файл "
-".vv і запущено $0."
+"У результаті натискання «Запустити віддалений переглядач» буде отримано "
+"файл .vv і запущено $0."
 
 #: pkg/kubernetes/views/auth-form.html:88
 msgid "Client Certificate"
 msgstr "Сертифікат клієнта"
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "Закрити"
 
@@ -1600,7 +1597,7 @@ msgstr "Закрити"
 msgid "Close Selected Pages"
 msgstr "Закрити позначені сторінки"
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr "Кластер"
@@ -1698,16 +1695,15 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}Вам варто спробувати {{#sync_link}}синхронізувати "
-"користувачів{{/sync_link}}.{{/can_sync}} Щоб отримати доступ до ширшого "
-"спектра способів розпізнавання та до підтримки діагностики помилок, будь "
-"ласка, оновіть cockpit-ws."
+"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"Вам варто спробувати {{#sync_link}}синхронізувати користувачів{{/sync_link}}."
+"{{/can_sync}} Щоб отримати доступ до ширшого спектра способів розпізнавання "
+"та до підтримки діагностики помилок, будь ласка, оновіть cockpit-ws."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1721,8 +1717,8 @@ msgid ""
 msgstr ""
 "Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. Щоб "
 "користуватися цим комп’ютером за допомогою cockpit, вам слід увімкнути "
-"вказані нижче способи розпізнавання у налаштуваннях sshd на "
-"{{#strong}}{{host}}{{/strong}}:"
+"вказані нижче способи розпізнавання у налаштуваннях sshd на {{#strong}}"
+"{{host}}{{/strong}}:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1731,9 +1727,9 @@ msgid ""
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
 "Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. Ви можете "
-"змінити ваші реєстраційні дані для розпізнавання нижче. "
-"{{#can_sync}}Можливо, варто надати перевагу {{#sync_link}}синхронізації "
-"облікових записів і паролів{{/sync_link}}.{{/can_sync}}"
+"змінити ваші реєстраційні дані для розпізнавання нижче. {{#can_sync}}"
+"Можливо, варто надати перевагу {{#sync_link}}синхронізації облікових записів "
+"і паролів{{/sync_link}}.{{/can_sync}}"
 
 #: pkg/dashboard/index.html:155 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1754,7 +1750,7 @@ msgstr[2] "Комбіноване використання $0 ядер проц�
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "Команда"
 
@@ -1799,8 +1795,8 @@ msgstr "Сумісний зі сучасними системами та жор�
 msgid "Compress crash dumps to save space"
 msgstr "Стиснути дампи аварійних завершень для заощадження місця"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "Стискання"
 
@@ -2014,10 +2010,11 @@ msgid "Container:"
 msgstr "Контейнер:"
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "Контейнери"
 
@@ -2132,10 +2129,10 @@ msgstr "Аварійно завершити роботу системи"
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "Створити"
 
@@ -2237,12 +2234,13 @@ msgstr "Створити розділ на $0"
 msgid "Create partition table"
 msgstr "Створити таблицю розділів"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "Створено"
 
@@ -2370,7 +2368,7 @@ msgstr "Домени пошуку DNS $val"
 msgid "Dashboard"
 msgstr "Панель приладів"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr "Використано даних"
 
@@ -2390,7 +2388,7 @@ msgstr "Деактивуємо $target"
 msgid "Debug and above"
 msgstr "Діагностика і вище"
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr "Скасування дублювання"
 
@@ -2415,12 +2413,11 @@ msgstr "Затримка"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2490,8 +2487,8 @@ msgid ""
 "automatically created again in some cases."
 msgstr ""
 "Вилучення кокона призведе до завершення роботи усіх пов’язаних із ним "
-"контейнерів. У певних випадках кокон може бути повторно створено автоматично."
-"\n"
+"контейнерів. У певних випадках кокон може бути повторно створено "
+"автоматично.\n"
 "          "
 
 #: pkg/storaged/mdraid-details.jsx:304
@@ -2502,7 +2499,7 @@ msgstr "Вилучення пристрою RAID призведе до вити�
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Вилучення пристрою VDO призведе до витирання усіх даних на ньому."
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 "Вилучення контейнера призведе до витирання усіх даних, що на ньому "
@@ -2518,7 +2515,6 @@ msgstr ""
 msgid "Deleting a partition will delete all data in it."
 msgstr ""
 "Вилучення розділу призведе до вилучення усіх даних, що на ньому зберігаються."
-""
 
 #: pkg/storaged/vgroup-details.jsx:214
 msgid "Deleting a volume group will erase all data on it."
@@ -2557,14 +2553,14 @@ msgstr "Налаштування розгортання"
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "Опис"
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "Опис:"
 
@@ -2577,10 +2573,10 @@ msgid "Detachable"
 msgstr "Змінний"
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "Подробиці"
 
@@ -2589,7 +2585,7 @@ msgstr "Подробиці"
 msgid "Device"
 msgstr "Пристрій"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr "Файл пристрою"
 
@@ -2671,9 +2667,9 @@ msgstr "Пароль до диска"
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "Диски"
 
@@ -2725,8 +2721,8 @@ msgstr ""
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
 "Хочете вилучити роль «{{ fields.displayRole }}» із запису учасника {{ fields."
 "member.metadata.name }}?"
@@ -2841,7 +2837,7 @@ msgstr "Дублювання псевдоніма"
 msgid "Duplicate port"
 msgstr "Дублювання порту"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr "Змінити"
 
@@ -3005,7 +3001,7 @@ msgstr ""
 msgid "Entry"
 msgstr "Запис"
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr "Точка входження"
 
@@ -3031,9 +3027,9 @@ msgid "Errata:"
 msgstr "Помилки:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "Помилка"
 
@@ -3121,7 +3117,7 @@ msgstr "Помилка"
 msgid "Failed to add machine: $0"
 msgstr "Не вдалося додати комп’ютер: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "Не вдалося змінити пароль"
 
@@ -3187,7 +3183,6 @@ msgstr "Монтування файлової системи"
 msgid "Filesystem Name"
 msgstr "Назва файлової системи"
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3195,6 +3190,7 @@ msgstr "Назва файлової системи"
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr "Тип файлової системи"
 
@@ -3210,7 +3206,7 @@ msgstr "Файлові системи"
 msgid "Filter Services"
 msgstr "Фільтрувати служби"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Відбиток"
 
@@ -3334,7 +3330,7 @@ msgstr "Загальний"
 msgid "Generating report"
 msgstr "Створюємо звіт"
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr "Отримати новий образ"
 
@@ -3399,9 +3395,9 @@ msgstr "Група або проект"
 msgid "Groups"
 msgstr "Групи"
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr "Збільшити"
 
@@ -3462,9 +3458,9 @@ msgstr "Час вітання $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "Вузол"
 
@@ -3504,8 +3500,8 @@ msgstr "Очікування В-В"
 msgid "INSTALL VM action failed"
 msgstr "Помилка під час дії зі встановлення ВМ"
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr "IP"
 
@@ -3545,7 +3541,7 @@ msgstr "Параметри IPv6"
 msgid "ISCSI"
 msgstr "ISCSI"
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr "Ід."
@@ -3634,11 +3630,10 @@ msgstr "Потік образу"
 msgid "Image:"
 msgstr "Зображення:"
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr "Зображення"
 
@@ -3696,16 +3691,15 @@ msgstr ""
 msgid ""
 "In order to begin pushing images to the registry, you need to create a "
 "project."
-msgstr ""
-"Щоб розпочати надсилання образів до реєстру, вам слід створити проект."
+msgstr "Щоб розпочати надсилання образів до реєстру, вам слід створити проект."
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Для синхронізації параметрів користувачів, слід увійти до "
-"{{#strong}}{{host}}{{/strong}}. "
+"Для синхронізації параметрів користувачів, слід увійти до {{#strong}}{{host}}"
+"{{/strong}}. "
 
 #: pkg/networkmanager/interfaces.js:822 pkg/networkmanager/interfaces.js:1418
 #: pkg/networkmanager/interfaces.js:1425 pkg/networkmanager/interfaces.js:2594
@@ -3720,7 +3714,7 @@ msgstr "Неактивний том"
 msgid "Incorrect Host Key"
 msgstr "Неправильний ключ вузла"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr "Пам'ять покажчика"
 
@@ -3736,9 +3730,9 @@ msgstr "Немає доступу до даних щодо резервного 
 msgid "Initializing..."
 msgstr "Ініціалізація…"
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr "Встановити"
 
@@ -3788,7 +3782,7 @@ msgstr "Встановлено"
 msgid "Installed products"
 msgstr "Встановлені продукти"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "Встановлення"
@@ -3801,8 +3795,8 @@ msgstr "Встановлюємо $0"
 msgid "Instantiate"
 msgstr "Створити екземпляр"
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr "Інтерфейс"
 
@@ -3826,11 +3820,11 @@ msgstr "Некоректна адреса $0"
 msgid "Invalid credentials"
 msgstr "Реєстраційні дані вказано з помилками"
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "Некоректний формат дати"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "Некоректний формат дати і часу"
 
@@ -3878,7 +3872,7 @@ msgstr "Некоректний префікс $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "Некоректний префікс або маска мережі $0"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "Некоректний формат визначення часу"
 
@@ -3886,7 +3880,7 @@ msgstr "Некоректний формат визначення часу"
 msgid "Invalid time zone"
 msgstr "Некоректний часовий пояс"
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr "Некоректне ім’я користувача чи пароль"
@@ -4006,11 +4000,12 @@ msgstr "Кластер Kubernetes"
 msgid "LACP Key"
 msgstr "Ключ LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Мітки"
@@ -4055,8 +4050,8 @@ msgstr "Останнє оновлення"
 msgid "Last checked: $0 ago"
 msgstr "Востаннє перевірено: $0 тому"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr "Найсвіжіша версія"
 
@@ -4087,7 +4082,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Не заповнюйте, щоб встановити з’єднання із цією машиною від імені поточного "
 "користувача системи{{#default_user}} ({{default_user}}){{/default_user}}. "
@@ -4154,8 +4148,8 @@ msgstr "Завантажуємо доступні оновлення, зачек
 msgid "Loading data ..."
 msgstr "Завантажуємо дані…"
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "Завантаження…"
 
@@ -4231,17 +4225,17 @@ msgstr "Повідомлення журналу"
 msgid "Logged In"
 msgstr "Вхід"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr "Логічний"
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr "Логічний розмір"
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr "Логічний номер модуля"
 
@@ -4439,9 +4433,10 @@ msgstr "Участь"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4473,8 +4468,8 @@ msgstr "Використання пам'яті:"
 msgid "Memory:"
 msgstr "Пам’ять:"
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "Повідомлення"
 
@@ -4489,7 +4484,7 @@ msgstr "Повідомлення користувачам, які увійшли
 msgid "Metadata"
 msgstr "Метадані"
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr "Використано метаданих"
 
@@ -4569,8 +4564,8 @@ msgstr "Докладніше"
 msgid "More details"
 msgstr "Докладніше"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "Змонтувати"
 
@@ -4578,17 +4573,17 @@ msgstr "Змонтувати"
 msgid "Mount Location"
 msgstr "Місце монтування"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "Параметри монтування"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "Точка монтування"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr "Змонтувати при завантаженні"
 
@@ -4612,7 +4607,7 @@ msgstr "Точка монтування не може бути порожньо�
 msgid "Mount point must start with \"/\"."
 msgstr "Запис точки монтування має починатися з «/»."
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr "Змонтувати лише для читання"
 
@@ -4676,37 +4671,38 @@ msgstr "Сервер NTP"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "Назва"
 
@@ -4740,7 +4736,6 @@ msgstr "Назва не може складатися лише із порожн
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4751,6 +4746,7 @@ msgstr "Назва не може складатися лише із порожн
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "Простір назв"
@@ -4764,8 +4760,8 @@ msgid "Need at least one NTP server"
 msgstr "Потрібен принаймні один сервер NTP"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "Мережа"
 
@@ -4833,8 +4829,8 @@ msgstr "Новий проект"
 msgid "New Volume Name"
 msgstr "Назва нового тому"
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr "Новий потік образу"
 
@@ -4842,7 +4838,7 @@ msgstr "Новий потік образу"
 msgid "New passphrase"
 msgstr "Новий пароль"
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "Новий пароль не прийнято"
 
@@ -4852,7 +4848,7 @@ msgstr "Новий пароль не прийнято"
 msgid "New project"
 msgstr "Новий проект"
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Далі"
 
@@ -4967,9 +4963,9 @@ msgstr "Немає контейнерів, які проходять поточ�
 msgid "No description provided."
 msgstr "Опису не надано."
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr "Немає доступних дисків."
 
@@ -4997,7 +4993,7 @@ msgstr "Немає груп."
 msgid "No host keys found."
 msgstr "Не знайдено ключів вузлів."
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr "Призначень iSCSI не налаштовано"
 
@@ -5005,7 +5001,7 @@ msgstr "Призначень iSCSI не налаштовано"
 msgid "No image streams are present."
 msgstr "Немає потоків образів."
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr "Немає образів"
 
@@ -5013,7 +5009,7 @@ msgstr "Немає образів"
 msgid "No images pushed"
 msgstr "Не вивантажено жодного образу"
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr "Немає образів, які проходять поточні умови фільтрування"
 
@@ -5165,9 +5161,9 @@ msgstr "Вузол"
 msgid "Node:"
 msgstr "Вузол:"
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr "Вузли"
 
@@ -5178,7 +5174,7 @@ msgstr "Вузли — комп’ютери, на яких запущено в�
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "Немає"
 
@@ -5220,8 +5216,8 @@ msgstr "Недоступний"
 msgid "Not connected"
 msgstr "Не з’єднано"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr "Не розгорнуто"
 
@@ -5237,7 +5233,7 @@ msgstr "Не змонтовано"
 msgid "Not permitted to perform this action."
 msgstr "Немає дозволу на виконання цієї дії."
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "Зупинено"
 
@@ -5265,8 +5261,8 @@ msgstr "Зауваження і вище"
 msgid "Number of virtual CPUs that gonna be used."
 msgstr "Кількість віртуальних процесорів, які слід використовувати."
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr "Гаразд"
 
@@ -5298,8 +5294,8 @@ msgstr "Сталося між $0 і $1"
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "Вимкнено"
 
@@ -5315,14 +5311,14 @@ msgstr "Старий пароль"
 msgid "Old passphrase"
 msgstr "Старий пароль"
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "Старий пароль не прийнято"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "Увімкнено"
 
@@ -5506,11 +5502,12 @@ msgstr "Вилучення пароля може завадити розблок
 msgid "Passphrases do not match"
 msgstr "Паролі не збігаються"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5551,10 +5548,10 @@ msgstr "Вставте JSON нижче, "
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Сюди слід вставити вміст файла вашого відкритого ключа SSH"
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "Шлях"
 
@@ -5618,7 +5615,7 @@ msgstr "Сталі томи"
 msgid "Phase"
 msgstr "Фаза"
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr "Фізичний"
 
@@ -5650,8 +5647,8 @@ msgstr "Ціль тестування луною"
 msgid "Pizza Box"
 msgstr "З коробку для піци"
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5669,7 +5666,6 @@ msgstr "Будь ласка, підтвердьте зупинку $0"
 msgid "Please confirm, the host shall be switched to maintenance mode."
 msgstr ""
 "Будь ласка, підтвердьте, що вузол має бути перемкнуто у режим обслуговування."
-""
 
 #: pkg/kubernetes/scripts/dashboard.js:440
 msgid "Please create another namespace for $0 \"$1\""
@@ -5880,9 +5876,8 @@ msgstr "Заповнити"
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr "Порт"
 
@@ -5898,7 +5893,7 @@ msgstr "Група портів"
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "Порти"
 
@@ -5981,7 +5976,7 @@ msgstr "Дані щодо проблеми"
 msgid "Problems"
 msgstr "Проблеми"
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr "Процес"
 
@@ -5995,7 +5990,6 @@ msgstr "Назва продукту"
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -6007,6 +6001,7 @@ msgstr "Назва продукту"
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "Проект"
@@ -6041,10 +6036,10 @@ msgstr "Сайт проекту"
 msgid "Project:"
 msgstr "Проект:"
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr "Проекти"
 
@@ -6076,7 +6071,7 @@ msgstr "Проксі"
 msgid "Proxy Version"
 msgstr "Версія проксі"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Відкритий ключ"
 
@@ -6104,8 +6099,8 @@ msgstr "Призначення"
 msgid "Push an image:"
 msgstr "Вивантажити образ:"
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr "Повна назва"
 
@@ -6169,7 +6164,7 @@ msgstr "Апаратний блок RAID"
 msgid "RAID Device"
 msgstr "пристрій RAID"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "Пристій RAID $0"
 
@@ -6205,7 +6200,6 @@ msgstr "Випадковий"
 msgid "Raw to a device"
 msgstr "Без обробки на пристрій"
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6217,6 +6211,7 @@ msgstr "Без обробки на пристрій"
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr "Лише читання"
 
@@ -6283,7 +6278,7 @@ msgstr "Назва справжнього вузла має складатися
 msgid "Reason"
 msgstr "Підстава"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "Перезавантажити"
 
@@ -6339,8 +6334,8 @@ msgstr "Відмовляємо у з’єднанні. Ключі вузла н�
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Відмовляємо у з’єднанні. Невідомий ключ вузла."
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr "Зареєструвати"
 
@@ -6368,8 +6363,8 @@ msgstr "Реєструємо oVirt на Cockpit"
 msgid "Register…"
 msgstr "Зареєструвати…"
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "Перезавантажити"
 
@@ -6410,9 +6405,9 @@ msgstr "Вилучення:"
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "Вилучити"
 
@@ -6464,7 +6459,7 @@ msgstr "Вилучити пароль"
 msgid "Remove passphrase in $0?"
 msgstr "Вилучити пароль у $0?"
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr "Вилучаємо"
 
@@ -6534,10 +6529,10 @@ msgstr "Повторювати щороку"
 msgid "Repeat passphrase"
 msgstr "Повторіть пароль"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "Репліки"
 
@@ -6654,8 +6649,8 @@ msgstr "Усуньте наведені вище помилки, щоб прод
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "Перезапустити"
 
@@ -6704,8 +6699,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Повторно використати ваш пароль для привілейованих завдань"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Повторно використати ваш пароль для привілейованих завдань та з’єднання з "
 "іншими комп’ютерами"
@@ -6761,7 +6755,7 @@ msgstr "Запустити від імені"
 msgid "Runner"
 msgstr "Засіб для запуску"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "Працює"
 
@@ -6849,8 +6843,8 @@ msgstr "Не вдалося виконати дію SUSPEND"
 msgid "Saturday"
 msgstr "субота"
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "Зберегти"
 
@@ -6905,7 +6899,7 @@ msgstr "Ключі захищеної оболонки (SSH)"
 msgid "Securely erasing $target"
 msgstr "Безпечно витираємо $target"
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr "Безпека"
 
@@ -6937,11 +6931,11 @@ msgstr "Виберіть об’єкт для перегляду ширшого 
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Виберіть користувачів, записи яких ви б хотіли синхронізувати з "
-"{{#strong}}{{host}}{{/strong}}"
+"Виберіть користувачів, записи яких ви б хотіли синхронізувати з {{#strong}}"
+"{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:65
 msgid "Send Non-Maskable Interrupt"
@@ -6961,15 +6955,14 @@ msgstr "Надсилання"
 msgid "Serial Console"
 msgstr "Послідовна консоль"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "Сервер"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr "Адреса сервера"
 
@@ -6977,7 +6970,7 @@ msgstr "Адреса сервера"
 msgid "Server Administrator"
 msgstr "Адміністратор сервера"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr "Адреса сервера не може бути порожньою."
 
@@ -6996,7 +6989,7 @@ msgstr "Сервери"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "Служба"
 
@@ -7047,7 +7040,7 @@ msgstr ""
 "збалансовану за навантаженням IP-адресу для доступу до них."
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr "Сеанс"
 
@@ -7185,7 +7178,7 @@ msgstr "Показати усі образи"
 msgid "Show fingerprints"
 msgstr "Показати відбитки"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr "Стиснути"
 
@@ -7206,34 +7199,34 @@ msgstr "З"
 msgid "Since $0"
 msgstr "З $0"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "Розмір"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "Розмір не може бути від’ємним"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "Розмір не може бути нульовим"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr "Розмір є надто великим"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "Розмір має бути числом"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr "Розмір має бути не меншим за $0"
 
@@ -7329,7 +7322,7 @@ msgid "Stable"
 msgstr "Стабільний"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "Почати"
@@ -7370,10 +7363,10 @@ msgstr "Починається"
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "Стан"
 
@@ -7395,10 +7388,11 @@ msgid "Static"
 msgstr "Статичний"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7421,7 +7415,7 @@ msgid "Sticky"
 msgstr "Липкий"
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7662,7 +7656,7 @@ msgstr "Мітка"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr "Мітки"
 
@@ -7684,7 +7678,7 @@ msgstr "Портал призначення"
 msgid "Target World Wide Names"
 msgstr "WWN призначень"
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr "Призначення"
 
@@ -7821,8 +7815,8 @@ msgstr "У адресі містяться некоректні символи"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Не вдалося встановити ідентичність вузла {{#strong}}{{host}}{{/strong}}. Ви "
 "справді хочете продовжити спробу встановити з’єднання?"
@@ -7844,8 +7838,7 @@ msgstr "Контейнера «{{ target }}» не існує."
 #: pkg/storaged/vdo-details.jsx:106
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
-msgstr ""
-"Створення цього пристрою VDO не завершено, ним не можна користуватися."
+msgstr "Створення цього пристрою VDO не завершено, ним не можна користуватися."
 
 #: pkg/subscriptions/subscriptions-view.jsx:192
 msgid "The current user isn't allowed to access system subscription status."
@@ -7866,13 +7859,13 @@ msgstr "Налаштувань розгортання «{{ target }}» не іс
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 "Файлова система використовується службами системи або сеансами користувачів. "
 "Виконання цієї дії призведе до припинення роботи цих служб та сеансів."
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7886,9 +7879,8 @@ msgstr ""
 "Файлова система використовується сеансами користувачів. Виконання цієї дії "
 "призведе до припинення роботи цих сеансів."
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7899,14 +7891,13 @@ msgstr ""
 "Файлова система використовується службами системи. Виконання цієї дії "
 "призведе до припинення роботи цих служб."
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "Вказані нижче контейнери залежать від цього образу, отже стануть "
 "непридатними до використання."
@@ -7939,9 +7930,9 @@ msgid ""
 "in use. Unless this machine was recently replaced, it is likely that someone "
 "is trying to attack your connection to this machine."
 msgstr ""
-"Ключ {{#strong}}{{host}}{{/strong}} не відповідає раніше використаному ключу."
-" Якщо нещодавно ніхто не міняв цього комп’ютера, ймовірною причиною є спроба "
-"атаки на ваше з’єднання із цим комп’ютером."
+"Ключ {{#strong}}{{host}}{{/strong}} не відповідає раніше використаному "
+"ключу. Якщо нещодавно ніхто не міняв цього комп’ютера, ймовірною причиною є "
+"спроба атаки на ваше з’єднання із цим комп’ютером."
 
 #: pkg/users/authorized-keys.js:119
 msgid "The key you provided was not valid."
@@ -8015,11 +8006,11 @@ msgstr "Контролера реплікації «{{ target }}» не існу
 msgid "The route '{{ target }}' does not exist."
 msgstr "Маршруту «{{ target }}» не існує."
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "Скануванням від $time ($type) вразливостей не знайдено."
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr "Сканування $time ($type) виконати не вдалося."
 
@@ -8114,8 +8105,7 @@ msgstr ""
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "Налаштування програми для перегляду інтернету забороняють запуск Cockpit "
 "(недоступна можливість $0)"
@@ -8184,13 +8174,13 @@ msgstr ""
 "На цьому пристрої міститься файлова система, яка зараз використовується. "
 "Виконання дії призведе до демонтування усіх файлових систем на пристрої."
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr "Цей пристрій зараз використовується для пристроїв RAID."
 
@@ -8202,18 +8192,18 @@ msgstr ""
 "Цей пристрій зараз використовується для формування пристроїв RAID. Якщо дію "
 "буде виконано, пристрій буде вилучено із його пристроїв RAID."
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 "Цей пристрій зараз використовується для зберігання даних пристроїв VDO."
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr "Цей пристрій зараза використовується для груп томів."
 
@@ -8225,7 +8215,7 @@ msgstr ""
 "Цей пристрій зараз використовується для груп томів. Якщо дію буде виконано, "
 "пристрій буде вилучено із його груп томів."
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8248,7 +8238,7 @@ msgstr ""
 "Цей вузол керується засобом керування віртуалізацією, тому створення нових "
 "віртуальних машин з вузла неможливе."
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr "Цього образу не існує."
 
@@ -8323,12 +8313,12 @@ msgstr "Ця віртуальна машина не керується з бок
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
-"Цей том може бути заявлено для {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Його вилучення порушить цю заявку і може "
+"Цей том може бути заявлено для {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Його вилучення порушить цю заявку і може "
 "призвести до проблем із усіма коконами, які від нього залежать."
 
 #: pkg/kubernetes/views/pv-claim.html:23
@@ -8337,8 +8327,7 @@ msgstr "Цей том не заявлено"
 
 #: pkg/storaged/lvol-tabs.jsx:329
 msgid "This volume needs to be activated before it can be resized."
-msgstr ""
-"Перш ніж розмір цього тому можна буде змінювати, його слід активувати."
+msgstr "Перш ніж розмір цього тому можна буде змінювати, його слід активувати."
 
 #: src/ws/login.js:141
 msgid "This web browser is too old to run Cockpit (missing $0)"
@@ -8498,11 +8487,11 @@ msgstr "Tuned не запущено"
 msgid "Tuned is off"
 msgstr "Tuned вимкнено"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "Тип"
@@ -8565,7 +8554,7 @@ msgstr "Не вдалося отримати параметри нагадува
 msgid "Unable to get alert: $0"
 msgstr "Не вдалося отримати нагадування: $0"
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Не вдалося досягти сервера"
 
@@ -8611,23 +8600,23 @@ msgstr "Неочікувана помилка"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr "Модуль"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "Невідомий"
 
@@ -8651,7 +8640,7 @@ msgstr "Невідомий ключ вузла"
 msgid "Unknown configuration"
 msgstr "Невідомі налаштування"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr "Невідома назва вузла"
 
@@ -8696,7 +8685,7 @@ msgstr "Некеровані інтерфейси"
 msgid "Unmask"
 msgstr "Розмаскувати"
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "Демонтувати"
 
@@ -8786,7 +8775,7 @@ msgstr "Доступні оновлення"
 msgid "Updates are disabled."
 msgstr "Оновлення вимкнено."
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr "Оновлення"
 
@@ -8838,13 +8827,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr "Використовувати параметр у /etc/kdump.conf"
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "Використано"
 
@@ -8854,10 +8843,10 @@ msgstr "Використано контейнерами"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8876,7 +8865,7 @@ msgstr "Пароль користувача"
 msgid "User interface for Linux servers"
 msgstr "Інтерфейс користувача для серверів Linux"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Ім'я користувача"
@@ -8889,8 +8878,8 @@ msgstr "Ім’я користувача не може бути порожнім
 msgid "User or Group"
 msgstr "Користувач або група"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "Користувач"
 
@@ -9051,9 +9040,9 @@ msgid "Verifying"
 msgstr "Перевіряємо"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "Версія"
 
@@ -9115,8 +9104,8 @@ msgstr "Групи томів"
 msgid "Volume ID"
 msgstr "Ід. тому"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "Назва тому"
 
@@ -9124,9 +9113,8 @@ msgstr "Назва тому"
 msgid "Volume Type"
 msgstr "Тип тому"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Томи"
@@ -9267,8 +9255,7 @@ msgstr ""
 
 #: pkg/docker/storage.jsx:475
 msgid "You don't have permission to manage the Docker storage pool."
-msgstr ""
-"У вас немає прав доступу до керування резервним сховищем даних Docker."
+msgstr "У вас немає прав доступу до керування резервним сховищем даних Docker."
 
 #: pkg/packagekit/updates.jsx:811
 msgid "You need to re-subscribe this system."
@@ -9438,7 +9425,7 @@ msgstr "пристрій осн. системи"
 msgid "iSCSI"
 msgstr "iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr "Призначення iSCSI"
 
@@ -9513,10 +9500,10 @@ msgstr "не придатна до роботи"
 msgid "non responsive"
 msgstr "не відповідає"
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9697,7 +9684,7 @@ msgstr "udp"
 msgid "unassigned"
 msgstr "не прив'язано"
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "не визначено"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-05 15:20+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-09-12 14:18+0200\n"
 "PO-Revision-Date: 2017-10-23 08:19+0000\n"
 "Last-Translator: vanlos wang <vanloswang@126.com>\n"
 "Language-Team: Chinese (China)\n"
 "Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
@@ -53,7 +53,9 @@ msgid ""
 "$0 Only users with local credentials will be able to log into this machine. "
 "This may also effect other services as DNS resolution settings and the list "
 "of trusted CAs may change."
-msgstr "$0 仅本地用户可登录到该主机。这可能也会影响其他服务，比如DNS解析配置，并且信任的CA列表可能改变。"
+msgstr ""
+"$0 仅本地用户可登录到该主机。这可能也会影响其他服务，比如DNS解析配置，并且信"
+"任的CA列表可能改变。"
 
 #: pkg/systemd/init.js:377 pkg/systemd/init.js:711
 msgid "$0 Template"
@@ -77,7 +79,7 @@ msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "$0 字节"
 
-#: pkg/storaged/vdo-details.jsx:278
+#: pkg/storaged/vdo-details.jsx:279
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
@@ -134,7 +136,8 @@ msgstr[0] "$0 小时"
 msgid ""
 "$0 is available for most operating systems. To install it, search for it in "
 "GNOME Software or run the following:"
-msgstr "$0 对大多数操作系统可用。为了安装它，在 GNOME 软件中心搜索它或运行以下命令： "
+msgstr ""
+"$0 对大多数操作系统可用。为了安装它，在 GNOME 软件中心搜索它或运行以下命令： "
 
 #: pkg/storaged/content-views.jsx:274 pkg/storaged/content-views.jsx:487
 #: pkg/storaged/format-dialog.jsx:253 pkg/storaged/lvol-tabs.jsx:153
@@ -184,7 +187,7 @@ msgid "$0 update"
 msgid_plural "$0 updates"
 msgstr[0] "$0 可更新"
 
-#: pkg/storaged/vdo-details.jsx:291
+#: pkg/storaged/vdo-details.jsx:292
 msgid "$0 used of $1 ($2 saved)"
 msgstr ""
 
@@ -208,7 +211,6 @@ msgid_plural "$0 years"
 msgstr[0] "$0 年"
 
 #: pkg/kubernetes/scripts/nodes.js:874
-#, c-format
 msgid "$0% Free"
 msgid_plural "$0% Free"
 msgstr[0] "$0% 空闲的"
@@ -555,7 +557,7 @@ msgid "Access"
 msgstr "访问"
 
 #: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
+#: pkg/kubernetes/views/pvc-body.html:18 pkg/kubernetes/views/pv-modify.html:69
 msgid "Access Modes"
 msgstr "访问模式"
 
@@ -619,7 +621,7 @@ msgid "Active Pages"
 msgstr "激活页面"
 
 #: pkg/storaged/index.html:377 pkg/storaged/index.html:397
-#: pkg/storaged/dialogx.jsx:724 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/dialogx.jsx:788 pkg/storaged/dialogx.jsx:792
 msgid "Active since"
 msgstr ""
 
@@ -640,11 +642,11 @@ msgstr "自适应传输负载均衡"
 #: pkg/kubernetes/views/add-user-dialog.html:27
 #: pkg/kubernetes/views/node-add.html:50
 #: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:445
-#: pkg/storaged/crypto-keyslots.jsx:201 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/iscsi-panel.jsx:183 pkg/storaged/mdraid-details.jsx:61
-#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/vgroup-details.jsx:65
+#: pkg/kubernetes/views/user-group-add.html:30 pkg/shell/index.html:181
+#: pkg/lib/machine-add.html:43 pkg/machines/components/diskAdd.jsx:445
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-keyslots.jsx:201
+#: pkg/storaged/iscsi-panel.jsx:133 pkg/storaged/iscsi-panel.jsx:156
+#: pkg/storaged/mdraid-details.jsx:61 pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "添加"
 
@@ -804,7 +806,7 @@ msgstr ""
 #: pkg/kubernetes/views/details-page.html:174
 #: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
 #: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
-#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:150
+#: pkg/machines/vmnetworktab.jsx:60 pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "地址"
 
@@ -922,8 +924,8 @@ msgstr ""
 msgid "Always"
 msgstr "通常"
 
-#: pkg/kubernetes/views/node-body.html:57
 #: pkg/kubernetes/views/route-body.html:27
+#: pkg/kubernetes/views/node-body.html:57
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "注释"
@@ -932,8 +934,8 @@ msgstr "注释"
 msgid "Anonymous: Allow all unauthenticated users to pull images"
 msgstr "匿名的：允许所有未鉴定的用户拉取镜像"
 
-#: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/index.html:23 pkg/apps/application.jsx:143
+#: pkg/apps/application-list.jsx:152
 msgid "Applications"
 msgstr "应用"
 
@@ -941,11 +943,11 @@ msgstr "应用"
 #: pkg/networkmanager/index.html:700 pkg/networkmanager/index.html:724
 #: pkg/networkmanager/index.html:748 pkg/networkmanager/index.html:772
 #: pkg/networkmanager/index.html:796 pkg/networkmanager/index.html:820
-#: pkg/networkmanager/index.html:844 pkg/kdump/kdump-view.jsx:358
-#: pkg/machines/components/vcpuModal.jsx:223
-#: pkg/ovirt/components/vcpuModal.jsx:97 pkg/storaged/crypto-tab.jsx:78
+#: pkg/networkmanager/index.html:844 pkg/machines/components/vcpuModal.jsx:223
+#: pkg/storaged/nfs-details.jsx:177 pkg/storaged/crypto-tab.jsx:78
 #: pkg/storaged/crypto-tab.jsx:107 pkg/storaged/fsys-tab.jsx:73
-#: pkg/storaged/fsys-tab.jsx:120 pkg/storaged/nfs-details.jsx:177
+#: pkg/storaged/fsys-tab.jsx:120 pkg/kdump/kdump-view.jsx:358
+#: pkg/ovirt/components/vcpuModal.jsx:97
 msgid "Apply"
 msgstr "应用"
 
@@ -994,8 +996,8 @@ msgstr "资产标记"
 msgid "At least $0 disks are needed."
 msgstr "至少需要 $0 块磁盘。"
 
-#: pkg/storaged/mdraid-details.jsx:56 pkg/storaged/vgroup-details.jsx:60
-#: pkg/storaged/vgroups-panel.jsx:66
+#: pkg/storaged/vgroups-panel.jsx:66 pkg/storaged/mdraid-details.jsx:56
+#: pkg/storaged/vgroup-details.jsx:60
 msgid "At least one disk is needed."
 msgstr "至少需要 1 块磁盘。"
 
@@ -1015,9 +1017,9 @@ msgstr "审计日志"
 msgid "Authenticating"
 msgstr "认证中"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
-#: pkg/realmd/operation.html:35 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/kubernetes/views/auth-form.html:85 pkg/realmd/operation.html:35
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "认证"
 
@@ -1033,13 +1035,13 @@ msgstr "认证失败： 服务关闭连接"
 msgid "Authentication failed"
 msgstr "认证失败"
 
-#: pkg/storaged/iscsi-panel.jsx:171
+#: pkg/storaged/iscsi-panel.jsx:148
 msgid "Authentication required"
 msgstr "需要认证"
 
 #: pkg/docker/index.html:694
 #: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:396
+#: pkg/docker/containers-view.jsx:398
 msgid "Author"
 msgstr "作者"
 
@@ -1096,7 +1098,7 @@ msgstr "可用的"
 msgid "Available Updates"
 msgstr "可用的更新"
 
-#: pkg/storaged/iscsi-panel.jsx:145
+#: pkg/storaged/iscsi-panel.jsx:124
 msgid "Available targets on $0"
 msgstr "$0 上可用的目标"
 
@@ -1124,7 +1126,7 @@ msgstr ""
 msgid "Back to Accounts"
 msgstr "返回账号"
 
-#: pkg/storaged/vdo-details.jsx:266
+#: pkg/storaged/vdo-details.jsx:267
 msgid "Backing Device"
 msgstr ""
 
@@ -1247,10 +1249,10 @@ msgid "CHANGE NETWORK STATE action failed"
 msgstr ""
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:268
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:599
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:821
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:85
-#: pkg/systemd/hwinfo.jsx:62
+#: pkg/kubernetes/scripts/graphs.js:599 pkg/kubernetes/scripts/nodes.js:715
+#: pkg/kubernetes/scripts/nodes.js:821 pkg/systemd/hwinfo.jsx:62
 msgid "CPU"
 msgstr "CPU"
 
@@ -1315,7 +1317,6 @@ msgstr ""
 #: pkg/kubernetes/views/project-delete.html:8
 #: pkg/kubernetes/views/project-modify.html:71
 #: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
 #: pkg/kubernetes/views/pvc-delete.html:14
 #: pkg/kubernetes/views/remove-role-dialog.html:7
 #: pkg/kubernetes/views/replicationcontroller-modify.html:16
@@ -1327,27 +1328,27 @@ msgstr ""
 #: pkg/kubernetes/views/user-group-remove.html:9
 #: pkg/kubernetes/views/user-modify.html:26
 #: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
+#: pkg/kubernetes/views/pv-modify.html:203 pkg/networkmanager/index.html:651
+#: pkg/networkmanager/index.html:675 pkg/networkmanager/index.html:699
+#: pkg/networkmanager/index.html:723 pkg/networkmanager/index.html:747
+#: pkg/networkmanager/index.html:771 pkg/networkmanager/index.html:795
+#: pkg/networkmanager/index.html:819 pkg/networkmanager/index.html:843
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:92
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/shell/stub.html:105
+#: pkg/storaged/index.html:416 pkg/systemd/index.html:361
+#: pkg/systemd/index.html:448 pkg/systemd/index.html:500
+#: pkg/systemd/index.html:516 pkg/systemd/services.html:506
+#: pkg/users/index.html:225 pkg/users/index.html:289 pkg/users/index.html:328
+#: pkg/users/index.html:367 pkg/users/index.html:384 pkg/users/index.html:408
+#: pkg/users/index.html:465 pkg/lib/machine-add.html:42
 #: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:651 pkg/networkmanager/index.html:675
-#: pkg/networkmanager/index.html:699 pkg/networkmanager/index.html:723
-#: pkg/networkmanager/index.html:747 pkg/networkmanager/index.html:771
-#: pkg/networkmanager/index.html:795 pkg/networkmanager/index.html:819
-#: pkg/networkmanager/index.html:843 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:92 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/storaged/index.html:416
-#: pkg/systemd/index.html:361 pkg/systemd/index.html:448
-#: pkg/systemd/index.html:500 pkg/systemd/index.html:516
-#: pkg/systemd/services.html:506 pkg/users/index.html:225
-#: pkg/users/index.html:289 pkg/users/index.html:328 pkg/users/index.html:367
-#: pkg/users/index.html:384 pkg/users/index.html:408 pkg/users/index.html:465
-#: pkg/apps/utils.jsx:85 pkg/lib/cockpit-components-dialog.jsx:153
-#: pkg/networkmanager/firewall.jsx:258
+#: pkg/lib/machine-change-auth.html:80 pkg/networkmanager/firewall.jsx:258
+#: pkg/sosreport/index.js:51 pkg/storaged/job-views.jsx:43
+#: pkg/storaged/jobs-panel.jsx:123 pkg/storaged/dialogx.jsx:341
+#: pkg/lib/cockpit-components-dialog.jsx:153 pkg/apps/utils.jsx:85
+#: pkg/ovirt/components/VdsmView.jsx:97 pkg/ovirt/components/VdsmView.jsx:111
 #: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:183
-#: pkg/sosreport/index.js:51 pkg/storaged/dialogx.jsx:296
-#: pkg/storaged/job-views.jsx:43 pkg/storaged/jobs-panel.jsx:123
+#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/packagekit/updates.jsx:183
 msgid "Cancel"
 msgstr "取消"
 
@@ -1368,7 +1369,7 @@ msgid "Cannot schedule event in the past"
 msgstr "无法调度以前的事件"
 
 #: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
+#: pkg/kubernetes/views/pvc-body.html:32 pkg/kubernetes/views/pv-modify.html:44
 #: pkg/machines/components/vmDisksTab.jsx:68
 msgid "Capacity"
 msgstr "容量"
@@ -1386,11 +1387,11 @@ msgid "Ceph Monitors"
 msgstr "Ceph 监视器"
 
 #: pkg/docker/index.html:657 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
 #: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:362
+#: pkg/kubernetes/views/route-modify.html:17
+#: pkg/kubernetes/views/pv-modify.html:205 pkg/systemd/index.html:362
 #: pkg/systemd/index.html:449 pkg/users/index.html:329 pkg/users/index.html:368
-#: pkg/storaged/iscsi-panel.jsx:216
+#: pkg/storaged/iscsi-panel.jsx:182
 msgid "Change"
 msgstr "变更"
 
@@ -1418,7 +1419,7 @@ msgstr "修改系统时间"
 msgid "Change User"
 msgstr "变更用户"
 
-#: pkg/storaged/iscsi-panel.jsx:208
+#: pkg/storaged/iscsi-panel.jsx:177
 msgid "Change iSCSI Initiator Name"
 msgstr "变更 iSCSI Initiator 名称"
 
@@ -1529,16 +1530,17 @@ msgstr "点击 \"加载远程查看其\" 将下载一个  .vv 文件并加载 $0
 msgid "Client Certificate"
 msgstr "客户端证书"
 
-#: pkg/docker/index.html:729 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:19
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:862 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/storaged/index.html:79
-#: pkg/storaged/index.html:421 pkg/systemd/index.html:307
-#: pkg/systemd/services.html:347 pkg/systemd/services.html:365
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:296
+#: pkg/docker/index.html:729 pkg/networkmanager/index.html:862
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:343
+#: pkg/shell/simple.html:72 pkg/shell/stub.html:79 pkg/shell/stub.html:122
+#: pkg/storaged/index.html:79 pkg/storaged/index.html:421
+#: pkg/systemd/index.html:307 pkg/systemd/services.html:347
+#: pkg/systemd/services.html:365 pkg/users/index.html:45
+#: pkg/lib/machine-auth-failed.html:20 pkg/lib/machine-change-port.html:45
+#: pkg/lib/machine-invalid-hostkey.html:19 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:110 pkg/storaged/dialogx.jsx:341
+#: pkg/apps/utils.jsx:107
 msgid "Close"
 msgstr "关闭"
 
@@ -1546,7 +1548,7 @@ msgstr "关闭"
 msgid "Close Selected Pages"
 msgstr "关闭已选的页面"
 
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
+#: pkg/kubernetes/views/auth-form.html:5 pkg/kubernetes/index.html:37
 #: pkg/ovirt/components/App.jsx:105
 msgid "Cluster"
 msgstr "集群"
@@ -1571,7 +1573,9 @@ msgstr "Cockpit 认证配置不正确。"
 msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
-msgstr "Cockpit 无法与指定主机 $0 联系。请确认已经在端口 $1 上运行 SSH，或者在该地址中指定另一个端口。"
+msgstr ""
+"Cockpit 无法与指定主机 $0 联系。请确认已经在端口 $1 上运行 SSH，或者在该地址"
+"中指定另一个端口。"
 
 #: src/base1/cockpit.js:4018
 msgid "Cockpit could not contact the given host."
@@ -1583,8 +1587,9 @@ msgid ""
 "Cockpit by pressing refresh in your browser. The javascript console contains "
 "details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
-"Cockpit 遇到意外的内部错误。 <br/><br/>可以尝试通过刷新浏览器重启 Cockpit。Javascript 控制台包含关于该错误的详情 "
-"（大多数浏览器中按<b>Ctrl-Shift-J</b> ）。"
+"Cockpit 遇到意外的内部错误。 <br/><br/>可以尝试通过刷新浏览器重启 Cockpit。"
+"Javascript 控制台包含关于该错误的详情 （大多数浏览器中按<b>Ctrl-Shift-J</"
+"b> ）。"
 
 #: cockpit.appdata.xml.in.h:2
 msgid ""
@@ -1594,8 +1599,9 @@ msgid ""
 "Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
 "journal interface."
 msgstr ""
-"Cockpit 是一个服务器管理器, 可以方便地通过浏览器来管理你的 Linux 服务器.在终端和 web 工具间切换没有任何问题. 服务可以通过 "
-"Cockpit 启动, 通过终端停止.同样地, 如果在终端中发生错误, 也可以​​在 Cockpit journal 接口中看到."
+"Cockpit 是一个服务器管理器, 可以方便地通过浏览器来管理你的 Linux 服务器.在终"
+"端和 web 工具间切换没有任何问题. 服务可以通过 Cockpit 启动, 通过终端停止.同样"
+"地, 如果在终端中发生错误, 也可以​​在 Cockpit journal 接口中看到."
 
 #: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
 msgid "Cockpit is an interactive Linux server admin interface."
@@ -1621,8 +1627,9 @@ msgid ""
 "same time. Just add them with a single click and your machines will look "
 "after its buddies."
 msgstr ""
-"Cockpit 是完美的系统管理员工具, 它可以轻松完成简单的任务, 如存储管理, 检查 journals 和启动/停止服务. "
-"您可以同时监控和管理几个服务器. 只需要逐一添加, 您的机器就可以看到它们了."
+"Cockpit 是完美的系统管理员工具, 它可以轻松完成简单的任务, 如存储管理, 检查 "
+"journals 和启动/停止服务. 您可以同时监控和管理几个服务器. 只需要逐一添加, 您"
+"的机器就可以看到它们了."
 
 #: pkg/lib/machine-change-port.html:9
 msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
@@ -1630,14 +1637,14 @@ msgstr "Cockpit 无法联系 {{#strong}}{{host}}{{/strong}}。"
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 {{#can_sync}}也许想要尝试 "
-"{{#sync_link}}同步用户{{/sync_link}}。{{/can_sync}} 更多认证选项和排错支持，请更新 cockpit-ws "
-"到一个新版本。"
+"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 {{#can_sync}}也许想要尝"
+"试 {{#sync_link}}同步用户{{/sync_link}}。{{/can_sync}} 更多认证选项和排错支"
+"持，请更新 cockpit-ws 到一个新版本。"
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1650,8 +1657,8 @@ msgid ""
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
 "Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 To use this machine with "
-"cockpit 需要在 {{#strong}}{{host}}{{/strong}} 上的 sshd 配置中启用以下认证方式其中之一 来使用该主机的 "
-"Cockpit:"
+"cockpit 需要在 {{#strong}}{{host}}{{/strong}} 上的 sshd 配置中启用以下认证方"
+"式其中之一 来使用该主机的 Cockpit:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1659,8 +1666,9 @@ msgid ""
 "change your authentication credentials below. {{#can_sync}}You may prefer to "
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
-"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。可以变更以下认证凭证。{{#can_sync}}也许想要 "
-"{{#sync_link}}同步账号和密码{{/sync_link}}.{{/can_sync}}"
+"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。可以变更以下认证凭证。"
+"{{#can_sync}}也许想要 {{#sync_link}}同步账号和密码{{/sync_link}}.{{/"
+"can_sync}}"
 
 #: pkg/dashboard/index.html:155 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1679,7 +1687,7 @@ msgstr[0] ""
 #: pkg/docker/index.html:700 pkg/systemd/services.html:411
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:127 pkg/docker/containers-view.jsx:351
-#: pkg/docker/containers-view.jsx:394
+#: pkg/docker/containers-view.jsx:396
 msgid "Command"
 msgstr "命令"
 
@@ -1724,8 +1732,8 @@ msgstr "兼容现代系统，且支持磁盘 > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "压缩故障转储到保存空间"
 
-#: pkg/kdump/kdump-view.jsx:190 pkg/storaged/vdo-details.jsx:305
-#: pkg/storaged/vdos-panel.jsx:94
+#: pkg/storaged/vdos-panel.jsx:94 pkg/storaged/vdo-details.jsx:306
+#: pkg/kdump/kdump-view.jsx:190
 msgid "Compression"
 msgstr "压缩"
 
@@ -1935,10 +1943,11 @@ msgid "Container:"
 msgstr "容器："
 
 #: pkg/docker/index.html:23 pkg/docker/index.html:285
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
+#: pkg/kubernetes/views/containers-listing.html:5
 #: pkg/kubernetes/views/dashboard-page.html:158
 #: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:367
+#: pkg/kubernetes/views/pod-page.html:36 pkg/kubernetes/index.html:55
+#: pkg/docker/containers-view.jsx:367
 msgid "Containers"
 msgstr "容器"
 
@@ -2051,10 +2060,10 @@ msgstr "故障系统"
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:63
 #: pkg/kubernetes/scripts/virtual-machines/components/createVmButton.jsx:76
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:414
+#: pkg/storaged/mdraids-panel.jsx:84 pkg/storaged/vdos-panel.jsx:108
+#: pkg/storaged/vgroups-panel.jsx:71 pkg/storaged/content-views.jsx:114
+#: pkg/storaged/content-views.jsx:671 pkg/storaged/lvol-tabs.jsx:267
 #: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:114 pkg/storaged/content-views.jsx:671
-#: pkg/storaged/lvol-tabs.jsx:267 pkg/storaged/mdraids-panel.jsx:84
-#: pkg/storaged/vdos-panel.jsx:108 pkg/storaged/vgroups-panel.jsx:71
 msgid "Create"
 msgstr "创建"
 
@@ -2156,12 +2165,13 @@ msgstr "为 $0 创建分区"
 msgid "Create partition table"
 msgstr "创建分区表"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
+#: pkg/kubernetes/views/pod-body.html:7
 #: pkg/kubernetes/views/replicationcontroller-body.html:7
 #: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:124
-#: pkg/docker/containers-view.jsx:395 pkg/docker/containers-view.jsx:664
+#: pkg/kubernetes/views/service-body.html:7
+#: pkg/kubernetes/views/deploymentconfig-body.html:7
+#: pkg/kubernetes/views/node-body.html:3 pkg/docker/containers-view.jsx:124
+#: pkg/docker/containers-view.jsx:397 pkg/docker/containers-view.jsx:666
 msgid "Created"
 msgstr "创建于"
 
@@ -2281,7 +2291,7 @@ msgstr "DNS 搜索域 $val"
 msgid "Dashboard"
 msgstr "仪表板"
 
-#: pkg/storaged/lvol-tabs.jsx:412
+#: pkg/storaged/lvol-tabs.jsx:414
 msgid "Data Used"
 msgstr "数据已使用空间"
 
@@ -2301,7 +2311,7 @@ msgstr "停用 $target"
 msgid "Debug and above"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:311 pkg/storaged/vdos-panel.jsx:99
+#: pkg/storaged/vdos-panel.jsx:99 pkg/storaged/vdo-details.jsx:312
 msgid "Deduplication"
 msgstr ""
 
@@ -2326,12 +2336,11 @@ msgstr "延时"
 #: pkg/kubernetes/views/pvc-delete.html:15
 #: pkg/kubernetes/views/user-remove-membership.html:10
 #: pkg/networkmanager/index.html:607 pkg/users/index.html:79
-#: pkg/users/index.html:409 pkg/docker/containers-view.jsx:196
-#: pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/users/index.html:409 pkg/docker/details.js:286 pkg/docker/util.js:634
+#: pkg/docker/containers-view.jsx:196 pkg/kubernetes/scripts/volumes.js:218
 #: pkg/kubernetes/scripts/virtual-machines/components/VmActions.jsx:49
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/machines/components/deleteDialog.jsx:92
 #: pkg/storaged/content-views.jsx:284 pkg/storaged/content-views.jsx:305
 #: pkg/storaged/mdraid-details.jsx:303 pkg/storaged/mdraid-details.jsx:326
 #: pkg/storaged/vdo-details.jsx:192 pkg/storaged/vdo-details.jsx:256
@@ -2407,7 +2416,7 @@ msgstr "删除 RAID 设备将擦除其中的所有数据."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:195 pkg/docker/details.js:285
+#: pkg/docker/details.js:285 pkg/docker/containers-view.jsx:195
 msgid "Deleting a container will erase all data in it."
 msgstr "删除容器将清除其中的所有数据。"
 
@@ -2454,14 +2463,14 @@ msgstr "部署配置"
 #: pkg/kubernetes/views/project-listing.html:54
 #: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:397
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/init.js:271 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:271
+#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Description"
 msgstr "描述"
 
-#: pkg/ovirt/components/OVirtTab.jsx:146
 #: pkg/ovirt/components/VmOverviewColumn.jsx:52
+#: pkg/ovirt/components/OVirtTab.jsx:146
 msgid "Description:"
 msgstr "描述："
 
@@ -2474,10 +2483,10 @@ msgid "Detachable"
 msgstr ""
 
 #: pkg/kubernetes/index.html:73 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:484
-#: pkg/docker/containers-view.jsx:494 pkg/docker/containers-view.jsx:623
-#: pkg/networkmanager/firewall.jsx:85 pkg/packagekit/updates.jsx:378
-#: pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/docker/containers-view.jsx:328 pkg/docker/containers-view.jsx:486
+#: pkg/docker/containers-view.jsx:496 pkg/docker/containers-view.jsx:625
+#: pkg/networkmanager/firewall.jsx:85
+#: pkg/subscriptions/subscriptions-view.jsx:209 pkg/packagekit/updates.jsx:378
 msgid "Details"
 msgstr "详情"
 
@@ -2486,7 +2495,7 @@ msgstr "详情"
 msgid "Device"
 msgstr "设备"
 
-#: pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/vdo-details.jsx:263
 msgid "Device File"
 msgstr ""
 
@@ -2567,9 +2576,9 @@ msgstr ""
 
 #: pkg/kubernetes/scripts/virtual-machines/components/VmDetail.jsx:74
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListingRow.jsx:61
-#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraid-details.jsx:47
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:72
-#: pkg/storaged/vgroup-details.jsx:51 pkg/storaged/vgroups-panel.jsx:61
+#: pkg/machines/components/vm/vm.jsx:45 pkg/storaged/mdraids-panel.jsx:72
+#: pkg/storaged/vgroups-panel.jsx:61 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/vgroup-details.jsx:51
 msgid "Disks"
 msgstr "磁盘"
 
@@ -2590,7 +2599,9 @@ msgstr "是否想要添加角色 '{{ fields.displayRole }}'？"
 msgid ""
 "Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
 "name}}' image stream?"
-msgstr "是否想要删除镜像流 '{{stream.metadata.namespace}}/{{stream.metadata.name}}' ？"
+msgstr ""
+"是否想要删除镜像流 '{{stream.metadata.namespace}}/{{stream.metadata."
+"name}}' ？"
 
 #: pkg/kubernetes/views/pv-delete.html:6
 msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
@@ -2614,15 +2625,16 @@ msgid ""
 "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
 "{{stream.metadata.name}}:{{tag.tag}}'?"
 msgstr ""
-"是否想要移除镜像标记 '{{stream.metadata.namespace}}/{{stream.metadata.name}}:{{tag."
-"tag}}'？"
+"是否想要移除镜像标记 '{{stream.metadata.namespace}}/{{stream.metadata.name}}:"
+"{{tag.tag}}'？"
 
 #: pkg/kubernetes/views/remove-role-dialog.html:5
 msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
+"Do you want to remove the role '{{ fields.displayRole }}' from member "
+"{{ fields.member.metadata.name }}?"
 msgstr ""
-"是否想要从成员 {{ fields.member.metadata.name }} 移除角色 '{{ fields.displayRole }}'？"
+"是否想要从成员 {{ fields.member.metadata.name }} 移除角色 '{{ fields."
+"displayRole }}'？"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2734,7 +2746,7 @@ msgstr "重复别名"
 msgid "Duplicate port"
 msgstr "重复端口"
 
-#: pkg/storaged/crypto-tab.jsx:133 pkg/storaged/nfs-details.jsx:288
+#: pkg/storaged/nfs-details.jsx:288 pkg/storaged/crypto-tab.jsx:133
 msgid "Edit"
 msgstr "编辑"
 
@@ -2893,7 +2905,7 @@ msgstr "在这里输入不同的密码意味着将要在每次重新连接该主
 msgid "Entry"
 msgstr "条目"
 
-#: pkg/docker/containers-view.jsx:393
+#: pkg/docker/containers-view.jsx:395
 msgid "Entrypoint"
 msgstr "入口点"
 
@@ -2919,9 +2931,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:359 pkg/apps/utils.jsx:99
-#: pkg/storaged/devices.js:107 pkg/storaged/storage-controls.jsx:88
-#: pkg/storaged/storage-controls.jsx:180 pkg/users/local.js:1400
+#: pkg/systemd/services.html:359 pkg/storaged/devices.js:107
+#: pkg/storaged/storage-controls.jsx:88 pkg/storaged/storage-controls.jsx:182
+#: pkg/users/local.js:1400 pkg/apps/utils.jsx:99
 msgid "Error"
 msgstr "错误"
 
@@ -3009,7 +3021,7 @@ msgstr "已失败"
 msgid "Failed to add machine: $0"
 msgstr "添加主机失败: $0"
 
-#: pkg/lib/credentials.js:230 pkg/users/local.js:114 pkg/users/local.js:145
+#: pkg/users/local.js:114 pkg/users/local.js:145 pkg/lib/credentials.js:230
 msgid "Failed to change password"
 msgstr "修改密码失败"
 
@@ -3074,7 +3086,6 @@ msgstr "文件系统挂载"
 msgid "Filesystem Name"
 msgstr "文件系统名称"
 
-#: pkg/kubernetes/views/pv-modify.html:181
 #: pkg/kubernetes/views/volume-body.html:6
 #: pkg/kubernetes/views/volume-body.html:16
 #: pkg/kubernetes/views/volume-body.html:62
@@ -3082,6 +3093,7 @@ msgstr "文件系统名称"
 #: pkg/kubernetes/views/volume-body.html:91
 #: pkg/kubernetes/views/volume-body.html:120
 #: pkg/kubernetes/views/volume-body.html:132
+#: pkg/kubernetes/views/pv-modify.html:181
 msgid "Filesystem Type"
 msgstr "文件系统类型"
 
@@ -3097,7 +3109,7 @@ msgstr "文件系统"
 msgid "Filter Services"
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:289 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "指印"
 
@@ -3218,7 +3230,7 @@ msgstr "通用"
 msgid "Generating report"
 msgstr "正在生成报告"
 
-#: pkg/docker/containers-view.jsx:661
+#: pkg/docker/containers-view.jsx:663
 msgid "Get new image"
 msgstr "获取新镜像"
 
@@ -3281,9 +3293,9 @@ msgstr "组或项目"
 msgid "Groups"
 msgstr "组"
 
-#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:367
-#: pkg/storaged/lvol-tabs.jsx:407 pkg/storaged/vdo-details.jsx:223
-#: pkg/storaged/vdo-details.jsx:297
+#: pkg/storaged/lvol-tabs.jsx:181 pkg/storaged/lvol-tabs.jsx:368
+#: pkg/storaged/lvol-tabs.jsx:409 pkg/storaged/vdo-details.jsx:223
+#: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr ""
 
@@ -3344,9 +3356,9 @@ msgstr "Hello 时间 $hello_time"
 #: pkg/kubernetes/views/details-page.html:73
 #: pkg/kubernetes/views/route-body.html:9
 #: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
+#: pkg/machines/components/vmDiskSourceCell.jsx:41 pkg/shell/indexes.js:333
 #: pkg/ovirt/components/App.jsx:101 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:333
+#: pkg/ovirt/components/ClusterVms.jsx:182
 msgid "Host"
 msgstr "主机"
 
@@ -3386,8 +3398,8 @@ msgstr "I/O 等待"
 msgid "INSTALL VM action failed"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:10
 #: pkg/kubernetes/views/service-body.html:9
+#: pkg/kubernetes/views/node-body.html:10
 msgid "IP"
 msgstr "IP"
 
@@ -3427,7 +3439,7 @@ msgstr "IPv6 设置"
 msgid "ISCSI"
 msgstr "ISCSI"
 
-#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:391
+#: pkg/docker/containers-view.jsx:123 pkg/docker/containers-view.jsx:393
 #: pkg/systemd/init.js:272
 msgid "Id"
 msgstr "ID"
@@ -3516,11 +3528,10 @@ msgstr "镜像流"
 msgid "Image:"
 msgstr "镜像："
 
-#: pkg/kubernetes/index.html:87 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
 #: pkg/kubernetes/views/registry-dashboard-page.html:19
-#: pkg/docker/containers-view.jsx:692
+#: pkg/kubernetes/views/images-page.html:13
+#: pkg/kubernetes/views/imagestream-page.html:24 pkg/kubernetes/index.html:87
+#: pkg/kubernetes/registry.html:49 pkg/docker/containers-view.jsx:694
 msgid "Images"
 msgstr "镜像"
 
@@ -3594,7 +3605,7 @@ msgstr "暂停卷"
 msgid "Incorrect Host Key"
 msgstr "不正确的主机密钥"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdos-panel.jsx:84 pkg/storaged/vdo-details.jsx:302
 msgid "Index Memory"
 msgstr ""
 
@@ -3610,9 +3621,9 @@ msgstr "关于容器存储池的信息不可用。"
 msgid "Initializing..."
 msgstr "正在初始化中..."
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:83
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application.jsx:112 pkg/apps/application-list.jsx:87
 msgid "Install"
 msgstr "安装"
 
@@ -3660,7 +3671,7 @@ msgstr "已安装"
 msgid "Installed products"
 msgstr "已安装的产品"
 
-#: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
+#: pkg/apps/application.jsx:55 pkg/apps/application-list.jsx:47
 #: pkg/packagekit/updates.jsx:50
 msgid "Installing"
 msgstr "正在安装"
@@ -3673,8 +3684,8 @@ msgstr ""
 msgid "Instantiate"
 msgstr "实例"
 
-#: pkg/kubernetes/views/pv-modify.html:170
 #: pkg/kubernetes/views/volume-body.html:81
+#: pkg/kubernetes/views/pv-modify.html:170
 msgid "Interface"
 msgstr "接口"
 
@@ -3698,11 +3709,11 @@ msgstr "无效的地址 $0"
 msgid "Invalid credentials"
 msgstr "无效的凭证"
 
-#: pkg/systemd/host.js:1328 pkg/systemd/shutdown.js:142
+#: pkg/systemd/shutdown.js:142 pkg/systemd/host.js:1328
 msgid "Invalid date format"
 msgstr "无效的日期格式"
 
-#: pkg/systemd/host.js:1324 pkg/systemd/shutdown.js:138
+#: pkg/systemd/shutdown.js:138 pkg/systemd/host.js:1324
 msgid "Invalid date format and invalid time format"
 msgstr "无效的日期格式和时间格式"
 
@@ -3750,7 +3761,7 @@ msgstr "无效的前缀 $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "无效的前缀或掩码 $0"
 
-#: pkg/systemd/host.js:1326 pkg/systemd/shutdown.js:140
+#: pkg/systemd/shutdown.js:140 pkg/systemd/host.js:1326
 msgid "Invalid time format"
 msgstr "无效的时间格式"
 
@@ -3758,7 +3769,7 @@ msgstr "无效的时间格式"
 msgid "Invalid time zone"
 msgstr "无效的时区"
 
-#: pkg/storaged/iscsi-panel.jsx:103 pkg/storaged/iscsi-panel.jsx:194
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:164
 #: pkg/subscriptions/subscriptions-client.js:194
 msgid "Invalid username or password"
 msgstr "无效的用户名或密码"
@@ -3876,11 +3887,12 @@ msgstr "Kubernetes 集群"
 msgid "LACP Key"
 msgstr "LACP 密钥"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
+#: pkg/kubernetes/views/pod-body.html:26
 #: pkg/kubernetes/views/replicationcontroller-body.html:17
 #: pkg/kubernetes/views/route-body.html:22
 #: pkg/kubernetes/views/service-body.html:26
+#: pkg/kubernetes/views/deploymentconfig-body.html:41
+#: pkg/kubernetes/views/node-body.html:31
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "标签"
@@ -3925,8 +3937,8 @@ msgstr "最近更新时间"
 msgid "Last checked: $0 ago"
 msgstr "最后检查于： $0 前"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
 #: pkg/kubernetes/views/details-page.html:107
+#: pkg/kubernetes/views/deploymentconfig-body.html:15
 msgid "Latest Version"
 msgstr "最近的版本"
 
@@ -3947,17 +3959,18 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in user. If "
 "you enter a different username, that user will always be used when "
 "connecting to this machine."
-msgstr "以当前登录用户来连接到该主机则保留为空。如果输入另一个用户名，连接到该主机时通常将会使用该用户。"
+msgstr ""
+"以当前登录用户来连接到该主机则保留为空。如果输入另一个用户名，连接到该主机时"
+"通常将会使用该用户。"
 
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
-"以当前登录的用户 {{#default_user}} ({{default_user}}){{/default_user}} "
-"来连接该主机则保留为空。如果输入一个不同的用户名，将总会用那个用户连接该主机。"
+"以当前登录的用户 {{#default_user}} ({{default_user}}){{/default_user}} 来连接"
+"该主机则保留为空。如果输入一个不同的用户名，将总会用那个用户连接该主机。"
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
 msgid "Licensed under:"
@@ -4019,8 +4032,8 @@ msgstr "正在加载可用的更新，请等待..."
 msgid "Loading data ..."
 msgstr "正在加载数据 ..."
 
-#: pkg/kdump/kdump-view.jsx:372 pkg/systemd/logs.js:140 pkg/systemd/logs.js:155
-#: pkg/systemd/logs.js:199 pkg/systemd/logs.js:240
+#: pkg/systemd/logs.js:140 pkg/systemd/logs.js:155 pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:240 pkg/kdump/kdump-view.jsx:372
 msgid "Loading..."
 msgstr "载入中..."
 
@@ -4096,17 +4109,17 @@ msgstr "日志消息"
 msgid "Logged In"
 msgstr "登录"
 
-#: pkg/storaged/vdo-details.jsx:288
+#: pkg/storaged/vdo-details.jsx:289
 msgid "Logical"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:214 pkg/storaged/vdos-panel.jsx:68
+#: pkg/storaged/vdos-panel.jsx:68 pkg/storaged/vdo-details.jsx:214
 msgid "Logical Size"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:159
 #: pkg/kubernetes/views/volume-body.html:79
 #: pkg/kubernetes/views/volume-body.html:118
+#: pkg/kubernetes/views/pv-modify.html:159
 msgid "Logical Unit Number"
 msgstr "逻辑单元编号"
 
@@ -4301,9 +4314,10 @@ msgstr "成员关系"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:269
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:230
-#: pkg/docker/containers-view.jsx:351 pkg/kubernetes/scripts/graphs.js:604
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:830
+#: pkg/docker/containers-view.jsx:351
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:94
+#: pkg/kubernetes/scripts/graphs.js:604 pkg/kubernetes/scripts/nodes.js:719
+#: pkg/kubernetes/scripts/nodes.js:830
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:270
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181
@@ -4335,8 +4349,8 @@ msgstr "内存占用率："
 msgid "Memory:"
 msgstr "内存："
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
+#: pkg/kubernetes/views/pv-body.html:27 pkg/kubernetes/views/pv-claim.html:32
+#: pkg/kubernetes/views/pvc-body.html:15 pkg/kubernetes/views/node-body.html:47
 msgid "Message"
 msgstr "消息"
 
@@ -4351,7 +4365,7 @@ msgstr "登录用户信息"
 msgid "Metadata"
 msgstr "元数据"
 
-#: pkg/storaged/lvol-tabs.jsx:416
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Metadata Used"
 msgstr "已使用的元数据"
 
@@ -4431,8 +4445,8 @@ msgstr "更多信息"
 msgid "More details"
 msgstr "更多详情"
 
-#: pkg/kdump/kdump-view.jsx:104 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:197 pkg/storaged/nfs-details.jsx:283
+#: pkg/storaged/nfs-details.jsx:283 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:197 pkg/kdump/kdump-view.jsx:104
 msgid "Mount"
 msgstr "挂载"
 
@@ -4440,17 +4454,17 @@ msgstr "挂载"
 msgid "Mount Location"
 msgstr "挂载位置"
 
-#: pkg/storaged/fsys-tab.jsx:178 pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:162 pkg/storaged/fsys-tab.jsx:178
 msgid "Mount Options"
 msgstr "挂载选项"
 
-#: pkg/storaged/format-dialog.jsx:77 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:159 pkg/storaged/nfs-details.jsx:302
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/nfs-details.jsx:302 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/format-dialog.jsx:77
+#: pkg/storaged/fsys-tab.jsx:159
 msgid "Mount Point"
 msgstr "挂载点"
 
-#: pkg/storaged/format-dialog.jsx:87 pkg/storaged/nfs-details.jsx:164
+#: pkg/storaged/nfs-details.jsx:164 pkg/storaged/format-dialog.jsx:87
 msgid "Mount at boot"
 msgstr ""
 
@@ -4474,7 +4488,7 @@ msgstr ""
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:100 pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:168 pkg/storaged/format-dialog.jsx:100
 msgid "Mount read only"
 msgstr ""
 
@@ -4538,37 +4552,38 @@ msgstr "NTP 服务器"
 #: pkg/kubernetes/views/details-page.html:171
 #: pkg/kubernetes/views/imagestream-modify.html:10
 #: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
 #: pkg/kubernetes/views/project-listing.html:14
 #: pkg/kubernetes/views/project-listing.html:53
 #: pkg/kubernetes/views/project-listing.html:90
 #: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
+#: pkg/kubernetes/views/pv-claim.html:4
 #: pkg/kubernetes/views/service-modify.html:9
 #: pkg/kubernetes/views/user-modify.html:9
 #: pkg/kubernetes/views/volume-body.html:31
 #: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
+#: pkg/kubernetes/views/volumes-page.html:57
+#: pkg/kubernetes/views/nodes-page.html:41
+#: pkg/kubernetes/views/pv-modify.html:32 pkg/networkmanager/index.html:127
 #: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:183
 #: pkg/networkmanager/index.html:239 pkg/networkmanager/index.html:338
 #: pkg/networkmanager/index.html:438
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:664
+#: pkg/docker/containers-view.jsx:351 pkg/docker/containers-view.jsx:666
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 #: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:92
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
+#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/vdos-panel.jsx:51
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/storaged/content-views.jsx:102
+#: pkg/storaged/content-views.jsx:623 pkg/storaged/format-dialog.jsx:276
+#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:179
+#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
+#: pkg/storaged/lvol-tabs.jsx:357 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:40
 #: pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:375
-#: pkg/storaged/content-views.jsx:102 pkg/storaged/content-views.jsx:623
-#: pkg/storaged/format-dialog.jsx:276 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:69 pkg/storaged/fsys-tab.jsx:149
-#: pkg/storaged/iscsi-panel.jsx:150 pkg/storaged/iscsi-panel.jsx:211
-#: pkg/storaged/lvol-tabs.jsx:40 pkg/storaged/lvol-tabs.jsx:253
-#: pkg/storaged/lvol-tabs.jsx:356 pkg/storaged/lvol-tabs.jsx:397
-#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:38
-#: pkg/storaged/vdos-panel.jsx:51 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:40
 msgid "Name"
 msgstr "名称"
 
@@ -4602,7 +4617,6 @@ msgstr ""
 
 #: pkg/kubernetes/views/containers-listing.html:14
 #: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/views/details-page.html:36
 #: pkg/kubernetes/views/details-page.html:72
 #: pkg/kubernetes/views/details-page.html:105
@@ -4613,6 +4627,7 @@ msgstr ""
 #: pkg/kubernetes/views/route-body.html:5
 #: pkg/kubernetes/views/service-body.html:5
 #: pkg/kubernetes/views/volumes-page.html:59
+#: pkg/kubernetes/views/deploymentconfig-body.html:5
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Namespace"
 msgstr "名称空间"
@@ -4626,8 +4641,8 @@ msgid "Need at least one NTP server"
 msgstr "至少需要一个 NTP 服务器"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:609
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:116
+#: pkg/kubernetes/scripts/graphs.js:609
 msgid "Network"
 msgstr "网络"
 
@@ -4693,8 +4708,8 @@ msgstr "新建项目"
 msgid "New Volume Name"
 msgstr ""
 
-#: pkg/kubernetes/views/images-page.html:11
 #: pkg/kubernetes/views/registry-dashboard-page.html:86
+#: pkg/kubernetes/views/images-page.html:11
 msgid "New image stream"
 msgstr "新建镜像流"
 
@@ -4702,7 +4717,7 @@ msgstr "新建镜像流"
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:238 pkg/users/local.js:122
+#: pkg/users/local.js:122 pkg/lib/credentials.js:238
 msgid "New password was not accepted"
 msgstr "新密码不被接受"
 
@@ -4712,7 +4727,7 @@ msgstr "新密码不被接受"
 msgid "New project"
 msgstr "新建项目"
 
-#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:59
+#: pkg/realmd/operation.html:93 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "下一步"
 
@@ -4827,9 +4842,9 @@ msgstr "没有容器匹配当前过滤器"
 msgid "No description provided."
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:53 pkg/storaged/mdraids-panel.jsx:74
-#: pkg/storaged/vdos-panel.jsx:60 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:74 pkg/storaged/vdos-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:53
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "No disks are available."
 msgstr "没有可用的磁盘。"
 
@@ -4857,7 +4872,7 @@ msgstr "没有组用于显示。"
 msgid "No host keys found."
 msgstr "没有找到主机密钥。"
 
-#: pkg/storaged/iscsi-panel.jsx:294
+#: pkg/storaged/iscsi-panel.jsx:260
 msgid "No iSCSI targets set up"
 msgstr "没有设置 iSCSI 目标"
 
@@ -4865,7 +4880,7 @@ msgstr "没有设置 iSCSI 目标"
 msgid "No image streams are present."
 msgstr "没有镜像流用于显示。"
 
-#: pkg/docker/containers-view.jsx:686
+#: pkg/docker/containers-view.jsx:688
 msgid "No images"
 msgstr "没有镜像"
 
@@ -4873,7 +4888,7 @@ msgstr "没有镜像"
 msgid "No images pushed"
 msgstr "没有推送的镜像"
 
-#: pkg/docker/containers-view.jsx:688
+#: pkg/docker/containers-view.jsx:690
 msgid "No images that match the current filter"
 msgstr "没有匹配当前过滤器的镜像"
 
@@ -5023,9 +5038,9 @@ msgstr "节点"
 msgid "Node:"
 msgstr ""
 
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
+#: pkg/kubernetes/views/dashboard-page.html:90
 #: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
+#: pkg/kubernetes/views/nodes-page.html:36 pkg/kubernetes/index.html:49
 msgid "Nodes"
 msgstr "节点"
 
@@ -5036,7 +5051,7 @@ msgstr "节点是运行容器的主机。"
 #: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
 #: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:420 pkg/tuned/dialog.js:233
+#: pkg/tuned/dialog.js:233 pkg/kdump/kdump-view.jsx:420
 msgid "None"
 msgstr "无"
 
@@ -5078,8 +5093,8 @@ msgstr "不可用"
 msgid "Not connected"
 msgstr "未连接"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
 #: pkg/kubernetes/views/details-page.html:122
+#: pkg/kubernetes/views/deploymentconfig-body.html:17
 msgid "Not deployed"
 msgstr "未部署"
 
@@ -5095,7 +5110,7 @@ msgstr ""
 msgid "Not permitted to perform this action."
 msgstr "不允许执行该动作。"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Not running"
 msgstr "未运行"
 
@@ -5123,8 +5138,8 @@ msgstr ""
 msgid "Number of virtual CPUs that gonna be used."
 msgstr ""
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
 #: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
+#: pkg/ovirt/components/HostToMaintenance.jsx:47
 msgid "OK"
 msgstr "确认"
 
@@ -5156,8 +5171,8 @@ msgstr "在 $0 和 $1 间发生"
 
 #: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:95
 #: pkg/playground/jquery-patterns.html:108 pkg/shell/index.html:241
-#: pkg/systemd/index.html:177 pkg/lib/cockpit-components-onoff.jsx:38
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:177 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:38
 msgid "Off"
 msgstr "关"
 
@@ -5173,14 +5188,14 @@ msgstr "旧密码"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:220 pkg/users/local.js:79
+#: pkg/users/local.js:79 pkg/lib/credentials.js:220
 msgid "Old password not accepted"
 msgstr "旧密码不被接受"
 
 #: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:91
 #: pkg/playground/jquery-patterns.html:104 pkg/shell/index.html:237
-#: pkg/systemd/index.html:173 pkg/lib/cockpit-components-onoff.jsx:39
-#: pkg/lib/patterns.js:244
+#: pkg/systemd/index.html:173 pkg/lib/patterns.js:244
+#: pkg/lib/cockpit-components-onoff.jsx:39
 msgid "On"
 msgstr "开"
 
@@ -5362,11 +5377,12 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "口令不匹配"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:119 pkg/users/index.html:181 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:55 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/kubernetes/views/auth-form.html:105 pkg/shell/index.html:212
+#: pkg/shell/index.html:251 pkg/shell/index.html:264 pkg/users/index.html:119
+#: pkg/users/index.html:181 pkg/lib/machine-auth-failed.html:8
+#: pkg/lib/machine-sync-users.html:61 pkg/lib/machine-change-auth.html:52
+#: src/ws/login.html:50 pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:152
 #: pkg/subscriptions/subscriptions-register.jsx:88
 #: pkg/subscriptions/subscriptions-register.jsx:152
 msgid "Password"
@@ -5405,10 +5421,10 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "在这里粘贴 SSH 公钥文件内容"
 
-#: pkg/kubernetes/views/pv-modify.html:126
 #: pkg/kubernetes/views/volume-body.html:37
 #: pkg/kubernetes/views/volume-body.html:49
 #: pkg/kubernetes/views/volume-body.html:101
+#: pkg/kubernetes/views/pv-modify.html:126
 msgid "Path"
 msgstr "路径"
 
@@ -5472,7 +5488,7 @@ msgstr "持久卷"
 msgid "Phase"
 msgstr "阶段"
 
-#: pkg/storaged/vdo-details.jsx:275
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Physical"
 msgstr ""
 
@@ -5504,8 +5520,8 @@ msgstr "Ping 目标"
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:194 pkg/docker/details.js:284
-#: pkg/docker/util.js:605 pkg/storaged/content-views.jsx:280
+#: pkg/docker/details.js:284 pkg/docker/util.js:605
+#: pkg/docker/containers-view.jsx:194 pkg/storaged/content-views.jsx:280
 #: pkg/storaged/mdraid-details.jsx:298 pkg/storaged/vdo-details.jsx:187
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
@@ -5722,9 +5738,8 @@ msgstr "填入"
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/machines/vmnetworktab.jsx:61
+#: pkg/machines/vmnetworktab.jsx:61 pkg/storaged/iscsi-panel.jsx:127
 #: pkg/ovirt/components/InstallationDialog.jsx:65
-#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Port"
 msgstr "端口"
 
@@ -5740,7 +5755,7 @@ msgstr ""
 #: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:248
 #: pkg/networkmanager/index.html:447
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:397 pkg/networkmanager/interfaces.js:2974
+#: pkg/docker/containers-view.jsx:399 pkg/networkmanager/interfaces.js:2974
 msgid "Ports"
 msgstr "端口"
 
@@ -5823,7 +5838,7 @@ msgstr ""
 msgid "Problems"
 msgstr ""
 
-#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/index.html:376 pkg/storaged/dialogx.jsx:788
 msgid "Process"
 msgstr ""
 
@@ -5837,7 +5852,6 @@ msgstr "产品名"
 
 #: pkg/kubernetes/views/containers-listing.html:13
 #: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/views/details-page.html:35
 #: pkg/kubernetes/views/details-page.html:71
 #: pkg/kubernetes/views/details-page.html:104
@@ -5849,6 +5863,7 @@ msgstr "产品名"
 #: pkg/kubernetes/views/route-body.html:4
 #: pkg/kubernetes/views/service-body.html:4
 #: pkg/kubernetes/views/volumes-page.html:58
+#: pkg/kubernetes/views/deploymentconfig-body.html:4
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:33
 msgid "Project"
 msgstr "项目"
@@ -5877,10 +5892,10 @@ msgstr "项目网站"
 msgid "Project:"
 msgstr "项目:"
 
-#: pkg/kubernetes/index.html:94 pkg/kubernetes/registry.html:55
 #: pkg/kubernetes/views/group-delete.html:10
 #: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
+#: pkg/kubernetes/views/user-delete.html:10 pkg/kubernetes/index.html:94
+#: pkg/kubernetes/registry.html:55
 msgid "Projects"
 msgstr "项目"
 
@@ -5912,7 +5927,7 @@ msgstr "代理"
 msgid "Proxy Version"
 msgstr "代理版本"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:250 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "公钥"
 
@@ -5940,8 +5955,8 @@ msgstr "目的"
 msgid "Push an image:"
 msgstr "推送镜像:"
 
-#: pkg/kubernetes/views/pv-modify.html:148
 #: pkg/kubernetes/views/volume-body.html:77
+#: pkg/kubernetes/views/pv-modify.html:148
 msgid "Qualified Name"
 msgstr "限定名"
 
@@ -6005,7 +6020,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "RAID 设备"
 
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/utils.js:213
+#: pkg/storaged/utils.js:213 pkg/storaged/mdraid-details.jsx:319
 msgid "RAID Device $0"
 msgstr "RAID 设备 $0"
 
@@ -6041,7 +6056,6 @@ msgstr "随机"
 msgid "Raw to a device"
 msgstr "格式化设备"
 
-#: pkg/kubernetes/views/pv-modify.html:195
 #: pkg/kubernetes/views/volume-body.html:10
 #: pkg/kubernetes/views/volume-body.html:20
 #: pkg/kubernetes/views/volume-body.html:44
@@ -6053,6 +6067,7 @@ msgstr "格式化设备"
 #: pkg/kubernetes/views/volume-body.html:122
 #: pkg/kubernetes/views/volume-body.html:136
 #: pkg/kubernetes/views/volume-body.html:143
+#: pkg/kubernetes/views/pv-modify.html:195
 msgid "Read Only"
 msgstr "只读"
 
@@ -6117,7 +6132,7 @@ msgstr "实际主机名必须小于等于64个字符"
 msgid "Reason"
 msgstr "原因"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:242
+#: pkg/lib/journal.js:242 pkg/lib/cockpit-components-logs-panel.jsx:82
 msgid "Reboot"
 msgstr "重启"
 
@@ -6173,8 +6188,8 @@ msgstr "拒绝连接。主机密钥不匹配"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "拒绝连接。未知主机密钥"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:143
+#: pkg/kubernetes/views/pv-modify.html:206
+#: pkg/subscriptions/subscriptions-view.jsx:143 pkg/subscriptions/main.js:46
 msgid "Register"
 msgstr "注册"
 
@@ -6202,8 +6217,8 @@ msgstr "注册 oVirt 到 Cockpit"
 msgid "Register…"
 msgstr "注册…"
 
-#: pkg/ovirt/components/App.jsx:60 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:519
+#: pkg/systemd/init.js:519 pkg/ovirt/components/VdsmView.jsx:100
+#: pkg/ovirt/components/App.jsx:60
 msgid "Reload"
 msgstr "重载"
 
@@ -6244,9 +6259,9 @@ msgstr ""
 #: pkg/kubernetes/views/remove-role-dialog.html:8
 #: pkg/kubernetes/views/user-delete.html:25
 #: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:364 pkg/storaged/crypto-keyslots.jsx:400
-#: pkg/storaged/nfs-details.jsx:290
+#: pkg/storaged/nfs-details.jsx:290 pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:400 pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85
 msgid "Remove"
 msgstr "删除"
 
@@ -6298,7 +6313,7 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
+#: pkg/apps/application.jsx:59 pkg/apps/application-list.jsx:51
 msgid "Removing"
 msgstr "正在移除"
 
@@ -6366,10 +6381,10 @@ msgstr "每年重复"
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
 #: pkg/kubernetes/views/details-page.html:141
 #: pkg/kubernetes/views/replicationcontroller-body.html:9
 #: pkg/kubernetes/views/replicationcontroller-modify.html:8
+#: pkg/kubernetes/views/deploymentconfig-body.html:9
 msgid "Replicas"
 msgstr "复用"
 
@@ -6481,8 +6496,8 @@ msgstr ""
 
 #: pkg/docker/index.html:135 pkg/systemd/index.html:143
 #: pkg/systemd/index.html:153 pkg/docker/containers-view.jsx:309
-#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/init.js:518
-#: pkg/systemd/shutdown.js:96 pkg/systemd/shutdown.js:97
+#: pkg/machines/components/vm/vmActions.jsx:41 pkg/systemd/shutdown.js:96
+#: pkg/systemd/shutdown.js:97 pkg/systemd/init.js:518
 msgid "Restart"
 msgstr "重启"
 
@@ -6531,8 +6546,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr "为特权任务和连接其他主机重用我的密码"
 
 #: pkg/kubernetes/views/volume-body.html:26
@@ -6587,7 +6601,7 @@ msgstr "运行为"
 msgid "Runner"
 msgstr "分流道"
 
-#: pkg/storaged/mdraid-details.jsx:350
+#: pkg/storaged/mdraid-details.jsx:351
 msgid "Running"
 msgstr "运行中"
 
@@ -6675,8 +6689,8 @@ msgstr "挂起操作失败"
 msgid "Saturday"
 msgstr "星期六"
 
-#: pkg/systemd/services.html:507 pkg/ovirt/components/VdsmView.jsx:114
-#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:248
+#: pkg/systemd/services.html:507 pkg/storaged/crypto-keyslots.jsx:233
+#: pkg/storaged/crypto-keyslots.jsx:248 pkg/ovirt/components/VdsmView.jsx:114
 msgid "Save"
 msgstr "保存"
 
@@ -6729,7 +6743,7 @@ msgstr "安全 Shell  密钥"
 msgid "Securely erasing $target"
 msgstr "安全擦除 $target"
 
-#: pkg/docker/containers-view.jsx:486 pkg/docker/containers-view.jsx:630
+#: pkg/docker/containers-view.jsx:488 pkg/docker/containers-view.jsx:632
 msgid "Security"
 msgstr "安全性"
 
@@ -6761,8 +6775,8 @@ msgstr "选择一个对象来查看更多详情。"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr "选择你想要与 {{#strong}}{{host}}{{/strong}} 同步的用户"
 
 #: pkg/machines/components/vm/vmActions.jsx:65
@@ -6783,15 +6797,14 @@ msgstr "发送中"
 msgid "Serial Console"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:127 pkg/storaged/nfs-details.jsx:298
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:64
+#: pkg/kubernetes/views/volume-body.html:47
+#: pkg/kubernetes/views/pv-modify.html:82 src/ws/login.html:94
+#: pkg/storaged/nfs-details.jsx:298 pkg/storaged/nfs-panel.jsx:101
+#: pkg/subscriptions/subscriptions-register.jsx:64 pkg/kdump/kdump-view.jsx:127
 msgid "Server"
 msgstr "服务器"
 
-#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:131
+#: pkg/storaged/nfs-details.jsx:131 pkg/storaged/iscsi-panel.jsx:43
 msgid "Server Address"
 msgstr "服务器地址"
 
@@ -6799,7 +6812,7 @@ msgstr "服务器地址"
 msgid "Server Administrator"
 msgstr "服务器管理员"
 
-#: pkg/storaged/iscsi-panel.jsx:47
+#: pkg/storaged/iscsi-panel.jsx:44
 msgid "Server address cannot be empty."
 msgstr "服务器地址不能为空。"
 
@@ -6818,7 +6831,7 @@ msgstr "服务器"
 #: pkg/kubernetes/views/service-page.html:12
 #: pkg/kubernetes/views/service-panel.html:8
 #: pkg/kubernetes/views/topology-page.html:30 pkg/storaged/index.html:395
-#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:728
+#: pkg/networkmanager/firewall.jsx:326 pkg/storaged/dialogx.jsx:792
 msgid "Service"
 msgstr "服务"
 
@@ -6864,10 +6877,11 @@ msgstr "服务"
 msgid ""
 "Services group pods and provide a common DNS name and an optional, load-"
 "balanced IP address to access them."
-msgstr "服务组织容器舱并提供一个通用DNS名称和一个可选的负载均衡的IP地址来访问它们。"
+msgstr ""
+"服务组织容器舱并提供一个通用DNS名称和一个可选的负载均衡的IP地址来访问它们。"
 
 #: pkg/storaged/index.html:375 pkg/machines/helpers.es6:178
-#: pkg/storaged/dialogx.jsx:724
+#: pkg/storaged/dialogx.jsx:788
 msgid "Session"
 msgstr "会话"
 
@@ -7003,7 +7017,7 @@ msgstr "显示所有镜像"
 msgid "Show fingerprints"
 msgstr "显示指印"
 
-#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:366
+#: pkg/storaged/lvol-tabs.jsx:226 pkg/storaged/lvol-tabs.jsx:367
 msgid "Shrink"
 msgstr ""
 
@@ -7024,34 +7038,34 @@ msgstr "自从"
 msgid "Since $0"
 msgstr "由于 $0"
 
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:664
-#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/content-views.jsx:106
+#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:666
+#: pkg/machines/components/diskAdd.jsx:148 pkg/storaged/nfs-details.jsx:306
+#: pkg/storaged/part-tab.jsx:42 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/nfs-panel.jsx:103 pkg/storaged/content-views.jsx:106
 #: pkg/storaged/content-views.jsx:666 pkg/storaged/format-dialog.jsx:262
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:165
-#: pkg/storaged/lvol-tabs.jsx:214 pkg/storaged/lvol-tabs.jsx:257
-#: pkg/storaged/lvol-tabs.jsx:362 pkg/storaged/lvol-tabs.jsx:403
-#: pkg/storaged/nfs-details.jsx:306 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/lvol-tabs.jsx:165 pkg/storaged/lvol-tabs.jsx:214
+#: pkg/storaged/lvol-tabs.jsx:257 pkg/storaged/lvol-tabs.jsx:363
+#: pkg/storaged/lvol-tabs.jsx:405
 msgid "Size"
 msgstr "大小"
 
-#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:606
+#: pkg/storaged/dialog.js:450 pkg/storaged/dialogx.jsx:670
 msgid "Size cannot be negative"
 msgstr "大小不能为负数"
 
-#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:604
+#: pkg/storaged/dialog.js:448 pkg/storaged/dialogx.jsx:668
 msgid "Size cannot be zero"
 msgstr "大小不能为零"
 
-#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:608
+#: pkg/storaged/dialog.js:452 pkg/storaged/dialogx.jsx:672
 msgid "Size is too large"
 msgstr "大小太大"
 
-#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:602
+#: pkg/storaged/dialog.js:446 pkg/storaged/dialogx.jsx:666
 msgid "Size must be a number"
 msgstr "大小必须是一个数字"
 
-#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:610
+#: pkg/storaged/dialog.js:454 pkg/storaged/dialogx.jsx:674
 msgid "Size must be at least $0"
 msgstr ""
 
@@ -7145,7 +7159,7 @@ msgid "Stable"
 msgstr "稳定的"
 
 #: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:306
-#: pkg/storaged/mdraid-details.jsx:323 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:253 pkg/systemd/init.js:514
 msgid "Start"
 msgstr "启动"
@@ -7186,10 +7200,10 @@ msgstr "开头"
 #: pkg/kubernetes/views/details-page.html:38
 #: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:351
-#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/kubernetes/scripts/virtual-machines/components/VmsListing.jsx:56
+#: pkg/kubernetes/scripts/virtual-machines/components/VmOverviewTabKubevirt.jsx:84
 #: pkg/machines/hostvmslist.jsx:92 pkg/machines/vmnetworktab.jsx:119
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:276
+#: pkg/systemd/init.js:276 pkg/ovirt/components/ClusterVms.jsx:184
 msgid "State"
 msgstr "状态"
 
@@ -7211,10 +7225,11 @@ msgid "Static"
 msgstr "静态"
 
 #: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
+#: pkg/kubernetes/views/pv-body.html:24 pkg/kubernetes/views/pv-claim.html:29
+#: pkg/kubernetes/views/pvc-body.html:13
 #: pkg/kubernetes/views/volumes-page.html:21
+#: pkg/kubernetes/views/node-body.html:39
+#: pkg/kubernetes/views/nodes-page.html:44
 #: pkg/networkmanager/interfaces.js:2601
 #: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Status"
@@ -7238,7 +7253,7 @@ msgid "Sticky"
 msgstr "粘性的"
 
 #: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:304
-#: pkg/storaged/mdraid-details.jsx:322 pkg/storaged/swap-tab.jsx:75
+#: pkg/storaged/swap-tab.jsx:75 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:148 pkg/storaged/vdo-details.jsx:252
 #: pkg/systemd/init.js:515
 msgid "Stop"
@@ -7471,7 +7486,7 @@ msgstr "标签"
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
-#: pkg/docker/containers-view.jsx:392
+#: pkg/docker/containers-view.jsx:394
 msgid "Tags"
 msgstr "标记"
 
@@ -7493,7 +7508,7 @@ msgstr "目标门户"
 msgid "Target World Wide Names"
 msgstr "目标全球通用名称"
 
-#: pkg/systemd/services.html:53 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/systemd/services.html:53
 msgid "Targets"
 msgstr "目标"
 
@@ -7624,8 +7639,8 @@ msgstr "地址包含无效字符"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr "主机 {{#strong}}{{host}}{{/strong}} 的认证无法完成。确认想要继续连接？"
 
 #: pkg/sosreport/index.html:35
@@ -7660,11 +7675,11 @@ msgstr "部署配置 '{{ target }}' 不存在。"
 
 #: pkg/storaged/index.html:357
 msgid ""
-"The filesystem is in use by login sessions and system services.              "
-"  Proceeding will stop these."
+"The filesystem is in use by login sessions and system "
+"services.                Proceeding will stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:693
+#: pkg/storaged/dialogx.jsx:757
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7676,9 +7691,8 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:695
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialogx.jsx:759
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/index.html:367
@@ -7687,14 +7701,13 @@ msgid ""
 "stop these."
 msgstr ""
 
-#: pkg/storaged/dialogx.jsx:697
+#: pkg/storaged/dialogx.jsx:761
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 
 #: pkg/docker/util.js:624
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/packagekit/updates.jsx:393
@@ -7710,7 +7723,9 @@ msgid ""
 "The generated archive contains data considered sensitive and its content "
 "should be reviewed by the originating organization before being passed to "
 "any third party."
-msgstr "生成的文档包含被认为敏感的数据并且其内容在传递到第三方前应该由发起组织检查通过。"
+msgstr ""
+"生成的文档包含被认为敏感的数据并且其内容在传递到第三方前应该由发起组织检查通"
+"过。"
 
 #: pkg/kubernetes/views/group-page.html:47
 msgid "The group '{{ groupName }}' does not exist."
@@ -7722,7 +7737,8 @@ msgid ""
 "in use. Unless this machine was recently replaced, it is likely that someone "
 "is trying to attack your connection to this machine."
 msgstr ""
-"{{#strong}}{{host}}{{/strong}} 的密钥与之前使用的不匹配。除非该主机最近被替换，否则可能有人正在攻击与该主机的连接。"
+"{{#strong}}{{host}}{{/strong}} 的密钥与之前使用的不匹配。除非该主机最近被替"
+"换，否则可能有人正在攻击与该主机的连接。"
 
 #: pkg/users/authorized-keys.js:119
 msgid "The key you provided was not valid."
@@ -7796,11 +7812,11 @@ msgstr "复制控制器 '{{ target }}' 不存在。"
 msgid "The route '{{ target }}' does not exist."
 msgstr "路由 '{{ target }}' 不存在。"
 
-#: pkg/docker/containers-view.jsx:417
+#: pkg/docker/containers-view.jsx:419
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "从 $time ($type) 开始的扫描没有找到缺陷。"
 
-#: pkg/docker/containers-view.jsx:415
+#: pkg/docker/containers-view.jsx:417
 msgid "The scan from $time ($type) was not successful."
 msgstr "从 $time ($type) 开始的扫描未成功。"
 
@@ -7812,7 +7828,8 @@ msgstr "所选的文件不是有效的 Kubernetes 应用程序清单."
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
 "no other supported authentication methods are available."
-msgstr "服务器拒绝使用密码认证来认证 '$0'，并且没有其他支持的认证途径可以使用。"
+msgstr ""
+"服务器拒绝使用密码认证来认证 '$0'，并且没有其他支持的认证途径可以使用。"
 
 #: src/base1/cockpit.js:3998
 msgid "The server refused to authenticate using any supported methods."
@@ -7886,8 +7903,7 @@ msgstr "用户名仅能包含 a-z、数字、点、破折号和下划线的字�
 
 #: src/ws/login.js:135
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr "浏览器配置阻止 Cockpit 运行 （无法访问 $0）"
 
 #: pkg/shell/active-pages-dialog.jsx:59
@@ -7941,15 +7957,16 @@ msgstr "该设备不能在这里被管理。"
 msgid ""
 "This device has filesystems that are currently in use.                "
 "Proceeding will unmount all filesystems on it."
-msgstr "该设备有正在使用的文件系统。               程序将卸载其上的所有文件系统。"
+msgstr ""
+"该设备有正在使用的文件系统。               程序将卸载其上的所有文件系统。"
 
-#: pkg/storaged/dialogx.jsx:678
+#: pkg/storaged/dialogx.jsx:742
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
 msgstr ""
 
-#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:657
+#: pkg/storaged/index.html:110 pkg/storaged/dialogx.jsx:721
 msgid "This device is currently used for RAID devices."
 msgstr "该设备正在被 RAID 设备使用。"
 
@@ -7957,19 +7974,20 @@ msgstr "该设备正在被 RAID 设备使用。"
 msgid ""
 "This device is currently used for RAID devices.                Proceeding "
 "will remove it from its RAID devices."
-msgstr "该设备正在被 RAID 设备使用。                程序将从其 RAID 设备中移除它。"
+msgstr ""
+"该设备正在被 RAID 设备使用。                程序将从其 RAID 设备中移除它。"
 
-#: pkg/storaged/dialogx.jsx:686
+#: pkg/storaged/dialogx.jsx:750
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
 
-#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:661
+#: pkg/storaged/index.html:118 pkg/storaged/dialogx.jsx:725
 msgid "This device is currently used for VDO devices."
 msgstr ""
 
-#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:653
+#: pkg/storaged/index.html:102 pkg/storaged/dialogx.jsx:717
 msgid "This device is currently used for volume groups."
 msgstr "该设备正在被卷组使用。"
 
@@ -7979,7 +7997,7 @@ msgid ""
 "will remove it from its volume groups."
 msgstr "该设备正在被卷组使用。                程序将从其卷组中移除它。"
 
-#: pkg/storaged/dialogx.jsx:682
+#: pkg/storaged/dialogx.jsx:746
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -7999,7 +8017,7 @@ msgid ""
 "from the host is not possible."
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:474
+#: pkg/docker/containers-view.jsx:476
 msgid "This image does not exist."
 msgstr "该镜像不存在。"
 
@@ -8068,12 +8086,13 @@ msgstr "该虚拟机没有被 oVirt 管理"
 
 #: pkg/kubernetes/views/pv-delete.html:7
 msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+"{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+"may cause issues with any pods depending on it."
 msgstr ""
-"该卷已经被 {{ item.item.spec.claimRef.namespace }} / {{ item.item.spec.claimRef."
-"name }} 声明。删除它将会损坏该声明并且也许会对依赖于它的容器舱尝试影响。"
+"该卷已经被 {{ item.item.spec.claimRef.namespace }} / {{ item.item.spec."
+"claimRef.name }} 声明。删除它将会损坏该声明并且也许会对依赖于它的容器舱尝试影"
+"响。"
 
 #: pkg/kubernetes/views/pv-claim.html:23
 msgid "This volume has not been claimed"
@@ -8096,7 +8115,9 @@ msgid ""
 "This will test kdump settings by crashing the kernel and thereby the system. "
 "Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
-msgstr "这将通过崩溃内核和系统并测试 kdump 设置。依赖于这些设置，系统也许不会自动重启，并且过程将持续一段时间。"
+msgstr ""
+"这将通过崩溃内核和系统并测试 kdump 设置。依赖于这些设置，系统也许不会自动重"
+"启，并且过程将持续一段时间。"
 
 #: pkg/kdump/kdump-view.jsx:519
 msgid "This will test the kdump configuration by crashing the kernel."
@@ -8129,7 +8150,9 @@ msgstr "提示：使关键密码匹配登录密码来自动认证 其他系统�
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
-msgstr "为了获取软件更新，该系统需要注册到红帽，使用红帽消费者门户或一个本地的订阅服务器。"
+msgstr ""
+"为了获取软件更新，该系统需要注册到红帽，使用红帽消费者门户或一个本地的订阅服"
+"务器。"
 
 #: node_modules/registry-image-widgets/views/image-pull.html:4
 msgid "To pull this image:"
@@ -8231,11 +8254,11 @@ msgstr "Tuned 未运行"
 msgid "Tuned is off"
 msgstr "Tuned 已关闭"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/format-dialog.jsx:274
-#: pkg/storaged/part-tab.jsx:50 pkg/storaged/unrecognized-tab.jsx:45
+#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/service-body.html:11
+#: pkg/kubernetes/views/volumes-page.html:20
+#: pkg/kubernetes/views/pv-modify.html:10 pkg/shell/index.html:285
+#: pkg/machines/vmnetworktab.jsx:66 pkg/storaged/part-tab.jsx:50
+#: pkg/storaged/unrecognized-tab.jsx:45 pkg/storaged/format-dialog.jsx:274
 #: pkg/systemd/hwinfo.jsx:36
 msgid "Type"
 msgstr "类型"
@@ -8298,7 +8321,7 @@ msgstr "无法获取警告详情。"
 msgid "Unable to get alert: $0"
 msgstr "无法获取警告： $0"
 
-#: pkg/storaged/iscsi-panel.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "无法到达服务器"
 
@@ -8344,23 +8367,23 @@ msgstr "意外的错误"
 msgid "Unique name"
 msgstr ""
 
-#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:728
+#: pkg/storaged/index.html:396 pkg/storaged/dialogx.jsx:792
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
+#: pkg/kubernetes/views/pv-body.html:26 pkg/kubernetes/views/pv-claim.html:31
 #: pkg/kubernetes/views/volumes-page.html:35
+#: pkg/kubernetes/views/node-body.html:12
+#: pkg/kubernetes/views/node-body.html:43
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:664
-#: pkg/kubernetes/scripts/nodes.js:757 pkg/kubernetes/scripts/volumes.js:266
-#: pkg/lib/machine-info.es6:61 pkg/networkmanager/interfaces.js:592
-#: pkg/networkmanager/interfaces.js:1066 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2527 pkg/storaged/fsys-tab.jsx:61
-#: pkg/storaged/swap-tab.jsx:56
+#: pkg/kubernetes/scripts/volumes.js:266 pkg/kubernetes/scripts/nodes.js:316
+#: pkg/kubernetes/scripts/nodes.js:664 pkg/kubernetes/scripts/nodes.js:757
+#: pkg/networkmanager/interfaces.js:592 pkg/networkmanager/interfaces.js:1066
+#: pkg/networkmanager/interfaces.js:2525 pkg/networkmanager/interfaces.js:2527
+#: pkg/storaged/swap-tab.jsx:56 pkg/storaged/fsys-tab.jsx:61
+#: pkg/lib/machine-info.es6:61
 msgid "Unknown"
 msgstr "未知"
 
@@ -8384,7 +8407,7 @@ msgstr "未知主机密钥"
 msgid "Unknown configuration"
 msgstr "未知配置"
 
-#: pkg/storaged/iscsi-panel.jsx:108
+#: pkg/storaged/iscsi-panel.jsx:84
 msgid "Unknown host name"
 msgstr "未知主机名"
 
@@ -8429,7 +8452,7 @@ msgstr "未管理的接口"
 msgid "Unmask"
 msgstr "Unmask"
 
-#: pkg/storaged/fsys-tab.jsx:196 pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:282 pkg/storaged/fsys-tab.jsx:196
 msgid "Unmount"
 msgstr "卸载"
 
@@ -8519,7 +8542,7 @@ msgstr ""
 msgid "Updates are disabled."
 msgstr "更新不可用。"
 
-#: pkg/packagekit/updates.jsx:51 pkg/subscriptions/subscriptions-view.jsx:187
+#: pkg/subscriptions/subscriptions-view.jsx:187 pkg/packagekit/updates.jsx:51
 msgid "Updating"
 msgstr "更新"
 
@@ -8567,13 +8590,13 @@ msgid "Use the setting in /etc/kdump.conf"
 msgstr "使用 /etc/kdump.conf 中的设置"
 
 #: pkg/systemd/index.html:281 pkg/docker/storage.jsx:314
-#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:66
 #: pkg/kubernetes/scripts/virtual-machines/components/VmMetricsTab.jsx:73
+#: pkg/kubernetes/scripts/nodes.js:832 pkg/kubernetes/scripts/nodes.js:841
 #: pkg/machines/components/vm/vmUsageTab.jsx:63
 #: pkg/machines/components/vm/vmUsageTab.jsx:74
-#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/fsys-tab.jsx:206
-#: pkg/storaged/swap-tab.jsx:82 pkg/systemd/host.js:1546
+#: pkg/machines/components/vmDisksTab.jsx:66 pkg/storaged/swap-tab.jsx:82
+#: pkg/storaged/fsys-tab.jsx:206 pkg/systemd/host.js:1546
 msgid "Used"
 msgstr "已使用"
 
@@ -8583,10 +8606,10 @@ msgstr "被容器使用"
 
 #: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
 #: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
 #: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/kubernetes/views/volume-body.html:103
+#: pkg/kubernetes/views/user-page.html:20
+#: pkg/kubernetes/views/user-panel.html:9 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:259
 #: pkg/subscriptions/subscriptions-register.jsx:76 pkg/systemd/host.js:1454
 msgid "User"
@@ -8605,7 +8628,7 @@ msgstr "用户密码"
 msgid "User interface for Linux servers"
 msgstr "Linux 服务器用户接口"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "用户名"
@@ -8618,8 +8641,8 @@ msgstr "用户名不能为空"
 msgid "User or Group"
 msgstr "用户或组"
 
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:51
-#: pkg/storaged/iscsi-panel.jsx:174
+#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
+#: pkg/storaged/iscsi-panel.jsx:150
 msgid "Username"
 msgstr "用户名"
 
@@ -8779,9 +8802,9 @@ msgid "Verifying"
 msgstr "正在验证"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:115 pkg/ovirt/components/ClusterTemplates.jsx:135
+#: pkg/systemd/index.html:115 pkg/subscriptions/subscriptions-view.jsx:34
+#: pkg/systemd/hwinfo.jsx:44 pkg/ovirt/components/ClusterTemplates.jsx:135
 #: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:376
-#: pkg/subscriptions/subscriptions-view.jsx:34 pkg/systemd/hwinfo.jsx:44
 msgid "Version"
 msgstr "版本"
 
@@ -8843,8 +8866,8 @@ msgstr "卷组"
 msgid "Volume ID"
 msgstr "卷编号"
 
-#: pkg/kubernetes/views/pv-modify.html:115
 #: pkg/kubernetes/views/volume-body.html:42
+#: pkg/kubernetes/views/pv-modify.html:115
 msgid "Volume Name"
 msgstr "卷名称"
 
@@ -8852,9 +8875,8 @@ msgstr "卷名称"
 msgid "Volume Type"
 msgstr "卷类型"
 
-#: pkg/docker/index.html:512 pkg/kubernetes/index.html:80
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:512 pkg/kubernetes/views/dashboard-page.html:47
+#: pkg/kubernetes/views/pod-page.html:18 pkg/kubernetes/index.html:80
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "卷"
@@ -8949,7 +8971,9 @@ msgstr "是"
 msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
-msgstr "已经连接到 {{#strong}}{{host}}{{/strong}}，然而为了同步用户，需要一个特权用户。"
+msgstr ""
+"已经连接到 {{#strong}}{{host}}{{/strong}}，然而为了同步用户，需要一个特权用"
+"户。"
 
 #: pkg/dashboard/list.js:431
 msgid ""
@@ -9144,7 +9168,7 @@ msgstr ""
 msgid "iSCSI"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:293
+#: pkg/storaged/iscsi-panel.jsx:259
 msgid "iSCSI Targets"
 msgstr "iSCSI 目标"
 
@@ -9219,10 +9243,10 @@ msgstr "不可操作"
 msgid "non responsive"
 msgstr "未响应"
 
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
 #: pkg/kubernetes/views/route-body.html:24
 #: pkg/kubernetes/views/route-body.html:29
+#: pkg/kubernetes/views/node-body.html:33
+#: pkg/kubernetes/views/node-body.html:59
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:418 pkg/docker/run.js:474 pkg/docker/run.js:528
 #: pkg/docker/run.js:573 pkg/tuned/dialog.js:106
@@ -9245,7 +9269,9 @@ msgstr "oVirt 供应商安装脚本因缺少参数失败。"
 msgid ""
 "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
 "machines-ovirt.config, try as root."
-msgstr "oVirt 供应商安装脚本失败：无法写入 /etc/cockpit/machines-ovirt.config，尝试重启。"
+msgstr ""
+"oVirt 供应商安装脚本失败：无法写入 /etc/cockpit/machines-ovirt.config，尝试重"
+"启。"
 
 #: pkg/ovirt/components/InstallationDialog.jsx:164
 msgid "oVirt installation script failed with following output: "
@@ -9396,7 +9422,7 @@ msgstr ""
 msgid "unassigned"
 msgstr "未指定"
 
-#: pkg/lib/cockpit-components-select.jsx:31
+#: pkg/lib/cockpit-components-select.jsx:29
 msgid "undefined"
 msgstr "未定义"
 
@@ -9462,5 +9488,5 @@ msgid ""
 "{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
 "count: {{ condition.generation }}"
 msgstr ""
-"{{ condition.message }}。时间戳： {{ condition.lastTransitionTime }} 错误计数： {{ "
-"condition.generation }}"
+"{{ condition.message }}。时间戳： {{ condition.lastTransitionTime }} 错误计"
+"数： {{ condition.generation }}"


### PR DESCRIPTION
We don't use printf-style C format macros like "%s" in the JavaScript
code, at least not for translations. But xgettext interprets the "$0% Free"
in pkg/kubernetes/scripts/nodes.js as C format string, which confuses
translation tools and blocks the proper translation of this string.

As there doesn't seem to be a way to change the `--keyword=ngettext`
argument to do that, just filter out the `c-format` tag with sed.
