### PR TITLE
naughty: Close 8869: Fedora 28: systemd services with DynamicUser=yes fail due to SELinux policy

### DIFF
--- a/bots/naughty/fedora-28/8869-selinux-dynamicuser
+++ b/bots/naughty/fedora-28/8869-selinux-dynamicuser
@@ -1,2 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { * } for * name=".pwd.lock"
-

--- a/bots/naughty/fedora-29/8869-selinux-dynamicuser
+++ b/bots/naughty/fedora-29/8869-selinux-dynamicuser
@@ -1,2 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { * } for * name=".pwd.lock"
-

--- a/bots/naughty/rhel-x/8869-selinux-dynamicuser
+++ b/bots/naughty/rhel-x/8869-selinux-dynamicuser
@@ -1,2 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { * } for * name=".pwd.lock"
-


### PR DESCRIPTION
Known issue which has not occurred in 22 days

Fedora 28: systemd services with DynamicUser=yes fail due to SELinux policy

Fixes #8869