### PR TITLE
test: Fix network connection id retrieval

### DIFF
--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -55,7 +55,7 @@ class TestNetworking(NetworkCase):
         b.wait_popdown("network-ip-settings-dialog")
         b.wait_in_text("#network-interface .panel:contains('%s')" % iface, "1.2.3.4/18")
 
-        con_id = self.iface_con_id(iface)
+        con_id = wait(lambda: self.iface_con_id(iface))
 
         # Disconnect
         #

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -97,7 +97,7 @@ class NetworkCase(MachineCase):
 
     def iface_con_id(self, iface):
         con_id = self.machine.execute("nmcli -m tabular -t -f GENERAL.CONNECTION device show %s" % iface).strip()
-        if con_id == "--":
+        if con_id == "" or con_id == "--":
             return None
         else:
             return con_id


### PR DESCRIPTION
Recognize the empy string as meaning "no connection" in addition to
"--" and wait for a connection also in testBasic.

For a device without connection, earlier versions of nmcli have
returned "--" also with --terse, but newer versions return "" in that
case.