### PR TITLE
bots: Handle GitHub statuses without a target_url field

### DIFF
--- a/bots/tests-data
+++ b/bots/tests-data
@@ -396,7 +396,9 @@ def logs(revision):
             # not entire test suite statuses
             if status["state"] in [ "pending" ]:
                 continue
-            target = status["target_url"]
+            target = status.get("target_url")
+            if not target:
+                continue
             if target.endswith(".html"):
                 target = target[:-5]
             if target in SEEDED:


### PR DESCRIPTION
These sometimes occur, and have been seen in production.

https://fedorapeople.org/groups/cockpit/logs/tests-data-10276-20181011-114444/log

```
Traceback (most recent call last):
  File "/build/cockpit/bots/task/__init__.py", line 265, in run
    ret = function(context, **kwargs)
  File "bots/tests-data", line 78, in run
    for (context, created, url, log) in logs(commit):
  File "bots/tests-data", line 400, in logs
    if target.endswith(".html"):
AttributeError: 'NoneType' object has no attribute 'endswith'
```