### PR TITLE
ws: Add cockpit-desktop script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ depcomp
 /com.redhat.lvm2.c
 /com.redhat.lvm2.h
 /liblvmdbus.a
+/cockpit-desktop
 /cockpit-ws
 /cockpit-ws.8
 /po/cockpit.pot
@@ -125,6 +126,7 @@ cockpitd
 /doc/man/cockpit.1
 /doc/man/cockpit-bridge.1
 /doc/man/cockpit-ws.8
+/doc/man/cockpit-desktop.1
 /doc/man/cockpit.conf.5
 /doc/man/cockpitd.8
 /doc/man/remotectl.8

--- a/doc/guide/cockpit-guide.xml
+++ b/doc/guide/cockpit-guide.xml
@@ -19,6 +19,7 @@
       <title>Manual pages</title>
       <xi:include href="../man/cockpit.conf.xml"/>
       <xi:include href="../man/cockpit-ws.xml"/>
+      <xi:include href="../man/cockpit-desktop.xml"/>
       <xi:include href="../man/remotectl.xml"/>
       <xi:include href="../man/cockpit-bridge.xml"/>
     </chapter>

--- a/doc/man/Makefile-man.am
+++ b/doc/man/Makefile-man.am
@@ -8,6 +8,7 @@ EXTRA_DIST += \
 
 man_MANS += \
 	doc/man/cockpit.1 \
+	doc/man/cockpit-desktop.1 \
 	doc/man/cockpit-ws.8 \
 	doc/man/cockpit.conf.5 \
 	doc/man/pam_ssh_add.8 \
@@ -17,6 +18,7 @@ man_MANS += \
 EXTRA_DIST += \
 	doc/man/cockpit.xml \
 	doc/man/cockpit-ws.xml \
+	doc/man/cockpit-desktop.xml \
 	doc/man/cockpit.conf.xml \
 	doc/man/pam_ssh_add.xml \
 	doc/man/remotectl.xml \

--- a/doc/man/cockpit-desktop.xml
+++ b/doc/man/cockpit-desktop.xml
@@ -1,0 +1,112 @@
+<refentry id="cockpit-desktop.1">
+
+  <!--
+  This file is part of Cockpit.
+
+  Copyright (C) 2018 Red Hat, Inc.
+
+  Cockpit is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  Cockpit is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+  <refentryinfo>
+    <title>cockpit-desktop</title>
+    <productname>cockpit</productname>
+  </refentryinfo>
+
+  <refmeta>
+    <refentrytitle>cockpit-desktop</refentrytitle>
+    <manvolnum>1</manvolnum>
+    <refmiscinfo class="version"></refmiscinfo>
+  </refmeta>
+
+  <refnamediv>
+    <refname>cockpit-desktop</refname>
+    <refpurpose>Cockpit Desktop integration</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis>
+      <command>cockpit-desktop</command>
+       <arg choice="req">URLPATH</arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+
+  <refsect1 id="cockpit-desktop-description">
+    <title>DESCRIPTION</title>
+    <para>
+      The <command>cockpit-desktop</command> program provides secure access to
+      Cockpit pages in an already running desktop session. It starts a web server
+      (<command>cockpit-ws</command>) and a web browser in an isolated network
+      namespace, and a
+      <citerefentry>
+        <refentrytitle>cockpit-bridge</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>
+      in the running user session.
+    </para>
+    <para>
+      This avoids having to log into Cockpit, and having to enable
+      <filename>cockpit.socket</filename> system-wide. The network isolation
+      ensures that no other user, and not even other processes in the user's
+      session, can access this local web server.
+    </para>
+
+    <para>
+      <literal>URLPATH</literal> is the Cockpit page to open, i. e. the path
+      component of Cockpit URLs. It is highly recommended to only open a
+      <ulink url="https://cockpit-project.org/guide/latest/embedding.html">particular page frame</ulink>,
+      not the entire Cockpit navigation and menu. For example, the path
+      <literal>/cockpit/@localhost/storage/index.html</literal> will open the Storage
+      page.
+    </para>
+  </refsect1>
+
+  <refsect1 id="cockpit-desktop-environment">
+    <title>ENVIRONMENT</title>
+    <para>
+      The <literal>BROWSER </literal> environment variable specifies
+      the browser command (and possibly options) that will be used to open the
+      requested Cockpit page. If not set, <command>cockpit-desktop</command> uses
+      <citerefentry>
+        <refentrytitle>xdg-open</refentrytitle><manvolnum>1</manvolnum>
+      </citerefentry>.
+    </para>
+  </refsect1>
+
+  <refsect1 id="cockpit-desktop-bugs">
+    <title>BUGS</title>
+    <para>
+      Please send bug reports to either the distribution bug tracker or the
+      <ulink url="https://github.com/cockpit-project/cockpit/issues/new">upstream bug tracker</ulink>.
+    </para>
+  </refsect1>
+
+  <refsect1 id="cockpit-desktop-author">
+    <title>AUTHOR</title>
+    <para>Cockpit has been written by many
+      <ulink url="https://github.com/cockpit-project/cockpit/">contributors</ulink>.</para>
+  </refsect1>
+
+  <refsect1 id="cockpit-desktop-also">
+    <title>SEE ALSO</title>
+    <para>
+      <citerefentry>
+        <refentrytitle>cockpit-ws</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+        <refentrytitle>cockpit-bridge</refentrytitle><manvolnum>1</manvolnum>
+      </citerefentry>
+    </para>
+  </refsect1>
+</refentry>

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -192,10 +192,16 @@ install-exec-hook::
 	chown -f root:$(COCKPIT_GROUP) $(DESTDIR)$(libexecdir)/cockpit-session || true
 	test "$(COCKPIT_USER)" != "root" && chmod -f 4750 $(DESTDIR)$(libexecdir)/cockpit-session || true
 
