### PR TITLE
doc: Document proper FreeIPA sudo setup

### DIFF
--- a/doc/guide/sso.xml
+++ b/doc/guide/sso.xml
@@ -73,6 +73,17 @@ user@example.com:*:381001109:381000513:User Name:/home/user:/bin/sh
       for the hosts running Cockpit, and in some cases the <code>HTTP</code> service as well.
       When joining an IPA domain, this is enabled by default.</para>
 
+    <para>Domain admins (usually the <code>admins@example.com</code> group) should normally
+      also be able to administer any joined machine. Enable sudo access for that group
+      with the following commands, as a domain admin on any joined machine:</para>
+
+<programlisting>
+ipa sudorule-add --hostcat=all --cmdcat=all All
+ipa sudorule-add-user --groups=admins All
+</programlisting>
+
+    <para>Note that this does not change security properties; domain admins can give this
+      privilege to themselves, so it is safe to enable by default.</para>
   </section>
 
   <section id="sso-client">


### PR DESCRIPTION
FreeIPA server does not set up a proper sudo rule by
default (https://pagure.io/freeipa/issue/7538). This is
an "unbreak my setup" setup, but FreeIPA has decided that this is
intended. So instead document the necessary steps as part of the server
requirements. This reflects the `addSudoRule()` hack in check-realms.

Note that it is not appropriate for Cockpit to silently do this by
itself. Joining a domain is a client-side operation and should not
change the server configuration. We also don't know about any deliberate
policy changes on existing servers, so this would only be appropriate as
part of the Cockpit FreeIPA installer UI, not the client joining.

Fixes #10169