### PR TITLE
containers: Document that unit-test container needs bigger shared memory

### DIFF
--- a/containers/Makefile.am
+++ b/containers/Makefile.am
@@ -52,7 +52,7 @@ unit-tests-container:
 	sudo docker tag  cockpit/unit-tests:i386 docker.io/cockpit/unit-tests:i386
 
 unit-tests-container-run:
-	sudo docker run -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests
+	sudo docker run --shm-size=512M -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests
 
 unit-tests-container-shell:
-	sudo docker run -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests /bin/bash
+	sudo docker run --shm-size=512M -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests /bin/bash

--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -26,7 +26,7 @@ Tests in that container for the default configuration get started with
 
 or equivalently with
 
-    $ sudo docker run -ti --volume `pwd`:/source:ro cockpit/unit-tests
+    $ sudo docker run --shm-size=512M -ti --volume `pwd`:/source:ro cockpit/unit-tests
 
 You can pass `--env=CC=clang` to build with Clang instead of gcc, or run
 `cockpit/unit-tests:i386` to run on a 32 bit architecture.


### PR DESCRIPTION
docker's default 64 MB isn't enough to reliably run the browser tests.
Just like in Cockpituous [1] and in our selenium containers [2], bump
them to 512 MB, which has been proven to work reliably.

[1] https://github.com/cockpit-project/cockpituous/commit/7506c4828347bd20b
[2] https://github.com/cockpit-project/cockpit/commit/c282dfcb7d