### PR TITLE
ws: Add minimal Python WebKit2 browser as preferred alternative

### DIFF
--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -23,8 +23,73 @@
 # network namespace, and thus are totally isolated from everything else.
 #
 # Example: cockpit-desktop /cockpit/@localhost/system/index.html
-
 set -eu
+
+# minimalistic WebKit browser
+PYWEBKIT='
+import sys
+import gi
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("WebKit2", "4.0")
+
+from gi.repository import Gtk, Gdk, WebKit2
+
+class Browser(Gtk.Window):
+    def __init__(self, uri):
+        super().__init__()
+        self.set_title("Web Console")
+
+        self.set_size_request(800, 600)
+
+        self.webview = WebKit2.WebView()
+        self.add(self.webview)
+        self.webview.show()
+        self.webview.connect("load-changed", self._title_changed)
+
+        self.connect("destroy", Gtk.main_quit)
+        self.connect("key-press-event", self._key_pressed)
+
+        self.show()
+        self.webview.load_uri(uri)
+
+    def _title_changed(self, widget, event):
+        self.set_title(self.webview.get_title() or "")
+
+    def _zoom_in(self):
+        cur = self.webview.get_zoom_level()
+        if cur < 3:
+            self.webview.set_zoom_level(cur * 1.1)
+
+    def _zoom_out(self):
+        cur = self.webview.get_zoom_level()
+        if cur > 0.5:
+            self.webview.set_zoom_level(cur / 1.1)
+
+    def _key_pressed(self, widget, event):
+        modifiers = Gtk.accelerator_get_default_mod_mask()
+        mapping = {Gdk.KEY_r: self.webview.reload,
+                   Gdk.KEY_plus: self._zoom_in,
+                   Gdk.KEY_equal: self._zoom_in,
+                   Gdk.KEY_minus: self._zoom_out,
+                   Gdk.KEY_w: Gtk.main_quit,
+                   Gdk.KEY_q: Gtk.main_quit}
+
+        if event.state & modifiers == Gdk.ModifierType.CONTROL_MASK \
+          and event.keyval in mapping:
+            mapping[event.keyval]()
+
+
+if len(sys.argv) == 2:
+    Gtk.init(sys.argv)
+    browser = Browser(sys.argv[1])
+    Gtk.main()
+elif len(sys.argv) > 2:
+    sys.stderr.write("Usage: %s <URL>\n" % sys.argv[0])
+else:
+    # just a test if imports work
+    pass
+'
 
 # find suitable browser, unless already set by $BROWSER
 # We can't use xdg-open, it does too much magic behind the back to connect to
@@ -33,6 +98,11 @@ set -eu
 detect_browser()
 {
     [ -z "${BROWSER:-}" ] || return 0
+
+    if python3 -c "$PYWEBKIT" 2>/dev/null; then
+        BROWSER="python3 -c '$PYWEBKIT'"
+        return 0
+    fi
 
     for browser in chromium-browser chromium google-chrome; do
         if type $browser >/dev/null 2>&1; then

--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -81,7 +81,7 @@ export BROWSER_HOME=$(mktemp --directory --tmpdir cockpit.desktop.XXXXXX)
 # forward parent stdin and stdout (from bridge) to cockpit-ws
 # it pretty well does not matter which port we use in our own namespace, so use standard http
 # disable /etc/cockpit/
-XDG_CONFIG_DIRS="$BROWSER_HOME" @libexecdir@/cockpit-ws -p 80 -a 127.0.0.90 --local-session=- <&0 >&1 &
+XDG_CONFIG_DIRS="$BROWSER_HOME" '${COCKPIT_WS:-@libexecdir@/cockpit-ws}' -p 80 -a 127.0.0.90 --local-session=- <&0 >&1 &
 WS_PID=$!
 # ... and stop using that stdin/out for everything else
 exec 0</dev/null


### PR DESCRIPTION
If Python3, GI, GTK3, and WebKit2 are installed, use these to show an
embedded web view, instead of Firefox or Chromium. This provides a much
nicer impression of a "desktop web app".