### PR TITLE
ssh: Eliminate $COCKPIT_SSH_KNOWN_HOSTS_DATA

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -99,9 +99,8 @@ The section ```SSH-Login``` defines the options for all ssh commands. The sectio
 has the same options as the other authentication sections with the following additions.
 
  * ```host``` The default host to log into. Defaults to 127.0.0.1.
- * ```allowUnknown```. By default cockpit will refuse to connect to any machines that
- are not already present in ssh's global known_hosts file (usually ```/etc/ssh/ssh_known_hosts```).
- Set this to ```true``` is to allow those connections to proceed.
+ * ```connectToUnknownHosts```. By default cockpit will refuse to connect to any machines that
+ are not already present in ssh's global known_hosts file (usually ```/etc/ssh/ssh_known_hosts```). Set this to ```true``` is to allow those connections to proceed.
 
 # Actions
 
@@ -133,7 +132,6 @@ The following environment variables are set by cockpit-ws when spawning an auth 
 
 The following environment variables are used to set options for the ```cockpit-ssh``` process.
 
- * **COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS**` Set to ```1``` to  allow connecting to hosts that are not present in the current ```known_hosts``` files. If not set, Cockpit will only connect to unknown hosts if either the remote peer is local, or if the ```Ssh-Login``` section in ```cockpit.conf``` has an ```allowUnknown``` option set to a true value (```1```, ```yes``` or ```true```).
+ * **COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS**` Set to ```1``` to  allow connecting to hosts that are not present in the current ```known_hosts``` files. If not set, Cockpit will only connect to unknown hosts if either the remote peer is local, or if the ```Ssh-Login``` section in ```cockpit.conf``` has an ```connectToUnknownHosts``` option set to a true value (```1```, ```yes``` or ```true```).
  * **COCKPIT_SSH_KNOWN_HOSTS_FILE** Path to knownhost files. Defaults to ```PACKAGE_SYSCONF_DIR/ssh/ssh_known_hosts```
  * **COCKPIT_SSH_BRIDGE_COMMAND** Command to launch after a ssh connection is established. Defaults to ```cockpit-bridge``` if not provided.
- * **COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT** Set to ```1``` to receive an authorize challenge if the host is unknown, before connecting to the host. This is done in cockpit-bridge, but not for direct URL logins in cockpit-ws. This is an internal hack to mimic the obsolete magic ```COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize``` mode, until cockpit-ws starts to set this through the JSON protocol. Don't set this outside of Cockpit, this is *not* API!

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -133,7 +133,7 @@ The following environment variables are set by cockpit-ws when spawning an auth 
 
 The following environment variables are used to set options for the ```cockpit-ssh``` process.
 
- * **COCKPIT_SSH_ALLOW_UNKNOWN**` Set to ```1``` to  allow connecting to hosts that are not saved in the current knownhosts file. If not set cockpit will only connect to unknown hosts if either the remote_peer is local or if the ```Ssh-Login``` section in ```cockpit.conf``` has a ```allowUnknown``` option set to a truthy value (```1```, ```yes``` or ```true```).
+ * **COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS**` Set to ```1``` to  allow connecting to hosts that are not present in the current ```known_hosts``` files. If not set, Cockpit will only connect to unknown hosts if either the remote peer is local, or if the ```Ssh-Login``` section in ```cockpit.conf``` has an ```allowUnknown``` option set to a true value (```1```, ```yes``` or ```true```).
  * **COCKPIT_SSH_KNOWN_HOSTS_FILE** Path to knownhost files. Defaults to ```PACKAGE_SYSCONF_DIR/ssh/ssh_known_hosts```
