### PR TITLE
bots: Ignore certificate validation when pulling test logs

### DIFF
--- a/bots/tests-data
+++ b/bots/tests-data
@@ -23,6 +23,7 @@ import json
 import os
 import re
 import socket
+import ssl
 import subprocess
 import sys
 import tempfile
@@ -204,7 +205,11 @@ class Pulls():
 
 # Retrieves the content of the given URL
 def retrieve(url):
-    return urllib.request.urlopen(url).read().decode('utf-8', 'replace')
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    req = urllib.request.urlopen(url, context=ctx)
+    return req.read().decode('utf-8', 'replace')
 
 # Returns a list of all results at the given URL
 def links(url):


### PR DESCRIPTION
We should ignore HTTPS validation when pulling test logs. Often
we even pull over HTTP. We really want to opportunistically get
whatever logs are available, rather than ensuring they are perfect.

 * [x] tests-data tests-train-1.jsonl.gz