### PR TITLE
naughty: Close 10426: libssh 0.8.1 fails to parse known_hosts, resulting in SSH_SERVER_FOUND_OTHER error for hostkey verification

### DIFF
--- a/bots/naughty/ubuntu-stable/10426-libssh-known-hosts-parse
+++ b/bots/naughty/ubuntu-stable/10426-libssh-known-hosts-parse
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-realms", line *, in testIpa
-    b.wait_popdown('dashboard_setup_server_dialog')
-*
-Error: timeout

--- a/bots/naughty/ubuntu-stable/10426-libssh-known-hosts-parse-2
+++ b/bots/naughty/ubuntu-stable/10426-libssh-known-hosts-parse-2
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-realms", line *, in testNegotiate
-    b.wait_in_text('#troubleshoot-dialog h4', "Log in to")
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 26 days

libssh 0.8.1 fails to parse known_hosts, resulting in SSH_SERVER_FOUND_OTHER error for hostkey verification

Fixes #10426