### PR TITLE
lib: Fix FileAutoComplete input

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -29,7 +29,7 @@ const _ = cockpit.gettext;
 class FileAutoComplete extends React.Component {
     constructor(props) {
         super(props);
-        var value = props.value || "";
+        const value = props.value || "";
         this.updateFiles(value);
         this.state = {
             value: value,
@@ -117,20 +117,18 @@ class FileAutoComplete extends React.Component {
     }
 
     delayedOnChange(ev) {
-        var self = this;
-        var value = ev.currentTarget.value;
+        const value = ev.currentTarget.value;
         if (this.timer)
             window.clearTimeout(this.timer);
 
         if (this.state.value !== value)
-            this.timer = window.setTimeout(function() {
-                self.onChange(value);
-                self.timer = null;
+            this.timer = window.setTimeout(() => {
+                this.onChange(value);
+                this.timer = null;
             }, 250);
     }
 
     updateFiles(path) {
-        var self = this;
         var channel = cockpit.channel({ payload: "fslist1",
                                         path: path || "/",
                                         superuser: this.props.superuser });
@@ -138,16 +136,16 @@ class FileAutoComplete extends React.Component {
         var results = [];
         var error = null;
 
-        channel.addEventListener("ready", function () {
-            self.finishUpdate(results, null);
+        channel.addEventListener("ready", () => {
+            this.finishUpdate(results, null);
         });
 
-        channel.addEventListener("close", function (ev, data) {
-            self.finishUpdate(results, error || cockpit.format(cockpit.message(data)));
+        channel.addEventListener("close", (ev, data) => {
+            this.finishUpdate(results, error || cockpit.format(cockpit.message(data)));
         });
 
-        channel.addEventListener("message", function (ev, data) {
-            var item = JSON.parse(data);
+        channel.addEventListener("message", (ev, data) => {
+            let item = JSON.parse(data);
             if (item && item.path) {
                 if (item.type == "directory")
                     item.path = item.path + "/";
@@ -162,8 +160,8 @@ class FileAutoComplete extends React.Component {
     }
 
     updateIfDirectoryChanged(value) {
-        var directory = this.getDirectoryForValue(value);
-        var changed = directory !== this.state.directory;
+        const directory = this.getDirectoryForValue(value);
+        const changed = directory !== this.state.directory;
         if (changed && this.state.directoryFiles !== null) {
             this.setState({
                 displayFiles: [],
@@ -177,9 +175,7 @@ class FileAutoComplete extends React.Component {
     }
 
     finishUpdate(results, error) {
-        results = results.sort(function(a, b) {
-            return a.path.localeCompare(b.path, { sensitivity: 'base' });
-        });
+        results = results.sort((a, b) => a.path.localeCompare(b.path, { sensitivity: 'base' }));
 
         this.onChangeCallback(this.state.value, {
             error,
@@ -194,19 +190,16 @@ class FileAutoComplete extends React.Component {
 
     filterFiles(value) {
         var inputValue = value.trim().toLowerCase();
-        var dirLength = this.state.directory.length;
+        const dirLength = this.state.directory.length;
         var matches = [];
-        var inputLength;
 
         inputValue = inputValue.slice(dirLength);
-        inputLength = inputValue.length;
+        const inputLength = inputValue.length;
 
         var error;
 
         if (this.state.directoryFiles !== null) {
-            matches = this.state.directoryFiles.filter(function (v) {
-                return v.path.toLowerCase().slice(0, inputLength) === inputValue;
-            });
+            matches = this.state.directoryFiles.filter(v => v.path.toLowerCase().slice(0, inputLength) === inputValue);
 
             if (matches.length < 1)
                 error = _("No matching files found");
@@ -269,7 +262,7 @@ class FileAutoComplete extends React.Component {
     }
 
     render() {
-        var placeholder = this.props.placeholder || _("Path to file");
+        const placeholder = this.props.placeholder || _("Path to file");
         var controlClasses = "form-control-feedback ";
         var classes = "input-group";
         if (this.state.open)

--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -43,7 +43,6 @@ class FileAutoComplete extends React.Component {
         this.onMouseDown = this.onMouseDown.bind(this);
         this.onChangeCallback = this.onChangeCallback.bind(this);
         this.onBlur = this.onBlur.bind(this);
-        this.delayedOnChange = this.delayedOnChange.bind(this);
         this.updateFiles = this.updateFiles.bind(this);
         this.updateIfDirectoryChanged = this.updateIfDirectoryChanged.bind(this);
         this.finishUpdate = this.finishUpdate.bind(this);
@@ -67,24 +66,6 @@ class FileAutoComplete extends React.Component {
             dir = "/" + dir;
 
         return dir;
-    }
-
-    onChange(value) {
-        if (value && value.indexOf("/") !== 0)
-            value = "/" + value;
-
-        var stateUpdate;
-        if (!this.updateIfDirectoryChanged(value))
-            stateUpdate = this.filterFiles(value);
-        else
-            stateUpdate = {};
-
-        stateUpdate.value = value;
-        this.setState(stateUpdate);
-
-        this.onChangeCallback(value, {
-            error: stateUpdate.error,
-        });
     }
 
     onChangeCallback(value, options) {
@@ -116,16 +97,27 @@ class FileAutoComplete extends React.Component {
         });
     }
 
-    delayedOnChange(ev) {
-        const value = ev.currentTarget.value;
+    onChange(ev) {
+        var value = ev.currentTarget.value;
+
+        if (value && value.indexOf("/") !== 0)
+            value = "/" + value;
+
         if (this.timer)
             window.clearTimeout(this.timer);
 
         if (this.state.value !== value)
             this.timer = window.setTimeout(() => {
-                this.onChange(value);
                 this.timer = null;
+
+                if (!this.updateIfDirectoryChanged(value)) {
+                    var stateUpdate = this.filterFiles(value);
+                    this.setState(stateUpdate);
+                    this.onChangeCallback(value, { error: stateUpdate.error });
+                }
             }, 250);
+
+        this.setState({ value });
     }
 
     updateFiles(path) {
@@ -289,7 +281,7 @@ class FileAutoComplete extends React.Component {
         return (
             <div className="combobox-container file-autocomplete-ct" id={this.props.id}>
                 <div className={classes}>
-                    <input ref="input" autoComplete="false" placeholder={placeholder} className="combobox form-control" type="text" onChange={this.delayedOnChange} value={this.state.value} onBlur={this.onBlur} />
+                    <input ref="input" autoComplete="false" placeholder={placeholder} className="combobox form-control" type="text" onChange={this.onChange} value={this.state.value} onBlur={this.onBlur} />
                     <span onClick={this.showAllOptions} className={controlClasses} />
                     <ul onMouseDown={this.onMouseDown} onClick={this.selectItem} className="typeahead typeahead-long dropdown-menu">
                         {listItems}


### PR DESCRIPTION
Moving to full React broke the input behaviour of the FileAutoComplete
component, as React (unlike react-lite) enforces controlled components.
When typing several keys at normal speed, all but one would get ignored,
due to the deferred state update.

Immediately update the value state in each change event instead, which
restores the normal responsiveness to key presses. In the deferred
timer, only do the directory reading/autocompletion, as before. As that
is small enough, fold this into the main `change` handler, which makes
the whole thing easier to understand as it's in one place.

https://bugzilla.redhat.com/show_bug.cgi?id=1637866
https://bugzilla.redhat.com/show_bug.cgi?id=1644195