### PR TITLE
Fix rhel-x image

### DIFF
--- a/bots/images/rhel-x
+++ b/bots/images/rhel-x
@@ -1,1 +1,1 @@
-rhel-x-e74d8849fac5ac5a16bf19deb1e26655a3082c7b973fc4bdfb9f6d2b0c34eed3.qcow2
+rhel-x-a8bc5c2b640be8c6b2e70b77f533c91bfa8dba6eb82d3157b8bd4eebb9bfb51a.qcow2

--- a/bots/images/scripts/rhel.setup
+++ b/bots/images/scripts/rhel.setup
@@ -76,7 +76,7 @@ enabled=1
 gpgcheck=0
 EOF
         # make ipa-client available
-        dnf module enable -y idm:4
+        dnf module enable -y idm:client
     else
         # if disabling the repos doesn't work, do without
         yum -y --disablerepo=rhel-7-server-htb-rpms --disablerepo=rhel-sjis-for-rhel-7-server-rpms install yum-utils || yum -y install yum-utils

--- a/bots/naughty/rhel-x/10084-selinux-unit-status
+++ b/bots/naughty/rhel-x/10084-selinux-unit-status
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "test/verify/check-connection", line *, in testSocket
+*
+AssertionError: '9090' unexpectedly found in 'Web console: https://localhost:9090/\n\n'

--- a/bots/naughty/rhel-x/10086-selinux-certmonger-run-cockpit
+++ b/bots/naughty/rhel-x/10086-selinux-certmonger-run-cockpit
@@ -1,0 +1,6 @@
+Traceback (most recent call last):
+  File "test/verify/check-realms", line *, in testIpa
+    out = m.execute("openssl s_client -verify 5 -verify_return_error -connect localhost:9090")
+*
+subprocess.CalledProcessError: Command 'openssl s_client -verify 5 -verify_return_error -connect localhost:9090' returned non-zero exit status 1.
+

--- a/bots/naughty/rhel-x/9598-selinux-dnsmasq-nm
+++ b/bots/naughty/rhel-x/9598-selinux-dnsmasq-nm
@@ -1,1 +1,1 @@
-*type=1400 audit(*): avc:  denied  { search } * comm="dnsmasq" name="NetworkManager"
+*type=1400 audit(*): avc:  denied * comm="dnsmasq" name="NetworkManager"

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -844,6 +844,9 @@ class MachineCase(unittest.TestCase):
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1571377
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { .* } for .* path="/dev/random" .*')
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { read } for .* name="random" .*')
+            # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1629588
+            self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { read } for .* comm="agetty" name="motd".*')
+            self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { read } for .* comm="sshd" name="motd".*')
 
         # these images don't have tuned; keep in sync with bots/images/scripts/debian.setup
         if self.image in ["ubuntu-1604", "debian-stable"]:


### PR DESCRIPTION
Fixes #10042 

 * [x] image-refresh rhel-x
 * [x] ignore SELinux errors about sshd/agetty motd read denial (https://bugzilla.redhat.com/show_bug.cgi?id=1629588)
 * [x] override `check-connection testSocket` regresssion (known issue #10084)
 * [x] override `testIpa` regression (known issue #10086)
 * [x] override `testOtherSettings` SELinux violation