### PR TITLE
bots: Update CentOS Atomic cloud image download

### DIFF
--- a/bots/images/continuous-atomic
+++ b/bots/images/continuous-atomic
@@ -1,1 +1,1 @@
-continuous-atomic-c08b0a2bc7f295d6eadd9bf77d0a48f16ada0a4063e7f0195fc69e65461efe02.qcow2
+continuous-atomic-b71d705d272ced2cb431144676b0b137ed74997681d17153c5e7275a85433a6f.qcow2

--- a/bots/images/scripts/continuous-atomic.bootstrap
+++ b/bots/images/scripts/continuous-atomic.bootstrap
@@ -3,8 +3,8 @@
 
 set -e
 
-url="http://cloud.centos.org/centos/7/atomic/images"
-prefix="CentOS-Atomic-Host-7-GenericCloud.qcow2"
+url="https://cloud.centos.org/centos/7/atomic/images"
+prefix="CentOS-Atomic-Host-GenericCloud.qcow2"
 
 BASE=$(dirname $0)
 $BASE/atomic.bootstrap "$1" "$url" "$prefix"


### PR DESCRIPTION
The file name dropped the "-7". Also move to https:// URL.

Fixes #9971

 * [x] image-refresh continuous-atomic