### PR TITLE
wip - services: relayout the service page to make it easier to understand

### DIFF
--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -278,16 +278,8 @@ a.disabled {
     text-align: left;
 }
 
-.service-panel td:first-child {
-    text-align: left;
-}
-
 .service-panel span {
     font-weight: bold;
-}
-
-.service-panel td:last-child {
-    text-align: right;
 }
 
 .service-panel table {

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -92,35 +92,16 @@
       <div class="panel-heading">{{Unit.Description}}</div>
       <div class="list-group">
         <div class="list-group-item">
-          <table>
-            <tr>
-              <td>
-                <span>{{Unit.ActiveState}}</span>
-                ({{Unit.SubState}})
-                <br/>
-                {{Since}}
-              </td>
-              <td>
-                {{{UnitButton}}}
-              </td>
-            </tr>
+
+          <table class="form-table-ct">
+            <tr><td class="top-right">Status</td><td>{{Unit.ActiveState}} {{{UnitButton}}}</td></tr>
+            <tr><td class="top-right">Running Since</td><td>{{Since}}</td></tr>
+            <tr><td class="top-right">Automatic Startup</td><td>{{Unit.UnitFileState}} {{{FileButton}}}</td></tr>
+            <tr><td class="top-right">Path</td><td>{{Unit.FragmentPath}}</td></tr>
           </table>
         </div>
         <div class="list-group-item">
           <table>
-            <tr>
-              <td>
-                {{#HasLoadError}}
-                {{Unit.LoadState}} (Reason: {{LoadError}})
-                {{/HasLoadError}}
-                {{^HasLoadError}}
-                {{Unit.LoadState}} ({{Unit.FragmentPath}}; {{Unit.UnitFileState}})
-                {{/HasLoadError}}
-              </td>
-              <td>
-                {{{FileButton}}}
-              </td>
-            </tr>
             {{#TemplateDescription}}
             <tr>
               <td>{{{.}}}</td>


### PR DESCRIPTION
The service details page was hard to understand for administrators
with a non-linux background. This commit clears up the labels a bit
in order to address that.

Fixes issue #10009