### PR TITLE
bots: Fix markdown for GitHub comment in npm-update

### DIFF
--- a/bots/npm-update
+++ b/bots/npm-update
@@ -128,7 +128,7 @@ def run(package, verbose=False, **kwargs):
 
             # List of files that probably touch this package
             lines = output("git", "grep", "-w", package)
-            comment = "Please manually check features related to these files:\n\n```{0}```".format(lines)
+            comment = "Please manually check features related to these files:\n\n```\n{0}```".format(lines)
 
             if branch:
                 kwargs["title"] = title


### PR DESCRIPTION
The "```" mark must be on a line by itself.