### PR TITLE
naughty: Close 6901: Ubuntu: Apparmor denies libvirt from accessing /etc/gss/mech.d/

### DIFF
--- a/bots/naughty/debian-testing/6901-apparmor-denied-libvirt-gss
+++ b/bots/naughty/debian-testing/6901-apparmor-denied-libvirt-gss
@@ -1,1 +1,0 @@
-apparmor="DENIED" operation="open" profile="libvirt* name="/etc/gss/mech.d/"

--- a/bots/naughty/ubuntu-1804/6901-apparmor-denied-libvirt-gss
+++ b/bots/naughty/ubuntu-1804/6901-apparmor-denied-libvirt-gss
@@ -1,1 +1,0 @@
-apparmor="DENIED" operation="open" profile="libvirt* name="/etc/gss/mech.d/"

--- a/bots/naughty/ubuntu-stable/6901-apparmor-denied-libvirt-gss
+++ b/bots/naughty/ubuntu-stable/6901-apparmor-denied-libvirt-gss
@@ -1,1 +1,0 @@
-apparmor="DENIED" operation="open" profile="libvirt* name="/etc/gss/mech.d/"


### PR DESCRIPTION
Known issue which has not occurred in 21 days

Ubuntu: Apparmor denies libvirt from accessing /etc/gss/mech.d/

Fixes #6901