### PR TITLE
testlib: adjust set_input_text and key_press functions for setting input

### DIFF
--- a/pkg/machines/helpers.es6
+++ b/pkg/machines/helpers.es6
@@ -154,6 +154,7 @@ export function digitFilter(event, allowDots = false) {
                  event.key === 'Backspace' || event.key === 'Delete' || event.key === 'Tab' ||
                  event.key === 'ArrowLeft' || event.key === 'ArrowRight' ||
                  event.key === 'ArrowUp' || event.key === 'ArrowDown' ||
+                 (event.key === 'a' && event.ctrlKey) ||
                  event.key === 'Home' || event.key === 'End';
 
     if (!accept)

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -58,18 +58,6 @@ class TestKdump(MachineCase):
         self.browser.switch_to_top()
         self.browser.relogin("/kdump")
 
-    # TODO: move to common library
-    def _type_val(self, selector, value):
-        b = self.browser
-        value = str(value)
-
-        b.wait_present(selector)
-        b.wait_visible(selector)
-        b.click(selector)
-        b.focus(selector)
-        b.set_val(selector, '')  # clear value
-        b.key_press(value)
-
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -124,10 +112,10 @@ class TestKdump(MachineCase):
             b.click("a:contains('Remote over NFS')")
             mountInput = "#kdump-settings-nfs-mount"
             b.wait_present(mountInput)
-            self._type_val(mountInput, ":/var/crash")
+            b.set_input_text(mountInput, ":/var/crash")
             b.click("button.btn-primary:contains('Apply')")
             b.wait_present("div.dialog-error:contains('Unable to apply settings')")
-            self._type_val(mountInput, "localhost:");
+            b.set_input_text(mountInput, "localhost:");
             b.click("button.btn-primary:contains('Apply')")
             b.wait_present("div.dialog-error:contains('Unable to apply settings')")
             b.click("button.btn-default:contains('Cancel')")
@@ -151,12 +139,12 @@ class TestKdump(MachineCase):
             b.click("a:contains('Remote over SSH')")
             sshInput = "#kdump-settings-ssh-server"
             b.wait_present(sshInput)
-            self._type_val(sshInput, "root@localhost")
+            b.set_input_text(sshInput, "root@localhost")
             sshKeyInput = "#kdump-settings-ssh-key"
             b.wait_present(sshKeyInput)
-            self._type_val(sshKeyInput, "/root/.ssh/id_rsa")
+            b.set_input_text(sshKeyInput, "/root/.ssh/id_rsa")
             b.wait_present(pathInput)
-            self._type_val(pathInput, "/var/crash")
+            b.set_input_text(pathInput, "/var/crash")
             b.click("button.btn-primary:contains('Apply')")
             b.wait_not_present(pathInput)
 
@@ -182,7 +170,7 @@ class TestKdump(MachineCase):
         b.click("a:contains('Local Filesystem')")
         pathInput = "#kdump-settings-local-directory"
         b.wait_present(pathInput)
-        self._type_val(pathInput, customPath)
+        b.set_input_text(pathInput, customPath)
         b.click("button.btn-primary:contains('Apply')")
         # we should get an error
         b.wait_present("div.dialog-error:contains('Unable to apply settings')")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -360,7 +360,7 @@ OnCalendar=daily
             b.key_press(c)
         # need to wait for the widget's "fast typing" inhibition delay to trigger the completion popup
         time.sleep(1)
-        b.key_press([ " ", "Backspace" ])
+        b.key_press([ " ", "\b" ])
         b.wait_present(".file-autocomplete-ct .dropdown-menu")
         b.wait_visible(".file-autocomplete-ct .dropdown-menu")
         b.wait_present(".file-autocomplete-ct .dropdown-menu a[data-type='file']")
@@ -376,7 +376,7 @@ OnCalendar=daily
         m.execute("touch /tmp/stuff/file1.txt")
         b.focus(".file-autocomplete-ct input")
         time.sleep(1)
-        b.key_press([ " ", "Backspace" ])
+        b.key_press([ " ", "\b" ])
         b.wait_present(".file-autocomplete-ct .dropdown-menu")
         b.wait_visible(".file-autocomplete-ct .dropdown-menu")
         # this should still be unique
@@ -391,7 +391,7 @@ OnCalendar=daily
         m.execute("touch /tmp/stuff/other")
         b.focus(".file-autocomplete-ct input")
         # FIXME: need to tickle the widget to re-read the directory by changing out and back in
-        b.key_press([ "Backspace" ])
+        b.key_press([ "\b" ])
         time.sleep(1)
         b.key_press("/")
         time.sleep(1)

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -630,6 +630,7 @@ class TestMachines(MachineCase):
         b.click(".add-disk-dialog label:contains(Use Existing)")
         # default_tmp pool should be autoselected since it's the first in alphabetical order
         # defaultVol volume should be autoselected since it's the only volume in default_tmp pool
+        b.wait_present('#vm-subVmTest1-disks-adddisk-existing-target')
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-existing-target", "vdc")
         b.click("#vm-subVmTest1-disks-adddisk-dialog-add")
         b.wait_not_present("#add-disk-dialog")

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -549,8 +549,8 @@ class TestMachines(MachineCase):
 
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", "myPoolOne")
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-target", "vde")
-        self._setVal("#vm-subVmTest1-disks-adddisk-new-name", "mydiskofpoolone_temporary")
-        self._setVal("#vm-subVmTest1-disks-adddisk-new-size", 2048)
+        b.set_input_text("#vm-subVmTest1-disks-adddisk-new-name", "mydiskofpoolone_temporary")
+        b.set_input_text("#vm-subVmTest1-disks-adddisk-new-size", "2048")
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", "myPoolOne")
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-unit", "MiB")
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-diskfileformat", "raw") # verify content of the dropdown box
@@ -571,8 +571,8 @@ class TestMachines(MachineCase):
         b.click("#vm-subVmTest1-disks-adddisk-new-permanent")
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", "myPoolOne")
         self._selectFromDropdown("#vm-subVmTest1-disks-adddisk-new-target", "vda")
-        self._setVal("#vm-subVmTest1-disks-adddisk-new-name", "mydiskofpoolone_permanent")
-        self._setVal("#vm-subVmTest1-disks-adddisk-new-size", 2) # keep GiB and qcow2 format
+        b.set_input_text("#vm-subVmTest1-disks-adddisk-new-name", "mydiskofpoolone_permanent")
+        b.set_input_text("#vm-subVmTest1-disks-adddisk-new-size", "2") # keep GiB and qcow2 format
         b.click("#vm-subVmTest1-disks-adddisk-dialog-add")
         b.wait_not_present("#add-disk-dialog")
         b.wait_present("#vm-subVmTest1-disks-vda-target") # verify after modal dialog close
@@ -653,9 +653,6 @@ class TestMachines(MachineCase):
 
     def _selectFromDropdown(self, selector, value):
         selectFromDropdown(self.browser, selector, value)
-
-    def _setVal(self, selector, value):
-        setValToElement(self.browser, selector, value)
 
     def testNetworks(self):
         b = self.browser
@@ -1258,22 +1255,22 @@ class TestMachines(MachineCase):
 
         def fill(self):
             b = self.browser
-            self._setVal("#vm-name", self.name)
+            b.set_input_text("#vm-name", self.name)
 
             expected_source_type = 'Filesystem' if self.is_filesystem_location else 'URL'
             self._selectFromDropdown("#source-type", expected_source_type)
             if self.is_filesystem_location:
                 self._setFileAutocompleteVal("#source-file", self.location)
             else:
-                self._setVal("#source-url", self.location)
+                b.set_input_text("#source-url", self.location)
 
             self._selectFromDropdown("#vendor-select", self.os_vendor)
             self._selectFromDropdown("#system-select", self.os_name)
 
-            self._setVal("#memory-size", self.memory_size)
+            b.set_input_text("#memory-size", str(self.memory_size))
             self._selectFromDropdown("#memory-size-unit-select", self.memory_size_unit)
 
-            self._setVal("#storage-size", self.storage_size)
+            b.set_input_text("#storage-size", str(self.storage_size))
             self._selectFromDropdown("#storage-size-unit-select", self.storage_size_unit)
 
             b.wait_visible("#start-vm")
@@ -1383,9 +1380,6 @@ class TestMachines(MachineCase):
 
             b.wait_not_present(spinner_selector)
             b.wait_val(selector + " input", location)
-
-        def _setVal(self, selector, value):
-            setValToElement(self.browser, selector, value)
 
     class CreateVmRunner:
         def __init__(self, test_obj):
@@ -1551,17 +1545,6 @@ def selectFromDropdown(b, selector, value):
         b.wait_visible(item_selector)
         b.click(item_selector)
         b.wait_in_text(button_text_selector, value)
-
-def setValToElement(b, selector, value):
-    value = str(value)
-
-    b.wait_present(selector)
-    b.wait_visible(selector)
-    b.click(selector)
-    b.focus(selector)
-    b.set_val(selector, '')  # clear value
-    b.key_press(value)
-    b.wait_val(selector, value)
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
_setVal should wait for the field to be cleared before attempting
to fill it again because otherwise race conditions can appear.

There seems to be race condition with _setVal not able to empty the field before attempting to fill it back in.
https://fedorapeople.org/groups/cockpit/logs/pull-10567-20181115-131414-b6f9fe35-verify-ubuntu-stable/TestMachinesVirsh-testAddDisk-ubuntu-stable-127.0.0.2-2301-FAIL.png

Same for testVCPU.
https://fedorapeople.org/groups/cockpit/logs/pull-10413-20181115-150404-e6813d22-verify-rhel-7-6-distropkg/log.html#43