### PR TITLE
tests: machines: skip testing virsh provider on fedora and rhel-x

### DIFF
--- a/test/verify/check-machines-virsh
+++ b/test/verify/check-machines-virsh
@@ -22,6 +22,8 @@ import parent
 from testlib import *
 
 
+@skipImage("LibvirtDBus is the only available provider",
+           "fedora-28", "fedora-29", "fedora-i386", "fedora-testing", "rhel-x")
 class TestMachinesVirsh(machineslib.TestMachines):
 
     def removeLibvirtDBus(self):


### PR DESCRIPTION
These distros have libvirt-dbus as a required dependency of
cockpit-machines, thus we can stop testing the virsh provider code there.