### PR TITLE
retrofit our own lists to match a PatternFly style

### DIFF
--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -509,7 +509,7 @@ div.spinner {
 }
 
 .drives-panel-body table tr:hover {
-    background-color: #d4edfa;
+    background-color: #edf8ff;
 }
 
 .drives-panel-body table tr td {

--- a/pkg/kubernetes/styles/images.less
+++ b/pkg/kubernetes/styles/images.less
@@ -7,7 +7,7 @@ table.images-listing {
     min-width: 85%;
 
     tbody:hover {
-        background-color: #d4edfa;
+        background-color: #edf8ff;
     }
 
     thead {

--- a/pkg/lib/journal.css
+++ b/pkg/lib/journal.css
@@ -73,8 +73,12 @@
     padding-left: 20px;
 }
 
-.cockpit-log-panel .cockpit-logline:hover {
-    background-color: #edf8ff;
+.cockpit-log-panel > .cockpit-logline:hover {
+    background-color: #def3ff; /* pf-blue-50 */
+}
+
+.cockpit-log-panel > .cockpit-logline:hover .cockpit-log-message {
+    color: #0088ce; /* pf-blue-400 */
 }
 
 .cockpit-log-panel > .cockpit-logline:hover {

--- a/pkg/lib/journal.css
+++ b/pkg/lib/journal.css
@@ -74,7 +74,7 @@
 }
 
 .cockpit-log-panel .cockpit-logline:hover {
-    background-color: #d4edfa;
+    background-color: #edf8ff;
 }
 
 .cockpit-log-panel > .cockpit-logline:hover {

--- a/pkg/lib/listing.less
+++ b/pkg/lib/listing.less
@@ -417,7 +417,8 @@ table.listing-ct tbody.open {
 }
 
 /* By default these are hidden */
-tbody tr.listing-ct-head,
+/* (HACK: Special-case the user auth dialog) */
+tbody:not(.ssh-key-body) tr.listing-ct-head,
 tbody tr.listing-ct-panel,
 tbody tr.listing-ct-body {
     display: none;

--- a/pkg/lib/listing.less
+++ b/pkg/lib/listing.less
@@ -50,6 +50,7 @@ table.listing-ct > thead th:last-child {
 
 /* A listing item is a row in the table */
 tbody > tr.listing-ct-item {
+    border: 1px solid transparent;
     border-top: 1px solid @gray-lighter;
     border-bottom: 1px solid @gray-lighter;
     cursor: pointer;
@@ -73,11 +74,12 @@ tbody > tr.listing-ct-item.listing-ct-warning {
 }
 
 tbody.open > tr.listing-ct-item {
-    background-color: @color-pf-black-200;
+    background-color: @color-pf-blue-50;
     border-bottom: none;
     border-top: none;
     border-left: 1px solid @listing-ct-border;
     border-right: 1px solid @listing-ct-border;
+    transition: all 200ms;
 }
 
 tbody.open > tr.listing-ct-item td,
@@ -116,68 +118,72 @@ tbody:not(.open) > tr.listing-ct-item.listing-ct-nonavigate:hover td.listing-ct-
     color: @listing-ct-active;
 }
 
-/* use gray for a row that's expanded or if navigation isn't available */
-tbody.open > tr.listing-ct-item:hover,
+/* use hover color expanded rows even if navigation isn't available */
+tbody.open:hover > tr.listing-ct-item,
 tr.listing-ct-item.listing-ct-nonavigate:hover {
-    background-color: @color-pf-black-200;
-}
-
-/* always highlight caret when hovering over an expanded row */
-tbody.open > tr.listing-ct-item:hover td.listing-ct-toggle {
-    color: @listing-ct-active;
+    background-color: @listing-ct-hover;
 }
 
 tr.listing-ct-item .listing-ct-toggle {
-    padding: 0 !important;
     width: 35px;
-    color: @color-pf-black;
+    color: @color-pf-black-800;
 }
 
-table.listing-ct thead .listing-ct-toggle + th,
-tr.listing-ct-item .listing-ct-toggle + td,
-tr.listing-ct-item .listing-ct-toggle + th {
-    padding-left: 0;
+/* Highlight toggle color when hovered or if the row is open */
+.listing-ct-toggle:hover,
+tbody.open .listing-ct-toggle {
+    color: @listing-ct-active;
 }
 
-tr:not(.listing-ct-selected) {
-    td.listing-ct-toggle:hover {
-        color: @listing-ct-active;
-        background-color: @color-pf-black-200;
+.listing-ct > thead > .listing-ct-toggle + th,
+.listing-ct-item > .listing-ct-toggle + td,
+.listing-ct-item > .listing-ct-toggle + th {
+    padding-left: 10px;
+    position: relative;
+}
 
-        ~ td, ~ th {
-            background-color: @color-pf-black-200;
-        }
-    }
- }
+.listing-ct-item > .listing-ct-toggle:not(:empty) + th::before,
+.listing-ct-item > .listing-ct-toggle:not(:empty) + td::before {
+    border-left: 1px solid rgba(0, 0, 0, 0.18); /* pf-black-300 */
+    content: "";
+    height: @line-height-base * 1em;
+    left: -5px;
+    position: absolute;
+    top: @listing-ct-padding * 1.5;
+}
+
+
 td.listing-ct-toggle i {
-    font-size: 24px;
-    visibility: hidden;
-}
-
-tr.listing-ct-item:hover td.listing-ct-toggle i,
-tr.listing-ct-item td.listing-ct-toggle:hover i {
-    visibility: visible;
+    font-size: 17px;
 }
 
 td.listing-ct-toggle i:before {
+    position: relative;
     content: "\f105";
-}
-
-tbody.open td.listing-ct-toggle i {
-    visibility: visible;
+    display: block;
 }
 
 tbody.open td.listing-ct-toggle i:before {
     content: "\f107";
+    animation: listingCtToggleOpen 100ms ease-in-out;
+    top: 1px;
+}
+
+@keyframes listingCtToggleOpen {
+    0% {
+       transform-origin: 50% 50%;
+       transform: translate(0, -1px) rotate(-90deg);
+    }
+    100% {
+       transform: translate(0, 0) rotate(0);
+    }
 }
 
 /* Listing items have decent padding ... */
-tr.listing-ct-item td {
-    padding: @listing-ct-padding;
-}
-
+tr.listing-ct-item td,
 tr.listing-ct-item th {
-    padding: @listing-ct-padding @listing-ct-padding @listing-ct-padding @listing-ct-spacing;
+    padding: @listing-ct-padding * 1.5;
+    vertical-align: text-top; /* baseline doesn't support wrapped lines */
 }
 
 /* Listing caption is text next to the actions, text should be similar to nav (.nav-tabs-pf > li > a)*/
@@ -218,10 +224,6 @@ tr.listing-ct-item.listing-ct-selected .badge {
 
 .listing-ct-head .listing-ct-actions {
     margin-top: -7px;
-}
-
-tr.listing-ct-item td:first-child {
-    padding-left: @listing-ct-padding * 2;
 }
 
 /* The last column of a listing is always right aligned */
@@ -276,8 +278,9 @@ tbody.active .listing-ct-head {
 }
 
 .listing-ct-head .nav li a {
-    padding-top: 0px;
     font-size: 13px;
+    /* Counteract listing-ct-head padding */
+    margin-top: -@listing-ct-padding;
 }
 
 .listing-ct-head .nav-tabs {
@@ -285,7 +288,8 @@ tbody.active .listing-ct-head {
 }
 
 .listing-ct-head .nav-tabs-pf {
-    margin-left: -@listing-ct-padding;
+    /* Counteract listing-ct-head padding */
+    margin: -@listing-ct-padding 0 0 -@listing-ct-padding;
 }
 
 /* To display info instead of tabs */
@@ -371,7 +375,6 @@ tbody.active .listing-ct-head {
     width: 100px;
     min-height: 26px;
     white-space: nowrap;
-    overflow: hidden;
     text-overflow: ellipsis;
     color: @listing-ct-metadata;
     font-weight: normal;
@@ -389,7 +392,6 @@ tbody.active .listing-ct-head {
     margin-left: 110px;
     min-height: 26px;
     max-width: 1000px;
-    overflow: hidden;
     text-overflow: ellipsis;
 }
 
@@ -405,11 +407,17 @@ tbody.active .listing-ct-head {
     margin-left: 0px;
 }
 
-table.listing-ct tbody.open {
-    box-shadow: 1px 1px 1px 1px @color-pf-black-150;
+table.listing-ct tbody {
+    transition: all 100ms ease-out;
 }
 
-/* By default these thincgs are hidden */
+table.listing-ct tbody.open {
+    transition: all 100ms ease-in;
+    box-shadow: 0 2px 6px rgba(3, 3, 3, 0.2);
+}
+
+/* By default these are hidden */
+tbody tr.listing-ct-head,
 tbody tr.listing-ct-panel,
 tbody tr.listing-ct-body {
     display: none;
@@ -420,6 +428,41 @@ tbody.open tr.listing-ct-head,
 tbody.open tr.listing-ct-panel,
 tbody.open tr.listing-ct-body {
     display: table-row;
+}
+
+/* Animate the listing head & the last visible body */
+/* (Switching tabs will adds new listing-ct-bodys & toggle visibility) */
+tbody.open div.listing-ct-head,
+tbody.open div.listing-ct-head + div.listing-ct-body:not([hidden]):last-child {
+    animation: listingCtShow 100ms ease-in-out;
+}
+
+@keyframes listingCtShow {
+    0% {
+        margin-bottom: 0;
+        margin-top: 0;
+        max-height: 0;
+        opacity: 0;
+        padding-bottom: 0;
+        padding-top: 0;
+        line-height: 0;
+    } 50% {
+        opacity: 0;
+        line-height: 1;
+    }
+    100% {
+        max-height: 100vh;
+        opacity: 1;
+    }
+}
+
+/* Turn off animation if requested by the browser/OS (where supported) */
+@media (prefers-reduced-motion: reduce) {
+    tbody.open td.listing-ct-toggle i:before,
+    tbody.open div.listing-ct-head,
+    tbody.open div.listing-ct-body {
+        animation: none;
+    }
 }
 
 tbody.open tr.listing-ct-head {
@@ -499,4 +542,20 @@ tbody tr.listing-ct-noexpand {
 .nav-tabs-pf > li.active a:before {
     height: @listing-ct-open-width;
     left: 0px;
+}
+
+/* Force word-wraps when words are too long */
+.listing-ct-item td,
+.listing-ct-item th,
+.listing-ct-body {
+    overflow-wrap: break-word;
+    hyphens: auto;
+}
+.listing-ct-item td,
+.listing-ct-item th {
+    max-width: calc(100vw - 18rem);
+}
+.listing-ct-body {
+    /* 42 = (20px padding + 1px border) * 2 */
+    max-width: calc(100vw - 42px);
 }

--- a/pkg/lib/page.css
+++ b/pkg/lib/page.css
@@ -65,7 +65,7 @@ a.disabled:hover {
 }
 
 .highlight-ct {
-    background-color: #d4edfa;
+    background-color: #edf8ff;
 }
 
 /* Well and Blankslate */

--- a/pkg/lib/plot.js
+++ b/pkg/lib/plot.js
@@ -925,7 +925,7 @@ plotter.setup_plot_controls = function setup_plot_controls(container, element, p
         plots.forEach(function (p) {
             var options = p.get_options();
             if (!options.selection || options.selection.mode != mode) {
-                options.selection = { mode: mode, color: "#d4edfa" };
+                options.selection = { mode: mode, color: "#edf8ff" };
                 p.set_options(options);
                 p.refresh();
             }

--- a/pkg/lib/table.css
+++ b/pkg/lib/table.css
@@ -32,7 +32,7 @@
 .table-hover > tbody > tr:hover > td,
 .table-hover > tbody > tr:hover > th,
 .dialog-list-ct .list-group-item:hover:not(.active) {
-    background-color: #d4edfa;
+    background-color: #edf8ff;
 }
 
 /* Override patternfly to fit buttons and such */

--- a/pkg/lib/variables.less
+++ b/pkg/lib/variables.less
@@ -3,7 +3,7 @@
 
 @metadata-color: #888;
 
-@listing-ct-hover: @list-group-hover-bg;
+@listing-ct-hover: #edf8ff;
 @listing-ct-active: #65bedf;
 @listing-ct-padding: 10px;
 @listing-ct-spacing: 15px;

--- a/pkg/packagekit/updates.less
+++ b/pkg/packagekit/updates.less
@@ -46,17 +46,18 @@ table.listing-ct thead th {
 }
 
 tr.listing-ct-item {
-    td {
-        vertical-align: baseline;
+    td, th {
+        /* We *should* align to baseline, but names wrap */
+        /* Padding and text side is the same, so top works here */
+        /* Too bad table doesn't align to "first baseline", like flex/grid */
+        vertical-align: top;
+    }
+    td:not(:first-child) {
         padding-left: 0;
+    }
 
-        &.listing-ct-toggle {
-            position: relative;
-            top: 2px;
-        }
-        &:last-child {
-            text-align: left;
-        }
+    th:last-child {
+        text-align: left;
     }
 
     @media screen and (min-width: 641px) {
@@ -74,7 +75,7 @@ tr.listing-ct-item {
                 overflow: visible;
 
                 .truncating {
-                    background: linear-gradient(to left, rgba(222, 243, 255, 0), rgb(222, 243, 255) 3em);
+                    background: linear-gradient(to left, rgba(237, 248, 255, 0), rgb(237, 248, 255) 3em);
                     position: relative;
                     padding: 0.5em 4em 0.5em 0;
                 }
@@ -97,6 +98,11 @@ tr.listing-ct-item {
         vertical-align: top;
         text-align: left;
 
+        * {
+            display: inline;
+            font: inherit;
+        }
+
         &, p {
             max-width: 60vw;
             margin-bottom: 0;  // counter-act <Markdown>
@@ -105,16 +111,6 @@ tr.listing-ct-item {
             text-overflow: ellipsis;
         }
     }
-}
-tbody.open {
-    td.version:hover .truncating {
-        /* Adapt background color for version expansion when row is expanded */
-        background: linear-gradient(to left, rgba(237, 237, 237, 0), rgb(237, 237, 237) 3em);
-    }
-}
-
-.listing-ct .security td.version:hover .truncating {
-    background: #fbf0f0;
 }
 
 .severity-critical {
@@ -159,6 +155,12 @@ tr.security.listing-ct-item {
     background-color: #fbf0f0 !important;  /* keep red background when expanded */
     border-top: 1px solid #e0e0e0;
     border-bottom: 1px solid #e0e0e0;
+
+    @media screen and (min-width: 641px) {
+        td.version:hover .truncating {
+            background: linear-gradient(to left, rgba(251, 240, 240, 0), rgb(251, 240, 240) 3em);
+        }
+    }
 }
 
 

--- a/pkg/users/users.css
+++ b/pkg/users/users.css
@@ -13,7 +13,7 @@
 }
 
 .cockpit-account:hover {
-    background-color: #d4edfa;
+    background-color: #edf8ff;
     cursor: pointer;
 }
 
@@ -58,7 +58,7 @@
 }
 
 #dashboard_setup_address_discovered li:hover {
-    background-color: #d4edfa;
+    background-color: #edf8ff;
 }
 
 #account-pic {

--- a/src/base1/cockpit.css
+++ b/src/base1/cockpit.css
@@ -193,7 +193,7 @@ a {
 }
 
 .highlight-ct {
-    background-color: #d4edfa;
+    background-color: #edf8ff;
 }
 
 /*
@@ -210,7 +210,7 @@ a {
 .table-hover > tbody > tr:hover > td,
 .table-hover > tbody > tr:hover > th,
 .dialog-list-ct .list-group-item:hover:not(.active) {
-    background-color: #d4edfa;
+    background-color: #edf8ff;
 }
 
 /* Override patternfly to fit buttons and such */
@@ -519,7 +519,7 @@ tbody.open tr.listing-ct-panel td div.listing-ct-head {
 
 /* only highlight the row if navigation is available */
 tbody:not(.open) tr.listing-ct-item:not(.listing-ct-nonavigate):hover {
-    background-color: #d4edfa;
+    background-color: #edf8ff;
 }
 
 /* if we can't navigate to a row but expand is available, highlight the caret */


### PR DESCRIPTION
By adopting PatternFly's look, our own lists should appear more clickable.