### PR TITLE
naughty: Close 9050: openshift 3.9 regression: image registry whitelist enabled by default and hard to configure

### DIFF
--- a/bots/naughty/fedora-29/9050-openshift-image-registry-whitelist
+++ b/bots/naughty/fedora-29/9050-openshift-image-registry-whitelist
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/kubelib.py", line *, in testImagestreamImport
-    b.wait_not_present("modal-dialog")
-*
-Error: timeout
-*
-warning: ImageStream "alltags" is invalid: spec.dockerImageRepository: Forbidden: registry "localhost:5555" not allowed by whitelist*

--- a/bots/naughty/rhel-7/9050-openshift-image-registry-whitelist
+++ b/bots/naughty/rhel-7/9050-openshift-image-registry-whitelist
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/kubelib.py", line *, in testImagestreamImport
-    b.wait_not_present("modal-dialog")
-*
-Error: timeout
-*
-warning: ImageStream "alltags" is invalid: spec.dockerImageRepository: Forbidden: registry "localhost:5555" not allowed by whitelist*


### PR DESCRIPTION
Known issue which has not occurred in 26 days

openshift 3.9 regression: image registry whitelist enabled by default and hard to configure

Fixes #9050