### PR TITLE
ssh: Parse ssh config file before connecting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,9 @@ if test "$enable_ssh" != "no"; then
 
   AC_DEFINE_UNQUOTED(WITH_COCKPIT_SSH, 1, [Build cockpit-ssh and include libssh dependency])
 
+  PKG_CHECK_MODULES(LIBSSH_SAFE_PROXY_COMMANDS, [libssh >= 0.8.5],
+    [AC_DEFINE_UNQUOTED(HAVE_SAFE_PROXY_COMMANDS, [1], [Proxy commands break cockpit pre libssh-0.8.5])], [0])
+
   AC_CHECK_LIB(ssh, ssh_get_server_publickey, [
     AC_DEFINE_UNQUOTED(HAVE_SSH_GET_SERVER_PUBLICKEY, 1, Whether ssh_get_server_publickey is available)
   ])

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -192,6 +192,28 @@ class TestMultiMachineAdd(MachineCase):
                                     ".*: bridge failed: .*",
                                     ".*: bridge program failed: Child process exited with code .*")
 
+    @skipImage("Newer version (>= 0.8.5) of libssh required", "debian-stable", "debian-testing",
+               "ubuntu-1804", "ubuntu-stable", "fedora-atomic", "rhel-atomic", "continuous-atomic",
+               "rhel-x", "centos-7", "rhel-7-6", "rhel-7-6-distropkg")
+    def testGlobalSSHConfig(self):
+        b = self.browser
+        m = self.machine
+        m3 = self.machine3
+
+        change_ssh_port(m3, "10.111.113.3", 2222)
+        m.execute("echo -e 'Host m2\n\tHostName 10.111.113.2\n' >> /etc/ssh/ssh_config")
+        m.execute("echo -e 'Host m3\n\tHostName 10.111.113.3\n\tPort 2222\n' >> /etc/ssh/ssh_config")
+
+        self.login_and_go(None)
+        add_machine(b, "m2")
+        add_machine(b, "m3")
+
+        b.go("/dashboard")
+        b.enter_page("/dashboard")
+        b.wait_present("#dashboard-hosts a[data-address='m2'] img")
+        b.wait_attr("#dashboard-hosts a[data-address='m2'] img", 'src', '../shell/images/server-small.png')
+        b.wait_present("#dashboard-hosts a[data-address='m3'] img")
+        b.wait_attr("#dashboard-hosts a[data-address='m3'] img", 'src', '../shell/images/server-small.png')
 
 class TestMultiMachine(MachineCase):
     provision = {


### PR DESCRIPTION
If the (local or global) config file contains a `ProxyCommand`, the fd that cockpit interacts with is not bidirectional, and results in cockpit being broken. So this change is blocked on some api consistency on the libssh side:

- [x] https://bugs.libssh.org/T115
- [x] get libssh 0.8.5 onto fedora-testing: #10491
- [x] get libssh 0.8.5 onto fedora-29: #10520
- [x] get libssh 0.8.5 onto fedora-28: #10540
- [x] get libssh 0.8.5 onto fedora-i386: #10536
- [ ] ~get libssh 0.8.5 onto rhel-x: https://bugzilla.redhat.com/show_bug.cgi?id=1640812~ (not a blocker)
- [ ] ~get libssh 0.8.5 into Debian: https://bugs.debian.org/913242~ (not a blocker)