### PR TITLE
machines: Fix use of "xterm"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "redux-thunk": "2.3.0",
     "registry-image-widgets": "0.0.16",
     "requirejs": "2.1.22",
-    "term.js-cockpit": "0.0.10"
+    "term.js-cockpit": "0.0.10",
+    "xterm": "3.9.0"
   },
   "devDependencies": {
     "axe-core": "^2.6.1",

--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -6,7 +6,7 @@
 @import (less) "../../node_modules/c3/c3.css";
 
 // For patternfly-react and @patternfly/react-console
-@import "~xterm/dist/xterm.css";
+@import "~xterm/lib/xterm.css";
 @import "~bootstrap/less/variables";
 @import "~patternfly/dist/less/variables";
 @import "~patternfly-react/dist/less/patternfly-react.less";


### PR DESCRIPTION
The location of "xterm.css" seems to have changed.  Use the new one
and lock down the version of xterm so that this doesn't happen again
without us noticing.