### PR TITLE
ssh: Use SHA256 fingerprints when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,8 @@ if test "$enable_ssh" != "no"; then
     AC_DEFINE_UNQUOTED(HAVE_SSH_GET_SERVER_PUBLICKEY, 1, Whether ssh_get_server_publickey is available)
   ])
 
+  AC_CHECK_DECLS([SSH_PUBLICKEY_HASH_SHA256, ssh_get_fingerprint_hash], [], [], [[#include <libssh/libssh.h>]])
+
   COCKPIT_SSH_SESSION_CFLAGS="$COCKPIT_CFLAGS $LIBSSH_CFLAGS $KRB5_CFLAGS"
   COCKPIT_SSH_SESSION_LIBS="$COCKPIT_LIBS $LIBSSH_LIBS $KRB5_LIBS"
   AC_SUBST(COCKPIT_SSH_SESSION_LIBS)

--- a/src/ssh/test-sshbridge.c
+++ b/src/ssh/test-sshbridge.c
@@ -609,7 +609,13 @@ test_echo_large (TestCase *tc,
 
 #define MOCK_RSA_KEY "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCYzo07OA0H6f7orVun9nIVjGYrkf8AuPDScqWGzlKpAqSipoQ9oY/mwONwIOu4uhKh7FTQCq5p+NaOJ6+Q4z++xBzSOLFseKX+zyLxgNG28jnF06WSmrMsSfvPdNuZKt9rZcQFKn9fRNa8oixa+RsqEEVEvTYhGtRf7w2wsV49xIoIza/bln1ABX1YLaCByZow+dK3ZlHn/UU0r4ewpAIZhve4vCvAsMe5+6KJH8ft/OKXXQY06h6jCythLV4h18gY/sYosOa+/4XgpmBiE7fDeFRKVjP3mvkxMpxce+ckOFae2+aJu51h513S9kxY2PmKaV/JU9HBYO+yO4j+j24v"
 
+#if HAVE_DECL_SSH_PUBLICKEY_HASH_SHA256
+static const gchar MOCK_RSA_FP[] = "SHA256:XQ8a7zGxMFstDrGecBRUP9OMnOUXd/T3vkNGtYShs2w";
+#define SSH_PUBLICKEY_HASH_NAME "SHA256"
+#else
 static const gchar MOCK_RSA_FP[] = "0e:6a:c8:b1:07:72:e2:04:95:9f:0e:b3:56:af:48:e2";
+#define SSH_PUBLICKEY_HASH_NAME "MD5"
+#endif
 
 #define MOCK_DSA_PUB_KEY "ssh-dss AAAAB3NzaC1kc3MAAACBAIK3RTEWBw+rAPcYUM2Qq4kEw59gXpUQ/WvkdeY7QDO64MHaaorySj8xsraNudmQFh4xb/i5Q1EMnNchOFxtilfU5bUJgdTvetyZEWFL+2HxqBs8GaWRyB1vtSFAw3GO8VUEnjF844N3dNyLoc0NX8IvzwNIaQho6KTsueQlG1X9AAAAFQCXUl4a5UvElL4thi/8QlxR5PtEewAAAIBqNpl5MTBxKQu5jT0+WASa7pAqwT53ofv7ZTDIEokYRb57/nwzDgkcs1fsBRrI6eczJ/VlXWwKbsgkx2Nh3ZiWYwC+HY5uqRpDaj3HERC6LMn4dzdcl29fYeziEibCbRjJX5lZF2vIaA1Ewv8yT0UlunyHZRiyw4WlEglkf/NITAAAAIBxLsdBBXn+8qEYwWK9KT+arRqNXC/lrl0Fp5YyxGNGCv82JcnuOShGGTzhYf8AtTCY1u5oixiW9kea6KXGAKgTjfJShr7n47SZVfOPOrBT3VLhRdGGO3GblDUppzfL8wsEdoqXjzrJuxSdrGnkFu8S9QjkPn9dCtScvWEcluHqMw=="
 
@@ -681,7 +687,7 @@ do_hostkey_conversation (TestCase *tc,
                                  (int)tc->ssh_port, MOCK_RSA_FP,
                                  (int)tc->ssh_port, MOCK_RSA_KEY);
 
-  do_auth_conversation (tc->transport, "MD5 Fingerprint (ssh-rsa):",
+  do_auth_conversation (tc->transport, SSH_PUBLICKEY_HASH_NAME " Fingerprint (ssh-rsa):",
                         expect_json, response, add_header);
   g_free (expect_json);
 }

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -324,7 +324,7 @@ class TestMultiMachine(MachineCase):
         b.wait_not_visible("#user-group")
         b.wait_not_visible("#option-group")
         b.wait_not_visible("#server-group")
-        b.wait_in_text("#conversation-prompt", "MD5 Fingerprint")
+        b.wait_in_text("#conversation-prompt", "Fingerprint")
         b.wait_in_text("#conversation-message", "Do you want to proceed this time?")
         b.set_val('#conversation-input', 'foobar')
         b.click('#login-button')
@@ -347,16 +347,19 @@ class TestMultiMachine(MachineCase):
         b.wait_not_visible("#user-group")
         b.wait_not_visible("#option-group")
         b.wait_not_visible("#server-group")
-        b.wait_in_text("#conversation-prompt", "MD5 Fingerprint")
+        b.wait_in_text("#conversation-prompt", "Fingerprint")
         b.wait_in_text("#conversation-message", "Do you want to proceed this time?")
 
+        match = re.match(r'(MD5|SHA256) Fingerprint \(ssh-(.*)\):', b.text("#conversation-prompt"))
+        assert match
+        (hash_fn, algo) = match.groups()
         try:
-            algo = re.sub(r'MD5 Fingerprint \(ssh-(.*)\):', r'\1', b.text("#conversation-prompt"))
-            line = m2.execute("ssh-keygen -l -E md5 -f /etc/ssh/ssh_host_%s_key.pub" % algo, quiet=True)
+            line = m2.execute("ssh-keygen -l -E %s -f /etc/ssh/ssh_host_%s_key.pub" % (hash_fn, algo.lower()), quiet=True)
+            # SHA256 base64 fingerprints include an "SHA256:" prefix, but MD5 hex FPs don't
             fp = line.split(" ")[1].replace('MD5:', '')
             self.assertEqual(b.val('#conversation-input'), fp)
-        # ssh-keygen doesn't support -E, just make sure we have a fp
         except subprocess.CalledProcessError:
+            # ssh-keygen doesn't support -E, just make sure we have a fp
             self.assertTrue(b.val('#conversation-input'))
 
         b.click('#login-button')
@@ -411,7 +414,7 @@ class TestMultiMachine(MachineCase):
         b.wait_not_visible("#user-group")
         b.wait_not_visible("#option-group")
         b.wait_not_visible("#server-group")
-        b.wait_in_text("#conversation-prompt", "MD5 Fingerprint")
+        b.wait_in_text("#conversation-prompt", "Fingerprint")
         b.wait_in_text("#conversation-message", "Do you want to proceed this time?")
         b.click('#login-button')
         b.expect_load()


### PR DESCRIPTION
libssh 0.8 offers SHA256 fingerprints in addition to the old MD5/SHA1
ones. The latter are both cryptographically broken, and not allowed when
running in FIPS mode -- these cause an assertion crash in OpenSSL.

The "ssh" CLI hasn't shown MD5 fingerprints in a long time, not even on
RHEL 7 (it shows SHA1 and SHA256 there by default), so this actually
improves compatibility with ssh.

Use libssh 0.8's ssh_get_fingerprint_hash() function, as ssh itself
shows SHA256 fingerprints  in base64 instead of hex. cockpit-ssh's
fingerprint prompts should be compatible, and hex fingerprints would be
overly long.

Adjust most check-multi-machine tests to not care about the particular
type of fingerprint, as they don't check the actual fingerprint anyway.
Only `TestMultiMachine.testDirectLogin` does, so adjust the test to
accept both MD5 and SHA256 fingerprints.

https://bugzilla.redhat.com/show_bug.cgi?id=158519

- [x] get a recent fedora-atomic image with current libssh (#10243)
