### PR TITLE
bots: Only run external tests on master branch PRs

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -335,6 +335,8 @@ def cockpit_tasks(api, update, contexts, repo):
         def trigger_externals():
             if repo:  # already a non-cockpit project
                 return False
+            if base != "master":  # bots/ is always taken from master branch
+                return False
             if LABEL_TEST_EXTERNAL in labels():  # already checked before?
                 return True
 


### PR DESCRIPTION
bots/ is always being used from master, both in cockpit itself and
external projects. So there is no point running external tests for
branches.

Note that stable cockpit branches should not have bots/ in the first
place, but some still do.