### PR TITLE
common: Never send Content-Length with chunked encoding

### DIFF
--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -486,7 +486,7 @@ test_content_encoding (TestCase *tc,
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_SENT);
 
   g_assert_cmpstr (resp, ==, "HTTP/1.1 200 OK\r\nContent-Encoding: blah\r\n"
-                   "Content-Length: 50\r\nTransfer-Encoding: chunked\r\n"
+                   "Transfer-Encoding: chunked\r\n"
                    "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n\r\n"
                    "26\r\nCockpit is perfect for new sysadmins, \r\n0\r\n\r\n");
 }
@@ -544,7 +544,7 @@ test_pressure (TestCase *tc,
   g_signal_connect (tc->response, "pressure", G_CALLBACK (on_pressure_set_throttle), &throttle);
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_READY);
 
-  cockpit_web_response_headers (tc->response, 200, "OK", 11, NULL);
+  cockpit_web_response_headers (tc->response, 200, "OK", -1, NULL);
 
   g_assert_cmpint (cockpit_web_response_get_state (tc->response), ==, COCKPIT_WEB_RESPONSE_QUEUING);
 


### PR DESCRIPTION
This fixes loading of manifest.js and manifest.json with cypress' proxy, so that we can test the "Display Language"  dialog and translations.

This is WIP for now. This *does* fix the bug (see https://github.com/cockpit-project/starter-kit/pull/50), but I'm not yet sure if this is even the right direction. I'd appreciate a comment from @stefwalter here.

This also needs test cases.