### PR TITLE
test: Fix unexpected message in check-accounts

### DIFF
--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -161,6 +161,7 @@ class TestAccounts(MachineCase):
 
         self.allow_journal_messages("Password quality check failed:")
         self.allow_journal_messages("The password is a palindrome")
+        self.allow_journal_messages("passwd: user.*does not exist")
 
     def accountExpiryInfo(self, account, field):
         for line in self.machine.execute("LC_ALL=C chage -l {0}".format(account)).split("\n"):


### PR DESCRIPTION
This often fails with

    testlib.Error: passwd: user 'anton' does not exist

This is expected in that test, so ignore it.