### PR TITLE
common: Return HTTP 400 errors on invalid characters

### DIFF
--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -530,7 +530,7 @@ test_no_path (TestCase *tc,
 }
 
 static const Fixture fixture_bad_path = {
-  .path = "../test/sub/file.ext"
+  .path = "/../test/sub/file.ext"
 };
 
 static void
@@ -549,7 +549,7 @@ test_bad_path (TestCase *tc,
 }
 
 static const Fixture fixture_no_package = {
-  .path = "test"
+  .path = "/test"
 };
 
 static void

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -944,6 +944,12 @@ parse_and_process_request (CockpitRequest *request)
       request->delayed_reply = 400;
       goto out;
     }
+  if (!path || path[0] != '/')
+    {
+      g_message ("received invalid HTTP path");
+      request->delayed_reply = 400;
+      goto out;
+    }
 
   off2 = web_socket_util_parse_headers ((const gchar *)request->buffer->data + off1,
                                         request->buffer->len - off1,

--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -364,9 +364,6 @@ test_parse_headers_bad (void)
   gssize ret;
   gint i;
 
-  g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
-                         "received invalid header line*");
-
   for (i = 0; i < G_N_ELEMENTS (input); i++)
     {
       ret = web_socket_util_parse_headers (input[i], strlen (input[i]), NULL);


### PR DESCRIPTION
Don't let fundamentally invalid characters in our HTTP request.
It causes other parts of cockpit-ws to later have an assertion
during their checks.