### PR TITLE
naughty: Close 9993: Kdump service crash on fedora-29

### DIFF
--- a/bots/naughty/fedora-29/9993-kdump-unhandled-rela-relocation
+++ b/bots/naughty/fedora-29/9993-kdump-unhandled-rela-relocation
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-kdump", line *, in testBasic
-    self.browser.wait_in_text("#app", "Service is running")


### PR DESCRIPTION
Known issue which has not occurred in 21 days

Kdump service crash on fedora-29

Fixes #9993