### PR TITLE
updates: Use PatternFly-React components

### DIFF
--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -20,7 +20,7 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import OnOffSwitch from "cockpit-components-onoff.jsx";
+import { Switch } from "patternfly-react";
 import * as Select from "cockpit-components-select.jsx";
 import { install_dialog } from "cockpit-components-install-dialog.jsx";
 
@@ -340,15 +340,16 @@ export default class AutoUpdates extends React.Component {
             <div className="header-buttons pk-updates--header pk-updates--header--auto" id="automatic">
                 <h2 className="pk-updates--header--heading">{_("Automatic Updates")}</h2>
                 <div className="pk-updates--header--actions">
-                    <OnOffSwitch.OnOffSwitch state={onOffState} enabled={!this.state.pending}
-                                             onChange={e => {
-                                                 if (!this.state.backend.installed) {
-                                                     install_dialog(this.state.backend.packageName)
-                                                             .then(() => { this.initializeBackend(true).then(() => { this.handleChange(e, null, null, null) }) }, () => null);
-                                                 } else {
-                                                     this.handleChange(e, null, null, null);
-                                                 }
-                                             }} />
+                    <Switch value={onOffState} disabled={this.state.pending}
+                         onChange={ev => {
+                             if (!this.state.backend.installed) {
+                                 install_dialog(this.state.backend.packageName)
+                                         .then(() => { this.initializeBackend(true).then(() => { this.handleChange(ev.state.value, null, null, null) }) }, () => null);
+                             } else {
+                                 this.handleChange(ev.state.value, null, null, null);
+                             }
+                         }}
+                    />
                 </div>
                 {autoConfig}
             </div>);

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -23,7 +23,7 @@ import React from "react";
 import ReactDOM from 'react-dom';
 
 import moment from "moment";
-import { Tooltip } from "cockpit-components-tooltip.jsx";
+import { OverlayTrigger, Tooltip } from "patternfly-react";
 import Markdown from "react-remarkable";
 import AutoUpdates from "./autoupdates.jsx";
 
@@ -268,7 +268,11 @@ class UpdateItem extends React.Component {
                 </React.Fragment>);
         }
 
-        var pkgList = this.props.pkgNames.map(n => (<Tooltip key={n} tip={packageSummaries[n]}><span>{n}</span></Tooltip>));
+        var pkgList = this.props.pkgNames.map(n => (
+            <OverlayTrigger overlay={ <Tooltip>{packageSummaries[n]}</Tooltip> } placement="top">
+                <span>{n}</span>
+            </OverlayTrigger>)
+        );
         var pkgs = insertCommas(pkgList);
         var pkgsTruncated = pkgs;
         if (pkgList.length > 4)
@@ -391,7 +395,11 @@ function UpdateHistory(props) {
     function formatPkgs(pkgs) {
         let names = Object.keys(pkgs).filter(i => i != "_time");
         names.sort();
-        return names.map(n => <Tooltip key={n} tip={ n + " " + pkgs[n] }><li>{n}</li></Tooltip>);
+        return names.map(n => (
+            <OverlayTrigger overlay={ <Tooltip>{ n + " " + pkgs[n] }</Tooltip> } placement="top">
+                <li>{n}</li>
+            </OverlayTrigger>)
+        );
     }
 
     let history = props.history;


### PR DESCRIPTION
This is my first attempt at replacing our custom Cockpit components with PF-React. The Toolbar and OnOffSwitch are pretty simple to replace, so let's do that for the Software Updates page to show how this works. From there it should be simple to apply that to other pages.

[Switch docs](https://patternfly-react.surge.sh/patternfly-3/?knob-Style=default&knob-Size=normal&knob-Submit%20Form%20On%20Enter=true&knob-On%20Color=primary&knob-Off%20Color=default&knob-animate=true&selectedKind=patternfly-react%2FWidgets%2FSwitch&selectedStory=Switch&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Fstories%2Fstories-panel)

For the record, there is no PF-React component for our "Select" component. The closest one is [Filter](https://patternfly-react.surge.sh/patternfly-3/?knob-Style=default&knob-Size=normal&knob-Submit%20Form%20On%20Enter=true&knob-On%20Color=primary&knob-Off%20Color=default&knob-animate=true&selectedKind=patternfly-react%2FForms%20and%20Controls%2FFilter&selectedStory=Filter&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Fstories%2Fstories-panel), which includes a Select button, but it's not available as a separate component.

List Views as replacement of our Listing component are available, though. But replacing this will be much more effort, given how complex our lists are.