### PR TITLE
test: Fix check-kubernetes import ordering issue

### DIFF
--- a/test/verify/check-kubernetes
+++ b/test/verify/check-kubernetes
@@ -20,8 +20,9 @@
 
 import unittest
 
-import kubelib
 import parent
+
+import kubelib
 from testlib import *
 
 


### PR DESCRIPTION
`import parent` has to come before `import kubelib`. There were other files with `import parent` not being first but those run without any issues.
```Traceback (most recent call last):
  File "./test/verify/check-kubernetes", line 23, in <module>
    import kubelib
  File "/home/dell/cockpit/test/verify/kubelib.py", line 26, in <module>
    import testlib
ModuleNotFoundError: No module named 'testlib'

