### PR TITLE
test: Always run windows with graphical console in vm-run

### DIFF
--- a/test/vm-run
+++ b/test/vm-run
@@ -95,7 +95,7 @@ try:
     if "windows" in args.image and memory is None:
         memory = 4096
 
-    graphics = args.graphics
+    graphics = args.graphics or 'windows' in args.image
     network = testvm.VirtNetwork(0, bridge=bridge)
 
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, maintain=args.maintain,


### PR DESCRIPTION
In #10051 I reverted the change in vm-run and moved the "graphics always on" from vm-run to testvm as some tests use testvm directly. However since `vm-run` also makes some decisions based on the graphics flag, always enable it there too.