### PR TITLE
users: Handle password change frequency limits better

### DIFF
--- a/pkg/users/local.es6
+++ b/pkg/users/local.es6
@@ -73,6 +73,9 @@ function passwd_self(old_pass, new_pass) {
     var bad_exps = [
         /.*BAD PASSWORD:.*/
     ];
+    var too_new_exps = [
+        /.*must wait longer to change.*/
+    ];
 
     var dfd = cockpit.defer();
     var buffer = "";
@@ -104,6 +107,15 @@ function passwd_self(old_pass, new_pass) {
                     if (old_exps[i].test(buffer)) {
                         buffer = "";
                         this.input(old_pass + "\n", true);
+                        return;
+                    }
+                }
+
+                for (i = 0; i < too_new_exps.length; i++) {
+                    if (too_new_exps[i].test(buffer)) {
+                        buffer = "";
+                        failure = _("You must wait longer to change your password");
+                        this.input("\n", true);
                         return;
                     }
                 }

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -173,6 +173,7 @@ class TestAccounts(MachineCase):
         m = self.machine
         b = self.browser
         new_password = "tqymuVh.Zf5"
+        new_password_2 = "cEwghLYX"
 
         # defaults to empty shell on debian-stable (Debian 9 only), so specify it explicitly
         m.execute("useradd --shell /bin/bash anton; echo anton:foobar | chpasswd")
@@ -197,6 +198,22 @@ class TestAccounts(MachineCase):
         b.click('#login-button')
         b.expect_load()
         b.wait_present('#content')
+
+        # Set minimum age to disallow changing it immediately again
+        m.execute("chage --mindays 7 anton")
+        b.enter_page("/users")
+        b.go("#/anton")
+        b.wait_present("#account-user-name")
+        b.wait_text("#account-user-name", "anton")
+        b.wait_present('#account-set-password:enabled')
+        b.click('#account-set-password')
+        b.wait_popup('account-set-password-dialog')
+        b.set_val("#account-set-password-old", new_password)
+        b.set_val("#account-set-password-pw1", new_password_2)
+        b.set_val("#account-set-password-pw2", new_password_2)
+        b.click('#account-set-password-apply')
+        b.wait_present(".dialog-error")
+        b.wait_in_text(".dialog-error", "must wait longer")
 
         self.allow_restart_journal_messages()
         self.allow_authorize_journal_messages()


### PR DESCRIPTION
Display a specific message about the password change being disallowed
rather than falling back to the default, and confusing, "Old password
not accepted".

This is the minimal fix for #10322.

I'm not sure how to write tests for this though as they require specific system configuration. (I'm happy to do the work to write them I just need guidance in the right way, place, etc. to do that.)

- [x] Fix changing user's own password: PR #10638 
- [x] Add integration test