### PR TITLE
webpack: don't generate jquery.js and cockpit.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -378,20 +378,6 @@ info.tests.forEach(function(test) {
     }
 });
 
-/* Just for the sake of tests, jquery.js and cockpit.js files */
-if (!section || section.indexOf("base1") === 0) {
-    files.push({
-        from: srcdir + path.sep + "src/base1/cockpit.js",
-        to: "base1/cockpit.js"
-    }, {
-        from: nodedir + path.sep + "jquery/dist/jquery.js",
-        to: "base1/jquery.js"
-    }, {
-        from: srcdir + path.sep + "po/po.js",
-        to: "shell/po.js"
-    });
-}
-
 var aliases = {
     "angular": "angular/angular.js",
     "angular-route": "angular-route/angular-route.js",


### PR DESCRIPTION
For local development you can run `webpack` with `--watch` parameter
to have automatic syncing of changes done to source files.

However, this will also override `dist/base1/jquery.js` file with clean
upstream jquery.js that lacks tooltip from bootstrap and some other
merged plugins.  If you want to run `./test/verify/check-***` it will
fail with "RuntimeError: TypeError: r.tooltip is not a function".

Since commit <161266d99e4450ec8856adf5b3716397d3e32b19> the direct
invocation of `webpack` was removed from `HACKING.md` and you should
always run `make` we can safely remove the generation.

This was reintroduced by commit <2b2e9ab2eb2ff3746efbba16129bb8af3de467ab>.

Signed-off-by: Pavel Hrdina <phrdina@redhat.com>