### PR TITLE
ws: Fix updating gettext files

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -219,12 +219,10 @@ pixmap_DATA = src/ws/cockpit.png
 
 CLEANFILES += \
 	$(nodist_appdata_DATA) \
-	$(nodist_desktop_DATA) \
 	$(NULL)
 
 EXTRA_DIST += \
 	$(appdata_in) \
-	$(desktop_in) \
 	$(pixmap_DATA) \
 	$(NULL)
 
@@ -414,8 +412,4 @@ prepare-po-appdata: $(appdata_in)
 	cp $< .
 	$(INTLTOOL_EXTRACT) -l --type=gettext/xml $(notdir $(appdata_in))
 
-prepare-po-desktop: $(desktop_in)
-	cp $< .
-	$(INTLTOOL_EXTRACT) -l --type=gettext/ini $(notdir $(desktop_in))
-
-prepare-po:: prepare-po-appdata prepare-po-desktop
+prepare-po:: prepare-po-appdata


### PR DESCRIPTION
Commit dab20ffefe6 broke updating/uploading/downloading PO files:

    cp src/ws/cockpit.appdata.xml.in .
    /bin/intltool-extract -l --type=gettext/xml cockpit.appdata.xml.in
    Wrote ./tmp/cockpit.appdata.xml.in.h
    cp  .
    cp: missing destination file operand after '.'
    Try 'cp --help' for more information.
    make: *** [Makefile:9906: prepare-po-desktop] Error 1

Clean up the desktop file leftovers in the Makefile to fix that.