### PR TITLE
bots: Make test/vm-run work without SSH enabled on host

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -1094,12 +1094,12 @@ class VirtMachine(Machine):
             while pid == 0:
                 if message:
                     try:
-                        self.execute("true", quiet=True)
+                        with stdchannel_redirected(sys.stderr, os.devnull):
+                            Machine.wait_boot(self)
                         sys.stderr.write(message)
-                        self.disconnect()
-                        message = None
-                    except subprocess.CalledProcessError:
+                    except (Failure, subprocess.CalledProcessError):
                         pass
+                    message = None
                 (pid, ret) = os.waitpid(proc.pid, message and os.WNOHANG or 0)
 
             try:


### PR DESCRIPTION
When SSH is not enabled on the target VM image or keys are not
provisioned, then test/vm-run just cycles with an endless loop
of messages like this:

    Received disconnect: Too many authentication failures
    Received disconnect: Too many authentication failures

Since we don't actually need SSH access to use test/vm-run (it's
only used to display a message once the machine is ready) ... lets
ignore those failures.