### PR TITLE
packagekit: Always show empty state pattern for unsubscribed systems

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -787,6 +787,24 @@ class OsUpdates extends React.Component {
     renderContent() {
         var applySecurity, applyAll, unregisteredWarning;
 
+        if (this.state.unregistered) {
+            // always show empty state pattern, even if there are some repositories enabled that don't require subscriptions
+            return (
+                <div className="blank-slate-pf">
+                    <div className="blank-slate-pf-icon">
+                        <span className="fa fa-exclamation-circle" />
+                    </div>
+                    <h1>{_("This system is not registered")}</h1>
+                    <p>{_("To get software updates, this system needs to be registered with Red Hat, either using the Red Hat Customer Portal or a local subscription server.")}</p>
+                    <div className="blank-slate-pf-main-action">
+                        <button className="btn btn-lg btn-primary"
+                            onClick={ () => cockpit.jump("/subscriptions", cockpit.transport.host) }>
+                            {_("Register…")}
+                        </button>
+                    </div>
+                </div>);
+        }
+
         switch (this.state.state) {
         case "loading":
         case "refreshing":
@@ -803,25 +821,7 @@ class OsUpdates extends React.Component {
                 return <div className="spinner spinner-lg progress-main-view" />;
 
         case "available":
-            // when unregistered, hide the Apply buttons and show a warning
-            if (this.state.unregistered) {
-                unregisteredWarning = (
-                    <React.Fragment>
-                        <h2>{ _("Unregistered System") }</h2>
-                        <div className="alert alert-warning">
-                            <span className="pficon pficon-warning-triangle-o" />
-                            <span>
-                                <strong>{ _("Updates are disabled.") }</strong>
-                                    &nbsp;
-                                { _("You need to re-subscribe this system.") }
-                            </span>
-                            <button className="btn btn-primary pull-right"
-                                onClick={ () => cockpit.jump("/subscriptions", cockpit.transport.host) }>
-                                { _("View Registration Details") }
-                            </button>
-                        </div>
-                    </React.Fragment>);
-            } else {
+            {
                 let num_updates = Object.keys(this.state.updates).length;
                 let num_security_updates = count_security_updates(this.state.updates);
 
@@ -895,23 +895,6 @@ class OsUpdates extends React.Component {
                 </div>);
 
         case "uptodate":
-            if (this.state.unregistered) {
-                return (
-                    <div className="blank-slate-pf">
-                        <div className="blank-slate-pf-icon">
-                            <span className="fa fa-exclamation-circle" />
-                        </div>
-                        <h1>{_("This system is not registered")}</h1>
-                        <p>{_("To get software updates, this system needs to be registered with Red Hat, either using the Red Hat Customer Portal or a local subscription server.")}</p>
-                        <div className="blank-slate-pf-main-action">
-                            <button className="btn btn-lg btn-primary"
-                                onClick={ () => cockpit.jump("/subscriptions", cockpit.transport.host) }>
-                                {_("Register…")}
-                            </button>
-                        </div>
-                    </div>);
-            }
-
             return (
                 <React.Fragment>
                     <AutoUpdates onInitialized={ enabled => this.setState({ autoUpdatesEnabled: enabled }) } />

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -719,17 +719,16 @@ class TestUpdatesSubscriptions(PackageCase):
         b.wait_in_text("#system_information_updates_text", "Not Registered")
         self.assertIn("triangle", b.attr("#system_information_updates_icon", "class"))
 
-        # and also on software updates page
+        # software updates page also shows unregistered
         b.go("/updates")
         b.enter_page("/updates")
-
         # empty state visible in main area
         b.wait_present(".container-fluid div.blank-slate-pf button")
         b.wait_in_text(".container-fluid div.blank-slate-pf", "This system is not registered")
-        # hides the header bar
-        self.assertFalse(b.is_present(".content-header-extra"))
+        # no header bar
+        b.wait_not_present(".content-header-extra")
 
-        # use the button to switch to Subscriptions
+        # test the button to switch to Subscriptions
         b.click(".container-fluid div.blank-slate-pf button")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname === "/subscriptions"')
@@ -772,35 +771,27 @@ class TestUpdatesSubscriptions(PackageCase):
         b.click("#system_information_updates_text a")
         b.enter_page("/subscriptions")
 
-        # /updates should show available update and unregistered warning, but no other action buttons
+        # software updates page also shows unregistered
         b.go("/updates")
         b.enter_page("/updates")
-        b.wait_present(".alert-warning")
-        b.wait_in_text(".alert-warning", "subscribe")
-        b.wait_present("table.listing-ct")
-        b.wait_in_text("table.listing-ct", "vanilla")
+
+        # empty state visible in main area
+        b.wait_present(".container-fluid div.blank-slate-pf button")
+        b.wait_in_text(".container-fluid div.blank-slate-pf", "This system is not registered")
+
         # should show header bar
         b.wait_present("#state")
-        self.assertEqual(b.text("#state"), "1 update")
-        b.wait_present(".content-header-extra")
+        b.wait_text("#state", "1 update")
         b.wait_text(".content-header-extra--updated", "Last checked: a few seconds ago")
-        # should be unique; no other action buttons
-        b.wait_present("button")
-        b.wait_in_text("button", "Registration")
 
-        # use the button to switch to Subscriptions
-        b.click("button")
-        b.switch_to_top()
-        b.wait_js_cond('window.location.pathname === "/subscriptions"')
-
-        # after registration it should show the usual "system is up to date"
+        # after registration it should show available updates
         self.register()
         b.go("/updates")
         b.enter_page("/updates")
-        b.wait_not_present(".alert-warning")
-        # no update history yet, no warning any more
+        b.wait_not_present(".container-fluid div.blank-slate-pf")
         b.wait_present("#available h2")
         b.wait_in_text("#available h2", "Available Updates")
+        # no update history yet
         self.assertFalse(b.is_present("#history"))
 
         # has action buttons


### PR DESCRIPTION
Usability tests have shown that listing available updates while the
system is not subscribed does more harm than good, and confuses too many
users. It's also a corner case, mostly just when you use third-party
repositories like COPR/EPEL that are not restricted by subscriptions.

Remove that case and always show the empty state pattern if the system
is unsubscribed. Still keep the header bar though, to give at least some
indication that updates are available.

Fixes #9926