### PR TITLE
bots: Adjust naughty override for 7891 for rhel-7.6 branch

### DIFF
--- a/bots/naughty/rhel-7/7891-selinux-denies-virtlogd-dbus-2
+++ b/bots/naughty/rhel-7/7891-selinux-denies-virtlogd-dbus-2
@@ -1,5 +1,5 @@
 Traceback (most recent call last):
-  File "test/verify/machineslib.py", line *, in testBasic
+  File "test/verify/*machines*", line *, in testBasic
     wait(lambda: "Linux version" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
 *
 Error: Condition did not become true.


### PR DESCRIPTION
The rhel-7.6 branch does not yet have the libvirt-dbus support, there
the test is still in test/verify/check-machines. Adjust the naughty
override to apply to both "check-machines" and "machineslib.py".