### PR TITLE
bots: Fix stdout usage in tests-data

### DIFF
--- a/bots/tests-data
+++ b/bots/tests-data
@@ -62,7 +62,7 @@ def run(filename, verbose=False, dry=False, **kwargs):
             with gzip.open(filename, 'rb') as fp:
                 seed(since, fp, pulls, output)
     else:
-        output = sys.stdout
+        output = sys.stdout.buffer
         outname = None
 
     def write(**kwargs):


### PR DESCRIPTION
This fixes invoking tests-data directly, there's a regression and
its unable to print to stdout, due to a bytes vs. string error.