### PR TITLE
ws: Fix bug parsing invalid base64 headers

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1188,16 +1188,19 @@ cockpit_auth_class_init (CockpitAuthClass *klass)
   cockpit_authorize_logger (authorize_logger, 0);
 }
 
-static char *
+static gchar *
 base64_decode_string (const char *enc)
 {
+  gchar *dec;
+  gsize len;
+
   if (enc == NULL)
     return NULL;
 
-  char *dec = g_strdup (enc);
-  gsize len;
-  g_base64_decode_inplace (dec, &len);
-  dec[len] = '\0';
+  dec = (gchar *)g_base64_decode (enc, &len);
+  if (dec)
+    dec[len] = '\0';
+
   return dec;
 }
 

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -286,6 +286,12 @@ test_headers_bad (Test *test,
   if (cockpit_auth_check_cookie (test->auth, "/cockpit", headers))
       g_assert_not_reached ();
 
+  /* Bad encoding */
+  g_hash_table_remove_all (headers);
+  g_hash_table_insert (headers, g_strdup ("Cookie"), g_strdup ("cockpit=d"));
+  if (cockpit_auth_check_cookie (test->auth, "/cockpit", headers))
+      g_assert_not_reached ();
+
   g_hash_table_destroy (headers);
 }
 


### PR DESCRIPTION
The len parameter to g_base64_decode_inplace() is a inout
parameter, and needs to be initialized. Lets just use
the simpler g_base64_decode() function. This fixes a segfault.