### PR TITLE
machines: Remove fake vim modelines from scripts

### DIFF
--- a/pkg/machines/scripts/create_machine.sh
+++ b/pkg/machines/scripts/create_machine.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu -o noglob
 
-CONNECTION_URI="qemu:///$1" # ex: qemu:///system
+CONNECTION_URI="qemu:///$1" # example: qemu:///system
 VM_NAME="$2"
 SOURCE="$3"
 OS="$4"

--- a/pkg/machines/scripts/install_machine.sh
+++ b/pkg/machines/scripts/install_machine.sh
@@ -2,7 +2,7 @@
 
 set -u -o noglob
 
-CONNECTION_URI="qemu:///$1" # ex: qemu:///system
+CONNECTION_URI="qemu:///$1" # example: qemu:///system
 VM_NAME="$2"
 SOURCE="$3"
 OS="$4"


### PR DESCRIPTION
The string "ex:" is interpreted by vim as a modeline, which in turn results in a warning like

```
"pkg/machines/scripts/create_machine.sh" 129L, 3986C
Error detected while processing modelines:
line    4:
E518: Unknown option: qemu
Press ENTER or type command to continue
```

every time a file containing it is opened.

Use "example:" instead of "ex:" in comments to avoid the issue.