### PR TITLE
common: Fix null dereference of known hosts filename

### DIFF
--- a/src/common/cockpitknownhosts.c
+++ b/src/common/cockpitknownhosts.c
@@ -264,6 +264,9 @@ cockpit_is_host_known (const gchar *known_hosts_file,
   gchar *ptr;
   gchar *hostport = NULL;
 
+  if (!known_hosts_file)
+    return FALSE;
+
   FILE *file = g_fopen (known_hosts_file, "r");
   gboolean ret = FALSE;
 


### PR DESCRIPTION
The tmp_knownhost_file variable may be NULL if creating it fails.
We need to be careful to handle that case when looking up hosts.