- * **COCKPIT_SSH_KNOWN_HOSTS_DATA** Known host data to validate against or '*' to skip validation```
  * **COCKPIT_SSH_BRIDGE_COMMAND** Command to launch after a ssh connection is established. Defaults to ```cockpit-bridge``` if not provided.
+ * **COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT** Set to ```1``` to receive an authorize challenge if the host is unknown, before connecting to the host. This is done in cockpit-bridge, but not for direct URL logins in cockpit-ws. This is an internal hack to mimic the obsolete magic ```COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize``` mode, until cockpit-ws starts to set this through the JSON protocol. Don't set this outside of Cockpit, this is *not* API!

--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -7,8 +7,8 @@
     "bridges": [
         {
             "match": { "session": "private", "user": null, "host": null },
-            "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize",
+            "environ": [ "COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS=true",
+                         "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT=true",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
@@ -16,8 +16,8 @@
         },
         {
             "match": { "session": "private", "host": null },
-            "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize",
+            "environ": [ "COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS=true",
+                         "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT=true",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
@@ -25,14 +25,14 @@
         },
         {
             "match": { "user": null, "host": null },
-            "environ": [ "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
+            "environ": [ "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT=true" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
             "problem": "not-supported"
         },
         {
             "match": { "host": null },
-            "environ": [ "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
+            "environ": [ "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT=true" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
             "problem": "not-supported"

--- a/src/ssh/cockpitsshoptions.h
+++ b/src/ssh/cockpitsshoptions.h
@@ -25,13 +25,11 @@
 G_BEGIN_DECLS
 
 typedef struct {
-  const gchar *knownhosts_data;
   const gchar *knownhosts_file;
   const gchar *command;
   const gchar *remote_peer;
-  gboolean allow_unknown_hosts;
-  gboolean ignore_hostkey;
-  gboolean knownhosts_authorize;
+  gboolean connect_to_unknown_hosts;
+  gboolean challenge_unknown_host_preconnect;
 } CockpitSshOptions;
 
 CockpitSshOptions * cockpit_ssh_options_from_env   (gchar **env);

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -691,9 +691,12 @@ set_knownhosts_file (CockpitSshData *data,
         {
           if (write_tmp_knownhosts_file (data, authorize_knownhosts_data, &problem))
             {
+              /* this should always be known now, but let's make double-sure */
               host_known = cockpit_is_host_known (tmp_knownhost_file, host, port);
               if (host_known)
                 data->ssh_options->knownhosts_file = tmp_knownhost_file;
+              else
+                g_warning ("authorize challenge reported key for %s:%u which is not known to cockpit_is_host_known()", host, port);
             }
           else
             goto out;

--- a/src/ws/mock-config/cockpit/cockpit-alt.conf
+++ b/src/ws/mock-config/cockpit/cockpit-alt.conf
@@ -4,7 +4,7 @@ ProtocolHeader = X-Forwarded-Proto
 [Ssh-Login]
 command = mock-auth-command
 host = default-host
-allowUnknown = true
+connectToUnknownHosts = true
 
 [testsshscheme]
 action = remote-login-ssh

--- a/src/ws/mock-config/cockpit/cockpit-deprecated.conf
+++ b/src/ws/mock-config/cockpit/cockpit-deprecated.conf
@@ -1,0 +1,10 @@
+[WebService]
+ProtocolHeader = X-Forwarded-Proto
+
+[Ssh-Login]
+command = mock-auth-command
+host = default-host
+allowUnknown = true
+
+[testsshscheme]
+action = remote-login-ssh

--- a/src/ws/mock-config/cockpit/cockpit-deprecated.conf
+++ b/src/ws/mock-config/cockpit/cockpit-deprecated.conf
@@ -4,6 +4,8 @@ ProtocolHeader = X-Forwarded-Proto
 [Ssh-Login]
 command = mock-auth-command
 host = default-host
+# Config to test fallback to deprecated allowUnknown option
+# This option was superseded by connectToUnknownHosts
 allowUnknown = true
 
 [testsshscheme]


### PR DESCRIPTION
 * [x] Implementation
 * [x] Update tests
 * [x] Ensure we have tests for whatever old or compat behavior we still carry.
 * [x] Check the [ManageIQ](https://github.com/ManageIQ/manageiq) code base to make sure this does not break functionality.
 * [x] Check the  [ovirt-cockpit-sso](https://github.com/oVirt/ovirt-cockpit-sso) to make sure this does not break functionality.
 * [X] Ensure we do not land this change in any LTS or stable operating system (such as RHEL 7.x) - Yes, this is not aimed at RHEL/CentOS 7.