+libexec_SCRIPTS = cockpit-desktop
+
+cockpit-desktop: src/ws/cockpit-desktop.in
+	$(SUBST_RULE)
+
 EXTRA_DIST += \
 	src/ws/cockpit-motd.service.in \
 	src/ws/cockpit.service.in \
 	src/ws/cockpit.socket.in \
+	src/ws/cockpit-desktop.in \
 	$(firewall_DATA) \
 	$(tempconf_in) \
 	$(NULL)
@@ -205,6 +211,7 @@ CLEANFILES += \
 	src/ws/cockpit.service \
 	src/ws/cockpit-motd.service \
 	$(nodist_tempconf_DATA) \
+	cockpit-desktop \
 	$(NULL)
 
 appdatadir = $(datadir)/metainfo

--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# Run a local bridge, web server, and browser for a particular Cockpit page.
+# This is useful for integration into .desktop files, for systems which don't
+# have cockpit.socket enabled. The web server and browser run in an unshared
+# network namespace, and thus are totally isolated from everything else.
+#
+# Example: cockpit-desktop /cockpit/@localhost/system/index.html
+
+set -eu
+
+# find suitable browser, unless already set by $BROWSER
+# We can't use xdg-open, it does too much magic behind the back to connect to
+# existing instances (outside of our namespace) and does not allow us to reduce
+# the UI, or pass options like chromium's --no-sandbox.
+detect_browser()
+{
+    [ -z "${BROWSER:-}" ] || return 0
+
+    for browser in chromium-browser chromium google-chrome; do
+        if type $browser >/dev/null 2>&1; then
+            # need to disable sandboxing in user namespace, but that already isolates
+            # TODO: Find a way to disable the URL bar
+            BROWSER="$browser --no-sandbox --disable-infobars"
+            return 0
+        fi
+    done
+
+    if type firefox >/dev/null 2>&1; then
+        # TODO: Find a way to disable the privacy notice tab, via mozilla.cfg?
+        # TODO: Find a way to disable the URL bar
+        BROWSER="firefox --no-remote"
+        return 0
+    fi
+
+    # TODO: is there a simple way to use webkitgtk?
+    echo "No suitable browser found (Chromium/Chrome, or Firefox)" >&2
+    exit 1
+}
+
+
+if [ -z "${1:-}" ]; then
+    echo "Usage: $0 <Cockpit path>" >&2
+    exit 1
+fi
+
+URL_PATH="$1"
+
+detect_browser
+
+# start the bridge; this needs to run in the normal user session/namespace
+coproc cockpit-bridge
+trap "kill $COPROC_PID; wait $COPROC_PID || true" EXIT INT QUIT PIPE
+
+# start ws and browser in a detached network namespace
+SCRIPT='
+set -eu
+# new namespaces have lo down by default
+ip link set lo up >&2
+
+# start browser in a temporary home dir, so that it does not interfere with your real one
+export BROWSER_HOME=$(mktemp --directory --tmpdir cockpit.desktop.XXXXXX)
+
+# forward parent stdin and stdout (from bridge) to cockpit-ws
+# it pretty well does not matter which port we use in our own namespace, so use standard http
+# disable /etc/cockpit/
+XDG_CONFIG_DIRS="$BROWSER_HOME" @libexecdir@/cockpit-ws -p 80 -a 127.0.0.90 --local-session=- <&0 >&1 &
+WS_PID=$!
+# ... and stop using that stdin/out for everything else
+exec 0</dev/null
+exec 1>&2
+
+trap "set +e; kill $WS_PID; wait $WS_PID; rm -rf $BROWSER_HOME" EXIT INT QUIT PIPE
+
+# if we have netcat, use it for waiting until ws is up
+if type nc >/dev/null 2>&1; then
+    for retry in `seq 10`; do
+        nc -z 127.0.0.90 80 && break
+        sleep 0.5;
+    done
+else
+    # otherwise, just wait a bit
+    sleep 3
+fi
+
+HOME="$BROWSER_HOME" '$BROWSER' http://127.0.0.90'"$URL_PATH"'
+'
+unshare --user --map-root-user --net /bin/bash -c "$SCRIPT" <&${COPROC[0]} >&${COPROC[1]}

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -347,6 +347,26 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 
+    @skipImage("Atomic doesn't have cockpit-ws installed", "fedora-atomic", "rhel-atomic", "continuous-atomic")
+    @skipImage("Kernel does not allow user namespaces", "centos-7", "rhel-7-6", "debian-stable", "debian-testing")
+    @skipImage("Added in 184", "rhel-7-6-distropkg")
+    def testCockpitDesktop(self):
+        m = self.machine
+
+        if "debian" in m.image or "ubuntu" in m.image:
+            cockpit_desktop = "/usr/lib/cockpit/cockpit-desktop"
+        else:
+            cockpit_desktop = "/usr/libexec/cockpit-desktop"
+
+        m.execute('''su - -c 'BROWSER="curl --compressed -o /tmp/out.html" %s /cockpit/@localhost/system/index.html' admin''' % cockpit_desktop)
+        out = m.execute("cat /tmp/out.html")
+        self.assertIn('id="system_machine_id"', out)
+        self.assertIn('data-action="shutdown"', out)
+        # should clean up processes
+        self.assertEqual(m.execute("! pgrep -a cockpit-ws && ! pgrep -a cockpit-bridge"), "")
+
+        self.allow_journal_messages("couldn't register polkit authentication agent.*")
+
 
 if __name__ == '__main__':
     test_main()

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -317,7 +317,7 @@ done
 for lib in systemd tmpfiles.d firewalld; do
     rm -r %{buildroot}/%{_prefix}/%{__lib}/$lib
 done
