### PR TITLE
Clean up and generalize the test log extraction

### DIFF
--- a/bots/learn/extractor.py
+++ b/bots/learn/extractor.py
@@ -43,19 +43,6 @@ IGNORE_THRESHHOLD = 0.07
 # some cluster seeds
 TRACKER_SPARSE = 100
 
-# TODO: We should be able to detect these automatically and ignore them
-# But for now this is a pragmatic hack to reduce noise and processing time
-NOISE = {
-    "Wrote file": re.compile("Wrote.*\.(png|html|log)"),
-    "Journal extracted": re.compile("Journal extracted to.*\.log"),
-    "Core dumps downloaded": re.compile("Core dumps downloaded to.*\.core"),
-    "not ok": re.compile("^not ok.*"),
-    "ok": re.compile("^ok.*"),
-    "# Flake": re.compile("# Flake.*"),
-    'File "\\1"': re.compile('File "/[^"]+/([^/]+)"'),
-    "### ": re.compile('#{3,80}\s+'),
-}
-
 DIGITS = re.compile('\d+')
 
 # Various features extracted
@@ -104,11 +91,7 @@ class Extractor():
         result = [ ]
         value = item["log"] or ""
         for line in value.replace('\r\n', '\n').replace('\r', '\n').split('\n'):
-            line = line.strip()
-            for substitute, pattern in NOISE.items():
-                line = pattern.sub(substitute, line)
-            else:
-                result.append(DIGITS.sub('000', line))
+            result.append(DIGITS.sub('000', line.strip()))
         return result
 
     def fit(self, items, tokenized=None):

--- a/bots/learn/extractor.py
+++ b/bots/learn/extractor.py
@@ -43,7 +43,30 @@ IGNORE_THRESHHOLD = 0.07
 # some cluster seeds
 TRACKER_SPARSE = 100
 
