### PR TITLE
doc: Move docs about authentication rate limits to guide

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -121,12 +121,8 @@ action = none
 
 # Limits
 
-Like ```sshd``` cockpit can be configured to limit the number of concurrent
-login attempts allowed. This is done by adding a ```MaxStartups```
-option to the ```WebService``` section of your cockpit configuration.
-Additional connections will be dropped until authentication succeeds or
-the connections are closed. See the man page for cockpit.conf for more
-details. By default the limit is set to 10.
+Cockpit can be configured to limit the number of concurrent login processes. See cockpit.conf
+for more details. This will affect how many custom authentication processes can be launched.
 
 Environment Variables
 ================================

--- a/doc/guide/authentication.xml
+++ b/doc/guide/authentication.xml
@@ -29,6 +29,13 @@
       </filename> will need to be configured to allow password based authentication.
       Alternatively you can setup a <link linkend="sso">Kerberos based SSO
       solution</link>.</para>
+
+    <para>Like <filename>sshd</filename>, cockpit can be configured to limit the number
+      of concurrent login attempts allowed. This is done by adding a <code>MaxStartups</code>
+      option to the <code>WebService</code> section of your <code>cockpit.conf</code>.
+      Additional connections will be dropped until authentication succeeds or
+      the connections are closed.</para>
+
   </section>
 
   <section id="secondary-auth">


### PR DESCRIPTION
These docs belong in the guide where they can be easily seen
on the website.