### PR TITLE
test: Fix unexpected message in check-pages

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -301,7 +301,6 @@ OnCalendar=daily
         self.assertEqual(b.text('#angular-interpolate'), 'Deletar \'Marmalade\'')
 
         # Log out and check that login page is translated now
-        self.allow_journal_messages("Error receiving data: Connection reset by peer")
         b.logout()
         b.wait_visible('#password-group')
         b.wait_text('#password-group > label', 'Senha')
@@ -327,6 +326,8 @@ OnCalendar=daily
         b.wait_present('#file-content')
         b.wait_text('#file-content', "1")
 
+        self.allow_restart_journal_messages()
+
     @skipImage("Shell too old", "rhel-7-5-distropkg")
     def testShellReload(self):
         b = self.browser
@@ -340,6 +341,8 @@ OnCalendar=daily
                 '{ "menu": { "index": { "label": "FOO!" } } }')
         b.reload()
         b.wait_in_text("#host-apps", "FOO!")
+
+        self.allow_restart_journal_messages()
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
test{Shell,Frame}Reload sometimes fail with

    testlib.Error: Error receiving data: Connection reset by peer

due to the page reload. Allow restart messages in general.

Drop the specific "Connection reset" filter from testPtBRLocale, as that
already calls the more general allow_restart_journal_messages().