-DIGITS = re.compile('\d+')
+NUMBERS = (
+    # 512 bit hashes
+    ("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", re.compile('[0-9a-f]{128}')),
+    ("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", re.compile('[0-9A-F]{128}')),
+
+    # 256 bit hashes
+    ("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", re.compile('/[0-9a-f]{64}')),
+    ("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", re.compile('/[0-9A-F]{64}')),
+
+    # 160 bit hashes
+    ("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", re.compile('[0-9a-f]{40}')),
+    ("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", re.compile('[0-9A-F]{40}')),
+
+    # 128 bit hashes
+    ("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", re.compile('[0-9a-f]{32}')),
+    ("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", re.compile('[0-9A-F]{32}')),
+
+    # GUIDs
+    ('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+        re.compile('[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')),
+
+    # Digits
+    ('000', re.compile('\d+'))
+)
 
 # Various features extracted
 FEATURE_LOG = 0                # string: The normalized and collapsed log extracted
@@ -91,7 +114,10 @@ class Extractor():
         result = [ ]
         value = item["log"] or ""
         for line in value.replace('\r\n', '\n').replace('\r', '\n').split('\n'):
-            result.append(DIGITS.sub('000', line.strip()))
+            line = line.strip()
+            for (substitute, pattern) in NUMBERS:
+                line = pattern.sub(substitute, line)
+            result.append(line)
         return result
 
     def fit(self, items, tokenized=None):

--- a/bots/learn/extractor.py
+++ b/bots/learn/extractor.py
@@ -170,20 +170,27 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Look for noise lines in input jsonl")
     parser.add_argument("--only", action="append", help="Only analyze these statuses")
     parser.add_argument("-v", "--verbose", action="store_true", help="Print verbose progress output")
-    parser.add_argument("filename", help="The filename in JSONL gzip format")
+    parser.add_argument("-t", "--tokenize", action="store_true", help="Just tokenize a raw file")
+    parser.add_argument("filename", help="The filename in JSONL gzip format or raw file for --tokenize")
     opts = parser.parse_args()
 
-    # The kind of statuses to inlcude
-    if not opts.only:
-        only = None
+    if opts.tokenize:
+        with open(opts.filename, "r") as fp:
+            contents = fp.read()
+            print("\n".join(Extractor.tokenize({ "log": contents })))
+
     else:
-        only = lambda item: item.get("status") in opts.only
+        # The kind of statuses to inlcude
+        if not opts.only:
+            only = None
+        else:
+            only = lambda item: item.get("status") in opts.only
 
-    # Load the actual data
-    items = data.load(opts.filename, only=only, verbose=opts.verbose)
+        # Load the actual data
+        items = data.load(opts.filename, only=only, verbose=opts.verbose)
 
-    # Print out all lines we think are stop lines in the data
-    extract = Extractor()
-    extract.fit(items)
-    for stop in extract.stop_tokens():
-        print(stop)
+        # Print out all lines we think are stop lines in the data
+        extract = Extractor()
+        extract.fit(items)
+        for stop in extract.stop_tokens():
+            print(stop)

--- a/bots/task/tap.py
+++ b/bots/task/tap.py
@@ -28,13 +28,20 @@ import re
 #
 # When the right hand side matches, we replace with left
 NOISE = {
+    # Status lines about downloading artifacts
     "Wrote file": re.compile("^Wrote.*\.(png|html|log)"),
     "Journal extracted": re.compile("^Journal extracted to.*\.log"),
     "Core dumps downloaded": re.compile("^Core dumps downloaded to.*\.core"),
+    'File "\\1"': re.compile('^File "/[^"]+/([^/]+)"'),
+
+    # Flakes
+    "": re.compile("^# Flake.*"),
+
+    # Tap output
     "not ok": re.compile("^not ok.*"),
     "ok": re.compile("^ok.*"),
-    "": re.compile("^# Flake.*"),
-    'File "\\1"': re.compile('^File "/[^"]+/([^/]+)"'),
+
+    # Progress from Curl
     "### ": re.compile('^#{3,80}\s+'),
 }
 

--- a/bots/task/tap.py
+++ b/bots/task/tap.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# Common functions for processing task and test output
+
+import re
+
+# These are lines that we preprocess away. Most of the noise can be
+# found by the machine learning, but these are examples of lines that
+# vary too much in the test corpus, and we normalize them.
+#
+# When the right hand side matches, we replace with left
+NOISE = {
+    "Wrote file": re.compile("^Wrote.*\.(png|html|log)"),
+    "Journal extracted": re.compile("^Journal extracted to.*\.log"),
+    "Core dumps downloaded": re.compile("^Core dumps downloaded to.*\.core"),
+    "not ok": re.compile("^not ok.*"),
+    "ok": re.compile("^ok.*"),
+    "": re.compile("^# Flake.*"),
+    'File "\\1"': re.compile('^File "/[^"]+/([^/]+)"'),
+    "### ": re.compile('^#{3,80}\s+'),
+}
+
+# Normalize a line of tests according to noise
+def normalize(line):
+    for substitute, pattern in NOISE.items():
+        line = pattern.sub(substitute, line)
+    return line
+
+# Generate (status, name, body, tracker) for each Test Anything Protocol test
+# in the content.
+#
+# status: possible values "success", "failure", "skip"
+# name: the name of the test
+# body: full log of the test
+# tracker: url tracking the failure, or None
+def parse(content, prefix=None, blocks=False):
+    name = status = tracker = None
+    body = [ ]
+    for line in content.split('\n'):
+        # The test intro, everything before here is fluff
+        if not prefix and line.startswith("1.."):
+            prefix = line
+            body = [ ]
+            name = status = tracker = None
+
+        # A TAP test status line
+        elif line.startswith("ok ") or line.startswith("not ok "):
+            body.append(normalize(line))
+            # Parse out the status
+            if line.startswith("not ok "):
+                status = "failure"
+                line = line[7:]
+            else:
+                line = line[3:]
+                if "# SKIP KNOWN ISSUE" in line.upper():
+                    status = "failure"
+                    (unused, delim, issue) = line.partition("#")
+                    tracker = issue
+                if "# SKIP" in line.upper():
+                    status = "skip"
+                else:
+                    status = "success"
+            # Parse out the name
+            while line[0].isspace() or line[0].isdigit():
+                line = line[1:]
+            (name, delim, directive) = line.partition("#")
+            (name, delim, directive) = name.partition("duration")
+            name = name.strip()
+            # Old Cockpit tests had strange blocks
+            if not blocks:
+                yield (status, name, "\n".join(body), tracker)
+                status = name = tracker = None
+                body = [ ]
+        else:
+            # Old Cockpit tests didn't separate bound their stuff properly
+            if line.startswith("# --------------------"):
+                blocks = True
+                if status:
+                    yield (status, name, "\n".join(body), tracker)
+                name = status = tracker = None
+                body = [ ]
+            body.append(normalize(line))
+
+    if status:
+        yield (status, name, "\n".join(body), tracker)
+

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -37,6 +37,7 @@ import html.parser
 sys.dont_write_bytecode = True
 
 import task
+import task.tap
 
 # The number of days of previous closed pull requests to learn from
 SINCE_DAYS = 120
@@ -78,10 +79,10 @@ def run(filename, verbose=False, dry=False, **kwargs):
         for (context, created, url, log) in logs(commit):
             if verbose:
                 sys.stderr.write("  - {0} {1}\n".format(created, context))
-            for (status, name, body, tracker) in tap(log):
+            for (status, name, body, tracker) in task.tap.parse(log):
                 write(pull=pull, revision=commit, status=status,
                       context=context, date=created, merged=merged,
-                      test=name, url=url, tracker=tracker, log=body)
+                      test=name, url=url, tracker=qualify(tracker), log=body)
                 logged = True
 
             # Nothing found for this log
@@ -413,63 +414,6 @@ def logs(revision):
             if log is not None:
                 yield (status["context"], status["created_at"], target, log)
 
-
-# Generate (status, name, body, tracker) for each Test Anything Protocol test
-# in the content.
-#
-# status: possible values "success", "failure", "skip"
-# name: the name of the test
-# body: full log of the test
-# tracker: url tracking the failure, or None
-def tap(content):
-    name = status = tracker = None
-    prefix = None
-    body = [ ]
-    blocks = False
-    for line in content.split('\n'):
-        # The test intro, everything before here is fluff
-        if not prefix and line.startswith("1.."):
-            prefix = line
-            body = [ ]
-            name = status = tracker = None
-
-        # A TAP test status line
-        elif line.startswith("ok ") or line.startswith("not ok "):
-            body.append(line)
-            # Parse out the status
-            if line.startswith("not ok "):
-                status = "failure"
-                line = line[7:]
-            else:
-                line = line[3:]
-                if "# SKIP KNOWN ISSUE" in line.upper():
-                    status = "failure"
-                    (unused, delim, issue) = line.partition("#")
-                    tracker = qualify("issues/{0}".format(issue))
-                if "# SKIP" in line.upper():
-                    status = "skip"
-                else:
-                    status = "success"
-            # Parse out the name
-            while line[0].isspace() or line[0].isdigit():
-                line = line[1:]
-            (name, delim, directive) = line.partition("#")
-            (name, delim, directive) = name.partition("duration")
-            name = name.strip()
-            # Old Cockpit tests had strange blocks
-            if not blocks:
-                yield (status, name, "\n".join(body), tracker)
-                status = name = tracker = None
-                body = [ ]
-        else:
-            # Old Cockpit tests didn't separate bound their stuff properly
-            if line.startswith("# --------------------"):
-                blocks = True
-                if status:
-                    yield (status, name, "\n".join(body), tracker)
-                name = status = tracker = None
-                body = [ ]
-            body.append(line)
 
 # Qualify a URL into the GitHub repository
 def qualify(path):

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -32,6 +32,8 @@ import warnings
 sys.dont_write_bytecode = True
 
 from task import github
+from task import tap
+
 try:
     from machine.testvm import get_test_image
 except ImportError:
@@ -123,19 +125,6 @@ def filterRetry(output, retry):
             lines[i] = line + " " + retry
     return "\n".join(lines)
 
-# Figure out the name from a failed test
-def parseName(output):
-    for line in output.split("\n"):
-        if line.startswith("not ok "):
-            line = line[7:]
-            while line[0].isspace() or line[0].isdigit():
-                line = line[1:]
-            (name, delim, directive) = line.partition("#")
-            (name, delim, directive) = name.partition("duration")
-            name = name.strip()
-            return name
-    return ""
-
 # -----------------------------------------------------------------------------
 # Flakiness Checks
 
@@ -146,22 +135,27 @@ def guessFlake(output, context):
         return output
 
     # The two different models we're using
-    model = learn.cluster.load(DATA)
+    for (status, name, body, tracker) in tap.parse(output, prefix="1..", blocks=True):
+        break
+    else:
+        return output
 
     # Build up an item just like in tests-data
     item = {
         "pull": None,
         "revision": os.environ.get("TEST_REVISION"),
-        "status": "failure",
+        "status": status,
         "context": context,
         "date": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "merged": None,
-        "test": parseName(output),
+        "test": name,
+        "tracker": tracker,
         "url": None,
-        "log": output
+        "log": body,
     }
 
-    # The new model
+    model = learn.cluster.load(DATA)
+
     flake = False
     if model:
         result = model.predict([ item ])[0]


### PR DESCRIPTION
This moves Cockpit specific code into tests-data, and general code into the learn code. This is done with the intent of moving the learn code out of the Cockpit repo.
 * [x] tests-data tests-train-1.jsonl.gz
 * [x] learn-tests tests-train-1.jsonl.gz