### PR TITLE
naughty: Close 9486: Ubuntu: libvirtd crashes in pci_get_strings

### DIFF
--- a/bots/naughty/ubuntu-1804/9486-libvirtd-crash-pci_get_strings
+++ b/bots/naughty/ubuntu-1804/9486-libvirtd-crash-pci_get_strings
@@ -1,4 +1,0 @@
-Process * (libvirtd) of user 0 dumped core.
-*
-Stack trace of thread*
-*pci_get_strings*

--- a/bots/naughty/ubuntu-stable/9486-libvirtd-crash-pci_get_strings
+++ b/bots/naughty/ubuntu-stable/9486-libvirtd-crash-pci_get_strings
@@ -1,4 +1,0 @@
-Process * (libvirtd) of user 0 dumped core.
-*
-Stack trace of thread*
-*pci_get_strings*


### PR DESCRIPTION
Known issue which has not occurred in 25 days

Ubuntu: libvirtd crashes in pci_get_strings

Fixes #9486