### PR TITLE
test: Fix unit tests for dbus-broker

### DIFF
--- a/src/base1/test-dbus.js
+++ b/src/base1/test-dbus.js
@@ -631,7 +631,7 @@ QUnit.asyncTest("publish object replaces", function() {
 });
 
 QUnit.asyncTest("publish object unpublish", function() {
-    assert.expect(3);
+    assert.expect(5);
 
     var info = {
         "org.Interface": {
@@ -664,9 +664,9 @@ QUnit.asyncTest("publish object unpublish", function() {
                     }, function(ex) {
                         assert.strictEqual(ex.name, "org.freedesktop.DBus.Error.UnknownMethod",
                                            "got right error name");
-                        assert.strictEqual(ex.message,
-                                "No such interface 'org.Interface' on object at path /a/path",
-                                "got right error message");
+                        assert.ok(ex.message.indexOf("No such interface") == 0, "unexpected error: " + ex.message);
+                        assert.ok(ex.message.indexOf("org.Interface") > 0, "unexpected error: " + ex.message);
+                        assert.ok(ex.message.indexOf("/a/path") > 0, "unexpected error: " + ex.message);
                     }).always(function() {
                         dbus.close();
                         QUnit.start();

--- a/src/base1/test-stub.js
+++ b/src/base1/test-stub.js
@@ -107,14 +107,17 @@ QUnit.asyncTest("internal dbus environment", function() {
 });
 
 QUnit.asyncTest("internal user dbus", function() {
-    assert.expect(2);
+    assert.expect(4);
 
     var dbus = cockpit.dbus(null, { "bus": "internal" });
     dbus.call("/user", "org.freedesktop.DBus.Properties",
               "GetAll", [ "cockpit.User" ],
               { "type": "s" })
         .fail(function(ex) {
-            assert.equal(ex.message, "No such interface 'org.freedesktop.DBus.Properties' on object at path /user");
+            assert.ok(ex.message.indexOf("No such interface") == 0, "unexpected error: " + ex.message);
+            assert.ok(ex.message.indexOf("org.freedesktop.DBus.Properties") > 0, "unexpected error: " + ex.message);
+            assert.ok(ex.message.indexOf("/user") > 0, "unexpected error: " + ex.message);
+
         })
         .always(function() {
             assert.equal(this.state(), "rejected", "finished successfuly");


### PR DESCRIPTION
With dbus-broker, the error messages use “ quotes instead of '.