### PR TITLE
lib: list within list action scrollable area

### DIFF
--- a/pkg/lib/listing.less
+++ b/pkg/lib/listing.less
@@ -98,6 +98,30 @@ tbody.open > .listing-ct-panel {
 tbody.open > .listing-ct-panel > td > .listing-ct-body {
     border: none;
     overflow: auto;
+    max-height: calc(80vh - 5rem);
+    position: relative;
+
+    /* FIXME: these two lines are for debugging only. Remove! */
+    .machines-disks { display: inline; }
+    .machines-disks-source-value { height: 900vh; }
+
+    .listing-ct {
+        margin-top: 0;
+
+        > caption {
+            @sticky-offset-hack: 50px;
+            position: -webkit-sticky;
+            position: sticky;
+            top: 0;
+            bottom: calc(100% - @sticky-offset-hack);
+            //margin-top: -@sticky-offset-hack;
+            //margin-bottom: @sticky-offset-hack;
+            background: #fff;
+
+            > div {
+            }
+        }
+    }
 }
 
 tbody.open > tr.listing-ct-panel + tr.listing-ct-body {


### PR DESCRIPTION
1. Automatically overflow panels when the content is larger than 80% of the vertical screen minus 5rem (approx height of unexpanded list item).
2. Make actions in a sub-list sticky, so they're always present — even when scrolling.