### PR TITLE
containers: Export git url to test-bots in unit-tests container

### DIFF
--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -32,7 +32,9 @@ case $ARCH in
 esac
 
 if [ -d bots ]; then
-    bots/test-bots
+    # Set GITHUB_BASE so that "import task" works without failure.
+    # https://github.com/cockpit-project/cockpit/issues/10578
+    GITHUB_BASE=unused bots/test-bots
 fi
 
 # bots/ is by and large an independent project, and for supporting stable


### PR DESCRIPTION
In the unit-tests container the remote url is a file url, and the bots
try to extract the project path from this url, which fails.

Run `make unit-tests-container-run` with & without this patch to test.

Another option would be to change `get_origin_repo()` (task/github.py:86) to also handle file paths, whereby it would recursively call itself with the file path as a git repo to extract the remote from.

@mvollmer which seems best to you?