### PR TITLE
bots: Fix fedora-testing install file

### DIFF
--- a/bots/images/scripts/fedora-testing.install
+++ b/bots/images/scripts/fedora-testing.install
@@ -1,1 +1,1 @@
-fedora-28.install
+fedora-29.install


### PR DESCRIPTION
Commit 89e5639ac23661 was missing to adjust the .install symlink target.
Now that fedora-28 is gone, fedora-testing fails to install.