### PR TITLE
lib: cockpit-components-listing: Fix PropTypes for initiallyActiveTab

### DIFF
--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -275,7 +275,7 @@ ListingRow.propTypes = {
     selected: PropTypes.bool,
     initiallyExpanded: PropTypes.bool,
     expandChanged: PropTypes.func,
-    initiallyActiveTab: PropTypes.bool
+    initiallyActiveTab: PropTypes.number
 };
 /* Implements a PatternFly 'List View' pattern
  * https://www.patternfly.org/list-view/


### PR DESCRIPTION
initallyActiveTab is the index of the tab to have initially active and
it should be a number instead of a bool.

Fixes #10176
Closes #10196