### PR TITLE
networkmanager: Fix broken string interpolation

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -293,7 +293,7 @@ export class Firewall extends React.Component {
         if (!this.state.firewall.installed) {
             return (
                 <EmptyState title={_("Firewall is not available")} icon="fa fa-exclamation-circle">
-                    <p>{cockpit.format(_("Please install the {0} package"), "firewalld")}</p>
+                    <p>{cockpit.format(_("Please install the $0 package"), "firewalld")}</p>
                 </EmptyState>
             );
         }

--- a/po/ca.po
+++ b/po/ca.po
@@ -5529,8 +5529,8 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
-msgstr "Si us plau, instal·leu el paquet {0}"
+msgid "Please install the $0 package"
+msgstr "Si us plau, instal·leu el paquet $0"
 
 #: pkg/kubernetes/scripts/volumes.js:574
 msgid "Please provide a GlusterFS volume name"

--- a/po/cs.po
+++ b/po/cs.po
@@ -5727,8 +5727,8 @@ msgid "Please enter new volume size"
 msgstr "Zadejte velikost nového svazku"
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
-msgstr "Nainstalujte balíček {0}"
+msgid "Please install the $0 package"
+msgstr "Nainstalujte balíček $0"
 
 #: pkg/kubernetes/scripts/volumes.js:574
 msgid "Please provide a GlusterFS volume name"

--- a/po/da.po
+++ b/po/da.po
@@ -5584,7 +5584,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:292
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/de.po
+++ b/po/de.po
@@ -5568,7 +5568,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/es.po
+++ b/po/es.po
@@ -5645,8 +5645,8 @@ msgid "Please enter new volume size"
 msgstr "Introduzca el nuevo tamaño de volumen"
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
-msgstr "Por favor instale el paquete {0}"
+msgid "Please install the $0 package"
+msgstr "Por favor instale el paquete $0"
 
 #: pkg/kubernetes/scripts/volumes.js:574
 msgid "Please provide a GlusterFS volume name"

--- a/po/eu.po
+++ b/po/eu.po
@@ -5475,7 +5475,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/fi.po
+++ b/po/fi.po
@@ -5557,7 +5557,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/fr.po
+++ b/po/fr.po
@@ -5620,8 +5620,8 @@ msgid "Please enter new volume size"
 msgstr "Veuillez saisir une nouvelle taille de volume"
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
-msgstr "Veuillez installer le paquet {0}"
+msgid "Please install the $0 package"
+msgstr "Veuillez installer le paquet $0"
 
 #: pkg/kubernetes/scripts/volumes.js:574
 msgid "Please provide a GlusterFS volume name"

--- a/po/hr.po
+++ b/po/hr.po
@@ -5548,7 +5548,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/hu.po
+++ b/po/hu.po
@@ -5481,7 +5481,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/ja.po
+++ b/po/ja.po
@@ -5486,8 +5486,8 @@ msgid "Please enter new volume size"
 msgstr "新しいボリュームサイズを入力してください"
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
-msgstr "{0} パッケージをインストールしてください"
+msgid "Please install the $0 package"
+msgstr "$0 パッケージをインストールしてください"
 
 #: pkg/kubernetes/scripts/volumes.js:574
 msgid "Please provide a GlusterFS volume name"

--- a/po/ko.po
+++ b/po/ko.po
@@ -5530,7 +5530,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/my.po
+++ b/po/my.po
@@ -5460,7 +5460,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/nl.po
+++ b/po/nl.po
@@ -5489,7 +5489,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/pa.po
+++ b/po/pa.po
@@ -5476,7 +5476,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/pl.po
+++ b/po/pl.po
@@ -5601,8 +5601,8 @@ msgid "Please enter new volume size"
 msgstr "Proszę podać rozmiar nowego woluminu"
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
-msgstr "Proszę zainstalować pakiet {0}"
+msgid "Please install the $0 package"
+msgstr "Proszę zainstalować pakiet $0"
 
 #: pkg/kubernetes/scripts/volumes.js:574
 msgid "Please provide a GlusterFS volume name"

--- a/po/pt.po
+++ b/po/pt.po
@@ -5475,7 +5475,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5581,8 +5581,8 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
-msgstr "Por favor, instale o pacote {0}"
+msgid "Please install the $0 package"
+msgstr "Por favor, instale o pacote $0"
 
 #: pkg/kubernetes/scripts/volumes.js:574
 msgid "Please provide a GlusterFS volume name"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5549,7 +5549,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/tr.po
+++ b/po/tr.po
@@ -5537,7 +5537,7 @@ msgid "Please enter new volume size"
 msgstr ""
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
+msgid "Please install the $0 package"
 msgstr ""
 
 #: pkg/kubernetes/scripts/volumes.js:574

--- a/po/uk.po
+++ b/po/uk.po
@@ -5615,8 +5615,8 @@ msgid "Please enter new volume size"
 msgstr "Будь ласка, введіть розмір нового тому"
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
-msgstr "Будь ласка, встановіть пакунок {0}"
+msgid "Please install the $0 package"
+msgstr "Будь ласка, встановіть пакунок $0"
 
 #: pkg/kubernetes/scripts/volumes.js:574
 msgid "Please provide a GlusterFS volume name"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5482,8 +5482,8 @@ msgid "Please enter new volume size"
 msgstr "请输入新的卷大小"
 
 #: pkg/networkmanager/firewall.jsx:296
-msgid "Please install the {0} package"
-msgstr "请安装{0}软件包"
+msgid "Please install the $0 package"
+msgstr "请安装$0软件包"
 
 #: pkg/kubernetes/scripts/volumes.js:574
 msgid "Please provide a GlusterFS volume name"


### PR DESCRIPTION
`cockpit.format()` is not like Python's `.format()` :-)