### PR TITLE
packagekit: Add missing React key to UpdatesList

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -373,7 +373,7 @@ function UpdatesList(props) {
                     <th>{_("Details")}</th>
                 </tr>
             </thead>
-            { updates.map(id => <UpdateItem pkgNames={packageNames[id].sort()} info={props.updates[id]} />) }
+            { updates.map(id => <UpdateItem key={id} pkgNames={packageNames[id].sort()} info={props.updates[id]} />) }
         </table>
     );
 }


### PR DESCRIPTION
```
Warning: Each child in an array or iterator should have a unique "key" prop.

Check the render method of `UpdatesList`.
    in UpdateItem (created by UpdatesList)
    in UpdatesList (created by OsUpdates)
    in div (created by OsUpdates)
    in div (created by OsUpdates)
    in div (created by OsUpdates)
    in OsUpdates
```