### PR TITLE
machines: cleanup UPDATE_STORAGE_POOLS and UPDATE_STORAGE_VOLUMES reducers

### DIFF
--- a/pkg/machines/reducers.es6
+++ b/pkg/machines/reducers.es6
@@ -226,12 +226,25 @@ function storagePools(state, action) {
         const { connectionName, pools } = action.payload;
 
         const newState = Object.assign({}, state);
-        newState[connectionName] = {};
+        if (!(connectionName in newState))
+            newState[connectionName] = {};
+        else
+            newState[connectionName] = Object.assign({}, state[connectionName]);
 
-        // Array of strings (pool names)
-        pools.forEach(poolName => {
-            newState[connectionName][poolName] = []; // will be filled by UPDATE_STORAGE_VOLUMES
-        });
+        // Delete pools from state that are not in the payload
+        for (var poolCurrent in newState[connectionName]) {
+            if (!pools.includes(poolCurrent)) {
+                delete newState[connectionName][poolCurrent];
+            }
+        }
+
+        // Add new pools to state
+        for (var i in pools) {
+            let poolName = pools[i];
+            if (!(poolName in newState[connectionName])) {
+                newState[connectionName][poolName] = [];
+            }
+        }
 
         return newState;
     }


### PR DESCRIPTION
UPDATE_STORAGE_POOLS reducer was overwriting storage volumes of each pool with
empty array each time it was called.
Then it expected that the UPDATE_STORAGE_VOLUMES re-filled the arrays.
This approach is not correct, since it causes component rerendering without actual
changes in the state and also in some cases we might even read wrong data,
if we try to read the state, after UPDATE_STORAGE_POOLS ran but not
UPDATE_STORAGE_VOLUMEs.