### PR TITLE
machines: use compact list pattern for Networks and Disks

### DIFF
--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -89,7 +89,7 @@ const VmDisksTab = ({ idPrefix, vm, disks, actions, renderCapacity, notification
         <div>
             {notification}
             {message}
-            <Listing columnTitles={columnTitles} actions={actions} emptyCaption={_("No disks defined for this VM")}>
+            <Listing compact columnTitles={columnTitles} actions={actions} emptyCaption={_("No disks defined for this VM")}>
                 {disks.map(disk => {
                     const idPrefixRow = `${idPrefix}-${disk.target || disk.device}`;
                     const columns = [

--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -154,7 +154,7 @@ const VmNetworkTab = function ({ vm, dispatch, config, hostDevices, networks }) 
     return (
         <div className="machines-network-list">
             {message}
-            <Listing columnTitles={detailMap.map(target => target.name)} actions={null} emptyCaption=''>
+            <Listing compact columnTitles={detailMap.map(target => target.name)} actions={null} emptyCaption=''>
                 {vm.interfaces.sort().map(target => {
                     const columns = detailMap.map(d => {
                         let column = null;


### PR DESCRIPTION
The rows inside the tabs were very tall, so fix that.

Fixes #10658