### PR TITLE
bots: Move cockpit-podman and starter-kit tests to Fedora 29

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -55,14 +55,14 @@ REDHAT_VERIFY = {
 EXTERNAL_PROJECTS = {
     'cockpit-project/starter-kit': [
         'cockpit/centos-7',
-        'cockpit/fedora-28',
+        'cockpit/fedora-29',
     ],
     'cockpit-project/cockpit-ostree': [
         'cockpit/fedora-atomic',
         'cockpit/continuous-atomic',
     ],
     'cockpit-project/cockpit-podman': [
-        'cockpit/fedora-28',
+        'cockpit/fedora-29',
     ],
     'weldr/welder-web': [
         'cockpit/fedora-29/chrome',


### PR DESCRIPTION
I manually verified that cockpit-podman and starter-kit master both work with `TEST_OS=fedora-29 make check`.