### PR TITLE
bots: Drop unused import

### DIFF
--- a/bots/flakes-refresh
+++ b/bots/flakes-refresh
@@ -17,12 +17,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import argparse
 import sys
 import time
 import os
 import urllib
-import socket
 import json
 import re
 


### PR DESCRIPTION
Regression from commit 46f55f52c9461fb that introduced pyflakes errors.