### PR TITLE
machines: fix race condition when updating VM UI info

### DIFF
--- a/pkg/machines/actions/provider-actions.es6
+++ b/pkg/machines/actions/provider-actions.es6
@@ -126,11 +126,12 @@ export function getStorageVolumes(connectionName, poolName) {
     return virt(GET_STORAGE_VOLUMES, { connectionName, poolName });
 }
 
-export function getVm({connectionName, name, id}) {
+export function getVm({connectionName, name, id, updateOnly = false}) {
     return virt(GET_VM, {
         connectionName,
         name,
-        id
+        id,
+        updateOnly,
     });
 }
 

--- a/pkg/machines/libvirt-common.es6
+++ b/pkg/machines/libvirt-common.es6
@@ -8,7 +8,6 @@ import getLibvirtServiceNameScript from 'raw!./scripts/get_libvirt_service_name.
 import {
     vmActionFailed,
     updateLibvirtState,
-    updateOrAddVm,
     updateOsInfoList,
 } from './actions/store-actions.es6';
 
@@ -206,7 +205,7 @@ export function parseDumpxml(dispatch, connectionName, domXml, id_overwrite) {
 
     const ui = resolveUiState(dispatch, name);
 
-    dispatch(updateOrAddVm({
+    return {
         connectionName,
         name,
         id,
@@ -222,7 +221,7 @@ export function parseDumpxml(dispatch, connectionName, domXml, id_overwrite) {
         interfaces,
         metadata,
         ui,
-    }));
+    };
 }
 
 export function parseDumpxmlForBootOrder(osElem, devicesElem) {

--- a/pkg/machines/libvirt-dbus.es6
+++ b/pkg/machines/libvirt-dbus.es6
@@ -498,7 +498,8 @@ LIBVIRT_DBUS_PROVIDER = {
      */
     GET_VM({
         id: objPath,
-        connectionName
+        connectionName,
+        updateOnly,
     }) {
         let props = {};
         let domainXML;
@@ -545,7 +546,10 @@ LIBVIRT_DBUS_PROVIDER = {
                         logDebug(`${this.name}.GET_VM(${objPath}, ${connectionName}): update props ${JSON.stringify(props)}`);
 
                         let dumpxmlParams = parseDumpxml(dispatch, connectionName, domainXML, objPath);
-                        dispatch(updateOrAddVm(Object.assign({}, props, dumpxmlParams)));
+                        if (updateOnly)
+                            dispatch(updateVm(Object.assign({}, props, dumpxmlParams)));
+                        else
+                            dispatch(updateOrAddVm(Object.assign({}, props, dumpxmlParams)));
                     })
                     .catch(function(ex) { console.warn("GET_VM action failed failed for path", objPath, ex) });
         };
@@ -848,7 +852,8 @@ function startEventMonitor(dispatch, connectionName, libvirtServiceName) {
             case domainEvent["Stopped"]:
                 dispatch(getVm({
                     connectionName,
-                    id: objPath
+                    id: objPath,
+                    updateOnly: true,
                 }));
                 // transient VMs don't have a separate Undefined event, so remove them on stop
                 dispatch(undefineVm({connectionName, id: objPath, transientOnly: true}));

--- a/pkg/machines/libvirt-dbus.es6
+++ b/pkg/machines/libvirt-dbus.es6
@@ -101,8 +101,10 @@ const Enum = {
     VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA: 2,
     VIR_DOMAIN_UNDEFINE_NVRAM: 4,
     VIR_DOMAIN_STATS_BALLOON: 4,
+    VIR_DOMAIN_SHUTOFF: 5,
     VIR_DOMAIN_STATS_VCPU: 8,
     VIR_DOMAIN_STATS_BLOCK: 32,
+    VIR_DOMAIN_STATS_STATE: 1,
     VIR_DOMAIN_XML_INACTIVE: 2,
     VIR_CONNECT_LIST_NETWORKS_ACTIVE: 2,
     VIR_CONNECT_LIST_STORAGE_POOLS_ACTIVE: 2,
@@ -746,7 +748,7 @@ function doUsagePolling(name, connectionName, objPath) {
             logDebug(`doUsagePolling(${name}, ${connectionName}): usage polling disabled, stopping loop`);
             return;
         }
-        let flags = Enum.VIR_DOMAIN_STATS_BALLOON | Enum.VIR_DOMAIN_STATS_VCPU | Enum.VIR_DOMAIN_STATS_BLOCK;
+        let flags = Enum.VIR_DOMAIN_STATS_BALLOON | Enum.VIR_DOMAIN_STATS_VCPU | Enum.VIR_DOMAIN_STATS_BLOCK | Enum.VIR_DOMAIN_STATS_STATE;
 
         call(connectionName, objPath, 'org.libvirt.Domain', 'GetStats', [flags, 0], { timeout: 5000 })
                 .done(info => {
@@ -757,6 +759,8 @@ function doUsagePolling(name, connectionName, objPath) {
 
                         if ('balloon.rss' in info)
                             props['rssMemory'] = info['balloon.rss'].v.v;
+                        else if ('state.state' in info && info['state.state'].v.v == Enum.VIR_DOMAIN_SHUTOFF)
+                            props['rssMemory'] = 0.0;
                         for (var i = 0; i < info['vcpu.maximum'].v.v; i++) {
                             if (!(`vcpu.${i}.time` in info))
                                 continue;

--- a/pkg/machines/libvirt-dbus.es6
+++ b/pkg/machines/libvirt-dbus.es6
@@ -39,6 +39,7 @@ import {
     deleteUnlistedVMs,
     undefineVm,
     updateNetworks,
+    updateOrAddVm,
     updateStoragePools,
     updateStorageVolumes,
     updateVm,
@@ -535,8 +536,8 @@ LIBVIRT_DBUS_PROVIDER = {
 
                                                 logDebug(`${this.name}.GET_VM(${objPath}, ${connectionName}): update props ${JSON.stringify(props)}`);
 
-                                                parseDumpxml(dispatch, connectionName, domXml[0], objPath);
-                                                dispatch(updateVm(props));
+                                                let dumpxmlParams = parseDumpxml(dispatch, connectionName, domXml[0], objPath);
+                                                dispatch(updateOrAddVm(Object.assign({}, props, dumpxmlParams)));
                                             })
                                             .fail(function(ex) { console.warn("failed waiting for Domain proxy to get ready", ex) });
                                 })

--- a/pkg/machines/libvirt-dbus.es6
+++ b/pkg/machines/libvirt-dbus.es6
@@ -500,7 +500,6 @@ LIBVIRT_DBUS_PROVIDER = {
         return dispatch => {
             call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [0], TIMEOUT)
                     .done(domXml => {
-                        parseDumpxml(dispatch, connectionName, domXml[0], objPath);
                         call(connectionName, objPath, 'org.libvirt.Domain', 'GetState', [0], TIMEOUT)
                                 .done(state => {
                                     let DOMAINSTATE = [
@@ -535,6 +534,8 @@ LIBVIRT_DBUS_PROVIDER = {
                                                     props.autostart = returnProps[0].Autostart.v.v;
 
                                                 logDebug(`${this.name}.GET_VM(${objPath}, ${connectionName}): update props ${JSON.stringify(props)}`);
+
+                                                parseDumpxml(dispatch, connectionName, domXml[0], objPath);
                                                 dispatch(updateVm(props));
                                             })
                                             .fail(function(ex) { console.warn("failed waiting for Domain proxy to get ready", ex) });

--- a/pkg/machines/libvirt-virsh.es6
+++ b/pkg/machines/libvirt-virsh.es6
@@ -152,14 +152,16 @@ LIBVIRT_PROVIDER = {
      */
     GET_VM ({ name, connectionName }) {
         logDebug(`${this.name}.GET_VM()`);
+        let xmlDesc;
 
         return dispatch => {
             if (!isEmpty(name)) {
                 return spawnVirshReadOnly({connectionName, method: 'dumpxml', name}).then(domXml => {
-                    parseDumpxml(dispatch, connectionName, domXml);
+                    xmlDesc = domXml;
                     return spawnVirshReadOnly({connectionName, method: 'dominfo', name});
                 })
                         .then(domInfo => {
+                            parseDumpxml(dispatch, connectionName, xmlDesc);
                             parseDominfo(dispatch, connectionName, name, domInfo);
                         }); // end of GET_VM return
             }

--- a/pkg/machines/libvirt-virsh.es6
+++ b/pkg/machines/libvirt-virsh.es6
@@ -151,7 +151,7 @@ LIBVIRT_PROVIDER = {
      * @param VM name
      * @returns {Function}
      */
-    GET_VM ({ name, connectionName }) {
+    GET_VM ({ name, connectionName, updateOnly }) {
         logDebug(`${this.name}.GET_VM()`);
         let xmlDesc;
 
@@ -165,9 +165,14 @@ LIBVIRT_PROVIDER = {
                             let dumpxmlParams = parseDumpxml(dispatch, connectionName, xmlDesc);
                             let domInfoParams = parseDominfo(dispatch, connectionName, name, domInfo);
 
-                            dispatch(updateOrAddVm(
-                                Object.assign({}, dumpxmlParams, domInfoParams)
-                            ));
+                            if (updateOnly)
+                                dispatch(updateVm(
+                                    Object.assign({}, dumpxmlParams, domInfoParams)
+                                ));
+                            else
+                                dispatch(updateOrAddVm(
+                                    Object.assign({}, dumpxmlParams, domInfoParams)
+                                ));
                         }); // end of GET_VM return
             }
         };
@@ -627,7 +632,7 @@ function handleEvent(dispatch, connectionName, line) {
 
         case 'Stopped':
             // there might be changes between live and permanent domain definition, so full reload
-            dispatch(getVm({connectionName, name}));
+            dispatch(getVm({connectionName, name, updateOnly: true}));
 
             // transient VMs don't have a separate Undefined event, so remove them on stop
             dispatch(undefineVm({connectionName, name, transientOnly: true}));

--- a/pkg/machines/libvirt-virsh.es6
+++ b/pkg/machines/libvirt-virsh.es6
@@ -478,12 +478,12 @@ function parseDomstats(dispatch, connectionName, name, domstats) {
 
     const cpuTime = getValueFromLine(lines, 'cpu.time=');
     // TODO: Add network usage statistics
+    let retParams = {connectionName, name, actualTimeInMs, disksStats: parseDomstatsForDisks(lines)};
 
     if (cpuTime) {
-        return {connectionName, name, actualTimeInMs, cpuTime};
+        retParams['cpuTime'] = cpuTime;
     }
-
-    return {connectionName, name, disksStats: parseDomstatsForDisks(lines)};
+    return retParams;
 }
 
 function parseDomstatsForDisks(domstatsLines) {


### PR DESCRIPTION
We should update UI only if both dumpxml and dominfo calls succeeded.
If the first succeeded and the second failed, we 'll get a UI with
visible VM missing the state info.