### PR TITLE
Fixes check-system-info test import ordering issue

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -21,8 +21,8 @@
 import subprocess
 import time
 
-import packagelib
 import parent
+import packagelib
 from testlib import *
 
 


### PR DESCRIPTION
```import parent``` have to be before ```import packagelib```, otherwise we will get an error when trying to run the test:

```Traceback (most recent call last):
  File "./test/verify/check-system-info", line 24, in <module>
    import packagelib
  File "/home/dell/cockpit/test/verify/packagelib.py", line 23, in <module>
    from testlib import *
ModuleNotFoundError: No module named 'testlib'