### PR TITLE
bots: Stop including bots in $PATH during tests

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -120,11 +120,6 @@ def run(image, verbose=False, **kwargs):
     # Cleanup any extraneous disk usage elsewhere
     subprocess.check_call([ os.path.join(BASE, "test", "vm-reset") ])
 
-    # Setup network if necessary, any failures caught during testing
-    prep = os.path.join(BASE, "test", "vm-prep")
-    if os.path.exists(prep):
-        subprocess.call(["sudo", "-n", prep ])
-
     cmd = [ os.path.join(BOTS, "image-create"), "--verbose", "--upload" ]
     if store:
         cmd += [ "--store", store ]

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -349,11 +349,6 @@ class PullTask(object):
         env = os.environ.copy()
         env["PATH"] = "{0}:{1}:{2}".format(env.get("PATH", "/bin:/sbin"), BOTS, test)
 
-        # Setup network if necessary, any failures caught during testing
-        prep = os.path.join(BASE, "test", "vm-prep")
-        if os.path.exists(prep):
-            subprocess.call(["sudo", "-n", prep ], env=env)
-
         # Prepare the image to run
         if not ret and prefix != "cockpit":
             ret = self.prepare(prefix, value, image, opts.verbose)

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -346,9 +346,6 @@ class PullTask(object):
             ret = "Unknown context"
 
 
-        env = os.environ.copy()
-        env["PATH"] = "{0}:{1}:{2}".format(env.get("PATH", "/bin:/sbin"), BOTS, test)
-
         # Prepare the image to run
         if not ret and prefix != "cockpit":
             ret = self.prepare(prefix, value, image, opts.verbose)
@@ -361,7 +358,7 @@ class PullTask(object):
         if not ret:
             if opts.verbose:
                 cmd.append("--verbose")
-            ret = subprocess.call(cmd, env=env)
+            ret = subprocess.call(cmd)
 
         # All done
         if self.sink:


### PR DESCRIPTION
We don't want our tests to rely on this, but call scripts from
`BOTS_DIR` explicitly. This will avoid traps for external Cockpit
projects, like the one fixed in commit 127211baf576d0a.

Also clean up some obsolete code.