### PR TITLE
package.json: Drop redux-saga dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react-redux": "5.0.7",
     "react-remarkable": "1.1.3",
     "redux": "3.7.2",
-    "redux-saga": "0.16.0",
     "redux-thunk": "2.3.0",
     "registry-image-widgets": "0.0.16",
     "requirejs": "2.1.22",


### PR DESCRIPTION
Looks like this package was used only in k8s plugin and it's not there anymore.