### PR TITLE
bots: Fix VirtMachine.pull() to work with normal $PATH

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -1143,7 +1143,7 @@ class VirtMachine(Machine):
             image_file = os.path.join(BOTS_DIR, "images", image)
         if not os.path.exists(image_file):
             try:
-                subprocess.check_call([ "image-download", image_file ])
+                subprocess.check_call([ os.path.join(BOTS_DIR, "image-download"), image_file ])
             except OSError as ex:
                 if ex.errno != errno.ENOENT:
                     raise


### PR DESCRIPTION
Call `image-download` from the bots/ directory instead of relying on the
caller to add it to `$PATH`. This makes it easier for external projects
to use `pull()`.