### PR TITLE
bots: Enable welder-web testing

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -66,6 +66,9 @@ EXTERNAL_PROJECTS = {
     'cockpit-project/cockpit-podman': [
         'cockpit/fedora-28',
     ],
+    'weldr/welder-web': [
+        'cockpit/rhel-7-6',
+    ],
 }
 
 # Label: should a PR trigger external tests


### PR DESCRIPTION
This goes together with converting welder-web's tests conversion to use
Cockpit's VMs and test APIs: https://github.com/weldr/welder-web/pull/357