### PR TITLE
ws: Mark the deleted cookie as 'HttpOnly'

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1649,7 +1649,7 @@ cockpit_auth_empty_cookie_value (const gchar *path)
   gchar *application = cockpit_auth_parse_application (path, NULL);
   gchar *cookie = application_cookie_name (application);
 
-  gchar *cookie_line = g_strdup_printf ("%s=deleted; PATH=/", cookie);
+  gchar *cookie_line = g_strdup_printf ("%s=deleted; PATH=/; HttpOnly", cookie);
 
   g_free (application);
   g_free (cookie);


### PR DESCRIPTION
Vulnerability management software such as Rapid7 InsightVM reports this as a vulnerability.

https://bugzilla.redhat.com/show_bug.cgi?id=1656339