### PR TITLE
ws: Drop cockpit.desktop, update AppStream metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,6 @@ depcomp
 /mock/
 *.min.html
 /src/ws/cockpit.appdata.xml
-/src/ws/cockpit.desktop
 /src/ws/cockpit.service
 /src/ws/cockpit.socket
 /src/ws/cockpit-tempfiles.conf

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -214,13 +214,6 @@ appdata_in = src/ws/cockpit.appdata.xml.in
 $(nodist_appdata_DATA): $(appdata_in) $(PO_FILES)
 	$(AM_V_GEN) LC_ALL=C $(INTLTOOL_MERGE) -q -x -u $(top_srcdir)/po $< $@
 
-desktopdir = $(datadir)/applications
-nodist_desktop_DATA = src/ws/cockpit.desktop
-desktop_in = src/ws/cockpit.desktop.in
-
-$(nodist_desktop_DATA): $(desktop_in) $(PO_FILES)
-	$(AM_V_GEN) LC_ALL=C $(INTLTOOL_MERGE) -q -d -u $(top_srcdir)/po $< $@
-
 pixmapdir = $(datadir)/pixmaps
 pixmap_DATA = src/ws/cockpit.png
 

--- a/src/ws/cockpit.appdata.xml.in
+++ b/src/ws/cockpit.appdata.xml.in
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
-<component type="desktop-application">
+<component type="web-application">
   <id>cockpit.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LGPL-2.0+</project_license>
   <name>Cockpit</name>
-  <_summary>User interface for Linux servers</_summary>
+  <_summary>Web Console for Linux servers</_summary>
   <description>
     <_p>
       Cockpit is a server manager that makes it easy to administer your Linux
@@ -23,27 +23,28 @@
       Just add them with a single click and your machines will look after its
       buddies.
     </_p>
+    <_p>
+      Once Cockpit is installed, enable it with "systemctl enable --now cockpit.socket".
+    </_p>
   </description>
+  <translation type="gettext">cockpit</translation>
+  <icon type="local" width="128" height="128">/usr/share/pixmaps/cockpit.png</icon>
+  <launchable type="url">https://localhost:9090</launchable>
   <screenshots>
-    <!-- FIXME: we need some 16:9 screenshots of the latest code; also putting
-                them on https://cockpit-project.org/ would be best to control
-                them in the future -->
     <screenshot type="default">
-        <image>https://cockpit-project.org/screenshots/cockpit-overview.png</image>
+        <image>https://cockpit-project.org/images/site/screenshot-storage.png</image>
     </screenshot>
     <screenshot>
-        <image>https://cockpit-project.org/screenshots/cockpit-services.png</image>
+        <image>https://cockpit-project.org/images/site/screenshot-docker.png</image>
     </screenshot>
     <screenshot>
-        <image>https://cockpit-project.org/screenshots/cockpit-journal.png</image>
+        <image>https://cockpit-project.org/images/site/screenshot-network.png</image>
     </screenshot>
     <screenshot>
-        <image>https://cockpit-project.org/screenshots/cockpit-network.png</image>
-    </screenshot>
-    <screenshot>
-        <image>https://cockpit-project.org/screenshots/cockpit-storage.png</image>
+        <image>https://cockpit-project.org/images/site/screenshot-dashboard.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://cockpit-project.org/</url>
+  <url type="help">https://cockpit-project.org/running.html</url>
   <update_contact>anilsson_at_redhat.com</update_contact>
 </component>

--- a/src/ws/cockpit.desktop.in
+++ b/src/ws/cockpit.desktop.in
@@ -1,9 +1,0 @@
-[Desktop Entry]
-_Name=Cockpit
-_Comment=A user interface for GNU/Linux servers
-Icon=cockpit
-Exec=xdg-open http://localhost:9090
-Terminal=false
-Type=Application
-Categories=GNOME;GTK;System;Profiling;
-_Keywords=Remote;Administration;

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -401,7 +401,6 @@ troubleshooting, interactive command-line sessions, and more.
 %{_docdir}/cockpit/README.md
 %dir %{_datadir}/cockpit
 %{_datadir}/metainfo/cockpit.appdata.xml
-%{_datadir}/applications/cockpit.desktop
 %{_datadir}/pixmaps/cockpit.png
 %doc %{_mandir}/man1/cockpit.1.gz
 

--- a/tools/debian/cockpit.install
+++ b/tools/debian/cockpit.install
@@ -1,4 +1,3 @@
 usr/share/metainfo/cockpit.appdata.xml
-usr/share/applications/cockpit.desktop
 usr/share/pixmaps/cockpit.png
 usr/share/man/man1/cockpit.1

--- a/tools/debian/cockpit.lintian-overrides
+++ b/tools/debian/cockpit.lintian-overrides
@@ -1,2 +1,0 @@
-# We depend on xdg-utils for xdg-open
-cockpit: desktop-command-not-in-package usr/share/applications/cockpit.desktop xdg-open


### PR DESCRIPTION
The current user experience with this .desktop file is rather poor:

 - cockpit.socket is not enabled by default (on purpose).
 - Desktop users rarely see the motd message how to enable it.
 - You will need to log in again in the browser, even though you are in
   an already running session.

We are working on a better integrated solution, with .desktop files for
individual components (and not showing the full navigation and menu).
Until then, remove this to avoid the above confusion on a desktop.

Keep shipping the cockpit.png icon though, it may come in handy in the
future.