### PR TITLE
bridge: Fix use of pointer after free in CockpitFsList

### DIFF
--- a/src/bridge/cockpitfslist.c
+++ b/src/bridge/cockpitfslist.c
@@ -101,7 +101,7 @@ on_files_listed (GObject *source_object,
           cockpit_channel_close (COCKPIT_CHANNEL (self), "internal-error");
         }
       g_clear_error (&error);
-      return;
+      goto out;
     }
 
   CockpitFslist *self = COCKPIT_FSLIST (user_data);
@@ -118,7 +118,7 @@ on_files_listed (GObject *source_object,
           cockpit_channel_control (COCKPIT_CHANNEL (self), "done", NULL);
           cockpit_channel_close (COCKPIT_CHANNEL (self), NULL);
         }
-      return;
+      goto out;
     }
 
   for (GList *l = files; l; l = l->next)
@@ -146,7 +146,9 @@ on_files_listed (GObject *source_object,
                                       G_PRIORITY_DEFAULT,
                                       self->cancellable,
                                       on_files_listed,
-                                      self);
+                                      g_object_ref (self));
+out:
+  g_object_unref (user_data);
 }
 
 static void
@@ -175,7 +177,7 @@ on_enumerator_ready (GObject *source_object,
           cockpit_channel_close (COCKPIT_CHANNEL (self), problem ? problem : "internal-error");
         }
       g_clear_error (&error);
-      return;
+      goto out;
     }
 
   CockpitFslist *self = COCKPIT_FSLIST (user_data);
@@ -185,7 +187,9 @@ on_enumerator_ready (GObject *source_object,
                                       G_PRIORITY_DEFAULT,
                                       self->cancellable,
                                       on_files_listed,
-                                      self);
+                                      g_object_ref (self));
+out:
+  g_object_unref (user_data);
 }
 
 static void
@@ -251,7 +255,7 @@ cockpit_fslist_prepare (CockpitChannel *channel)
                                    G_PRIORITY_DEFAULT,
                                    self->cancellable,
                                    on_enumerator_ready,
-                                   self);
+                                   g_object_ref (self));
 out:
   g_clear_error (&error);
   if (file)


### PR DESCRIPTION
What happens here, is during an async call, we close the channel.
However the channel has not yet sent its close messages. Because
it's not "ready", and thus frozen. It doesn't send any messages yet.

Once the channel is "ready" (via ```cockpit_channel_ready()```) it thaws
(via ```cockpit_transport_thaw()```) and sends its close message, which
causes the channel to be unreffed by its owner.

Thus the remaining lines of code in ```on_files_listed()``` cause a
segfault when accessing self.

This is fixed by correctly holding refs during async calls.