### PR TITLE
naughty: Close 9633: SELinux is preventing sshd from 'read' accesses on the file active.motd

### DIFF
--- a/bots/naughty/fedora-28/9633-sselinux-ssh-motd
+++ b/bots/naughty/fedora-28/9633-sselinux-ssh-motd
@@ -1,1 +1,0 @@
-* audit: type=1400 audit(*): avc:  denied  { read } for * comm="sshd" name="active.motd"

--- a/bots/naughty/fedora-29/9633-sselinux-ssh-motd
+++ b/bots/naughty/fedora-29/9633-sselinux-ssh-motd
@@ -1,1 +1,0 @@
-* audit: type=1400 audit(*): avc:  denied  { read } for * comm="sshd" name="active.motd"


### PR DESCRIPTION
Known issue which has not occurred in 21 days

SELinux is preventing sshd from 'read' accesses on the file active.motd

Fixes #9633