### PR TITLE
naughty: Close 9970:  SELinux denials for dogtag-ipa-rene when starting certmonger.service

### DIFF
--- a/bots/naughty/rhel-x/9970-selinux-certmonger
+++ b/bots/naughty/rhel-x/9970-selinux-certmonger
@@ -1,1 +1,0 @@
-Error: * type=1400 * avc:  denied  { * } for * comm="dogtag-ipa-rene" * scontext=system_u:system_r:certmonger_t:s0


### PR DESCRIPTION
Known issue which has not occurred in 22 days

 SELinux denials for dogtag-ipa-rene when starting certmonger.service

Fixes #9970