### PR TITLE
bots: Print url when GitHub API calls fail

### DIFF
--- a/bots/push-rewrite
+++ b/bots/push-rewrite
@@ -58,7 +58,7 @@ def main():
 
     for n in range(100,0,-1):
         try:
-            if api.get("commits/%s" % local, verbose=False):
+            if api.get("commits/%s" % local):
                 break
         except RuntimeError as e:
             if not "Unprocessable Entity" in str(e) or n <= 1:


### PR DESCRIPTION
Be more verbose when a GitHub API call fails. This makes debugging
easier, especially to discover which repository a call was against.

Also move those errors into its own exception to avoid printing verbose
errors every time.