### PR TITLE
tools: Reduce system-logos to a Recommends

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -487,13 +487,11 @@ Conflicts: firewalld < 0.6.0-1
 %endif
 %if 0%{?fedora} || 0%{?rhel} >= 8
 Recommends: sscg >= 2.3
+Recommends: system-logos
 %endif
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
-%if 0%{?rhel}
-Requires: system-logos
-%endif
 
 %description ws
 The Cockpit Web Service listens on the network, and authenticates users.


### PR DESCRIPTION
The logo is not absolutely required to run cockpit-ws, and the logo
package is also absent from the cockpit/ws container (causing image
preparation failures of rhel-atomic).

This avoids introducing a massive new dependency until the -logos
package splits out the backgrounds into a separate package

This avoids introducing a massive new dependency until the -logos
package splits out the backgrounds into a separate package
(https://bugzilla.redhat.com/show_bug.cgi?id=1626388).