### PR TITLE
Detect and fix "Failed prop type" and "misspelled propType" React warnings

### DIFF
--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -149,7 +149,12 @@ def build_and_install(build_image, build_results, skips, args):
     completed = False
 
     # While the machine is booting, make a tarball
-    source = subprocess.check_output([ os.path.join(BOTS, "make-source") ], universal_newlines=True).strip()
+    # Do a development build on the latest Fedora image so that we can spot React and other dev-only warnings
+    env = os.environ.copy()
+    if os.path.basename(build_image) == "fedora-29":
+        env["NODE_ENV"] = "development"
+    source = subprocess.check_output([ os.path.join(BOTS, "make-source") ],
+                                     universal_newlines=True, env=env).strip()
     machine.start()
     completed = False
 

--- a/configure.ac
+++ b/configure.ac
@@ -504,7 +504,7 @@ elif test "$enable_debug" = "no"; then
   NODE_ENV="production"
 else
   debug_status="default"
-  NODE_ENV="production"
+  NODE_ENV="${NODE_ENV:-production}"
 fi
 AM_CONDITIONAL(WITH_DEBUG, test "$enable_debug" = "yes")
 AC_MSG_RESULT($debug_status)
@@ -591,6 +591,7 @@ echo "
         Maintainer mode:            ${USE_MAINTAINER_MODE}
         Building docs:              ${enable_doc}
         Debug mode:                 ${debug_status}
+        Node environment:           ${NODE_ENV}
         With coverage:              ${enable_coverage}
         With address sanitizer:     ${asan_status}
         With PCP:                   ${enable_pcp}

--- a/pkg/docker/storage.jsx
+++ b/pkg/docker/storage.jsx
@@ -182,6 +182,7 @@
                 drive_rows.push(
                     <tr key={drive.path} onClick={self.toggleDrive.bind(self, drive)}>
                         <td><input type="checkbox"
+                                   onChange={ () => null /* click handled by parent element, silence React warning */ }
                                    checked={self.driveChecked(drive)} />
                         </td>
                         <td><img role="presentation" src="images/drive-harddisk-symbolic.svg" /></td>

--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -236,10 +236,11 @@ class DialogFooter extends React.Component {
         );
     }
 }
-DialogFooter.PropTypes = {
+
+DialogFooter.propTypes = {
     cancel_clicked: PropTypes.func,
     cancel_caption: PropTypes.string,
-    actions: PropTypes.array,
+    actions: PropTypes.array.isRequired,
     static_error: PropTypes.string,
     dialog_done: PropTypes.func,
 };
@@ -289,7 +290,7 @@ class Dialog extends React.Component {
         );
     }
 }
-Dialog.PropTypes = {
+Dialog.propTypes = {
     // TODO: fix following by refactoring the logic showing modal dialog (recently show_modal_dialog())
     title: PropTypes.string, // is effectively required, but show_modal_dialog() provides initially no props and resets them later.
     no_backdrop: PropTypes.bool,

--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -306,7 +306,7 @@ class FileAutoComplete extends React.Component {
         );
     }
 }
