### PR TITLE
webpack: Tighten jshint path match

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -397,7 +397,7 @@ module.exports = {
     module: {
         preLoaders: [
             {
-                test: /\/src\/.*\.js$/,
+                test: /\/src\/(base1|ws)\/[^/]*\.js$/,
                 exclude: /\/node_modules\/.*\//, // exclude external dependencies
                 loader: "jshint-loader"
             },


### PR DESCRIPTION
The pattern apparently applies to a full absolute path, not a relative
one within the source tree. Thus it would previously also catch
checkouts which had a `/src` parent directory anywhere.

Tighten the path match to avoid that.