### PR TITLE
naughty: Close 4181: Debian, Ubuntu: Storaged gets confused by add/remove/add uevent sequence 

### DIFF
--- a/bots/naughty/debian-stable/4181-confused-storaged
+++ b/bots/naughty/debian-stable/4181-confused-storaged
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-luks", line *, in testLuks
-    b.wait_in_text("#detail-content", "ext4 File System")

--- a/bots/naughty/debian-stable/4181-confused-storaged-2
+++ b/bots/naughty/debian-stable/4181-confused-storaged-2
@@ -1,1 +1,0 @@
-wipefs: error: /dev/*: probing initialization failed: No such file or directory

--- a/bots/naughty/debian-testing/4181-confused-storaged
+++ b/bots/naughty/debian-testing/4181-confused-storaged
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "check-storage-luks", line *, in testLuks
-    b.wait_in_text("#detail-content", "ext4 File System")

--- a/bots/naughty/debian-testing/4181-confused-storaged-2
+++ b/bots/naughty/debian-testing/4181-confused-storaged-2
@@ -1,1 +1,0 @@
-wipefs: error: /dev/*: probing initialization failed: No such file or directory


### PR DESCRIPTION
Known issue which has not occurred in 21 days

Debian, Ubuntu: Storaged gets confused by add/remove/add uevent sequence 

Fixes #4181