### PR TITLE
ws: Display problem in channel response errors

### DIFF
--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -238,16 +238,17 @@ cockpit_channel_response_close (CockpitChannel *channel,
       else if (g_str_equal (problem, "no-host") ||
                g_str_equal (problem, "no-cockpit") ||
                g_str_equal (problem, "unknown-hostkey") ||
+               g_str_equal (problem, "unknown-host") ||
                g_str_equal (problem, "authentication-failed") ||
                g_str_equal (problem, "disconnected"))
         {
           g_debug ("%s: remote server unavailable: %s", self->logname, problem);
-          cockpit_web_response_error (self->response, 502, NULL, NULL);
+          cockpit_web_response_error (self->response, 502, NULL, "%s", problem);
         }
       else
         {
           g_message ("%s: external channel failed: %s", self->logname, problem);
-          cockpit_web_response_error (self->response, 500, NULL, NULL);
+          cockpit_web_response_error (self->response, 500, NULL, "%s", problem);
         }
     }
   else

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -436,21 +436,25 @@ test_resource_failure (TestResourceCase *tc,
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
     g_main_context_iteration (NULL, TRUE);
 
+  /* Null terminate for str-match below */
+  g_output_stream_write_all (G_OUTPUT_STREAM (tc->output), "\0", 1, NULL, NULL, &error);
+  g_assert_no_error (error);
+
   g_output_stream_close (G_OUTPUT_STREAM (tc->output), NULL, &error);
   g_assert_no_error (error);
 
   bytes = g_memory_output_stream_steal_as_bytes (tc->output);
-  cockpit_assert_bytes_eq (bytes,
-                           "HTTP/1.1 500 Internal Server Error\r\n"
+  cockpit_assert_strmatch (g_bytes_get_data (bytes, NULL),
+                           "HTTP/1.1 500 *\r\n"
                            "Content-Type: text/html; charset=utf8\r\n"
                            "Transfer-Encoding: chunked\r\n"
                            "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
                            "\r\n13\r\n"
-                           "<html><head><title>\r\n15\r\n"
-                           "Internal Server Error\r\n15\r\n"
-                           "</title></head><body>\r\n15\r\n"
-                           "Internal Server Error\r\nf\r\n"
-                           "</body></html>\n\r\n0\r\n\r\n", -1);
+                           "<html><head><title>\r\n*\r\n"
+                           "*\r\n"
+                           "</title></head><body>\r\n*\r\n"
+                           "*\r\n"
+                           "</body></html>\n\r\n0\r\n\r\n");
   g_bytes_unref (bytes);
   g_object_unref (response);
 }


### PR DESCRIPTION
For 500 or 502 errors from a channel response, display the
problem code instead of just 'Internal Server Error'. These can only
happen once authenticated, so there is no information leak.