### PR TITLE
Fix statuses watching in tests-invoke

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -118,7 +118,7 @@ class PullTask(object):
                 "requests": [
                     # Set status to pending
                     { "method": "POST",
-                      "resource": api.qualify("statuses/" + self.github_revision),
+                      "resource": api.qualify("commits/" + self.github_revision + "/statuses"),
                       "data": self.github_status_data
                     }
                 ],

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -123,7 +123,7 @@ class PullTask(object):
                     }
                 ],
                 "watches": [{
-                    "resource": api.qualify("commits/" + self.github_revision + "/status"),
+                    "resource": api.qualify("commits/" + self.github_revision + "/status?per_page=100"),
                     "result": {
                         "statuses": [
                             {


### PR DESCRIPTION
This currently breaks PR #10760, #10759, and a few others, where tests are forever stuck in "in progress", and tests repeatedly [fail](https://fedorapeople.org/groups/cockpit/logs/pull-10760-20181205-092727-1b3466a9-verify-rhel-atomic/log.html) on collision detection.

In this cases, the [/statuses API](https://api.github.com/repos/cockpit-project/cockpit/commits/1b3466a90fa5c59a95620b49a46f0e4da3aaec28/statuses) has the correct values, including the recently triggered verify/rhel-atomic test.  But the [/status API](https://api.github.com/repos/cockpit-project/cockpit/commits/1b3466a90fa5c59a95620b49a46f0e4da3aaec28/status) is wrong, it doesn't even have a verify/rhel-atomic context.