### PR TITLE
test: Ignore stack traces in testPackageKitCrash

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -842,6 +842,9 @@ class MachineCase(unittest.TestCase):
         for m in messages:
             # remove leading/trailing whitespace
             m = m.strip()
+            # Ignore empty lines
+            if not m:
+                continue
             found = False
             for p in self.allowed_messages:
                 match = re.match(p, m)

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -643,7 +643,8 @@ class TestUpdates(PackageCase):
 
         self.allow_journal_messages(".*org.freedesktop.PackageKit.*Error.NoReply.*")
         self.allow_journal_messages("Process .* dumped core.*")
-        self.allow_journal_messages("Stack trace of thread")
+        self.allow_journal_messages("Stack trace of thread.*")
+        self.allow_journal_messages("#[0-9].*")
 
     def testNoPackageKit(self):
         b = self.browser


### PR DESCRIPTION
There are stack traces in the journal when packagekit crashes. Lets ignore them
