### PR TITLE
color: change light blue to patternfly's pf-blue-50

### DIFF
--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -509,7 +509,7 @@ div.spinner {
 }
 
 .drives-panel-body table tr:hover {
-    background-color: #d4edfa;
+    background-color: #def3ff;
 }
 
 .drives-panel-body table tr td {

--- a/pkg/lib/journal.css
+++ b/pkg/lib/journal.css
@@ -74,7 +74,7 @@
 }
 
 .cockpit-log-panel .cockpit-logline:hover {
-    background-color: #d4edfa;
+    background-color: #def3ff;
 }
 
 .cockpit-log-panel > .cockpit-logline:hover {

--- a/pkg/lib/page.css
+++ b/pkg/lib/page.css
@@ -65,7 +65,7 @@ a.disabled:hover {
 }
 
 .highlight-ct {
-    background-color: #d4edfa;
+    background-color: #def3ff;
 }
 
 /* Well and Blankslate */

--- a/pkg/lib/plot.js
+++ b/pkg/lib/plot.js
@@ -925,7 +925,7 @@ plotter.setup_plot_controls = function setup_plot_controls(container, element, p
         plots.forEach(function (p) {
             var options = p.get_options();
             if (!options.selection || options.selection.mode != mode) {
-                options.selection = { mode: mode, color: "#d4edfa" };
+                options.selection = { mode: mode, color: "#def3ff" };
                 p.set_options(options);
                 p.refresh();
             }

--- a/pkg/lib/table.css
+++ b/pkg/lib/table.css
@@ -32,7 +32,7 @@
 .table-hover > tbody > tr:hover > td,
 .table-hover > tbody > tr:hover > th,
 .dialog-list-ct .list-group-item:hover:not(.active) {
-    background-color: #d4edfa;
+    background-color: #def3ff;
 }
 
 /* Override patternfly to fit buttons and such */

--- a/pkg/users/users.css
+++ b/pkg/users/users.css
@@ -13,7 +13,7 @@
 }
 
 .cockpit-account:hover {
-    background-color: #d4edfa;
+    background-color: #def3ff;
     cursor: pointer;
 }
 
@@ -58,7 +58,7 @@
 }
 
 #dashboard_setup_address_discovered li:hover {
-    background-color: #d4edfa;
+    background-color: #def3ff;
 }
 
 #account-pic {

--- a/src/base1/cockpit.css
+++ b/src/base1/cockpit.css
@@ -193,7 +193,7 @@ a {
 }
 
 .highlight-ct {
-    background-color: #d4edfa;
+    background-color: #def3ff;
 }
 
 /*
@@ -210,7 +210,7 @@ a {
 .table-hover > tbody > tr:hover > td,
 .table-hover > tbody > tr:hover > th,
 .dialog-list-ct .list-group-item:hover:not(.active) {
-    background-color: #d4edfa;
+    background-color: #def3ff;
 }
 
 /* Override patternfly to fit buttons and such */
@@ -519,7 +519,7 @@ tbody.open tr.listing-ct-panel td div.listing-ct-head {
 
 /* only highlight the row if navigation is available */
 tbody:not(.open) tr.listing-ct-item:not(.listing-ct-nonavigate):hover {
-    background-color: #d4edfa;
+    background-color: #def3ff;
 }
 
 /* if we can't navigate to a row but expand is available, highlight the caret */


### PR DESCRIPTION
Cockpit has used #d4edfa since at least 2014 — it's not a PatternFly color. However, there's a color that's close, and that's pf-blue-50, aka: #def3ff.