### PR TITLE
bots: Declare ubuntu-1804 image

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -38,6 +38,7 @@ DEFAULT_VERIFY = {
     'verify/fedora-atomic': [ 'master' ],
     'verify/fedora-testing': [ ],
     'verify/ubuntu-1604': [ 'master' ],
+    'verify/ubuntu-1804': [ ],
     'verify/ubuntu-stable': [ 'master' ],
 }
 


### PR DESCRIPTION
Ubuntu 18.10 just got released, so ubuntu-stable will move from 18.04 to
18.10. 18.04 is an LTS which we want to support now instead of 16.04.