### PR TITLE
test: Drop unused variables

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -239,7 +239,7 @@ def wait_lock(target):
         try:
             fcntl.flock(wait_lock.f, fcntl.LOCK_NB | fcntl.LOCK_EX)
             return
-        except BlockingIOError as e:
+        except BlockingIOError:
             if retry == 0:
                 print("Waiting for concurrent image-download of %s..." % os.path.basename(target))
             time.sleep(10)

--- a/test/avocado/timeoutlib.py
+++ b/test/avocado/timeoutlib.py
@@ -117,7 +117,7 @@ class Retry(object):
                         if not self.inverse:
                             return output
 
-                    except (self.exceptions + (TimeoutError,)) as e:
+                    except (self.exceptions + (TimeoutError,)):
                         if self.inverse:
                             return True
 
@@ -152,7 +152,7 @@ if __name__ == '__main__':
     try:
         do_something1(2, 4, 6, d = 97)
 
-    except IFailedError as e:
+    except IFailedError:
         retry = do_something1.func_closure[1].cell_contents
 
         assert len(white_horse) == 5
@@ -173,7 +173,7 @@ if __name__ == '__main__':
     try:
         do_something2(1, 2)
 
-    except IFailedError as e:
+    except IFailedError:
         retry = do_something2.func_closure[1].cell_contents
 
         assert not len(brown_horse)
@@ -189,7 +189,7 @@ if __name__ == '__main__':
     try:
         do_something3()
 
-    except IndexError as e:
+    except IndexError:
         retry = do_something3.func_closure[1].cell_contents
 
         assert retry.failed_attempts == 1
@@ -215,7 +215,7 @@ if __name__ == '__main__':
 
         do_something5()
 
-    except IFailedError as e:
+    except IFailedError:
         end_time = time.time()
 
         retry = do_something5.func_closure[1].cell_contents
@@ -236,7 +236,7 @@ if __name__ == '__main__':
     try:
         do_something6()
 
-    except IndexError as e:
+    except IndexError:
         retry = do_something6.func_closure[1].cell_contents
 
         assert retry.failed_attempts == 1

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1228,7 +1228,7 @@ class TestMachines(MachineCase):
                     b.wait_visible(system_item_selector)
                 # os found which is not ok
                 raise AssertionError("{0} was not filtered".format(self.os_name))
-            except AssertionError as e:
+            except AssertionError:
                 raise
             except Exception:
                 # os not found which is ok


### PR DESCRIPTION
Fixes errors with current pyflakes:

```
bots/image-download:242: local variable 'e' is assigned to but never used
not ok 1 pyflakes bots pkg tools
test/avocado/timeoutlib.py:120: local variable 'e' is assigned to but never used
test/avocado/timeoutlib.py:155: local variable 'e' is assigned to but never used
test/avocado/timeoutlib.py:176: local variable 'e' is assigned to but never used
test/avocado/timeoutlib.py:192: local variable 'e' is assigned to but never used
test/avocado/timeoutlib.py:218: local variable 'e' is assigned to but never used
test/avocado/timeoutlib.py:239: local variable 'e' is assigned to but never used
test/verify/machineslib.py:1231: local variable 'e' is assigned to but never used
not ok 2 pyflakes test
```