### PR TITLE
Revert "test: Ensure docker is started before running sosrport"

### DIFF
--- a/test/avocado/selenium-sosreport.py
+++ b/test/avocado/selenium-sosreport.py
@@ -18,9 +18,6 @@ class SosReportingTab(SeleniumTest):
     :avocado: enable
     """
     def test10SosReport(self):
-        # Docker must be running otherwise sosreport hangs
-        process.run("systemctl start docker", shell=True)
-
         self.login()
         self.wait_id("host-apps")
         self.click(self.wait_link('Diagnostic Report', cond=clickable))


### PR DESCRIPTION
This reverts commit e375bd1efe81596a8f5cf38c719b4e23da32c28e.

https://bugzilla.redhat.com/show_bug.cgi?id=1441236 got fixed in docker
long ago, and this breaks running the Selenium tests on platforms that
don't have docker.