### PR TITLE
Revert "bots: Run welder-web tests with chrome and firefox scenarios"

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -73,8 +73,7 @@ REDHAT_EXTERNAL_PROJECTS = {
         'cockpit/rhel-atomic',
     ],
     'weldr/welder-web': [
-        'cockpit/rhel-7-6/chrome',
-        'cockpit/rhel-7-6/firefox',
+        'cockpit/rhel-7-6',
     ],
 }
 


### PR DESCRIPTION
This causes a regression when the test gets triggered as external
project from a cockpit bot PR:

    # VM running cockpit, composer, and end to end test container
    bots/image-customize -v \
    	-i `pwd`/cockpit-composer-*.noarch.rpm -i gcc-c++ \
    	-s /build/cockpit/test/vm.install \
    	rhel-7-6/chrome
    image-download: image link does not exist: chrome

Also, chrome tests currently have some failures, so let's get them fixed first.

This reverts commit caf897157b9ca193907ce302c260e94dcc5b430d.