### PR TITLE
bots: Add a margin on the log.html page

### DIFF
--- a/bots/task/log.html
+++ b/bots/task/log.html
@@ -13,6 +13,9 @@
         * {
          font-family: "Open Sans";
         }
+        body {
+            margin: 10px;
+        }
         .panel-heading:last-child:after {
             font-family:'Glyphicons Halflings';
             content:"\e114";


### PR DESCRIPTION
The log.html page seen in CI results has no margin since
bootstrap changed. Lets add it back and make new results
look nice.