### PR TITLE
po: Don't mark JavaScript strings as c-format

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -85,13 +85,14 @@ po/cockpit.html.pot: po/POTFILES.html.in
 
 # Extract cockpit style javascript translations
 po/cockpit.js.pot: po/POTFILES.js.in
-	$(XGETTEXT) --default-domain=cockpit --output=$@ --language=C --keyword= \
+	$(XGETTEXT) --default-domain=cockpit --output=- --language=C --keyword= \
 		--keyword=_:1,1t --keyword=_:1c,2,1t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
 		--keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
-		--from-code=UTF-8 --directory=$(srcdir) --files-from=$^
+		--from-code=UTF-8 --directory=$(srcdir) --files-from=$^ | \
+		sed '/^#/ s/, c-format//' > $@
 
 po/cockpit.manifest.pot: po/POTFILES.manifest.in
 	$(srcdir)/tools/missing $(srcdir)/po/manifest2po -d $(srcdir) -f $^ -o $@

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -51,6 +51,12 @@
 %define build_subscriptions 1
 %endif
 
+# cockpit-kubernetes is RHEL 7 only, and 64 bit arches only
+%if 0%{?fedora} || (0%{?rhel}%{?centos} >= 7 && 0%{?rhel}%{?centos} < 8)
+%ifarch aarch64 x86_64 ppc64le s390x
+%define build_kubernetes 1
+%endif
+%endif
 
 %define libssh_version 0.7.1
 %if 0%{?fedora} > 0 && 0%{?fedora} < 22
@@ -138,7 +144,9 @@ Recommends: cockpit-packagekit
 Recommends: subscription-manager-cockpit
 %endif
 Suggests: cockpit-pcp
+%if 0%{?build_kubernetes}
 Suggests: cockpit-kubernetes
+%endif
 Suggests: cockpit-selinux
 %endif
 
@@ -284,7 +292,7 @@ rm -rf %{buildroot}/%{_datadir}/cockpit/docker
 touch docker.list
 %endif
 
-%ifarch aarch64 x86_64 ppc64le s390x
+%if 0%{?build_kubernetes}
 %if %{defined wip}
 %else
 rm %{buildroot}/%{_datadir}/cockpit/kubernetes/override.json
@@ -780,7 +788,7 @@ This package is not yet complete.
 %endif
 %endif
 
-%ifarch aarch64 x86_64 ppc64le s390x
+%if 0%{?build_kubernetes}
 
 %package -n cockpit-kubernetes
 Summary: Cockpit user interface for Kubernetes cluster


### PR DESCRIPTION
We don't use printf-style C format macros like "%s" in the JavaScript
code, at least not for translations. But xgettext interprets the "$0% Free"
in pkg/kubernetes/scripts/nodes.js as C format string, which confuses
translation tools and blocks the proper translation of this string.

As there doesn't seem to be a way to change the `--keyword=ngettext`
argument to do that, just filter out the `c-format` tag with sed.

Cherry-picked from master commit 449d76c0e6d