### PR TITLE
build: Use timeout for webpack-make

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -177,7 +177,7 @@ V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
 V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/stamp=%)";
 
 WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) BUILDDIR=$(builddir) \
-	       $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
+	       timeout 5m $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
 
 WEBPACK_CONFIG = $(srcdir)/webpack.config.js
 WEBPACK_INPUTS =


### PR DESCRIPTION
In our CI containers, node often hangs eternally, with no observable
action from outside. This regularly requires us to rsh into them and
kill them.

Automatically terminate node (through webpack-make) after 5 minutes to
avoid that.