### PR TITLE
kdump: Settings dialog dump target fixes

### DIFF
--- a/pkg/kdump/config-client.es6
+++ b/pkg/kdump/config-client.es6
@@ -128,7 +128,7 @@ export class ConfigFile {
         let linesToDelete = [];
         // first find the settings lines that have been disabled/deleted
         Object.keys(this._originalSettings).forEach((key) => {
-            if (!(key in settings)) {
+            if (!(key in settings) || !(key in settings && settings[key].value)) {
                 let origEntry = this._originalSettings[key];
                 // if the line had a comment, keep it, otherwise delete
                 if (origEntry.comment !== undefined)
@@ -137,6 +137,7 @@ export class ConfigFile {
                     linesToDelete.push(origEntry.index);
             }
         });
+
         // we take the lines from our last read operation and modify them with the new settings
         Object.keys(settings).forEach((key) => {
             let entry = settings[key];
@@ -158,7 +159,7 @@ export class ConfigFile {
                     lines.splice(lineIndex, 1);
                 });
 
-        return lines.join("\n");
+        return lines.join("\n") + "\n";
     }
 
     /* write settings back to file

--- a/pkg/kdump/kdump-client.es6
+++ b/pkg/kdump/kdump-client.es6
@@ -147,15 +147,20 @@ export class KdumpClient {
             if (target.target != "unknown")
                 target.multipleTargets = true;
             target.target = "nfs";
-            target.mount = settings.nfs;
+            target.nfs = settings.nfs;
             if ("path" in settings)
                 target.path = settings.path;
         } else if ("ssh" in settings) {
             if (target.target != "unknown")
                 target.multipleTargets = true;
+            target.target = "ssh";
+            target.ssh = settings.ssh;
+            target.sshkey = settings.sshkey;
         } else if ("raw" in settings) {
             if (target.target != "unknown")
                 target.multipleTargets = true;
+            target.target = "raw";
+            target.raw = settings.raw;
         } else {
             // probably local, but we might also have a mount
             // check all keys against known keys, the ones left over may be a mount target
@@ -164,7 +169,7 @@ export class KdumpClient {
                 if (!key || key in knownKeys || key in deprecatedKeys)
                     return;
                 // if we have a UUID, LABEL or /dev in the value, we can be pretty sure it's a mount option
-                var value = String(settings[key]).toLowerCase();
+                var value = JSON.stringify(settings[key]).toLowerCase();
                 if (value.indexOf("uuid") > -1 || value.indexOf("label") > -1 || value.indexOf("/dev") > -1) {
                     if (target.target != "unknown")
                         target.multipleTargets = true;

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -35,13 +35,11 @@ const _ = cockpit.gettext;
  *   - initialTarget      initial target, e.g. "local"
  *   - compressionEnabled whether compression is enabled for all targets
  *
- * Internally, the dialog has four modes, defined by target storage:
+ * Internally, the dialog has three modes, defined by target storage:
  *   - local
  *   - nfs
  *   - ssh
- *   - other This is used if the config file has no known target explicitly set
  *
- * nfs and ssh are disabled for now
  */
 
 class KdumpTargetBody extends React.Component {
@@ -54,19 +52,14 @@ class KdumpTargetBody extends React.Component {
     }
 
     changeLocation(target) {
-        // if previous dest wasn't "other", remove that
         // settings for the new target will be changed when the details are edited
-        if (this.state.storeDest != "other")
-            this.props.onChange(this.state.storeDest.target, undefined);
+        this.props.onChange("target", target);
         // depending on our chosen target, we should send the default values we show in the ui
         this.setState({ storeDest: target });
     }
 
     changeValue(key, e) {
-        if (this.props.onChange) {
-            if (e && e.target && e.target.value)
-                this.props.onChange(key, e.target.value);
-        }
+        this.props.onChange(key, e.target.value);
     }
 
     handleCompressionClick(e) {
@@ -81,10 +74,11 @@ class KdumpTargetBody extends React.Component {
             !("core_collector" in this.props.settings) ||
             (this.props.settings["core_collector"].value.trim().indexOf("makedumpfile") === 0)
         );
+        var directory = "";
+        if (this.props.settings && "path" in this.props.settings)
+            directory = this.props.settings["path"].value;
+
         if (this.state.storeDest == "local") {
-            var directory;
-            if (this.props.settings && "path" in this.props.settings)
-                directory = this.props.settings["path"].value;
             detailRows = (
                 <tr key="directory">
                     <td className="top">
@@ -101,7 +95,7 @@ class KdumpTargetBody extends React.Component {
                 </tr>
             );
         } else if (this.state.storeDest == "nfs") {
-            var nfs;
+            var nfs = "";
             if (this.props.settings && "nfs" in this.props.settings)
                 nfs = this.props.settings["nfs"].value;
             detailRows = (
@@ -121,10 +115,10 @@ class KdumpTargetBody extends React.Component {
                 </tr>
             );
         } else if (this.state.storeDest == "ssh") {
-            var ssh;
+            var ssh = "";
             if (this.props.settings && "ssh" in this.props.settings)
                 ssh = this.props.settings["ssh"].value;
-            var sshkey;
+            var sshkey = "";
             if (this.props.settings && "sshkey" in this.props.settings)
                 sshkey = this.props.settings["sshkey"].value;
             detailRows = [
@@ -135,11 +129,9 @@ class KdumpTargetBody extends React.Component {
                         </label>
                     </td>
                     <td>
-                        <label>
-                            <input id="kdump-settings-ssh-server" className="form-control" type="text"
-                                   placeholder="user@server.com" value={ssh}
-                                   onChange={this.changeValue.bind(this, "ssh")} />
-                        </label>
+                        <input id="kdump-settings-ssh-server" className="form-control" type="text"
+                               placeholder="user@server.com" value={ssh}
+                               onChange={this.changeValue.bind(this, "ssh")} />
                     </td>
                 </tr>),
                 (<tr key="ssh-key">
@@ -149,29 +141,34 @@ class KdumpTargetBody extends React.Component {
                         </label>
                     </td>
                     <td>
-                        <label>
-                            <input id="kdump-settings-ssh-server" className="form-control" type="text"
-                                   placeholder="/root/.ssh/kdump_id_rsa" value={sshkey}
-                                   onChange={this.changeValue.bind(this, "sshkey")} />
+                        <input id="kdump-settings-ssh-key" className="form-control" type="text"
+                               placeholder="/root/.ssh/kdump_id_rsa" value={sshkey}
+                               onChange={this.changeValue.bind(this, "sshkey")} />
+                    </td>
+                </tr>),
+                (<tr key="directory">
+                    <td className="top">
+                        <label className="control-label">
+                            {_("Directory")}
                         </label>
+                    </td>
+                    <td>
+                        <input id="kdump-settings-local-directory" className="form-control" type="text"
+                               placeholder="/var/crash" value={directory}
+                               data-stored={directory}
+                               onChange={this.changeValue.bind(this, "path")} />
                     </td>
                 </tr>),
             ];
         }
-        /* some options are disabled for now
-               <Select.SelectEntry data='nfs' key='nfs'>{targetDescription.nfs}</Select.SelectEntry>
-               <Select.SelectEntry data='ssh' key='ssh'>{targetDescription.ssh}</Select.SelectEntry>
-         */
+
         var targetDescription = {
             local: _("Local Filesystem"),
             nfs: _("Remote over NFS"),
             ssh: _("Remote over SSH"),
-            other: _("Use the setting in /etc/kdump.conf"),
         };
         // we don't support all known storage options currently
         var storageDest = this.state.storeDest;
-        if (["local", "other"].indexOf(this.state.storeDest) === -1)
-            storageDest = "other";
         return (
             <div className="modal-body">
                 <table className="form-table-ct">
@@ -186,7 +183,8 @@ class KdumpTargetBody extends React.Component {
                                 <Select.Select key='location' onChange={this.changeLocation}
                                                id="kdump-settings-location" initial={storageDest}>
                                     <Select.SelectEntry data='local' key='local'>{targetDescription.local}</Select.SelectEntry>
-                                    <Select.SelectEntry data='other' key='other'>{targetDescription.other}</Select.SelectEntry>
+                                    <Select.SelectEntry data='ssh' key='ssh'>{targetDescription.ssh}</Select.SelectEntry>
+                                    <Select.SelectEntry data='nfs' key='nfs'>{targetDescription.nfs}</Select.SelectEntry>
                                 </Select.Select>
                             </td>
                         </tr>
@@ -251,18 +249,15 @@ class KdumpPage extends React.Component {
     changeSetting(key, value) {
         var settings = this.state.dialogSettings;
 
-        // is compression enabled in the current config?
-        var compressionEnabled = this.compressionStatus(this.props.kdumpStatus.config);
-
         // a few special cases, otherwise write to config directly
         if (key == "compression") {
-            if (value && !compressionEnabled) {
+            if (value) {
                 // enable compression
                 if ("core_collector" in settings)
                     settings["core_collector"].value = settings["core_collector"].value + " -c";
                 else
                     settings["core_collector"] = { value: "makedumpfile -c" };
-            } else if (!value && compressionEnabled) {
+            } else {
                 // disable compression
                 if ("core_collector" in this.props.kdumpStatus.config) {
                     // just remove all "-c" parameters
@@ -276,12 +271,37 @@ class KdumpPage extends React.Component {
                     // we can get rid of the entry altogether
                     delete settings["core_collector"];
                 }
-            } else {
-                console.log("not changing compression setting");
-                return;
+            }
+        } else if (key === "target") {
+            /* target changed, restore settings and wipe all settings associated
+             * with a target so no conflicting settings remain */
+            settings = {};
+            Object.keys(this.props.kdumpStatus.config).forEach((key) => {
+                settings[key] = cockpit.extend({}, this.props.kdumpStatus.config[key]);
+            });
+            Object.keys(this.props.kdumpStatus.target).forEach((key) => {
+                if (settings[key])
+                    delete settings[key];
+            });
+            if (value === "ssh")
+                settings.ssh = { value: "" };
+            else if (value === "nfs")
+                settings.nfs = { value: "" };
+
+            if ("core_collector" in settings &&
+                settings["core_collector"].value.includes("makedumpfile")) {
+                /* ssh target needs a flattened vmcore for transport */
+                if (value === "ssh" && !settings["core_collector"].value.includes("-F"))
+                    settings["core_collector"].value += " -F";
+                else if (settings["core_collector"].value.includes("-F"))
+                    settings["core_collector"].value =
+                        settings["core_collector"].value
+                                .split(" ")
+                                .filter(e => e != "-F")
+                                .join(" ");
             }
         } else if (key !== undefined) {
-            if (value === undefined) {
+            if (!value) {
                 if (settings[key])
                     delete settings[key];
             } else {
@@ -292,12 +312,11 @@ class KdumpPage extends React.Component {
             }
         }
         this.setState({ dialogSettings: settings });
-        this.state.dialogObj.updateDialogBody();
+        this.state.dialogObj.updateDialogBody(settings);
         this.state.dialogObj.render();
     }
 
     handleApplyClick() {
-        // TODO test settings (e.g. path writable, nfs mountable, ssh key works)
         var dfd = cockpit.defer();
         this.props.onApplySettings(this.state.dialogSettings)
                 .done(dfd.resolve)
@@ -361,12 +380,12 @@ class KdumpPage extends React.Component {
             title: _("Crash dump location"),
             id: "kdump-settings-dialog"
         };
-        var updateDialogBody = function() {
+        var updateDialogBody = function(newSettings) {
             dialogProps.body = React.createElement(KdumpTargetBody, {
-                settings: settings,
+                settings: newSettings || settings,
                 onChange: self.changeSetting,
                 initialTarget: self.props.kdumpStatus.target,
-                compressionEnabled: self.compressionStatus(settings)
+                compressionEnabled: self.compressionStatus(newSettings || settings)
             });
         };
         updateDialogBody();
@@ -382,7 +401,7 @@ class KdumpPage extends React.Component {
         };
         var dialogObj = dialogPattern.show_modal_dialog(dialogProps, footerProps);
         dialogObj.updateDialogBody = updateDialogBody;
-        this.setState({ dialogSettings: settings, dialogObj: dialogObj });
+        this.setState({ dialogSettings: settings, dialogTarget: self.props.kdumpStatus.target, dialogObj: dialogObj });
     }
 
     render() {
@@ -411,8 +430,12 @@ class KdumpPage extends React.Component {
                     kdumpLocation = _("Remote over NFS");
                 } else if (target.target == "raw") {
                     kdumpLocation = _("Raw to a device");
+                    targetCanChange = false;
                 } else if (target.target == "mount") {
+                    /* mount targets outside of nfs are too complex for the
+                     * current target dialog */
                     kdumpLocation = _("On a mounted device");
+                    targetCanChange = false;
                 } else {
                     kdumpLocation = _("No configuration found");
                     targetCanChange = false;

--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -33,7 +33,7 @@ var initStore = function(rootElement) {
 
     dataStore.applySettings = function(settings) {
         var dfd = cockpit.defer();
-        dataStore.kdumpClient.testWriteLocation(settings)
+        dataStore.kdumpClient.validateSettings(settings)
             .done(function() {
                 dataStore.kdumpClient.writeSettings(settings)
                     .done(dfd.resolve)

--- a/pkg/kdump/test-config-client.js
+++ b/pkg/kdump/test-config-client.js
@@ -40,7 +40,8 @@ var changedConfig = [
     "indented value",
     "",
     "#key value #comment",
-    "hooray value"
+    "hooray value",
+    ""
 ].join("\n");
 
 QUnit.asyncTest("config_update", function() {

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -44,6 +44,12 @@ class TestKdump(MachineCase):
             self.machine.execute("grub2-mkconfig -o /boot/grub2/grub.cfg")
         self.machine.execute("mkdir -p /var/crash")
 
+    def enableLocalSsh(self):
+        self.machine.execute("[ -f /root/.ssh/id_rsa ] || ssh-keygen -t rsa -N '' -f /root/.ssh/id_rsa")
+        self.machine.execute("cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys")
+        self.machine.execute("ssh-keyscan -H localhost >> /root/.ssh/known_hosts")
+
+
     def rebootMachine(self):
         # Now reboot things
         self.machine.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
@@ -103,25 +109,58 @@ class TestKdump(MachineCase):
         self.enableKdump()
         self.rebootMachine()
         self.browser.wait_visible("#app")
+        self.enableLocalSsh()
+
+        if self.machine.image not in ["rhel-7-6-distropkg"]:
+            # generate a valid kdump config with ssh target
+            settingsLink = "a:contains('locally in /var/crash')"
+            self.browser.wait_present(settingsLink)
+            self.browser.wait_visible(settingsLink)
+            self.browser.click(settingsLink, True)
+            self.browser.wait_present("#kdump-settings-location")
+            self.browser.click("#kdump-settings-location")
+            self.browser.wait_present("a:contains('Remote over SSH')")
+            self.browser.click("a:contains('Remote over SSH')")
+            sshInput = "#kdump-settings-ssh-server"
+            self.browser.wait_present(sshInput)
+            self.browser.wait_visible(sshInput)
+            self._type_val(sshInput, "root@localhost")
+            sshKeyInput = "#kdump-settings-ssh-key"
+            self.browser.wait_present(sshKeyInput)
+            self.browser.wait_visible(sshKeyInput)
+            self._type_val(sshKeyInput, "/root/.ssh/id_rsa")
+            pathInput = "#kdump-settings-local-directory"
+            self.browser.wait_present(pathInput)
+            self.browser.wait_visible(pathInput)
+            self._type_val(pathInput, "/var/crash")
+            self.browser.click("button.btn-primary:contains('Apply')")
+            self.browser.wait_not_present(pathInput)
 
         # we should have the amount of memory reserved that we indicated
         self.browser.wait_in_text("#app", "256 MiB")
         # service should start up properly and the button should be on
         self.browser.wait_in_text("#app", "Service is running")
         self.browser.wait_in_text(onOffSelectorActive, "On")
+        self.browser.wait_in_text("#app", "Service is running")
 
-        customPath = "/var/crash2"
         # try to change the path to a directory that doesn't exist
-        settingsLink = "a:contains('locally in /var/crash')"
+        customPath = "/var/crash2"
+        # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1536327
+        if self.machine.image in ["rhel-7-6-distropkg"]:
+            return
+        else:
+            settingsLink = "a:contains('Remote over SSH')"
         self.browser.wait_present(settingsLink)
         self.browser.wait_visible(settingsLink)
         self.browser.click(settingsLink, True)
+        self.browser.wait_present("#kdump-settings-location")
+        self.browser.click("#kdump-settings-location")
+        self.browser.wait_present("a:contains('Local Filesystem')")
+        self.browser.click("a:contains('Local Filesystem')")
         pathInput = "#kdump-settings-local-directory"
         self.browser.wait_present(pathInput)
         self.browser.wait_visible(pathInput)
         self._type_val(pathInput, customPath)
-        # make sure the backend is updated before we try hitting apply
-        self.browser.wait_attr(pathInput, "data-stored", customPath)
         self.browser.click("button.btn-primary:contains('Apply')")
         # we should get an error
         self.browser.wait_present("div.dialog-error:contains('Unable to apply settings')")

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -71,155 +71,154 @@ class TestKdump(MachineCase):
         b.key_press(value)
 
     def testBasic(self):
-        self.browser.wait_timeout(120)
+        b = self.browser
+        m = self.machine
 
+        b.wait_timeout(120)
         self.allow_restart_journal_messages()
 
-        if not "atomic" in self.machine.image:
-            self.machine.execute("systemctl enable kdump && systemctl start kdump || true")
+        if not "atomic" in m.image:
+            m.execute("systemctl enable kdump && systemctl start kdump || true")
 
         self.login_and_go("/kdump")
 
-        self.browser.wait_visible("#app")
+        b.wait_visible("#app")
 
         onOffSelectorActive = "div.btn-onoff-ct label.active"
 
-        if self.machine.image in ["rhel-x"]:
+        if m.image in ["rhel-x"]:
             # some OSes have kdump enabled by default (crashkernel=auto)
-            self.browser.wait_in_text("#app", "Service is running")
-            self.browser.wait_in_text(onOffSelectorActive, "On")
+            b.wait_in_text("#app", "Service is running")
+            b.wait_in_text(onOffSelectorActive, "On")
         else:
             # right now we have no memory reserved
-            if self.machine.image in ["rhel-7-5-distropkg", "rhel-7-6-distropkg"]:
+            if m.image in ["rhel-7-5-distropkg", "rhel-7-6-distropkg"]:
                 # Old cockpit-system versions used custom Tooltip component
-                self.browser.wait_in_text("#app", "No memory reserved.")
+                b.wait_in_text("#app", "No memory reserved.")
             else:
-                self.browser.wait_present("#app span.popover-ct-kdump")
-                self.browser.mouse("#app span.popover-ct-kdump", "mouseover")
-                self.browser.wait_present("div.tooltip")
-                self.browser.wait_in_text("div.tooltip", "No memory reserved.")
-                self.browser.mouse("#app span.popover-ct-kdump", "mouseout")
+                b.wait_present("#app span.popover-ct-kdump")
+                b.mouse("#app span.popover-ct-kdump", "mouseover")
+                b.wait_present("div.tooltip")
+                b.wait_in_text("div.tooltip", "No memory reserved.")
+                b.mouse("#app span.popover-ct-kdump", "mouseout")
             # service should indicate an error and the button should be off
-            self.browser.wait_in_text("#app", "Service has an error")
-            self.browser.wait_in_text(onOffSelectorActive, "Off")
+            b.wait_in_text("#app", "Service has an error")
+            b.wait_in_text(onOffSelectorActive, "Off")
 
         # there shouldn't be any crash reports in the target directory
-        self.assertEqual(self.machine.execute("""find "/var/crash" -maxdepth 1 -mindepth 1 -type d -exec echo {} \;"""), "")
+        self.assertEqual(m.execute("""find "/var/crash" -maxdepth 1 -mindepth 1 -type d -exec echo {} \;"""), "")
 
         self.enableKdump()
         self.rebootMachine()
-        self.browser.wait_visible("#app")
+        b.wait_visible("#app")
         self.enableLocalSsh()
 
-        if self.machine.image not in ["rhel-7-6-distropkg"]:
+        if m.image not in ["rhel-7-6-distropkg"]:
             # minimal nfs validation
             settingsLink = "a:contains('locally in /var/crash')"
-            self.browser.wait_present(settingsLink)
-            self.browser.wait_visible(settingsLink)
-            self.browser.click(settingsLink, True)
-            self.browser.wait_present("#kdump-settings-location")
-            self.browser.click("#kdump-settings-location")
-            self.browser.wait_present("a:contains('Remote over NFS')")
-            self.browser.click("a:contains('Remote over NFS')")
+            b.wait_present(settingsLink)
+            b.click(settingsLink, True)
+            b.wait_present("#kdump-settings-location")
+            b.click("#kdump-settings-location")
+            b.wait_present("a:contains('Remote over NFS')")
+            b.click("a:contains('Remote over NFS')")
             mountInput = "#kdump-settings-nfs-mount"
-            self.browser.wait_present(mountInput)
-            self.browser.wait_visible(mountInput)
+            b.wait_present(mountInput)
             self._type_val(mountInput, ":/var/crash")
-            self.browser.click("button.btn-primary:contains('Apply')")
-            self.browser.wait_present("div.dialog-error:contains('Unable to apply settings')")
+            b.click("button.btn-primary:contains('Apply')")
+            b.wait_present("div.dialog-error:contains('Unable to apply settings')")
             self._type_val(mountInput, "localhost:");
-            self.browser.click("button.btn-primary:contains('Apply')")
-            self.browser.wait_present("div.dialog-error:contains('Unable to apply settings')")
-            self.browser.click("button.btn-default:contains('Cancel')")
+            b.click("button.btn-primary:contains('Apply')")
+            b.wait_present("div.dialog-error:contains('Unable to apply settings')")
+            b.click("button.btn-default:contains('Cancel')")
+
+            # test compression
+            b.click(settingsLink, True)
+            b.wait_present("#kdump-settings-location")
+            b.click("#kdump-settings-compression")
+            pathInput = "#kdump-settings-local-directory"
+            b.click("button.btn-primary:contains('Apply')")
+            b.wait_not_present(pathInput)
+            m.execute("cat /etc/kdump.conf | grep -qE 'makedumpfile.*-c.*'")
+
 
             # generate a valid kdump config with ssh target
-            settingsLink = "a:contains('locally in /var/crash')"
-            self.browser.wait_present(settingsLink)
-            self.browser.wait_visible(settingsLink)
-            self.browser.click(settingsLink, True)
-            self.browser.wait_present("#kdump-settings-location")
-            self.browser.click("#kdump-settings-location")
-            self.browser.wait_present("a:contains('Remote over SSH')")
-            self.browser.click("a:contains('Remote over SSH')")
+            b.wait_present(settingsLink)
+            b.click(settingsLink, True)
+            b.wait_present("#kdump-settings-location")
+            b.click("#kdump-settings-location")
+            b.wait_present("a:contains('Remote over SSH')")
+            b.click("a:contains('Remote over SSH')")
             sshInput = "#kdump-settings-ssh-server"
-            self.browser.wait_present(sshInput)
-            self.browser.wait_visible(sshInput)
+            b.wait_present(sshInput)
             self._type_val(sshInput, "root@localhost")
             sshKeyInput = "#kdump-settings-ssh-key"
-            self.browser.wait_present(sshKeyInput)
-            self.browser.wait_visible(sshKeyInput)
+            b.wait_present(sshKeyInput)
             self._type_val(sshKeyInput, "/root/.ssh/id_rsa")
-            pathInput = "#kdump-settings-local-directory"
-            self.browser.wait_present(pathInput)
-            self.browser.wait_visible(pathInput)
+            b.wait_present(pathInput)
             self._type_val(pathInput, "/var/crash")
-            self.browser.click("button.btn-primary:contains('Apply')")
-            self.browser.wait_not_present(pathInput)
+            b.click("button.btn-primary:contains('Apply')")
+            b.wait_not_present(pathInput)
 
         # we should have the amount of memory reserved that we indicated
-        self.browser.wait_in_text("#app", "256 MiB")
+        b.wait_in_text("#app", "256 MiB")
         # service should start up properly and the button should be on
-        self.browser.wait_in_text("#app", "Service is running")
-        self.browser.wait_in_text(onOffSelectorActive, "On")
-        self.browser.wait_in_text("#app", "Service is running")
+        b.wait_in_text("#app", "Service is running")
+        b.wait_in_text(onOffSelectorActive, "On")
+        b.wait_in_text("#app", "Service is running")
+
+        # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1536327
+        if m.image in ["rhel-7-6-distropkg"]:
+            return
 
         # try to change the path to a directory that doesn't exist
         customPath = "/var/crash2"
-        # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1536327
-        if self.machine.image in ["rhel-7-6-distropkg"]:
-            return
-        else:
-            settingsLink = "a:contains('Remote over SSH')"
-        self.browser.wait_present(settingsLink)
-        self.browser.wait_visible(settingsLink)
-        self.browser.click(settingsLink, True)
-        self.browser.wait_present("#kdump-settings-location")
-        self.browser.click("#kdump-settings-location")
-        self.browser.wait_present("a:contains('Local Filesystem')")
-        self.browser.click("a:contains('Local Filesystem')")
+        settingsLink = "a:contains('Remote over SSH')"
+        b.wait_present(settingsLink)
+        b.click(settingsLink, True)
+        b.wait_present("#kdump-settings-location")
+        b.click("#kdump-settings-location")
+        b.wait_present("a:contains('Local Filesystem')")
+        b.click("a:contains('Local Filesystem')")
         pathInput = "#kdump-settings-local-directory"
-        self.browser.wait_present(pathInput)
-        self.browser.wait_visible(pathInput)
+        b.wait_present(pathInput)
         self._type_val(pathInput, customPath)
-        self.browser.click("button.btn-primary:contains('Apply')")
+        b.click("button.btn-primary:contains('Apply')")
         # we should get an error
-        self.browser.wait_present("div.dialog-error:contains('Unable to apply settings')")
+        b.wait_present("div.dialog-error:contains('Unable to apply settings')")
         # also allow the journal message about failed touch
         self.allow_journal_messages(".*mktemp: failed to create file via template.*")
         # create the directory and try again
-        self.machine.execute("mkdir -p {0}".format(customPath))
-        self.browser.click("button.btn-primary:contains('Apply')")
-        self.browser.wait_not_present(pathInput)
-        self.browser.wait_present("a:contains('locally in {0}')".format(customPath))
+        m.execute("mkdir -p {0}".format(customPath))
+        b.click("button.btn-primary:contains('Apply')")
+        b.wait_not_present(pathInput)
+        b.wait_present("a:contains('locally in {0}')".format(customPath))
 
         # service has to restart after changing the config, wait for it to be running
         # otherwise the button to test will be disabled
-        self.browser.wait_in_text("#app", "Service is running")
-        self.browser.wait_in_text(onOffSelectorActive, "On")
+        b.wait_in_text("#app", "Service is running")
+        b.wait_in_text(onOffSelectorActive, "On")
 
         # crash the kernel and make sure it wrote a report into the right directory
-        self.browser.click("button.btn-default")
+        b.click("button.btn-default")
         # we should get a warning dialog, confirm
         crashButton = "button.btn-danger:contains('Crash system')"
-        self.browser.wait_present(crashButton)
-        self.browser.wait_visible(crashButton)
-        self.browser.click(crashButton)
+        b.wait_present(crashButton)
+        b.click(crashButton)
 
         # wait until we've actuall triggered a crash
-        self.browser.wait_present("div.spinner")
-        self.browser.wait_visible("div.spinner")
+        b.wait_present("div.spinner")
 
         # wait for disconnect and then try connecting again
-        self.browser.switch_to_top()
-        self.browser.wait_present("div.curtains-ct")
-        self.browser.wait_visible("div.curtains-ct")
-        self.browser.wait_in_text("div.curtains-ct h1", "Disconnected")
-        self.machine.disconnect()
-        self.machine.wait_boot(timeout_sec=300)
-        #self.browser.click("#machine-reconnect")
-        #self.browser.expect_load()
-        #self.browser.wait_visible("#login")
-        self.assertNotEqual(self.machine.execute("""find "{0}" -maxdepth 1 -mindepth 1 -type d -exec echo {{}} \;""".format(customPath)), "")
+        b.switch_to_top()
+        b.wait_present("div.curtains-ct")
+        b.wait_in_text("div.curtains-ct h1", "Disconnected")
+        m.disconnect()
+        m.wait_boot(timeout_sec=300)
+        #b.click("#machine-reconnect")
+        #b.expect_load()
+        #b.wait_visible("#login")
+        self.assertNotEqual(m.execute("""find "{0}" -maxdepth 1 -mindepth 1 -type d -exec echo {{}} \;""".format(customPath)), "")
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -112,6 +112,26 @@ class TestKdump(MachineCase):
         self.enableLocalSsh()
 
         if self.machine.image not in ["rhel-7-6-distropkg"]:
+            # minimal nfs validation
+            settingsLink = "a:contains('locally in /var/crash')"
+            self.browser.wait_present(settingsLink)
+            self.browser.wait_visible(settingsLink)
+            self.browser.click(settingsLink, True)
+            self.browser.wait_present("#kdump-settings-location")
+            self.browser.click("#kdump-settings-location")
+            self.browser.wait_present("a:contains('Remote over NFS')")
+            self.browser.click("a:contains('Remote over NFS')")
+            mountInput = "#kdump-settings-nfs-mount"
+            self.browser.wait_present(mountInput)
+            self.browser.wait_visible(mountInput)
+            self._type_val(mountInput, ":/var/crash")
+            self.browser.click("button.btn-primary:contains('Apply')")
+            self.browser.wait_present("div.dialog-error:contains('Unable to apply settings')")
+            self._type_val(mountInput, "localhost:");
+            self.browser.click("button.btn-primary:contains('Apply')")
+            self.browser.wait_present("div.dialog-error:contains('Unable to apply settings')")
+            self.browser.click("button.btn-default:contains('Cancel')")
+
             # generate a valid kdump config with ssh target
             settingsLink = "a:contains('locally in /var/crash')"
             self.browser.wait_present(settingsLink)


### PR DESCRIPTION
Recognize ssh and raw dump targets.
Eliminate "other" dump target.
Overwrite old dump targets when writing config as the kdump config
should only contain one target at a time.
No editing dump targets we don't support.