### PR TITLE
naughty: Close 10240: fedora 29: grub2-mkconfig crashes

### DIFF
--- a/bots/naughty/fedora-29/10240-grub2-mkconfig-syntax-error
+++ b/bots/naughty/fedora-29/10240-grub2-mkconfig-syntax-error
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-kdump", line *, in testBasic
-    self.enableKdump()
-  File "test/verify/check-kdump", line *, in enableKdump
-    self.machine.execute("grub2-mkconfig -o /boot/grub2/grub.cfg")
-*
-subprocess.CalledProcessError: Command 'grub2-mkconfig -o /boot/grub2/grub.cfg' returned non-zero exit status 1.


### PR DESCRIPTION
Known issue which has not occurred in 22 days

fedora 29: grub2-mkconfig crashes

Fixes #10240