### PR TITLE
test: Allow using a graphics console with any vm-run image

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -945,7 +945,7 @@ class VirtMachine(Machine):
     memory_mb = None
     cpus = None
 
-    def __init__(self, image, networking=None, maintain=False, memory_mb=None, cpus=None, **args):
+    def __init__(self, image, networking=None, maintain=False, memory_mb=None, cpus=None, graphics=False, **args):
         self.maintain = maintain
 
         # Currently all images are run on x86_64. When that changes we will have
@@ -954,6 +954,7 @@ class VirtMachine(Machine):
 
         self.memory_mb = memory_mb or VirtMachine.memory_mb or MEMORY_MB
         self.cpus = cpus or VirtMachine.cpus or 1
+        self.graphics = graphics
 
         # Set up some temporary networking info if necessary
         if networking is None:
@@ -1052,10 +1053,12 @@ class VirtMachine(Machine):
         # No need or use for redir network on windows
         if "windows" in self.image:
             keys["disk"] = "ide"
-            keys["console"] = TEST_GRAPHICS_XML.format(**keys)
             keys["redir"] = ""
         else:
             keys["disk"] = "virtio"
+        if self.graphics:
+            keys["console"] = TEST_GRAPHICS_XML.format(**keys)
+        else:
             keys["console"] = TEST_CONSOLE_XML.format(**keys)
         if "windows-10" in self.image:
             keys["loader"] = "<loader readonly='yes' type='pflash'>/usr/share/edk2/ovmf/OVMF_CODE.fd</loader>"

--- a/test/vm-run
+++ b/test/vm-run
@@ -69,6 +69,7 @@ parser = argparse.ArgumentParser(description='Run a test machine')
 parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose details')
 parser.add_argument('-m', '--maintain', action='store_true', help='Changes are permanent')
 parser.add_argument('-M', '--memory', default=None, type=int, help='Memory (in MiB) of the target machine')
+parser.add_argument('-G', '--graphics', action='store_true', help='Display a graphics console')
 parser.add_argument('-C', '--cpus', default=None, type=int, help='Number of cpus in the target machine')
 parser.add_argument('--network', action='store_true', help='Setup a bridged network for running machines')
 parser.add_argument('--no-network', action='store_true', help='Do not connect the machine to the Internet')
@@ -94,10 +95,12 @@ try:
     if "windows" in args.image and memory is None:
         memory = 4096
 
+    graphics = args.graphics or "windows" in args.image
     network = testvm.VirtNetwork(0, bridge=bridge)
 
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, maintain=args.maintain,
-                                 networking=network.host(restrict=args.no_network), memory_mb=memory, cpus=args.cpus)
+                                 networking=network.host(restrict=args.no_network),
+                                 memory_mb=memory, cpus=args.cpus, graphics=graphics)
 
     # Hack to make things easier for users who don't know about kubeconfig
     if 'openshift' in args.image:
@@ -132,7 +135,7 @@ try:
         message = "\nBRIDGE IP FROM HOST\n  %s\n" % ip
 
     # Graphics console necessary
-    if "windows" in args.image:
+    if graphics:
         machine.graphics_console()
 
     # No graphics console necessary


### PR DESCRIPTION
Previously we only used a graphics console with windows images.
We still do that, but now have an argument --graphics that allows
us to use a graphical console when running any image.