### PR TITLE
networkmanager: Fix enabling firewalld on Firewall page

### DIFF
--- a/bots/naughty/rhel-x/9722-firewalld-bad-rule-3
+++ b/bots/naughty/rhel-x/9722-firewalld-bad-rule-3
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "test/verify/check-networking-firewall", line *, in testNetworkingPage
+    m.execute("systemctl stop firewalld")
+*
+RuntimeError: Timed out on 'systemctl stop firewalld'

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -35,34 +35,40 @@ def wait_unit_state(machine, unit, state):
 
 
 @skipImage("firewalld not installed", "fedora-atomic", "rhel-atomic", "continuous-atomic", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1804")
+@skipImage("enabling firewall got fixed in PR #10511", "rhel-7-6-distropkg")
 class TestFirewall(MachineCase):
 
     def testNetworkingPage(self):
         b = self.browser
         m = self.machine
 
+        m.execute("systemctl stop firewalld")
+
         self.login_and_go("/network")
         b.wait_visible("#networking-firewall")
-
-        m.execute("systemctl stop firewalld")
         b.wait_in_text("#networking-firewall-switch label.active", "Off")
-        m.execute("systemctl start firewalld")
-        b.wait_in_text("#networking-firewall-switch label.active", "On")
 
         # to toggle the switch, click on the non-active label, where the slider is
+        b.click("#networking-firewall-switch label:not(.active)")
+        b.wait_present("#networking-firewall-switch label.active:not(.disabled)")
+        b.wait_in_text("#networking-firewall-switch label.active", "On")
+        wait_unit_state(m, "firewalld", "active")
+        active_rules = m.execute("firewall-cmd --list-services").split()
+        b.wait_in_text("#networking-firewall-summary", "{} Active Rule".format(len(active_rules)))
+
         b.click("#networking-firewall-switch label:not(.active)")
         b.wait_present("#networking-firewall-switch label.active:not(.disabled)")
         b.wait_in_text("#networking-firewall-switch label.active", "Off")
         wait_unit_state(m, "firewalld", "inactive")
         b.wait_in_text("#networking-firewall-summary", "0 Active Rules")
 
-        b.click("#networking-firewall-switch label:not(.active)")
-        b.wait_present("#networking-firewall-switch label.active:not(.disabled)")
+        # toggle the service from CLI, page should react
+        m.execute("systemctl start firewalld")
         b.wait_in_text("#networking-firewall-switch label.active", "On")
-        wait_unit_state(m, "firewalld", "active")
-
-        active_rules = m.execute("firewall-cmd --list-services").split()
         b.wait_in_text("#networking-firewall-summary", "{} Active Rule".format(len(active_rules)))
+        m.execute("systemctl stop firewalld")
+        b.wait_in_text("#networking-firewall-switch label.active", "Off")
+        b.wait_in_text("#networking-firewall-summary", "0 Active Rules")
 
         b.click("#networking-firewall-link")
         b.enter_page("/network/firewall")
@@ -70,13 +76,20 @@ class TestFirewall(MachineCase):
         b.click(".breadcrumb li:first a")
         b.enter_page("/network")
 
-
     def testFirewallPage(self):
         b = self.browser
         m = self.machine
 
+        m.execute("systemctl stop firewalld")
         self.login_and_go("/network/firewall")
-        m.execute("systemctl start firewalld")
+
+        # to toggle the switch, click on the non-active label, where the slider is
+        b.wait_present(".btn-onoff-ct label.active")
+        b.wait_in_text(".btn-onoff-ct label.active", "Off")
+        b.click(".btn-onoff-ct label.active span")
+        b.wait_present(".btn-onoff-ct label.active:not(.disabled)")
+        b.wait_in_text(".btn-onoff-ct label.active", "On")
+        wait_unit_state(m, "firewalld", "active")
 
         # ensure that pop3 is not enabled (shouldn't be on any of our images),
         # so that we can use it for testing
@@ -96,6 +109,12 @@ class TestFirewall(MachineCase):
         b.click("tr[data-row-id='pop3'] .btn.pficon-delete")
         b.wait_not_present("tr[data-row-id='pop3']")
         self.assertNotIn('pop3', m.execute("firewall-cmd --list-services").split())
+
+        # switch service off again
+        b.click(".btn-onoff-ct label.active span")
+        b.wait_present(".btn-onoff-ct label.active:not(.disabled)")
+        b.wait_in_text(".btn-onoff-ct label.active", "Off")
+        wait_unit_state(m, "firewalld", "inactive")
 
 
     def testAddServices(self):


### PR DESCRIPTION
Enabling the firewall on the Network » Firewall page depends on the
firewalld D-Bus client "owner" signal to fire. This works if the
cockpit.dbus() proxy got instantiated at a time when the D-Bus service was
running (or at least activatable), but it's completely dead if not. This
caused the On/Off button to forever remain in disabled state.

https://github.com/cockpit-project/cockpit/pull/9125 attempts to fix
this in a generic way, but it's apparently a bit problematic to land
this. So work around that by re-initializing the FirewallD1 D-Bus client
and its subscriptions when firewalld.service goes to state "running".

Adjust the tests to start with firewalld being disabled, which
exposes the bug in both test cases. Previously the test was cheating by
pre-starting firewalld on the command line.

Fixes #10501