### PR TITLE
bots: Use Fedora 29 to build packages for Fedora Atomic

### DIFF
--- a/bots/machine/machine_core/machine_virtual.py
+++ b/bots/machine/machine_core/machine_virtual.py
@@ -39,11 +39,11 @@ MEMORY_MB = 1024
 
 # The Atomic variants can't build their own packages, so we build in
 # their non-Atomic siblings.  For example, fedora-atomic is built
-# in fedora-28
+# in fedora-29
 def get_build_image(image):
     (test_os, unused) = os.path.splitext(os.path.basename(image))
     if test_os == "fedora-atomic":
-        image = "fedora-28"
+        image = "fedora-29"
     elif test_os == "rhel-atomic":
         image = "rhel-7-6"
     elif test_os == "continuous-atomic":

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -877,12 +877,12 @@ class MachineCase(unittest.TestCase):
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1557913
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1563143
         # these fail tons of tests due to the SELinux violations (so naughty override causes too much spamming)
-        if self.image in ['fedora-28', 'fedora-atomic']:
+        if self.image in ['fedora-28']:
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { dac_override }.*')
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { module_request }.*')
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { getattr } for .* comm="which" path="/usr/sbin/setfiles".*')
 
-        if self.image in ['fedora-29', 'fedora-testing', 'fedora-i386']:
+        if self.image in ['fedora-29', 'fedora-testing', 'fedora-i386', 'fedora-atomic']:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1563143
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { getattr } for .* comm="which" path="/usr/sbin/setfiles".*')
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1629588


### PR DESCRIPTION
Our fedora-atomic image is Fedora 29 now.