### PR TITLE
networkmanager: Fix data type handling in Firewall "Add Services" dialog

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -257,7 +257,7 @@ export class Firewall extends React.Component {
         show_modal_dialog(
             {
                 title: _("Add Services"),
-                body: <AddServicesDialogBody selectionChanged={s => { selected = [...s] }} />
+                body: <AddServicesDialogBody selectionChanged={s => { selected = new Set(s) }} />
             },
             {
                 cancel_caption: _("Cancel"),
@@ -265,7 +265,7 @@ export class Firewall extends React.Component {
                     {
                         caption: _("Add Services"),
                         style: 'primary',
-                        clicked: () => firewall.addServices(selected)
+                        clicked: () => firewall.addServices([...selected])
                     }
                 ]
             });

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -115,13 +115,21 @@ class TestFirewall(MachineCase):
         b.wait_in_text(".btn-onoff-ct label.active", "Off")
         wait_unit_state(m, "firewalld", "inactive")
 
-
     def testAddServices(self):
         b = self.browser
 
         self.login_and_go("/network/firewall")
 
         # click on the "Add Services…" button
+        # don't select anything in the dialog
+        b.wait_present("caption button.btn-primary:enabled")
+        b.click("caption button.btn-primary")
+        b.wait_present("#cockpit_modal_dialog li input#pop3")
+        b.wait_present("#cockpit_modal_dialog .btn-primary")
+        b.click("#cockpit_modal_dialog .btn-primary")
+        b.wait_not_present("#cockpit_modal_dialog")
+
+        # now add pop3
         b.wait_present("caption button.btn-primary:enabled")
         b.click("caption button.btn-primary")
         b.wait_present("#cockpit_modal_dialog li input#pop3")


### PR DESCRIPTION
`selected` starts out to be a Set. Keep it a set instead of turning it
into an arry in `selectionChanged()`. Convert it to a list in the
`addServices()` call, as that cannot deal with sets, only arrays.

This fixes a `TypeError: services.map is not a function` crash when
clicking "Add Services" button in the dialog without any selection.

https://bugzilla.redhat.com/show_bug.cgi?id=1652207