### PR TITLE
test: Ignore unhandled browser exceptions during screenshots

### DIFF
--- a/test/common/cdp-driver.js
+++ b/test/common/cdp-driver.js
@@ -67,6 +67,11 @@ var logPromiseResolver;
 var nReportedLogMessages = 0;
 var unhandledExceptions = [];
 
+function clearExceptions() {
+    unhandledExceptions.length = 0;
+    return Promise.resolve();
+}
+
 function setupLogging(client) {
     client.Runtime.enable();
 
@@ -320,7 +325,7 @@ CDP.New(options)
                                 } else {
                                     let message = unhandledExceptions[0];
                                     fail(message.split("\n")[0]);
-                                    unhandledExceptions.length = 0;
+                                    clearExceptions();
                                 }
                             }, fail);
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -515,6 +515,8 @@ class Browser:
             title: Used for the filename.
         """
         if self.cdp and self.cdp.valid:
+            self.cdp.command("clearExceptions()")
+
             filename = "{0}-{1}.png".format(label or self.label, title)
             ret = self.cdp.invoke("Page.captureScreenshot", no_trace=True)
             if "data" in ret:


### PR DESCRIPTION
When getting screenshots or HTML dumps, after a test fails,
ignore any unhandled browser exceptions.

Otherwise we get awkward errors like this in the logs, and no
screenshot or HTML dump:

    ...
    testlib.Error: timeout
    wait_js_cond(ph_is_visible("#login")): #login not found

    not ok 248 testFirewallPage (check_networking_firewall.TestFirewall)
    Traceback (most recent call last):
      File "/build/cockpit/test/common/testlib.py", line 692, in intercept
        self.snapshot("FAIL")
      File "/build/cockpit/test/common/testlib.py", line 964, in snapshot
        self.browser.snapshot(title, label)
      File "/build/cockpit/test/common/testlib.py", line 482, in snapshot
        ret = self.cdp.invoke("Page.captureScreenshot", no_trace=True)
      File "/build/cockpit/test/common/cdp.py", line 85, in invoke
        res = self.command(cmd)
      File "/build/cockpit/test/common/cdp.py", line 112, in command
        raise RuntimeError(res["error"])
    RuntimeError: #login not found
    not ok 248 testFirewallPage (check_networking_firewall.TestFirewall)