### PR TITLE
ws: Handle x-host-key challenge

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -102,6 +102,30 @@ has the same options as the other authentication sections with the following add
  * ```connectToUnknownHosts```. By default cockpit will refuse to connect to any machines that
  are not already present in ssh's global known_hosts file (usually ```/etc/ssh/ssh_known_hosts```). Set this to ```true``` is to allow those connections to proceed.
 
+This uses the [cockpit-ssh](https://github.com/cockpit-project/cockpit/tree/master/src/ssh)
+bridge. After the user authentication with the `"*"` challenge, if the remote
+host is not already present in any local `known_hosts` file, this will send an
+`"x-host-key"` challenge:
+
+```
+{
+    "command": "authorize",
+    "challenge": "x-host-key"
+    "cookie": "cookie",
+}
+```
+
+The caller responds to that with either a valid key like below, or an empty
+string response if there is no available key.
+
+```
+{
+    "command": "authorize",
+    "cookie": "cookie",
+    "response": "ssh-rsa AAAA1234...",
+}
+```
+
 # Actions
 
 Setting an action can modify the behavior for an auth scheme. Currently two actions

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -780,6 +780,21 @@ on_transport_control (CockpitTransport *transport,
     }
   else if (g_str_equal (command, "authorize"))
     {
+      const gchar *challenge;
+
+      /* handle x-host-key challenge */
+      if (cockpit_json_get_string (options, "challenge", NULL, &challenge) && g_strcmp0 (challenge, "x-host-key") == 0)
+        {
+          const gchar *cookie;
+          g_return_val_if_fail (cockpit_json_get_string (options, "cookie", NULL, &cookie), FALSE);
+
+          /* return a negative answer; we handle unknown hosts interactively, or want to fail on them */
+          g_debug ("received x-host-key authorize challenge");
+          send_authorize_reply (session->transport, cookie, "");
+          return TRUE;
+        }
+
+      /* handle login ("*") challenge */
       g_debug ("received authorize challenge");
       if (session->authorize)
         json_object_unref (session->authorize);


### PR DESCRIPTION
Besides the login (`*`) challenge, cockpit-ssh can also challenge for 
`x-host-key` when trying to connect to unknown remote machines. Don't
treat them as login authorize challenges, but just return a negative
(empty) reply. In ws we handle unknown hosts interactively in the UI. 

This allows us to drop the `$COCKPIT_SSH_CHALLENGE_UNKNOWN_HOST_PRECONNECT`
special case/hack, which is curently applied everywhere for 
cockpit-bridge except for cockpit-ws. Now that ws knows how to deal with
these, we can clean up the protocol to always send the challenge.