### PR TITLE
machines: testVCPU: fix race condition when reading state for UI update

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -773,6 +773,7 @@ class TestMachines(MachineCase):
         b.click("#vm-subVmTest1-vcpus-count")
 
         b.wait_present(".vcpu-detail-modal-table")
+        b.wait_not_present(".machines-vcpu-caution")
 
         b.set_val("#machines-vcpu-count-field", "2")
 
@@ -790,12 +791,16 @@ class TestMachines(MachineCase):
 
         b.wait(lambda: m.execute("virsh dumpxml subVmTest1 | xmllint --xpath '/domain/cpu/topology[@sockets=\"2\"][@threads=\"1\"][@cores=\"2\"]' -"))
 
+        # Run VM - this ensures that the internal state is updated before we move on.
+        # We need this here because we can't wait for UI updates after we open the modal dialog.
+        b.click("#vm-subVmTest1-run")
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+
         # Open dialog
         b.wait_present("#vm-subVmTest1-vcpus-count")
         b.click("#vm-subVmTest1-vcpus-count")
 
         b.wait_present(".vcpu-detail-modal-table")
-        b.wait_not_present(".machines-vcpu-caution")
 
         # Set new socket value
         b.wait_in_text("#coresSelect button", "2")


### PR DESCRIPTION
There is a time frame between the UI component rerendering and the actual
update of the state.
In tests we solve this issue by using wait_present/wait_in_text function.
In the case we are opening modal dialog though, these are of no use,
since modal dialog values will not be updated while the modal is open.

This patch fixes such scenario for testVCPU.