### PR TITLE
bots: Update Red Hat internal task matching

### DIFF
--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -37,8 +37,8 @@ KVM_TASKS = [
 
 # RHEL tasks have to be done inside Red Hat network
 REDHAT_TASKS = [
-    "rhel-7",
-    "rhel-atomic"
+    "rhel",
+    "redhat"
 ]
 
 # Windows tasks have to be done by a human


### PR DESCRIPTION
These are bot tasks that should only be done in the Red Hat
network. Make their matching more general.

Fixes #10330