### PR TITLE
bots: Use libvirt XML instead of raw qemu args for bridge

### DIFF
--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -812,6 +812,7 @@ TEST_DOMAIN_XML="""
     <rng model='virtio'>
       <backend model='random'>/dev/urandom</backend>
     </rng>
+    {bridgedev}
   </devices>
   <qemu:commandline>
     {ethernet}
@@ -844,10 +845,11 @@ TEST_MCAST_XML="""
 """
 
 TEST_BRIDGE_XML="""
-    <qemu:arg value='-netdev'/>
-    <qemu:arg value='bridge,br={bridge},id=bridge0'/>
-    <qemu:arg value='-device'/>
-    <qemu:arg value='rtl8139,netdev=bridge0,mac={mac},bus=pci.0,addr=0x0f'/>
+    <interface type="bridge">
+      <source bridge="{bridge}"/>
+      <mac address="{mac}"/>
+      <model type="rtl8139"/>
+    </interface>
 """
 
 # Used to access SSH from the main host into the virtual machines
@@ -943,12 +945,15 @@ class VirtNetwork:
 
         if isolate:
             result["bridge"] = ""
+            result["bridgedev"] = ""
             result["ethernet"] = ""
         elif self.bridge:
             result["bridge"] = self.bridge
-            result["ethernet"] = TEST_BRIDGE_XML.format(**result)
+            result["bridgedev"] = TEST_BRIDGE_XML.format(**result)
+            result["ethernet"] = ""
         else:
             result["bridge"] = ""
+            result["bridgedev"] = ""
             result["ethernet"] = TEST_MCAST_XML.format(**result)
         result["forwards"] = ",".join(forwards)
         result["redir"] = TEST_REDIR_XML.format(**result)


### PR DESCRIPTION
In Fedora 29, `<qemu:arg>` does not work any more for defining a bridge,
as this breaks limitations of `-sandbox on`:

    $ test/vm-run --network cirros
    libvirt.libvirtError: internal error: qemu unexpectedly closed the monitor: 2018-10-31 07:15:57.311+0000: Domain id=8 is tainted: custom-argv
    2018-10-31T07:15:57.486306Z qemu-system-x86_64: bridge helper failed

qemu cannot run external programs like the bridge helper with
sandboxing.

Move the cockpit1 bridge definition to libvirt XML, in which case
libvirt starts the bridge helper by itself. Unfortunately the same does
not work for mcast; this ought to be

    <interface type="mcast">
      <source address="230.0.0.1" port="{mcast}"/>
      <mac address="{mac}"/>
      <model type="rtl8139"/>
    </interface>

but with that, there is no DHCP server for the VM and thus it does not
have any outside networking.

https://bugzilla.redhat.com/show_bug.cgi?id=1643853