### PR TITLE
bots: Add naughty override for SELinux regression on fedora-29

### DIFF
--- a/bots/naughty/fedora-29/10586-selinux-timesyncd-nnp_transition
+++ b/bots/naughty/fedora-29/10586-selinux-timesyncd-nnp_transition
@@ -1,0 +1,2 @@
+Error: audit: type=1400 audit(*): avc:  denied  { nnp_transition } for * comm="(imesyncd)"
+


### PR DESCRIPTION
See downstream bug https://bugzilla.redhat.com/show_bug.cgi?id=1649257
Known issue #10586