### PR TITLE
machines: Fix parsing of max vcpu count in libvirt-dbus provider

### DIFF
--- a/pkg/machines/libvirt-dbus.es6
+++ b/pkg/machines/libvirt-dbus.es6
@@ -620,7 +620,7 @@ function getDomainMaxVCPU(capsXML) {
 
     const domainCapsElem = xmlDoc.getElementsByTagName("domainCapabilities")[0];
     const vcpuElem = domainCapsElem.getElementsByTagName("vcpu")[0];
-    const vcpuMaxAttr = vcpuElem.attributes.getNamedItem('max');
+    const vcpuMaxAttr = vcpuElem.getAttribute('max');
 
     return vcpuMaxAttr;
 }


### PR DESCRIPTION
vcpuElem.attributes.getNamedItem('max') was returning string 'max'