### PR TITLE
bots: Add nightly repo to rhel-7-6 image

### DIFF
--- a/bots/images/rhel-7-6
+++ b/bots/images/rhel-7-6
@@ -1,1 +1,1 @@
-rhel-7-6-fe652f03d5f21ba27437cfe89b2c2ecc8566a982472260f7c95b2bcebbe6f7f2.qcow2
+rhel-7-6-8ccc48edcc7e857e9bfe85e8fb1afc2103f2e98b8df5f09c1032dcdb8ad16757.qcow2

--- a/bots/images/scripts/rhel.setup
+++ b/bots/images/scripts/rhel.setup
@@ -44,7 +44,26 @@ set -x
 if [ ! -f "$SKIP_REPO_FLAG" ]; then
     # Configure repositories.
 
-    if [ "$IMAGE" = "rhel-7-7" ]; then
+    if [ "$IMAGE" = "rhel-7-6" ]; then
+cat <<EOF > /etc/yum.repos.d/nightly.repo
+[RHEL-7.6-NIGHTLY]
+name=rhel-base-nightly
+baseurl=http://download.devel.redhat.com/nightly/updates/RHEL-7.6/latest-RHEL-7.6/compose/Server/x86_64/os/
+enabled=1
+gpgcheck=0
+
+[EXTRAS-7.6-NIGHTLY]
+name=rhel-extras-nightly
+baseurl=http://download.eng.bos.redhat.com/nightly/EXTRAS-RHEL-7.6/latest-EXTRAS-7.6-RHEL-7/compose/Server/x86_64/os/
+enabled=1
+gpgcheck=0
+EOF
+        # if disabling the repos doesn't work, do without
+        yum -y --disablerepo=rhel-7-server-htb-rpms --disablerepo=rhel-sjis-for-rhel-7-server-rpms install yum-utils || yum -y install yum-utils
+        yum-config-manager --enable rhel-7-server-optional-rpms
+        yum-config-manager --enable rhel-7-server-extras-rpms
+
+    elif [ "$IMAGE" = "rhel-7-7" ]; then
 cat <<EOF > /etc/yum.repos.d/nightly.repo
 [EXTRAS-7.7-LATEST]
 name=rhel-extras-compose
@@ -61,6 +80,7 @@ EOF
         # disable all default repos as they don't exist yet
         sed -i 's/enabled = 1/enabled = 0/' /etc/yum.repos.d/redhat.repo
         yum -y install yum-utils
+
     elif [ "$IMAGE" = "rhel-x" ]; then
 cat <<EOF > /etc/yum.repos.d/nightly.repo
 [RHEL-8-NIGHTLY-BaseOS]
@@ -77,11 +97,6 @@ gpgcheck=0
 EOF
         # make ipa-client available
         dnf module enable -y idm:client
-    else
-        # if disabling the repos doesn't work, do without
-        yum -y --disablerepo=rhel-7-server-htb-rpms --disablerepo=rhel-sjis-for-rhel-7-server-rpms install yum-utils || yum -y install yum-utils
-        yum-config-manager --enable rhel-7-server-optional-rpms
-        yum-config-manager --enable rhel-7-server-extras-rpms
     fi
 
     if [ "$IMAGE" != "rhel-x" ]; then


### PR DESCRIPTION
This allows us to test pending updates before they get released to the
next Z-stream, to catch issues early.

 * [x] image-refresh rhel-7-6