### PR TITLE
ssh: Drop $COCKPIT_SSH_KNOWN_HOSTS_DATA from ssh manifest

### DIFF
--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -8,7 +8,6 @@
         {
             "match": { "session": "private", "user": null, "host": null },
             "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
@@ -17,7 +16,6 @@
         {
             "match": { "session": "private", "host": null },
             "environ": [ "COCKPIT_SSH_ALLOW_UNKNOWN=true",
-                         "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
@@ -25,14 +23,12 @@
         },
         {
             "match": { "user": null, "host": null },
-            "environ": [ "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
             "problem": "not-supported"
         },
         {
             "match": { "host": null },
-            "environ": [ "COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
             "problem": "not-supported"


### PR DESCRIPTION
`authorize` is already the internal default in cockpitsshoptions.c,
there is no reason to repeat this again here.

This is a first step to eliminating this variable completely.