### PR TITLE
Move most remaining scripts to Python 3

### DIFF
--- a/bots/task/test-policy
+++ b/bots/task/test-policy
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/python3
 
 # This file is part of Cockpit.
 #

--- a/pkg/docker/cockpit-atomic-storage
+++ b/pkg/docker/cockpit-atomic-storage
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#! /usr/bin/python3
 
 # This utility fills in the gaps between the Atomic image storage API
 # and the Cockpit UI.

--- a/pkg/storaged/nfs-mounts.py
+++ b/pkg/storaged/nfs-mounts.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python3
 
 # nfs-mounts   --  Monitor and manage NFS mounts
 #

--- a/pkg/storaged/vdo-monitor.py
+++ b/pkg/storaged/vdo-monitor.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python3
 
 import sys, os, time, json
 


### PR DESCRIPTION
This leaves turd-polish (which fails in semaphore with Python 3, not yet known why), and bots/images/scripts/lib/atomic.install which is ready for Py3, but we can't switch until we stop supporting RHEL/CentOS 7.
