### PR TITLE
naughty: Close 10005: Certain libvirt commands fail on fedora-29 because of json parsing bug

### DIFF
--- a/bots/naughty/fedora-29/10005-libvirt-json-parse-fail
+++ b/bots/naughty/fedora-29/10005-libvirt-json-parse-fail
@@ -1,1 +1,0 @@
-error: *internal error: failed to parse JSON *:*: too big integer near '*'


### PR DESCRIPTION
Known issue which has not occurred in 26 days

Certain libvirt commands fail on fedora-29 because of json parsing bug

Fixes #10005