### PR TITLE
bots: Fix cirros image to boot fast

### DIFF
--- a/bots/images/cirros
+++ b/bots/images/cirros
@@ -1,1 +1,1 @@
-cirros-0.3.5-i386-disk.img
+cirros-d5fcb44e05f2dafc7eaab6bce906ba9cc06af51f84f1e7a527fe12102e34bbcf.qcow2

--- a/bots/images/scripts/cirros.bootstrap
+++ b/bots/images/scripts/cirros.bootstrap
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eux
+
+OUTPUT="$1"
+
+curl https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-i386-disk.img > "$OUTPUT"
+
+# prepare a cloud-init iso for disabling network source, to avoid a 90s timeout at boot
+WORKDIR=$(mktemp -d)
+trap "rm -rf '$WORKDIR'" EXIT INT QUIT PIPE
+cd "$WORKDIR"
+
+cat > meta-data <<EOF
+{ "instance-id": "nocloud" }
+EOF
+
+cat > user-data <<EOF
+#!/bin/sh
+set -ex
+sed -i 's/configdrive *//; s/ec2 *//' /etc/cirros-init/config
+(sleep 1; poweroff) &
+EOF
+
+genisoimage -input-charset utf-8 -output cloud-init.iso -volid cidata -joliet -rock user-data meta-data
+
+# boot it once with the cloud-init ISO
+qemu-system-x86_64 -enable-kvm -nographic -net none \
+    -drive file="$OUTPUT",if=virtio -cdrom cloud-init.iso

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1297,7 +1297,7 @@ class TestMachines(MachineCase):
                         break
                     time.sleep(5)
                 else:
-                    raise testlib.Error("Retry limit exceeded: %s is not part of the error message" % error)
+                    raise Error("Retry limit exceeded: %s is not part of the error message" % error)
 
             def allowBugErrors(location, original_exception):
                 # CPU must be supported to detect errors

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1035,7 +1035,7 @@ class TestMachines(MachineCase):
                                                    storage_size=100, storage_size_unit='MiB',
                                                    os_vendor=config.NOVELL_VENDOR,
                                                    os_name=config.NOVELL_NETWARE_6,
-                                                   start_vm=True), ["memory", "buffer"], ui_validation=False)
+                                                   start_vm=True), ["memory", "RAM", "buffer"], ui_validation=False)
 
         # disk
         checkDialogErrorTest(TestMachines.VmDialog(self, "subVmTestCreate9", location=config.NOVELL_MOCKUP_ISO_PATH,


### PR DESCRIPTION
Add a bootstrap script so that we can build the cirros image with
bots/image-prepare. In that, download cirros and boot it with a
with a sed command that disables network cloud-init sources in the
configuration. This avoids the long wait for an EC2 data source, and
reduces boot time from about a minute to a few seconds.

Fixes #9935