-FileAutoComplete.PropTypes = {
+FileAutoComplete.propTypes = {
     id: PropTypes.string,
     placeholder: PropTypes.string,
     value: PropTypes.string,

--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -279,12 +279,12 @@ ListingRow.propTypes = {
 };
 /* Implements a PatternFly 'List View' pattern
  * https://www.patternfly.org/list-view/
- * Properties:
+ * Properties (all optional):
  * - title
- * - fullWidth optional: set width to 100% of parent, defaults to true
- * - emptyCaption header caption to show if list is empty, defaults to "No entries"
+ * - fullWidth: set width to 100% of parent, defaults to true
+ * - emptyCaption: header caption to show if list is empty
  * - columnTitles: array of column titles, as strings
- * - columnTitleClick: optional callback for clicking on column title (for sorting)
+ * - columnTitleClick: callback for clicking on column title (for sorting)
  *                     receives the column index as argument
  * - actions: additional listing-wide actions (displayed next to the list's title)
  */
@@ -346,6 +346,7 @@ export const Listing = (props) => {
 Listing.defaultProps = {
     title: '',
     fullWidth: true,
+    emptyCaption: '',
     columnTitles: [],
     actions: []
 };
@@ -353,7 +354,7 @@ Listing.defaultProps = {
 Listing.propTypes = {
     title: PropTypes.string,
     fullWidth: PropTypes.bool,
-    emptyCaption: PropTypes.string.isRequired,
+    emptyCaption: PropTypes.node,
     columnTitles: PropTypes.arrayOf(
         PropTypes.oneOfType([
             PropTypes.string,

--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -196,7 +196,8 @@
             window.removeEventListener('beforeunload', this.onBeforeUnload);
         }
     }
-    Terminal.PropTypes = {
+
+    Terminal.propTypes = {
         cols: PropTypes.number,
         rows: PropTypes.number,
         channel: PropTypes.object.isRequired,

--- a/pkg/machines/components/vcpuModal.jsx
+++ b/pkg/machines/components/vcpuModal.jsx
@@ -216,7 +216,7 @@ export default function ({ vm, dispatch, config }) {
     return show_modal_dialog(
         {
             title: cockpit.format(_("$0 vCPU Details"), vm.name),
-            body: (<VCPUModalBody vcpus={vm.vcpus} cpu={vm.cpu} onChange={onStateChange} isRunning={vm.state == 'running'} hypervisorMax={config.hypervisorMaxVCPU[vm.connectionName]} />),
+            body: (<VCPUModalBody vcpus={vm.vcpus} cpu={vm.cpu} onChange={onStateChange} isRunning={vm.state == 'running'} hypervisorMax={parseInt(config.hypervisorMaxVCPU[vm.connectionName])} />),
             id: "machines-vcpu-modal-dialog"
         },
         { actions: [

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -201,7 +201,7 @@ class AddServicesDialogBody extends React.Component {
                                     <input id={s.id}
                                            type="checkbox"
                                            checked={this.state.selected.has(s.id)}
-                                           onClick={this.onToggleService} />
+                                           onChange={this.onToggleService} />
                                     &nbsp;
                                     <span>{s.name}</span>
                                 </label>

--- a/pkg/playground/react-demo-listing.jsx
+++ b/pkg/playground/react-demo-listing.jsx
@@ -46,7 +46,7 @@
             );
         }
     }
-    DemoListingTab.PropTypes = {
+    DemoListingTab.propTypes = {
         description: PropTypes.string.isRequired,
     };
 

--- a/pkg/tuned/change-profile.jsx
+++ b/pkg/tuned/change-profile.jsx
@@ -49,7 +49,7 @@ class TunedDialogProfile extends React.Component {
         );
     }
 }
-TunedDialogProfile.PropTypes = {
+TunedDialogProfile.propTypes = {
     name: PropTypes.string.isRequired,
     recommended: PropTypes.bool.isRequired,
     selected: PropTypes.bool.isRequired,

--- a/test/common/cdp-driver.js
+++ b/test/common/cdp-driver.js
@@ -70,6 +70,7 @@ var unhandledExceptions = [];
 // when encountering a log message that contains any of these strings, fail the test
 const fatalLogs = [
     /^Warning: Failed prop type:/,
+    /^Warning: Component.*declared.*instead of.*propTypes.*/,
 ];
 
 function setupLogging(client) {

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -643,6 +643,7 @@ class TestUpdates(PackageCase):
 
         self.allow_journal_messages(".*org.freedesktop.PackageKit.*Error.NoReply.*")
         self.allow_journal_messages("Process .* dumped core.*")
+        self.allow_journal_messages("Stack trace of thread")
 
     def testNoPackageKit(self):
         b = self.browser


### PR DESCRIPTION
See individual commits for details.

 - [x] Clean up React class creation (PR #10291)
 - [x] Fix missing `onChange` in pkg/docker/storage.jsx `DriveBox`
 - [x] Fix missing `emptyCaption` on Hardware Info page
 - [x] Fix wrong `emptyCaption` type in SETroubleshootPage Listing
 - [x] Fix wrong `hypervisorMax` on VCPUModalBody → InfoRecord
 - [x] Fix missing `onChange` on Firewall page