### PR TITLE
ws: Fix error propagation in certificate generation

### DIFF
--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -293,7 +293,7 @@ generate_temp_cert (const gchar *dir,
       cert_path = NULL;
       goto out;
     }
-  error = NULL;
+  g_clear_error (error);
 
   /* Fall back to using the openssl CLI */
 

--- a/src/ws/test-remotectlcertificate.c
+++ b/src/ws/test-remotectlcertificate.c
@@ -62,9 +62,9 @@ delete_all (TestCase *tc)
       g_free (path);
     }
 
+  g_rmdir (tc->cert_dir);
   parent = g_path_get_dirname (tc->cert_dir);
   g_rmdir (parent);
-  g_rmdir (tc->cert_dir);
   g_rmdir (config_dir);
 
 out:

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -180,6 +180,7 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          glib-networking,
          adduser,
+         openssl,
 Conflicts: ${ws:Conflicts}
 Description: Cockpit Web Service
  The Cockpit Web Service listens on the network, and authenticates


### PR DESCRIPTION
`error` is a pointer to a `GError*`. NULLing it completely broke error
propagation back to the caller. This caused a segfault when trying to
write `error->message`:

    $ mkdir -p /tmp/x/cockpit/ws-certs.d
    $ chmod a-w /tmp/x/cockpit/ws-certs.d
    $ XDG_CONFIG_DIRS=/tmp/x remotectl certificate --ensure --user=$(id -un) --group=$(id -gn)
    Segmentation fault (core dumped)

Use `g_clear_error()` instead to reset the error from a failed sscg
attempt.

In the test case, use a non-writable certificate directory to reproduce
this. In reality, this has been observed with neither sscg nor openssl
being available.

Fixes #8690