### PR TITLE
naughty: Close 5295: Ubuntu: apparmor="DENIED" during check-realms

### DIFF
--- a/bots/naughty/ubuntu-1804/5295-apparmor-denied-ntpd
+++ b/bots/naughty/ubuntu-1804/5295-apparmor-denied-ntpd
@@ -1,1 +1,0 @@
-apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd"

--- a/bots/naughty/ubuntu-stable/5295-apparmor-denied-ntpd
+++ b/bots/naughty/ubuntu-stable/5295-apparmor-denied-ntpd
@@ -1,1 +1,0 @@
-apparmor="DENIED" operation="open" profile="/usr/sbin/ntpd"


### PR DESCRIPTION
Known issue which has not occurred in 26 days

Ubuntu: apparmor="DENIED" during check-realms

Fixes #5295