### PR TITLE
bots: Add naughty override for qemu crashing when in tcg mode in debian stable

### DIFF
--- a/bots/naughty/debian-stable/10718-qemu-crash-in-tcg-mode
+++ b/bots/naughty/debian-stable/10718-qemu-crash-in-tcg-mode
@@ -1,0 +1,3 @@
+# testCreate (check_machines*
+*
+Process * (qemu-system-x86) of user * dumped core.


### PR DESCRIPTION
Related to: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=915116

Issue #10718