### PR TITLE
eslint: Mute warning about missing react version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,5 +48,10 @@
     "globals": {
         "require": false,
         "module": false
+    },
+    "settings": {
+        "react": {
+            "version": "latest"
+        }
     }
 }


### PR DESCRIPTION
Previously we were seeing the following error when running eslint.
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration.