### PR TITLE
bots: Use debug variants of selenium chrome/firefox containers

### DIFF
--- a/bots/images/scripts/selenium.setup
+++ b/bots/images/scripts/selenium.setup
@@ -36,8 +36,8 @@ systemctl enable docker
 
 # docker images that we need for integration testing
 docker pull selenium/hub:3
-docker pull selenium/node-chrome:3
-docker pull selenium/node-firefox:3
+docker pull selenium/node-chrome-debug:3
+docker pull selenium/node-firefox-debug:3
 
 # reduce image size
 dnf clean all

--- a/test/avocado/selenium_start.sh
+++ b/test/avocado/selenium_start.sh
@@ -46,7 +46,7 @@ systemctl start docker
 
 docker run  -d -p 4444:4444 --name selenium-hub selenium/hub:3
 wait_curl /grid/console "Grid Console"
-docker run -d --shm-size=512M --link selenium-hub:hub selenium/node-chrome:3
+docker run -d --shm-size=512M --link selenium-hub:hub -p 5901:5900 -e VNC_NO_PASSWORD=1 selenium/node-chrome-debug:3
 wait_curl /grid/console "browserName: chrome"
-docker run -d --shm-size=512M --link selenium-hub:hub selenium/node-firefox:3
+docker run -d --shm-size=512M --link selenium-hub:hub -p 5902:5900 -e VNC_NO_PASSWORD=1 selenium/node-firefox-debug:3
 wait_curl /grid/console "browserName: firefox"


### PR DESCRIPTION
Also forward the container's VNC port to the selenium VM. We can then
use this to further forward these VM ports to the host, for running
a VNC viewer on the host for following/debugging the tests.

- [ ] image-refresh selenium