### PR TITLE
machines: Don't translate empty strings

### DIFF
--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -90,7 +90,7 @@ const VmNetworkTab = function ({ vm, dispatch, hostDevices }) {
         { name: _("State"), value: (network, networkId) => {
             return <span className='machines-network-state' id={`${id}-network-${networkId}-state`}>{rephraseUI('networkState', network.state)}</span>;
         }},
-        { name: _(""), value: (network, networkId) => {
+        { name: "", value: (network, networkId) => {
             const isUp = network.state === 'up';
 
             return (<div className='machines-network-state' id={`${id}-network-${networkId}-state-btn`}>


### PR DESCRIPTION
This causes a warning in xgettext, and Gettext itself claims
the empty string translation for its header.