### PR TITLE
test: Drop authselect workaround in check-realms

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -276,10 +276,6 @@ class TestRealms(MachineCase):
         m.execute("printf '[cockpit.lan]\\nfully-qualified-names = no\\n'  >> /etc/realmd.conf")
         m.execute("echo foobarfoo | realm join -vU admin cockpit.lan")
 
-        if m.image in ["fedora-29", "fedora-testing"]:
-            # HACK: realmd breaks IPA's nsswitch (https://bugzilla.redhat.com/show_bug.cgi?id=1620097)
-            self.machine.execute("authselect enable-feature with-sudo")
-
         # wait until IPA user works
         m.execute('while ! su - -c "echo foobarfoo | sudo -S true" admin; do sleep 5; done',
                   timeout=300)


### PR DESCRIPTION
This got fixed two months ago, and got dropped from one test case, but
not the other.

 * [x] fix fedora-testing .install file: PR #10781