### PR TITLE
test: Update to QUnit 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "promise": "8.0.2",
     "prop-types": "15.6.2",
     "qunit-tap": "1.5.1",
-    "qunitjs": "1.23.1",
+    "qunit": "2.8.0",
     "react": "16.6.1",
     "react-bootstrap": "0.32.4",
     "react-dom": "16.6.1",

--- a/pkg/docker/test-docker.js
+++ b/pkg/docker/test-docker.js
@@ -23,9 +23,8 @@
     var docker = require("./docker");
     var util = require("./util");
     var QUnit = require("qunit-tests");
-    var assert = QUnit;
 
-    QUnit.test("bytes_from_format", function() {
+    QUnit.test("bytes_from_format", function (assert) {
         var checks = [
             [ "999", 999 ],
             [ "1.9 kb", 1945.6 ],
@@ -44,7 +43,7 @@
         }
     });
 
-    QUnit.test("json_skip", function() {
+    QUnit.test("json_skip", function (assert) {
         var checks = [
             [ "number", "0123456789",
                 [ 10, 0 ] ],
@@ -111,7 +110,7 @@
         }
     });
 
-    QUnit.test("quote_cmdline", function() {
+    QUnit.test("quote_cmdline", function (assert) {
         var checks = [
             [ [ "foo" ], "foo" ],
             [ [ "foo", "bar" ], "foo bar" ],
@@ -128,7 +127,7 @@
                                "quote(" + String(checks[i][0]) + ") = " + checks[i][1]);
     });
 
-    QUnit.test("unquote_cmdline", function() {
+    QUnit.test("unquote_cmdline", function (assert) {
         var checks = [
             [ [ "foo" ], "  foo  " ],
             [ [ "foo", "bar" ], "foo    bar  " ],
@@ -148,7 +147,7 @@
                              "unquote(" + String(checks[i][1]) + ") = " + checks[i][0]);
     });
 
-    QUnit.test("render_container_status", function() {
+    QUnit.test("render_container_status", function (assert) {
         var checks = [
             [ { Status: "blah", Running: true }, "blah" ],
             [ { Running: true, Paused: false }, "running" ],

--- a/pkg/kdump/test-config-client.js
+++ b/pkg/kdump/test-config-client.js
@@ -19,7 +19,6 @@
 
 var QUnit = require("qunit-tests");
 var cockpit = require("cockpit");
-var assert = QUnit;
 
 var kdump = require("./config-client.es6");
 
@@ -44,7 +43,8 @@ var changedConfig = [
     ""
 ].join("\n");
 
-QUnit.asyncTest("config_update", function() {
+QUnit.test("config_update", function (assert) {
+    var done = assert.async();
     assert.expect(10);
     var dataWasChanged = cockpit.defer();
     var config;
@@ -77,7 +77,7 @@ QUnit.asyncTest("config_update", function() {
                                 assert.equal(this.state(), "resolved", "writing to config didn't fail");
                                 dataWasChanged.promise().done(function() {
                                     assert.equal(this.state(), "resolved", "waiting for config change didn't fail");
-                                    QUnit.start();
+                                    done();
                                 });
                             });
                 });

--- a/pkg/kubernetes/scripts/test-connection.js
+++ b/pkg/kubernetes/scripts/test-connection.js
@@ -31,7 +31,6 @@ var QUnit = require("qunit-tests");
 
     /* Filled in with a function */
     var inject;
-    var assert = QUnit;
 
     var module = angular.module("kubernetes.connection.tests", [
         "kubeClient",
@@ -39,38 +38,44 @@ var QUnit = require("qunit-tests");
         "kubernetes.connection",
     ]);
 
-    function connectionTest(name, count, fixtures, func) {
-        QUnit.test(name, function() {
-            assert.expect(count);
-            inject([
-                "kubeLoader",
-                function(loader, data) {
-                    loader.reset(true);
-                    if (fixtures)
-                        loader.handle(fixtures);
-                }
-            ]);
-            inject(func);
-        });
+    function injectLoadFixtures(fixtures) {
+        inject([
+            "kubeLoader",
+            function(loader, data) {
+                loader.reset(true);
+                if (fixtures)
+                    loader.handle(fixtures);
+            }
+        ]);
     }
 
-    connectionTest("sessionCertificates test", 5, fixtures, [
-        "sessionCertificates",
-        function(sessionCertificates) {
-            sessionCertificates.trustCert(null, "data");
-            assert.equal(sessionCertificates.getCert("localhost"), "data", "data retrive");
-            assert.equal(sessionCertificates.getCert(null), "data", "null is localhost");
-            sessionCertificates.trustCert({}, "data1");
-            assert.equal(sessionCertificates.getCert("localhost"), "data1", "blank server retrive");
-            assert.equal(sessionCertificates.getCert("address"), undefined, "missing is undefined");
-            sessionCertificates.trustCert({ server: "address" }, "address-data");
-            assert.equal(sessionCertificates.getCert("address"), undefined, "address data");
-        }
-    ]);
+    QUnit.test("sessionCertificates test", function(assert) {
+        var done = assert.async();
+        assert.expect(5);
 
-    connectionTest("cockpitKubectlConfig parseKubeConfig", 5, fixtures, [
-        "cockpitKubectlConfig",
-        function (ckg) {
+        injectLoadFixtures(fixtures);
+        inject([
+            "sessionCertificates",
+            function(sessionCertificates) {
+                sessionCertificates.trustCert(null, "data");
+                assert.equal(sessionCertificates.getCert("localhost"), "data", "data retrive");
+                assert.equal(sessionCertificates.getCert(null), "data", "null is localhost");
+                sessionCertificates.trustCert({}, "data1");
+                assert.equal(sessionCertificates.getCert("localhost"), "data1", "blank server retrive");
+                assert.equal(sessionCertificates.getCert("address"), undefined, "missing is undefined");
+                sessionCertificates.trustCert({ server: "address" }, "address-data");
+                assert.equal(sessionCertificates.getCert("address"), undefined, "address data");
+                done();
+            }
+        ]);
+    });
+
+    QUnit.test("cockpitKubectlConfig parseKubeConfig", function (assert) {
+        var done = assert.async();
+        assert.expect(5);
+
+        injectLoadFixtures(fixtures);
+        inject(["cockpitKubectlConfig", function (ckg) {
             var alpha = {
                 "address": "alfa.org",
                 "headers": {
@@ -144,12 +149,16 @@ var QUnit = require("qunit-tests");
             assert.deepEqual(ckg.parseKubeConfig(configData, "charlie-with-token"), charlie);
             assert.deepEqual(ckg.parseKubeConfig(configData, "delta-with-cert"), delta1);
             assert.deepEqual(ckg.parseKubeConfig(configData, "delta-with-basic"), delta2);
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    connectionTest("connectionActions prepareData", 6, fixtures, [
-        "connectionActions",
-        function(connectionActions) {
+    QUnit.test("connectionActions prepareData", function (assert) {
+        var done = assert.async();
+        assert.expect(6);
+
+        injectLoadFixtures(fixtures);
+        inject(["connectionActions", function(connectionActions) {
             var cluster, context, user, data, config;
             data = connectionActions.prepareData();
             assert.deepEqual(data, {
@@ -250,8 +259,10 @@ var QUnit = require("qunit-tests");
             data = connectionActions.prepareData(config, cluster, user);
             pos = data.user.name.indexOf("user/127-0-0-1:8000");
             assert.ok(data.user.name != "user/127-0-0-1:8000" && pos === 0, "dedup user name");
-        }
-    ]);
+
+            done();
+        }]);
+    });
 
     angular.module('exceptionOverride', []).factory('$exceptionHandler', function() {
         return function(exception, cause) {

--- a/pkg/kubernetes/scripts/test-images.js
+++ b/pkg/kubernetes/scripts/test-images.js
@@ -28,32 +28,30 @@ function suite(fixtures) {
 
     /* Filled in with a function */
     var inject;
-    var assert = QUnit;
 
     var module = angular.module("registry.images.tests", [
         "kubeClient",
         "registry.images",
     ]);
 
-    function imagesTest(name, count, fixtures, func) {
-        QUnit.test(name, function() {
-            assert.expect(count);
-            inject([
-                "kubeLoader",
-                function(loader) {
-                    loader.reset(true);
-                    if (fixtures)
-                        loader.handle(fixtures);
-                }
-            ]);
-            inject(func);
-        });
+    function injectLoadFixtures(fixtures) {
+        inject([
+            "kubeLoader",
+            function(loader) {
+                loader.reset(true);
+                if (fixtures)
+                    loader.handle(fixtures);
+            }
+        ]);
     }
 
-    imagesTest("filter containsTagImage", 7, fixtures, [
-        "kubeSelect",
-        "imageData",
-        function(select, data) {
+    QUnit.test("filter containsTagImage", function (assert) {
+        var done = assert.async();
+        assert.expect(7);
+
+        injectLoadFixtures(fixtures);
+
+        inject([ "kubeSelect", "imageData", function(select, data) {
             var streams = select().containsTagImage("sha256:c1ee91e9f0f96ea280d17befdd968ce4e37653939fc9e5e36429cd9674a28719");
             assert.equal(streams.length, 2, "number ofstreams");
             assert.ok("/oapi/v1/namespaces/marmalade/imagestreams/busybee" in streams, "matched busybee");
@@ -67,13 +65,18 @@ function suite(fixtures) {
             /* An unknown image */
             streams = select().containsTagImage("sha256:2077956b196342f92271663ec85124aef44ee486f141b7d48e6ce5be410d78f1");
             assert.equal(streams.length, 0, "no streams selected");
-        }
-    ]);
 
-    imagesTest("filter taggedBy", 4, fixtures, [
-        "kubeSelect",
-        "imageData",
-        function(select, data) {
+            done();
+        }]);
+    });
+
+    QUnit.test("filter taggedBy", function (assert) {
+        var done = assert.async();
+        assert.expect(4);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["kubeSelect", "imageData", function(select, data) {
             var tag = { "tag": "2.5", "items": [
                 { "image": "sha256:beadfbc3da8d183c245ab5bad4dd185dacde72dbe81b270926e60e705e534afb" },
                 { "image": "sha256:0885eeaec4514820b2c879100425e9ea10beaf4412db7f67acfe53b4df2b9450" }
@@ -93,13 +96,18 @@ function suite(fixtures) {
             images = select().kind("Image")
                     .taggedBy(tag);
             assert.equal(images.length, 0, "no images matched");
-        }
-    ]);
 
-    imagesTest("filter taggedFirst", 4, fixtures, [
-        "kubeSelect",
-        "imageData",
-        function(select, data) {
+            done();
+        }]);
+    });
+
+    QUnit.test("filter taggedFirst", function (assert) {
+        var done = assert.async();
+        assert.expect(4);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["kubeSelect", "imageData", function(select, data) {
             var tag = { "tag": "2.5", "items": [
                 { "image": "sha256:beadfbc3da8d183c245ab5bad4dd185dacde72dbe81b270926e60e705e534afb" },
                 { "image": "sha256:0885eeaec4514820b2c879100425e9ea10beaf4412db7f67acfe53b4df2b9450" }
@@ -119,13 +127,18 @@ function suite(fixtures) {
             images = select().kind("Image")
                     .taggedFirst(tag);
             assert.equal(images.length, 0, "no images matched");
-        }
-    ]);
 
-    imagesTest("filter listTagNames", 3, fixtures, [
-        "kubeSelect",
-        "imageData",
-        function(select, data) {
+            done();
+        }]);
+    });
+
+    QUnit.test("filter listTagNames", function (assert) {
+        var done = assert.async();
+        assert.expect(3);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["kubeSelect", "imageData", function(select, data) {
             var names = select().listTagNames("sha256:c1ee91e9f0f96ea280d17befdd968ce4e37653939fc9e5e36429cd9674a28719");
             assert.deepEqual(names, ["marmalade/busybee:latest", "marmalade/juggs:extratag"], "got right names");
 
@@ -134,13 +147,18 @@ function suite(fixtures) {
 
             names = select().listTagNames("sha256:2077956b196342f92271663ec85124aef44ee486f141b7d48e6ce5be410d78f1");
             assert.deepEqual(names, [], "no names returned");
-        }
-    ]);
 
-    imagesTest("split dockerImageManifest", 3, fixtures, [
-        "kubeSelect",
-        "imageData",
-        function(select, data) {
+            done();
+        }]);
+    });
+
+    QUnit.test("split dockerImageManifest", function (assert) {
+        var done = assert.async();
+        assert.expect(3);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["kubeSelect", "imageData", function(select, data) {
             var items = select().kind("DockerImageManifest")
                     .name("sha256:63da16dc866fa7bfca4dd9d45b70feda28aa383c9ca1f1766c127ccc715a8cb7");
             assert.equal(items.length, 1, "only manifest returned");
@@ -149,13 +167,18 @@ function suite(fixtures) {
             assert.ok(!!item, "got right manifest");
 
             assert.equal(item.manifest.history[0].v1Compatibility.config.Hostname, "13709f13afe1", "parsed manifest and compat");
-        }
-    ]);
 
-    imagesTest("filter dockerConfigLabels", 3, fixtures, [
-        "kubeSelect",
-        "imageData",
-        function(select, data) {
+            done();
+        }]);
+    });
+
+    QUnit.test("filter dockerConfigLabels", function (assert) {
+        var done = assert.async();
+        assert.expect(3);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["kubeSelect", "imageData", function(select, data) {
             var results = select().kind("Image")
                     .dockerImageConfig()
                     .dockerConfigLabels();
@@ -168,8 +191,10 @@ function suite(fixtures) {
 
             var labels = results["/oapi/v1/images/sha256:63da16dc866fa7bfca4dd9d45b70feda28aa383c9ca1f1766c127ccc715a8cb7"];
             assert.deepEqual(labels, { "Test": "Value", "version": "1.0" }, "got right labels");
-        }
-    ]);
+
+            done();
+        }]);
+    });
 
     angular.module('exceptionOverride', []).factory('$exceptionHandler', function() {
         return function(exception, cause) {

--- a/pkg/kubernetes/scripts/test-nodes.js
+++ b/pkg/kubernetes/scripts/test-nodes.js
@@ -28,7 +28,6 @@ function suite(fixtures) {
 
     /* Filled in with a function */
     var inject;
-    var assert = QUnit;
 
     var module = angular.module("kubernetes.nodes.tests", [
         "kubeClient",
@@ -45,25 +44,24 @@ function suite(fixtures) {
                 }
             ]);
 
-    function nodesTest(name, count, fixtures, func) {
-        QUnit.test(name, function() {
-            assert.expect(count);
-            inject([
-                "kubeLoader",
-                function(loader, data) {
-                    loader.reset(true);
-                    if (fixtures)
-                        loader.handle(fixtures);
-                }
-            ]);
-            inject(func);
-        });
+    function injectLoadFixtures(fixtures) {
+        inject([
+            "kubeLoader",
+            function(loader, data) {
+                loader.reset(true);
+                if (fixtures)
+                    loader.handle(fixtures);
+            }
+        ]);
     }
 
-    nodesTest("nodeStatus tests", 10, fixtures, [
-        "nodeData",
-        "kubeSelect",
-        function(nodeData, select) {
+    QUnit.test("nodeStatus tests", function (assert) {
+        var done = assert.async();
+        assert.expect(10);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["nodeData", "kubeSelect", function(nodeData, select) {
             var nodes = select().kind("Node");
             assert.equal(nodeData.nodeStatus(), "Unknown", "undefined node");
             assert.equal(nodeData.nodeStatus({}), "Unknown", "empty node");
@@ -75,13 +73,17 @@ function suite(fixtures) {
             assert.equal(nodeData.nodeStatus(nodes['/api/v1/nodes/unschedulable-failed-node']), "Not Ready", "not ready and unschedulable");
             assert.equal(nodeData.nodeStatus(nodes['/api/v1/nodes/disk-node']), "Ready", "out of disk");
             assert.equal(nodeData.nodeStatus(nodes['/api/v1/nodes/mem-node']), "Ready", "out of memory");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    nodesTest("nodeStatusIcon tests", 10, fixtures, [
-        "nodeData",
-        "kubeSelect",
-        function(nodeData, select) {
+    QUnit.test("nodeStatusIcon tests", function (assert) {
+        var done = assert.async();
+        assert.expect(10);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["nodeData", "kubeSelect", function(nodeData, select) {
             var nodes = select().kind("Node");
             assert.equal(nodeData.nodeStatusIcon(), "wait", "undefined node");
             assert.equal(nodeData.nodeStatusIcon({}), "wait", "empty node");
@@ -93,13 +95,17 @@ function suite(fixtures) {
             assert.equal(nodeData.nodeStatusIcon(nodes['/api/v1/nodes/unschedulable-failed-node']), "fail", "not ready and unschedulable");
             assert.equal(nodeData.nodeStatusIcon(nodes['/api/v1/nodes/disk-node']), "warn", "out of disk");
             assert.equal(nodeData.nodeStatusIcon(nodes['/api/v1/nodes/mem-node']), "warn", "out of memory");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    nodesTest("nodeConditions tests", 5, fixtures, [
-        "nodeData",
-        "kubeSelect",
-        function(nodeData, select) {
+    QUnit.test("nodeConditions tests", function (assert) {
+        var done = assert.async();
+        assert.expect(5);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["nodeData", "kubeSelect", function(nodeData, select) {
             var nodes = select().kind("Node");
             assert.equal(nodeData.nodeConditions(), undefined);
             assert.equal(nodeData.nodeConditions(null), undefined);
@@ -116,8 +122,9 @@ function suite(fixtures) {
                 }
             }, "Correct object");
             assert.strictEqual(conditions, nodeData.nodeConditions(nodes['/api/v1/nodes/unschedulable-node']), "identical when called with the same object");
-        }
-    ]);
+            done();
+        }]);
+    });
 
     angular.module('exceptionOverride', []).factory('$exceptionHandler', function() {
         return function(exception, cause) {

--- a/pkg/kubernetes/scripts/test-tags.js
+++ b/pkg/kubernetes/scripts/test-tags.js
@@ -29,31 +29,27 @@ function suite() {
 
     /* Filled in with a function */
     var inject;
-    var assert = QUnit;
 
     var module = angular.module("registry.tags.tests", [
         "registry.tags"
     ]);
 
-    function tagsTest(name, count, func) {
-        QUnit.test(name, function() {
-            /* Nothing happening with fixtures yet */
-            assert.expect(count);
-            inject(func);
-        });
-    }
+    QUnit.test("parseSpec", function (assert) {
+        var done = assert.async();
+        assert.expect(1);
 
-    tagsTest("parseSpec", 1, [
-        "imageTagData",
-        function(data) {
+        inject(["imageTagData", function(data) {
             var names = data.parseSpec(specData);
             assert.deepEqual(names, [ "1", "1.23", "1.24.0", "1.24.2", "latest" ], "parsed names correctly");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    tagsTest("buildSpec with spec", 1, [
-        "imageTagData",
-        function(data) {
+    QUnit.test("buildSpec with spec", function (assert) {
+        var done = assert.async();
+        assert.expect(1);
+
+        inject(["imageTagData", function(data) {
             var spec = angular.extend({ }, specData);
             spec = data.buildSpec(["2.5", "latest", "second"], spec, true, 'docker.io/busybox');
             assert.deepEqual(spec, {
@@ -67,8 +63,9 @@ function suite() {
                       "from": { "kind": "DockerImage", "name": "docker.io/busybox:second" }}
                 ]
             }, "build spec correctly");
-        }
-    ]);
+            done();
+        }]);
+    });
 
     angular.module('exceptionOverride', []).factory('$exceptionHandler', function() {
         return function(exception, cause) {

--- a/pkg/kubernetes/scripts/test-utils.js
+++ b/pkg/kubernetes/scripts/test-utils.js
@@ -27,22 +27,16 @@ function suite() {
 
     /* Filled in with a function */
     var inject;
-    var assert = QUnit;
 
     var module = angular.module("kubeUtils.tests", [
         "kubeUtils",
     ]);
 
-    function utilsTest(name, count, func) {
-        QUnit.test(name, function() {
-            assert.expect(count);
-            inject(func);
-        });
-    }
+    QUnit.test("map Named Array", function (assert) {
+        var done = assert.async();
+        assert.expect(4);
 
-    utilsTest("map Named Array", 4, [
-        "KubeMapNamedArray",
-        function lala(mapNamedArray) {
+        inject(["KubeMapNamedArray", function lala(mapNamedArray) {
             var target = {
                 "one": {
                     "name": "one",
@@ -82,12 +76,15 @@ function suite() {
             assert.deepEqual(mapNamedArray([]), {});
             assert.deepEqual(mapNamedArray(source), target);
             assert.deepEqual(mapNamedArray(source, "other"), target2);
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    utilsTest("Kube string to bytes", 20, [
-        "KubeStringToBytes",
-        function(stringToBytes) {
+    QUnit.test("Kube string to bytes", function (assert) {
+        var done = assert.async();
+        assert.expect(20);
+
+        inject(["KubeStringToBytes", function(stringToBytes) {
             assert.deepEqual(stringToBytes(), undefined);
             assert.deepEqual(stringToBytes("bad"), undefined);
             assert.deepEqual(stringToBytes("10"), undefined);
@@ -108,8 +105,9 @@ function suite() {
             assert.deepEqual(stringToBytes("10Gi"), 10737418240);
             assert.deepEqual(stringToBytes("10Mi"), 10485760);
             assert.deepEqual(stringToBytes("10Ki"), 10240);
-        }
-    ]);
+            done();
+        }]);
+    });
 
     angular.module('exceptionOverride', []).factory('$exceptionHandler', function() {
         return function(exception, cause) {

--- a/pkg/kubernetes/scripts/test-volumes.js
+++ b/pkg/kubernetes/scripts/test-volumes.js
@@ -28,7 +28,6 @@ function suite(fixtures) {
 
     /* Filled in with a function */
     var inject;
-    var assert = QUnit;
 
     var module = angular.module("kubernetes.volumes.tests", [
         "kubeClient",
@@ -46,25 +45,24 @@ function suite(fixtures) {
                 }
             ]);
 
-    function volumesTest(name, count, fixtures, func) {
-        QUnit.test(name, function() {
-            assert.expect(count);
-            inject([
-                "kubeLoader",
-                function(loader, data) {
-                    loader.reset(true);
-                    if (fixtures)
-                        loader.handle(fixtures);
-                }
-            ]);
-            inject(func);
-        });
+    function injectLoadFixtures(fixtures) {
+        inject([
+            "kubeLoader",
+            function(loader, data) {
+                loader.reset(true);
+                if (fixtures)
+                    loader.handle(fixtures);
+            }
+        ]);
     }
 
-    volumesTest("pods for Claim", 4, fixtures, [
-        "volumeData",
-        'kubeSelect',
-        function(volumeData, select) {
+    QUnit.test("pods for Claim", function (assert) {
+        var done = assert.async();
+        assert.expect(4);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["volumeData", 'kubeSelect', function(volumeData, select) {
             var claim = select().kind("PersistentVolumeClaim")
                     .name("bound-claim")
                     .one();
@@ -77,13 +75,18 @@ function suite(fixtures) {
 
             pods = volumeData.podsForClaim({});
             assert.deepEqual(pods.length, 0, "empty claim pods");
-        }
-    ]);
 
-    volumesTest("volumes for Pod", 4, fixtures, [
-        "volumeData",
-        'kubeSelect',
-        function(volumeData, select) {
+            done();
+        }]);
+    });
+
+    QUnit.test("volumes for Pod", function (assert) {
+        var done = assert.async();
+        assert.expect(4);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["volumeData", 'kubeSelect', function(volumeData, select) {
             var pod = select().kind("Pod")
                     .one();
             var volumes = volumeData.volumesForPod(pod);
@@ -145,13 +148,18 @@ function suite(fixtures) {
 
             assert.deepEqual(volumeData.volumesForPod(), {}, "No null volumes");
             assert.deepEqual(volumeData.volumesForPod({}), {}, "No empty volumes");
-        }
-    ]);
 
-    volumesTest("claim From Volume Source", 4, fixtures, [
-        "volumeData",
-        'kubeSelect',
-        function(volumeData, select) {
+            done();
+        }]);
+    });
+
+    QUnit.test("claim From Volume Source", function (assert) {
+        var done = assert.async();
+        assert.expect(4);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["volumeData", 'kubeSelect', function(volumeData, select) {
             var pod = select().kind("Pod")
                     .one();
             var volumes = volumeData.volumesForPod(pod);
@@ -162,13 +170,18 @@ function suite(fixtures) {
 
             assert.deepEqual(volumeData.claimFromVolumeSource(), null, "No null volumes");
             assert.deepEqual(volumeData.claimFromVolumeSource({}), null, "No empty volumes");
-        }
-    ]);
 
-    volumesTest("claim For Volume", 5, fixtures, [
-        "volumeData",
-        'kubeSelect',
-        function(volumeData, select) {
+            done();
+        }]);
+    });
+
+    QUnit.test("claim For Volume", function (assert) {
+        var done = assert.async();
+        assert.expect(5);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["volumeData", 'kubeSelect', function(volumeData, select) {
             var bound = select().kind("PersistentVolume")
                     .name("bound")
                     .one();
@@ -184,13 +197,17 @@ function suite(fixtures) {
 
             assert.equal(volumeData.claimForVolume(), null, "null volume");
             assert.equal(volumeData.claimForVolume(), null, "empty volume");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    volumesTest("claim phases", 2, fixtures, [
-        "volumeData",
-        'kubeSelect',
-        function(volumeData, select) {
+    QUnit.test("claim phases", function (assert) {
+        var done = assert.async();
+        assert.expect(2);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["volumeData", 'kubeSelect', function(volumeData, select) {
             var claim = select().kind("PersistentVolumeClaim")
                     .statusPhase("Bound")
                     .one();
@@ -200,13 +217,17 @@ function suite(fixtures) {
                     .statusPhase("Pending")
                     .one();
             assert.equal(pending.metadata.name, "unbound-claim", "select unbound claims");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    volumesTest("volume Types", 4, fixtures, [
-        "volumeData",
-        'kubeSelect',
-        function(volumeData, select) {
+    QUnit.test("volume Types", function (assert) {
+        var done = assert.async();
+        assert.expect(4);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["volumeData", 'kubeSelect', function(volumeData, select) {
             var pv = select().kind("PersistentVolume")
                     .name("bound")
                     .one();
@@ -216,26 +237,34 @@ function suite(fixtures) {
             assert.equal(volumeData.getVolumeType(volumes["default-token-luvqo"]), "secret", "secret volume");
             assert.equal(volumeData.getVolumeType(), undefined, "null volume");
             assert.equal(volumeData.getVolumeType({}), undefined, "empty volume");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    volumesTest("volume Labels", 3, fixtures, [
-        "volumeData",
-        'kubeSelect',
-        function(volumeData, select) {
+    QUnit.test("volume Labels", function (assert) {
+        var done = assert.async();
+        assert.expect(3);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["volumeData", 'kubeSelect', function(volumeData, select) {
             var pv = select().kind("PersistentVolume")
                     .name("bound")
                     .one();
             assert.equal(volumeData.getVolumeLabel(), "Unknown", "null volume");
             assert.equal(volumeData.getVolumeLabel({}), "Unknown", "empty volume");
             assert.equal(volumeData.getVolumeLabel(pv.spec), "NFS Mount", "volume label");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    volumesTest("default volume build", 3, fixtures, [
-        "defaultVolumeFields",
-        "kubeSelect",
-        function(volumeFields, select) {
+    QUnit.test("default volume build", function (assert) {
+        var done = assert.async();
+        assert.expect(3);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["defaultVolumeFields", "kubeSelect", function(volumeFields, select) {
             var blank_fields = {
                 "accessModes": {
                     "ReadOnlyMany": "Read only from multiple nodes",
@@ -269,13 +298,17 @@ function suite(fixtures) {
                 }
             }, volumeFields.build(select().name("available")
                     .one()), "default fields");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    volumesTest("default volume validate", 15, fixtures, [
-        "defaultVolumeFields",
-        "kubeSelect",
-        function(volumeFields, select) {
+    QUnit.test("default volume validate", function (assert) {
+        var done = assert.async();
+        assert.expect(15);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["defaultVolumeFields", "kubeSelect", function(volumeFields, select) {
             var result = volumeFields.validate(null, {});
             assert.equal(result.data, null, "blank fields blank data");
             assert.equal(result.errors.length, 4);
@@ -329,13 +362,18 @@ function suite(fixtures) {
 
             result = volumeFields.validate({}, valid);
             assert.deepEqual(result.data, { "spec": spec }, "with item only spec");
-        }
-    ]);
 
-    volumesTest("gluster volume build", 3, fixtures, [
-        "glusterfsVolumeFields",
-        "kubeSelect",
-        function(gfs, select) {
+            done();
+        }]);
+    });
+
+    QUnit.test("gluster volume build", function (assert) {
+        var done = assert.async();
+        assert.expect(3);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["glusterfsVolumeFields", "kubeSelect", function(gfs, select) {
             var endpoints = select().kind("Endpoints");
             var blank_fields = {
                 "glusterfsPath": undefined,
@@ -359,12 +397,18 @@ function suite(fixtures) {
                 "endpoint": "my-gluster-endpoint",
             }, gfs.build(select().name("gfs-volume")
                     .one()), "gluster fields");
-        }
-    ]);
 
-    volumesTest("gfs volume validate", 9, fixtures, [
-        "glusterfsVolumeFields",
-        function(nfsVolumeFields) {
+            done();
+        }]);
+    });
+
+    QUnit.test("gfs volume validate", function (assert) {
+        var done = assert.async();
+        assert.expect(9);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["glusterfsVolumeFields", function(nfsVolumeFields) {
             var result = nfsVolumeFields.validate(null, {});
             assert.equal(result.data, null, "blank fields blank data");
             assert.equal(result.errors.length, 2);
@@ -392,13 +436,17 @@ function suite(fixtures) {
             result = nfsVolumeFields.validate(null, valid);
             assert.deepEqual(result.data, source, "valid source result");
             assert.equal(result.errors.length, 0, "no errors when valid");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    volumesTest("nfs volume build", 3, fixtures, [
-        "nfsVolumeFields",
-        "kubeSelect",
-        function(nfsVolumeFields, select) {
+    QUnit.test("nfs volume build", function (assert) {
+        var done = assert.async();
+        assert.expect(3);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["nfsVolumeFields", "kubeSelect", function(nfsVolumeFields, select) {
             var blank_fields = {
                 "path": undefined,
                 "readOnly": undefined,
@@ -421,12 +469,17 @@ function suite(fixtures) {
                 "server": "host-or.ip:port",
             }, nfsVolumeFields.build(select().name("bound")
                     .one()), "nfs fields");
-        }
-    ]);
+            done();
+        }]);
+    });
 
-    volumesTest("nfs volume validate", 10, fixtures, [
-        "nfsVolumeFields",
-        function(nfsVolumeFields) {
+    QUnit.test("nfs volume validate", function (assert) {
+        var done = assert.async();
+        assert.expect(10);
+
+        injectLoadFixtures(fixtures);
+
+        inject(["nfsVolumeFields", function(nfsVolumeFields) {
             var result = nfsVolumeFields.validate(null, {});
             assert.equal(result.data, null, "blank fields blank data");
             assert.equal(result.errors.length, 2);
@@ -455,8 +508,9 @@ function suite(fixtures) {
             result = nfsVolumeFields.validate(null, valid);
             assert.deepEqual(result.data, source, "valid source result");
             assert.equal(result.errors.length, 0, "no errors when valid");
-        }
-    ]);
+            done();
+        }]);
+    });
 
     angular.module('exceptionOverride', []).factory('$exceptionHandler', function() {
         return function(exception, cause) {

--- a/pkg/lib/qunit-config.js
+++ b/pkg/lib/qunit-config.js
@@ -80,6 +80,3 @@ window.setTimeout(function() {
 }, 20000);
 
 window.tests_included = true;
-
-if (module && module.exports)
-    module.exports = QUnit;

--- a/pkg/lib/qunit-tests.js
+++ b/pkg/lib/qunit-tests.js
@@ -21,12 +21,12 @@
     "use strict";
 
     /* QUnit needs to have 'window' as 'this' in order to load */
-    window.QUnit = require("qunitjs/qunit/qunit.js");
+    window.QUnit = require("qunit/qunit/qunit.js");
     window.qunitTap = require("qunit-tap/lib/qunit-tap.js");
 
     require("./qunit-config.js");
 
-    require("qunitjs/qunit/qunit.css");
+    require("qunit/qunit/qunit.css");
 
     module.exports = window.QUnit;
 }());

--- a/pkg/lib/test-dummy.js
+++ b/pkg/lib/test-dummy.js
@@ -18,10 +18,9 @@
  */
 
 var QUnit = require("qunit-tests");
-var assert = QUnit;
 
 function run_tests() {
-    QUnit.test("hello test", function() {
+    QUnit.test("hello test", function(assert) {
         assert.ok(1 == "1", "Dummy test case");
     });
     QUnit.start();

--- a/pkg/lib/test-machines.js
+++ b/pkg/lib/test-machines.js
@@ -18,11 +18,10 @@
  */
 
 var QUnit = require("qunit-tests");
-var assert = QUnit;
 
 var machines = require("machines");
 
-QUnit.test("colors.parse()", function() {
+QUnit.test("colors.parse()", function (assert) {
     var colors = [
         [ "#960064", "rgb(150, 0, 100)" ],
         [ "rgb(150, 0, 100)", "rgb(150, 0, 100)" ],

--- a/pkg/lib/test-patterns.js
+++ b/pkg/lib/test-patterns.js
@@ -18,12 +18,11 @@
  */
 
 var QUnit = require("qunit-tests");
-var assert = QUnit;
 
 var $ = require("jquery");
 require("patterns");
 
-QUnit.test("update_privileged", function() {
+QUnit.test("update_privileged", function (assert) {
     var p_true = { 'allowed' : true };
     var p_false = { 'allowed' : false };
     var p_unknown = { };

--- a/pkg/machines/test-machines.js
+++ b/pkg/machines/test-machines.js
@@ -1,9 +1,8 @@
 var QUnit = require("qunit-tests");
-var assert = QUnit;
 
 var helpers = require("./helpers.es6");
 
-QUnit.test("toFixedPrecision", function() {
+QUnit.test("toFixedPrecision", function (assert) {
     assert.equal("1.0", helpers.toFixedPrecision("1", 1));
     assert.equal("1.0", helpers.toFixedPrecision("1.0", 1));
     assert.equal("1.0", helpers.toFixedPrecision("1.01", 1));

--- a/pkg/networkmanager/test-utils.js
+++ b/pkg/networkmanager/test-utils.js
@@ -20,9 +20,8 @@
 var utils = require("./utils");
 var cockpit = require("cockpit");
 var QUnit = require("qunit-tests");
-var assert = QUnit;
 
-function assert_throws(func, checks) {
+function assert_throws(assert, func, checks) {
     assert.expect(checks.length);
 
     checks.forEach(function(c) {
@@ -32,7 +31,7 @@ function assert_throws(func, checks) {
     });
 }
 
-QUnit.test("ip_prefix_from_text", function() {
+QUnit.test("ip_prefix_from_text", function (assert) {
     var checks = [
         [ "0", 0 ],
         [ "12", 12 ],
@@ -46,7 +45,7 @@ QUnit.test("ip_prefix_from_text", function() {
     });
 });
 
-QUnit.test("ip_prefix_from_text invalids", function() {
+QUnit.test("ip_prefix_from_text invalids", function (assert) {
     var checks = [
         "",
         "-1",
@@ -56,10 +55,10 @@ QUnit.test("ip_prefix_from_text invalids", function() {
         "1 2 3"
     ];
 
-    assert_throws(utils.ip_prefix_from_text, checks);
+    assert_throws(assert, utils.ip_prefix_from_text, checks);
 });
 
-QUnit.test("ip_metric_from_text", function() {
+QUnit.test("ip_metric_from_text", function (assert) {
     var checks = [
         [ "", 0 ],
         [ "0", 0 ],
@@ -74,7 +73,7 @@ QUnit.test("ip_metric_from_text", function() {
     });
 });
 
-QUnit.test("ip_metric_from_text invalids", function() {
+QUnit.test("ip_metric_from_text invalids", function (assert) {
     var checks = [
         "-1",
         "foo",
@@ -83,10 +82,10 @@ QUnit.test("ip_metric_from_text invalids", function() {
         "1 2 3"
     ];
 
-    assert_throws(utils.ip_metric_from_text, checks);
+    assert_throws(assert, utils.ip_metric_from_text, checks);
 });
 
-QUnit.test("ip4_to/from_text be", function() {
+QUnit.test("ip4_to/from_text be", function (assert) {
     var checks = [
         [ "0.0.0.0", 0x00000000 ],
         [ "255.255.255.255", 0xFFFFFFFF ],
@@ -104,7 +103,7 @@ QUnit.test("ip4_to/from_text be", function() {
     });
 });
 
-QUnit.test("ip4_to/from_text le", function() {
+QUnit.test("ip4_to/from_text le", function (assert) {
     var checks = [
         [ "0.0.0.0", 0x00000000 ],
         [ "255.255.255.255", 0xFFFFFFFF ],
@@ -122,7 +121,7 @@ QUnit.test("ip4_to/from_text le", function() {
     });
 });
 
-QUnit.test("ip4_from_text invalids", function() {
+QUnit.test("ip4_from_text invalids", function (assert) {
     var checks = [
         "",
         "0",
@@ -138,20 +137,20 @@ QUnit.test("ip4_from_text invalids", function() {
         "1 1.2.3 3.4"
     ];
 
-    assert_throws(utils.ip4_from_text, checks);
+    assert_throws(assert, utils.ip4_from_text, checks);
 });
 
-QUnit.test("ip4_to_text zero", function() {
+QUnit.test("ip4_to_text zero", function (assert) {
     utils.set_byteorder("be");
     assert.strictEqual(utils.ip4_to_text(0, true), "");
 });
 
-QUnit.test("ip4_from_text empty", function() {
+QUnit.test("ip4_from_text empty", function (assert) {
     utils.set_byteorder("be");
     assert.strictEqual(utils.ip4_from_text("", true), 0);
 });
 
-QUnit.test("ip4_prefix_from_text", function() {
+QUnit.test("ip4_prefix_from_text", function (assert) {
     var checks = [
         "0.0.0.0",
 
@@ -199,7 +198,7 @@ QUnit.test("ip4_prefix_from_text", function() {
     });
 });
 
-QUnit.test("ip4_prefix_from_text invalids", function() {
+QUnit.test("ip4_prefix_from_text invalids", function (assert) {
     var checks = [
         "",
         "-1",
@@ -215,10 +214,10 @@ QUnit.test("ip4_prefix_from_text invalids", function() {
         "255.192.0.10"
     ];
 
-    assert_throws(utils.ip4_prefix_from_text, checks);
+    assert_throws(assert, utils.ip4_prefix_from_text, checks);
 });
 
-QUnit.test("ip6_to/from_text", function() {
+QUnit.test("ip6_to/from_text", function (assert) {
     var checks = [
         [ [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ],
@@ -242,7 +241,7 @@ QUnit.test("ip6_to/from_text", function() {
     });
 });
 
-QUnit.test("ip6_from_text abbrevs", function() {
+QUnit.test("ip6_from_text abbrevs", function (assert) {
     var checks = [
         [ "::",
             [ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -271,7 +270,7 @@ QUnit.test("ip6_from_text abbrevs", function() {
     });
 });
 
-QUnit.test("ip6_from_text invalids", function() {
+QUnit.test("ip6_from_text invalids", function (assert) {
     var checks = [
         "",
         "0",
@@ -293,17 +292,17 @@ QUnit.test("ip6_from_text invalids", function() {
         "1:2:3:4 4:5:6:7:8",
     ];
 
-    assert_throws(utils.ip6_from_text, checks);
+    assert_throws(assert, utils.ip6_from_text, checks);
 });
 
-QUnit.test("ip6_to_text zero", function() {
+QUnit.test("ip6_to_text zero", function (assert) {
     var zero = [ 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0
     ];
     assert.strictEqual(utils.ip6_to_text(cockpit.base64_encode(zero), true), "");
 });
 
-QUnit.test("ip6_from_text empty", function() {
+QUnit.test("ip6_from_text empty", function (assert) {
     var zero = [ 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0
     ];

--- a/pkg/storaged/test-util.js
+++ b/pkg/storaged/test-util.js
@@ -19,9 +19,8 @@
 
 var utils = require("./utils");
 var QUnit = require("qunit-tests");
-var assert = QUnit;
 
-QUnit.test("format_delay", function() {
+QUnit.test("format_delay", function (assert) {
     var checks = [
         [ 15550000, "4 hours" ]
     ];
@@ -33,7 +32,7 @@ QUnit.test("format_delay", function() {
     }
 });
 
-QUnit.test("compare_versions", function() {
+QUnit.test("compare_versions", function (assert) {
     var checks = [
         [ "", "", 0 ],
         [ "0", "0", 0 ],
@@ -56,21 +55,21 @@ QUnit.test("compare_versions", function() {
     }
 });
 
-QUnit.test("mdraid_name_nohostnamed", function() {
+QUnit.test("mdraid_name_nohostnamed", function (assert) {
     var orig_hostnamed = utils.hostnamed;
     utils.hostnamed = { StaticHostname: undefined };
     assert.strictEqual(utils.mdraid_name({ "Name": "somehost:mydev" }), "mydev", "remote host name is skipped when hostnamed is not available");
     utils.hostnamed = orig_hostnamed;
 });
 
-QUnit.test("mdraid_name_remote", function() {
+QUnit.test("mdraid_name_remote", function (assert) {
     var orig_hostnamed = utils.hostnamed;
     utils.hostnamed = { StaticHostname: "sweethome" };
     assert.strictEqual(utils.mdraid_name({ "Name": "somehost:mydev" }), "mydev (from somehost)", "expected name for remote host");
     utils.hostnamed = orig_hostnamed;
 });
 
-QUnit.test("mdraid_name_local", function() {
+QUnit.test("mdraid_name_local", function (assert) {
     var orig_hostnamed = utils.hostnamed;
     utils.hostnamed = { StaticHostname: "sweethome" };
     assert.strictEqual(utils.mdraid_name({ "Name": "sweethome:mydev" }), "mydev", "expected name for local host");

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -140,13 +140,13 @@ base_QUNIT_DEPS = \
 
 dist/base1/qunit.js:
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
-	cat $(srcdir)/node_modules/qunitjs/qunit/qunit.js \
+	cat $(srcdir)/node_modules/qunit/qunit/qunit.js \
 	    $(srcdir)/node_modules/qunit-tap/lib/qunit-tap.js \
             $(srcdir)/pkg/lib/qunit-config.js > $@.tmp && $(MV) $@.tmp $@
 
 dist/base1/qunit.css:
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
-	cp $(srcdir)/node_modules/qunitjs/qunit/qunit.css $@.tmp && $(MV) $@.tmp $@
+	cp $(srcdir)/node_modules/qunit/qunit/qunit.css $@.tmp && $(MV) $@.tmp $@
 
 dist/base1/test-dbus-common.js: src/base1/test-dbus-common.js
 	$(ESLINT_RULE)

--- a/src/base1/test-base64.js
+++ b/src/base1/test-base64.js
@@ -1,9 +1,6 @@
 /* global cockpit, QUnit, Uint8Array */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.test("base64 array", function() {
+QUnit.test("base64 array", function (assert) {
     var data = new Array(5);
     for (var i = 0; i < 5; i++)
         data[i] = i;
@@ -23,7 +20,7 @@ QUnit.test("base64 array", function() {
     assert.ok(match, "right data");
 });
 
-QUnit.test("base64 arraybuffer", function() {
+QUnit.test("base64 arraybuffer", function (assert) {
     var view = new Uint8Array(5);
     for (var i = 0; i < 5; i++)
         view[i] = i;
@@ -43,12 +40,12 @@ QUnit.test("base64 arraybuffer", function() {
     assert.ok(match, "right data");
 });
 
-QUnit.test("base64 string", function() {
+QUnit.test("base64 string", function (assert) {
     assert.equal(cockpit.base64_encode("blah"), "YmxhaA==", "encoded right");
     assert.strictEqual(cockpit.base64_decode("YmxhaA==", String), "blah", "decoded right");
 });
 
-QUnit.test("base64 round trip", function() {
+QUnit.test("base64 round trip", function (assert) {
     function random_int(min, max) {
         return Math.floor(Math.random() * (max - min)) + min;
     }

--- a/src/base1/test-browser-storage.js
+++ b/src/base1/test-browser-storage.js
@@ -1,9 +1,6 @@
 /* global cockpit, QUnit, unescape, escape */
 
-/* To help with future migration */
-var assert = QUnit;
-
-function test_storage (storage, cockpitStorage) {
+function test_storage (assert, storage, cockpitStorage) {
     assert.expect(29);
     storage.clear();
     window.mock = {
@@ -71,12 +68,12 @@ function test_storage (storage, cockpitStorage) {
     assert.equal(storage.getItem("cockpit+test:key2"), null, "clear full removes our application's key2");
 }
 
-QUnit.test("local-storage", function() {
-    test_storage(window.localStorage, cockpit.localStorage);
+QUnit.test("local-storage", function (assert) {
+    test_storage(assert, window.localStorage, cockpit.localStorage);
 });
 
-QUnit.test("session-storage", function() {
-    test_storage(window.sessionStorage, cockpit.sessionStorage);
+QUnit.test("session-storage", function (assert) {
+    test_storage(assert, window.sessionStorage, cockpit.sessionStorage);
 });
 
 // Start tests after we have a user object

--- a/src/base1/test-cache.js
+++ b/src/base1/test-cache.js
@@ -1,13 +1,11 @@
 /* global cockpit, QUnit, unescape, escape */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.test("public api", function() {
+QUnit.test("public api", function (assert) {
     assert.equal(typeof cockpit.cache, "function", "cockpit.cache is a function");
 });
 
-QUnit.asyncTest("single cache", function() {
+QUnit.test("single cache", function (assert) {
+    let done = assert.async();
     assert.expect(6);
 
     var closed = false;
@@ -36,13 +34,14 @@ QUnit.asyncTest("single cache", function() {
         cache.close();
         assert.equal(closed, true, "cache is closed");
 
-        QUnit.start();
+        done();
     }
 
     var cache = cockpit.cache("test-key-1", provider, consumer);
 });
 
-QUnit.asyncTest("multi cache", function() {
+QUnit.test("multi cache", function (assert) {
+    let done = assert.async();
     assert.expect(12);
 
     var closed1 = false;
@@ -92,7 +91,7 @@ QUnit.asyncTest("multi cache", function() {
             assert.equal(closed1, true, "cache1 is closed");
         } else if (count === 2) {
             assert.deepEqual(value, { myobject: "value2" }, "cache2 provided another value");
-            QUnit.start();
+            done();
         }
     }
 

--- a/src/base1/test-dbus-common.js
+++ b/src/base1/test-dbus-common.js
@@ -19,10 +19,9 @@
 
 /* global cockpit, QUnit, $ */
 
-var assert = QUnit;
-
 function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line no-unused-vars
-    QUnit.asyncTest("call method", function() {
+    QUnit.test("call method", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -34,11 +33,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("call method with timeout", function() {
+    QUnit.test("call method with timeout", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -52,16 +52,17 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "call timed out");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("close immediately", function() {
+    QUnit.test("close immediately", function (assert) {
+        let done = assert.async();
         assert.expect(1);
         var dbus = cockpit.dbus(bus_name, channel_options);
         $(dbus).on("close", function(event, options) {
             assert.equal(options.problem, "test-code", "got right code");
-            QUnit.start();
+            done();
         });
 
         window.setTimeout(function() {
@@ -69,7 +70,8 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
         }, 100);
     });
 
-    QUnit.asyncTest("call close", function() {
+    QUnit.test("call close", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -80,13 +82,14 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "call rejected");
-                    QUnit.start();
+                    done();
                 });
 
         dbus.close();
     });
 
-    QUnit.asyncTest("call closed", function() {
+    QUnit.test("call closed", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -99,11 +102,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "call rejected");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("primitive types", function() {
+    QUnit.test("primitive types", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -121,17 +125,18 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("integer bounds", function() {
+    QUnit.test("integer bounds", function (assert) {
         assert.expect(35);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
 
         function testNumber(type, value, valid) {
-            QUnit.stop();
+            let done = assert.async();
+
             dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
                       "TestVariant", [ { t: type, v: value } ])
                     .fail(function(ex) {
@@ -142,7 +147,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                             assert.equal(this.state(), "resolved", "accepted in bounds number");
                         else
                             assert.equal(this.state(), "rejected", "rejected out of bounds number");
-                        QUnit.start();
+                        done();
                     });
         }
 
@@ -170,11 +175,10 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
         testNumber('x', 0xfffffffff, true);
         testNumber('t', 0xfffffffff, true);
         testNumber('t', -1, false);
-
-        QUnit.start();
     });
 
-    QUnit.asyncTest("non-primitive types", function() {
+    QUnit.test("non-primitive types", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -194,11 +198,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("variants", function() {
+    QUnit.test("variants", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -217,11 +222,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad variants", function() {
+    QUnit.test("bad variants", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -239,11 +245,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad variants", function() {
+    QUnit.test("bad variants", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -261,11 +268,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("get all", function() {
+    QUnit.test("get all", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -296,11 +304,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("call unimplemented", function() {
+    QUnit.test("call unimplemented", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -312,11 +321,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("call bad base64", function() {
+    QUnit.test("call bad base64", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -329,11 +339,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("call unknown", function() {
+    QUnit.test("call unknown", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -345,11 +356,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("signals", function() {
+    QUnit.test("signals", function (assert) {
+        let done = assert.async();
         assert.expect(6);
 
         var received = false;
@@ -373,11 +385,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 .always(function() {
                     assert.equal(this.state(), "resolved", "emmision requested");
                     assert.equal(received, true, "signal received");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("signal unsubscribe", function() {
+    QUnit.test("signal unsubscribe", function (assert) {
+        let done = assert.async();
         assert.expect(4);
 
         var received = true;
@@ -405,12 +418,13 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                             .always(function() {
                                 assert.equal(this.state(), "resolved", "second emmision requested");
                                 assert.equal(received, false, "signal not received");
-                                QUnit.start();
+                                done();
                             });
                 });
     });
 
-    QUnit.asyncTest("with types", function() {
+    QUnit.test("with types", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -423,11 +437,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("with meta", function() {
+    QUnit.test("with meta", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var meta = {
@@ -457,11 +472,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     dbus.close();
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("empty base64", function() {
+    QUnit.test("empty base64", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -474,11 +490,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad object path", function() {
+    QUnit.test("bad object path", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -488,11 +505,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.equal(ex.message, "object path is invalid in dbus \"call\": invalid/path", "error message");
                 })
                 .always(function() {
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad interface name", function() {
+    QUnit.test("bad interface name", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -502,11 +520,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.equal(ex.message, "interface name is invalid in dbus \"call\": !invalid!interface!", "error message");
                 })
                 .always(function() {
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad method name", function() {
+    QUnit.test("bad method name", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -516,11 +535,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.equal(ex.message, "member name is invalid in dbus \"call\": !Invalid!Method!", "error message");
                 })
                 .always(function() {
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad flags", function() {
+    QUnit.test("bad flags", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -530,11 +550,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.equal(ex.message, "the \"flags\" field is invalid in dbus call", "error message");
                 })
                 .always(function() {
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad types", function() {
+    QUnit.test("bad types", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -546,11 +567,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad type invalid", function() {
+    QUnit.test("bad type invalid", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -561,11 +583,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad dict type", function() {
+    QUnit.test("bad dict type", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -577,11 +600,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad object path", function() {
+    QUnit.test("bad object path", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -593,11 +617,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("bad signature", function() {
+    QUnit.test("bad signature", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -609,11 +634,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "rejected", "should fail");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("flags", function() {
+    QUnit.test("flags", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -625,11 +651,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("without introspection", function() {
+    QUnit.test("without introspection", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -639,11 +666,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 })
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("watch path", function() {
+    QUnit.test("watch path", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var cache = { };
@@ -665,11 +693,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                                        "o": "/", "q": 0, "s": "", "t": 0, "u": 0, "x": 0,
                                        "y": 42 }, "correct data");
                     $(dbus).off();
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("watch object manager", function() {
+    QUnit.test("watch object manager", function (assert) {
+        let done = assert.async();
         assert.expect(1);
 
         var cache = { };
@@ -690,11 +719,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                             "o": "/", "q": 0, "s": "", "t": 0, "u": 0, "x": 0,
                             "y": 42 } } }, "correct data");
                     $(dbus).off();
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("watch change", function() {
+    QUnit.test("watch change", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var cache = { };
@@ -718,11 +748,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     "y": 42 }
             } }, "correct data");
             $(dbus).off();
-            QUnit.start();
+            done();
         });
     });
 
-    QUnit.asyncTest("watch barrier", function() {
+    QUnit.test("watch barrier", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var cache = { };
@@ -749,11 +780,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 .always(function() {
                     assert.equal(this.state(), "resolved", "finished successfuly");
                     $(dbus).off();
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("watch interfaces", function() {
+    QUnit.test("watch interfaces", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var cache = { };
@@ -798,13 +830,14 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                                                                                          "com.redhat.Cockpit.DBusTests.Alpha": null
                                             } }, "correct data");
                                             $(dbus).off();
-                                            QUnit.start();
+                                            done();
                                         });
                             });
                 });
     });
 
-    QUnit.asyncTest("path loop", function() {
+    QUnit.test("path loop", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var name = "yo" + new Date().getTime();
@@ -834,12 +867,13 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                             .always(function() {
                                 assert.equal(this.state(), "resolved", "method called");
                                 $(dbus).off();
-                                QUnit.start();
+                                done();
                             });
                 });
     });
 
-    QUnit.asyncTest("path signal", function() {
+    QUnit.test("path signal", function (assert) {
+        let done = assert.async();
         assert.expect(4);
 
         var name = "yo" + new Date().getTime();
@@ -860,7 +894,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                             "com.redhat.Cockpit.DBusTests.Hidden": { "Name": name }
                         }, "got data before signal");
                         $(dbus).off();
-                        QUnit.start();
+                        done();
                     });
                     dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
                               "EmitHidden", [ name ])
@@ -870,7 +904,8 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 });
     });
 
-    QUnit.asyncTest("proxy", function() {
+    QUnit.test("proxy", function (assert) {
+        let done = assert.async();
         assert.expect(7);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -898,12 +933,13 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     .always(function() {
                         assert.equal(this.state(), "resolved", "method called");
                         $(dbus).off();
-                        QUnit.start();
+                        done();
                     });
         });
     });
 
-    QUnit.asyncTest("proxy call", function() {
+    QUnit.test("proxy call", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -917,11 +953,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 .always(function() {
                     assert.equal(this.state(), "resolved", "method called");
                     $(dbus).off();
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("proxy call with timeout", function() {
+    QUnit.test("proxy call with timeout", function (assert) {
+        let done = assert.async();
         assert.expect(2);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -934,11 +971,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                 .always(function() {
                     assert.equal(this.state(), "rejected", "call timed out");
                     $(dbus).off();
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("proxy signal", function() {
+    QUnit.test("proxy signal", function (assert) {
+        let done = assert.async();
         assert.expect(4);
 
         var received = false;
@@ -960,11 +998,12 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.equal(received, true, "signal received");
                     $(dbus).off();
                     $(proxy).off();
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("proxy explicit notify", function() {
+    QUnit.test("proxy explicit notify", function (assert) {
+        let done = assert.async();
         assert.expect(1);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -974,7 +1013,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
             $(proxy).on("changed", function () {
                 assert.equal(proxy.FinallyNormalName, "externally injected");
                 $(proxy).off("changed");
-                QUnit.start();
+                done();
             });
             dbus.notify({
                 "/otree/frobber": {
@@ -986,7 +1025,8 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
         });
     });
 
-    QUnit.asyncTest("proxies", function() {
+    QUnit.test("proxies", function (assert) {
+        let done = assert.async();
         assert.expect(13);
 
         var dbus = cockpit.dbus(bus_name, channel_options);
@@ -1040,7 +1080,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                                                             assert.strictEqual(removed.valid, false, "removed is invalid");
                                                             dbus.close();
                                                             $(dbus).off();
-                                                            QUnit.start();
+                                                            done();
                                                         });
                                             });
                                 });
@@ -1050,7 +1090,8 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
 }
 
 function dbus_track_tests(channel_options, bus_name) { // eslint-disable-line no-unused-vars
-    QUnit.asyncTest("track name", function() {
+    QUnit.test("track name", function (assert) {
+        let done = assert.async();
         assert.expect(4);
 
         var name = "yo.x" + new Date().getTime();
@@ -1070,7 +1111,7 @@ function dbus_track_tests(channel_options, bus_name) { // eslint-disable-line no
                         assert.strictEqual(data.problem, undefined, "no problem");
                         gone = true;
                         if (released && gone)
-                            QUnit.start();
+                            done();
                     });
 
                     other.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
@@ -1084,13 +1125,14 @@ function dbus_track_tests(channel_options, bus_name) { // eslint-disable-line no
                                             assert.equal(this.state(), "resolved", "name released");
                                             released = true;
                                             if (released && gone)
-                                                QUnit.start();
+                                                done();
                                         });
                             });
                 });
     });
 
-    QUnit.asyncTest("no track name", function() {
+    QUnit.test("no track name", function (assert) {
+        let done = assert.async();
         assert.expect(5);
 
         var name = "yo.y" + new Date().getTime();
@@ -1122,14 +1164,15 @@ function dbus_track_tests(channel_options, bus_name) { // eslint-disable-line no
                                                     .always(function() {
                                                         assert.equal(this.state(), "rejected", "call after release should fail");
                                                         assert.equal(gone, false, "is not gone");
-                                                        QUnit.start();
+                                                        done();
                                                     });
                                         });
                             });
                 });
     });
 
-    QUnit.asyncTest("receive readable fd", function() {
+    QUnit.test("receive readable fd", function (assert) {
+        let done = assert.async();
         assert.expect(4);
 
         var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", channel_options);
@@ -1141,21 +1184,21 @@ function dbus_track_tests(channel_options, bus_name) { // eslint-disable-line no
 
                     var channel = cockpit.channel(fd);
 
-                    /* QUnit.start() and .stop() are ref-counted. Stop again until the message comes back */
-                    QUnit.stop();
+                    let messageReceived = assert.async();
                     channel.onmessage = function (event, data) {
                         assert.equal(data, 'Hello, fd');
                         channel.close();
-                        QUnit.start();
+                        messageReceived();
                     };
                 })
                 .always(function () {
                     assert.equal(this.state(), "resolved", "fd received");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("receive readable fd and ensure opening more than once fails", function() {
+    QUnit.test("receive readable fd and ensure opening more than once fails", function (assert) {
+        let done = assert.async();
         assert.expect(7);
 
         var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", channel_options);
@@ -1169,22 +1212,22 @@ function dbus_track_tests(channel_options, bus_name) { // eslint-disable-line no
                     assert.ok(channel1);
                     var channel2 = cockpit.channel(fd);
 
-                    /* QUnit.start() and .stop() are ref-counted. Stop again until the channel is closed */
-                    QUnit.stop();
+                    let closed = assert.async();
                     channel2.onclose = function (event, options) {
                         assert.equal(options.channel, channel2.id);
                         assert.equal(options.command, 'close');
                         assert.equal(options.problem, 'not-found');
-                        QUnit.start();
+                        closed();
                     };
                 })
                 .always(function () {
                     assert.equal(this.state(), "resolved", "fd received");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("receive readable fd and ensure writing fails", function() {
+    QUnit.test("receive readable fd and ensure writing fails", function (assert) {
+        let done = assert.async();
         assert.expect(6);
 
         var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", channel_options);
@@ -1197,23 +1240,22 @@ function dbus_track_tests(channel_options, bus_name) { // eslint-disable-line no
                     var channel = cockpit.channel(fd);
                     channel.send('Hello, fd');
 
-                    /* QUnit.start() and .stop() are ref-counted. Stop again until the channel is closed */
-                    QUnit.stop();
-
+                    let closed = assert.async();
                     channel.onclose = function (event, options) {
                         assert.equal(options.channel, channel.id);
                         assert.equal(options.command, 'close');
                         assert.equal(options.problem, 'protocol-error');
-                        QUnit.start();
+                        closed();
                     };
                 })
                 .always(function () {
                     assert.equal(this.state(), "resolved", "fd received");
-                    QUnit.start();
+                    done();
                 });
     });
 
-    QUnit.asyncTest("receive writable fd", function() {
+    QUnit.test("receive writable fd", function (assert) {
+        let done = assert.async();
         assert.expect(3);
 
         var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", channel_options);
@@ -1229,7 +1271,7 @@ function dbus_track_tests(channel_options, bus_name) { // eslint-disable-line no
                 })
                 .always(function () {
                     assert.equal(this.state(), "resolved", "fd received and not writable");
-                    QUnit.start();
+                    done();
                 });
     });
 }

--- a/src/base1/test-dbus.js
+++ b/src/base1/test-dbus.js
@@ -1,8 +1,5 @@
 /* global $, cockpit, QUnit, common_dbus_tests, dbus_track_tests */
 
-/* To help with future migration */
-var assert = QUnit;
-
 /* with a name */
 var options = {
     "bus": "session"
@@ -10,7 +7,7 @@ var options = {
 common_dbus_tests(options, "com.redhat.Cockpit.DBusTests.Test");
 dbus_track_tests(options, "com.redhat.Cockpit.DBusTests.Test");
 
-QUnit.test("proxy no stutter", function() {
+QUnit.test("proxy no stutter", function (assert) {
     var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
 
     var proxy = dbus.proxy();
@@ -18,7 +15,7 @@ QUnit.test("proxy no stutter", function() {
     assert.equal(proxy.path, "/com/redhat/Cockpit/DBusTests/Test", "path auto chosen");
 });
 
-QUnit.test("proxies no stutter", function() {
+QUnit.test("proxies no stutter", function (assert) {
     var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
 
     var proxies = dbus.proxies();
@@ -26,7 +23,7 @@ QUnit.test("proxies no stutter", function() {
     assert.equal(proxies.path_namespace, "/", "path auto chosen");
 });
 
-QUnit.test("exposed client and options", function() {
+QUnit.test("exposed client and options", function (assert) {
     var options = { host: "localhost", "bus": "session" };
     var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", options);
     var proxy = dbus.proxy("com.redhat.Cockpit.DBusTests.Frobber", "/otree/frobber");
@@ -37,7 +34,7 @@ QUnit.test("exposed client and options", function() {
     assert.strictEqual(proxies.client, dbus, "proxies object exposes client");
 });
 
-QUnit.test("subscriptions on closed client", function() {
+QUnit.test("subscriptions on closed client", function (assert) {
     function on_signal() {
     }
 
@@ -54,7 +51,7 @@ QUnit.test("subscriptions on closed client", function() {
     assert.ok(true, "can unsubscribe");
 });
 
-QUnit.test("watch promise recursive", function() {
+QUnit.test("watch promise recursive", function (assert) {
     assert.expect(7);
 
     var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
@@ -73,7 +70,8 @@ QUnit.test("watch promise recursive", function() {
     assert.equal(typeof promise3.remove, "function", "promise3.remove()");
 });
 
-QUnit.asyncTest("owned messages", function() {
+QUnit.test("owned messages", function (assert) {
+    let done = assert.async();
     assert.expect(9);
 
     var name = "yo.x" + new Date().getTime();
@@ -108,7 +106,7 @@ QUnit.asyncTest("owned messages", function() {
                         release_name();
                     } else {
                         assert.strictEqual(times_changed, 3, "owner changed three times");
-                        QUnit.start();
+                        done();
                     }
                 });
     }
@@ -130,27 +128,30 @@ QUnit.asyncTest("owned messages", function() {
     acquire_name();
 });
 
-QUnit.asyncTest("bad dbus address", function() {
+QUnit.test("bad dbus address", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var dbus = cockpit.dbus(null, { "bus": "none", "address": "bad" });
     $(dbus).on("close", function(event, options) {
         assert.equal(options.problem, "protocol-error", "bad address closed");
-        QUnit.start();
+        done();
     });
 });
 
-QUnit.asyncTest("bad dbus bus", function() {
+QUnit.test("bad dbus bus", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var dbus = cockpit.dbus(null, { "bus": "bad" });
     $(dbus).on("close", function(event, options) {
         assert.equal(options.problem, "protocol-error", "bad bus format");
-        QUnit.start();
+        done();
     });
 });
 
-QUnit.asyncTest("wait ready", function() {
+QUnit.test("wait ready", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
@@ -160,11 +161,12 @@ QUnit.asyncTest("wait ready", function() {
         assert.ok(false, "shouldn't fail");
     })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("wait fail", function() {
+QUnit.test("wait fail", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var dbus = cockpit.dbus(null, { "bus": "none", "address": "bad" });
@@ -174,11 +176,12 @@ QUnit.asyncTest("wait fail", function() {
         assert.ok(true, "should fail");
     })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("no default name", function() {
+QUnit.test("no default name", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
@@ -190,11 +193,12 @@ QUnit.asyncTest("no default name", function() {
                 assert.ok(false, "shouldn't fail");
             })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("no default name bad", function() {
+QUnit.test("no default name bad", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
@@ -207,11 +211,12 @@ QUnit.asyncTest("no default name bad", function() {
                 assert.equal(ex.message, "the \"name\" field is invalid in dbus call", "error message");
             })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("no default name invalid", function() {
+QUnit.test("no default name invalid", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
@@ -224,11 +229,12 @@ QUnit.asyncTest("no default name invalid", function() {
                 assert.equal(ex.message, "the \"name\" field in dbus call is not a valid bus name: !invalid!", "error message");
             })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("no default name missing", function() {
+QUnit.test("no default name missing", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
@@ -241,11 +247,12 @@ QUnit.asyncTest("no default name missing", function() {
                 assert.equal(ex.message, "the \"name\" field is missing in dbus call", "error message");
             })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("no default name second", function() {
+QUnit.test("no default name second", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session" });
@@ -265,11 +272,12 @@ QUnit.asyncTest("no default name second", function() {
                 assert.ok(false, "shouldn't fail");
             })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("override default name", function() {
+QUnit.test("override default name", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.Test", { "bus": "session" });
@@ -288,11 +296,12 @@ QUnit.asyncTest("override default name", function() {
                 assert.ok(false, "shouldn't fail");
             })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("watch no default name", function() {
+QUnit.test("watch no default name", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var cache = { };
@@ -310,11 +319,12 @@ QUnit.asyncTest("watch no default name", function() {
             })
             .always(function() {
                 dbus.close();
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("watch missing name", function() {
+QUnit.test("watch missing name", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session", "other": "option" });
@@ -327,11 +337,12 @@ QUnit.asyncTest("watch missing name", function() {
             })
             .always(function() {
                 dbus.close();
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("shared client", function() {
+QUnit.test("shared client", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var dbus1 = cockpit.dbus(null, { "bus": "session" });
@@ -352,11 +363,11 @@ QUnit.asyncTest("shared client", function() {
                 assert.ok(false, "shouldn't fail");
             })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.test("not shared option", function() {
+QUnit.test("not shared option", function (assert) {
     assert.expect(1);
 
     var dbus1 = cockpit.dbus(null, { "bus": "session" });
@@ -370,7 +381,8 @@ QUnit.test("not shared option", function() {
     dbus2.close();
 });
 
-QUnit.asyncTest("emit signal meta", function() {
+QUnit.test("emit signal meta", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var meta = {
@@ -394,14 +406,14 @@ QUnit.asyncTest("emit signal meta", function() {
             assert.deepEqual(args, [ 1, 2, 3, 4, "Bork" ], "reflected arguments");
             received = true;
             dbus.close();
-            QUnit.start();
+            done();
         });
 
         dbus.addEventListener("close", function(event, ex) {
             if (!received) {
                 console.log(ex);
                 assert.ok(false, "shouldn't fail");
-                QUnit.start();
+                done();
             }
         });
 
@@ -410,7 +422,8 @@ QUnit.asyncTest("emit signal meta", function() {
     });
 });
 
-QUnit.asyncTest("emit signal type", function() {
+QUnit.test("emit signal type", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var received = false;
@@ -423,14 +436,14 @@ QUnit.asyncTest("emit signal type", function() {
             assert.deepEqual(args, [ 1, 2, 3, 4, "Bork" ], "reflected arguments");
             received = true;
             dbus.close();
-            QUnit.start();
+            done();
         });
 
         dbus.addEventListener("close", function(event, ex) {
             if (!received) {
                 console.log(ex);
                 assert.ok(false, "shouldn't fail");
-                QUnit.start();
+                done();
             }
         });
 
@@ -439,7 +452,8 @@ QUnit.asyncTest("emit signal type", function() {
     });
 });
 
-QUnit.asyncTest("emit signal no meta", function() {
+QUnit.test("emit signal no meta", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var dbus = cockpit.dbus(null, { "bus": "session", "other": "option" });
@@ -449,14 +463,15 @@ QUnit.asyncTest("emit signal no meta", function() {
         assert.equal(ex.message, "signal argument types for signal borkety.Bork Bork unknown", "correct message");
         dbus.removeEventListener("close", closed);
         dbus.close();
-        QUnit.start();
+        done();
     }
 
     dbus.addEventListener("close", closed);
     dbus.signal("/bork", "borkety.Bork", "Bork", [ 1, 2, 3, 4, "Bork" ]);
 });
 
-QUnit.asyncTest("publish object", function() {
+QUnit.test("publish object", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var info = {
@@ -502,12 +517,13 @@ QUnit.asyncTest("publish object", function() {
                 })
                 .always(function() {
                     dbus.close();
-                    QUnit.start();
+                    done();
                 });
     });
 });
 
-QUnit.asyncTest("publish object promise", function() {
+QUnit.test("publish object promise", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var info = {
@@ -542,12 +558,13 @@ QUnit.asyncTest("publish object promise", function() {
                 })
                 .always(function() {
                     dbus.close();
-                    QUnit.start();
+                    done();
                 });
     });
 });
 
-QUnit.asyncTest("publish object failure", function() {
+QUnit.test("publish object failure", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var info = {
@@ -585,12 +602,13 @@ QUnit.asyncTest("publish object failure", function() {
                 })
                 .always(function() {
                     dbus.close();
-                    QUnit.start();
+                    done();
                 });
     });
 });
 
-QUnit.asyncTest("publish object replaces", function() {
+QUnit.test("publish object replaces", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var info = {
@@ -631,7 +649,7 @@ QUnit.asyncTest("publish object replaces", function() {
                             })
                             .always(function() {
                                 dbus.close();
-                                QUnit.start();
+                                done();
                             });
                 }, function(ex) {
                     assert.ok(false, "should not have failed");
@@ -639,7 +657,8 @@ QUnit.asyncTest("publish object replaces", function() {
     });
 });
 
-QUnit.asyncTest("publish object unpublish", function() {
+QUnit.test("publish object unpublish", function (assert) {
+    let done = assert.async();
     assert.expect(5);
 
     var info = {
@@ -679,7 +698,7 @@ QUnit.asyncTest("publish object unpublish", function() {
                             })
                             .always(function() {
                                 dbus.close();
-                                QUnit.start();
+                                done();
                             });
                 }, function(ex) {
                     assert.ok(false, "should not have failed");
@@ -687,7 +706,8 @@ QUnit.asyncTest("publish object unpublish", function() {
     });
 });
 
-function internal_test(options) {
+function internal_test(assert, options) {
+    let done = assert.async();
     assert.expect(2);
     var dbus = cockpit.dbus(null, options);
     dbus.call("/", "org.freedesktop.DBus.Introspectable", "Introspect")
@@ -696,23 +716,24 @@ function internal_test(options) {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "called internal");
-                QUnit.start();
+                done();
             });
 }
 
-QUnit.asyncTest("internal dbus", function() {
-    internal_test({"bus": "internal"});
+QUnit.test("internal dbus", function (assert) {
+    internal_test(assert, {"bus": "internal"});
 });
 
-QUnit.asyncTest("internal dbus bus none", function() {
-    internal_test({"bus": "none"});
+QUnit.test("internal dbus bus none", function (assert) {
+    internal_test(assert, {"bus": "none"});
 });
 
-QUnit.asyncTest("internal dbus bus none with address", function() {
-    internal_test({"bus": "none", "address": "internal"});
+QUnit.test("internal dbus bus none with address", function (assert) {
+    internal_test(assert, {"bus": "none", "address": "internal"});
 });
 
-QUnit.asyncTest("separate dbus connections for channel groups", function() {
+QUnit.test("separate dbus connections for channel groups", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var channel1 = cockpit.channel({ payload: 'dbus-json3', group: 'foo', bus: 'session' });
@@ -727,7 +748,7 @@ QUnit.asyncTest("separate dbus connections for channel groups", function() {
         assert.notEqual(ready1['unique-name'], ready2['unique-name']);
         assert.notEqual(ready1['unique-name'], ready4['unique-name']);
         assert.notEqual(ready2['unique-name'], ready4['unique-name']);
-        QUnit.start();
+        done();
     });
 });
 

--- a/src/base1/test-echo.js
+++ b/src/base1/test-echo.js
@@ -1,9 +1,7 @@
 /* global $, cockpit, QUnit, ArrayBuffer, Uint8Array */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.asyncTest("basic", function() {
+QUnit.test("basic", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var channel = cockpit.channel({ "payload": "echo" });
@@ -17,7 +15,7 @@ QUnit.asyncTest("basic", function() {
             assert.equal(options.command, "done", "got done");
             channel.close();
             $(channel).off();
-            QUnit.start();
+            done();
         }
     });
 
@@ -30,7 +28,8 @@ QUnit.asyncTest("basic", function() {
     channel.send("the payload");
 });
 
-QUnit.asyncTest("binary empty", function() {
+QUnit.test("binary empty", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var channel = cockpit.channel({
@@ -45,13 +44,14 @@ QUnit.asyncTest("binary empty", function() {
             assert.ok($.isArray(payload), "got a byte array");
         assert.strictEqual(payload.length, 0, "got the right payload");
         $(channel).off();
-        QUnit.start();
+        done();
     });
 
     channel.send("");
 });
 
-QUnit.asyncTest("binary", function() {
+QUnit.test("binary", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var channel = cockpit.channel({ "payload": "echo", "binary": true });
@@ -69,7 +69,7 @@ QUnit.asyncTest("binary", function() {
 
         channel.close();
         $(channel).off();
-        QUnit.start();
+        done();
     });
 
     var i, buffer;
@@ -89,7 +89,8 @@ QUnit.asyncTest("binary", function() {
     channel.send(buffer);
 });
 
-QUnit.asyncTest("fence", function() {
+QUnit.test("fence", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var before = cockpit.channel({ "payload": "echo" });
@@ -111,7 +112,7 @@ QUnit.asyncTest("fence", function() {
             assert.deepEqual(received, [ "1", "2", "3", "4", "5" ], "got back data in right order");
             before.close();
             after.close();
-            QUnit.start();
+            done();
         }
     }
 

--- a/src/base1/test-events.js
+++ b/src/base1/test-events.js
@@ -1,9 +1,6 @@
 /* global cockpit, QUnit */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.test("event dispatch", function() {
+QUnit.test("event dispatch", function (assert) {
     var obj = { };
     cockpit.event_target(obj);
 

--- a/src/base1/test-external.js
+++ b/src/base1/test-external.js
@@ -1,9 +1,7 @@
 /* global cockpit, QUnit, unescape, escape, WebSocket:true, XMLHttpRequest */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.asyncTest("external get", function() {
+QUnit.test("external get", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     /* The query string used to open the channel */
@@ -21,13 +19,14 @@ QUnit.asyncTest("external get", function() {
             assert.equal(req.statusText, "OK", "got right reason");
             assert.equal(req.getResponseHeader("Content-Type"), "application/octet-stream", "default type");
             assert.ok(req.responseText.indexOf('"present"'), "got listing");
-            QUnit.start();
+            done();
         }
     };
     req.send();
 });
 
-QUnit.asyncTest("external headers", function() {
+QUnit.test("external headers", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var query = window.btoa(JSON.stringify({
@@ -47,13 +46,14 @@ QUnit.asyncTest("external headers", function() {
             assert.equal(this.status, 200, "got right status");
             assert.equal(this.getResponseHeader("Content-Type"), "test/blah", "got type");
             assert.equal(this.getResponseHeader("Content-Disposition"), "my disposition; blah", "got disposition");
-            QUnit.start();
+            done();
         }
     };
     req.send();
 });
 
-QUnit.asyncTest("external invalid", function() {
+QUnit.test("external invalid", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var req = new XMLHttpRequest();
@@ -61,13 +61,14 @@ QUnit.asyncTest("external invalid", function() {
     req.onreadystatechange = function() {
         if (req.readyState == 4) {
             assert.equal(this.status, 404, "got not found");
-            QUnit.start();
+            done();
         }
     };
     req.send();
 });
 
-QUnit.asyncTest("external no token", function() {
+QUnit.test("external no token", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     /* The query string used to open the channel */
@@ -82,13 +83,14 @@ QUnit.asyncTest("external no token", function() {
     req.onreadystatechange = function() {
         if (req.readyState == 4) {
             assert.equal(this.status, 404, "got not found");
-            QUnit.start();
+            done();
         }
     };
     req.send();
 });
 
-QUnit.asyncTest("external websocket", function() {
+QUnit.test("external websocket", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var query = window.btoa(JSON.stringify({
@@ -116,7 +118,7 @@ QUnit.asyncTest("external websocket", function() {
         }
     };
     ws.onclose = function() {
-        QUnit.start();
+        done();
     };
 });
 

--- a/src/base1/test-file.js
+++ b/src/base1/test-file.js
@@ -1,11 +1,9 @@
 /* global cockpit, QUnit, unescape, escape, Uint8Array */
 
-/* To help with future migration */
-var assert = QUnit;
-
 var dir;
 
-QUnit.asyncTest("simple read", function() {
+QUnit.test("simple read", function (assert) {
+    let done = assert.async();
     assert.expect(3);
     var file = cockpit.file(dir + "/foo");
     assert.equal(file.path, dir + "/foo", "file has path");
@@ -15,11 +13,12 @@ QUnit.asyncTest("simple read", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("read non-existent", function() {
+QUnit.test("read non-existent", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir + "/blah").read()
             .done(function(resp) {
@@ -27,11 +26,12 @@ QUnit.asyncTest("read non-existent", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("parse read", function() {
+QUnit.test("parse read", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir + "/foo.json", { syntax: JSON }).read()
             .done(function(resp) {
@@ -39,11 +39,12 @@ QUnit.asyncTest("parse read", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("parse read error", function() {
+QUnit.test("parse read error", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir + "/foo.bin", { syntax: JSON }).read()
             .fail(function(error) {
@@ -51,11 +52,12 @@ QUnit.asyncTest("parse read error", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "failed");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("binary read", function() {
+QUnit.test("binary read", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir + "/foo.bin", { binary: true }).read()
             .done(function(resp) {
@@ -63,11 +65,12 @@ QUnit.asyncTest("binary read", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("read non-regular", function() {
+QUnit.test("read non-regular", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir, { binary: true }).read()
             .fail(function(error) {
@@ -75,11 +78,12 @@ QUnit.asyncTest("read non-regular", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "failed");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("read large", function() {
+QUnit.test("read large", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir + "/large.bin", { binary: true }).read()
             .done(function(resp) {
@@ -87,11 +91,12 @@ QUnit.asyncTest("read large", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("read too large", function() {
+QUnit.test("read too large", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir + "/large.bin", { binary: true, max_read_size: 8 * 1024 }).read()
             .fail(function(error) {
@@ -99,21 +104,23 @@ QUnit.asyncTest("read too large", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "failed");
-                QUnit.start();
+                done();
             });
 });
 
 /* regression: passing 'binary: false' made cockpit-ws close the whole connection */
-QUnit.asyncTest("binary false", function() {
+QUnit.test("binary false", function (assert) {
+    let done = assert.async();
     assert.expect(1);
     cockpit.file(dir + "/foo.bin", { binary: false }).read()
             .done(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("simple replace", function() {
+QUnit.test("simple replace", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir + "/bar").replace("4321\n")
             .always(function() {
@@ -121,12 +128,13 @@ QUnit.asyncTest("simple replace", function() {
                 cockpit.spawn([ "cat", dir + "/bar" ])
                         .done(function (res) {
                             assert.equal(res, "4321\n", "correct content");
-                            QUnit.start();
+                            done();
                         });
             });
 });
 
-QUnit.asyncTest("stringify replace", function() {
+QUnit.test("stringify replace", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir + "/bar", { syntax: JSON }).replace({ foo: 4321 })
             .always(function() {
@@ -134,12 +142,13 @@ QUnit.asyncTest("stringify replace", function() {
                 cockpit.spawn([ "cat", dir + "/bar" ])
                         .done(function (res) {
                             assert.deepEqual(JSON.parse(res), { foo: 4321 }, "correct content");
-                            QUnit.start();
+                            done();
                         });
             });
 });
 
-QUnit.asyncTest("stringify replace error", function() {
+QUnit.test("stringify replace error", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     var cycle = { };
     cycle.me = cycle;
@@ -149,11 +158,12 @@ QUnit.asyncTest("stringify replace error", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "failed");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("binary replace", function() {
+QUnit.test("binary replace", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.file(dir + "/bar", { binary: true }).replace(new Uint8Array([3, 2, 1, 0]))
             .always(function() {
@@ -161,12 +171,13 @@ QUnit.asyncTest("binary replace", function() {
                 cockpit.spawn([ "cat", dir + "/bar" ], { binary: true })
                         .done(function (res) {
                             assert.deepEqual(res, new Uint8Array([3, 2, 1, 0]), "correct content");
-                            QUnit.start();
+                            done();
                         });
             });
 });
 
-QUnit.asyncTest("replace large", function() {
+QUnit.test("replace large", function (assert) {
+    let done = assert.async();
     assert.expect(3);
     var str = new Array(23 * 1023).join('abcdef12345');
     cockpit.file(dir + "/large").replace(str)
@@ -176,12 +187,13 @@ QUnit.asyncTest("replace large", function() {
                         .done(function(res) {
                             assert.equal(res.length, str.length, "correct large length");
                             assert.ok(res == str, "correct large data");
-                            QUnit.start();
+                            done();
                         });
             });
 });
 
-QUnit.asyncTest("binary replace large", function() {
+QUnit.test("binary replace large", function (assert) {
+    let done = assert.async();
     assert.expect(4);
     var data = new Uint8Array(249 * 1023);
     var i;
@@ -205,12 +217,13 @@ QUnit.asyncTest("binary replace large", function() {
                                 }
                             }
                             assert.ok(eq, "got back same data");
-                            QUnit.start();
+                            done();
                         });
             });
 });
 
-QUnit.asyncTest("remove", function() {
+QUnit.test("remove", function (assert) {
+    let done = assert.async();
     assert.expect(3);
     cockpit.spawn([ "bash", "-c", "test -f " + dir + "/bar && echo exists" ])
             .done(function (res) {
@@ -221,13 +234,14 @@ QUnit.asyncTest("remove", function() {
                             cockpit.spawn([ "bash", "-c", "test -f " + dir + "/bar || echo gone" ])
                                     .done(function (res) {
                                         assert.equal(res, "gone\n", "gone");
-                                        QUnit.start();
+                                        done();
                                     });
                         });
             });
 });
 
-QUnit.asyncTest("abort replace", function() {
+QUnit.test("abort replace", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var file = cockpit.file(dir + "/bar");
@@ -236,7 +250,7 @@ QUnit.asyncTest("abort replace", function() {
     function start_after_two() {
         n += 1;
         if (n == 2)
-            QUnit.start();
+            done();
     }
 
     file.replace("1234\n")
@@ -252,7 +266,8 @@ QUnit.asyncTest("abort replace", function() {
             });
 });
 
-QUnit.asyncTest("replace with tag", function() {
+QUnit.test("replace with tag", function (assert) {
+    let done = assert.async();
     var file = cockpit.file(dir + "/barfoo");
 
     file.read()
@@ -277,14 +292,15 @@ QUnit.asyncTest("replace with tag", function() {
                                         file.replace("opqr\n", tag_2)
                                                 .fail(function (error) {
                                                     assert.equal(error.problem, "change-conflict", "wrong tag is rejected");
-                                                    QUnit.start();
+                                                    done();
                                                 });
                                     });
                         });
             });
 });
 
-QUnit.asyncTest("modify", function() {
+QUnit.test("modify", function (assert) {
+    let done = assert.async();
     assert.expect(7);
 
     var file = cockpit.file(dir + "/quux");
@@ -314,13 +330,14 @@ QUnit.asyncTest("modify", function() {
                             cockpit.spawn([ "cat", dir + "/quux" ])
                                     .done(function (res) {
                                         assert.equal(res, "dcba\n", "correct content");
-                                        QUnit.start();
+                                        done();
                                     });
                         });
             });
 });
 
-QUnit.asyncTest("modify with conflict", function() {
+QUnit.test("modify with conflict", function (assert) {
+    let done = assert.async();
     assert.expect(8);
 
     var file = cockpit.file(dir + "/baz");
@@ -355,14 +372,15 @@ QUnit.asyncTest("modify with conflict", function() {
                                         cockpit.spawn([ "cat", dir + "/baz" ])
                                                 .done(function (res) {
                                                     assert.equal(res, "xyz\n", "correct content");
-                                                    QUnit.start();
+                                                    done();
                                                 });
                                     });
                         });
             });
 });
 
-QUnit.asyncTest("watching", function() {
+QUnit.test("watching", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var file = cockpit.file(dir + "/foobar");
@@ -380,12 +398,13 @@ QUnit.asyncTest("watching", function() {
         } else if (n == 3) {
             assert.equal(content, null, "finally non-existent");
             watch.remove();
-            QUnit.start();
+            done();
         }
     }
 });
 
-QUnit.asyncTest("syntax watching", function() {
+QUnit.test("syntax watching", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var file = cockpit.file(dir + "/foobar.json", { syntax: JSON });
@@ -403,13 +422,14 @@ QUnit.asyncTest("syntax watching", function() {
         } else if (n == 3) {
             assert.ok(err instanceof SyntaxError, "got SyntaxError error");
             watch.remove();
-            QUnit.start();
+            done();
         } else
             assert.ok(false, "not reached");
     }
 });
 
-QUnit.asyncTest("closing", function() {
+QUnit.test("closing", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var file = cockpit.file(dir + "/foobarbaz");
@@ -420,7 +440,7 @@ QUnit.asyncTest("closing", function() {
         n += 1;
         if (n == 2) {
             watch.remove();
-            QUnit.start();
+            done();
         }
     }
 
@@ -445,23 +465,25 @@ QUnit.asyncTest("closing", function() {
     file.close();
 });
 
-QUnit.asyncTest("channel options", function() {
+QUnit.test("channel options", function (assert) {
+    let done = assert.async();
     assert.expect(1);
     cockpit.file(dir + "/foo", { binary: true }).read()
             .done(function(data) {
                 assert.ok(data instanceof window.Uint8Array, "options applied, got binary data");
             })
             .always(function() {
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("remove testdir", function() {
+QUnit.test("remove testdir", function (assert) {
+    let done = assert.async();
     assert.expect(1);
     cockpit.spawn([ "rm", "-rf", dir ])
             .always(function () {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 

--- a/src/base1/test-format.js
+++ b/src/base1/test-format.js
@@ -1,9 +1,6 @@
 /* global cockpit, QUnit, unescape, escape */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.test("format", function() {
+QUnit.test("format", function (assert) {
     assert.equal(cockpit.format("My $adj message with ${amount} of things", { adj: "special", amount: "lots" }),
                  "My special message with lots of things", "named keys");
     assert.equal(cockpit.format("My $0 message with $1 of things", [ "special", "lots" ]),
@@ -21,7 +18,7 @@ QUnit.test("format", function() {
     assert.equal(cockpit.format("$0", null), "", "`null` as argument");
 });
 
-QUnit.test("format_number", function () {
+QUnit.test("format_number", function (assert) {
     var checks = [
         [ 23.4, "23.4", "23,4" ],
         [ 23.46, "23.5", "23,5" ],
@@ -70,7 +67,7 @@ QUnit.test("format_number", function () {
     cockpit.language = saved_language;
 });
 
-QUnit.test("format_bytes", function() {
+QUnit.test("format_bytes", function (assert) {
     var checks = [
         [ 999, 1000, "999" ],
         [ 1934, undefined, "1.89 KiB" ],
@@ -108,7 +105,7 @@ QUnit.test("format_bytes", function() {
     }
 });
 
-QUnit.test("get_byte_units", function() {
+QUnit.test("get_byte_units", function (assert) {
     var mib = 1024 * 1024;
     var gib = mib * 1024;
     var tib = gib * 1024;
@@ -140,7 +137,7 @@ QUnit.test("get_byte_units", function() {
     }
 });
 
-QUnit.test("format_bytes_per_sec", function() {
+QUnit.test("format_bytes_per_sec", function (assert) {
     var checks = [
         [ 2555, "2.50 KiB/s" ]
     ];
@@ -152,7 +149,7 @@ QUnit.test("format_bytes_per_sec", function() {
     }
 });
 
-QUnit.test("format_bits_per_sec", function() {
+QUnit.test("format_bits_per_sec", function (assert) {
     var checks = [
         [ 55, "55 bps" ],
         [ 55.23456789, "55.2 bps" ],

--- a/src/base1/test-http.js
+++ b/src/base1/test-http.js
@@ -1,8 +1,5 @@
 /* global cockpit, QUnit, ArrayBuffer, Uint8Array */
 
-/* To help with future migration */
-var assert = QUnit;
-
 /* Set this to a regexp to ignore that warning once */
 /*
 function console_ignore_warning(exp) {
@@ -15,14 +12,15 @@ function console_ignore_warning(exp) {
 }
 */
 
-QUnit.test("public api", function() {
+QUnit.test("public api", function (assert) {
     var client = cockpit.http("/test");
     assert.equal(typeof client, "object", "http is an object");
     assert.equal(typeof client.get, "function", "http.get() is a function");
     assert.equal(typeof client.post, "function", "http.post() is a function");
 });
 
-QUnit.asyncTest("simple request", function() {
+QUnit.test("simple request", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     cockpit.http({ "internal": "/test-server" }).get("/pkg/playground/manifest.json.in")
@@ -54,11 +52,12 @@ QUnit.asyncTest("simple request", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("with params", function() {
+QUnit.test("with params", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     cockpit.http({ "internal": "/test-server" })
@@ -68,11 +67,12 @@ QUnit.asyncTest("with params", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("not found", function() {
+QUnit.test("not found", function (assert) {
+    let done = assert.async();
     assert.expect(7);
 
     var promise = cockpit.http({ "internal": "/test-server" })
@@ -89,11 +89,12 @@ QUnit.asyncTest("not found", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "should fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("streaming", function() {
+QUnit.test("streaming", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var at = 0;
@@ -112,11 +113,12 @@ QUnit.asyncTest("streaming", function() {
                     expected += String(i) + " ";
                 assert.equal(got, expected, "stream got right data");
                 assert.equal(this.state(), "resolved", "split response didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("close", function() {
+QUnit.test("close", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var req = cockpit.http({ "internal": "/test-server" }).get("/mock/stream");
@@ -133,11 +135,12 @@ QUnit.asyncTest("close", function() {
             .always(function() {
                 assert.equal(at, 1, "stream got cancelled");
                 assert.equal(this.state(), "rejected", "cancelling a response rejects it");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("close all", function() {
+QUnit.test("close all", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var http = cockpit.http({ "internal": "/test-server" });
@@ -156,11 +159,12 @@ QUnit.asyncTest("close all", function() {
                 assert.equal(at, 1, "stream got cancelled");
                 assert.equal(this.state(), "rejected", "cancelling a response rejects it");
                 http.close("closed"); // This should be a no-op now
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("headers", function() {
+QUnit.test("headers", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     cockpit.http({ "internal": "/test-server" })
@@ -178,11 +182,12 @@ QUnit.asyncTest("headers", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "split response didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("escape host header", function() {
+QUnit.test("escape host header", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     cockpit.http({ "internal": "/test-server" })
@@ -193,11 +198,12 @@ QUnit.asyncTest("escape host header", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "split response didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("connection headers", function() {
+QUnit.test("connection headers", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     cockpit.http({ "internal": "/test-server", "headers": { "Header1": "booo", "Header2": "not this" } })
@@ -216,11 +222,11 @@ QUnit.asyncTest("connection headers", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "split response didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.test("http promise recursive", function() {
+QUnit.test("http promise recursive", function (assert) {
     assert.expect(7);
 
     var promise = cockpit.http({ "internal": "/test-server" }).get("/");
@@ -238,7 +244,8 @@ QUnit.test("http promise recursive", function() {
     assert.equal(typeof promise3.input, "function", "promise3.input()");
 });
 
-QUnit.asyncTest("http keep alive", function() {
+QUnit.test("http keep alive", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     /*
@@ -259,12 +266,13 @@ QUnit.asyncTest("http keep alive", function() {
                         })
                         .always(function() {
                             assert.equal(this.state(), "resolved", "response didn't fail");
-                            QUnit.start();
+                            done();
                         });
             });
 });
 
-QUnit.asyncTest("http connection different", function() {
+QUnit.test("http connection different", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     /*
@@ -285,12 +293,13 @@ QUnit.asyncTest("http connection different", function() {
                         })
                         .always(function() {
                             assert.equal(this.state(), "resolved", "response didn't fail");
-                            QUnit.start();
+                            done();
                         });
             });
 });
 
-QUnit.asyncTest("http connection without address ", function() {
+QUnit.test("http connection without address ", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     /*
@@ -310,12 +319,13 @@ QUnit.asyncTest("http connection without address ", function() {
                         })
                         .always(function() {
                             assert.equal(this.state(), "resolved", "response didn't fail");
-                            QUnit.start();
+                            done();
                         });
             });
 });
 
-QUnit.asyncTest("no dns address", function() {
+QUnit.test("no dns address", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     cockpit.http({ "port": 8080,
@@ -329,11 +339,12 @@ QUnit.asyncTest("no dns address", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "should fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("address with params", function() {
+QUnit.test("address with params", function (assert) {
+    let done = assert.async();
     // use our window's host and port to request external
     assert.expect(2);
 
@@ -345,7 +356,7 @@ QUnit.asyncTest("address with params", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 

--- a/src/base1/test-locale.js
+++ b/src/base1/test-locale.js
@@ -1,8 +1,5 @@
 /* global $, cockpit, QUnit */
 
-/* To help with future migration */
-var assert = QUnit;
-
 var pig_latin = {
     "": { "language": "pig", "plural-forms": function(n) {
         var plural = (n != 1);
@@ -34,11 +31,11 @@ var ru = {
     "$0 bit": [ "$0 bits", "$0 бит", "$0 бита", "$0 бит" ]
 };
 
-QUnit.test("public api", function() {
+QUnit.test("public api", function (assert) {
     assert.equal(typeof cockpit.locale, "function", "cockpit.locale is a function");
 });
 
-QUnit.test("gettext", function() {
+QUnit.test("gettext", function (assert) {
     cockpit.locale(null); /* clear it */
     cockpit.locale(pig_latin);
     assert.equal(cockpit.language, "pig", "correct lang");
@@ -48,7 +45,7 @@ QUnit.test("gettext", function() {
     assert.equal(cockpit.gettext("verb", "Empty"), "Empty", "english default context");
 });
 
-QUnit.test("underscore", function() {
+QUnit.test("underscore", function (assert) {
     cockpit.locale(null); /* clear it */
     cockpit.locale(pig_latin);
     var _ = cockpit.gettext;
@@ -59,7 +56,7 @@ QUnit.test("underscore", function() {
     assert.equal(C_("verb", "Empty"), "Empty", "with context");
 });
 
-QUnit.test("ngettext simple", function() {
+QUnit.test("ngettext simple", function (assert) {
     cockpit.locale(null); /* clear it */
     cockpit.locale(pig_latin);
     assert.equal(cockpit.ngettext("$0 disk is missing", "$0 disks are missing", 0), "$0 isksbay are issingmay", "zero things");
@@ -77,7 +74,7 @@ QUnit.test("ngettext simple", function() {
     assert.equal(cockpit.ngettext("memory", "$0 byte", "$0 bytes", 2), "$0 bytes", "default multiple context");
 });
 
-QUnit.test("ngettext complex", function() {
+QUnit.test("ngettext complex", function (assert) {
     cockpit.locale(null); /* clear it */
     cockpit.locale(ru);
     assert.equal(cockpit.ngettext("$0 bit", "$0 bits", 0), "$0 бит", "zero things");
@@ -88,7 +85,7 @@ QUnit.test("ngettext complex", function() {
     assert.equal(cockpit.ngettext("$0 byte", "$0 bytes", 2), "$0 bytes", "default multiple");
 });
 
-QUnit.test("translate document", function() {
+QUnit.test("translate document", function (assert) {
     cockpit.locale(null);
     cockpit.locale(pig_latin);
 
@@ -101,7 +98,7 @@ QUnit.test("translate document", function() {
     assert.strictEqual($("#translatable-html").attr("translate"), undefined, "translate element attribute removed");
 });
 
-QUnit.test("translate elements", function() {
+QUnit.test("translate elements", function (assert) {
     cockpit.locale(null);
     cockpit.locale(pig_latin);
 
@@ -123,7 +120,7 @@ QUnit.test("translate elements", function() {
     assert.strictEqual($("#translatable-context-html").attr("translate"), undefined, "translate context attribute removed");
 });
 
-QUnit.test("translate array", function() {
+QUnit.test("translate array", function (assert) {
     cockpit.locale(null);
     cockpit.locale(pig_latin);
 
@@ -145,7 +142,7 @@ QUnit.test("translate array", function() {
     assert.strictEqual($("#translatable-context-html").attr("translate"), undefined, "translate context attribute removed");
 });
 
-QUnit.test("translate glade", function() {
+QUnit.test("translate glade", function (assert) {
     cockpit.locale(null);
     cockpit.locale(pig_latin);
 
@@ -162,7 +159,7 @@ QUnit.test("translate glade", function() {
     assert.strictEqual($("#translatable-glade-context").attr("translatable"), undefined, "translatable context attribute removed");
 });
 
-QUnit.test("translate attributes", function() {
+QUnit.test("translate attributes", function (assert) {
     cockpit.locale(null);
     cockpit.locale(pig_latin);
 

--- a/src/base1/test-location.js
+++ b/src/base1/test-location.js
@@ -1,9 +1,6 @@
 /* global $, cockpit, QUnit */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.test("basic", function() {
+QUnit.test("basic", function (assert) {
     window.location.hash = "";
 
     assert.equal(typeof cockpit.location, "object", "cockpit.location exists");
@@ -18,7 +15,7 @@ QUnit.test("basic", function() {
     assert.deepEqual(cockpit.location.options, { }, "options are empty");
 });
 
-QUnit.test("decode", function() {
+QUnit.test("decode", function (assert) {
     window.location.hash = "#/base/test";
 
     var checks = [
@@ -112,7 +109,7 @@ QUnit.test("decode", function() {
     }
 });
 
-QUnit.test("encode", function() {
+QUnit.test("encode", function (assert) {
     /* We don't check options here since we can't predict the order in
        which they appear in the hash.  Encoding of options is covered
        in the "roundtrip" test.
@@ -161,7 +158,7 @@ QUnit.test("encode", function() {
     }
 });
 
-QUnit.test("roundtrip", function() {
+QUnit.test("roundtrip", function (assert) {
     var checks = [
         { path: [ "path", "sub" ],
           options: { a: "1", b: "2" }
@@ -185,7 +182,7 @@ QUnit.test("roundtrip", function() {
     }
 });
 
-QUnit.test("external change", function() {
+QUnit.test("external change", function (assert) {
     var location = cockpit.location;
 
     window.location.hash = "#/a/b/c?x=1&y=2";
@@ -196,7 +193,7 @@ QUnit.test("external change", function() {
     assert.strictEqual(cockpit.location.options["y"], "2", "option y is correct");
 });
 
-QUnit.test("internal change", function() {
+QUnit.test("internal change", function (assert) {
     cockpit.location.go([ "x", "y", "z" ]);
 
     assert.strictEqual(window.location.hash, "#/x/y/z", "hash is correct");
@@ -204,7 +201,7 @@ QUnit.test("internal change", function() {
     assert.deepEqual(cockpit.location.options, { }, "options are empty");
 });
 
-QUnit.test("string change", function() {
+QUnit.test("string change", function (assert) {
     cockpit.location = "/p/x/../q/r?a=b";
 
     assert.strictEqual(window.location.hash, "#/p/q/r?a=b", "hash is correct");
@@ -212,7 +209,7 @@ QUnit.test("string change", function() {
     assert.deepEqual(cockpit.location.options, { "a": "b" }, "options are empty");
 });
 
-QUnit.test("string change", function() {
+QUnit.test("string change", function (assert) {
     window.location.href = "#/top/file";
     cockpit.location = "another";
 
@@ -220,7 +217,7 @@ QUnit.test("string change", function() {
     assert.deepEqual(cockpit.location.path, [ "top", "another" ], "path is correct");
 });
 
-QUnit.test("change options", function() {
+QUnit.test("change options", function (assert) {
     window.location.hash = "";
     assert.deepEqual(cockpit.location.path, [ ], "path is empty");
     assert.deepEqual(cockpit.location.options, { }, "options are empty");
@@ -234,7 +231,8 @@ QUnit.test("change options", function() {
     assert.strictEqual(window.location.hash, "#/", "hash is correct");
 });
 
-QUnit.asyncTest("event", function() {
+QUnit.test("test", function (assert) {
+    let done = assert.async();
     window.location.hash = "#/hello";
 
     var triggered = false;
@@ -244,14 +242,15 @@ QUnit.asyncTest("event", function() {
         assert.strictEqual(window.location.hash, "#/gonna-happen", "hash has changed");
         $(cockpit).off("locationchanged");
         triggered = true;
-        QUnit.start();
+        done();
     });
 
     cockpit.location.go(["gonna-happen"]);
     assert.ok(!triggered, "not yet triggered");
 });
 
-QUnit.asyncTest("delayed", function() {
+QUnit.test("test", function (assert) {
+    let done = assert.async();
     window.location.hash = "#/hello";
 
     var location = cockpit.location;
@@ -264,7 +263,7 @@ QUnit.asyncTest("delayed", function() {
         cockpit.location.go(["gonna-happen"]);
         assert.strictEqual(window.location.hash, "#/gonna-happen", "hash has changed");
 
-        QUnit.start();
+        done();
     }, 100);
 
     /* User or something else navigates */

--- a/src/base1/test-metrics.js
+++ b/src/base1/test-metrics.js
@@ -1,8 +1,5 @@
 /* global $, cockpit, QUnit */
 
-/* To help with future migration */
-var assert = QUnit;
-
 function MockPeer() {
     /*
      * Events triggered here:
@@ -106,7 +103,7 @@ function MockSink(expected, callback) {
     return self;
 }
 
-QUnit.test("non-instanced decompression", function() {
+QUnit.test("non-instanced decompression", function (assert) {
     assert.expect(1);
 
     var peer = new MockPeer();

--- a/src/base1/test-permissions.js
+++ b/src/base1/test-permissions.js
@@ -1,8 +1,5 @@
 /* global cockpit, QUnit, unescape, escape */
 
-/* To help with future migration */
-var assert = QUnit;
-
 var root_user = {
     name: "weird-root",
     id: 0,
@@ -27,7 +24,7 @@ QUnit.module("Permission tests", {
     }
 });
 
-QUnit.test("root-all-permissions", function() {
+QUnit.test("root-all-permissions", function (assert) {
     assert.expect(2);
 
     var p1 = cockpit.permission({ user: priv_user });
@@ -37,7 +34,7 @@ QUnit.test("root-all-permissions", function() {
     assert.equal(p2.allowed, true, "is root, allowed");
 });
 
-QUnit.test("group-permissions", function() {
+QUnit.test("group-permissions", function (assert) {
     assert.expect(4);
 
     var p1 = cockpit.permission({ user: priv_user, group: "badgroup" });
@@ -53,7 +50,7 @@ QUnit.test("group-permissions", function() {
     assert.equal(p4.allowed, true, "no group match but root, allowed");
 });
 
-QUnit.test("admin-permissions", function() {
+QUnit.test("admin-permissions", function (assert) {
     assert.expect(2);
 
     var p1 = cockpit.permission({ user: priv_user, _is_superuser: false, admin: true });

--- a/src/base1/test-series.js
+++ b/src/base1/test-series.js
@@ -1,9 +1,6 @@
 /* global $, cockpit, QUnit, unescape, escape */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.test("public api", function() {
+QUnit.test("public api", function (assert) {
     assert.equal(typeof cockpit.grid, "function", "cockpit.grid is a function");
     assert.equal(typeof cockpit.series, "function", "cockpit.series is a function");
 
@@ -31,7 +28,7 @@ QUnit.test("public api", function() {
     assert.equal(typeof sink.load, "function", "series.load()");
 });
 
-QUnit.test("calculated row", function() {
+QUnit.test("calculated row", function (assert) {
     var grid = cockpit.grid(1000, 3, 8);
     var calculated = grid.add(function(row, x, n) {
         for (var i = 0; i < n; i++)
@@ -42,7 +39,7 @@ QUnit.test("calculated row", function() {
     assert.deepEqual(calculated, [ undefined, 0, 1, 2, 3 ], "array contents");
 });
 
-QUnit.test("calculated order", function() {
+QUnit.test("calculated order", function (assert) {
     var grid = cockpit.grid(1000, 3, 8);
 
     var calculated = grid.add(function(row, x, n) {
@@ -60,7 +57,7 @@ QUnit.test("calculated order", function() {
     assert.deepEqual(dependant, [ undefined, 10, 11, 12, 13 ], "dependant array contents");
 });
 
-QUnit.test("calculated early", function() {
+QUnit.test("calculated early", function (assert) {
     var grid = cockpit.grid(1000, 3, 8);
 
     var calculated;
@@ -81,7 +78,7 @@ QUnit.test("calculated early", function() {
     assert.deepEqual(dependant, [ undefined, 10, 11, 12, 13 ], "dependant array contents");
 });
 
-QUnit.test("notify limit", function() {
+QUnit.test("notify limit", function (assert) {
     var grid = cockpit.grid(1000, 5, 15);
 
     var called = -1;
@@ -99,7 +96,7 @@ QUnit.test("notify limit", function() {
     assert.strictEqual(called, 9, "truncated to right limit");
 });
 
-QUnit.test("sink row", function() {
+QUnit.test("sink row", function (assert) {
     var grid = cockpit.grid(1000, 5, 15);
     var sink = cockpit.series(1000);
 
@@ -141,7 +138,7 @@ QUnit.test("sink row", function() {
     grid.close();
 });
 
-QUnit.test("sink no path", function() {
+QUnit.test("sink no path", function (assert) {
     var grid = cockpit.grid(1000, 5, 15);
     var sink = cockpit.series(1000);
 
@@ -154,7 +151,7 @@ QUnit.test("sink no path", function() {
     assert.deepEqual(row, [undefined, undefined, undefined, 567, 768, { "hello": "scruffy" }], "row without a path");
 });
 
-QUnit.test("sink after close", function() {
+QUnit.test("sink after close", function (assert) {
     var grid = cockpit.grid(1000, 5, 15);
     var sink = cockpit.series(1000);
 
@@ -174,7 +171,7 @@ QUnit.test("sink after close", function() {
     assert.deepEqual(row, [1, 2, 3, 1, 2, 3], "row got no more values");
 });
 
-QUnit.test("sink mapping", function() {
+QUnit.test("sink mapping", function (assert) {
     var grid = cockpit.grid(1000, 5, 15);
     var sink = cockpit.series(1000);
 
@@ -211,7 +208,7 @@ QUnit.test("sink mapping", function() {
     grid.close();
 });
 
-QUnit.test("cache simple", function() {
+QUnit.test("cache simple", function (assert) {
     var fetched = [];
     function fetch(beg, end) {
         fetched.push([ beg, end ]);
@@ -261,7 +258,7 @@ QUnit.test("cache simple", function() {
     grid.close();
 });
 
-QUnit.test("cache multiple", function() {
+QUnit.test("cache multiple", function (assert) {
     var fetched = [];
     function fetch(beg, end) {
         fetched.push([ beg, end ]);
@@ -311,7 +308,7 @@ QUnit.test("cache multiple", function() {
     grid.close();
 });
 
-QUnit.test("cache overlap", function() {
+QUnit.test("cache overlap", function (assert) {
     var fetched = [];
     function fetch(beg, end) {
         fetched.push([ beg, end ]);
@@ -362,7 +359,7 @@ QUnit.test("cache overlap", function() {
     grid.close();
 });
 
-QUnit.test("cache limit", function() {
+QUnit.test("cache limit", function (assert) {
     var series = cockpit.series(1000, null);
     series.limit = 5;
     series.input(8, [ "eight" ]);
@@ -393,7 +390,7 @@ QUnit.test("cache limit", function() {
     grid.close();
 });
 
-QUnit.test("move", function() {
+QUnit.test("move", function (assert) {
     var fetched = [];
     function fetch(beg, end) {
         fetched.push([ beg, end ]);
@@ -447,7 +444,7 @@ QUnit.test("move", function() {
     grid.close();
 });
 
-QUnit.test("move negative", function() {
+QUnit.test("move negative", function (assert) {
     var now = $.now();
     var grid = cockpit.grid(1000, -20, -5);
 
@@ -462,7 +459,8 @@ QUnit.test("move negative", function() {
     grid.close();
 });
 
-QUnit.asyncTest("walk", function() {
+QUnit.test("test", function (assert) {
+    let done = assert.async();
     assert.expect(5);
 
     var fetched = [];
@@ -485,7 +483,7 @@ QUnit.asyncTest("walk", function() {
 
         if (count == 5) {
             grid.close();
-            QUnit.start();
+            done();
         }
     });
 });

--- a/src/base1/test-spawn-proc.js
+++ b/src/base1/test-spawn-proc.js
@@ -1,9 +1,7 @@
 /* global cockpit, QUnit */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.asyncTest("simple process", function() {
+QUnit.test("simple process", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.spawn(["/bin/sh", "-c", "echo hi"])
             .done(function(resp) {
@@ -11,20 +9,22 @@ QUnit.asyncTest("simple process", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("path", function() {
+QUnit.test("path", function (assert) {
+    let done = assert.async();
     assert.expect(1);
     cockpit.spawn(["true"])
             .always(function() {
                 assert.equal(this.state(), "resolved", "found executable");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("directory", function() {
+QUnit.test("directory", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.spawn(["pwd"], { directory: "/tmp" })
             .done(function(resp) {
@@ -32,11 +32,12 @@ QUnit.asyncTest("directory", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("error log", function() {
+QUnit.test("error log", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2"])
             .done(function(resp) {
@@ -44,11 +45,12 @@ QUnit.asyncTest("error log", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("error output", function() {
+QUnit.test("error output", function (assert) {
+    let done = assert.async();
     assert.expect(2);
     cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2"], { err: "out" })
             .done(function(resp) {
@@ -56,11 +58,12 @@ QUnit.asyncTest("error output", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("error message", function() {
+QUnit.test("error message", function (assert) {
+    let done = assert.async();
     assert.expect(3);
     cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2"], { err: "message" })
             .done(function(resp, message) {
@@ -69,11 +72,12 @@ QUnit.asyncTest("error message", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("error message fail", function() {
+QUnit.test("error message fail", function (assert) {
+    let done = assert.async();
     assert.expect(3);
     cockpit.spawn(["/bin/sh", "-c", "echo hi; echo yo >&2; exit 2"], { err: "message" })
             .fail(function(ex, resp) {
@@ -82,11 +86,12 @@ QUnit.asyncTest("error message fail", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("write eof read", function() {
+QUnit.test("write eof read", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var proc = cockpit.spawn(["/usr/bin/sort"]);
@@ -97,14 +102,15 @@ QUnit.asyncTest("write eof read", function() {
 
     proc.always(function() {
         assert.equal(this.state(), "resolved", "didn't fail");
-        QUnit.start();
+        done();
     });
 
     proc.input("2\n", true);
     proc.input("3\n1\n");
 });
 
-QUnit.asyncTest("stream", function() {
+QUnit.test("stream", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var streamed = 0;
@@ -121,7 +127,7 @@ QUnit.asyncTest("stream", function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
                 assert.equal(result, "11\n22\n33\n", "stream data");
                 assert.ok(streamed > 0, "stream handler called");
-                QUnit.start();
+                done();
             });
 
     proc.input("11\n", true);
@@ -129,7 +135,8 @@ QUnit.asyncTest("stream", function() {
     proc.input("33\n");
 });
 
-QUnit.asyncTest("stream packets", function() {
+QUnit.test("stream packets", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var streamed = "";
@@ -143,7 +150,7 @@ QUnit.asyncTest("stream packets", function() {
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
                 assert.equal(streamed, "11\n22\n33\n", "stream data");
-                QUnit.start();
+                done();
             });
 
     proc.input("11\n", true);
@@ -151,7 +158,8 @@ QUnit.asyncTest("stream packets", function() {
     proc.input("33\n");
 });
 
-QUnit.asyncTest("stream replaced", function() {
+QUnit.test("stream replaced", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var first = false;
@@ -168,7 +176,7 @@ QUnit.asyncTest("stream replaced", function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
                 assert.ok(!first, "first stream handler not called");
                 assert.ok(second, "second stream handler called");
-                QUnit.start();
+                done();
             });
 
     proc.input("11\n", true);
@@ -176,7 +184,8 @@ QUnit.asyncTest("stream replaced", function() {
     proc.input("33\n");
 });
 
-QUnit.asyncTest("stream partial", function() {
+QUnit.test("stream partial", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var streamed = "";
@@ -193,13 +202,14 @@ QUnit.asyncTest("stream partial", function() {
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
                 assert.equal(streamed, "1", "stream data");
-                QUnit.start();
+                done();
             });
 
     proc.input("1234");
 });
 
-QUnit.asyncTest("stream partial binary", function() {
+QUnit.test("stream partial binary", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var streamed = [];
@@ -216,13 +226,14 @@ QUnit.asyncTest("stream partial binary", function() {
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
                 assert.deepEqual(streamed, [49], "stream data");
-                QUnit.start();
+                done();
             });
 
     proc.input("1234");
 });
 
-QUnit.asyncTest("script with input", function() {
+QUnit.test("script with input", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var script = "#!/bin/sh\n\n# Test\n/usr/bin/sort\necho $2\necho $1";
@@ -235,14 +246,15 @@ QUnit.asyncTest("script with input", function() {
 
     proc.always(function() {
         assert.equal(this.state(), "resolved", "didn't fail");
-        QUnit.start();
+        done();
     });
 
     proc.input("2\n", true);
     proc.input("3\n1\n");
 });
 
-QUnit.asyncTest("script with options", function() {
+QUnit.test("script with options", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var script = "#!/bin/sh\n\n# Test\n/usr/bin/sort\necho $2\necho $1 >&2";
@@ -255,14 +267,15 @@ QUnit.asyncTest("script with options", function() {
 
     proc.always(function() {
         assert.equal(this.state(), "resolved", "didn't fail");
-        QUnit.start();
+        done();
     });
 
     proc.input("2\n", true);
     proc.input("3\n1\n");
 });
 
-QUnit.asyncTest("script without args", function() {
+QUnit.test("script without args", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var script = "#!/bin/sh\n\n# Test\n/usr/bin/sort >&2";
@@ -275,7 +288,7 @@ QUnit.asyncTest("script without args", function() {
 
     proc.always(function() {
         assert.equal(this.state(), "resolved", "didn't fail");
-        QUnit.start();
+        done();
     });
 
     proc.input("2\n", true);

--- a/src/base1/test-spawn.js
+++ b/src/base1/test-spawn.js
@@ -1,8 +1,5 @@
 /* global $, cockpit, QUnit */
 
-/* To help with future migration */
-var assert = QUnit;
-
 /* Seems like something jQuery should provide */
 if (!console.assert) {
     console.assert = function(cond, msg) {
@@ -130,11 +127,12 @@ function MockPeer() {
     };
 }
 
-QUnit.test("public api", function() {
+QUnit.test("public api", function (assert) {
     assert.equal(typeof cockpit.spawn, "function", "spawn is a function");
 });
 
-QUnit.asyncTest("simple request", function() {
+QUnit.test("simple request", function (assert) {
+    let done = assert.async();
     assert.expect(5);
 
     var peer = new MockPeer();
@@ -155,24 +153,26 @@ QUnit.asyncTest("simple request", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("string command", function() {
+QUnit.test("string command", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     var peer = new MockPeer();
     $(peer).on("opened", function(event, channel, options) {
         assert.deepEqual(channel.options["spawn"], ["/the/path"], "passed spawn correctly");
         assert.equal(channel.options["host"], "hostname", "had host");
-        QUnit.start();
+        done();
     });
 
     cockpit.spawn("/the/path", { "host": "hostname" });
 });
 
-QUnit.asyncTest("channel options", function() {
+QUnit.test("channel options", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var peer = new MockPeer();
@@ -183,7 +183,7 @@ QUnit.asyncTest("channel options", function() {
             "extra-option": "zerogjuggs",
             "payload": "stream"
         }, "sent correctly");
-        QUnit.start();
+        done();
     });
 
     /* Don't care about the result ... */
@@ -191,7 +191,8 @@ QUnit.asyncTest("channel options", function() {
     cockpit.spawn(["/the/path", "arg"], options);
 });
 
-QUnit.asyncTest("streaming", function() {
+QUnit.test("streaming", function (assert) {
+    let done = assert.async();
     assert.expect(15);
 
     var peer = new MockPeer();
@@ -216,11 +217,12 @@ QUnit.asyncTest("streaming", function() {
             .always(function() {
                 assert.equal(this.state(), "resolved", "split response didn't fail");
                 assert.strictEqual(this, promise, "always got right this");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("with problem", function() {
+QUnit.test("with problem", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var peer = new MockPeer();
@@ -236,11 +238,12 @@ QUnit.asyncTest("with problem", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "should fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("with status", function() {
+QUnit.test("with status", function (assert) {
+    let done = assert.async();
     assert.expect(5);
 
     var peer = new MockPeer();
@@ -258,11 +261,12 @@ QUnit.asyncTest("with status", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "should fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("with signal", function() {
+QUnit.test("with signal", function (assert) {
+    let done = assert.async();
     assert.expect(5);
 
     var peer = new MockPeer();
@@ -280,11 +284,11 @@ QUnit.asyncTest("with signal", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "should fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.test("spawn promise recursive", function() {
+QUnit.test("spawn promise recursive", function (assert) {
     assert.expect(7);
 
     var promise = cockpit.spawn(["/the/path", "arg1", "arg2"]);

--- a/src/base1/test-stub.js
+++ b/src/base1/test-stub.js
@@ -1,13 +1,11 @@
 /* global $, cockpit, QUnit, unescape, escape, WebSocket */
 
-/* To help with future migration */
-var assert = QUnit;
-
 /* Tell cockpit to use an alternate url to connect to test-server */
 window.mock.url = cockpit.transport.uri();
 window.mock.url += "?cockpit-stub";
 
-function internal_test(options) {
+function internal_test(assert, options) {
+    let done = assert.async();
     assert.expect(2);
     var dbus = cockpit.dbus(null, options);
     dbus.call("/", "org.freedesktop.DBus.Introspectable", "Introspect")
@@ -16,23 +14,24 @@ function internal_test(options) {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "called internal");
-                QUnit.start();
+                done();
             });
 }
 
-QUnit.asyncTest("internal dbus", function() {
-    internal_test({"bus": "internal"});
+QUnit.test("internal dbus", function (assert) {
+    internal_test(assert, {"bus": "internal"});
 });
 
-QUnit.asyncTest("internal dbus bus none", function() {
-    internal_test({"bus": "none"});
+QUnit.test("internal dbus bus none", function (assert) {
+    internal_test(assert, {"bus": "none"});
 });
 
-QUnit.asyncTest("internal dbus bus none with address", function() {
-    internal_test({"bus": "none", "address": "internal"});
+QUnit.test("internal dbus bus none with address", function (assert) {
+    internal_test(assert, {"bus": "none", "address": "internal"});
 });
 
-QUnit.asyncTest("echo", function() {
+QUnit.test("echo", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var channel = cockpit.channel({ "payload": "echo" });
@@ -46,7 +45,7 @@ QUnit.asyncTest("echo", function() {
             assert.equal(options.command, "done", "got done");
             channel.close();
             $(channel).off();
-            QUnit.start();
+            done();
         }
     });
 
@@ -59,7 +58,8 @@ QUnit.asyncTest("echo", function() {
     channel.send("the payload");
 });
 
-QUnit.asyncTest("http", function() {
+QUnit.test("http", function (assert) {
+    let done = assert.async();
     assert.expect(2);
 
     cockpit.http({ "internal": "/test-server" }).get("/pkg/playground/manifest.json.in")
@@ -91,22 +91,24 @@ QUnit.asyncTest("http", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("internal dbus environment", function() {
+QUnit.test("internal dbus environment", function (assert) {
+    let done = assert.async();
     assert.expect(1);
 
     var dbus = cockpit.dbus(null, { "bus": "internal" });
     var proxy = dbus.proxy("cockpit.Environment", "/environment");
     proxy.wait(function () {
         assert.ok(typeof proxy.Variables["PATH"] === 'string', "has PATH environment var");
-        QUnit.start();
+        done();
     });
 });
 
-QUnit.asyncTest("internal user dbus", function() {
+QUnit.test("internal user dbus", function (assert) {
+    let done = assert.async();
     assert.expect(4);
 
     var dbus = cockpit.dbus(null, { "bus": "internal" });
@@ -120,11 +122,12 @@ QUnit.asyncTest("internal user dbus", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "finished successfuly");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("not supported types", function() {
+QUnit.test("not supported types", function (assert) {
+    let done = assert.async();
     var failures = 7;
     var seen = 0;
     assert.expect(failures);
@@ -133,7 +136,7 @@ QUnit.asyncTest("not supported types", function() {
         assert.equal(ex.problem, "not-supported", "not-supported");
         seen++;
         if (failures == seen)
-            QUnit.start();
+            done();
     }
 
     var flist = cockpit.channel({"payload":"fslist1", "path":"/foo"});
@@ -160,11 +163,12 @@ QUnit.asyncTest("not supported types", function() {
     $(metrics).on("close", failed);
 
     window.setTimeout(function () {
-        QUnit.start();
+        done();
     }, 5000);
 });
 
-QUnit.asyncTest("external channel websocket", function() {
+QUnit.test("external channel websocket", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var query = window.btoa(JSON.stringify({
@@ -195,7 +199,7 @@ QUnit.asyncTest("external channel websocket", function() {
         }
     };
     ws.onclose = function(ev) {
-        QUnit.start();
+        done();
     };
 });
 

--- a/src/base1/test-user.js
+++ b/src/base1/test-user.js
@@ -1,9 +1,7 @@
 /* global $, cockpit, QUnit */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.asyncTest("load user info", function() {
+QUnit.test("load user info", function (assert) {
+    let done = assert.async();
     assert.expect(9);
 
     var dbus = cockpit.dbus(null, { "bus": "internal" });
@@ -23,11 +21,12 @@ QUnit.asyncTest("load user info", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "finished successfuly");
-                QUnit.start();
+                done();
             });
 });
 
-QUnit.asyncTest("user object", function() {
+QUnit.test("user object", function (assert) {
+    let done = assert.async();
     assert.expect(6);
 
     cockpit.user().done(function (user) {
@@ -37,11 +36,12 @@ QUnit.asyncTest("user object", function() {
         assert.equal(typeof user.home, "string", "user home");
         assert.equal(typeof user.id, "number", "user id");
         assert.ok($.isArray(user.groups), "user groups");
-        QUnit.start();
+        done();
     });
 });
 
-QUnit.asyncTest("user environment", function() {
+QUnit.test("user environment", function (assert) {
+    let done = assert.async();
     assert.expect(6);
 
     cockpit.spawn([ "/bin/sh", "-c", "echo $USER~$SHELL~$HOME" ])
@@ -58,7 +58,7 @@ QUnit.asyncTest("user environment", function() {
             })
             .always(function() {
                 assert.equal(this.state(), "resolved", "finished successfully");
-                QUnit.start();
+                done();
             });
 });
 

--- a/src/base1/test-utf8.js
+++ b/src/base1/test-utf8.js
@@ -1,9 +1,6 @@
 /* global cockpit, QUnit, unescape, escape */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.test("utf8 basic", function() {
+QUnit.test("utf8 basic", function (assert) {
     var str = "Base 64 \u2014 Mozilla Developer Network";
     var expect = [ 66, 97, 115, 101, 32, 54, 52, 32, 226, 128, 148, 32, 77,
         111, 122, 105, 108, 108, 97, 32, 68, 101, 118, 101, 108,
@@ -34,7 +31,7 @@ QUnit.test("utf8 basic", function() {
 
 // Helpers for test_utf_roundtrip.
 
-QUnit.test("utf8 round trip", function() {
+QUnit.test("utf8 round trip", function (assert) {
     var MIN_CODEPOINT = 0;
     var MAX_CODEPOINT = 0x10FFFF;
     var BLOCK_SIZE = 0x1000;
@@ -82,7 +79,7 @@ QUnit.test("utf8 round trip", function() {
     assert.ok(true, "round trip all code points");
 });
 
-QUnit.test("utf8 samples", function() {
+QUnit.test("utf8 samples", function (assert) {
     // z, cent, CJK water, G-Clef, Private-use character
     var sample = "z\xA2\u6C34\uD834\uDD1E\uDBFF\uDFFD";
     var expected = [0x7A, 0xC2, 0xA2, 0xE6, 0xB0, 0xB4, 0xF0, 0x9D, 0x84, 0x9E, 0xF4, 0x8F, 0xBF, 0xBD];
@@ -94,7 +91,7 @@ QUnit.test("utf8 samples", function() {
     assert.deepEqual(decoded, sample, "decoded");
 });
 
-QUnit.test("utf8 stream", function() {
+QUnit.test("utf8 stream", function (assert) {
     // z, cent, CJK water, G-Clef, Private-use character
     var sample = "z\xA2\u6C34\uD834\uDD1E\uDBFF\uDFFD";
     var expected = [0x7A, 0xC2, 0xA2, 0xE6, 0xB0, 0xB4, 0xF0, 0x9D, 0x84, 0x9E, 0xF4, 0x8F, 0xBF, 0xBD];
@@ -109,7 +106,7 @@ QUnit.test("utf8 stream", function() {
     assert.deepEqual(decoded, sample, "decoded");
 });
 
-QUnit.test("utf8 invalid", function() {
+QUnit.test("utf8 invalid", function (assert) {
     var sample = "Base 64 \ufffd\ufffd Mozilla Developer Network";
     var data = [ 66, 97, 115, 101, 32, 54, 52, 32, 226, /* 128 */ 148, 32, 77,
         111, 122, 105, 108, 108, 97, 32, 68, 101, 118, 101, 108,
@@ -120,7 +117,7 @@ QUnit.test("utf8 invalid", function() {
     assert.deepEqual(decoded, sample, "decoded");
 });
 
-QUnit.test("utf8 fatal", function() {
+QUnit.test("utf8 fatal", function (assert) {
     var data = [ 66, 97, 115, 101, 32, 54, 52, 32, 226, /* 128 */ 148, 32, 77,
         111, 122, 105, 108, 108, 97, 32, 68, 101, 118, 101, 108,
         111, 112, 101, 114, 32, 78, 101, 116, 119, 111, 114, 107 ];

--- a/src/base1/test-websocket.js
+++ b/src/base1/test-websocket.js
@@ -1,9 +1,7 @@
 /* global cockpit, QUnit, WebSocket */
 
-/* To help with future migration */
-var assert = QUnit;
-
-QUnit.asyncTest("external channel websocket", function() {
+QUnit.test("external channel websocket", function (assert) {
+    let done = assert.async();
     assert.expect(3);
 
     var query = window.btoa(JSON.stringify({
@@ -34,11 +32,12 @@ QUnit.asyncTest("external channel websocket", function() {
         }
     };
     ws.onclose = function(ev) {
-        QUnit.start();
+        done();
     };
 });
 
-QUnit.asyncTest("bad channel options websocket", function() {
+QUnit.test("bad channel options websocket", function (assert) {
+    let done = assert.async();
     var payloads = [
         window.btoa(JSON.stringify({
             payload: "websocket-stream1",
@@ -68,7 +67,7 @@ QUnit.asyncTest("bad channel options websocket", function() {
             assert.notEqual(ev.code, 0, url + "websocket error code");
             ws = null;
             if (payloads.length === 0)
-                QUnit.start();
+                done();
             else
                 step();
         };


### PR DESCRIPTION
The package we were depending on ("qunitjs") is no longer maintained.

Change all unit tests to make use of the new API.