### PR TITLE
ssh: Drop deprecated ssh_is_server_known API

### DIFF
--- a/src/ssh/cockpitsshknownhosts.c
+++ b/src/ssh/cockpitsshknownhosts.c
@@ -456,3 +456,23 @@ cockpit_is_host_known (const gchar *known_hosts_file,
   /* we did not find anything, end of file*/
   return ret;
 }
+
+enum ssh_known_hosts_e
+ssh_session_is_known_server (ssh_session session)
+{
+    enum ssh_server_known_e result;
+
+    result = ssh_is_server_known (session);
+
+    switch(result)
+      {
+          case SSH_SERVER_ERROR: return SSH_KNOWN_HOSTS_ERROR;
+          case SSH_SERVER_FILE_NOT_FOUND: return SSH_KNOWN_HOSTS_NOT_FOUND;
+          case SSH_SERVER_NOT_KNOWN: return SSH_KNOWN_HOSTS_UNKNOWN;
+          case SSH_SERVER_KNOWN_OK: return SSH_KNOWN_HOSTS_OK;
+          case SSH_SERVER_KNOWN_CHANGED: return SSH_KNOWN_HOSTS_CHANGED;
+          case SSH_SERVER_FOUND_OTHER: return SSH_KNOWN_HOSTS_OTHER;
+      }
+
+    g_assert_not_reached ();
+}

--- a/src/ssh/cockpitsshknownhosts.h
+++ b/src/ssh/cockpitsshknownhosts.h
@@ -26,7 +26,15 @@
 
 G_BEGIN_DECLS
 
-#define SSH_KNOWN_HOSTS_OK TRUE
+/* translate to old ssh_server_known_e enum for deprecated ssh_is_server_known() API */
+enum ssh_known_hosts_e {
+    SSH_KNOWN_HOSTS_ERROR = -2,
+    SSH_KNOWN_HOSTS_NOT_FOUND = -1,
+    SSH_KNOWN_HOSTS_UNKNOWN = 0,
+    SSH_KNOWN_HOSTS_OK,
+    SSH_KNOWN_HOSTS_CHANGED,
+    SSH_KNOWN_HOSTS_OTHER,
+};
 
 void            shim_set_knownhosts_file                   (const gchar *file);
 
@@ -39,6 +47,7 @@ gboolean        cockpit_is_host_known                      (const gchar *known_h
                                                             const gchar *host,
                                                             guint port);
 
+enum            ssh_known_hosts_e ssh_session_is_known_server (ssh_session session);
 
 G_END_DECLS
 


### PR DESCRIPTION
Use `ssh_session_is_known_server()` instead. This behaves correctly (i. e.
like ssh) with known_hosts port specificity.

For OSes with libssh 0.7, provide a shim implementation.