### PR TITLE
users: Fix changing user's own password on current Fedora

### DIFF
--- a/pkg/users/local.es6
+++ b/pkg/users/local.es6
@@ -63,6 +63,7 @@ function update_accounts_privileged() {
 
 function passwd_self(old_pass, new_pass) {
     var old_exps = [
+        /Current password: $/,
         /.*\(current\) UNIX password: $/,
     ];
     var new_exps = [

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -169,6 +169,38 @@ class TestAccounts(MachineCase):
         self.allow_journal_messages("The password is a palindrome")
         self.allow_journal_messages("passwd: user.*does not exist")
 
+    def testUnprivileged(self):
+        m = self.machine
+        b = self.browser
+        new_password = "tqymuVh.Zf5"
+
+        # defaults to empty shell on debian-stable (Debian 9 only), so specify it explicitly
+        m.execute("useradd --shell /bin/bash anton; echo anton:foobar | chpasswd")
+        self.login_and_go("/users", user="anton", authorized=False)
+        b.go("#/anton")
+        b.wait_text("#account-user-name", "anton")
+        b.wait_present('#account-set-password:enabled')
+        b.click('#account-set-password')
+        b.wait_popup('account-set-password-dialog')
+        b.set_val("#account-set-password-old", "foobar")
+        b.set_val("#account-set-password-pw1", new_password)
+        b.set_val("#account-set-password-pw2", new_password)
+        b.click('#account-set-password-apply')
+        b.wait_popdown('account-set-password-dialog')
+
+        # Logout and login with the new password
+        b.logout()
+        b.open("/users")
+        b.wait_visible("#login")
+        b.set_val("#login-user-input", "anton")
+        b.set_val("#login-password-input", new_password)
+        b.click('#login-button')
+        b.expect_load()
+        b.wait_present('#content')
+
+        self.allow_restart_journal_messages()
+        self.allow_authorize_journal_messages()
+
     def accountExpiryInfo(self, account, field):
         for line in self.machine.execute("LC_ALL=C chage -l {0}".format(account)).split("\n"):
             if line.startswith(field):


### PR DESCRIPTION
The "passwd" prompt is now "Current password:" which does not match the
expected pattern. This leads to a timeout.

Add a test to cover this scenario, so that we see if/when it fails on
any OS. This will be extended later to cover more functionality in
unprivileged mode.