### PR TITLE
tools: Drop cockpit-kubernetes on Fedora ≥ 30

### DIFF
--- a/test/verify/check-kubernetes
+++ b/test/verify/check-kubernetes
@@ -25,7 +25,7 @@ from testlib import *
 import kubelib
 
 @skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386", "rhel-7-5", "rhel-7-5-distropkg", "rhel-7-6", "rhel-7-6-distropkg", "rhel-x", "centos-7")
-@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic")
+@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "fedora-30")
 @skipPackage("cockpit-kubernetes")
 class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
 
@@ -41,7 +41,7 @@ class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
         m.execute("docker tag gcr.io/google_containers/pause-amd64:3.0 k8s.gcr.io/pause-amd64:3.1 || true")
 
 @skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386", "rhel-7-5", "rhel-7-5-distropkg", "rhel-7-6", "rhel-7-6-distropkg", "rhel-x", "centos-7")
-@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic")
+@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "fedora-30")
 @skipPackage("cockpit-kubernetes")
 class TestConnection(kubelib.KubernetesCase):
     def testConnect(self):

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -56,7 +56,7 @@ def wait_project(machine, project):
             time.sleep(2)
 
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
-@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "rhel-x")
+@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "rhel-x", "fedora-30")
 class TestOpenshift(MachineCase, OpenshiftCommonTests):
     provision = {
         "machine1": { "address": "10.111.113.1/20" },
@@ -398,7 +398,7 @@ class TestOpenshiftPrerelease(TestOpenshift):
     }
 
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1604", "ubuntu-stable", "fedora-i386")
-@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "rhel-x")
+@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "rhel-x", "fedora-30")
 class TestRegistry(MachineCase, RegistryTests):
     provision = {
         "machine1": { "address": "10.111.113.1/20" },

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -56,8 +56,8 @@
 %define build_subscriptions 1
 %endif
 
-# cockpit-kubernetes is RHEL 7 only, and 64 bit arches only
-%if 0%{?fedora} || (0%{?rhel} >= 7 && 0%{?rhel} < 8)
+# cockpit-kubernetes is RHEL 7 and Fedora < 30 only, and 64 bit arches only
+%if (0%{?fedora} && 0%{?fedora} < 30) || (0%{?rhel} >= 7 && 0%{?rhel} < 8)
 %ifarch aarch64 x86_64 ppc64le s390x
 %define build_kubernetes 1
 %endif


### PR DESCRIPTION
cockpit-kubernetes has been in maintenance mode for a while, and is
being deprecated in favor of OpenShift Console/Tectonic.

Still keep it in Fedora 29 as this is past beta/feature freeze.

https://lists.fedorahosted.org/archives/list/cockpit-devel@lists.fedorahosted.org/thread/SBDE64DAIVTLIYRGVMESUPR5STRRFCGW/