### PR TITLE
naughty: Close 10264: kvdo broken on current rhel-x: kernel version mismatch

### DIFF
--- a/bots/naughty/rhel-x/10264-kvdo-missing
+++ b/bots/naughty/rhel-x/10264-kvdo-missing
@@ -1,4 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-vdo", line *, in testVdo
-*
-warning: vdo: ERROR - Kernel module kvdo not installed


### PR DESCRIPTION
Known issue which has not occurred in 26 days

kvdo broken on current rhel-x: kernel version mismatch

Fixes #10264