### PR TITLE
containers: Run one semaphore test without bots/ directory

### DIFF
--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -33,6 +33,14 @@ esac
 
 bots/test-bots
 
+# bots/ is by and large an independent project, and for supporting stable
+# ranches, we want build/check/dist to work without it; so run everything
+# without bots/ in one run (to make sure this works), and keep it in the
+# others (to make sure its existence does not break anything)
+if [ "${CC:-}" = clang ]; then
+    rm -rf bots
+fi
+
 ./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
 
 make V=1 all


### PR DESCRIPTION
Distributed tarballs don't ship bots/, it is obsolete (and will soon be
removed) from stable branches, and for the most part bots/ is an
independent code base now.

Make sure that we can build, check, and dist without bots/ by running it
for one of our Semaphore test runs (clang). Don't do it for all of them
though, to make sure the presence of bots/ does not break anything.