### PR TITLE
bots: Declare rhel-8-0 image

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -46,6 +46,7 @@ REDHAT_VERIFY = {
     "verify/rhel-7-6": [ 'rhel-7.6' ],
     "verify/rhel-7-6-distropkg": [ 'master' ],
     "verify/rhel-x": [ 'master', 'rhel-8.0' ],
+    "verify/rhel-8-0": [ ],
     "verify/rhel-atomic": [ 'master' ],
     'selenium/edge': [ 'master' ],
 }


### PR DESCRIPTION
We will soon rename our rhel-x image to rhel-8-0.