### PR TITLE
tools: Stop hardcoding the Python 3 package name

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -21,6 +21,10 @@
 %define rhel %{centos}
 %endif
 
+%if "%{!?__python3:1}"
+%define __python3 /usr/bin/python3
+%endif
+
 # for testing this already gets set in fedora.install, as we want the target
 # VERSION_ID, not the mock chroot's one
 %if "%{!?os_version_id:1}"
@@ -638,7 +642,7 @@ Recommends: udisks2-lvm2 >= 2.6
 Recommends: udisks2-iscsi >= 2.6
 Recommends: device-mapper-multipath
 Recommends: clevis-luks
-Requires: python3
+Requires: %{__python3}
 Requires: python3-dbus
 %endif
 BuildArch: noarch
@@ -750,7 +754,7 @@ Requires: cockpit-shell >= %{required_base}
 Requires: /usr/bin/docker
 Requires: /usr/lib/systemd/system/docker.service
 %if 0%{?fedora}
-Requires: python3
+Requires: %{__python3}
 %else
 Requires: python2
 %endif


### PR DESCRIPTION
Consistently use the RPM macro instead and depend on the interpreter
executable directly.

Since the macro does not yet exist in current Fedora 28/29 (it will
soon), provide a fallback with the current value.

Thanks to Tomas Orsava for the original patch!

https://bugzilla.redhat.com/show_bug.cgi?id=1631174