### PR TITLE
systemd: make the PCP store metrics label consistent

### DIFF
--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -165,7 +165,7 @@
                     </td>
                 </tr>
                 <tr id="server-pmlogger-onoff-row" hidden>
-                    <td translatable="yes">Store Performance Data</td>
+                    <td translatable="yes">Store metrics</td>
                     <td>
                         <div class="btn-group btn-onoff-ct" id="server-pmlogger-switch" data-toggle="buttons">
                             <label class="btn">
@@ -184,7 +184,7 @@
                     <td>
                         <a id="system-information-enable-pcp-link">
                             <span class="pficon pficon-info"></span>
-                            <span translate>Enable persistent metrics…</span>
+                            <span translate>Enable stored metrics…</span>
                         </a>
                     </td>
                 </tr>

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -420,7 +420,10 @@ class TestPcp(packagelib.PackageCase):
         b.wait_present("#server-pmlogger-onoff-row")
         b.wait_not_visible("#server-pmlogger-onoff-row")
         b.wait_visible("#system-information-enable-pcp")
-        b.wait_in_text("#system-information-enable-pcp", "Enable persistent metrics…")
+        if m.image in ["rhel-7-6-distropkg"]:
+            b.wait_in_text("#system-information-enable-pcp", "Enable persistent metrics…")
+        else:
+            b.wait_in_text("#system-information-enable-pcp", "Enable stored metrics…")
         b.click("#system-information-enable-pcp-link")
         b.wait_present("#cockpit_modal_dialog .modal-footer button.btn-primary:not([disabled])")
         b.click("#cockpit_modal_dialog .modal-footer button.btn-primary")


### PR DESCRIPTION
The label was called two different things before and after
installing PCP.

Fixes issue #10626