### PR TITLE
naughty: Close 9996: PackageKit on fedora-29 shows no detailed information about updates

### DIFF
--- a/bots/naughty/fedora-29/9996-packagekit-list-update-details-empty
+++ b/bots/naughty/fedora-29/9996-packagekit-list-update-details-empty
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-packagekit", line *, in testSecurityOnly
-    self.assertEqual(b.text("#state"), "1 security fix")

--- a/bots/naughty/fedora-29/9996-packagekit-list-update-details-empty-2
+++ b/bots/naughty/fedora-29/9996-packagekit-list-update-details-empty-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-packagekit", line *, in testInfoSecurity
-    self.assertEqual(b.text("#state"), "* updates, including * security fixes")

--- a/bots/naughty/fedora-29/9996-packagekit-list-update-details-empty-3
+++ b/bots/naughty/fedora-29/9996-packagekit-list-update-details-empty-3
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-packagekit", line *, in testInfoTruncation
-    b.wait_in_text("table.listing-ct", "Things change")


### PR DESCRIPTION
Known issue which has not occurred in 21 days

PackageKit on fedora-29 shows no detailed information about updates

Fixes #9996