### PR TITLE
networkmanager: Disable "Add Services" firewall button when firewall is off

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -308,7 +308,9 @@ export class Firewall extends React.Component {
                 </OverlayTrigger>
             );
         } else {
-            addServiceAction = <button className="btn btn-primary pull-right" onClick={this.onAddServices}>{_("Add Services…")}</button>;
+            addServiceAction = <button className="btn btn-primary pull-right"
+                                       onClick={this.onAddServices}
+                                       disabled={!this.state.firewall.enabled}>{_("Add Services…")}</button>;
         }
 
         var services = [...this.state.firewall.enabledServices].map(id => this.state.firewall.services[id]);

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -83,6 +83,9 @@ class TestFirewall(MachineCase):
         m.execute("systemctl stop firewalld")
         self.login_and_go("/network/firewall")
 
+        # "Add Services…" button should be disabled
+        b.wait_present("caption button.btn-primary:disabled")
+
         # to toggle the switch, click on the non-active label, where the slider is
         b.wait_present(".btn-onoff-ct label.active")
         b.wait_in_text(".btn-onoff-ct label.active", "Off")
@@ -90,6 +93,9 @@ class TestFirewall(MachineCase):
         b.wait_present(".btn-onoff-ct label.active:not(.disabled)")
         b.wait_in_text(".btn-onoff-ct label.active", "On")
         wait_unit_state(m, "firewalld", "active")
+
+        # "Add Services…" button should be enabled
+        b.wait_present("caption button.btn-primary:enabled")
 
         # ensure that pop3 is not enabled (shouldn't be on any of our images),
         # so that we can use it for testing
@@ -115,6 +121,8 @@ class TestFirewall(MachineCase):
         b.wait_present(".btn-onoff-ct label.active:not(.disabled)")
         b.wait_in_text(".btn-onoff-ct label.active", "Off")
         wait_unit_state(m, "firewalld", "inactive")
+        # "Add Services…" button should be disabled again
+        b.wait_present("caption button.btn-primary:disabled")
 
 
     def testAddServices(self):


### PR DESCRIPTION
It won't work then, the dialog will just have an eternal spinner trying
to read the services from a nonexisting firewalld service.