### PR TITLE
naughty: Close 6493: Fedora: SELinux prevents sosreport from working

### DIFF
--- a/bots/naughty/fedora-28/6493-selinux-sosreport-relabelto
+++ b/bots/naughty/fedora-28/6493-selinux-sosreport-relabelto
@@ -1,1 +1,0 @@
-Error: audit: type=1400*avc:  denied  { relabelto } for * comm="sosreport"

--- a/bots/naughty/fedora-29/6493-selinux-sosreport-relabelto
+++ b/bots/naughty/fedora-29/6493-selinux-sosreport-relabelto
@@ -1,1 +1,0 @@
-Error: audit: type=1400*avc:  denied  { relabelto } for * comm="sosreport"


### PR DESCRIPTION
Known issue which has not occurred in 33 days

Fedora: SELinux prevents sosreport from working

Fixes #6493