### PR TITLE
bots: Adjust tests-scan for rhel-x → rhel-8.0 branch renaming

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -20,7 +20,7 @@
 
 BASELINE_PRIORITY = 10
 
-BRANCHES = [ 'master', 'rhel-7.6', 'rhel-x' ]
+BRANCHES = [ 'master', 'rhel-7.6', 'rhel-8.0' ]
 
 DEFAULT_VERIFY = {
     'avocado/fedora': BRANCHES,
@@ -45,7 +45,7 @@ DEFAULT_VERIFY = {
 REDHAT_VERIFY = {
     "verify/rhel-7-6": [ 'rhel-7.6' ],
     "verify/rhel-7-6-distropkg": [ 'master' ],
-    "verify/rhel-x": [ 'master', 'rhel-x' ],
+    "verify/rhel-x": [ 'master', 'rhel-8.0' ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/edge': [ 'master' ],
 }


### PR DESCRIPTION
Now that 8.0 beta is public, there will be a future RHEL development
version "rhel-x" which is not 8.0, so avoid ambiguity.