### PR TITLE
test: Robustify console error checking, disambiguate key on Storage space

### DIFF
--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -215,7 +215,7 @@ function getBackend(forceReinit) {
         let dfd = cockpit.defer();
         getBackend.promise = dfd.promise();
 
-        cockpit.script(["command -v dnf yum apt | head -n1 | xargs basename"], [], { err: "message" })
+        cockpit.spawn(["bash", "-ec", "command -v dnf yum apt | head -n1 | xargs basename"], [], { err: "message" })
                 .done(output => {
                     output = output.trim();
                     debug("getBackend(): detection finished, output", output);
@@ -235,7 +235,7 @@ function getBackend(forceReinit) {
                         dfd.resolve(null);
                 })
                 .fail(error => {
-                // the detection shell script is supposed to always succeed
+                    // the detection shell script is supposed to always succeed
                     console.error("automatic updates getBackend() detection failed:", error);
                     dfd.resolve(null);
                 });

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -626,7 +626,7 @@ export const SelectSpaces = (tag, title, options) => {
                         };
 
                         return (
-                            <li key={spc.desc} className="list-group-item">
+                            <li key={spc.block ? spc.block.Device : spc.desc} className="list-group-item">
                                 <div className="checkbox">
                                     <label>
                                         <input type="checkbox" checked={selected} onChange={on_change} />
@@ -665,7 +665,7 @@ export const SelectSpace = (tag, title, options) => {
                         };
 
                         return (
-                            <li key={spc.desc} className="list-group-item">
+                            <li key={spc.block ? spc.block.Device : spc.desc} className="list-group-item">
                                 <div className="radio">
                                     <label>
                                         <input type="radio" checked={val == spc} onChange={on_change} />

--- a/test/common/cdp-driver.js
+++ b/test/common/cdp-driver.js
@@ -67,16 +67,6 @@ var logPromiseResolver;
 var nReportedLogMessages = 0;
 var unhandledExceptions = [];
 
-// when encountering a log message that contains any of these strings, fail the test
-const fatalLogs = [
-    /^Warning: Failed prop type:/,
-    /^Warning: Component.*declared.*instead of.*propTypes.*/,
-    /^Warning: Invalid DOM property/,
-    /^Warning: Received the .* for the .* attribute/,
-    /^Warning: validateDOMNesting/,
-    /^Warning: .*unique "key" prop.*/,
-];
-
 function setupLogging(client) {
     client.Runtime.enable();
 
@@ -84,9 +74,6 @@ function setupLogging(client) {
         let msg = info.args.map(v => (v.value || "").toString()).join(" ");
         messages.push([ info.type, msg ]);
         process.stderr.write("> " + info.type + ": " + msg + "\n")
-
-        if (fatalLogs.find(pattern => pattern.test(msg)))
-            unhandledExceptions.push(msg);
 
         resolveLogPromise();
     });

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -654,6 +654,8 @@ class TestUpdates(PackageCase):
                      rm /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service
                      systemctl daemon-reload''')
 
+        self.allow_browser_errors("loading available updates failed:.*not-found")
+
         m.start_cockpit()
         b.login_and_go("/updates")
 


### PR DESCRIPTION
Now that we fixed most React errors, turn the current blacklist into a
whitelist. This will also catch other React errors, and guard against
typos.

We currently only have one remaining React warning left:

    Warning: Can't call setState (or forceUpdate) on an unmounted
    component. This is a no-op, but it indicates a memory leak in your
    application. To fix, cancel all subscriptions and asynchronous tasks
    in the componentWillUnmount method.

The impact of this is very low, and debugging all of these will take
time, so generally whitelist this one for now.

Also, a few tests check error conditions and deliberately produce
console errors. Introduce a per-test whitelist mechanism similar to what
we do for expected systemd journal messages.

Move this out of the low-level cdp-driver.js into testlib.py, and merge
it with the already existing "unhandled exception" checking; that is
just a special case of a console error.

 - [ ] fix duplicate key on Storage page