### PR TITLE
naughty: Close 9036: debian-testing known issue: apparmor failure on libvirtd signal sending

### DIFF
--- a/bots/naughty/debian-testing/9036-apparmor-denied-libvirt-signal
+++ b/bots/naughty/debian-testing/9036-apparmor-denied-libvirt-signal
@@ -1,1 +1,0 @@
-Error: audit: type=1400 * apparmor="DENIED" operation="signal" profile="/usr/sbin/libvirtd" * requested_mask="send" denied_mask="send" signal=hup peer="unconfined"


### PR DESCRIPTION
Known issue which has not occurred in 22 days

debian-testing known issue: apparmor failure on libvirtd signal sending

Fixes #9036