-for libexec in cockpit-askpass cockpit-session cockpit-ws; do
+for libexec in cockpit-askpass cockpit-session cockpit-ws cockpit-desktop; do
     rm %{buildroot}/%{_libexecdir}/$libexec
 done
 rm -r %{buildroot}/%{_libdir}/security %{buildroot}/%{_sysconfdir}/pam.d %{buildroot}/%{_sysconfdir}/motd.d %{buildroot}/%{_sysconfdir}/issue.d
@@ -512,6 +512,7 @@ Requires(postun): systemd
 The Cockpit Web Service listens on the network, and authenticates users.
 
 %files ws -f cockpit.lang
+%doc %{_mandir}/man1/cockpit-desktop.1.gz
 %doc %{_mandir}/man5/cockpit.conf.5.gz
 %doc %{_mandir}/man8/cockpit-ws.8.gz
 %doc %{_mandir}/man8/remotectl.8.gz
@@ -532,6 +533,7 @@ The Cockpit Web Service listens on the network, and authenticates users.
 %{_sbindir}/remotectl
 %{_libdir}/security/pam_ssh_add.so
 %{_libexecdir}/cockpit-ws
+%{_libexecdir}/cockpit-desktop
 %attr(4750, root, cockpit-ws) %{_libexecdir}/cockpit-session
 %attr(775, -, wheel) %{_localstatedir}/lib/cockpit
 %{_datadir}/cockpit/static

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -9,12 +9,14 @@ lib/*/security/pam_ssh_add.so
 usr/lib/tmpfiles.d/cockpit-tempfiles.conf
 usr/lib/cockpit/cockpit-session
 usr/lib/cockpit/cockpit-ws
+usr/lib/cockpit/cockpit-desktop
 usr/lib/firewalld/services/cockpit.xml
 usr/sbin/remotectl
 usr/share/cockpit/branding/
 usr/share/cockpit/motd/
 usr/share/cockpit/static/
 usr/share/locale/
+usr/share/man/man1/cockpit-desktop.1
 usr/share/man/man5/cockpit.conf.5
 usr/share/man/man8/cockpit-ws.8
 usr/share/man/man8/pam_ssh_add.8


### PR DESCRIPTION
Run a local bridge, web server, and browser for a particular Cockpit
page.  This is useful for integration into .desktop files, for systems
which don't have cockpit.socket enabled. The web server and browser run
in an unshared network namespace, and thus are totally isolated from
everything else.

 - [x] Add --local-session option (PR #10683)
 - [x] Decide that we actually want this
 - [x] Add standard copyright header
 - [x] Add integration test
 - [x] Add documentation
 - [x] Stop hardcoding firefox
 - [x] Set `XDG_CONFIG_DIRS`
 - [x] Fix invocation of chromium in namespace