### PR TITLE
ssh: Drop challenge_unknown_host_preconnect hack

### DIFF
--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -8,7 +8,6 @@
         {
             "match": { "session": "private", "user": null, "host": null },
             "environ": [ "COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS=true",
-                         "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT=true",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
@@ -17,7 +16,6 @@
         {
             "match": { "session": "private", "host": null },
             "environ": [ "COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS=true",
-                         "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT=true",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
@@ -25,14 +23,12 @@
         },
         {
             "match": { "user": null, "host": null },
-            "environ": [ "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT=true" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
             "problem": "not-supported"
         },
         {
             "match": { "host": null },
-            "environ": [ "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT=true" ],
             "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
             "problem": "not-supported"

--- a/src/ssh/cockpitsshoptions.c
+++ b/src/ssh/cockpitsshoptions.c
@@ -106,19 +106,6 @@ cockpit_ssh_options_from_env (gchar **env)
   options->remote_peer = get_environment_val (env, "COCKPIT_REMOTE_PEER", "localhost");
   options->connect_to_unknown_hosts = get_connect_to_unknown_hosts (env);
 
-  /* HACK: Set to receive an authorize challenge if the host is unknown, before
-   * connecting to the host. This is done in cockpit-bridge (via
-   * pkg/ssh/manifest.json.in), but not for direct URL logins in cockpit-ws.
-   * This is an internal hack to mimic the obsolete magic
-   * COCKPIT_SSH_KNOWN_HOSTS_DATA=authorize mode, until cockpit-ws starts to
-   * set this through the JSON protocol.*/
-  options->challenge_unknown_host_preconnect =
-    get_environment_bool (env, "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT", FALSE);
-  if (!has_environment_val (env, "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT") &&
-      g_str_equal (get_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA", ""),
-                   "authorize"))
-    options->challenge_unknown_host_preconnect = TRUE;
-
   return options;
 }
 
@@ -128,8 +115,6 @@ cockpit_ssh_options_to_env (CockpitSshOptions *options,
 {
   env = set_environment_bool (env, "COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS",
                               options->connect_to_unknown_hosts);
-  env = set_environment_bool (env, "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT",
-                              options->challenge_unknown_host_preconnect);
   env = set_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
                              options->knownhosts_file);
   env = set_environment_val (env, "COCKPIT_REMOTE_PEER",

--- a/src/ssh/cockpitsshoptions.h
+++ b/src/ssh/cockpitsshoptions.h
@@ -29,7 +29,6 @@ typedef struct {
   const gchar *command;
   const gchar *remote_peer;
   gboolean connect_to_unknown_hosts;
-  gboolean challenge_unknown_host_preconnect;
 } CockpitSshOptions;
 
 CockpitSshOptions * cockpit_ssh_options_from_env   (gchar **env);

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -641,7 +641,7 @@ set_knownhosts_file (CockpitSshData *data,
         }
     }
 
-  if (!host_known && data->ssh_options->challenge_unknown_host_preconnect)
+  if (!host_known)
     {
       authorize_knownhosts_data = challenge_for_knownhosts_data (data);
       if (authorize_knownhosts_data)

--- a/src/ssh/test-sshoptions.c
+++ b/src/ssh/test-sshoptions.c
@@ -84,16 +84,6 @@ test_ssh_options (void)
   options = cockpit_ssh_options_from_env (env);
   g_assert_false (options->connect_to_unknown_hosts);
   g_free (options);
-
-  env = g_environ_setenv (env, "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT", "", TRUE);
-  options = cockpit_ssh_options_from_env (env);
-  g_assert_false (options->challenge_unknown_host_preconnect);
-  g_free (options);
-
-  env = g_environ_setenv (env, "COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT", "yes", TRUE);
-  options = cockpit_ssh_options_from_env (env);
-  g_assert_true (options->challenge_unknown_host_preconnect);
-  g_free (options);
   g_strfreev (env);
 
   env = g_environ_setenv (NULL, "COCKPIT_REMOTE_PEER", "127.0.0.1", TRUE);
@@ -118,17 +108,14 @@ test_ssh_options_deprecated (void)
   env = g_environ_setenv (NULL, "COCKPIT_SSH_ALLOW_UNKNOWN", "yes", TRUE);
   options = cockpit_ssh_options_from_env (env);
   g_assert_true (options->connect_to_unknown_hosts);
-  g_assert_false (options->challenge_unknown_host_preconnect);
   g_free (options);
 
   env = g_environ_setenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "authorize", TRUE);
   options = cockpit_ssh_options_from_env (env);
-  g_assert_true (options->challenge_unknown_host_preconnect);
   g_free (options);
 
   env = g_environ_setenv (env, "COCKPIT_SSH_KNOWN_HOSTS_DATA", "", TRUE);
   options = cockpit_ssh_options_from_env (env);
-  g_assert_false (options->challenge_unknown_host_preconnect);
   g_free (options);
 
   g_strfreev (env);

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -407,6 +407,8 @@ Requires: glib-networking
 Provides: cockpit-ssh = %{version}-%{release}
 # cockpit-ssh moved from dashboard to bridge in 171
 Conflicts: cockpit-dashboard < 170.x
+# PR #10430 dropped workaround for ws' inability to understand x-host-key challenge
+Conflicts: cockpit-ws < 181.x
 %endif
 
 %description bridge
@@ -741,11 +743,13 @@ Summary: Cockpit remote servers and dashboard
 Provides: cockpit-ssh = %{version}-%{release}
 # nothing depends on the dashboard, but we can't use it with older versions of the bridge
 Conflicts: cockpit-bridge < 135
+# PR #10430 dropped workaround for ws' inability to understand x-host-key challenge
+Conflicts: cockpit-ws < 173.1
 %else
 BuildArch: noarch
 Requires: cockpit-ssh >= 135
-%endif
 Conflicts: cockpit-ws < 135
+%endif
 
 %description -n cockpit-dashboard
 Cockpit support for connecting to remote servers (through ssh),

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -55,8 +55,8 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          glib-networking
 Provides: cockpit-ssh
-Breaks: cockpit-dashboard (<< 170.x)
-Replaces: cockpit-dashboard (<< 170.x)
+Breaks: cockpit-dashboard (<< 170.x), cockpit-ws (<< 181.x)
+Replaces: cockpit-dashboard (<< 170.x), cockpit-ws (<< 181.x)
 Description: Cockpit bridge server-side component
  The Cockpit bridge component installed server side and runs commands on
  the system on behalf of the web based user interface.


### PR DESCRIPTION
Conceptually we always want the bridge to send a challenge for unknown hosts, to keep the protocol non-magical and well-defined.

This does not break existing cockpit/ws containers for existing bastion host setups: This does not change the behaviour of cockpit-bridge, only cockpit-ssh. And cockpit/ws containers always include their matching cockpit-ssh (with possibly the old behaviour), they don't talk to a remote cockpit-ssh directly. But let's make double-sure.

 - [x] Fix cockpit-ws to respond to host key challenges: PR #10442
 - [x] Make double-sure that old (e. g. RHEL 7) cockpit/ws can talk to a remote with this new behaviour.
 - [x] Check the [ManageIQ](https://github.com/ManageIQ/manageiq) code base to make sure this does not break functionality.
 - [x] Check the  [ovirt-cockpit-sso](https://github.com/oVirt/ovirt-cockpit-sso) to make sure this does not break functionality.
 - [x] Bump dependencies to fixed cockpit-ws
 - [x] for RHEL/CentOS 7, either wait until the fix lands there: PR #10585 