### PR TITLE
networking: More robust detection of masters

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1773,8 +1773,12 @@ PageNetworking.prototype = {
         self.model.list_interfaces().forEach(function (iface) {
 
             function has_master(iface) {
-                return ((iface.Device && iface.Device.ActiveConnection && iface.Device.ActiveConnection.Master) ||
-                        (iface.MainConnection && iface.MainConnection.Masters.length > 0));
+                return ((iface.Device &&
+                         iface.Device.ActiveConnection &&
+                         iface.Device.ActiveConnection.Master &&
+                         iface.Device.ActiveConnection.Master.Slaves.length > 0) ||
+                        (iface.MainConnection &&
+                         iface.MainConnection.Masters.length > 0));
             }
 
             // Skip loopback


### PR DESCRIPTION
Sometimes when a bond has been deleted, NetworkManager keeps
ActiveConnection.Master of a previous slave pointing to the now
non-existing bond device.  We detect these spurious masters by looking
at how many slaves they have.