### PR TITLE
bots: Enable rhel-x testing of welder-web

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -75,6 +75,8 @@ REDHAT_EXTERNAL_PROJECTS = {
     'weldr/welder-web': [
         'cockpit/rhel-7-6/chrome',
         'cockpit/rhel-7-6/firefox',
+        'cockpit/rhel-x/chrome',
+        'cockpit/rhel-x/firefox',
     ],
 }
 


### PR DESCRIPTION
- [x] land https://github.com/weldr/welder-web/pull/390 to fix rhel-x test