### PR TITLE
test: Ignore core dump messages in testPackageKitCrash

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -642,6 +642,7 @@ class TestUpdates(PackageCase):
         b.wait_in_text("#app .container-fluid", "PackageKit crashed")
 
         self.allow_journal_messages(".*org.freedesktop.PackageKit.*Error.NoReply.*")
+        self.allow_journal_messages("Process .* dumped core.*")
 
     def testNoPackageKit(self):
         b = self.browser


### PR DESCRIPTION
This test sends a signal to an entire systemd service. There may
be other processes running like a shell in that service. Lets
ignore any core dump message.