### PR TITLE
users: Fix creation of locked accounts

### DIFF
--- a/pkg/users/local.es6
+++ b/pkg/users/local.es6
@@ -484,6 +484,10 @@ PageAccountsCreate.prototype = {
             }
         ];
 
+        tasks.push(function change_passwd() {
+            return passwd_change($('#accounts-create-user-name').val(), $('#accounts-create-pw1').val());
+        });
+
         if ($('#accounts-create-locked').prop('checked')) {
             tasks.push(function adjust_locked() {
                 return cockpit.spawn([
@@ -493,10 +497,6 @@ PageAccountsCreate.prototype = {
                 ], { superuser: "require", err: "message" });
             });
         }
-
-        tasks.push(function change_passwd() {
-            return passwd_change($('#accounts-create-user-name').val(), $('#accounts-create-pw1').val());
-        });
 
         var promise = this.validate()
                 .fail(function(ex) {

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -104,9 +104,16 @@ class TestAccounts(MachineCase):
         b.wait_popdown('accounts-create-dialog')
         b.wait_in_text('#accounts-list', "Jussi Junior")
 
+        def is_locked():
+            return m.execute("passwd -S jussi | cut -d' ' -f2").strip() in [ "L", "LK" ]
+
+        def is_admin():
+            return "jussi" in m.execute("getent group %s" % m.get_admin_group())
+
         admin_role_sel = 'input[data-name="%s"]' % m.get_admin_group()
         b.wait(lambda: "jussi" in m.execute("grep jussi /etc/passwd"))
-        b.wait(lambda: "jussi" not in m.execute("grep %s /etc/group" % m.get_admin_group()))
+        b.wait(lambda: not is_admin())
+        b.wait(is_locked)
 
         # Unlock it and make it an admin
         b.go("#/jussi")
@@ -114,15 +121,16 @@ class TestAccounts(MachineCase):
         b.wait_text("#account-user-name", "jussi")
         b.wait_present('#account-locked:not([disabled])')
         b.set_checked('#account-locked', False)
+        b.wait(lambda: not is_locked())
         b.wait_present(admin_role_sel + ":not(:checked):not([disabled])")
         b.set_checked(admin_role_sel, True)
-        b.wait(lambda: "jussi" in m.execute("grep %s /etc/group" % m.get_admin_group()))
+        b.wait(is_admin)
         # An alert which shows up once we've changed things
         if m.image != 'rhel-7-5-distropkg':
             b.wait_present("#account-roles .alert-info")
         b.wait_present(admin_role_sel + ":checked:not([disabled])")
         b.set_checked(admin_role_sel, False)
-        b.wait(lambda: "jussi" not in m.execute("grep %s /etc/group" % m.get_admin_group()))
+        b.wait(lambda: not is_admin())
         m.execute("/usr/sbin/usermod jussi -G %s -a" % m.get_admin_group())
         b.wait_present(admin_role_sel + ":checked:not([disabled])")
 

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -23,6 +23,7 @@ import datetime
 import parent
 from testlib import *
 
+@skipImage("Don't run upstream tests against distro packages", "rhel-7-5-distropkg", "rhel-7-6-distropkg")
 class TestAccounts(MachineCase):
     def testBasic(self):
         b = self.browser
@@ -67,11 +68,9 @@ class TestAccounts(MachineCase):
         b.wait_present("#account-locked:not(:checked)")
         # root account should not be locked by default on our images
         self.assertIn(m.execute("passwd -S root").split()[1], ["P", "PS"])
-        # (un)locking root account introduced in version 161
-        if m.image != 'rhel-7-5-distropkg':
-            # now lock account
-            b.set_checked("#account-locked", True)
-            b.wait(lambda: m.execute("passwd -S root").split()[1] in ["L", "LK"])
+        # now lock account
+        b.set_checked("#account-locked", True)
+        b.wait(lambda: m.execute("passwd -S root").split()[1] in ["L", "LK"])
 
         # go back to accounts overview, check breadcrumb
         b.click("#account .breadcrumb a")
@@ -126,8 +125,7 @@ class TestAccounts(MachineCase):
         b.set_checked(admin_role_sel, True)
         b.wait(is_admin)
         # An alert which shows up once we've changed things
-        if m.image != 'rhel-7-5-distropkg':
-            b.wait_present("#account-roles .alert-info")
+        b.wait_present("#account-roles .alert-info")
         b.wait_present(admin_role_sel + ":checked:not([disabled])")
         b.set_checked(admin_role_sel, False)
         b.wait(lambda: not is_admin())


### PR DESCRIPTION
Running "chpasswd" last will undo the earlier "usermod --lock", so we
do it the other way around.

The added checks in the test also remove a race condition. We need to
wait for the unlocking finish before changing the groups.