### PR TITLE
pkg: Drop function wrappers from modules with exports

### DIFF
--- a/pkg/docker/bar.js
+++ b/pkg/docker/bar.js
@@ -17,175 +17,173 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
+var $ = require("jquery");
 
-    /* ----------------------------------------------------------------------------
-     * Bar Graphs (in table rows)
-     *
-     * <td>
-     *    <div class="bar-row" graph="name" value="50/100"/>
-     * </td>
-     * <td>
-     *    <div class="bar-row" graph="name" value="80"/>
-     * </td>
-     *
-     * The various rows must have class="bar-row". Add the "bar-row-danger"
-     * class if you want the bar to show up as a warning (ie: red)
-     *
-     * The graph="xxx" attribute must for all the bars that are part of the
-     * same graph, in order for the rows lengths to be coordinated with one
-     * another. Length are based on percentage, so the parent of each
-     * div.bar-row must be the same size.
-     *
-     * value="x" can either be a number, or two numbers separated by a slash
-     * the latter one is the limit. Change the attribute on the DOM and the
-     * graph should update a short while later.
-     *
-     * On document creation any div.bar-row are automatically turned into
-     * Bar graphs. Or use controls.BarRow('name') constructor.
-     *
-     * You can also use the el.reflow() function on the element to reflow
-     * the corresponding graph.
+/* ----------------------------------------------------------------------------
+ * Bar Graphs (in table rows)
+ *
+ * <td>
+ *    <div class="bar-row" graph="name" value="50/100"/>
+ * </td>
+ * <td>
+ *    <div class="bar-row" graph="name" value="80"/>
+ * </td>
+ *
+ * The various rows must have class="bar-row". Add the "bar-row-danger"
+ * class if you want the bar to show up as a warning (ie: red)
+ *
+ * The graph="xxx" attribute must for all the bars that are part of the
+ * same graph, in order for the rows lengths to be coordinated with one
+ * another. Length are based on percentage, so the parent of each
+ * div.bar-row must be the same size.
+ *
+ * value="x" can either be a number, or two numbers separated by a slash
+ * the latter one is the limit. Change the attribute on the DOM and the
+ * graph should update a short while later.
+ *
+ * On document creation any div.bar-row are automatically turned into
+ * Bar graphs. Or use controls.BarRow('name') constructor.
+ *
+ * You can also use the el.reflow() function on the element to reflow
+ * the corresponding graph.
+ */
+
+function reflow_bar_graph(graph, div) {
+    var parts;
+    if (graph) {
+        var selector = "div.bar-row[graph='" + graph + "']";
+        parts = $(selector);
+    } else if (div) {
+        parts = $(div);
+    } else {
+        parts = $([]);
+    }
+
+    function value_parts(el) {
+        var value = $(el).attr('value');
+        if (value === undefined)
+            return [NaN];
+        var values = value.split("/", 2);
+        var portion = parseInt(values[0], 10);
+        if (values.length == 1)
+            return [portion];
+        var limit = parseInt(values[1], 10);
+        if (!isNaN(limit) && portion > limit)
+            portion = limit;
+        if (portion < 0)
+            portion = 0;
+        return [portion, limit];
+    }
+
+    /* One pass to calculate the absolute maximum */
+    var max = 0;
+    parts.each(function() {
+        var limit = value_parts(this).pop();
+        if (!isNaN(limit) && limit > max)
+            max = limit;
+    });
+
+    /* Max gets rounded up to the nearest 100 MiB for sets of bar rows
      */
+    if (graph) {
+        var bound = 100 * 1024 * 1024;
+        max = max - (max % bound) + bound;
+    }
 
-    function reflow_bar_graph(graph, div) {
-        var parts;
-        if (graph) {
-            var selector = "div.bar-row[graph='" + graph + "']";
-            parts = $(selector);
-        } else if (div) {
-            parts = $(div);
+    /* Now resize everything to the right aspect */
+    parts.each(function() {
+        var bits = value_parts(this);
+        var portion = bits.shift();
+        var limit = bits.pop();
+        if (isNaN(portion) || limit === 0) {
+            $(this).css("visibility", "hidden");
         } else {
-            parts = $([]);
-        }
-
-        function value_parts(el) {
-            var value = $(el).attr('value');
-            if (value === undefined)
-                return [NaN];
-            var values = value.split("/", 2);
-            var portion = parseInt(values[0], 10);
-            if (values.length == 1)
-                return [portion];
-            var limit = parseInt(values[1], 10);
-            if (!isNaN(limit) && portion > limit)
-                portion = limit;
-            if (portion < 0)
-                portion = 0;
-            return [portion, limit];
-        }
-
-        /* One pass to calculate the absolute maximum */
-        var max = 0;
-        parts.each(function() {
-            var limit = value_parts(this).pop();
-            if (!isNaN(limit) && limit > max)
-                max = limit;
-        });
-
-        /* Max gets rounded up to the nearest 100 MiB for sets of bar rows
-         */
-        if (graph) {
-            var bound = 100 * 1024 * 1024;
-            max = max - (max % bound) + bound;
-        }
-
-        /* Now resize everything to the right aspect */
-        parts.each(function() {
-            var bits = value_parts(this);
-            var portion = bits.shift();
-            var limit = bits.pop();
-            if (isNaN(portion) || limit === 0) {
-                $(this).css("visibility", "hidden");
+            var bar_progress = $(this).data('bar-progress');
+            if (isNaN(limit)) {
+                bar_progress.addClass("progress-no-limit");
+                limit = portion;
             } else {
-                var bar_progress = $(this).data('bar-progress');
-                if (isNaN(limit)) {
-                    bar_progress.addClass("progress-no-limit");
-                    limit = portion;
-                } else {
-                    bar_progress.removeClass("progress-no-limit");
-                }
-                $(this).css('visibility', 'visible');
-                bar_progress.css("width", ((limit / max) * 100) + "%");
-                $(this).data('bar-progress-bar')
-                        .css('width', ((portion / limit) * 100) + "%")
-                        .toggle(portion > 0);
+                bar_progress.removeClass("progress-no-limit");
             }
-        });
-    }
-
-    var reflow_timeouts = { };
-    function reflow_bar_graph_soon(graph, div) {
-        if (graph === undefined) {
-            if (div)
-                graph = $(div).attr("graph");
+            $(this).css('visibility', 'visible');
+            bar_progress.css("width", ((limit / max) * 100) + "%");
+            $(this).data('bar-progress-bar')
+                    .css('width', ((portion / limit) * 100) + "%")
+                    .toggle(portion > 0);
         }
+    });
+}
 
-        /* If no other parts to this bar, no sense in waiting */
-        if (!graph) {
-            reflow_bar_graph(undefined, div);
-            return;
-        }
-
-        /* Wait until later in case other updates come in to other bits */
-        if (reflow_timeouts[graph] !== "undefined")
-            window.clearTimeout(reflow_timeouts[graph]);
-        reflow_timeouts[graph] = window.setTimeout(function() {
-            delete reflow_timeouts[graph];
-            reflow_bar_graph(graph);
-        }, 10);
+var reflow_timeouts = { };
+function reflow_bar_graph_soon(graph, div) {
+    if (graph === undefined) {
+        if (div)
+            graph = $(div).attr("graph");
     }
 
-    function setup_bar_graph(div) {
-        /*
-         * We consume <div class="bar-row"> elements and turn them into:
-         *
-         * <div class="bar-row">
-         *    <div class="progress">
-         *      <div class="progress-bar">
-         *    </div>
-         * </div>
-         */
-        var progress_bar = $("<div>").addClass("progress-bar");
-        var progress = $("<div>").addClass("progress")
-                .append(progress_bar);
-        $(div)
-                .addClass('bar-row')
-                .append(progress)
-                .data('bar-progress', progress)
-                .data('bar-progress-bar', progress_bar);
-
-        /* Public API */
-        div.reflow = function() {
-            reflow_bar_graph(this.getAttribute("graph"), this);
-        };
-
-        reflow_bar_graph_soon(undefined, div);
+    /* If no other parts to this bar, no sense in waiting */
+    if (!graph) {
+        reflow_bar_graph(undefined, div);
+        return;
     }
 
-    function setup_bar_graphs() {
-        $("div.bar-row").each(function() {
-            setup_bar_graph(this, false);
-        });
-    }
+    /* Wait until later in case other updates come in to other bits */
+    if (reflow_timeouts[graph] !== "undefined")
+        window.clearTimeout(reflow_timeouts[graph]);
+    reflow_timeouts[graph] = window.setTimeout(function() {
+        delete reflow_timeouts[graph];
+        reflow_bar_graph(graph);
+    }, 10);
+}
 
-    $(document).ready(setup_bar_graphs);
+function setup_bar_graph(div) {
+    /*
+     * We consume <div class="bar-row"> elements and turn them into:
+     *
+     * <div class="bar-row">
+     *    <div class="progress">
+     *      <div class="progress-bar">
+     *    </div>
+     * </div>
+     */
+    var progress_bar = $("<div>").addClass("progress-bar");
+    var progress = $("<div>").addClass("progress")
+            .append(progress_bar);
+    $(div)
+            .addClass('bar-row')
+            .append(progress)
+            .data('bar-progress', progress)
+            .data('bar-progress-bar', progress_bar);
 
     /* Public API */
-    module.exports = {
-        create: function create(graph) {
-            var div = $("<div>").addClass('bar-row')
-                    .attr('graph', graph);
-            setup_bar_graph(div);
-            return div;
-        },
-        update: function update() {
-            $("div.bar-row").each(function() {
-                reflow_bar_graph_soon(this.getAttribute("graph"), this);
-            });
-        }
+    div.reflow = function() {
+        reflow_bar_graph(this.getAttribute("graph"), this);
     };
-}());
+
+    reflow_bar_graph_soon(undefined, div);
+}
+
+function setup_bar_graphs() {
+    $("div.bar-row").each(function() {
+        setup_bar_graph(this, false);
+    });
+}
+
+$(document).ready(setup_bar_graphs);
+
+/* Public API */
+module.exports = {
+    create: function create(graph) {
+        var div = $("<div>").addClass('bar-row')
+                .attr('graph', graph);
+        setup_bar_graph(div);
+        return div;
+    },
+    update: function update() {
+        $("div.bar-row").each(function() {
+            reflow_bar_graph_soon(this.getAttribute("graph"), this);
+        });
+    }
+};

--- a/pkg/docker/client.js
+++ b/pkg/docker/client.js
@@ -17,757 +17,755 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
-    var util = require("./util");
-    var docker = require("./docker");
+var $ = require("jquery");
+var cockpit = require("cockpit");
+var util = require("./util");
+var docker = require("./docker");
 
-    function ignoreException(ex) {
-        if (ex.status == 500 && ex.message && ex.message.indexOf("layer does not exist") === 0) {
-            console.warn(ex);
-            return true;
+function ignoreException(ex) {
+    if (ex.status == 500 && ex.message && ex.message.indexOf("layer does not exist") === 0) {
+        console.warn(ex);
+        return true;
+    }
+    return false;
+}
+
+/* DOCKER CLIENT
+ */
+
+function DockerClient() {
+    var self = this;
+    var events;
+    var watch;
+    var http;
+    var connected;
+    var got_failure;
+    var alive = true;
+
+    var later;
+    function trigger_event() {
+        if (!later) {
+            later = window.setTimeout(function() {
+                later = null;
+                $(self).trigger("event");
+            }, 300);
         }
-        return false;
     }
 
-    /* DOCKER CLIENT
+    /* This is a named function because we call it recursively */
+    function connect_events() {
+        if (!connected)
+            return;
+
+        /* Trigger the event signal when JSON from /events */
+        events = http.get("/v1.12/events");
+        events.stream(function(resp) {
+            util.docker_debug("event:", resp);
+            trigger_event();
+        })
+
+        /* Reconnect to /events when it disconnects/fails */
+                .always(function() {
+                    window.setTimeout(function() {
+                        if (alive && events) {
+                            connect_events();
+                            alive = false;
+                        }
+                    }, 1000);
+                });
+    }
+
+    /*
+     * Exposed API, all containers and images
+     * Contains the combined /container/json and /container/xxx/json
+     * output indexed by Id (err id).
+     *
+     * Same for images
      */
+    this.containers = { };
+    this.images = { };
 
-    function DockerClient() {
-        var self = this;
-        var events;
-        var watch;
-        var http;
-        var connected;
-        var got_failure;
-        var alive = true;
+    /* Containers we're waiting for an action to complete on */
+    this.waiting = { };
 
-        var later;
-        function trigger_event() {
-            if (!later) {
-                later = window.setTimeout(function() {
-                    later = null;
-                    $(self).trigger("event");
-                }, 300);
-            }
+    /* images we're currently pulling */
+    this.pulling = [];
+
+    var containers_meta = { };
+    var containers_by_name = { };
+
+    var images_meta = { };
+
+    /* Resource usage sampling */
+    var usage_metrics_channel;
+    var usage_grid;
+    var usage_samples = { };
+
+    function container_to_name(container) {
+        if (!container.Name)
+            return null;
+        var name = container.Name;
+        if (name[0] === '/')
+            name = name.substring(1);
+        return name;
+    }
+
+    function populate_container(id, container) {
+        if (container.State === undefined)
+            container.State = { };
+        if (container.Config === undefined)
+            container.Config = { };
+
+        // Keep the "Image" field from meta for display
+        // and ensure we have an id.
+        // "ImageID" may be present on a ContainerSummary
+        // "Image" in the full result is always an id.
+        // "Image" in the ContainerSummary is translated to a name
+        // when possible
+        if (containers_meta[id]) {
+            if (!containers_meta[id]["ImageID"])
+                containers_meta[id]["ImageID"] = container["Image"];
+            if (containers_meta[id]["Image"])
+                container["Image"] = containers_meta[id]["Image"];
         }
 
-        /* This is a named function because we call it recursively */
-        function connect_events() {
-            if (!connected)
-                return;
-
-            /* Trigger the event signal when JSON from /events */
-            events = http.get("/v1.12/events");
-            events.stream(function(resp) {
-                util.docker_debug("event:", resp);
-                trigger_event();
-            })
-
-            /* Reconnect to /events when it disconnects/fails */
-                    .always(function() {
-                        window.setTimeout(function() {
-                            if (alive && events) {
-                                connect_events();
-                                alive = false;
-                            }
-                        }, 1000);
-                    });
+        // Add in the fields of the short form of the container
+        // info, but never overwrite fields that are already in
+        // the long form.
+        //
+        // TODO: Figure out and document why we do this at all.
+        for (var m in containers_meta[id]) {
+            if (container[m] === undefined)
+                container[m] = containers_meta[id][m];
         }
 
-        /*
-         * Exposed API, all containers and images
-         * Contains the combined /container/json and /container/xxx/json
-         * output indexed by Id (err id).
-         *
-         * Same for images
-         */
-        this.containers = { };
-        this.images = { };
+        var name = container_to_name(container);
+        if (name)
+            containers_by_name[name] = id;
+    }
 
-        /* Containers we're waiting for an action to complete on */
-        this.waiting = { };
-
-        /* images we're currently pulling */
-        this.pulling = [];
-
-        var containers_meta = { };
-        var containers_by_name = { };
-
-        var images_meta = { };
-
-        /* Resource usage sampling */
-        var usage_metrics_channel;
-        var usage_grid;
-        var usage_samples = { };
-
-        function container_to_name(container) {
-            if (!container.Name)
-                return null;
-            var name = container.Name;
-            if (name[0] === '/')
-                name = name.substring(1);
-            return name;
-        }
-
-        function populate_container(id, container) {
-            if (container.State === undefined)
-                container.State = { };
-            if (container.Config === undefined)
-                container.Config = { };
-
-            // Keep the "Image" field from meta for display
-            // and ensure we have an id.
-            // "ImageID" may be present on a ContainerSummary
-            // "Image" in the full result is always an id.
-            // "Image" in the ContainerSummary is translated to a name
-            // when possible
-            if (containers_meta[id]) {
-                if (!containers_meta[id]["ImageID"])
-                    containers_meta[id]["ImageID"] = container["Image"];
-                if (containers_meta[id]["Image"])
-                    container["Image"] = containers_meta[id]["Image"];
-            }
-
-            // Add in the fields of the short form of the container
-            // info, but never overwrite fields that are already in
-            // the long form.
-            //
-            // TODO: Figure out and document why we do this at all.
-            for (var m in containers_meta[id]) {
-                if (container[m] === undefined)
-                    container[m] = containers_meta[id][m];
-            }
-
+    function remove_container(id) {
+        var container = self.containers[id];
+        if (container) {
             var name = container_to_name(container);
-            if (name)
-                containers_by_name[name] = id;
+            if (name && containers_by_name[name] == id)
+                delete containers_by_name[name];
+            delete self.containers[id];
+            $(self).trigger("container", [id, undefined]);
         }
+    }
 
-        function remove_container(id) {
-            var container = self.containers[id];
-            if (container) {
-                var name = container_to_name(container);
-                if (name && containers_by_name[name] == id)
-                    delete containers_by_name[name];
-                delete self.containers[id];
-                $(self).trigger("container", [id, undefined]);
-            }
-        }
-
-        function fetch_containers() {
-            /*
-             * Gets a list of the containers and details for each one.  We use
-             * /events for notification when something changes as well as some
-             * file monitoring.
-             */
-            http.get("/v1.12/containers/json", { all: 1 })
-                    .done(function(data) {
-                        var containers = JSON.parse(data);
-                        alive = true;
-
-                        var seen = {};
-                        $(containers).each(function(i, item) {
-                            var id = item.Id;
-                            if (!id)
-                                return;
-
-                            seen[id] = id;
-                            containers_meta[id] = item;
-                            http.get("/v1.12/containers/" + encodeURIComponent(id) + "/json")
-                                    .done(function(data) {
-                                        var container = JSON.parse(data);
-                                        populate_container(id, container);
-                                        if (self.containers[id]) {
-                                            /* We need to rescue the CGroup
-                                     * from the old instance since we
-                                     * only set it once per ID in
-                                     * update_usage_grid below.
-                                     */
-                                            container.CGroup = self.containers[id].CGroup;
-                                        }
-                                        self.containers[id] = container;
-                                        update_usage_grid();
-                                        $(self).trigger("container", [id, container]);
-                                    });
-                        });
-
-                        var removed = [];
-                        $.each(self.containers, function(id) {
-                            if (!seen[id])
-                                removed.push(id);
-                        });
-
-                        $.each(removed, function(i, id) {
-                            remove_container(id);
-                        });
-                    })
-                    .fail(function(ex) {
-                        if (connected && !ignoreException(ex)) {
-                            got_failure = true;
-                            $(self).trigger("failure", [ex]);
-                        }
-                    });
-        }
-
-        /* Various versions of docker + systemd use different scopes
-         * and cgroups.  The order matters: earlier ones are
-         * preferred, and that in turn matters for containers that
-         * have more than one cgroup.
+    function fetch_containers() {
+        /*
+         * Gets a list of the containers and details for each one.  We use
+         * /events for notification when something changes as well as some
+         * file monitoring.
          */
-        var cgroup_prefixes = [
-            "init.scope/system.slice/docker-",
-            "system.slice/docker/",
-            "system.slice/docker-",
-            "docker/",
-            "kubepods"
-        ];
+        http.get("/v1.12/containers/json", { all: 1 })
+                .done(function(data) {
+                    var containers = JSON.parse(data);
+                    alive = true;
 
-        function update_usage_grid() {
-            var meta = usage_metrics_channel.meta || { };
-            var metrics = meta.metrics || [ ];
+                    var seen = {};
+                    $(containers).each(function(i, item) {
+                        var id = item.Id;
+                        if (!id)
+                            return;
 
-            metrics.forEach(function(metric) {
-                var instances = metric.instances || [ ];
-
-                /*
-                 * Take a look at all the cgroups and map them to all the
-                 * containers.
-                 */
-                cgroup_prefixes.forEach(function(prefix) {
-                    instances.forEach(function(cgroup) {
-                        if (cgroup.indexOf(prefix) === 0) {
-                            var id;
-
-                            if (prefix === "kubepods") {
-                                /* k8s containers have a long and irregular/impredictable prefix
-
-                                   systemd driver looks like kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod2e7[...].slice/docker-DOCKERID.scope/
-                                   cgroupfs driver looks like kubepods/besteffort/pod5827[...]/DOCKERID
-                                */
-                                var offset = cgroup.lastIndexOf("docker-");
-                                if (offset > 0)
-                                    id = cgroup.substr(offset + 7, 64);
-                                else
-                                    id = cgroup.substr(cgroup.lastIndexOf('/') + 1);
-                            } else {
-                                // normal docker containers have a predictable prefix
-                                id = cgroup.substr(prefix.length, 64);
-                            }
-
-                            if (self.containers[id] && !usage_samples[id]) {
-                                self.containers[id].CGroup = cgroup;
-                                usage_samples[id] = [
-                                    usage_grid.add(usage_metrics_channel, [ "cgroup.memory.usage", cgroup ]),
-                                    usage_grid.add(usage_metrics_channel, [ "cgroup.cpu.usage", cgroup ]),
-                                    usage_grid.add(usage_metrics_channel, [ "cgroup.memory.limit", cgroup ]),
-                                    usage_grid.add(usage_metrics_channel, [ "cgroup.cpu.shares", cgroup ])
-                                ];
-                            }
-                        }
+                        seen[id] = id;
+                        containers_meta[id] = item;
+                        http.get("/v1.12/containers/" + encodeURIComponent(id) + "/json")
+                                .done(function(data) {
+                                    var container = JSON.parse(data);
+                                    populate_container(id, container);
+                                    if (self.containers[id]) {
+                                        /* We need to rescue the CGroup
+                                 * from the old instance since we
+                                 * only set it once per ID in
+                                 * update_usage_grid below.
+                                 */
+                                        container.CGroup = self.containers[id].CGroup;
+                                    }
+                                    self.containers[id] = container;
+                                    update_usage_grid();
+                                    $(self).trigger("container", [id, container]);
+                                });
                     });
+
+                    var removed = [];
+                    $.each(self.containers, function(id) {
+                        if (!seen[id])
+                            removed.push(id);
+                    });
+
+                    $.each(removed, function(i, id) {
+                        remove_container(id);
+                    });
+                })
+                .fail(function(ex) {
+                    if (connected && !ignoreException(ex)) {
+                        got_failure = true;
+                        $(self).trigger("failure", [ex]);
+                    }
+                });
+    }
+
+    /* Various versions of docker + systemd use different scopes
+     * and cgroups.  The order matters: earlier ones are
+     * preferred, and that in turn matters for containers that
+     * have more than one cgroup.
+     */
+    var cgroup_prefixes = [
+        "init.scope/system.slice/docker-",
+        "system.slice/docker/",
+        "system.slice/docker-",
+        "docker/",
+        "kubepods"
+    ];
+
+    function update_usage_grid() {
+        var meta = usage_metrics_channel.meta || { };
+        var metrics = meta.metrics || [ ];
+
+        metrics.forEach(function(metric) {
+            var instances = metric.instances || [ ];
+
+            /*
+             * Take a look at all the cgroups and map them to all the
+             * containers.
+             */
+            cgroup_prefixes.forEach(function(prefix) {
+                instances.forEach(function(cgroup) {
+                    if (cgroup.indexOf(prefix) === 0) {
+                        var id;
+
+                        if (prefix === "kubepods") {
+                            /* k8s containers have a long and irregular/impredictable prefix
+
+                               systemd driver looks like kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod2e7[...].slice/docker-DOCKERID.scope/
+                               cgroupfs driver looks like kubepods/besteffort/pod5827[...]/DOCKERID
+                            */
+                            var offset = cgroup.lastIndexOf("docker-");
+                            if (offset > 0)
+                                id = cgroup.substr(offset + 7, 64);
+                            else
+                                id = cgroup.substr(cgroup.lastIndexOf('/') + 1);
+                        } else {
+                            // normal docker containers have a predictable prefix
+                            id = cgroup.substr(prefix.length, 64);
+                        }
+
+                        if (self.containers[id] && !usage_samples[id]) {
+                            self.containers[id].CGroup = cgroup;
+                            usage_samples[id] = [
+                                usage_grid.add(usage_metrics_channel, [ "cgroup.memory.usage", cgroup ]),
+                                usage_grid.add(usage_metrics_channel, [ "cgroup.cpu.usage", cgroup ]),
+                                usage_grid.add(usage_metrics_channel, [ "cgroup.memory.limit", cgroup ]),
+                                usage_grid.add(usage_metrics_channel, [ "cgroup.cpu.shares", cgroup ])
+                            ];
+                        }
+                    }
                 });
             });
-        }
-
-        function handle_usage_samples() {
-            for (var id in usage_samples) {
-                var container = self.containers[id];
-                if (!container)
-                    continue;
-                var samples = usage_samples[id];
-                var mem = samples[0][0];
-                var limit = samples[2][0];
-                /* if the limit is extremely high, consider the value to mean unlimited
-                 * 1.115e18 is roughly 2^60
-                 */
-                if (limit > 1.115e18)
-                    limit = undefined;
-                var cpu = samples[1][0] / 10;
-                var priority = samples[3][0];
-                if (mem != container.MemoryUsage ||
-                    limit != container.MemoryLimit ||
-                    cpu != container.CpuUsage ||
-                    priority != container.CpuPriority) {
-                    container.MemoryUsage = mem;
-                    container.MemoryLimit = limit;
-                    container.CpuUsage = cpu;
-                    container.CpuPriority = priority;
-                    $(self).trigger("container", [id, container]);
-                }
-            }
-        }
-
-        function populate_image(id, image) {
-            if (image.Config === undefined) {
-                if (image.ContainerConfig)
-                    image.Config = image.ContainerConfig;
-                else
-                    image.Config = { };
-            }
-
-            // Save the original of these as
-            // the summary version is prettified
-            // ie: <none>:<none>
-            // and the detail is not.
-            image["ActualRepoTags"] = image.RepoTags;
-            image["ActualRepoDigests"] = image.RepoDigests;
-            $.extend(image, images_meta[id]);
-
-            /* HACK: TODO upstream bug */
-            if (image.RepoTags)
-                image.RepoTags.sort();
-        }
-
-        function remove_image(id) {
-            if (self.images[id]) {
-                delete self.images[id];
-                $(self).trigger("image", [id, undefined]);
-            }
-        }
-
-        function fetch_images() {
-            /*
-             * Gets a list of images and keeps it up to date.
-             */
-            http.get("/v1.12/images/json")
-                    .done(function(data) {
-                        var images = JSON.parse(data);
-                        alive = true;
-
-                        var seen = {};
-                        $.each(images, function(i, item) {
-                            var id = item.Id;
-                            if (!id)
-                                return;
-
-                            seen[id] = id;
-                            images_meta[id] = item;
-                            http.get("/v1.12/images/" + encodeURIComponent(id) + "/json")
-                                    .done(function(data) {
-                                        var image = JSON.parse(data);
-                                        populate_image(id, image);
-                                        self.images[id] = image;
-                                        $(self).trigger("image", [id, image]);
-                                    });
-                        });
-
-                        var removed = [];
-                        $.each(self.images, function(id) {
-                            if (!seen[id])
-                                removed.push(id);
-                        });
-
-                        $.each(removed, function(i, id) {
-                            remove_image(id);
-                        });
-                    })
-                    .fail(function(ex) {
-                        if (connected && !ignoreException(ex)) {
-                            got_failure = true;
-                            $(self).trigger("failure", [ex]);
-                        }
-                    });
-        }
-
-        function fetch_info() {
-            http.get("/v1.12/info")
-                    .fail(function(ex) {
-                        util.docker_debug("info failed:", ex);
-
-                        /* Failed to connect */
-                        if (connected && connected.state() == "pending")
-                            connected.reject(ex);
-                    })
-                    .done(function(data) {
-                        util.docker_debug("info:", data);
-                        self.info = data && JSON.parse(data);
-                        $(self).triggerHandler("info", self.info);
-
-                        /* Ready to display stuff */
-                        if (connected && connected.state() == "pending")
-                            connected.resolve();
-                    });
-        }
-
-        $(self).on("event", function() {
-            if (connected) {
-                fetch_containers();
-                fetch_images();
-                fetch_info();
-            }
         });
-
-        function perform_connect() {
-            got_failure = false;
-            connected = $.Deferred();
-            http = cockpit.http("/var/run/docker.sock", { superuser: "try" });
-
-            connect_events();
-
-            if (watch && watch.valid)
-                watch.close();
-
-            function got_info() {
-                watch = cockpit.channel({ payload: "fslist1", path: self.info["DockerRootDir"], superuser: "try" });
-                $(watch)
-                        .on("message", function(event, data) {
-                            trigger_event();
-                        })
-                        .on("close", function(event, options) {
-                            if (options.problem && options.problem != "not-found")
-                                console.warn("monitor for docker directory failed: " + options.problem);
-                        });
-                $(self).off("info", got_info);
-            }
-
-            $(self).on("info", got_info);
-
-            /* Starts fetching things */
-            $(self).triggerHandler("event");
-
-            usage_metrics_channel = cockpit.metrics(1000,
-                                                    { source: "internal",
-                                                      metrics: [ { name: "cgroup.memory.usage",
-                                                                   units: "bytes"
-                                                      },
-                                                      { name: "cgroup.cpu.usage",
-                                                        units: "millisec",
-                                                        derive: "rate"
-                                                      },
-                                                      { name: "cgroup.memory.limit",
-                                                        units: "bytes"
-                                                      },
-                                                      { name: "cgroup.cpu.shares",
-                                                        units: "count"
-                                                      }
-                                                      ]
-                                                    });
-
-            $(usage_metrics_channel).on("changed", function() {
-                update_usage_grid();
-            });
-
-            usage_grid = cockpit.grid(1000, -1, -0);
-
-            usage_metrics_channel.follow();
-            usage_grid.walk();
-
-            $(usage_grid).on('notify', function (event, index, count) {
-                handle_usage_samples();
-            });
-        }
-
-        function trigger_id(id) {
-            if (id in self.containers)
-                $(self).trigger("container", [id, self.containers[id]]);
-            else if (id in self.images)
-                $(self).trigger("image", [id, self.images[id]]);
-        }
-
-        function waiting(id, yes) {
-            if (id in self.waiting) {
-                self.waiting[id]++;
-            } else {
-                self.waiting[id] = 1;
-                trigger_id(id);
-            }
-        }
-
-        function not_waiting(id) {
-            self.waiting[id]--;
-            if (self.waiting[id] === 0) {
-                delete self.waiting[id];
-                trigger_id(id);
-            }
-        }
-
-        /* Actually connect initially */
-        perform_connect();
-
-        this.start = function start(id, options) {
-            waiting(id);
-            util.docker_debug("starting:", id);
-            return http.request({
-                method: "POST",
-                path: "/v1.12/containers/" + encodeURIComponent(id) + "/start",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(options || { })
-            })
-                    .fail(function(ex) {
-                        util.docker_debug("start failed:", id, ex);
-                    })
-                    .done(function(resp) {
-                        util.docker_debug("started:", id, resp);
-                    })
-                    .always(function() {
-                        not_waiting(id);
-                    });
-        };
-
-        this.stop = function stop(id, timeout) {
-            waiting(id);
-            if (timeout === undefined)
-                timeout = 10;
-            util.docker_debug("stopping:", id, timeout);
-            return http.request({
-                method: "POST",
-                path: "/v1.12/containers/" + encodeURIComponent(id) + "/stop",
-                params: { 't': timeout },
-                body: ""
-            })
-                    .fail(function(ex) {
-                        util.docker_debug("stop failed:", id, ex);
-                    })
-                    .done(function(resp) {
-                        util.docker_debug("stopped:", id, resp);
-                    })
-                    .always(function() {
-                        not_waiting(id);
-                    });
-        };
-
-        this.restart = function restart(id, timeout) {
-            waiting(id);
-            if (timeout === undefined)
-                timeout = 10;
-            util.docker_debug("restarting:", id);
-            return http.request({
-                method: "POST",
-                path: "/v1.12/containers/" + encodeURIComponent(id) + "/restart",
-                params: { 't': timeout },
-                body: ""
-            })
-                    .fail(function(ex) {
-                        util.docker_debug("restart failed:", id, ex);
-                    })
-                    .done(function(resp) {
-                        util.docker_debug("restarted:", id, resp);
-                    })
-                    .always(function() {
-                        not_waiting(id);
-                    });
-        };
-
-        this.create = function create(name, options) {
-            var body = JSON.stringify(options || { });
-            util.docker_debug("creating:", name, body);
-            return http.request({
-                method: "POST",
-                path: "/v1.12/containers/create",
-                params: { "name": name },
-                headers: { "Content-Type": "application/json" },
-                body: body,
-            })
-                    .fail(function(ex) {
-                        util.docker_debug("create failed:", name, ex);
-                    })
-                    .done(function(resp) {
-                        util.docker_debug("created:", name, resp);
-                    })
-                    .then(JSON.parse);
-        };
-
-        this.search = function search(term) {
-            util.docker_debug("searching:", term);
-            return http.get("/v1.12/images/search", { "term": term })
-                    .fail(function(ex) {
-                        util.docker_debug("search failed:", term, ex);
-                    })
-                    .done(function(resp) {
-                        util.docker_debug("searched:", term, resp);
-                    });
-        };
-
-        this.commit = function create(id, repotag, options, run_config) {
-            var args = {
-                "container": id,
-                "repo": repotag
-            };
-            $.extend(args, options);
-
-            waiting(id);
-            util.docker_debug("committing:", id, repotag, options, run_config);
-            return http.request({
-                method: "POST",
-                path: "/v1.12/commit",
-                params: args,
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(run_config || { })
-            })
-                    .fail(function(ex) {
-                        util.docker_debug("commit failed:", repotag, ex);
-                    })
-                    .done(function(resp) {
-                        util.docker_debug("committed:", repotag);
-                    })
-                    .always(function() {
-                        not_waiting(id);
-                    })
-                    .then(JSON.parse);
-        };
-
-        this.rm = function rm(id, forced) {
-            if (forced === undefined)
-                forced = false;
-            waiting(id);
-            util.docker_debug("deleting:", id);
-            return http.request({
-                method: "DELETE",
-                path: "/v1.12/containers/" + encodeURIComponent(id),
-                params: { "force": forced },
-                body: ""
-            })
-                    .fail(function(ex) {
-                        util.docker_debug("delete failed:", id, ex);
-                    })
-                    .done(function(resp) {
-                        util.docker_debug("deleted:", id, resp);
-                        remove_container(id);
-                    })
-                    .always(function() {
-                        not_waiting(id);
-                    });
-        };
-
-        this.rmi = function rmi(id, forced) {
-            forced = forced || false;
-            waiting(id);
-            util.docker_debug("deleting:", id);
-            return http.request({
-                method: "DELETE",
-                path: "/v1.12/images/" + encodeURIComponent(id),
-                params: { "force": forced },
-                body: ""
-            })
-                    .fail(function(ex) {
-                        util.docker_debug("delete failed:", id, ex);
-                    })
-                    .done(function(resp) {
-                        util.docker_debug("deleted:", id, resp);
-                        remove_image(id);
-                    })
-                    .always(function() {
-                        not_waiting(id);
-                    });
-        };
-
-        this.pull = function (repo, tag, registry) {
-            var job = {
-                name: repo
-            };
-
-            docker.pull(repo, tag, registry)
-                    .progress(function(message, progress) {
-                        job.status = progress.status;
-                        if (progress.progressDetail && 'current' in progress.progressDetail && 'total' in progress.progressDetail)
-                            job.progress = progress.progressDetail;
-                        else
-                            delete job.progress;
-                        $(self).trigger("pulling");
-                    })
-                    .done(function () {
-                        self.pulling = self.pulling.filter(function (j) {
-                            return j !== job;
-                        });
-                        $(self).trigger("pulling");
-                    })
-                    .fail(function (error) {
-                        job.status = 'Error getting image: ' + error.message;
-                        delete job.progress;
-                        $(self).trigger("pulling");
-                    });
-
-            self.pulling.push(job);
-        };
-
-        function change_cgroup(directory, cgroup, filename, value) {
-            /* TODO: Yup need a nicer way of doing this ... likely systemd once we're geard'd out */
-            var path = "/sys/fs/cgroup/" + directory + "/" + cgroup + "/" + filename;
-            var command = "if test -f " + path + "; then echo '" + value.toFixed(0) + "' > " + path + "; fi";
-            util.docker_debug("changing cgroup:", command);
-
-            return cockpit.spawn(["sh", "-c", command], { "superuser": "try", "err": "message" });
-        }
-
-        this.change_memory_limit = function change_memory_limit(id, value) {
-            var cgroup = this.containers[id].CGroup;
-            if (value === undefined || value <= 0)
-                value = -1;
-
-            /* The order in which we set memory.memsw and memory is important. */
-            if (value === -1) {
-                return change_cgroup("memory", cgroup, "memory.memsw.limit_in_bytes", -1)
-                        .then(function() {
-                            return change_cgroup("memory", cgroup, "memory.limit_in_bytes", -1);
-                        });
-            } else {
-                return change_cgroup("memory", cgroup, "memory.limit_in_bytes", value)
-                        .then(function() {
-                            return change_cgroup("memory", cgroup, "memory.memsw.limit_in_bytes", value * 2);
-                        });
-            }
-        };
-
-        this.change_cpu_priority = function change_cpu_priority(id, value) {
-            if (value === undefined || value <= 0)
-                value = 1024;
-            return change_cgroup("cpuacct", this.containers[id].CGroup, "cpu.shares", value);
-        };
-
-        this.close = function close() {
-            if (usage_metrics_channel) {
-                usage_metrics_channel.close();
-                $(usage_metrics_channel).off();
-                usage_metrics_channel = null;
-                usage_grid.close();
-                $(usage_grid).off();
-                usage_grid = null;
-            }
-            http.close("closed");
-            connected = null;
-        };
-
-        this.connect = function connect() {
-            if (!connected)
-                perform_connect();
-            return connected.promise();
-        };
-
-        this.maybe_reconnect = function maybe_reconnect() {
-            if (got_failure) {
-                this.close();
-                perform_connect();
-            }
-            return connected.promise();
-        };
-
-        this.containers_for_image = function containers_for_image(id) {
-            util.docker_debug('containers search on image id: ', id);
-            return http.get('/v1.12/containers/json', { all: 1, filters: JSON.stringify({ ancestor: [ id ] }) })
-                    .fail(function(ex) {
-                        util.docker_debug('containers search on image id failed:', id, ex);
-                    })
-                    .done(function(data) {
-                        util.docker_debug('containers search on image id succeeded:', id);
-                    })
-                    .then(JSON.parse);
-        };
-
-        /* Initially empty info data */
-        self.info = { };
     }
 
-    var client;
+    function handle_usage_samples() {
+        for (var id in usage_samples) {
+            var container = self.containers[id];
+            if (!container)
+                continue;
+            var samples = usage_samples[id];
+            var mem = samples[0][0];
+            var limit = samples[2][0];
+            /* if the limit is extremely high, consider the value to mean unlimited
+             * 1.115e18 is roughly 2^60
+             */
+            if (limit > 1.115e18)
+                limit = undefined;
+            var cpu = samples[1][0] / 10;
+            var priority = samples[3][0];
+            if (mem != container.MemoryUsage ||
+                limit != container.MemoryLimit ||
+                cpu != container.CpuUsage ||
+                priority != container.CpuPriority) {
+                container.MemoryUsage = mem;
+                container.MemoryLimit = limit;
+                container.CpuUsage = cpu;
+                container.CpuPriority = priority;
+                $(self).trigger("container", [id, container]);
+            }
+        }
+    }
 
-    module.exports = {
-        instance: function() {
-            if (!client)
-                client = new DockerClient();
-            return client;
+    function populate_image(id, image) {
+        if (image.Config === undefined) {
+            if (image.ContainerConfig)
+                image.Config = image.ContainerConfig;
+            else
+                image.Config = { };
+        }
+
+        // Save the original of these as
+        // the summary version is prettified
+        // ie: <none>:<none>
+        // and the detail is not.
+        image["ActualRepoTags"] = image.RepoTags;
+        image["ActualRepoDigests"] = image.RepoDigests;
+        $.extend(image, images_meta[id]);
+
+        /* HACK: TODO upstream bug */
+        if (image.RepoTags)
+            image.RepoTags.sort();
+    }
+
+    function remove_image(id) {
+        if (self.images[id]) {
+            delete self.images[id];
+            $(self).trigger("image", [id, undefined]);
+        }
+    }
+
+    function fetch_images() {
+        /*
+         * Gets a list of images and keeps it up to date.
+         */
+        http.get("/v1.12/images/json")
+                .done(function(data) {
+                    var images = JSON.parse(data);
+                    alive = true;
+
+                    var seen = {};
+                    $.each(images, function(i, item) {
+                        var id = item.Id;
+                        if (!id)
+                            return;
+
+                        seen[id] = id;
+                        images_meta[id] = item;
+                        http.get("/v1.12/images/" + encodeURIComponent(id) + "/json")
+                                .done(function(data) {
+                                    var image = JSON.parse(data);
+                                    populate_image(id, image);
+                                    self.images[id] = image;
+                                    $(self).trigger("image", [id, image]);
+                                });
+                    });
+
+                    var removed = [];
+                    $.each(self.images, function(id) {
+                        if (!seen[id])
+                            removed.push(id);
+                    });
+
+                    $.each(removed, function(i, id) {
+                        remove_image(id);
+                    });
+                })
+                .fail(function(ex) {
+                    if (connected && !ignoreException(ex)) {
+                        got_failure = true;
+                        $(self).trigger("failure", [ex]);
+                    }
+                });
+    }
+
+    function fetch_info() {
+        http.get("/v1.12/info")
+                .fail(function(ex) {
+                    util.docker_debug("info failed:", ex);
+
+                    /* Failed to connect */
+                    if (connected && connected.state() == "pending")
+                        connected.reject(ex);
+                })
+                .done(function(data) {
+                    util.docker_debug("info:", data);
+                    self.info = data && JSON.parse(data);
+                    $(self).triggerHandler("info", self.info);
+
+                    /* Ready to display stuff */
+                    if (connected && connected.state() == "pending")
+                        connected.resolve();
+                });
+    }
+
+    $(self).on("event", function() {
+        if (connected) {
+            fetch_containers();
+            fetch_images();
+            fetch_info();
+        }
+    });
+
+    function perform_connect() {
+        got_failure = false;
+        connected = $.Deferred();
+        http = cockpit.http("/var/run/docker.sock", { superuser: "try" });
+
+        connect_events();
+
+        if (watch && watch.valid)
+            watch.close();
+
+        function got_info() {
+            watch = cockpit.channel({ payload: "fslist1", path: self.info["DockerRootDir"], superuser: "try" });
+            $(watch)
+                    .on("message", function(event, data) {
+                        trigger_event();
+                    })
+                    .on("close", function(event, options) {
+                        if (options.problem && options.problem != "not-found")
+                            console.warn("monitor for docker directory failed: " + options.problem);
+                    });
+            $(self).off("info", got_info);
+        }
+
+        $(self).on("info", got_info);
+
+        /* Starts fetching things */
+        $(self).triggerHandler("event");
+
+        usage_metrics_channel = cockpit.metrics(1000,
+                                                { source: "internal",
+                                                  metrics: [ { name: "cgroup.memory.usage",
+                                                               units: "bytes"
+                                                  },
+                                                  { name: "cgroup.cpu.usage",
+                                                    units: "millisec",
+                                                    derive: "rate"
+                                                  },
+                                                  { name: "cgroup.memory.limit",
+                                                    units: "bytes"
+                                                  },
+                                                  { name: "cgroup.cpu.shares",
+                                                    units: "count"
+                                                  }
+                                                  ]
+                                                });
+
+        $(usage_metrics_channel).on("changed", function() {
+            update_usage_grid();
+        });
+
+        usage_grid = cockpit.grid(1000, -1, -0);
+
+        usage_metrics_channel.follow();
+        usage_grid.walk();
+
+        $(usage_grid).on('notify', function (event, index, count) {
+            handle_usage_samples();
+        });
+    }
+
+    function trigger_id(id) {
+        if (id in self.containers)
+            $(self).trigger("container", [id, self.containers[id]]);
+        else if (id in self.images)
+            $(self).trigger("image", [id, self.images[id]]);
+    }
+
+    function waiting(id, yes) {
+        if (id in self.waiting) {
+            self.waiting[id]++;
+        } else {
+            self.waiting[id] = 1;
+            trigger_id(id);
+        }
+    }
+
+    function not_waiting(id) {
+        self.waiting[id]--;
+        if (self.waiting[id] === 0) {
+            delete self.waiting[id];
+            trigger_id(id);
+        }
+    }
+
+    /* Actually connect initially */
+    perform_connect();
+
+    this.start = function start(id, options) {
+        waiting(id);
+        util.docker_debug("starting:", id);
+        return http.request({
+            method: "POST",
+            path: "/v1.12/containers/" + encodeURIComponent(id) + "/start",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(options || { })
+        })
+                .fail(function(ex) {
+                    util.docker_debug("start failed:", id, ex);
+                })
+                .done(function(resp) {
+                    util.docker_debug("started:", id, resp);
+                })
+                .always(function() {
+                    not_waiting(id);
+                });
+    };
+
+    this.stop = function stop(id, timeout) {
+        waiting(id);
+        if (timeout === undefined)
+            timeout = 10;
+        util.docker_debug("stopping:", id, timeout);
+        return http.request({
+            method: "POST",
+            path: "/v1.12/containers/" + encodeURIComponent(id) + "/stop",
+            params: { 't': timeout },
+            body: ""
+        })
+                .fail(function(ex) {
+                    util.docker_debug("stop failed:", id, ex);
+                })
+                .done(function(resp) {
+                    util.docker_debug("stopped:", id, resp);
+                })
+                .always(function() {
+                    not_waiting(id);
+                });
+    };
+
+    this.restart = function restart(id, timeout) {
+        waiting(id);
+        if (timeout === undefined)
+            timeout = 10;
+        util.docker_debug("restarting:", id);
+        return http.request({
+            method: "POST",
+            path: "/v1.12/containers/" + encodeURIComponent(id) + "/restart",
+            params: { 't': timeout },
+            body: ""
+        })
+                .fail(function(ex) {
+                    util.docker_debug("restart failed:", id, ex);
+                })
+                .done(function(resp) {
+                    util.docker_debug("restarted:", id, resp);
+                })
+                .always(function() {
+                    not_waiting(id);
+                });
+    };
+
+    this.create = function create(name, options) {
+        var body = JSON.stringify(options || { });
+        util.docker_debug("creating:", name, body);
+        return http.request({
+            method: "POST",
+            path: "/v1.12/containers/create",
+            params: { "name": name },
+            headers: { "Content-Type": "application/json" },
+            body: body,
+        })
+                .fail(function(ex) {
+                    util.docker_debug("create failed:", name, ex);
+                })
+                .done(function(resp) {
+                    util.docker_debug("created:", name, resp);
+                })
+                .then(JSON.parse);
+    };
+
+    this.search = function search(term) {
+        util.docker_debug("searching:", term);
+        return http.get("/v1.12/images/search", { "term": term })
+                .fail(function(ex) {
+                    util.docker_debug("search failed:", term, ex);
+                })
+                .done(function(resp) {
+                    util.docker_debug("searched:", term, resp);
+                });
+    };
+
+    this.commit = function create(id, repotag, options, run_config) {
+        var args = {
+            "container": id,
+            "repo": repotag
+        };
+        $.extend(args, options);
+
+        waiting(id);
+        util.docker_debug("committing:", id, repotag, options, run_config);
+        return http.request({
+            method: "POST",
+            path: "/v1.12/commit",
+            params: args,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(run_config || { })
+        })
+                .fail(function(ex) {
+                    util.docker_debug("commit failed:", repotag, ex);
+                })
+                .done(function(resp) {
+                    util.docker_debug("committed:", repotag);
+                })
+                .always(function() {
+                    not_waiting(id);
+                })
+                .then(JSON.parse);
+    };
+
+    this.rm = function rm(id, forced) {
+        if (forced === undefined)
+            forced = false;
+        waiting(id);
+        util.docker_debug("deleting:", id);
+        return http.request({
+            method: "DELETE",
+            path: "/v1.12/containers/" + encodeURIComponent(id),
+            params: { "force": forced },
+            body: ""
+        })
+                .fail(function(ex) {
+                    util.docker_debug("delete failed:", id, ex);
+                })
+                .done(function(resp) {
+                    util.docker_debug("deleted:", id, resp);
+                    remove_container(id);
+                })
+                .always(function() {
+                    not_waiting(id);
+                });
+    };
+
+    this.rmi = function rmi(id, forced) {
+        forced = forced || false;
+        waiting(id);
+        util.docker_debug("deleting:", id);
+        return http.request({
+            method: "DELETE",
+            path: "/v1.12/images/" + encodeURIComponent(id),
+            params: { "force": forced },
+            body: ""
+        })
+                .fail(function(ex) {
+                    util.docker_debug("delete failed:", id, ex);
+                })
+                .done(function(resp) {
+                    util.docker_debug("deleted:", id, resp);
+                    remove_image(id);
+                })
+                .always(function() {
+                    not_waiting(id);
+                });
+    };
+
+    this.pull = function (repo, tag, registry) {
+        var job = {
+            name: repo
+        };
+
+        docker.pull(repo, tag, registry)
+                .progress(function(message, progress) {
+                    job.status = progress.status;
+                    if (progress.progressDetail && 'current' in progress.progressDetail && 'total' in progress.progressDetail)
+                        job.progress = progress.progressDetail;
+                    else
+                        delete job.progress;
+                    $(self).trigger("pulling");
+                })
+                .done(function () {
+                    self.pulling = self.pulling.filter(function (j) {
+                        return j !== job;
+                    });
+                    $(self).trigger("pulling");
+                })
+                .fail(function (error) {
+                    job.status = 'Error getting image: ' + error.message;
+                    delete job.progress;
+                    $(self).trigger("pulling");
+                });
+
+        self.pulling.push(job);
+    };
+
+    function change_cgroup(directory, cgroup, filename, value) {
+        /* TODO: Yup need a nicer way of doing this ... likely systemd once we're geard'd out */
+        var path = "/sys/fs/cgroup/" + directory + "/" + cgroup + "/" + filename;
+        var command = "if test -f " + path + "; then echo '" + value.toFixed(0) + "' > " + path + "; fi";
+        util.docker_debug("changing cgroup:", command);
+
+        return cockpit.spawn(["sh", "-c", command], { "superuser": "try", "err": "message" });
+    }
+
+    this.change_memory_limit = function change_memory_limit(id, value) {
+        var cgroup = this.containers[id].CGroup;
+        if (value === undefined || value <= 0)
+            value = -1;
+
+        /* The order in which we set memory.memsw and memory is important. */
+        if (value === -1) {
+            return change_cgroup("memory", cgroup, "memory.memsw.limit_in_bytes", -1)
+                    .then(function() {
+                        return change_cgroup("memory", cgroup, "memory.limit_in_bytes", -1);
+                    });
+        } else {
+            return change_cgroup("memory", cgroup, "memory.limit_in_bytes", value)
+                    .then(function() {
+                        return change_cgroup("memory", cgroup, "memory.memsw.limit_in_bytes", value * 2);
+                    });
         }
     };
-}());
+
+    this.change_cpu_priority = function change_cpu_priority(id, value) {
+        if (value === undefined || value <= 0)
+            value = 1024;
+        return change_cgroup("cpuacct", this.containers[id].CGroup, "cpu.shares", value);
+    };
+
+    this.close = function close() {
+        if (usage_metrics_channel) {
+            usage_metrics_channel.close();
+            $(usage_metrics_channel).off();
+            usage_metrics_channel = null;
+            usage_grid.close();
+            $(usage_grid).off();
+            usage_grid = null;
+        }
+        http.close("closed");
+        connected = null;
+    };
+
+    this.connect = function connect() {
+        if (!connected)
+            perform_connect();
+        return connected.promise();
+    };
+
+    this.maybe_reconnect = function maybe_reconnect() {
+        if (got_failure) {
+            this.close();
+            perform_connect();
+        }
+        return connected.promise();
+    };
+
+    this.containers_for_image = function containers_for_image(id) {
+        util.docker_debug('containers search on image id: ', id);
+        return http.get('/v1.12/containers/json', { all: 1, filters: JSON.stringify({ ancestor: [ id ] }) })
+                .fail(function(ex) {
+                    util.docker_debug('containers search on image id failed:', id, ex);
+                })
+                .done(function(data) {
+                    util.docker_debug('containers search on image id succeeded:', id);
+                })
+                .then(JSON.parse);
+    };
+
+    /* Initially empty info data */
+    self.info = { };
+}
+
+var client;
+
+module.exports = {
+    instance: function() {
+        if (!client)
+            client = new DockerClient();
+        return client;
+    }
+};

--- a/pkg/docker/details.js
+++ b/pkg/docker/details.js
@@ -17,308 +17,306 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
-    var moment = require("moment");
-    moment.locale(cockpit.language);
+var $ = require("jquery");
+var cockpit = require("cockpit");
+var moment = require("moment");
+moment.locale(cockpit.language);
 
-    require("patterns");
+require("patterns");
 
-    var docker = require("./docker");
-    var util = require("./util");
+var docker = require("./docker");
+var util = require("./util");
 
-    require("console.css");
+require("console.css");
 
-    var _ = cockpit.gettext;
-    var C_ = cockpit.gettext;
+var _ = cockpit.gettext;
+var C_ = cockpit.gettext;
 
-    /* CONTAINER DETAILS PAGE
-     */
+/* CONTAINER DETAILS PAGE
+ */
 
-    PageContainerDetails.prototype = {
-        _init: function(client) {
-            this.client = client;
+PageContainerDetails.prototype = {
+    _init: function(client) {
+        this.client = client;
+        this.terminal = null;
+    },
+
+    getTitle: function() {
+        return C_("page-title", "Containers");
+    },
+
+    setup: function() {
+        var self = this;
+
+        $('#container-details .content-filter a').on("click", function() {
+            cockpit.location.go('/');
+        });
+
+        $('#container-details-start').on('click', $.proxy(this, "start_container"));
+        $('#container-details-stop').on('click', $.proxy(this, "stop_container"));
+        $('#container-details-restart').on('click', $.proxy(this, "restart_container"));
+        $('#container-details-delete').on('click', $.proxy(this, "delete_container"));
+
+        self.memory_limit = new util.MemorySlider($("#container-resources-dialog .memory-slider"),
+                                                  10 * 1024 * 1024, 2 * 1024 * 1024 * 1024);
+        self.cpu_priority = new util.CpuSlider($("#container-resources-dialog .cpu-slider"),
+                                               2, 1000000);
+
+        self.memory_usage = $('#container-details-memory .bar-row');
+        $('#container-resources-dialog')
+                .on("show.bs.modal", function() {
+                    var info = self.client.containers[self.container_id];
+
+                    /* This slider is only visible if docker says this option is available */
+                    $("#container-resources-dialog .memory-slider")
+                            .toggle(!!self.client.info.MemoryLimit);
+
+                    if (self.client.info.MemTotal)
+                        self.memory_limit.max = self.client.info.MemTotal;
+
+                    /* Fill in the resource dialog */
+                    $(this).find(".container-name")
+                            .text(self.name);
+                    self.memory_limit.value = info.MemoryLimit || undefined;
+                    self.cpu_priority.value = info.CpuPriority || undefined;
+                })
+                .find(".btn-primary")
+                .on("click", function() {
+                    var mem;
+                    var prom = self.client.change_cpu_priority(self.container_id, self.cpu_priority.value);
+                    if (self.client.info.MemoryLimit) {
+                        mem = self.client.change_memory_limit(self.container_id, self.memory_limit.value);
+                        prom = cockpit.all(mem, prom);
+                    }
+                    $('#container-resources-dialog').dialog('promise', prom);
+                });
+    },
+
+    enter: function(container_id) {
+        var self = this;
+
+        $(this.client).off('.container-details');
+
+        if (this.terminal) {
+            this.terminal.close();
             this.terminal = null;
-        },
+        }
+        $("#container-terminal").hide();
 
-        getTitle: function() {
-            return C_("page-title", "Containers");
-        },
+        this.container_id = container_id;
+        this.name = this.container_id.slice(0, 12);
 
-        setup: function() {
-            var self = this;
+        $(this.client).on('container.container-details', function (event, id, container) {
+            if (id == self.container_id)
+                self.update();
+        });
 
-            $('#container-details .content-filter a').on("click", function() {
-                cockpit.location.go('/');
-            });
+        $('#container-details-commit')[0].dataset.containerId = container_id;
 
-            $('#container-details-start').on('click', $.proxy(this, "start_container"));
-            $('#container-details-stop').on('click', $.proxy(this, "stop_container"));
-            $('#container-details-restart').on('click', $.proxy(this, "restart_container"));
-            $('#container-details-delete').on('click', $.proxy(this, "delete_container"));
+        this.update();
+    },
 
-            self.memory_limit = new util.MemorySlider($("#container-resources-dialog .memory-slider"),
-                                                      10 * 1024 * 1024, 2 * 1024 * 1024 * 1024);
-            self.cpu_priority = new util.CpuSlider($("#container-resources-dialog .cpu-slider"),
-                                                   2, 1000000);
+    maybe_show_terminal: function(info) {
+        if (!this.terminal) {
+            this.terminal = docker.console(this.container_id, { tty: info.Config.Tty });
+            $("#container-terminal").empty()
+                    .append(this.terminal);
+            this.terminal.connect();
+        }
+        this.terminal.typeable(info.State.Running);
+        $("#container-terminal").show();
+    },
 
-            self.memory_usage = $('#container-details-memory .bar-row');
-            $('#container-resources-dialog')
-                    .on("show.bs.modal", function() {
-                        var info = self.client.containers[self.container_id];
+    maybe_reconnect_terminal: function() {
+        if (this.terminal && !this.terminal.connected) {
+            this.terminal.connect();
+            this.terminal.typeable(true);
+        }
+    },
 
-                        /* This slider is only visible if docker says this option is available */
-                        $("#container-resources-dialog .memory-slider")
-                                .toggle(!!self.client.info.MemoryLimit);
-
-                        if (self.client.info.MemTotal)
-                            self.memory_limit.max = self.client.info.MemTotal;
-
-                        /* Fill in the resource dialog */
-                        $(this).find(".container-name")
-                                .text(self.name);
-                        self.memory_limit.value = info.MemoryLimit || undefined;
-                        self.cpu_priority.value = info.CpuPriority || undefined;
-                    })
-                    .find(".btn-primary")
-                    .on("click", function() {
-                        var mem;
-                        var prom = self.client.change_cpu_priority(self.container_id, self.cpu_priority.value);
-                        if (self.client.info.MemoryLimit) {
-                            mem = self.client.change_memory_limit(self.container_id, self.memory_limit.value);
-                            prom = cockpit.all(mem, prom);
-                        }
-                        $('#container-resources-dialog').dialog('promise', prom);
-                    });
-        },
-
-        enter: function(container_id) {
-            var self = this;
-
-            $(this.client).off('.container-details');
-
-            if (this.terminal) {
-                this.terminal.close();
-                this.terminal = null;
+    add_bindings: function(bindings, config) {
+        for (var p in config) {
+            var h = config[p];
+            if (!h)
+                continue;
+            for (var i = 0; i < h.length; i++) {
+                var host_ip = h[i].HostIp;
+                if (host_ip === '')
+                    host_ip = '0.0.0.0';
+                var desc = cockpit.format(_("${hip}:${hport} -> $cport"),
+                                          { hip: host_ip,
+                                            hport: h[i].HostPort,
+                                            cport: p
+                                          });
+                /* make sure we don't push anything we already have */
+                if (bindings.indexOf(desc) === -1)
+                    bindings.push(desc);
             }
-            $("#container-terminal").hide();
+        }
+        return bindings;
+    },
 
-            this.container_id = container_id;
-            this.name = this.container_id.slice(0, 12);
+    update: function() {
+        $('#container-details-names').text("");
+        $('#container-details-id').text("");
+        $('#container-details-created').text("");
+        $('#container-details-image').text("");
+        $('#container-details-command').text("");
+        $('#container-details-state').text("");
+        $('#container-details-restart-policy').text("");
+        $('#container-details-ipaddr').text("");
+        $('#container-details-ipprefixlen').text("");
+        $('#container-details-gateway').text("");
+        $('#container-details-macaddr').text("");
+        $('#container-details-ports-row').hide();
+        $('#container-details-links-row').hide();
+        $('#container-details-resource-row').hide();
+        $('#container-details-volumes-row').hide();
 
-            $(this.client).on('container.container-details', function (event, id, container) {
-                if (id == self.container_id)
-                    self.update();
-            });
+        var info = this.client.containers[this.container_id];
+        util.docker_debug("container-details", this.container_id, info);
 
-            $('#container-details-commit')[0].dataset.containerId = container_id;
-
-            this.update();
-        },
-
-        maybe_show_terminal: function(info) {
-            if (!this.terminal) {
-                this.terminal = docker.console(this.container_id, { tty: info.Config.Tty });
-                $("#container-terminal").empty()
-                        .append(this.terminal);
-                this.terminal.connect();
-            }
-            this.terminal.typeable(info.State.Running);
-            $("#container-terminal").show();
-        },
-
-        maybe_reconnect_terminal: function() {
-            if (this.terminal && !this.terminal.connected) {
-                this.terminal.connect();
-                this.terminal.typeable(true);
-            }
-        },
-
-        add_bindings: function(bindings, config) {
-            for (var p in config) {
-                var h = config[p];
-                if (!h)
-                    continue;
-                for (var i = 0; i < h.length; i++) {
-                    var host_ip = h[i].HostIp;
-                    if (host_ip === '')
-                        host_ip = '0.0.0.0';
-                    var desc = cockpit.format(_("${hip}:${hport} -> $cport"),
-                                              { hip: host_ip,
-                                                hport: h[i].HostPort,
-                                                cport: p
-                                              });
-                    /* make sure we don't push anything we already have */
-                    if (bindings.indexOf(desc) === -1)
-                        bindings.push(desc);
-                }
-            }
-            return bindings;
-        },
-
-        update: function() {
-            $('#container-details-names').text("");
-            $('#container-details-id').text("");
-            $('#container-details-created').text("");
-            $('#container-details-image').text("");
-            $('#container-details-command').text("");
-            $('#container-details-state').text("");
-            $('#container-details-restart-policy').text("");
-            $('#container-details-ipaddr').text("");
-            $('#container-details-ipprefixlen').text("");
-            $('#container-details-gateway').text("");
-            $('#container-details-macaddr').text("");
-            $('#container-details-ports-row').hide();
-            $('#container-details-links-row').hide();
-            $('#container-details-resource-row').hide();
-            $('#container-details-volumes-row').hide();
-
-            var info = this.client.containers[this.container_id];
-            util.docker_debug("container-details", this.container_id, info);
-
-            if (!info) {
-                $('#container-details-names').text(_("Not found"));
-                return;
-            }
-
-            var waiting = !!(this.client.waiting[this.container_id]);
-            $('#container-details div.spinner').toggle(waiting);
-            $('#container-details button').toggle(!waiting);
-            $('#container-details-start').prop('disabled', info.State.Running);
-            $('#container-details-stop').prop('disabled', !info.State.Running);
-            $('#container-details-restart').prop('disabled', !info.State.Running);
-            $('#container-details-commit').prop('disabled', !!info.State.Running);
-            $('#container-details-memory-row').toggle(!!info.State.Running);
-            $('#container-details-cpu-row').toggle(!!info.State.Running);
-            $('#container-details-resource-row').toggle(!!info.State.Running);
-
-            this.name = util.render_container_name(info.Name);
-            $('#container-details .content-filter h3 span').text(this.name);
-
-            var port_bindings = [ ];
-            if (info.NetworkSettings)
-                this.add_bindings(port_bindings, info.NetworkSettings.Ports);
-            if (info.HostConfig)
-                this.add_bindings(port_bindings, info.HostConfig.PortBindings);
-
-            $('#container-details-id').text(info.Id);
-            $('#container-details-names').text(util.render_container_name(info.Name));
-            $('#container-details-created').text(moment(info.Created).isValid()
-                ? moment(info.Created).calendar() : info.Created);
-
-            $('#container-details-image').text(info.Image);
-            $('#container-details-image-id').text(info.ImageID);
-            $('#container-details-image-id').toggle(info.ImageID && info.ImageID != info.Image);
-
-            $('#container-details-command').text(util.render_container_cmdline(info));
-            $('#container-details-state').text(util.render_container_state(info.State));
-            $('#container-details-restart-policy').text(util.render_container_restart_policy(info.HostConfig.RestartPolicy));
-            $('#container-details-ipaddr').text(info.NetworkSettings.IPAddress);
-            $('#container-details-ipprefixlen').text(String(info.NetworkSettings.IPPrefixLen));
-            $('#container-details-gateway').text(info.NetworkSettings.Gateway);
-            $('#container-details-macaddr').text(info.NetworkSettings.MacAddress);
-
-            $('#container-details-ports-row').toggle(port_bindings.length > 0);
-            $('#container-details-ports').html(util.multi_line(port_bindings));
-
-            this.update_links(info);
-
-            util.update_memory_bar(this.memory_usage, info.MemoryUsage, info.MemoryLimit);
-            $('#container-details-memory-text').text(util.format_memory_and_limit(info.MemoryUsage, info.MemoryLimit));
-
-            $('#container-details .cpu-usage').text(util.format_cpu_usage(info.CpuUsage));
-            $('#container-details .cpu-shares').text(util.format_cpu_shares(info.CpuPriority));
-
-            this.maybe_show_terminal(info);
-
-            var volume_bindings = info.HostConfig.Binds;
-            if (volume_bindings) {
-                $('#container-details-volumes-row').toggle(volume_bindings.length > 0);
-                $('#container-details-volumes').html(util.multi_line(volume_bindings));
-            }
-        },
-
-        update_links: function(info) {
-            $('#container-details-links').empty();
-            var links = info.HostConfig.Links;
-            if (links) {
-                $('#container-details-links-row').toggle(true);
-                $('#container-details-links').html(
-                    links.join('<br/>')
-                );
-            }
-        },
-
-        start_container: function () {
-            var self = this;
-            var id = this.container_id;
-            this.client.start(this.container_id)
-                    .fail(function(ex) {
-                        util.handle_scope_start_container(self.client, id, ex.message, function() { self.maybe_reconnect_terminal() }, null);
-                    })
-                    .done(function() {
-                        self.maybe_reconnect_terminal();
-                    });
-        },
-
-        stop_container: function () {
-            this.client.stop(this.container_id)
-                    .fail(function(ex) {
-                        util.show_unexpected_error(ex);
-                    });
-        },
-
-        restart_container: function () {
-            var self = this;
-            this.client.restart(this.container_id)
-                    .fail(function(ex) {
-                        util.show_unexpected_error(ex);
-                    })
-                    .done(function() {
-                        self.maybe_reconnect_terminal();
-                    });
-        },
-
-        delete_container: function () {
-            var self = this;
-            var location = cockpit.location;
-            util.confirm(cockpit.format(_("Please confirm deletion of $0"), self.name),
-                         _("Deleting a container will erase all data in it."),
-                         _("Delete"))
-                    .done(function () {
-                        util.docker_container_delete(self.client, self.container_id, function() { location.go("/") }, function () { });
-                    });
+        if (!info) {
+            $('#container-details-names').text(_("Not found"));
+            return;
         }
 
-    };
+        var waiting = !!(this.client.waiting[this.container_id]);
+        $('#container-details div.spinner').toggle(waiting);
+        $('#container-details button').toggle(!waiting);
+        $('#container-details-start').prop('disabled', info.State.Running);
+        $('#container-details-stop').prop('disabled', !info.State.Running);
+        $('#container-details-restart').prop('disabled', !info.State.Running);
+        $('#container-details-commit').prop('disabled', !!info.State.Running);
+        $('#container-details-memory-row').toggle(!!info.State.Running);
+        $('#container-details-cpu-row').toggle(!!info.State.Running);
+        $('#container-details-resource-row').toggle(!!info.State.Running);
 
-    function PageContainerDetails(client) {
-        this._init(client);
+        this.name = util.render_container_name(info.Name);
+        $('#container-details .content-filter h3 span').text(this.name);
+
+        var port_bindings = [ ];
+        if (info.NetworkSettings)
+            this.add_bindings(port_bindings, info.NetworkSettings.Ports);
+        if (info.HostConfig)
+            this.add_bindings(port_bindings, info.HostConfig.PortBindings);
+
+        $('#container-details-id').text(info.Id);
+        $('#container-details-names').text(util.render_container_name(info.Name));
+        $('#container-details-created').text(moment(info.Created).isValid()
+            ? moment(info.Created).calendar() : info.Created);
+
+        $('#container-details-image').text(info.Image);
+        $('#container-details-image-id').text(info.ImageID);
+        $('#container-details-image-id').toggle(info.ImageID && info.ImageID != info.Image);
+
+        $('#container-details-command').text(util.render_container_cmdline(info));
+        $('#container-details-state').text(util.render_container_state(info.State));
+        $('#container-details-restart-policy').text(util.render_container_restart_policy(info.HostConfig.RestartPolicy));
+        $('#container-details-ipaddr').text(info.NetworkSettings.IPAddress);
+        $('#container-details-ipprefixlen').text(String(info.NetworkSettings.IPPrefixLen));
+        $('#container-details-gateway').text(info.NetworkSettings.Gateway);
+        $('#container-details-macaddr').text(info.NetworkSettings.MacAddress);
+
+        $('#container-details-ports-row').toggle(port_bindings.length > 0);
+        $('#container-details-ports').html(util.multi_line(port_bindings));
+
+        this.update_links(info);
+
+        util.update_memory_bar(this.memory_usage, info.MemoryUsage, info.MemoryLimit);
+        $('#container-details-memory-text').text(util.format_memory_and_limit(info.MemoryUsage, info.MemoryLimit));
+
+        $('#container-details .cpu-usage').text(util.format_cpu_usage(info.CpuUsage));
+        $('#container-details .cpu-shares').text(util.format_cpu_shares(info.CpuPriority));
+
+        this.maybe_show_terminal(info);
+
+        var volume_bindings = info.HostConfig.Binds;
+        if (volume_bindings) {
+            $('#container-details-volumes-row').toggle(volume_bindings.length > 0);
+            $('#container-details-volumes').html(util.multi_line(volume_bindings));
+        }
+    },
+
+    update_links: function(info) {
+        $('#container-details-links').empty();
+        var links = info.HostConfig.Links;
+        if (links) {
+            $('#container-details-links-row').toggle(true);
+            $('#container-details-links').html(
+                links.join('<br/>')
+            );
+        }
+    },
+
+    start_container: function () {
+        var self = this;
+        var id = this.container_id;
+        this.client.start(this.container_id)
+                .fail(function(ex) {
+                    util.handle_scope_start_container(self.client, id, ex.message, function() { self.maybe_reconnect_terminal() }, null);
+                })
+                .done(function() {
+                    self.maybe_reconnect_terminal();
+                });
+    },
+
+    stop_container: function () {
+        this.client.stop(this.container_id)
+                .fail(function(ex) {
+                    util.show_unexpected_error(ex);
+                });
+    },
+
+    restart_container: function () {
+        var self = this;
+        this.client.restart(this.container_id)
+                .fail(function(ex) {
+                    util.show_unexpected_error(ex);
+                })
+                .done(function() {
+                    self.maybe_reconnect_terminal();
+                });
+    },
+
+    delete_container: function () {
+        var self = this;
+        var location = cockpit.location;
+        util.confirm(cockpit.format(_("Please confirm deletion of $0"), self.name),
+                     _("Deleting a container will erase all data in it."),
+                     _("Delete"))
+                .done(function () {
+                    util.docker_container_delete(self.client, self.container_id, function() { location.go("/") }, function () { });
+                });
     }
 
-    function init_container_details(client) {
-        var page = new PageContainerDetails(client);
-        page.setup();
+};
 
-        function hide() {
-            $('#container-details').hide();
-        }
+function PageContainerDetails(client) {
+    this._init(client);
+}
 
-        function show(id) {
-            page.enter(id);
-            $('#container-details').show();
-        }
+function init_container_details(client) {
+    var page = new PageContainerDetails(client);
+    page.setup();
 
-        return {
-            show: show,
-            hide: hide
-        };
+    function hide() {
+        $('#container-details').hide();
     }
 
-    module.exports = {
-        init: init_container_details
+    function show(id) {
+        page.enter(id);
+        $('#container-details').show();
+    }
+
+    return {
+        show: show,
+        hide: hide
     };
-}());
+}
+
+module.exports = {
+    init: init_container_details
+};

--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -17,744 +17,742 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
+var $ = require("jquery");
+var cockpit = require("cockpit");
 
-    var Terminal = require("term");
+var Terminal = require("term");
 
-    var docker = { };
+var docker = { };
 
-    function docker_debug() {
-        if (window.debugging == "all" || window.debugging == "docker")
-            console.debug.apply(console, arguments);
-    }
+function docker_debug() {
+    if (window.debugging == "all" || window.debugging == "docker")
+        console.debug.apply(console, arguments);
+}
 
-    /* This doesn't create a channel until a request */
-    var http = cockpit.http("/var/run/docker.sock", { superuser: true });
+/* This doesn't create a channel until a request */
+var http = cockpit.http("/var/run/docker.sock", { superuser: true });
 
-    /**
-     * pull:
-     * @repo: the image repository
-     * @tag: the tag to pull
-     *
-     * Pull an image from the registry. If no @tag is specified
-     * then the "latest" tag will be used.
-     *
-     * A Promise is returned. It completes when the image has
-     * been downloaded, or fails with an error. The progress callbacks
-     * on the download are called with status updates from docker.
+/**
+ * pull:
+ * @repo: the image repository
+ * @tag: the tag to pull
+ *
+ * Pull an image from the registry. If no @tag is specified
+ * then the "latest" tag will be used.
+ *
+ * A Promise is returned. It completes when the image has
+ * been downloaded, or fails with an error. The progress callbacks
+ * on the download are called with status updates from docker.
+ */
+docker.pull = function pull(repo, tag, registry) {
+    var dfd = $.Deferred();
+
+    if (!tag)
+        tag = "latest";
+
+    /*
+     * Although in theory the docker images/create API has
+     * a registry parameter, when you use it the resulting
+     * image is labeled completely wrong.
      */
-    docker.pull = function pull(repo, tag, registry) {
-        var dfd = $.Deferred();
 
-        if (!tag)
-            tag = "latest";
+    if (registry)
+        repo = registry + "/" + repo;
 
-        /*
-         * Although in theory the docker images/create API has
-         * a registry parameter, when you use it the resulting
-         * image is labeled completely wrong.
-         */
+    docker_debug("pulling: " + repo + ":" + tag);
 
-        if (registry)
-            repo = registry + "/" + repo;
-
-        docker_debug("pulling: " + repo + ":" + tag);
-
-        var options = {
-            method: "POST",
-            path: "/v1.12/images/create",
-            body: "",
-            params: {
-                fromImage: repo,
-                tag: tag
-            }
-        };
-
-        var error;
-
-        var buffer = "";
-        var req = http.request(options)
-                .stream(function(data) {
-                    buffer += data;
-                    var next = docker.json_skip(buffer, 0);
-                    if (next === 0)
-                        return; /* not enough data yet */
-                    var progress = JSON.parse(buffer.substring(0, next));
-                    buffer = buffer.substring(next);
-                    if (progress.error)
-                        error = progress.error;
-                    else if (progress.status)
-                        dfd.notify(progress.status, progress);
-                })
-                .fail(function(ex) {
-                    dfd.reject(ex);
-                })
-                .done(function() {
-                    if (error)
-                        dfd.reject(new Error(error));
-                    else
-                        dfd.resolve();
-                });
-
-        var promise = dfd.promise();
-        promise.cancel = function cancel() {
-            req.close("cancelled");
-            return promise;
-        };
-
-        return promise;
+    var options = {
+        method: "POST",
+        path: "/v1.12/images/create",
+        body: "",
+        params: {
+            fromImage: repo,
+            tag: tag
+        }
     };
 
-    /* Gets image info locally */
-    docker.inspect_image = function inspect_image(image) {
-        var dfd = $.Deferred();
-        http.get("/v1.12/images/" + encodeURIComponent(image) + "/json")
-                .done(function(data) {
-                    dfd.resolve(JSON.parse(data));
-                })
-                .fail(function(ex) {
-                    dfd.reject(ex);
-                });
-        var promise = dfd.promise();
-        promise.cancel = function cancel() {
-            return promise;
-        };
-        return promise;
-    };
+    var error;
 
-    function DockerTerminal(parent, channel) {
-        var self = this;
-
-        var term = new Terminal({
-            cols: 80,
-            rows: 24,
-            screenKeys: true,
-            inlineStyle: false,
-            useFocus: false,
-        });
-
-        var enable_input = true;
-        var decoder = cockpit.utf8_decoder();
-        var encoder = cockpit.utf8_encoder();
-
-        /* term.js wants the parent element to build its terminal inside of */
-        parent.empty();
-        term.open(parent[0]);
-
-        /* Shows and hides the cursor */
-        self.typeable = function typeable(yes) {
-            term.cursorHidden = !yes;
-            term.refresh(term.y, term.y);
-            enable_input = yes;
-        };
-
-        self.focus = function focus() {
-            term.focus();
-        };
-
-        /* Allows caller to cleanup nicely */
-        self.close = function close() {
-            term.destroy();
-        };
-
-        if (typeof channel == "string") {
-            term.write('\x1b[31m' + channel + '\x1b[m\r\n');
-            self.close = function() { };
-            self.typeable(false);
-            return self;
-        }
-
-        $(channel)
-                .on("close", function(ev, options) {
-                    var problem = options.problem || "disconnected";
-                    term.write('\x1b[31m' + problem + '\x1b[m\r\n');
-                    self.typeable(false);
-                    $(channel).off("message");
-                    channel = null;
-                });
-
-        self.process = function process(buffer) {
-            term.write(decoder.decode(buffer));
-            return buffer.length;
-        };
-
-        term.on('data', function(data) {
-            /* Send typed input back through channel */
-            if (enable_input && channel)
-                channel.send(encoder.encode(data));
-        });
-
-        return self;
-    }
-
-    function DockerLogs(parent, channel) {
-        var self = this;
-
-        var pre = $("<pre>");
-        parent.empty();
-        parent.append(pre);
-
-        var wait;
-        var writing = [];
-        function write(data) {
-            writing.push(data);
-            if (!wait) {
-                wait = window.setTimeout(function() {
-                    wait = null;
-                    var at_bottom = pre[0].scrollHeight - pre.scrollTop() <= pre.outerHeight();
-                    var span = $("<span>").text(writing.join(""));
-                    writing.length = 0;
-                    pre.append(span);
-                    if (at_bottom)
-                        pre.scrollTop(pre.prop("scrollHeight"));
-                }, 50);
-            }
-        }
-
-        /* Just display the failure */
-        if (typeof channel == "string") {
-            write(channel);
-            self.close = function() { };
-            return self;
-        }
-
-        channel.control({ batch: 16384, latency: 50 });
-
-        var decoder = cockpit.utf8_decoder(false);
-
-        self.process = function process(buffer) {
-            var at = 0;
-            var size, block;
-            var length = buffer.length;
-            while (true) {
-                if (length < at + 8)
-                    return at; /* more data */
-
-                size = ((buffer[at + 4] & 0xFF) << 24) | ((buffer[at + 5] & 0xFF) << 16) |
-                       ((buffer[at + 6] & 0xFF) << 8) | (buffer[at + 7] & 0xFF);
-
-                if (length < at + 8 + size)
-                    return at; /* more data */
-
-                /* Output the data */
-                if (buffer.subarray)
-                    block = buffer.subarray(at + 8, at + 8 + size);
+    var buffer = "";
+    var req = http.request(options)
+            .stream(function(data) {
+                buffer += data;
+                var next = docker.json_skip(buffer, 0);
+                if (next === 0)
+                    return; /* not enough data yet */
+                var progress = JSON.parse(buffer.substring(0, next));
+                buffer = buffer.substring(next);
+                if (progress.error)
+                    error = progress.error;
+                else if (progress.status)
+                    dfd.notify(progress.status, progress);
+            })
+            .fail(function(ex) {
+                dfd.reject(ex);
+            })
+            .done(function() {
+                if (error)
+                    dfd.reject(new Error(error));
                 else
-                    block = buffer.slice(at + 8, at + 8 + size);
-                write(decoder.decode(block, { stream: true }));
-                at += 8 + size;
-            }
-        };
-
-        self.focus = function() {
-            /* Nothing to do */
-        };
-
-        self.close = function() {
-            /* Nothing to do */
-        };
-
-        /*
-         * A raw channel over which we speak Docker's even stranger /logs
-         * protocol. It starts with a HTTP GET, and then quickly
-         * degenerates into a stream with framing.
-         */
-        $(channel)
-                .on("close", function(ev, options) {
-                    write(options.reason || "disconnected");
-                    $(channel).off();
-                    channel = null;
-                });
-
-        return self;
-    }
-
-    function sequence_find(seq, find) {
-        var f;
-        var fl = find.length;
-        var s;
-        var sl = (seq.length - fl) + 1;
-        for (s = 0; s < sl; s++) {
-            for (f = 0; f < fl; f++) {
-                if (seq[s + f] !== find[f])
-                    break;
-            }
-            if (f == fl)
-                return s;
-        }
-
-        return -1;
-    }
-
-    /**
-     * docker.console(container_id, options)
-     * docker.console(container_id, command, options):
-     *
-     * @container_id: full docker container id
-     * @command: optional array of command argv to exec
-     * @options: other options, including 'tty' true/false
-     *
-     * Creates a docker console/logs element and returns it. If options.tty is true
-     * then creates a full term.js terminal. Otherwise creates a logs output
-     * area. If options.tty is null/undefined autodetect whether to use tty or not.
-     *
-     * The returned element needs to have its .connect() method called to start the
-     * connection process.
-     *
-     * The returned value is an HTMLElement with the following extra methods/properties:
-     *
-     * cons.connected: true/false if connected or not
-     * cons.connect(): connect or reconnect
-     * cons.typeable(true/false): set typeable state or not, only applies to console
-     * cons.close(): disconnect and close
-     */
-    docker.console = function console_(container_id, command, options) {
-        var self = $("<div>").addClass("console-ct");
-        self.connected = false;
-        var want_typeable = false;
-        var focused = false;
-        var channel = null;
-        var view = null;
-        var exec;
-        var tty;
-
-        /* If there's a command, then we have to exec it in the container */
-        if (Array.isArray(command)) {
-            if (!options)
-                options = { };
-
-            /* When executing default to having a tty */
-            tty = options.tty;
-            if (tty === undefined || tty === null)
-                tty = true;
-
-            exec = {
-                method: "POST",
-                path: "/v1.15/containers/" + encodeURIComponent(container_id) + "/exec",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    "AttachStdin": tty,
-                    "AttachStdout": true,
-                    "AttachStderr": true,
-                    "Tty": tty,
-                    "Cmd": command
-                })
-            };
-
-            docker_debug("preparing to exec:", command);
-
-        /* Just connect to the main container console */
-        } else {
-            docker_debug("preparing to attach");
-            options = command || { };
-            tty = options.tty;
-        }
-
-        delete options.tty;
-
-        /* A promise being prepared */
-        var prep = null;
-
-        function failure(message) {
-            if (tty)
-                view = new DockerTerminal(self, message);
-            else
-                view = new DockerLogs(self, message);
-        }
-
-        function prepare() {
-            self.connected = false;
-
-            /* Nothing to prepare? Connect diretly to container? */
-            if (!exec) {
-                if (tty === false) {
-                    return attach("GET /v1.15/containers/" + encodeURIComponent(container_id) +
-                                  "/logs?follow=1&stdout=1&stderr=1&tail=1000&timestamps=0 HTTP/1.0\r\n" +
-                                  "Content-Length: 0\r\n\r\n");
-                } else {
-                    return attach("POST /v1.15/containers/" + encodeURIComponent(container_id) +
-                                  "/attach?logs=1&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.0\r\n" +
-                                  "Content-Length: 0\r\n\r\n");
-                }
-            }
-
-            /* Prepare the command to be executed */
-            prep = http.request($.extend({ }, options, exec))
-                    .always(function() {
-                        prep = null;
-                    })
-                    .done(function(data) {
-                        var resp = JSON.parse(data);
-                        var body = JSON.stringify({ Detach: false, Tty: tty });
-                        return attach("POST /v1.15/exec/" + encodeURIComponent(resp.Id) +
-                                  "/start HTTP/1.0\r\n" +
-                                  "Content-Length: " + body.length + "\r\n\r\n" + body);
-                    })
-                    .fail(function(ex) {
-                        failure(ex.message);
-                    });
-        }
-
-        /*
-         * A raw channel over which we speak Docker's strange /attach
-         * protocol. It starts with a HTTP POST, and then quickly
-         * degenerates into a stream sometimes binary.
-         *
-         * See: http://docs.docker.io/en/latest/reference/api/docker_remote_api_v1.8/#attach-to-a-container
-         */
-        function attach(request) {
-            if (view)
-                view.close();
-            view = null;
-
-            var opts = $.extend({ }, options, {
-                "payload": "stream",
-                "unix": "/var/run/docker.sock",
-                "superuser": true,
-                "binary": true
+                    dfd.resolve();
             });
 
-            channel = cockpit.channel(opts);
+    var promise = dfd.promise();
+    promise.cancel = function cancel() {
+        req.close("cancelled");
+        return promise;
+    };
 
-            docker_debug(request);
-            channel.send(request);
+    return promise;
+};
 
-            $(channel)
-                    .on("close.attach", function(ev, options) {
-                        docker_debug(container_id + ": console close: ", options);
-                        $(channel).off(".attach");
-                        channel = null;
+/* Gets image info locally */
+docker.inspect_image = function inspect_image(image) {
+    var dfd = $.Deferred();
+    http.get("/v1.12/images/" + encodeURIComponent(image) + "/json")
+            .done(function(data) {
+                dfd.resolve(JSON.parse(data));
+            })
+            .fail(function(ex) {
+                dfd.reject(ex);
+            });
+    var promise = dfd.promise();
+    promise.cancel = function cancel() {
+        return promise;
+    };
+    return promise;
+};
 
-                        /*
-                     * HACK: If we're disconnected unceremoniously, try
-                     * and reconnect. Certain versions of docker do this
-                     * during container startup.
-                     */
-                        if (self.connected && !options.problem) {
-                            window.setTimeout(function() {
-                                if (self.connected && !channel)
-                                    attach(request);
-                            }, 1000);
-                        }
-                    });
+function DockerTerminal(parent, channel) {
+    var self = this;
 
-            var headers = null;
-            var buffer = channel.buffer();
-            buffer.callback = function(data) {
-                var ret = 0;
-                var pos = 0;
-                var parts;
+    var term = new Terminal({
+        cols: 80,
+        rows: 24,
+        screenKeys: true,
+        inlineStyle: false,
+        useFocus: false,
+    });
 
-                /* Look for end of headers first */
-                if (headers === null) {
-                    pos = sequence_find(data, [ 13, 10, 13, 10 ]);
-                    if (pos == -1)
-                        return ret;
+    var enable_input = true;
+    var decoder = cockpit.utf8_decoder();
+    var encoder = cockpit.utf8_encoder();
 
-                    if (data.subarray)
-                        headers = cockpit.utf8_decoder().decode(data.subarray(0, pos));
-                    else
-                        headers = cockpit.utf8_decoder().decode(data.slice(0, pos));
-                    docker_debug(container_id + ": console headers: ", headers);
+    /* term.js wants the parent element to build its terminal inside of */
+    parent.empty();
+    term.open(parent[0]);
 
-                    parts = headers.split("\r\n", 1)[0].split(" ");
-                    if (parts[1] != "200") {
-                        failure(parts.slice(2).join(" "));
-                        buffer.callback = null;
-                        return;
-                    } else if (data.subarray) {
-                        data = data.subarray(pos + 4);
-                        ret += pos + 4;
-                    } else {
-                        data = data.slice(pos + 4);
-                        ret += pos + 4;
-                    }
-                }
+    /* Shows and hides the cursor */
+    self.typeable = function typeable(yes) {
+        term.cursorHidden = !yes;
+        term.refresh(term.y, term.y);
+        enable_input = yes;
+    };
 
-                /* We need at least two bytes to determine stream type */
-                if (tty === undefined || tty === null) {
-                    if (data.length < 2)
-                        return ret;
-                    tty = !((data[0] === 0 || data[0] === 1 || data[0] === 2) && data[1] === 0);
-                    docker_debug(container_id + ": mode tty: " + tty);
-                }
+    self.focus = function focus() {
+        term.focus();
+    };
 
-                if (tty)
-                    view = new DockerTerminal(self, channel);
-                else
-                    view = new DockerLogs(self, channel);
-                self.typeable(want_typeable);
-                self.connected = true;
+    /* Allows caller to cleanup nicely */
+    self.close = function close() {
+        term.destroy();
+    };
 
-                buffer.callback = view.process;
-                var consumed = view.process(data);
-                return ret + consumed;
-            };
+    if (typeof channel == "string") {
+        term.write('\x1b[31m' + channel + '\x1b[m\r\n');
+        self.close = function() { };
+        self.typeable(false);
+        return self;
+    }
+
+    $(channel)
+            .on("close", function(ev, options) {
+                var problem = options.problem || "disconnected";
+                term.write('\x1b[31m' + problem + '\x1b[m\r\n');
+                self.typeable(false);
+                $(channel).off("message");
+                channel = null;
+            });
+
+    self.process = function process(buffer) {
+        term.write(decoder.decode(buffer));
+        return buffer.length;
+    };
+
+    term.on('data', function(data) {
+        /* Send typed input back through channel */
+        if (enable_input && channel)
+            channel.send(encoder.encode(data));
+    });
+
+    return self;
+}
+
+function DockerLogs(parent, channel) {
+    var self = this;
+
+    var pre = $("<pre>");
+    parent.empty();
+    parent.append(pre);
+
+    var wait;
+    var writing = [];
+    function write(data) {
+        writing.push(data);
+        if (!wait) {
+            wait = window.setTimeout(function() {
+                wait = null;
+                var at_bottom = pre[0].scrollHeight - pre.scrollTop() <= pre.outerHeight();
+                var span = $("<span>").text(writing.join(""));
+                writing.length = 0;
+                pre.append(span);
+                if (at_bottom)
+                    pre.scrollTop(pre.prop("scrollHeight"));
+            }, 50);
         }
+    }
 
-        /* Allows caller to cleanup nicely */
-        self.close = function close(problem) {
-            self.connected = false;
-            if (prep)
-                prep.close(problem);
-            if (channel)
-                channel.close(problem);
-            if (view) {
-                view.close();
-                view = null;
+    /* Just display the failure */
+    if (typeof channel == "string") {
+        write(channel);
+        self.close = function() { };
+        return self;
+    }
+
+    channel.control({ batch: 16384, latency: 50 });
+
+    var decoder = cockpit.utf8_decoder(false);
+
+    self.process = function process(buffer) {
+        var at = 0;
+        var size, block;
+        var length = buffer.length;
+        while (true) {
+            if (length < at + 8)
+                return at; /* more data */
+
+            size = ((buffer[at + 4] & 0xFF) << 24) | ((buffer[at + 5] & 0xFF) << 16) |
+                   ((buffer[at + 6] & 0xFF) << 8) | (buffer[at + 7] & 0xFF);
+
+            if (length < at + 8 + size)
+                return at; /* more data */
+
+            /* Output the data */
+            if (buffer.subarray)
+                block = buffer.subarray(at + 8, at + 8 + size);
+            else
+                block = buffer.slice(at + 8, at + 8 + size);
+            write(decoder.decode(block, { stream: true }));
+            at += 8 + size;
+        }
+    };
+
+    self.focus = function() {
+        /* Nothing to do */
+    };
+
+    self.close = function() {
+        /* Nothing to do */
+    };
+
+    /*
+     * A raw channel over which we speak Docker's even stranger /logs
+     * protocol. It starts with a HTTP GET, and then quickly
+     * degenerates into a stream with framing.
+     */
+    $(channel)
+            .on("close", function(ev, options) {
+                write(options.reason || "disconnected");
+                $(channel).off();
+                channel = null;
+            });
+
+    return self;
+}
+
+function sequence_find(seq, find) {
+    var f;
+    var fl = find.length;
+    var s;
+    var sl = (seq.length - fl) + 1;
+    for (s = 0; s < sl; s++) {
+        for (f = 0; f < fl; f++) {
+            if (seq[s + f] !== find[f])
+                break;
+        }
+        if (f == fl)
+            return s;
+    }
+
+    return -1;
+}
+
+/**
+ * docker.console(container_id, options)
+ * docker.console(container_id, command, options):
+ *
+ * @container_id: full docker container id
+ * @command: optional array of command argv to exec
+ * @options: other options, including 'tty' true/false
+ *
+ * Creates a docker console/logs element and returns it. If options.tty is true
+ * then creates a full term.js terminal. Otherwise creates a logs output
+ * area. If options.tty is null/undefined autodetect whether to use tty or not.
+ *
+ * The returned element needs to have its .connect() method called to start the
+ * connection process.
+ *
+ * The returned value is an HTMLElement with the following extra methods/properties:
+ *
+ * cons.connected: true/false if connected or not
+ * cons.connect(): connect or reconnect
+ * cons.typeable(true/false): set typeable state or not, only applies to console
+ * cons.close(): disconnect and close
+ */
+docker.console = function console_(container_id, command, options) {
+    var self = $("<div>").addClass("console-ct");
+    self.connected = false;
+    var want_typeable = false;
+    var focused = false;
+    var channel = null;
+    var view = null;
+    var exec;
+    var tty;
+
+    /* If there's a command, then we have to exec it in the container */
+    if (Array.isArray(command)) {
+        if (!options)
+            options = { };
+
+        /* When executing default to having a tty */
+        tty = options.tty;
+        if (tty === undefined || tty === null)
+            tty = true;
+
+        exec = {
+            method: "POST",
+            path: "/v1.15/containers/" + encodeURIComponent(container_id) + "/exec",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                "AttachStdin": tty,
+                "AttachStdout": true,
+                "AttachStderr": true,
+                "Tty": tty,
+                "Cmd": command
+            })
+        };
+
+        docker_debug("preparing to exec:", command);
+
+    /* Just connect to the main container console */
+    } else {
+        docker_debug("preparing to attach");
+        options = command || { };
+        tty = options.tty;
+    }
+
+    delete options.tty;
+
+    /* A promise being prepared */
+    var prep = null;
+
+    function failure(message) {
+        if (tty)
+            view = new DockerTerminal(self, message);
+        else
+            view = new DockerLogs(self, message);
+    }
+
+    function prepare() {
+        self.connected = false;
+
+        /* Nothing to prepare? Connect diretly to container? */
+        if (!exec) {
+            if (tty === false) {
+                return attach("GET /v1.15/containers/" + encodeURIComponent(container_id) +
+                              "/logs?follow=1&stdout=1&stderr=1&tail=1000&timestamps=0 HTTP/1.0\r\n" +
+                              "Content-Length: 0\r\n\r\n");
+            } else {
+                return attach("POST /v1.15/containers/" + encodeURIComponent(container_id) +
+                              "/attach?logs=1&stream=1&stdin=1&stdout=1&stderr=1 HTTP/1.0\r\n" +
+                              "Content-Length: 0\r\n\r\n");
             }
-        };
-
-        /* Allows the curser to restart the attach request */
-        self.connect = function connect() {
-            self.close("disconnected");
-            prepare();
-        };
-
-        function update_typeable() {
-            if (view && view.typeable)
-                view.typeable(want_typeable && focused);
         }
 
-        $(self)
-                .on("focusin", function() {
-                    focused = true;
-                    update_typeable();
-                    view.focus();
+        /* Prepare the command to be executed */
+        prep = http.request($.extend({ }, options, exec))
+                .always(function() {
+                    prep = null;
                 })
-                .on("focusout", function() {
-                    focused = false;
-                    update_typeable();
+                .done(function(data) {
+                    var resp = JSON.parse(data);
+                    var body = JSON.stringify({ Detach: false, Tty: tty });
+                    return attach("POST /v1.15/exec/" + encodeURIComponent(resp.Id) +
+                              "/start HTTP/1.0\r\n" +
+                              "Content-Length: " + body.length + "\r\n\r\n" + body);
+                })
+                .fail(function(ex) {
+                    failure(ex.message);
+                });
+    }
+
+    /*
+     * A raw channel over which we speak Docker's strange /attach
+     * protocol. It starts with a HTTP POST, and then quickly
+     * degenerates into a stream sometimes binary.
+     *
+     * See: http://docs.docker.io/en/latest/reference/api/docker_remote_api_v1.8/#attach-to-a-container
+     */
+    function attach(request) {
+        if (view)
+            view.close();
+        view = null;
+
+        var opts = $.extend({ }, options, {
+            "payload": "stream",
+            "unix": "/var/run/docker.sock",
+            "superuser": true,
+            "binary": true
+        });
+
+        channel = cockpit.channel(opts);
+
+        docker_debug(request);
+        channel.send(request);
+
+        $(channel)
+                .on("close.attach", function(ev, options) {
+                    docker_debug(container_id + ": console close: ", options);
+                    $(channel).off(".attach");
+                    channel = null;
+
+                    /*
+                 * HACK: If we're disconnected unceremoniously, try
+                 * and reconnect. Certain versions of docker do this
+                 * during container startup.
+                 */
+                    if (self.connected && !options.problem) {
+                        window.setTimeout(function() {
+                            if (self.connected && !channel)
+                                attach(request);
+                        }, 1000);
+                    }
                 });
 
-        self.typeable = function typeable(yes) {
-            want_typeable = yes;
-            update_typeable();
-        };
+        var headers = null;
+        var buffer = channel.buffer();
+        buffer.callback = function(data) {
+            var ret = 0;
+            var pos = 0;
+            var parts;
 
-        return self;
+            /* Look for end of headers first */
+            if (headers === null) {
+                pos = sequence_find(data, [ 13, 10, 13, 10 ]);
+                if (pos == -1)
+                    return ret;
+
+                if (data.subarray)
+                    headers = cockpit.utf8_decoder().decode(data.subarray(0, pos));
+                else
+                    headers = cockpit.utf8_decoder().decode(data.slice(0, pos));
+                docker_debug(container_id + ": console headers: ", headers);
+
+                parts = headers.split("\r\n", 1)[0].split(" ");
+                if (parts[1] != "200") {
+                    failure(parts.slice(2).join(" "));
+                    buffer.callback = null;
+                    return;
+                } else if (data.subarray) {
+                    data = data.subarray(pos + 4);
+                    ret += pos + 4;
+                } else {
+                    data = data.slice(pos + 4);
+                    ret += pos + 4;
+                }
+            }
+
+            /* We need at least two bytes to determine stream type */
+            if (tty === undefined || tty === null) {
+                if (data.length < 2)
+                    return ret;
+                tty = !((data[0] === 0 || data[0] === 1 || data[0] === 2) && data[1] === 0);
+                docker_debug(container_id + ": mode tty: " + tty);
+            }
+
+            if (tty)
+                view = new DockerTerminal(self, channel);
+            else
+                view = new DockerLogs(self, channel);
+            self.typeable(want_typeable);
+            self.connected = true;
+
+            buffer.callback = view.process;
+            var consumed = view.process(data);
+            return ret + consumed;
+        };
+    }
+
+    /* Allows caller to cleanup nicely */
+    self.close = function close(problem) {
+        self.connected = false;
+        if (prep)
+            prep.close(problem);
+        if (channel)
+            channel.close(problem);
+        if (view) {
+            view.close();
+            view = null;
+        }
     };
 
-    /*
-     * docker.json_skip(string, pos = 0)
-     * @string: the JSON string
-     * @pos: optionally, the starting position in string, or zero
-     *
-     * Sometimes docker returns multiple JSON strings concatenated.
-     *
-     * Skip over one item in a stream of JSON things, like objects,
-     * numbers, strings, etc... The things can be separated by whitespace
-     * or in some cases (strings, objects, arrays) be right next to
-     * each other.
-     *
-     * We do not validate the JSON. It's assumed that a later parse
-     * will check for validity.
-     *
-     * Returns: the number of characters to skip over next json block
-     * or zero if no complete json block found.
-     */
+    /* Allows the curser to restart the attach request */
+    self.connect = function connect() {
+        self.close("disconnected");
+        prepare();
+    };
 
-    docker.json_skip = function(string, pos) {
-        var any = false;
-        var end = string.length;
-        var depth = 0;
-        var inword = false;
-        var instr = false;
-        var endword = " \t\n\r\v[{}]\"";
-        var spaces = " \t\n\r\v";
-        var ch;
+    function update_typeable() {
+        if (view && view.typeable)
+            view.typeable(want_typeable && focused);
+    }
 
-        if (pos === undefined)
-            pos = 0;
+    $(self)
+            .on("focusin", function() {
+                focused = true;
+                update_typeable();
+                view.focus();
+            })
+            .on("focusout", function() {
+                focused = false;
+                update_typeable();
+            });
 
-        for (end = string.length; pos != end; pos++) {
-            if (any && depth <= 0)
-                break; /* skipped over one thing */
+    self.typeable = function typeable(yes) {
+        want_typeable = yes;
+        update_typeable();
+    };
 
-            ch = string[pos];
-            if (inword) {
-                if (endword.indexOf(ch) != -1) {
-                    inword = false;
-                    depth--;
-                    pos--;
-                }
-                continue;
-            }
+    return self;
+};
 
-            if (spaces.indexOf(ch) != -1)
-                continue;
+/*
+ * docker.json_skip(string, pos = 0)
+ * @string: the JSON string
+ * @pos: optionally, the starting position in string, or zero
+ *
+ * Sometimes docker returns multiple JSON strings concatenated.
+ *
+ * Skip over one item in a stream of JSON things, like objects,
+ * numbers, strings, etc... The things can be separated by whitespace
+ * or in some cases (strings, objects, arrays) be right next to
+ * each other.
+ *
+ * We do not validate the JSON. It's assumed that a later parse
+ * will check for validity.
+ *
+ * Returns: the number of characters to skip over next json block
+ * or zero if no complete json block found.
+ */
 
-            if (instr) {
-                switch (ch) {
-                case '\\':
-                    if (pos + 1 == end)
-                        continue;
-                    pos++; /* skip char after bs */
-                    break;
-                case '"':
-                    instr = false;
-                    depth--;
-                    break;
-                default:
-                    break;
-                }
-                continue;
-            }
+docker.json_skip = function(string, pos) {
+    var any = false;
+    var end = string.length;
+    var depth = 0;
+    var inword = false;
+    var instr = false;
+    var endword = " \t\n\r\v[{}]\"";
+    var spaces = " \t\n\r\v";
+    var ch;
 
-            any = true;
-            switch (ch) {
-            case '[':
-            case '{':
-                depth++;
-                break;
-            case ']':
-            case '}':
+    if (pos === undefined)
+        pos = 0;
+
+    for (end = string.length; pos != end; pos++) {
+        if (any && depth <= 0)
+            break; /* skipped over one thing */
+
+        ch = string[pos];
+        if (inword) {
+            if (endword.indexOf(ch) != -1) {
+                inword = false;
                 depth--;
+                pos--;
+            }
+            continue;
+        }
+
+        if (spaces.indexOf(ch) != -1)
+            continue;
+
+        if (instr) {
+            switch (ch) {
+            case '\\':
+                if (pos + 1 == end)
+                    continue;
+                pos++; /* skip char after bs */
                 break;
             case '"':
-                instr = true;
-                depth++;
+                instr = false;
+                depth--;
                 break;
             default:
-                inword = true;
-                depth++;
                 break;
             }
+            continue;
         }
 
-        if (inword && depth == 1)
-            depth = 0;
-
-        /* No complete JSON blocks found */
-        if (!any || depth > 0)
-            return 0;
-
-        /* The position at which we found th eend */
-        return pos;
-    };
-
-    /*
-     * The functions docker.quote_cmdline and docker.unquote_cmdline implement
-     * a simple shell-like quoting syntax.  They are used when letting the
-     * user edit a sequence of words as a single string.
-     *
-     * When parsing, words are separated by whitespace.  Single and double
-     * quotes can be used to protect a sequence of characters that
-     * contains whitespace or the other quote character.  A backslash can
-     * be used to protect any character.  Quotes can appear in the middle
-     * of a word.
-     */
-
-    docker.quote_cmdline = function quote_cmdline(words) {
-        words = words || [];
-
-        function is_whitespace(c) {
-            return c == ' ';
+        any = true;
+        switch (ch) {
+        case '[':
+        case '{':
+            depth++;
+            break;
+        case ']':
+        case '}':
+            depth--;
+            break;
+        case '"':
+            instr = true;
+            depth++;
+            break;
+        default:
+            inword = true;
+            depth++;
+            break;
         }
+    }
 
-        function quote(word) {
-            var text = "";
-            var quote_char = "";
-            var i;
-            for (i = 0; i < word.length; i++) {
-                if (word[i] == '\\' || word[i] == quote_char)
-                    text += '\\';
-                else if (quote_char === "") {
-                    if (word[i] == "'" || is_whitespace(word[i]))
-                        quote_char = '"';
-                    else if (word[i] == '"')
-                        quote_char = "'";
-                }
-                text += word[i];
+    if (inword && depth == 1)
+        depth = 0;
+
+    /* No complete JSON blocks found */
+    if (!any || depth > 0)
+        return 0;
+
+    /* The position at which we found th eend */
+    return pos;
+};
+
+/*
+ * The functions docker.quote_cmdline and docker.unquote_cmdline implement
+ * a simple shell-like quoting syntax.  They are used when letting the
+ * user edit a sequence of words as a single string.
+ *
+ * When parsing, words are separated by whitespace.  Single and double
+ * quotes can be used to protect a sequence of characters that
+ * contains whitespace or the other quote character.  A backslash can
+ * be used to protect any character.  Quotes can appear in the middle
+ * of a word.
+ */
+
+docker.quote_cmdline = function quote_cmdline(words) {
+    words = words || [];
+
+    function is_whitespace(c) {
+        return c == ' ';
+    }
+
+    function quote(word) {
+        var text = "";
+        var quote_char = "";
+        var i;
+        for (i = 0; i < word.length; i++) {
+            if (word[i] == '\\' || word[i] == quote_char)
+                text += '\\';
+            else if (quote_char === "") {
+                if (word[i] == "'" || is_whitespace(word[i]))
+                    quote_char = '"';
+                else if (word[i] == '"')
+                    quote_char = "'";
             }
-
-            return quote_char + text + quote_char;
+            text += word[i];
         }
 
-        return words.map(quote).join(' ');
-    };
+        return quote_char + text + quote_char;
+    }
 
-    docker.unquote_cmdline = function unquote_cmdline(text) {
-        var words = [ ];
-        var next;
+    return words.map(quote).join(' ');
+};
 
-        function is_whitespace(c) {
-            return c == ' ';
-        }
+docker.unquote_cmdline = function unquote_cmdline(text) {
+    var words = [ ];
+    var next;
 
-        function skip_whitespace() {
-            while (next < text.length && is_whitespace(text[next]))
-                next++;
-        }
+    function is_whitespace(c) {
+        return c == ' ';
+    }
 
-        function parse_word() {
-            var word = "";
-            var quote_char = null;
+    function skip_whitespace() {
+        while (next < text.length && is_whitespace(text[next]))
+            next++;
+    }
 
-            while (next < text.length) {
-                if (text[next] == '\\') {
-                    next++;
-                    if (next < text.length) {
-                        word += text[next];
-                    }
-                } else if (text[next] == quote_char) {
-                    quote_char = null;
-                } else if (quote_char) {
-                    word += text[next];
-                } else if (text[next] == '"' || text[next] == "'") {
-                    quote_char = text[next];
-                } else if (is_whitespace(text[next])) {
-                    break;
-                } else
-                    word += text[next];
-                next++;
-            }
-            return word;
-        }
+    function parse_word() {
+        var word = "";
+        var quote_char = null;
 
-        next = 0;
-        skip_whitespace();
         while (next < text.length) {
-            words.push(parse_word());
-            skip_whitespace();
+            if (text[next] == '\\') {
+                next++;
+                if (next < text.length) {
+                    word += text[next];
+                }
+            } else if (text[next] == quote_char) {
+                quote_char = null;
+            } else if (quote_char) {
+                word += text[next];
+            } else if (text[next] == '"' || text[next] == "'") {
+                quote_char = text[next];
+            } else if (is_whitespace(text[next])) {
+                break;
+            } else
+                word += text[next];
+            next++;
         }
+        return word;
+    }
 
-        return words;
-    };
+    next = 0;
+    skip_whitespace();
+    while (next < text.length) {
+        words.push(parse_word());
+        skip_whitespace();
+    }
 
-    var byte_suffixes = [ null, "KB", "MB", "GB", "TB", "PB", "EB", "ZB" ];
+    return words;
+};
 
-    docker.bytes_from_format = function bytes_from_format(formatted, separate) {
-        var factor = 1024;
+var byte_suffixes = [ null, "KB", "MB", "GB", "TB", "PB", "EB", "ZB" ];
 
-        if (separate === undefined)
-            separate = " ";
+docker.bytes_from_format = function bytes_from_format(formatted, separate) {
+    var factor = 1024;
 
-        var format = formatted.split(separate).pop()
-                .toUpperCase();
-        var spot = byte_suffixes.indexOf(format);
+    if (separate === undefined)
+        separate = " ";
 
-        /* TODO: Make the decimal separator translatable */
-        var num = parseFloat(formatted);
+    var format = formatted.split(separate).pop()
+            .toUpperCase();
+    var spot = byte_suffixes.indexOf(format);
 
-        if (spot > 0 && !isNaN(num))
-            return num * Math.pow(factor, spot);
-        return num;
-    };
+    /* TODO: Make the decimal separator translatable */
+    var num = parseFloat(formatted);
 
-    /*
-     * Returns the short id of a docker container or image id.
-     */
-    docker.truncate_id = function (id) {
-        var c = id.indexOf(':');
-        if (c >= 0)
-            id = id.slice(c + 1);
-        return id.substr(0, 12);
-    };
+    if (spot > 0 && !isNaN(num))
+        return num * Math.pow(factor, spot);
+    return num;
+};
 
-    module.exports = docker;
-}());
+/*
+ * Returns the short id of a docker container or image id.
+ */
+docker.truncate_id = function (id) {
+    var c = id.indexOf(':');
+    if (c >= 0)
+        id = id.slice(c + 1);
+    return id.substr(0, 12);
+};
+
+module.exports = docker;

--- a/pkg/docker/overview.js
+++ b/pkg/docker/overview.js
@@ -17,217 +17,215 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
+var $ = require("jquery");
+var cockpit = require("cockpit");
 
-    var React = require("react");
-    var ReactDOM = require("react-dom");
+var React = require("react");
+var ReactDOM = require("react-dom");
 
-    var plot = require("plot.js");
-    var cpu_ram_info = require("machine-info.js").cpu_ram_info;
+var plot = require("plot.js");
+var cpu_ram_info = require("machine-info.js").cpu_ram_info;
 
-    var util = require("./util");
-    var storage = require("./storage.jsx");
-    var view = require("./containers-view.jsx");
+var util = require("./util");
+var storage = require("./storage.jsx");
+var view = require("./containers-view.jsx");
 
-    require("plot.css");
+require("plot.css");
 
-    /* OVERVIEW PAGE
-     */
+/* OVERVIEW PAGE
+ */
 
-    function init_overview (client) {
-        var headerNode = document.querySelector('#containers .content-filter');
-        var containerNode = document.getElementById('containers-containers');
-        var imageNode = document.getElementById('containers-images');
+function init_overview (client) {
+    var headerNode = document.querySelector('#containers .content-filter');
+    var containerNode = document.getElementById('containers-containers');
+    var imageNode = document.getElementById('containers-images');
 
-        function update_container_list(onlyShowRunning, filterText) {
-            ReactDOM.render(React.createElement(view.ContainerList, {
-                client: client,
-                onlyShowRunning: onlyShowRunning,
-                filterText: filterText
-            }), containerNode);
-        }
-
-        function update_image_list(filterText) {
-            ReactDOM.render(React.createElement(view.ImageList, {
-                client: client,
-                filterText: filterText
-            }), imageNode);
-        }
-
-        ReactDOM.render(React.createElement(view.ContainerHeader, {
-            onFilterChanged: function (filter, filterText) {
-                update_container_list(filter === 'running', filterText);
-                update_image_list(filterText);
-            }
-        }), headerNode);
-
-        update_container_list(true, '');
-        update_image_list('');
-
-        var cpu_series;
-        var mem_series;
-
-        var cpu_options = plot.plot_simple_template();
-        $.extend(cpu_options.yaxis, { tickFormatter: function(v) { return v.toFixed(0) },
-                                      max: 100
-        });
-        $.extend(cpu_options.grid, { hoverable: true,
-                                     autoHighlight: false
-        });
-
-        var cpu_plot = new plot.Plot($("#containers-cpu-graph"), 300);
-        cpu_plot.set_options(cpu_options);
-        cpu_plot.start_walking();
-
-        cpu_ram_info()
-                .done(function (info) {
-                    $('#containers-cpu-graph-title').text(
-                        cockpit.format(cockpit.ngettext("Combined usage of $0 CPU core",
-                                                        "Combined usage of $0 CPU cores",
-                                                        info.cpus),
-                                       info.cpus));
-
-                    var cpu_data = {
-                        internal: "cgroup.cpu.usage",
-                        units: "millisec",
-                        derive: "rate",
-                        factor: 0.1 / info.cpus // millisec / sec -> percent
-                    };
-
-                    cpu_series = cpu_plot.add_metrics_stacked_instances_series(cpu_data, { });
-                    $(cpu_series).on("value", function(ev, value) {
-                        $('#containers-cpu-text').text(util.format_cpu_usage(value));
-                    });
-
-                    $(client).on('container.containers', function(event, id, container) {
-                        if (container && container.CGroup) {
-                            cpu_series.add_instance(container.CGroup);
-                            mem_series.add_instance(container.CGroup);
-                        }
-                    });
-                });
-
-        var mem_data = {
-            internal: "cgroup.memory.usage",
-            units: "bytes"
-        };
-
-        var mem_options = plot.plot_simple_template();
-        $.extend(mem_options.yaxis, { ticks: plot.memory_ticks,
-                                      tickFormatter: plot.format_bytes_tick_no_unit
-        });
-        $.extend(mem_options.grid, { hoverable: true,
-                                     autoHighlight: false
-        });
-        mem_options.setup_hook = function (flot) {
-            var axes = flot.getAxes();
-            if (axes.yaxis.datamax < 1.5 * 1024 * 1024)
-                axes.yaxis.options.max = 1.5 * 1024 * 1024;
-            else
-                axes.yaxis.options.max = null;
-            axes.yaxis.options.min = 0;
-        };
-        mem_options.post_hook = function (flot) {
-            var axes = flot.getAxes();
-            $("#containers-mem-unit").text(plot.bytes_tick_unit(axes.yaxis));
-        };
-
-        var mem_plot = new plot.Plot($("#containers-mem-graph"), 300);
-        mem_plot.set_options(mem_options);
-        mem_series = mem_plot.add_metrics_stacked_instances_series(mem_data, { });
-        $(mem_series).on("value", function(ev, value) {
-            $('#containers-mem-text').text(cockpit.format_bytes(value, 1024));
-        });
-        mem_plot.start_walking();
-
-        $(window).on('resize', function () {
-            cpu_plot.resize();
-            mem_plot.resize();
-        });
-
-        ReactDOM.render(React.createElement(storage.OverviewBox,
-                                            { model: storage.get_storage_model(),
-                                              small: true }),
-                        $("#containers-storage-details")[0]);
-
-        var commit = $('#container-commit-dialog')[0];
-        $(commit)
-                .on("show.bs.modal", function(event) {
-                    var container = client.containers[event.relatedTarget.dataset.containerId];
-
-                    $(commit).find(".container-name")
-                            .text(container.Name.replace(/^\//, ''));
-                    $(commit).attr('data-container-id', container.Id);
-
-                    var image = client.images[container.Config.Image];
-                    var repo = "";
-                    if (image && image.RepoTags)
-                        repo = image.RepoTags[0].split(":", 1)[0];
-                    $(commit).find(".container-repository")
-                            .attr('value', repo);
-
-                    $(commit).find(".container-tag")
-                            .attr('value', "");
-
-                    cockpit.user().done(function (user) {
-                        var author = user.full_name || user.name;
-                        $(commit).find(".container-author")
-                                .attr('value', author);
-                    });
-
-                    var command = "";
-                    if (container.Config)
-                        command = util.quote_cmdline(container.Config.Cmd);
-                    if (!command)
-                        command = container.Command;
-                    $(commit).find(".container-command")
-                            .attr('value', command);
-                })
-                .find(".btn-primary")
-                .on("click", function() {
-                    var location = cockpit.location;
-                    var run = { "Cmd": util.unquote_cmdline($(commit).find(".container-command")
-                            .val()) };
-                    var options = {
-                        "author": $(commit).find(".container-author")
-                                .val()
-                    };
-                    var tag = $(commit).find(".container-tag")
-                            .val();
-                    if (tag)
-                        options["tag"] = tag;
-                    var repository = $(commit).find(".container-repository")
-                            .val();
-                    client.commit($(commit).attr('data-container-id'), repository, options, run)
-                            .fail(function(ex) {
-                                util.show_unexpected_error(ex);
-                            })
-                            .done(function() {
-                                location.go("/");
-                            });
-                });
-
-        function hide() {
-            $('#containers').hide();
-        }
-
-        function show() {
-            $('#containers').show();
-            cpu_plot.resize();
-            mem_plot.resize();
-        }
-
-        return {
-            show: show,
-            hide: hide
-        };
+    function update_container_list(onlyShowRunning, filterText) {
+        ReactDOM.render(React.createElement(view.ContainerList, {
+            client: client,
+            onlyShowRunning: onlyShowRunning,
+            filterText: filterText
+        }), containerNode);
     }
 
-    module.exports = {
-        init: init_overview
+    function update_image_list(filterText) {
+        ReactDOM.render(React.createElement(view.ImageList, {
+            client: client,
+            filterText: filterText
+        }), imageNode);
+    }
+
+    ReactDOM.render(React.createElement(view.ContainerHeader, {
+        onFilterChanged: function (filter, filterText) {
+            update_container_list(filter === 'running', filterText);
+            update_image_list(filterText);
+        }
+    }), headerNode);
+
+    update_container_list(true, '');
+    update_image_list('');
+
+    var cpu_series;
+    var mem_series;
+
+    var cpu_options = plot.plot_simple_template();
+    $.extend(cpu_options.yaxis, { tickFormatter: function(v) { return v.toFixed(0) },
+                                  max: 100
+    });
+    $.extend(cpu_options.grid, { hoverable: true,
+                                 autoHighlight: false
+    });
+
+    var cpu_plot = new plot.Plot($("#containers-cpu-graph"), 300);
+    cpu_plot.set_options(cpu_options);
+    cpu_plot.start_walking();
+
+    cpu_ram_info()
+            .done(function (info) {
+                $('#containers-cpu-graph-title').text(
+                    cockpit.format(cockpit.ngettext("Combined usage of $0 CPU core",
+                                                    "Combined usage of $0 CPU cores",
+                                                    info.cpus),
+                                   info.cpus));
+
+                var cpu_data = {
+                    internal: "cgroup.cpu.usage",
+                    units: "millisec",
+                    derive: "rate",
+                    factor: 0.1 / info.cpus // millisec / sec -> percent
+                };
+
+                cpu_series = cpu_plot.add_metrics_stacked_instances_series(cpu_data, { });
+                $(cpu_series).on("value", function(ev, value) {
+                    $('#containers-cpu-text').text(util.format_cpu_usage(value));
+                });
+
+                $(client).on('container.containers', function(event, id, container) {
+                    if (container && container.CGroup) {
+                        cpu_series.add_instance(container.CGroup);
+                        mem_series.add_instance(container.CGroup);
+                    }
+                });
+            });
+
+    var mem_data = {
+        internal: "cgroup.memory.usage",
+        units: "bytes"
     };
-}());
+
+    var mem_options = plot.plot_simple_template();
+    $.extend(mem_options.yaxis, { ticks: plot.memory_ticks,
+                                  tickFormatter: plot.format_bytes_tick_no_unit
+    });
+    $.extend(mem_options.grid, { hoverable: true,
+                                 autoHighlight: false
+    });
+    mem_options.setup_hook = function (flot) {
+        var axes = flot.getAxes();
+        if (axes.yaxis.datamax < 1.5 * 1024 * 1024)
+            axes.yaxis.options.max = 1.5 * 1024 * 1024;
+        else
+            axes.yaxis.options.max = null;
+        axes.yaxis.options.min = 0;
+    };
+    mem_options.post_hook = function (flot) {
+        var axes = flot.getAxes();
+        $("#containers-mem-unit").text(plot.bytes_tick_unit(axes.yaxis));
+    };
+
+    var mem_plot = new plot.Plot($("#containers-mem-graph"), 300);
+    mem_plot.set_options(mem_options);
+    mem_series = mem_plot.add_metrics_stacked_instances_series(mem_data, { });
+    $(mem_series).on("value", function(ev, value) {
+        $('#containers-mem-text').text(cockpit.format_bytes(value, 1024));
+    });
+    mem_plot.start_walking();
+
+    $(window).on('resize', function () {
+        cpu_plot.resize();
+        mem_plot.resize();
+    });
+
+    ReactDOM.render(React.createElement(storage.OverviewBox,
+                                        { model: storage.get_storage_model(),
+                                          small: true }),
+                    $("#containers-storage-details")[0]);
+
+    var commit = $('#container-commit-dialog')[0];
+    $(commit)
+            .on("show.bs.modal", function(event) {
+                var container = client.containers[event.relatedTarget.dataset.containerId];
+
+                $(commit).find(".container-name")
+                        .text(container.Name.replace(/^\//, ''));
+                $(commit).attr('data-container-id', container.Id);
+
+                var image = client.images[container.Config.Image];
+                var repo = "";
+                if (image && image.RepoTags)
+                    repo = image.RepoTags[0].split(":", 1)[0];
+                $(commit).find(".container-repository")
+                        .attr('value', repo);
+
+                $(commit).find(".container-tag")
+                        .attr('value', "");
+
+                cockpit.user().done(function (user) {
+                    var author = user.full_name || user.name;
+                    $(commit).find(".container-author")
+                            .attr('value', author);
+                });
+
+                var command = "";
+                if (container.Config)
+                    command = util.quote_cmdline(container.Config.Cmd);
+                if (!command)
+                    command = container.Command;
+                $(commit).find(".container-command")
+                        .attr('value', command);
+            })
+            .find(".btn-primary")
+            .on("click", function() {
+                var location = cockpit.location;
+                var run = { "Cmd": util.unquote_cmdline($(commit).find(".container-command")
+                        .val()) };
+                var options = {
+                    "author": $(commit).find(".container-author")
+                            .val()
+                };
+                var tag = $(commit).find(".container-tag")
+                        .val();
+                if (tag)
+                    options["tag"] = tag;
+                var repository = $(commit).find(".container-repository")
+                        .val();
+                client.commit($(commit).attr('data-container-id'), repository, options, run)
+                        .fail(function(ex) {
+                            util.show_unexpected_error(ex);
+                        })
+                        .done(function() {
+                            location.go("/");
+                        });
+            });
+
+    function hide() {
+        $('#containers').hide();
+    }
+
+    function show() {
+        $('#containers').show();
+        cpu_plot.resize();
+        mem_plot.resize();
+    }
+
+    return {
+        show: show,
+        hide: hide
+    };
+}
+
+module.exports = {
+    init: init_overview
+};

--- a/pkg/docker/search.js
+++ b/pkg/docker/search.js
@@ -17,182 +17,180 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
+var $ = require("jquery");
+var cockpit = require("cockpit");
 
-    var util = require("./util");
+var util = require("./util");
 
-    var _ = cockpit.gettext;
+var _ = cockpit.gettext;
 
-    /* SEARCH DIALOG */
+/* SEARCH DIALOG */
 
-    PageSearchImage.prototype = {
-        _init: function() {
-            this.id = "containers-search-image-dialog";
-        },
+PageSearchImage.prototype = {
+    _init: function() {
+        this.id = "containers-search-image-dialog";
+    },
 
-        show: function() {
-            $('#containers-search-image-search').focus();
-        },
+    show: function() {
+        $('#containers-search-image-search').focus();
+    },
 
-        leave: function() {
-            this.cancel_search();
+    leave: function() {
+        this.cancel_search();
 
-            $(this.client).off('.containers-search-image-dialog');
-            this.client = null;
+        $(this.client).off('.containers-search-image-dialog');
+        this.client = null;
 
-            this.dfd.reject();
-            this.dfd = null;
-        },
+        this.dfd.reject();
+        this.dfd = null;
+    },
 
-        setup: function() {
-            $("#containers-search-image-search").on('keypress', $.proxy(this, "input"));
-            $("#containers-search-image-search").attr("placeholder", _("search by name, namespace or description"));
-            $("#containers-search-download").on('click', $.proxy(this, 'start_download'));
-            $('#containers-search-tag').prop('disabled', true);
-            $('#containers-search-download').prop('disabled', true);
-            this.search_timeout = null;
-            this.search_request = null;
-        },
+    setup: function() {
+        $("#containers-search-image-search").on('keypress', $.proxy(this, "input"));
+        $("#containers-search-image-search").attr("placeholder", _("search by name, namespace or description"));
+        $("#containers-search-download").on('click', $.proxy(this, 'start_download'));
+        $('#containers-search-tag').prop('disabled', true);
+        $('#containers-search-download').prop('disabled', true);
+        this.search_timeout = null;
+        this.search_request = null;
+    },
 
-        enter: function() {
-            this.client = PageSearchImage.client;
-            this.dfd = PageSearchImage.dfd;
+    enter: function() {
+        this.client = PageSearchImage.client;
+        this.dfd = PageSearchImage.dfd;
 
-            // Clear the previous results and search string from previous time
-            $('#containers-search-image-results tbody tr').remove();
-            $('#containers-search-image-results').hide();
-            $('#containers-search-image-no-results').hide();
-            $('#containers-search-image-search')[0].value = '';
-        },
+        // Clear the previous results and search string from previous time
+        $('#containers-search-image-results tbody tr').remove();
+        $('#containers-search-image-results').hide();
+        $('#containers-search-image-no-results').hide();
+        $('#containers-search-image-search')[0].value = '';
+    },
 
-        input: function(event) {
-            this.cancel_search();
+    input: function(event) {
+        this.cancel_search();
 
-            // Only handle if the new value is at least 3 characters long or return was pressed
-            if (event.target.value.length < 3 && event.which != 13)
-                return;
+        // Only handle if the new value is at least 3 characters long or return was pressed
+        if (event.target.value.length < 3 && event.which != 13)
+            return;
 
-            var self = this;
+        var self = this;
 
-            this.search_timeout = window.setTimeout(function() {
-                self.perform_search(self.client);
-            }, event.which == 13 ? 0 : 2000);
-        },
+        this.search_timeout = window.setTimeout(function() {
+            self.perform_search(self.client);
+        }, event.which == 13 ? 0 : 2000);
+    },
 
-        start_download: function(event) {
-            var repo = $('#containers-search-download').data('repo');
-            var registry = $('#containers-search-download').data('registry') || undefined;
-            var tag = $('#containers-search-tag').val();
+    start_download: function(event) {
+        var repo = $('#containers-search-download').data('repo');
+        var registry = $('#containers-search-download').data('registry') || undefined;
+        var tag = $('#containers-search-tag').val();
 
-            this.dfd.resolve(repo, tag, registry);
+        this.dfd.resolve(repo, tag, registry);
 
-            $("#containers-search-image-dialog").modal('hide');
-        },
+        $("#containers-search-image-dialog").modal('hide');
+    },
 
-        perform_search: function(client) {
-            var term = $('#containers-search-image-search')[0].value;
+    perform_search: function(client) {
+        var term = $('#containers-search-image-search')[0].value;
 
-            $('#containers-search-image-waiting').addClass('spinner');
-            $('#containers-search-image-no-results').hide();
-            $('#containers-search-image-results').hide();
-            $('#containers-search-image-results tbody tr').remove();
-            this.search_request = client.search(term)
-                    .done(function(data) {
-                        var resp = data && JSON.parse(data);
-                        $('#containers-search-image-waiting').removeClass('spinner');
+        $('#containers-search-image-waiting').addClass('spinner');
+        $('#containers-search-image-no-results').hide();
+        $('#containers-search-image-results').hide();
+        $('#containers-search-image-results tbody tr').remove();
+        this.search_request = client.search(term)
+                .done(function(data) {
+                    var resp = data && JSON.parse(data);
+                    $('#containers-search-image-waiting').removeClass('spinner');
 
-                        if (resp && resp.length > 0) {
-                            $('#containers-search-image-results').show();
-                            resp.forEach(function(entry) {
-                                var row = $('<tr>').append(
-                                    $('<td>').text(entry.name),
-                                    $('<td>').text(entry.description));
-                                row.on('click', function(event) {
-                                // Remove the active class from all other rows
-                                    $('#containers-search-image-results tr').each(function() {
-                                        $(this).removeClass('active');
-                                    });
-
-                                    row.addClass('active');
-                                    $('#containers-search-tag').val('latest');
-                                    $('#containers-search-tag').prop('disabled', false);
-                                    $('#containers-search-download').data('repo', entry.name);
-                                    $('#containers-search-download').data('registry', entry.registry_name);
-                                    $('#containers-search-download').prop('disabled', false);
+                    if (resp && resp.length > 0) {
+                        $('#containers-search-image-results').show();
+                        resp.forEach(function(entry) {
+                            var row = $('<tr>').append(
+                                $('<td>').text(entry.name),
+                                $('<td>').text(entry.description));
+                            row.on('click', function(event) {
+                            // Remove the active class from all other rows
+                                $('#containers-search-image-results tr').each(function() {
+                                    $(this).removeClass('active');
                                 });
-                                row.data('entry', entry);
 
-                                util.insert_table_sorted_generic($('#containers-search-image-results'), row, function(row1, row2) {
-                                // Bigger than 0 means row1 after row2
-                                // Smaller than 0 means row1 before row2
-                                    if (row1.data('entry').is_official && !row2.data('entry').is_official)
-                                        return -1;
-                                    if (!row1.data('entry').is_official && row2.data('entry').is_official)
-                                        return 1;
-                                    if (row1.data('entry').is_automated && !row2.data('entry').is_automated)
-                                        return -1;
-                                    if (!row1.data('entry').is_automated && row2.data('entry').is_automated)
-                                        return 1;
-                                    if (row1.data('entry').star_count != row2.data('entry').star_count)
-                                        return row2.data('entry').star_count - row1.data('entry').star_count;
-                                    return row1.data('entry').name.localeCompare(row2.data('entry').name);
-                                });
+                                row.addClass('active');
+                                $('#containers-search-tag').val('latest');
+                                $('#containers-search-tag').prop('disabled', false);
+                                $('#containers-search-download').data('repo', entry.name);
+                                $('#containers-search-download').data('registry', entry.registry_name);
+                                $('#containers-search-download').prop('disabled', false);
                             });
-                        } else {
-                        // No results
-                            $('#containers-search-image-no-results').empty()
-                                    .append(
-                                        $("<span>").text(cockpit.format(_("No results for $0"), term)),
-                                        $("<br />"),
-                                        $("span>").text(_("Please try another term"))
-                                    );
-                            $('#containers-search-image-no-results').show();
-                        }
-                    });
-        },
+                            row.data('entry', entry);
 
-        cancel_search: function() {
-            window.clearTimeout(this.search_timeout);
-            $('#containers-search-image-no-results').hide();
-            $('#containers-search-image-results').hide();
-            $('#containers-search-image-results tbody tr').remove();
-            if (this.search_request !== null) {
-                this.search_request.close();
-                this.search_request = null;
-            }
-            $('#containers-search-image-waiting').removeClass('waiting');
+                            util.insert_table_sorted_generic($('#containers-search-image-results'), row, function(row1, row2) {
+                            // Bigger than 0 means row1 after row2
+                            // Smaller than 0 means row1 before row2
+                                if (row1.data('entry').is_official && !row2.data('entry').is_official)
+                                    return -1;
+                                if (!row1.data('entry').is_official && row2.data('entry').is_official)
+                                    return 1;
+                                if (row1.data('entry').is_automated && !row2.data('entry').is_automated)
+                                    return -1;
+                                if (!row1.data('entry').is_automated && row2.data('entry').is_automated)
+                                    return 1;
+                                if (row1.data('entry').star_count != row2.data('entry').star_count)
+                                    return row2.data('entry').star_count - row1.data('entry').star_count;
+                                return row1.data('entry').name.localeCompare(row2.data('entry').name);
+                            });
+                        });
+                    } else {
+                    // No results
+                        $('#containers-search-image-no-results').empty()
+                                .append(
+                                    $("<span>").text(cockpit.format(_("No results for $0"), term)),
+                                    $("<br />"),
+                                    $("span>").text(_("Please try another term"))
+                                );
+                        $('#containers-search-image-no-results').show();
+                    }
+                });
+    },
 
-            $('#containers-search-tag').prop('disabled', true);
-            $('#containers-search-download').prop('disabled', true);
+    cancel_search: function() {
+        window.clearTimeout(this.search_timeout);
+        $('#containers-search-image-no-results').hide();
+        $('#containers-search-image-results').hide();
+        $('#containers-search-image-results tbody tr').remove();
+        if (this.search_request !== null) {
+            this.search_request.close();
+            this.search_request = null;
         }
-    };
+        $('#containers-search-image-waiting').removeClass('waiting');
 
-    function PageSearchImage() {
-        this._init();
+        $('#containers-search-tag').prop('disabled', true);
+        $('#containers-search-download').prop('disabled', true);
     }
+};
 
-    var dialog = new PageSearchImage();
+function PageSearchImage() {
+    this._init();
+}
 
-    $(function() {
-        dialog.setup();
-        $("#containers-search-image-dialog")
-                .on('show.bs.modal', function () { dialog.enter() })
-                .on('shown.bs.modal', function () { dialog.show() })
-                .on('hidden.bs.modal', function () { dialog.leave() });
-    });
+var dialog = new PageSearchImage();
 
-    function search(client) {
-        PageSearchImage.client = client;
-        PageSearchImage.dfd = cockpit.defer();
+$(function() {
+    dialog.setup();
+    $("#containers-search-image-dialog")
+            .on('show.bs.modal', function () { dialog.enter() })
+            .on('shown.bs.modal', function () { dialog.show() })
+            .on('hidden.bs.modal', function () { dialog.leave() });
+});
 
-        $("#containers-search-image-dialog").modal('show');
+function search(client) {
+    PageSearchImage.client = client;
+    PageSearchImage.dfd = cockpit.defer();
 
-        return PageSearchImage.dfd.promise;
-    }
+    $("#containers-search-image-dialog").modal('show');
 
-    module.exports = search;
-}());
+    return PageSearchImage.dfd.promise;
+}
+
+module.exports = search;

--- a/pkg/docker/storage.jsx
+++ b/pkg/docker/storage.jsx
@@ -28,516 +28,512 @@ import dialog_view from "cockpit-components-dialog.jsx";
 import * as python from "python.js";
 import cockpit_atomic_storage from "raw-loader!./cockpit-atomic-storage";
 
-(function() {
-    "use strict";
+const _ = cockpit.gettext;
 
-    const _ = cockpit.gettext;
+function init_model() {
+    var process;
 
-    function init_model() {
-        var process;
+    var self = {
+        error: null,
+        pool_devices: [ ],
+        extra_devices: [ ],
+        total: 0,
+        used: 0
+    };
 
-        var self = {
-            error: null,
-            pool_devices: [ ],
-            extra_devices: [ ],
-            total: 0,
-            used: 0
-        };
+    function cmp_drive(a, b) {
+        return a.sort_index - b.sort_index;
+    }
 
-        function cmp_drive(a, b) {
-            return a.sort_index - b.sort_index;
-        }
-
-        function update() {
-            if (!cockpit.hidden && !process) {
-                process = python.spawn([ cockpit_atomic_storage ], ["monitor"],
-                                       { err: "ignore",
-                                         superuser: true })
-                        .stream(function (data) {
-                            // XXX - find the newlines here
-                            var info = JSON.parse(data);
-                            self.driver = info.driver;
-                            self.vgroup = info.vgroup;
-                            self.pool_devices = info.pool_devices.sort(cmp_drive);
-                            self.extra_devices = info.extra_devices.sort(cmp_drive);
-                            self.total = info.total;
-                            self.used = info.used;
-                            self.error = null;
-                            if (!info.can_manage || !info.vgroup)
-                                self.error = "unsupported";
+    function update() {
+        if (!cockpit.hidden && !process) {
+            process = python.spawn([ cockpit_atomic_storage ], ["monitor"],
+                                   { err: "ignore",
+                                     superuser: true })
+                    .stream(function (data) {
+                        // XXX - find the newlines here
+                        var info = JSON.parse(data);
+                        self.driver = info.driver;
+                        self.vgroup = info.vgroup;
+                        self.pool_devices = info.pool_devices.sort(cmp_drive);
+                        self.extra_devices = info.extra_devices.sort(cmp_drive);
+                        self.total = info.total;
+                        self.used = info.used;
+                        self.error = null;
+                        if (!info.can_manage || !info.vgroup)
+                            self.error = "unsupported";
+                        $(self).triggerHandler("changed");
+                    })
+                    .fail(function (error) {
+                        if (error != "closed") {
+                            console.warn(error);
+                            self.error = error.problem || "broken";
                             $(self).triggerHandler("changed");
-                        })
-                        .fail(function (error) {
-                            if (error != "closed") {
-                                console.warn(error);
-                                self.error = error.problem || "broken";
-                                $(self).triggerHandler("changed");
-                            }
-                        });
-            } else if (cockpit.hidden && process) {
-                process.close("closed");
-                process = null;
-            }
+                        }
+                    });
+        } else if (cockpit.hidden && process) {
+            process.close("closed");
+            process = null;
         }
-
-        $(cockpit).on("visibilitychange", update);
-        update();
-
-        return self;
     }
 
-    var storage_model = null;
+    $(cockpit).on("visibilitychange", update);
+    update();
 
-    function get_storage_model() {
-        if (!storage_model)
-            storage_model = init_model();
-        return storage_model;
+    return self;
+}
+
+var storage_model = null;
+
+function get_storage_model() {
+    if (!storage_model)
+        storage_model = init_model();
+    return storage_model;
+}
+
+/* A list of unused drives ready to be added to the Docker storage pool.
+ *
+ * model: The model as returned by get_storage_model.
+ *
+ * callback: Called as callback(drives, model) when
+ *           the "Add" button is clicked.
+ *
+ */
+class DriveBox extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            drives: this.props.model.extra_devices,
+            checked: { }
+        };
+        this.onModelChanged = this.onModelChanged.bind(this);
+        this.driveChecked = this.driveChecked.bind(this);
+        this.toggleDrive = this.toggleDrive.bind(this);
+        this.onButtonClicked = this.onButtonClicked.bind(this);
     }
 
-    /* A list of unused drives ready to be added to the Docker storage pool.
-     *
-     * model: The model as returned by get_storage_model.
-     *
-     * callback: Called as callback(drives, model) when
-     *           the "Add" button is clicked.
-     *
-     */
-    class DriveBox extends React.Component {
-        constructor(props) {
-            super(props);
-            this.state = {
-                drives: this.props.model.extra_devices,
-                checked: { }
-            };
-            this.onModelChanged = this.onModelChanged.bind(this);
-            this.driveChecked = this.driveChecked.bind(this);
-            this.toggleDrive = this.toggleDrive.bind(this);
-            this.onButtonClicked = this.onButtonClicked.bind(this);
-        }
+    onModelChanged() {
+        this.setState({ drives: this.props.model.extra_devices });
+    }
 
-        onModelChanged() {
-            this.setState({ drives: this.props.model.extra_devices });
-        }
+    componentDidMount() {
+        $(this.props.model).on("changed", this.onModelChanged);
+        this.onModelChanged();
+    }
 
-        componentDidMount() {
-            $(this.props.model).on("changed", this.onModelChanged);
-            this.onModelChanged();
-        }
+    componentWillUnmount() {
+        $(this.props.model).off("changed", this.onModelChanged);
+    }
 
-        componentWillUnmount() {
-            $(this.props.model).off("changed", this.onModelChanged);
-        }
+    driveChecked(drive) {
+        return !!this.state.checked[drive.path];
+    }
 
-        driveChecked(drive) {
-            return !!this.state.checked[drive.path];
-        }
+    toggleDrive(drive) {
+        this.state.checked[drive.path] = !this.state.checked[drive.path];
+        this.setState({ checked: this.state.checked });
+    }
 
-        toggleDrive(drive) {
-            this.state.checked[drive.path] = !this.state.checked[drive.path];
-            this.setState({ checked: this.state.checked });
-        }
-
-        onButtonClicked() {
-            var self = this;
-            if (self.props.callback) {
-                var drives = [ ];
-                for (var d in self.state.checked) {
-                    if (self.state.checked[d]) {
-                        for (var i = 0; i < self.state.drives.length; i++) {
-                            if (self.state.drives[i].path == d) {
-                                drives.push(self.state.drives[i]);
-                            }
+    onButtonClicked() {
+        var self = this;
+        if (self.props.callback) {
+            var drives = [ ];
+            for (var d in self.state.checked) {
+                if (self.state.checked[d]) {
+                    for (var i = 0; i < self.state.drives.length; i++) {
+                        if (self.state.drives[i].path == d) {
+                            drives.push(self.state.drives[i]);
                         }
                     }
                 }
-                self.setState({ checked: { } });
-                self.props.callback(drives, self.props.model);
+            }
+            self.setState({ checked: { } });
+            self.props.callback(drives, self.props.model);
+        }
+    }
+
+    render() {
+        var self = this;
+        var i;
+
+        var button_enabled = false;
+        var drive_rows = [ ];
+        var drive_paths = { };
+
+        function drive_class_desc(cl) {
+            switch (cl) {
+            case "sdd": return _("Solid-State Disk");
+            case "hdd": return _("Hard Disk");
+            default: return _("Drive");
             }
         }
 
-        render() {
-            var self = this;
-            var i;
+        for (i = 0; i < self.state.drives.length; i++) {
+            var drive = self.state.drives[i];
 
-            var button_enabled = false;
-            var drive_rows = [ ];
-            var drive_paths = { };
+            if (self.state.checked[drive.path])
+                button_enabled = true;
 
-            function drive_class_desc(cl) {
-                switch (cl) {
-                case "sdd": return _("Solid-State Disk");
-                case "hdd": return _("Hard Disk");
-                default: return _("Drive");
-                }
-            }
+            drive_paths[drive.path] = true;
 
-            for (i = 0; i < self.state.drives.length; i++) {
-                var drive = self.state.drives[i];
+            drive_rows.push(
+                <tr key={drive.path} onClick={self.toggleDrive.bind(self, drive)}>
+                    <td><input type="checkbox"
+                               onChange={ () => null /* click handled by parent element, silence React warning */ }
+                               checked={self.driveChecked(drive)} />
+                    </td>
+                    <td><img role="presentation" src="images/drive-harddisk-symbolic.svg" /></td>
+                    <td>
+                        <div>{drive.name}</div>
+                        <div>{cockpit.format_bytes(drive.size)} {drive_class_desc(drive.class)}</div>
+                    </td>
+                </tr>);
+        }
 
-                if (self.state.checked[drive.path])
-                    button_enabled = true;
+        var drive_list;
 
-                drive_paths[drive.path] = true;
+        if (drive_rows.length > 0) {
+            drive_list = (
+                <div>
+                    <h4>{_("Local Disks")}</h4>
+                    <table>
+                        <tbody>
+                            { drive_rows }
+                        </tbody>
+                    </table>
+                </div>);
+        } else {
+            drive_list = <span>{_("No additional local storage found.")}</span>;
+        }
 
-                drive_rows.push(
-                    <tr key={drive.path} onClick={self.toggleDrive.bind(self, drive)}>
-                        <td><input type="checkbox"
-                                   onChange={ () => null /* click handled by parent element, silence React warning */ }
-                                   checked={self.driveChecked(drive)} />
-                        </td>
-                        <td><img role="presentation" src="images/drive-harddisk-symbolic.svg" /></td>
-                        <td>
-                            <div>{drive.name}</div>
-                            <div>{cockpit.format_bytes(drive.size)} {drive_class_desc(drive.class)}</div>
-                        </td>
-                    </tr>);
-            }
-
-            var drive_list;
-
-            if (drive_rows.length > 0) {
-                drive_list = (
-                    <div>
-                        <h4>{_("Local Disks")}</h4>
-                        <table>
-                            <tbody>
-                                { drive_rows }
-                            </tbody>
-                        </table>
-                    </div>);
-            } else {
-                drive_list = <span>{_("No additional local storage found.")}</span>;
-            }
-
-            return (
-                <div className="drives-panel">
-                    <div className="drives-panel-body">
-                        { drive_list }
-                    </div>
-                    <div className="drives-panel-footer">
-                        <button className="btn btn-primary"
-                                disabled={ !button_enabled }
-                                onClick={ self.onButtonClicked }>{_("Add Storage")}</button>
-                    </div>
+        return (
+            <div className="drives-panel">
+                <div className="drives-panel-body">
+                    { drive_list }
                 </div>
-            );
-        }
+                <div className="drives-panel-footer">
+                    <button className="btn btn-primary"
+                            disabled={ !button_enabled }
+                            onClick={ self.onButtonClicked }>{_("Add Storage")}</button>
+                </div>
+            </div>
+        );
+    }
+}
+
+/* A list of drives in the Docker storage pool.
+ *
+ * model: The model as returned by get_storage_model.
+ */
+class PoolBox extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            drives: [ ]
+        };
+        this.onModelChanged = this.onModelChanged.bind(this);
     }
 
-    /* A list of drives in the Docker storage pool.
-     *
-     * model: The model as returned by get_storage_model.
-     */
-    class PoolBox extends React.Component {
-        constructor(props) {
-            super(props);
-            this.state = {
-                drives: [ ]
-            };
-            this.onModelChanged = this.onModelChanged.bind(this);
-        }
-
-        onModelChanged() {
-            this.setState({ drives: this.props.model.pool_devices });
-        }
-
-        componentDidMount() {
-            $(this.props.model).on("changed", this.onModelChanged);
-            this.onModelChanged();
-        }
-
-        componentWillUnmount() {
-            $(this.props.model).off("changed", this.onModelChanged);
-        }
-
-        render() {
-            var self = this;
-
-            function render_drive_rows() {
-                return self.state.drives.map(function (drive) {
-                    return (
-                        <tr key={drive.name}>
-                            <td>{cockpit.format_bytes(drive.size)}</td>
-                            <td><img role="presentation" src="images/drive-harddisk-symbolic.svg" /></td>
-                            <td>{drive.name}{drive.shared ? _(" (shared with the OS)") : ""}</td>
-                        </tr>);
-                });
-            }
-
-            return (
-                <table className="drive-list">
-                    <tbody>
-                        {render_drive_rows()}
-                    </tbody>
-                </table>);
-        }
+    onModelChanged() {
+        this.setState({ drives: this.props.model.pool_devices });
     }
 
-    /* An overview of the Docker Storage pool size and how much is used.
-     *
-     * model: The model as returned by get_storage_model.
-     *
-     * small: If true, a small version is rendered
-     *        with a link to the setup page.
-     */
-    class OverviewBox extends React.Component {
-        constructor(props) {
-            super(props);
-            this.state = {
-                total: 0,
-                used: 0
-            };
-            this.onModelChanged = this.onModelChanged.bind(this);
-        }
-
-        onModelChanged() {
-            this.setState({ error: this.props.model.error,
-                            total: this.props.model.total,
-                            used: this.props.model.used });
-        }
-
-        componentDidMount() {
-            $(this.props.model).on("changed", this.onModelChanged);
-            this.onModelChanged();
-        }
-
-        componentWillUnmount() {
-            $(this.props.model).off("changed", this.onModelChanged);
-        }
-
-        render() {
-            var self = this;
-
-            if (!self.state.total) {
-                return (<div>{_("Information about the Docker storage pool is not available.")}</div>);
-            }
-
-            var total_fmt = cockpit.format_bytes(self.state.total, undefined, true);
-            var used_fmt = cockpit.format_bytes(self.state.used, total_fmt[1], true);
-            var free_fmt = cockpit.format_bytes(self.state.total - self.state.used, undefined, true);
-
-            var used_perc = (self.state.used / self.state.total) * 100 + "%";
-
-            if (self.props.small) {
-                return (
-                    <div>
-                        <div>
-                            <div className="used-total">{used_fmt[0]} / {total_fmt[0]} {total_fmt[1]}</div>
-                            <div>
-                                <span className="free-text">{free_fmt[0]} </span>
-                                <span className="free-unit">{free_fmt[1]} </span><span>{_("Free")}</span>
-                            </div>
-                        </div>
-                        <div className="progress">
-                            <div className="progress-bar" style={{width: used_perc}} />
-                        </div>
-                        {self.state.error ? "" : <a translatable="yes" href="#/storage">{_("Configure storage...")}</a>}
-                    </div>);
-            } else {
-                return (
-                    <div>
-                        <div>
-                            <div className="used-total">
-                                <table>
-                                    <tbody>
-                                        <tr><td>{_("Used")}</td><td>{used_fmt[0]} {used_fmt[1]}</td></tr>
-                                        <tr><td>{_("Total")}</td><td>{total_fmt[0]} {total_fmt[1]}</td></tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                            <div>
-                                <span className="free-text">{free_fmt[0]}</span>
-                                <div className="free-unit">
-                                    {free_fmt[1]}<br />{_("Free")}
-                                </div>
-                            </div>
-                        </div>
-                        <div className="progress">
-                            <div className="progress-bar c2" style={{width: used_perc}} />
-                        </div>
-                    </div>);
-            }
-        }
+    componentDidMount() {
+        $(this.props.model).on("changed", this.onModelChanged);
+        this.onModelChanged();
     }
 
-    function add_storage(client, drives, model) {
+    componentWillUnmount() {
+        $(this.props.model).off("changed", this.onModelChanged);
+    }
+
+    render() {
+        var self = this;
+
         function render_drive_rows() {
-            return drives.map(function (drive) {
+            return self.state.drives.map(function (drive) {
                 return (
                     <tr key={drive.name}>
                         <td>{cockpit.format_bytes(drive.size)}</td>
                         <td><img role="presentation" src="images/drive-harddisk-symbolic.svg" /></td>
-                        <td>{drive.name}</td>
+                        <td>{drive.name}{drive.shared ? _(" (shared with the OS)") : ""}</td>
                     </tr>);
             });
         }
 
-        // This will never be true right now, but it might once
-        // Cockpit can change the driver, and we have all the code from a
-        // time when the driver might have changed, so why not keep it.
-        //
-        var docker_will_be_stopped = false;
-
-        dialog_view.show_modal_dialog({ 'title': _("Add Additional Storage"),
-                                        'body': (
-                                            <div className="modal-body">
-                                                <p>{_("All data on selected disks will be erased and disks will be added to the storage pool.")}</p>
-                                                <table className="drive-list">
-                                                    <tbody>
-                                                        { render_drive_rows() }
-                                                    </tbody>
-                                                </table>
-                                            </div>),
-        },
-                                      { 'actions': [ { 'caption': _("Reformat and add disks"),
-                                                       'clicked': add_drives,
-                                                       'style': "danger" } ]
-                                      });
-
-        function add_drives() {
-            var dfd = cockpit.defer();
-            var devs = drives.map(function (d) { return d.path });
-            if (docker_will_be_stopped)
-                client.close();
-
-            // We specify the driver explicitly here.  This is to make
-            // sure that docker-storage-setup uses the driver that docker
-            // is currently using, and doesn't unexpectantly change it to
-            // something else.
-            //
-            var args = { "devs": devs, "driver": model.driver };
-
-            var process = python.spawn(cockpit_atomic_storage, [ "add", JSON.stringify(args) ],
-                                       { 'err': 'out',
-                                         'superuser': true })
-                    .done(function () {
-                        if (docker_will_be_stopped) {
-                            client.connect().done(function () {
-                                dfd.resolve();
-                            });
-                        } else {
-                            dfd.resolve();
-                        }
-                    })
-                    .fail(function (error, data) {
-                        if (docker_will_be_stopped)
-                            client.connect();
-                        if (error.problem == "cancelled") {
-                            dfd.resolve();
-                            return;
-                        }
-                        dfd.reject(
-                            <div>
-                                <span>{_("Could not add all disks")}</span>
-                                <pre>{data}</pre>
-                            </div>);
-                    });
-            var promise = dfd.promise();
-            promise.cancel = function () {
-                process.close("cancelled");
-            };
-            return promise;
-        }
+        return (
+            <table className="drive-list">
+                <tbody>
+                    {render_drive_rows()}
+                </tbody>
+            </table>);
     }
+}
 
-    function reset_storage(client) {
-        dialog_view.show_modal_dialog({ 'title': _("Reset Storage Pool"),
-                                        'body': (
-                                            <div className="modal-body">
-                                                <p>{_("Resetting the storage pool will erase all containers and release disks in the pool.")}</p>
-                                            </div>),
-        },
-                                      { 'actions': [ { 'caption': _("Erase containers and reset storage pool"),
-                                                       'clicked': reset,
-                                                       'style': "danger" } ]
-                                      });
-        function reset() {
-            var dfd = cockpit.defer();
-            client.close();
-            var process = python.spawn(cockpit_atomic_storage, ["reset-and-reduce"],
-                                       { 'err': 'out',
-                                         'superuser': true })
-                    .done(function () {
-                        client.connect().done(dfd.resolve);
-                    })
-                    .fail(function (error, data) {
-                        client.connect();
-                        if (error.problem == "cancelled") {
-                            dfd.resolve();
-                            return;
-                        }
-                        dfd.reject(
-                            <div>
-                                <span>{_("Could not reset the storage pool")}</span>
-                                <pre>{data}</pre>
-                            </div>);
-                    });
-            var promise = dfd.promise();
-            promise.cancel = function () {
-                process.close("cancelled");
-            };
-            return promise;
-        }
-    }
-
-    function init_storage(client) {
-        $('#storage .breadcrumb a').on("click", function() {
-            cockpit.location.go('/');
-        });
-
-        $('#storage-reset').on('click', function () { reset_storage(client) });
-
-        function add_callback(drives, model) {
-            add_storage(client, drives, model);
-        }
-
-        var model = get_storage_model();
-
-        ReactDOM.render(<DriveBox model={model} callback={add_callback} />,
-                        $("#storage-drives")[0]);
-        ReactDOM.render(<PoolBox model={model} />,
-                        $("#storage-pool")[0]);
-        ReactDOM.render(<OverviewBox model={model} />,
-                        $("#storage-overview")[0]);
-
-        function update() {
-            if (model.error) {
-                if (model.error == "access-denied")
-                    $('#storage-unsupported-message').text(
-                        _("You don't have permission to manage the Docker storage pool."));
-                else
-                    $('#storage-unsupported-message').text(
-                        _("The Docker storage pool cannot be managed on this system."));
-                $("#storage-unsupported").show();
-                $("#storage-details").hide();
-            } else {
-                $("#storage-unsupported").hide();
-                $("#storage-details").show();
-                $("#storage-reset").toggle(model.driver == "devicemapper");
-            }
-        }
-
-        $(model).on("changed", update);
-        update();
-
-        function hide() {
-            $('#storage').hide();
-        }
-
-        function show() {
-            $('#storage').show();
-        }
-
-        return {
-            show: show,
-            hide: hide
+/* An overview of the Docker Storage pool size and how much is used.
+ *
+ * model: The model as returned by get_storage_model.
+ *
+ * small: If true, a small version is rendered
+ *        with a link to the setup page.
+ */
+class OverviewBox extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            total: 0,
+            used: 0
         };
+        this.onModelChanged = this.onModelChanged.bind(this);
     }
 
-    module.exports = {
-        get_storage_model: get_storage_model,
-        OverviewBox: OverviewBox,
+    onModelChanged() {
+        this.setState({ error: this.props.model.error,
+                        total: this.props.model.total,
+                        used: this.props.model.used });
+    }
 
-        init: init_storage
+    componentDidMount() {
+        $(this.props.model).on("changed", this.onModelChanged);
+        this.onModelChanged();
+    }
+
+    componentWillUnmount() {
+        $(this.props.model).off("changed", this.onModelChanged);
+    }
+
+    render() {
+        var self = this;
+
+        if (!self.state.total) {
+            return (<div>{_("Information about the Docker storage pool is not available.")}</div>);
+        }
+
+        var total_fmt = cockpit.format_bytes(self.state.total, undefined, true);
+        var used_fmt = cockpit.format_bytes(self.state.used, total_fmt[1], true);
+        var free_fmt = cockpit.format_bytes(self.state.total - self.state.used, undefined, true);
+
+        var used_perc = (self.state.used / self.state.total) * 100 + "%";
+
+        if (self.props.small) {
+            return (
+                <div>
+                    <div>
+                        <div className="used-total">{used_fmt[0]} / {total_fmt[0]} {total_fmt[1]}</div>
+                        <div>
+                            <span className="free-text">{free_fmt[0]} </span>
+                            <span className="free-unit">{free_fmt[1]} </span><span>{_("Free")}</span>
+                        </div>
+                    </div>
+                    <div className="progress">
+                        <div className="progress-bar" style={{width: used_perc}} />
+                    </div>
+                    {self.state.error ? "" : <a translatable="yes" href="#/storage">{_("Configure storage...")}</a>}
+                </div>);
+        } else {
+            return (
+                <div>
+                    <div>
+                        <div className="used-total">
+                            <table>
+                                <tbody>
+                                    <tr><td>{_("Used")}</td><td>{used_fmt[0]} {used_fmt[1]}</td></tr>
+                                    <tr><td>{_("Total")}</td><td>{total_fmt[0]} {total_fmt[1]}</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div>
+                            <span className="free-text">{free_fmt[0]}</span>
+                            <div className="free-unit">
+                                {free_fmt[1]}<br />{_("Free")}
+                            </div>
+                        </div>
+                    </div>
+                    <div className="progress">
+                        <div className="progress-bar c2" style={{width: used_perc}} />
+                    </div>
+                </div>);
+        }
+    }
+}
+
+function add_storage(client, drives, model) {
+    function render_drive_rows() {
+        return drives.map(function (drive) {
+            return (
+                <tr key={drive.name}>
+                    <td>{cockpit.format_bytes(drive.size)}</td>
+                    <td><img role="presentation" src="images/drive-harddisk-symbolic.svg" /></td>
+                    <td>{drive.name}</td>
+                </tr>);
+        });
+    }
+
+    // This will never be true right now, but it might once
+    // Cockpit can change the driver, and we have all the code from a
+    // time when the driver might have changed, so why not keep it.
+    //
+    var docker_will_be_stopped = false;
+
+    dialog_view.show_modal_dialog({ 'title': _("Add Additional Storage"),
+                                    'body': (
+                                        <div className="modal-body">
+                                            <p>{_("All data on selected disks will be erased and disks will be added to the storage pool.")}</p>
+                                            <table className="drive-list">
+                                                <tbody>
+                                                    { render_drive_rows() }
+                                                </tbody>
+                                            </table>
+                                        </div>),
+    },
+                                  { 'actions': [ { 'caption': _("Reformat and add disks"),
+                                                   'clicked': add_drives,
+                                                   'style': "danger" } ]
+                                  });
+
+    function add_drives() {
+        var dfd = cockpit.defer();
+        var devs = drives.map(function (d) { return d.path });
+        if (docker_will_be_stopped)
+            client.close();
+
+        // We specify the driver explicitly here.  This is to make
+        // sure that docker-storage-setup uses the driver that docker
+        // is currently using, and doesn't unexpectantly change it to
+        // something else.
+        //
+        var args = { "devs": devs, "driver": model.driver };
+
+        var process = python.spawn(cockpit_atomic_storage, [ "add", JSON.stringify(args) ],
+                                   { 'err': 'out',
+                                     'superuser': true })
+                .done(function () {
+                    if (docker_will_be_stopped) {
+                        client.connect().done(function () {
+                            dfd.resolve();
+                        });
+                    } else {
+                        dfd.resolve();
+                    }
+                })
+                .fail(function (error, data) {
+                    if (docker_will_be_stopped)
+                        client.connect();
+                    if (error.problem == "cancelled") {
+                        dfd.resolve();
+                        return;
+                    }
+                    dfd.reject(
+                        <div>
+                            <span>{_("Could not add all disks")}</span>
+                            <pre>{data}</pre>
+                        </div>);
+                });
+        var promise = dfd.promise();
+        promise.cancel = function () {
+            process.close("cancelled");
+        };
+        return promise;
+    }
+}
+
+function reset_storage(client) {
+    dialog_view.show_modal_dialog({ 'title': _("Reset Storage Pool"),
+                                    'body': (
+                                        <div className="modal-body">
+                                            <p>{_("Resetting the storage pool will erase all containers and release disks in the pool.")}</p>
+                                        </div>),
+    },
+                                  { 'actions': [ { 'caption': _("Erase containers and reset storage pool"),
+                                                   'clicked': reset,
+                                                   'style': "danger" } ]
+                                  });
+    function reset() {
+        var dfd = cockpit.defer();
+        client.close();
+        var process = python.spawn(cockpit_atomic_storage, ["reset-and-reduce"],
+                                   { 'err': 'out',
+                                     'superuser': true })
+                .done(function () {
+                    client.connect().done(dfd.resolve);
+                })
+                .fail(function (error, data) {
+                    client.connect();
+                    if (error.problem == "cancelled") {
+                        dfd.resolve();
+                        return;
+                    }
+                    dfd.reject(
+                        <div>
+                            <span>{_("Could not reset the storage pool")}</span>
+                            <pre>{data}</pre>
+                        </div>);
+                });
+        var promise = dfd.promise();
+        promise.cancel = function () {
+            process.close("cancelled");
+        };
+        return promise;
+    }
+}
+
+function init_storage(client) {
+    $('#storage .breadcrumb a').on("click", function() {
+        cockpit.location.go('/');
+    });
+
+    $('#storage-reset').on('click', function () { reset_storage(client) });
+
+    function add_callback(drives, model) {
+        add_storage(client, drives, model);
+    }
+
+    var model = get_storage_model();
+
+    ReactDOM.render(<DriveBox model={model} callback={add_callback} />,
+                    $("#storage-drives")[0]);
+    ReactDOM.render(<PoolBox model={model} />,
+                    $("#storage-pool")[0]);
+    ReactDOM.render(<OverviewBox model={model} />,
+                    $("#storage-overview")[0]);
+
+    function update() {
+        if (model.error) {
+            if (model.error == "access-denied")
+                $('#storage-unsupported-message').text(
+                    _("You don't have permission to manage the Docker storage pool."));
+            else
+                $('#storage-unsupported-message').text(
+                    _("The Docker storage pool cannot be managed on this system."));
+            $("#storage-unsupported").show();
+            $("#storage-details").hide();
+        } else {
+            $("#storage-unsupported").hide();
+            $("#storage-details").show();
+            $("#storage-reset").toggle(model.driver == "devicemapper");
+        }
+    }
+
+    $(model).on("changed", update);
+    update();
+
+    function hide() {
+        $('#storage').hide();
+    }
+
+    function show() {
+        $('#storage').show();
+    }
+
+    return {
+        show: show,
+        hide: hide
     };
-}());
+}
+
+module.exports = {
+    get_storage_model: get_storage_model,
+    OverviewBox: OverviewBox,
+
+    init: init_storage
+};

--- a/pkg/docker/util.js
+++ b/pkg/docker/util.js
@@ -17,720 +17,718 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
+var $ = require("jquery");
+var cockpit = require("cockpit");
 
-    var Mustache = require("mustache");
-    require("patterns");
+var Mustache = require("mustache");
+require("patterns");
 
-    var docker = require("./docker");
-    var bar = require("./bar");
-    var journal = require("journal");
-    var moment = require("moment");
-    moment.locale(cockpit.language);
+var docker = require("./docker");
+var bar = require("./bar");
+var journal = require("journal");
+var moment = require("moment");
+moment.locale(cockpit.language);
 
-    var _ = cockpit.gettext;
+var _ = cockpit.gettext;
 
-    var util = { };
+var util = { };
 
-    util.resource_debug = function resource_debug() {
-        if (window.debugging == "all" || window.debugging == "resource")
-            console.debug.apply(console, arguments);
-    };
+util.resource_debug = function resource_debug() {
+    if (window.debugging == "all" || window.debugging == "resource")
+        console.debug.apply(console, arguments);
+};
 
-    util.docker_debug = function docker_debug() {
-        if (window.debugging == "all" || window.debugging == "docker")
-            console.debug.apply(console, arguments);
-    };
+util.docker_debug = function docker_debug() {
+    if (window.debugging == "all" || window.debugging == "docker")
+        console.debug.apply(console, arguments);
+};
 
-    util.quote_cmdline = function quote_cmdline(cmds) {
-        return docker.quote_cmdline(cmds || []);
-    };
+util.quote_cmdline = function quote_cmdline(cmds) {
+    return docker.quote_cmdline(cmds || []);
+};
 
-    util.unquote_cmdline = function unquote_cmdline(string) {
-        return docker.unquote_cmdline(string);
-    };
+util.unquote_cmdline = function unquote_cmdline(string) {
+    return docker.unquote_cmdline(string);
+};
 
-    util.render_container_cmdline = function render_container_cmdline (container) {
-        // We do our own quoting in preference to using container.Command.
-        // We do this for consistency, and also to avoid bugs in how
-        // Docker creates container.Command.  Docker doesn't escape quote
-        // characters, for example.
+util.render_container_cmdline = function render_container_cmdline (container) {
+    // We do our own quoting in preference to using container.Command.
+    // We do this for consistency, and also to avoid bugs in how
+    // Docker creates container.Command.  Docker doesn't escape quote
+    // characters, for example.
 
-        if (container.Config)
-            return util.quote_cmdline((container.Config.Entrypoint || []).concat(container.Config.Cmd || []));
-        else
-            return container.Command;
-    };
+    if (container.Config)
+        return util.quote_cmdline((container.Config.Entrypoint || []).concat(container.Config.Cmd || []));
+    else
+        return container.Command;
+};
 
-    /*
-     * Recent versions of docker have a 'Status' field in the state,
-     * but earlier versions have distinct fields which we need to combine.
-     */
-    util.render_container_status = function render_container_status(state) {
-        if (state.Status)
-            return state.Status;
-        if (state.Running)
-            return "running";
-        if (state.Paused)
-            return "paused";
-        if (state.Restarting)
-            return "restarting";
-        if (state.FinishedAt && state.FinishedAt.indexOf("0001") === 0)
-            return "created";
-        return "exited";
-    };
+/*
+ * Recent versions of docker have a 'Status' field in the state,
+ * but earlier versions have distinct fields which we need to combine.
+ */
+util.render_container_status = function render_container_status(state) {
+    if (state.Status)
+        return state.Status;
+    if (state.Running)
+        return "running";
+    if (state.Paused)
+        return "paused";
+    if (state.Restarting)
+        return "restarting";
+    if (state.FinishedAt && state.FinishedAt.indexOf("0001") === 0)
+        return "created";
+    return "exited";
+};
 
-    util.render_container_name = function render_container_name (name) {
-        if (name.length > 0 && name[0] == "/")
-            return name.slice(1);
-        else
-            return name;
-    };
+util.render_container_name = function render_container_name (name) {
+    if (name.length > 0 && name[0] == "/")
+        return name.slice(1);
+    else
+        return name;
+};
 
-    util.render_container_state = function render_container_state (state) {
-        if (state.Running) {
-            var momentDate = moment(state.StartedAt);
-            return cockpit.format(_("Up since $0"), momentDate.isValid()
-                ? momentDate.calendar() : state.startedAt);
-        }
-        return cockpit.format(_("Exited $ExitCode"), state);
-    };
+util.render_container_state = function render_container_state (state) {
+    if (state.Running) {
+        var momentDate = moment(state.StartedAt);
+        return cockpit.format(_("Up since $0"), momentDate.isValid()
+            ? momentDate.calendar() : state.startedAt);
+    }
+    return cockpit.format(_("Exited $ExitCode"), state);
+};
 
-    util.render_container_restart_policy = function render_restart_policy(policy) {
-        switch (policy.Name) {
-        case "no":
-            return _("No");
-        case "on-failure":
-            var text = cockpit.ngettext("On failure, retry $0 time", "On failure, retry $0 times", policy.MaximumRetryCount);
-            return cockpit.format(text, policy.MaximumRetryCount);
-        case "always":
-            return _("Always");
-        case "unless-stopped":
-            return _("Unless Stopped");
-        default: /* Keeping this here just in case. http://stackoverflow.com/a/4878800 */
-            return policy.Name.replace('-', ' ').replace(/\w\S*/g, function(txt) {
-                return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-            });
-        }
-    };
-
-    util.multi_line = function multi_line(strings) {
-        return strings.map(function (str) { return Mustache.render("{{.}}", str) }).join('<br/>');
-    };
-
-    util.format_cpu_shares = function format_cpu_shares(priority) {
-        if (!priority)
-            return _("default");
-        return cockpit.format(_("$0 shares"), Math.round(priority));
-    };
-
-    util.format_cpu_usage = function format_cpu_usage(usage) {
-        if (usage === undefined || isNaN(usage))
-            return "";
-        return Math.round(usage) + "%";
-    };
-
-    util.update_memory_bar = function update_memory_bar(bar, usage, limit) {
-        var parts = [ usage ];
-        if (limit)
-            parts.push(limit);
-        $(bar)
-                .attr("value", parts.join("/"))
-                .toggleClass("bar-row-danger", !!(limit && usage > 0.9 * limit));
-    };
-
-    util.format_memory_and_limit = function format_memory_and_limit(usage, limit) {
-        if (usage === undefined || isNaN(usage))
-            return "";
-
-        var mtext = "";
-        var units = 1024;
-        var parts;
-        if (limit) {
-            parts = cockpit.format_bytes(limit, units, true);
-            mtext = " / " + parts.join(" ");
-            units = parts[1];
-        }
-
-        if (usage) {
-            parts = cockpit.format_bytes(usage, units, true);
-            if (mtext)
-                return parts[0] + mtext;
-            else
-                return parts.join(" ");
-        } else {
-            return "?" + mtext;
-        }
-    };
-
-    util.insert_table_sorted = function insert_table_sorted(table, row) {
-        util.insert_table_sorted_generic(table, row, function(row1, row2) {
-            return row1.text().localeCompare(row2.text());
+util.render_container_restart_policy = function render_restart_policy(policy) {
+    switch (policy.Name) {
+    case "no":
+        return _("No");
+    case "on-failure":
+        var text = cockpit.ngettext("On failure, retry $0 time", "On failure, retry $0 times", policy.MaximumRetryCount);
+        return cockpit.format(text, policy.MaximumRetryCount);
+    case "always":
+        return _("Always");
+    case "unless-stopped":
+        return _("Unless Stopped");
+    default: /* Keeping this here just in case. http://stackoverflow.com/a/4878800 */
+        return policy.Name.replace('-', ' ').replace(/\w\S*/g, function(txt) {
+            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
         });
-    };
+    }
+};
 
-    util.insert_table_sorted_generic = function insert_table_sorted_generic(table, row, cmp) {
-        var rows = $(table).find("tbody tr");
-        for (var j = 0; j < rows.length; j++) {
-            if (cmp($(rows[j]), row) > 0) {
-                $(row).insertBefore(rows[j]);
-                row = null;
-                break;
-            }
-        }
-        if (row !== null)
-            $(table).find("tbody")
-                    .append(row);
-    };
+util.multi_line = function multi_line(strings) {
+    return strings.map(function (str) { return Mustache.render("{{.}}", str) }).join('<br/>');
+};
 
-    util.setup_danger_button = function setup_danger_button(id, parent_id, callback) {
-        var danger_button = $('<button class="btn btn-default btn-control-ct fa fa-check enable-danger">')
-                .toggle(false)
-                .on("click", callback);
-        $(id + ' th.container-column-actions').append(danger_button);
-        $(parent_id)[0].addEventListener("click", function(ev) {
-            if ($(ev.target).parents(id).length === 0 &&
-                $(id + ' button.enable-danger').hasClass('active'))
-                callback();
-        }, true);
-    };
+util.format_cpu_shares = function format_cpu_shares(priority) {
+    if (!priority)
+        return _("default");
+    return cockpit.format(_("$0 shares"), Math.round(priority));
+};
 
-    util.render_container = function render_container(client, $panel,
-        prefix, id, container, danger_mode) {
-        // Docker ID can contain funny characters such as ":" so
-        // we take care not to embed them into jQuery query
-        // strings or HTML.
+util.format_cpu_usage = function format_cpu_usage(usage) {
+    if (usage === undefined || isNaN(usage))
+        return "";
+    return Math.round(usage) + "%";
+};
 
-        var tr = $(document.getElementById(prefix + id));
+util.update_memory_bar = function update_memory_bar(bar, usage, limit) {
+    var parts = [ usage ];
+    if (limit)
+        parts.push(limit);
+    $(bar)
+            .attr("value", parts.join("/"))
+            .toggleClass("bar-row-danger", !!(limit && usage > 0.9 * limit));
+};
 
-        if (!container) {
-            tr.remove();
-            if (!$panel.find('table > tbody > tr').length) {
-                $panel.find('button.enable-danger').toggle(false);
-            }
-            return;
-        }
+util.format_memory_and_limit = function format_memory_and_limit(usage, limit) {
+    if (usage === undefined || isNaN(usage))
+        return "";
 
-        var cputext;
-        var memuse, memlimit;
-        var membar, memtext, memtextstyle;
-
-        if (container.State && container.State.Running) {
-            cputext = util.format_cpu_usage(container.CpuUsage);
-
-            memuse = container.MemoryUsage;
-            memlimit = container.MemoryLimit;
-            memtext = util.format_memory_and_limit(memuse, memlimit);
-
-            membar = true;
-            memtextstyle = { 'color': 'inherit' };
-        } else {
-            cputext = "";
-            membar = false;
-            memtext = _("Stopped");
-            memtextstyle = { 'color': 'grey', 'text-align': 'right' };
-        }
-
-        var added = false;
-        if (!tr.length) {
-            $panel.find('button.enable-danger').toggle(true);
-            var img_waiting = $('<div class="spinner">');
-            var btn_delete = $('<button class="btn btn-danger pficon pficon-delete btn-delete">')
-                    .on("click", function() {
-                        var self = this;
-                        $(self).hide()
-                                .siblings("div.spinner")
-                                .show();
-                        util.docker_container_delete(client, id, function() { }, function () {
-                            $(self).show()
-                                    .siblings("div.spinner")
-                                    .hide();
-                        });
-                        return false;
-                    });
-            var btn_play = $('<button class="btn btn-default btn-control-ct fa fa-play">')
-                    .on("click", function() {
-                        $(this).hide()
-                                .siblings("div.spinner")
-                                .show();
-                        client.start(id)
-                                .fail(function(ex) {
-                                    util.handle_scope_start_container(client, id, ex.message);
-                                });
-                        return false;
-                    });
-            var btn_stop = $('<button class="btn btn-default btn-control-ct fa fa-stop">')
-                    .on("click", function() {
-                        $(this).hide()
-                                .siblings("div.spinner")
-                                .show();
-                        client.stop(id)
-                                .fail(function(ex) {
-                                    util.show_unexpected_error(ex);
-                                });
-                        return false;
-                    });
-            tr = $('<tr>', { 'id': prefix + id }).append(
-                $('<td class="container-column-name">'),
-                $('<td class="container-column-image">'),
-                $('<td class="container-column-command">'),
-                $('<td class="container-column-cpu">'),
-                $('<td class="container-column-memory-graph">').append(bar.create("containers-containers")),
-                $('<td class="container-column-memory-text">'),
-                $('<td class="container-column-danger cell-buttons">').append(btn_delete, img_waiting),
-                $('<td class="container-column-actions cell-buttons">').append(btn_play, btn_stop, img_waiting.clone()));
-
-            tr.on('click', function(event) {
-                cockpit.location.go([ id ]);
-            });
-
-            added = true;
-        }
-
-        var row = tr.children("td");
-        $(row[0]).text(util.render_container_name(container.Name));
-
-        var image = container.Image;
-        if (container.ImageID && image == container.ImageID)
-            image = docker.truncate_id(image);
-        $(row[1]).text(image);
-
-        $(row[2]).text(util.render_container_cmdline(container));
-        $(row[3]).text(cputext);
-        util.update_memory_bar($(row[4]).children("div")
-                .toggle(membar), memuse, memlimit);
-        $(row[5])
-                .css(memtextstyle)
-                .text(memtext);
-
-        var waiting = id in client.waiting;
-        $(row[6]).children("div.spinner")
-                .toggle(waiting);
-        $(row[6]).children("button.btn-delete")
-                .toggle(!waiting)
-                .toggleClass('disabled', container.State.Running);
-
-        var title = (waiting || container.State.Running) ? "You can only delete<br/> stopped containers" : "Delete immediately";
-
-        $(row[6]).children("button.btn-delete")
-                .tooltip('destroy')
-                .attr("title", title)
-                .tooltip({html: true});
-
-        $(row[7]).children("div.spinner")
-                .toggle(waiting);
-        $(row[7]).children("button.fa-play")
-                .toggle(!waiting && !container.State.Running);
-        $(row[7]).children("button.fa-stop")
-                .toggle(!waiting && container.State.Running);
-
-        $(row[6]).toggle(danger_mode);
-        $(row[7]).toggle(!danger_mode);
-
-        tr.toggleClass("unimportant", !container.State.Running);
-
-        if (added)
-            util.insert_table_sorted($panel.find('table'), tr);
-
-        bar.update();
-    };
-
-    /* Slider/text/checkbox interaction happens here */
-    function Slider(sel, min, max, parse, format) {
-        var self = this;
-        var slider, input, check;
-        var updating = false;
-        var data;
-
-        /* Logarithmic scale */
-        if (min < 0)
-            min = 0;
-        if (max < 0)
-            max = 0;
-        var minv = Math.log(min);
-        var maxv = Math.log(max);
-        var scale = (maxv - minv);
-
-        function limit(val) {
-            if (val < min)
-                val = min;
-            else if (val > max)
-                val = max;
-            return val;
-        }
-
-        function slider_load() {
-            if (check.checked)
-                data = limit(Math.round(Math.exp(minv + scale * slider.value)));
-            else
-                data = undefined;
-        }
-
-        function slider_update() {
-            updating = true;
-            if (data !== undefined)
-                $(slider).prop("value", (Math.log(data) - minv) / scale);
-            $(slider)
-                    .attr("disabled", !check.checked)
-                    .trigger("change");
-            updating = false;
-        }
-
-        function text_load() {
-            var val;
-            if (check.checked)
-                val = limit(parse($(input).val()));
-            else
-                val = undefined;
-            if (isNaN(val))
-                val = undefined;
-            data = val;
-        }
-
-        function text_update() {
-            updating = true;
-            if (data !== undefined)
-                $(input).val(format(data));
-            $(input).attr("disabled", data === undefined);
-            updating = false;
-        }
-
-        function check_load() {
-            if (!check.checked)
-                data = undefined;
-        }
-
-        function check_update() {
-            updating = true;
-            $(check).prop("checked", data !== undefined);
-            updating = false;
-        }
-
-        /* Slider to change CPU priority */
-        slider = sel.find("div.slider")
-                .on('change', function() {
-                    if (updating)
-                        return;
-                    slider_load();
-                    text_update();
-                })[0];
-
-        /* Number value of CPU priority */
-        input = sel.find("input.size-text-ct")
-                .on('change', function() {
-                    if (updating)
-                        return;
-                    text_load();
-                    slider_update();
-                })[0];
-
-        /* Default checkbox */
-        check = sel.find("input[type='checkbox']")
-                .on('change', function() {
-                    if (updating)
-                        return;
-                    check_load();
-                    if (this.checked)
-                        text_load();
-                    slider_update();
-                    text_update();
-                })[0];
-
-        Object.defineProperty(self, "value", {
-            get: function() {
-                return data;
-            },
-            set: function(v) {
-                data = v;
-                check_update();
-                slider_update();
-                text_update();
-            }
-        });
-
-        Object.defineProperty(self, "max", {
-            get: function() {
-                return max;
-            },
-            set: function(v) {
-                if (v < 0)
-                    v = 0;
-                max = v;
-                maxv = Math.log(max);
-                scale = (maxv - minv);
-                if (slider)
-                    slider_update();
-            }
-        });
-
-        return self;
+    var mtext = "";
+    var units = 1024;
+    var parts;
+    if (limit) {
+        parts = cockpit.format_bytes(limit, units, true);
+        mtext = " / " + parts.join(" ");
+        units = parts[1];
     }
 
-    /* Memory limit slider/checkbox interaction happens here */
-    util.MemorySlider = function MemorySlider(sel, min, max) {
-        function parse(val) {
-            return parseInt(val, 10) * 1024 * 1024;
-        }
-
-        function format(val) {
-            return cockpit.format_bytes(val, "MiB", true)[0];
-        }
-
-        return new Slider(sel, min, max, parse, format);
-    };
-
-    /* CPU priority slider/checkbox interaction happens here */
-    util.CpuSlider = function CpuSlider(sel, min, max) {
-        function parse(val) {
-            return parseInt(val, 10);
-        }
-
-        function format(val) {
-            return String(val);
-        }
-
-        return new Slider(sel, min, max, parse, format);
-    };
-
-    util.docker_container_delete = function docker_container_delete(docker_client, container_id, on_success, on_failure) {
-        docker_client.rm(container_id)
-                .fail(function(ex) {
-                /* if container is still running, ask user to force delete */
-                    if (ex.message.indexOf('remove a running container') > -1) {
-                        var container_info = docker_client.containers[container_id];
-                        var msg;
-                        if (container_info.State.Running) {
-                            msg = _("Container is currently running.");
-                        } else {
-                            msg = _("Container is currently marked as not running, but regular stopping failed.") +
-                            " " + _("Error message from Docker:") +
-                            " '" + ex.message + "'";
-                        }
-                        var name;
-                        if (container_info.Name)
-                            name = container_info.Name;
-                        else
-                            name = container_id;
-                        if (name.charAt(0) === '/')
-                            name = name.substring(1);
-                        util.confirm(cockpit.format(_("Please confirm forced deletion of $0"), name),
-                                     msg,
-                                     _("Force Delete"))
-                                .done(function () {
-                                    docker_client.rm(container_id, true)
-                                            .fail(function(ex) {
-                                                util.show_unexpected_error(ex);
-                                                on_failure();
-                                            })
-                                            .done(on_success);
-                                })
-                                .fail(on_failure);
-                        return;
-                    }
-                    util.show_unexpected_error(ex);
-                    on_failure();
-                })
-                .done(on_success);
-    };
-
-    /* if error message points to leftover scope, try to resolve the issue */
-    util.handle_scope_start_container = function handle_scope_start_container(docker_client, container_id, error_message, on_success, on_failure) {
-        var end_phrase = '.scope already exists';
-        var idx_end = error_message.indexOf(end_phrase);
-        /* HACK: workaround for https://github.com/docker/docker/issues/7015 */
-        if (idx_end > -1) {
-            var start_phrase = 'Unit docker-';
-            var idx_start = error_message.indexOf(start_phrase) + start_phrase.length;
-            var docker_container = error_message.substring(idx_start, idx_end);
-            cockpit.spawn([ "systemctl", "stop", "docker-" + docker_container + ".scope" ], { "superuser": "try" })
-                    .done(function () {
-                        docker_client.start(container_id)
-                                .fail(function(ex) {
-                                    if (on_failure)
-                                        on_failure();
-                                })
-                                .done(function() {
-                                    if (on_success)
-                                        on_success();
-                                });
-                    })
-                    .fail(function (error) {
-                        util.show_unexpected_error(cockpit.format(_("Failed to stop Docker scope: $0"), error));
-                        if (on_failure)
-                            on_failure();
-                    });
-            return;
-        }
-        util.show_unexpected_error(error_message);
-        if (on_failure)
-            on_failure();
-    };
-
-    util.show_unexpected_error = function show_unexpected_error(error) {
-        $("#error-popup-message").text(error.message || error || "???");
-        $('.modal[role="dialog"]').modal('hide');
-        $('#error-popup').modal('show');
-    };
-
-    util.confirm = function confirm(title, body, action_text) {
-        var deferred = $.Deferred();
-
-        $('#confirmation-dialog-title').text(title);
-        if (typeof body == "string")
-            $('#confirmation-dialog-body').text(body);
+    if (usage) {
+        parts = cockpit.format_bytes(usage, units, true);
+        if (mtext)
+            return parts[0] + mtext;
         else
-            $('#confirmation-dialog-body').html(body);
-        $('#confirmation-dialog-confirm').text(action_text);
+            return parts.join(" ");
+    } else {
+        return "?" + mtext;
+    }
+};
 
-        function close() {
-            $('#confirmation-dialog button').off('click');
-            $('#confirmation-dialog').modal('hide');
+util.insert_table_sorted = function insert_table_sorted(table, row) {
+    util.insert_table_sorted_generic(table, row, function(row1, row2) {
+        return row1.text().localeCompare(row2.text());
+    });
+};
+
+util.insert_table_sorted_generic = function insert_table_sorted_generic(table, row, cmp) {
+    var rows = $(table).find("tbody tr");
+    for (var j = 0; j < rows.length; j++) {
+        if (cmp($(rows[j]), row) > 0) {
+            $(row).insertBefore(rows[j]);
+            row = null;
+            break;
         }
+    }
+    if (row !== null)
+        $(table).find("tbody")
+                .append(row);
+};
 
-        $('#confirmation-dialog-confirm').click(function () {
-            close();
-            deferred.resolve();
+util.setup_danger_button = function setup_danger_button(id, parent_id, callback) {
+    var danger_button = $('<button class="btn btn-default btn-control-ct fa fa-check enable-danger">')
+            .toggle(false)
+            .on("click", callback);
+    $(id + ' th.container-column-actions').append(danger_button);
+    $(parent_id)[0].addEventListener("click", function(ev) {
+        if ($(ev.target).parents(id).length === 0 &&
+            $(id + ' button.enable-danger').hasClass('active'))
+            callback();
+    }, true);
+};
+
+util.render_container = function render_container(client, $panel,
+    prefix, id, container, danger_mode) {
+    // Docker ID can contain funny characters such as ":" so
+    // we take care not to embed them into jQuery query
+    // strings or HTML.
+
+    var tr = $(document.getElementById(prefix + id));
+
+    if (!container) {
+        tr.remove();
+        if (!$panel.find('table > tbody > tr').length) {
+            $panel.find('button.enable-danger').toggle(false);
+        }
+        return;
+    }
+
+    var cputext;
+    var memuse, memlimit;
+    var membar, memtext, memtextstyle;
+
+    if (container.State && container.State.Running) {
+        cputext = util.format_cpu_usage(container.CpuUsage);
+
+        memuse = container.MemoryUsage;
+        memlimit = container.MemoryLimit;
+        memtext = util.format_memory_and_limit(memuse, memlimit);
+
+        membar = true;
+        memtextstyle = { 'color': 'inherit' };
+    } else {
+        cputext = "";
+        membar = false;
+        memtext = _("Stopped");
+        memtextstyle = { 'color': 'grey', 'text-align': 'right' };
+    }
+
+    var added = false;
+    if (!tr.length) {
+        $panel.find('button.enable-danger').toggle(true);
+        var img_waiting = $('<div class="spinner">');
+        var btn_delete = $('<button class="btn btn-danger pficon pficon-delete btn-delete">')
+                .on("click", function() {
+                    var self = this;
+                    $(self).hide()
+                            .siblings("div.spinner")
+                            .show();
+                    util.docker_container_delete(client, id, function() { }, function () {
+                        $(self).show()
+                                .siblings("div.spinner")
+                                .hide();
+                    });
+                    return false;
+                });
+        var btn_play = $('<button class="btn btn-default btn-control-ct fa fa-play">')
+                .on("click", function() {
+                    $(this).hide()
+                            .siblings("div.spinner")
+                            .show();
+                    client.start(id)
+                            .fail(function(ex) {
+                                util.handle_scope_start_container(client, id, ex.message);
+                            });
+                    return false;
+                });
+        var btn_stop = $('<button class="btn btn-default btn-control-ct fa fa-stop">')
+                .on("click", function() {
+                    $(this).hide()
+                            .siblings("div.spinner")
+                            .show();
+                    client.stop(id)
+                            .fail(function(ex) {
+                                util.show_unexpected_error(ex);
+                            });
+                    return false;
+                });
+        tr = $('<tr>', { 'id': prefix + id }).append(
+            $('<td class="container-column-name">'),
+            $('<td class="container-column-image">'),
+            $('<td class="container-column-command">'),
+            $('<td class="container-column-cpu">'),
+            $('<td class="container-column-memory-graph">').append(bar.create("containers-containers")),
+            $('<td class="container-column-memory-text">'),
+            $('<td class="container-column-danger cell-buttons">').append(btn_delete, img_waiting),
+            $('<td class="container-column-actions cell-buttons">').append(btn_play, btn_stop, img_waiting.clone()));
+
+        tr.on('click', function(event) {
+            cockpit.location.go([ id ]);
         });
 
-        $('#confirmation-dialog-cancel').click(function () {
+        added = true;
+    }
+
+    var row = tr.children("td");
+    $(row[0]).text(util.render_container_name(container.Name));
+
+    var image = container.Image;
+    if (container.ImageID && image == container.ImageID)
+        image = docker.truncate_id(image);
+    $(row[1]).text(image);
+
+    $(row[2]).text(util.render_container_cmdline(container));
+    $(row[3]).text(cputext);
+    util.update_memory_bar($(row[4]).children("div")
+            .toggle(membar), memuse, memlimit);
+    $(row[5])
+            .css(memtextstyle)
+            .text(memtext);
+
+    var waiting = id in client.waiting;
+    $(row[6]).children("div.spinner")
+            .toggle(waiting);
+    $(row[6]).children("button.btn-delete")
+            .toggle(!waiting)
+            .toggleClass('disabled', container.State.Running);
+
+    var title = (waiting || container.State.Running) ? "You can only delete<br/> stopped containers" : "Delete immediately";
+
+    $(row[6]).children("button.btn-delete")
+            .tooltip('destroy')
+            .attr("title", title)
+            .tooltip({html: true});
+
+    $(row[7]).children("div.spinner")
+            .toggle(waiting);
+    $(row[7]).children("button.fa-play")
+            .toggle(!waiting && !container.State.Running);
+    $(row[7]).children("button.fa-stop")
+            .toggle(!waiting && container.State.Running);
+
+    $(row[6]).toggle(danger_mode);
+    $(row[7]).toggle(!danger_mode);
+
+    tr.toggleClass("unimportant", !container.State.Running);
+
+    if (added)
+        util.insert_table_sorted($panel.find('table'), tr);
+
+    bar.update();
+};
+
+/* Slider/text/checkbox interaction happens here */
+function Slider(sel, min, max, parse, format) {
+    var self = this;
+    var slider, input, check;
+    var updating = false;
+    var data;
+
+    /* Logarithmic scale */
+    if (min < 0)
+        min = 0;
+    if (max < 0)
+        max = 0;
+    var minv = Math.log(min);
+    var maxv = Math.log(max);
+    var scale = (maxv - minv);
+
+    function limit(val) {
+        if (val < min)
+            val = min;
+        else if (val > max)
+            val = max;
+        return val;
+    }
+
+    function slider_load() {
+        if (check.checked)
+            data = limit(Math.round(Math.exp(minv + scale * slider.value)));
+        else
+            data = undefined;
+    }
+
+    function slider_update() {
+        updating = true;
+        if (data !== undefined)
+            $(slider).prop("value", (Math.log(data) - minv) / scale);
+        $(slider)
+                .attr("disabled", !check.checked)
+                .trigger("change");
+        updating = false;
+    }
+
+    function text_load() {
+        var val;
+        if (check.checked)
+            val = limit(parse($(input).val()));
+        else
+            val = undefined;
+        if (isNaN(val))
+            val = undefined;
+        data = val;
+    }
+
+    function text_update() {
+        updating = true;
+        if (data !== undefined)
+            $(input).val(format(data));
+        $(input).attr("disabled", data === undefined);
+        updating = false;
+    }
+
+    function check_load() {
+        if (!check.checked)
+            data = undefined;
+    }
+
+    function check_update() {
+        updating = true;
+        $(check).prop("checked", data !== undefined);
+        updating = false;
+    }
+
+    /* Slider to change CPU priority */
+    slider = sel.find("div.slider")
+            .on('change', function() {
+                if (updating)
+                    return;
+                slider_load();
+                text_update();
+            })[0];
+
+    /* Number value of CPU priority */
+    input = sel.find("input.size-text-ct")
+            .on('change', function() {
+                if (updating)
+                    return;
+                text_load();
+                slider_update();
+            })[0];
+
+    /* Default checkbox */
+    check = sel.find("input[type='checkbox']")
+            .on('change', function() {
+                if (updating)
+                    return;
+                check_load();
+                if (this.checked)
+                    text_load();
+                slider_update();
+                text_update();
+            })[0];
+
+    Object.defineProperty(self, "value", {
+        get: function() {
+            return data;
+        },
+        set: function(v) {
+            data = v;
+            check_update();
+            slider_update();
+            text_update();
+        }
+    });
+
+    Object.defineProperty(self, "max", {
+        get: function() {
+            return max;
+        },
+        set: function(v) {
+            if (v < 0)
+                v = 0;
+            max = v;
+            maxv = Math.log(max);
+            scale = (maxv - minv);
+            if (slider)
+                slider_update();
+        }
+    });
+
+    return self;
+}
+
+/* Memory limit slider/checkbox interaction happens here */
+util.MemorySlider = function MemorySlider(sel, min, max) {
+    function parse(val) {
+        return parseInt(val, 10) * 1024 * 1024;
+    }
+
+    function format(val) {
+        return cockpit.format_bytes(val, "MiB", true)[0];
+    }
+
+    return new Slider(sel, min, max, parse, format);
+};
+
+/* CPU priority slider/checkbox interaction happens here */
+util.CpuSlider = function CpuSlider(sel, min, max) {
+    function parse(val) {
+        return parseInt(val, 10);
+    }
+
+    function format(val) {
+        return String(val);
+    }
+
+    return new Slider(sel, min, max, parse, format);
+};
+
+util.docker_container_delete = function docker_container_delete(docker_client, container_id, on_success, on_failure) {
+    docker_client.rm(container_id)
+            .fail(function(ex) {
+            /* if container is still running, ask user to force delete */
+                if (ex.message.indexOf('remove a running container') > -1) {
+                    var container_info = docker_client.containers[container_id];
+                    var msg;
+                    if (container_info.State.Running) {
+                        msg = _("Container is currently running.");
+                    } else {
+                        msg = _("Container is currently marked as not running, but regular stopping failed.") +
+                        " " + _("Error message from Docker:") +
+                        " '" + ex.message + "'";
+                    }
+                    var name;
+                    if (container_info.Name)
+                        name = container_info.Name;
+                    else
+                        name = container_id;
+                    if (name.charAt(0) === '/')
+                        name = name.substring(1);
+                    util.confirm(cockpit.format(_("Please confirm forced deletion of $0"), name),
+                                 msg,
+                                 _("Force Delete"))
+                            .done(function () {
+                                docker_client.rm(container_id, true)
+                                        .fail(function(ex) {
+                                            util.show_unexpected_error(ex);
+                                            on_failure();
+                                        })
+                                        .done(on_success);
+                            })
+                            .fail(on_failure);
+                    return;
+                }
+                util.show_unexpected_error(ex);
+                on_failure();
+            })
+            .done(on_success);
+};
+
+/* if error message points to leftover scope, try to resolve the issue */
+util.handle_scope_start_container = function handle_scope_start_container(docker_client, container_id, error_message, on_success, on_failure) {
+    var end_phrase = '.scope already exists';
+    var idx_end = error_message.indexOf(end_phrase);
+    /* HACK: workaround for https://github.com/docker/docker/issues/7015 */
+    if (idx_end > -1) {
+        var start_phrase = 'Unit docker-';
+        var idx_start = error_message.indexOf(start_phrase) + start_phrase.length;
+        var docker_container = error_message.substring(idx_start, idx_end);
+        cockpit.spawn([ "systemctl", "stop", "docker-" + docker_container + ".scope" ], { "superuser": "try" })
+                .done(function () {
+                    docker_client.start(container_id)
+                            .fail(function(ex) {
+                                if (on_failure)
+                                    on_failure();
+                            })
+                            .done(function() {
+                                if (on_success)
+                                    on_success();
+                            });
+                })
+                .fail(function (error) {
+                    util.show_unexpected_error(cockpit.format(_("Failed to stop Docker scope: $0"), error));
+                    if (on_failure)
+                        on_failure();
+                });
+        return;
+    }
+    util.show_unexpected_error(error_message);
+    if (on_failure)
+        on_failure();
+};
+
+util.show_unexpected_error = function show_unexpected_error(error) {
+    $("#error-popup-message").text(error.message || error || "???");
+    $('.modal[role="dialog"]').modal('hide');
+    $('#error-popup').modal('show');
+};
+
+util.confirm = function confirm(title, body, action_text) {
+    var deferred = $.Deferred();
+
+    $('#confirmation-dialog-title').text(title);
+    if (typeof body == "string")
+        $('#confirmation-dialog-body').text(body);
+    else
+        $('#confirmation-dialog-body').html(body);
+    $('#confirmation-dialog-confirm').text(action_text);
+
+    function close() {
+        $('#confirmation-dialog button').off('click');
+        $('#confirmation-dialog').modal('hide');
+    }
+
+    $('#confirmation-dialog-confirm').click(function () {
+        close();
+        deferred.resolve();
+    });
+
+    $('#confirmation-dialog-cancel').click(function () {
+        close();
+        deferred.reject();
+    });
+
+    $('#confirmation-dialog').modal('show');
+    return deferred.promise();
+};
+
+util.delete_image_confirm = function confirm(client, image) {
+    var deferred = $.Deferred();
+    var image_id = image.image_id || image.Id;
+    var image_name = image.name || util.render_container_name(image.RepoTags[0]);
+    var $dialog = $('#delete-image-confirmation-dialog');
+
+    $dialog.find('#delete-image-confirmation-dialog-title').text(
+        cockpit.format(_("Please confirm deletion of $0"), image_name));
+    $dialog.find('#delete-image-confirmation-dialog-containers .listing-ct-body').empty();
+    client.containers_for_image(image_id).then(function(containers) {
+        var running_containers = [];
+
+        $(containers).each(function(index, value) {
+            var container = client.containers[value.Id];
+            var $row = $('<tr />', { 'class': 'listing-ct-item' })
+                    .append($('<td />').text(container.Name.startsWith('/')
+                        ? container.Name.substring(1) : container.Name))
+                    .append($('<td />').text(util.render_container_status(container.State)));
+            $dialog.find('#delete-image-confirmation-dialog-containers .listing-ct-body')
+                    .append($row);
+            if (container.State.Running)
+                running_containers.push(container.Id);
+        });
+
+        if (containers.length > 0) {
+            $dialog.find('#delete-image-confirmation-dialog-body').text(
+                _("The following containers depend on this image and will become unusable."));
+            $dialog.find('#delete-image-confirmation-dialog-containers').show();
+        } else {
+            $dialog.find('#delete-image-confirmation-dialog-body').empty();
+            $dialog.find('#delete-image-confirmation-dialog-containers').hide();
+        }
+
+        if (running_containers.length > 0)
+            $dialog.find('#delete-image-confirmation-dialog-confirm').text(_("Stop and delete"));
+        else
+            $dialog.find('#delete-image-confirmation-dialog-confirm').text(_("Delete"));
+
+        function close() {
+            $dialog.find('button').off('click');
+            $dialog.modal('hide');
+        }
+
+        $dialog.find('#delete-image-confirmation-dialog-confirm').click(function () {
+            close();
+            deferred.resolve(running_containers, containers.length > 0);
+        });
+
+        $dialog.find('#delete-image-confirmation-dialog-cancel').click(function () {
             close();
             deferred.reject();
         });
 
-        $('#confirmation-dialog').modal('show');
-        return deferred.promise();
-    };
+        $dialog.modal('show');
+    });
+    return deferred.promise();
+};
 
-    util.delete_image_confirm = function confirm(client, image) {
-        var deferred = $.Deferred();
-        var image_id = image.image_id || image.Id;
-        var image_name = image.name || util.render_container_name(image.RepoTags[0]);
-        var $dialog = $('#delete-image-confirmation-dialog');
-
-        $dialog.find('#delete-image-confirmation-dialog-title').text(
-            cockpit.format(_("Please confirm deletion of $0"), image_name));
-        $dialog.find('#delete-image-confirmation-dialog-containers .listing-ct-body').empty();
-        client.containers_for_image(image_id).then(function(containers) {
-            var running_containers = [];
-
-            $(containers).each(function(index, value) {
-                var container = client.containers[value.Id];
-                var $row = $('<tr />', { 'class': 'listing-ct-item' })
-                        .append($('<td />').text(container.Name.startsWith('/')
-                            ? container.Name.substring(1) : container.Name))
-                        .append($('<td />').text(util.render_container_status(container.State)));
-                $dialog.find('#delete-image-confirmation-dialog-containers .listing-ct-body')
-                        .append($row);
-                if (container.State.Running)
-                    running_containers.push(container.Id);
-            });
-
-            if (containers.length > 0) {
-                $dialog.find('#delete-image-confirmation-dialog-body').text(
-                    _("The following containers depend on this image and will become unusable."));
-                $dialog.find('#delete-image-confirmation-dialog-containers').show();
-            } else {
-                $dialog.find('#delete-image-confirmation-dialog-body').empty();
-                $dialog.find('#delete-image-confirmation-dialog-containers').hide();
-            }
-
-            if (running_containers.length > 0)
-                $dialog.find('#delete-image-confirmation-dialog-confirm').text(_("Stop and delete"));
-            else
-                $dialog.find('#delete-image-confirmation-dialog-confirm').text(_("Delete"));
-
-            function close() {
-                $dialog.find('button').off('click');
-                $dialog.modal('hide');
-            }
-
-            $dialog.find('#delete-image-confirmation-dialog-confirm').click(function () {
-                close();
-                deferred.resolve(running_containers, containers.length > 0);
-            });
-
-            $dialog.find('#delete-image-confirmation-dialog-cancel').click(function () {
-                close();
-                deferred.reject();
-            });
-
-            $dialog.modal('show');
-        });
-        return deferred.promise();
-    };
-
-    util.find_container_log = function find_container_log(client, entry, resultCallback) {
-        client.call(entry, "org.freedesktop.DBus.Properties", "GetAll",
-                    ["org.freedesktop.Problems2.Entry"])
-                .fail(function (error) {
-                    console.log(error);
-                })
-                .done(function (sem_result) {
-                    client.call(entry, "org.freedesktop.Problems2.Entry",
-                                "ReadElements", [['container_id'], 0x4])
-                            .fail(function (error) {
-                                console.log(error);
-                            })
-                            .done(function (elem_result) {
-                                if ('container_id' in elem_result[0]) {
-                                    var problem_id = sem_result[0]['ID'].v;
-                                    // Wait for a while, until ABRT processes the problem and writes it into journal
-                                    window.setTimeout(util.problem_log, 2000, 0, problem_id, elem_result[0]['container_id'].v, resultCallback);
-                                }
-                            });
-                });
-    };
-
-    util.problem_log = function problem_log (poll_count, problem_id, c_id, resultCallback) {
-        var url = null;
-        var message = "";
-        var match = [ ];
-        var log_found = false;
-        match.push('SYSLOG_IDENTIFIER=abrt-notification');
-        match.push('PROBLEM_DIR=' + problem_id);
-        journal.journalctl(match, { follow: false, reverse: true, all: true })
-                .stream(function(entries) {
-                    log_found = true;
-                    // Only first entry is enough, since others are only previous occurrences
-                    url = cockpit.location.encode(entries[0]['__CURSOR']);
-                    url = "/system/logs#" + url;
-                    if (entries[0]['PROBLEM_REASON'])
-                        message = entries[0]['PROBLEM_REASON'];
-                    else
-                        message = entries[0]['MESSAGE'];
-
-                    resultCallback(c_id, url, message);
-                })
-                .done(function() {
-                // Try pooling for minute, then give up
-                    if (!log_found) {
-                        if (poll_count < 30) {
-                            window.setTimeout(util.problem_log, 2000, ++poll_count, problem_id, c_id, resultCallback);
-                        } else {
-                            console.warn("No journal log found for problem " + problem_id);
-                        }
-                    }
-                });
-    };
-
-    util.find_all_problems = function find_problems(problems, client, service, resultCallback) {
-        problems.wait(function() {
-            try {
-                service.GetProblems(0, {})
-                        .done(function(problem_paths, options) {
-                            for (var i in problem_paths) {
-                                util.find_container_log(client, problem_paths[i], resultCallback);
+util.find_container_log = function find_container_log(client, entry, resultCallback) {
+    client.call(entry, "org.freedesktop.DBus.Properties", "GetAll",
+                ["org.freedesktop.Problems2.Entry"])
+            .fail(function (error) {
+                console.log(error);
+            })
+            .done(function (sem_result) {
+                client.call(entry, "org.freedesktop.Problems2.Entry",
+                            "ReadElements", [['container_id'], 0x4])
+                        .fail(function (error) {
+                            console.log(error);
+                        })
+                        .done(function (elem_result) {
+                            if ('container_id' in elem_result[0]) {
+                                var problem_id = sem_result[0]['ID'].v;
+                                // Wait for a while, until ABRT processes the problem and writes it into journal
+                                window.setTimeout(util.problem_log, 2000, 0, problem_id, elem_result[0]['container_id'].v, resultCallback);
                             }
                         });
-            } catch (err) {
-                /* ignore errors */
-            }
-        });
-    };
+            });
+};
 
-    module.exports = util;
-}());
+util.problem_log = function problem_log (poll_count, problem_id, c_id, resultCallback) {
+    var url = null;
+    var message = "";
+    var match = [ ];
+    var log_found = false;
+    match.push('SYSLOG_IDENTIFIER=abrt-notification');
+    match.push('PROBLEM_DIR=' + problem_id);
+    journal.journalctl(match, { follow: false, reverse: true, all: true })
+            .stream(function(entries) {
+                log_found = true;
+                // Only first entry is enough, since others are only previous occurrences
+                url = cockpit.location.encode(entries[0]['__CURSOR']);
+                url = "/system/logs#" + url;
+                if (entries[0]['PROBLEM_REASON'])
+                    message = entries[0]['PROBLEM_REASON'];
+                else
+                    message = entries[0]['MESSAGE'];
+
+                resultCallback(c_id, url, message);
+            })
+            .done(function() {
+            // Try pooling for minute, then give up
+                if (!log_found) {
+                    if (poll_count < 30) {
+                        window.setTimeout(util.problem_log, 2000, ++poll_count, problem_id, c_id, resultCallback);
+                    } else {
+                        console.warn("No journal log found for problem " + problem_id);
+                    }
+                }
+            });
+};
+
+util.find_all_problems = function find_problems(problems, client, service, resultCallback) {
+    problems.wait(function() {
+        try {
+            service.GetProblems(0, {})
+                    .done(function(problem_paths, options) {
+                        for (var i in problem_paths) {
+                            util.find_container_log(client, problem_paths[i], resultCallback);
+                        }
+                    });
+        } catch (err) {
+            /* ignore errors */
+        }
+    });
+};
+
+module.exports = util;

--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -23,184 +23,180 @@ import PropTypes from "prop-types";
 import Term from "term";
 import "console.css";
 
-(function() {
-    "use strict";
+/*
+ * A terminal component that communicates over a cockpit channel.
+ *
+ * The only required property is 'channel', which must point to a cockpit
+ * stream channel.
+ *
+ * The size of the terminal can be set with the 'rows' and 'cols'
+ * properties. If those properties are not given, the terminal will fill
+ * its container.
+ *
+ * If the 'onTitleChanged' callback property is set, it will be called whenever
+ * the title of the terminal changes.
+ *
+ * Call focus() to set the input focus on the terminal.
+ */
+class Terminal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.onChannelMessage = this.onChannelMessage.bind(this);
+        this.onChannelClose = this.onChannelClose.bind(this);
+        this.onWindowResize = this.onWindowResize.bind(this);
+        this.connectChannel = this.connectChannel.bind(this);
+        this.disconnectChannel = this.disconnectChannel.bind(this);
+        this.focus = this.focus.bind(this);
+        this.onWindowResize = this.onWindowResize.bind(this);
+        this.onFocusIn = this.onFocusIn.bind(this);
+        this.onFocusOut = this.onFocusOut.bind(this);
+    }
 
-    /*
-     * A terminal component that communicates over a cockpit channel.
-     *
-     * The only required property is 'channel', which must point to a cockpit
-     * stream channel.
-     *
-     * The size of the terminal can be set with the 'rows' and 'cols'
-     * properties. If those properties are not given, the terminal will fill
-     * its container.
-     *
-     * If the 'onTitleChanged' callback property is set, it will be called whenever
-     * the title of the terminal changes.
-     *
-     * Call focus() to set the input focus on the terminal.
-     */
-    class Terminal extends React.Component {
-        constructor(props) {
-            super(props);
-            this.onChannelMessage = this.onChannelMessage.bind(this);
-            this.onChannelClose = this.onChannelClose.bind(this);
-            this.onWindowResize = this.onWindowResize.bind(this);
-            this.connectChannel = this.connectChannel.bind(this);
-            this.disconnectChannel = this.disconnectChannel.bind(this);
-            this.focus = this.focus.bind(this);
-            this.onWindowResize = this.onWindowResize.bind(this);
-            this.onFocusIn = this.onFocusIn.bind(this);
-            this.onFocusOut = this.onFocusOut.bind(this);
-        }
+    componentWillMount() {
+        var term = new Term({
+            cols: this.props.cols || 80,
+            rows: this.props.rows || 25,
+            screenKeys: true
+        });
 
-        componentWillMount() {
-            var term = new Term({
-                cols: this.props.cols || 80,
-                rows: this.props.rows || 25,
-                screenKeys: true
-            });
+        term.on('data', function(data) {
+            if (this.props.channel.valid)
+                this.props.channel.send(data);
+        }.bind(this));
 
-            term.on('data', function(data) {
-                if (this.props.channel.valid)
-                    this.props.channel.send(data);
-            }.bind(this));
+        if (this.props.onTitleChanged)
+            term.on('title', this.props.onTitleChanged);
 
-            if (this.props.onTitleChanged)
-                term.on('title', this.props.onTitleChanged);
+        this.setState({ terminal: term });
+    }
 
-            this.setState({ terminal: term });
-        }
+    componentDidMount() {
+        this.state.terminal.open(this.refs.terminal);
+        this.connectChannel();
 
-        componentDidMount() {
-            this.state.terminal.open(this.refs.terminal);
-            this.connectChannel();
-
-            if (!this.props.rows) {
-                window.addEventListener('resize', this.onWindowResize);
-                this.onWindowResize();
-            }
-        }
-
-        componentWillUpdate(nextProps, nextState) {
-            if (nextState.cols !== this.state.cols || nextState.rows !== this.state.rows) {
-                this.state.terminal.resize(nextState.cols, nextState.rows);
-                this.props.channel.control({
-                    window: {
-                        rows: nextState.rows,
-                        cols: nextState.cols
-                    }
-                });
-            }
-
-            if (nextProps.channel !== this.props.channel) {
-                this.state.terminal.reset();
-                this.disconnectChannel();
-            }
-        }
-
-        componentDidUpdate(prevProps) {
-            if (prevProps.channel !== this.props.channel) {
-                this.connectChannel();
-                this.props.channel.control({
-                    window: {
-                        rows: this.state.rows,
-                        cols: this.state.cols
-                    }
-                });
-            }
-        }
-
-        render() {
-            // ensure react never reuses this div by keying it with the terminal widget
-            return <div ref="terminal"
-                        key={this.state.terminal}
-                        className="console-ct"
-                        onFocus={this.onFocusIn}
-                        onBlur={this.onFocusOut} />;
-        }
-
-        componentWillUnmount() {
-            this.disconnectChannel();
-            this.state.terminal.destroy();
-            window.removeEventListener('resize', this.onWindowResize);
-        }
-
-        onChannelMessage(event, data) {
-            this.state.terminal.write(data);
-        }
-
-        onChannelClose(event, options) {
-            var term = this.state.terminal;
-            term.write('\x1b[31m' + (options.problem || 'disconnected') + '\x1b[m\r\n');
-            term.cursorHidden = true;
-            term.refresh(term.y, term.y);
-        }
-
-        connectChannel() {
-            var channel = this.props.channel;
-            if (channel && channel.valid) {
-                channel.addEventListener('message', this.onChannelMessage.bind(this));
-                channel.addEventListener('close', this.onChannelClose.bind(this));
-            }
-        }
-
-        disconnectChannel() {
-            if (this.props.channel) {
-                this.props.channel.removeEventListener('message', this.onChannelMessage);
-                this.props.channel.removeEventListener('close', this.onChannelClose);
-            }
-        }
-
-        focus() {
-            if (this.state.terminal)
-                this.state.terminal.focus();
-        }
-
-        onWindowResize() {
-            var padding = 2 * 11;
-            var node = ReactDOM.findDOMNode(this);
-            var terminal = this.refs.terminal.querySelector('.terminal');
-
-            var ch = document.createElement('span');
-            ch.textContent = 'M';
-            ch.style.position = 'absolute';
-            terminal.appendChild(ch);
-            var rect = ch.getBoundingClientRect();
-            terminal.removeChild(ch);
-
-            this.setState({
-                rows: Math.floor((node.parentElement.clientHeight - padding) / rect.height),
-                cols: Math.floor((node.parentElement.clientWidth - padding) / rect.width)
-            });
-        }
-
-        onBeforeUnload(event) {
-            // Firefox requires this when the page is in an iframe
-            event.preventDefault();
-
-            // see "an almost cross-browser solution" at
-            // https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload
-            event.returnValue = '';
-            return '';
-        }
-
-        onFocusIn() {
-            window.addEventListener('beforeunload', this.onBeforeUnload);
-        }
-
-        onFocusOut() {
-            window.removeEventListener('beforeunload', this.onBeforeUnload);
+        if (!this.props.rows) {
+            window.addEventListener('resize', this.onWindowResize);
+            this.onWindowResize();
         }
     }
 
-    Terminal.propTypes = {
-        cols: PropTypes.number,
-        rows: PropTypes.number,
-        channel: PropTypes.object.isRequired,
-        onTitleChanged: PropTypes.func
-    };
+    componentWillUpdate(nextProps, nextState) {
+        if (nextState.cols !== this.state.cols || nextState.rows !== this.state.rows) {
+            this.state.terminal.resize(nextState.cols, nextState.rows);
+            this.props.channel.control({
+                window: {
+                    rows: nextState.rows,
+                    cols: nextState.cols
+                }
+            });
+        }
 
-    module.exports = { Terminal: Terminal };
-}());
+        if (nextProps.channel !== this.props.channel) {
+            this.state.terminal.reset();
+            this.disconnectChannel();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.channel !== this.props.channel) {
+            this.connectChannel();
+            this.props.channel.control({
+                window: {
+                    rows: this.state.rows,
+                    cols: this.state.cols
+                }
+            });
+        }
+    }
+
+    render() {
+        // ensure react never reuses this div by keying it with the terminal widget
+        return <div ref="terminal"
+                    key={this.state.terminal}
+                    className="console-ct"
+                    onFocus={this.onFocusIn}
+                    onBlur={this.onFocusOut} />;
+    }
+
+    componentWillUnmount() {
+        this.disconnectChannel();
+        this.state.terminal.destroy();
+        window.removeEventListener('resize', this.onWindowResize);
+    }
+
+    onChannelMessage(event, data) {
+        this.state.terminal.write(data);
+    }
+
+    onChannelClose(event, options) {
+        var term = this.state.terminal;
+        term.write('\x1b[31m' + (options.problem || 'disconnected') + '\x1b[m\r\n');
+        term.cursorHidden = true;
+        term.refresh(term.y, term.y);
+    }
+
+    connectChannel() {
+        var channel = this.props.channel;
+        if (channel && channel.valid) {
+            channel.addEventListener('message', this.onChannelMessage.bind(this));
+            channel.addEventListener('close', this.onChannelClose.bind(this));
+        }
+    }
+
+    disconnectChannel() {
+        if (this.props.channel) {
+            this.props.channel.removeEventListener('message', this.onChannelMessage);
+            this.props.channel.removeEventListener('close', this.onChannelClose);
+        }
+    }
+
+    focus() {
+        if (this.state.terminal)
+            this.state.terminal.focus();
+    }
+
+    onWindowResize() {
+        var padding = 2 * 11;
+        var node = ReactDOM.findDOMNode(this);
+        var terminal = this.refs.terminal.querySelector('.terminal');
+
+        var ch = document.createElement('span');
+        ch.textContent = 'M';
+        ch.style.position = 'absolute';
+        terminal.appendChild(ch);
+        var rect = ch.getBoundingClientRect();
+        terminal.removeChild(ch);
+
+        this.setState({
+            rows: Math.floor((node.parentElement.clientHeight - padding) / rect.height),
+            cols: Math.floor((node.parentElement.clientWidth - padding) / rect.width)
+        });
+    }
+
+    onBeforeUnload(event) {
+        // Firefox requires this when the page is in an iframe
+        event.preventDefault();
+
+        // see "an almost cross-browser solution" at
+        // https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload
+        event.returnValue = '';
+        return '';
+    }
+
+    onFocusIn() {
+        window.addEventListener('beforeunload', this.onBeforeUnload);
+    }
+
+    onFocusOut() {
+        window.removeEventListener('beforeunload', this.onBeforeUnload);
+    }
+}
+
+Terminal.propTypes = {
+    cols: PropTypes.number,
+    rows: PropTypes.number,
+    channel: PropTypes.object.isRequired,
+    onTitleChanged: PropTypes.func
+};
+
+module.exports = { Terminal: Terminal };

--- a/pkg/lib/credentials.js
+++ b/pkg/lib/credentials.js
@@ -17,315 +17,311 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+var $ = require("jquery");
+var cockpit = require("cockpit");
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
+var lister = require("raw-loader!credentials-ssh-private-keys.sh");
+var remove_key = require("raw-loader!credentials-ssh-remove-key.sh");
 
-    var lister = require("raw-loader!credentials-ssh-private-keys.sh");
-    var remove_key = require("raw-loader!credentials-ssh-remove-key.sh");
+var _ = cockpit.gettext;
 
-    var _ = cockpit.gettext;
+function Keys() {
+    var self = this;
 
-    function Keys() {
-        var self = this;
+    self.path = null;
+    self.items = { };
 
-        self.path = null;
-        self.items = { };
+    var watch = null;
+    var proc = null;
+    var timeout = null;
 
-        var watch = null;
-        var proc = null;
-        var timeout = null;
+    cockpit.user().done(function (user) {
+        self.path = user.home + '/.ssh';
+        refresh();
+    });
 
-        cockpit.user().done(function (user) {
-            self.path = user.home + '/.ssh';
-            refresh();
-        });
-
-        function refresh() {
-            if (watch === null) {
-                watch = cockpit.channel({ payload: "fslist1", path: self.path });
-                $(watch)
-                        .on("close", function(ev, data) {
-                            $(watch).off();
-                            if (!data.problem || data.problem == "not-found") {
-                                watch = null; /* Watch again */
-                            } else {
-                                console.warn("couldn't watch " + self.path + ": " + (data.message || data.problem));
-                                watch = false; /* Don't watch again */
-                            }
-                        })
-                        .on("message", function(ev, payload) {
-                            var item = JSON.parse(payload);
-                            var name = item.path;
-                            if (name && name.indexOf("/") === -1 && name.slice(-4) === ".pub") {
-                                if (item.event === "present" || item.event === "created" ||
-                                item.event === "changed" || item.event === "deleted") {
-                                    window.clearInterval(timeout);
-                                    timeout = window.setTimeout(refresh, 100);
-                                }
-                            }
-                        });
-            }
-
-            if (proc)
-                return;
-
-            window.clearTimeout(timeout);
-            timeout = null;
-
-            proc = cockpit.script(lister, [ self.path ], { err: "message" })
-                    .always(function() {
-                        proc = null;
-
-                        if (!timeout)
-                            timeout = window.setTimeout(refresh, 5000);
-                    })
-                    .done(function(data) {
-                        process(data);
-                    })
-                    .fail(function(ex) {
-                        console.warn("failed to list keys in home directory: " + ex.message);
-                    });
-        }
-
-        function process(data) {
-            var blocks = data.split('\v');
-            var key;
-            var items = { };
-
-            /* First block is the data from ssh agent */
-            blocks[0].trim().split("\n")
-                    .forEach(function(line) {
-                        key = parse_key(line, items);
-                        if (key)
-                            key.loaded = true;
-                    });
-
-            /* Next come individual triples of blocks */
-            blocks.slice(1).forEach(function(block, i) {
-                switch (i % 3) {
-                case 0:
-                    key = parse_key(block, items);
-                    break;
-                case 1:
-                    if (key) {
-                        block = block.trim();
-                        if (block.slice(-4) === ".pub")
-                            key.name = block.slice(0, -4);
-                        else if (block)
-                            key.name = block;
-                        else
-                            key.agent_only = true;
-                    }
-                    break;
-                case 2:
-                    if (key)
-                        parse_info(block, key);
-                    break;
-                }
-            });
-
-            self.items = items;
-            $(self).triggerHandler("changed");
-        }
-
-        function parse_key(line, items) {
-            var parts = line.trim().split(" ");
-            var id, type, comment;
-
-            /* SSHv1 keys */
-            if (!isNaN(parseInt(parts[0], 10))) {
-                id = parts[2];
-                type = "RSA1";
-                comment = parts.slice(3).join(" ");
-            } else if (parts[0].indexOf("ssh-") === 0) {
-                id = parts[1];
-                type = parts[0].substring(4).toUpperCase();
-                comment = parts.slice(2).join(" ");
-            } else if (parts[0].indexOf("ecdsa-") === 0) {
-                id = parts[1];
-                type = "ECDSA";
-                comment = parts.slice(2).join(" ");
-            } else {
-                return;
-            }
-
-            var key = items[id];
-            if (!key)
-                key = items[id] = { };
-
-            key.type = type;
-            key.comment = comment;
-            key.data = line;
-            return key;
-        }
-
-        function parse_info(line, key) {
-            var parts = line.trim().split(" ");
-            parts = parts.filter(function(n) {
-                return !!n;
-            });
-
-            key.size = parseInt(parts[0], 10);
-            if (isNaN(key.size))
-                key.size = null;
-
-            key.fingerprint = parts[1];
-
-            if (parts[2] && !key.name && parts[2].indexOf("/") !== -1)
-                key.name = parts[2];
-        }
-
-        self.change = function change(name, old_pass, new_pass, two_pass) {
-            var old_exps = [ /.*Enter old passphrase: $/ ];
-            var new_exps = [ /.*Enter new passphrase.*/, /.*Enter same passphrase again: $/ ];
-            var bad_exps = [ /.*failed: passphrase is too short.*/ ];
-
-            var dfd = $.Deferred();
-            var buffer = "";
-            var sent_new = false;
-            var failure = _("No such file or directory");
-            var i;
-
-            if (new_pass !== two_pass) {
-                dfd.reject(new Error(_("The passwords do not match.")));
-                return dfd.promise();
-            }
-
-            var proc;
-            var timeout = window.setTimeout(function() {
-                failure = _("Prompting via ssh-keygen timed out");
-                proc.close("terminated");
-            }, 10 * 1000);
-
-            proc = cockpit.spawn(["ssh-keygen", "-p", "-f", name],
-                                 { pty: true, environ: [ "LC_ALL=C" ], err: "out", directory: self.path })
-                    .always(function() {
-                        window.clearInterval(timeout);
-                    })
-                    .done(function() {
-                        dfd.resolve();
-                    })
-                    .fail(function(ex) {
-                        if (ex.exit_status)
-                            ex = new Error(failure);
-                        dfd.reject(ex);
-                    })
-                    .stream(function(data) {
-                        buffer += data;
-                        for (i = 0; i < old_exps.length; i++) {
-                            if (old_exps[i].test(buffer)) {
-                                buffer = "";
-                                failure = _("Old password not accepted");
-                                this.input(old_pass + "\n", true);
-                                return;
-                            }
+    function refresh() {
+        if (watch === null) {
+            watch = cockpit.channel({ payload: "fslist1", path: self.path });
+            $(watch)
+                    .on("close", function(ev, data) {
+                        $(watch).off();
+                        if (!data.problem || data.problem == "not-found") {
+                            watch = null; /* Watch again */
+                        } else {
+                            console.warn("couldn't watch " + self.path + ": " + (data.message || data.problem));
+                            watch = false; /* Don't watch again */
                         }
-
-                        for (i = 0; i < new_exps.length; i++) {
-                            if (new_exps[i].test(buffer)) {
-                                buffer = "";
-                                this.input(new_pass + "\n", true);
-                                failure = _("Failed to change password");
-                                sent_new = true;
-                                return;
-                            }
-                        }
-
-                        if (sent_new) {
-                            for (i = 0; i < bad_exps.length; i++) {
-                                if (bad_exps[i].test(buffer)) {
-                                    failure = _("New password was not accepted");
-                                    return;
-                                }
+                    })
+                    .on("message", function(ev, payload) {
+                        var item = JSON.parse(payload);
+                        var name = item.path;
+                        if (name && name.indexOf("/") === -1 && name.slice(-4) === ".pub") {
+                            if (item.event === "present" || item.event === "created" ||
+                            item.event === "changed" || item.event === "deleted") {
+                                window.clearInterval(timeout);
+                                timeout = window.setTimeout(refresh, 100);
                             }
                         }
                     });
+        }
 
-            return dfd.promise();
-        };
+        if (proc)
+            return;
 
-        self.load = function(name, password) {
-            var ask_exp = /.*Enter passphrase for .*/;
-            var perm_exp = /.*UNPROTECTED PRIVATE KEY FILE.*/;
-            var bad_exp = /.*Bad passphrase.*/;
+        window.clearTimeout(timeout);
+        timeout = null;
 
-            var dfd = $.Deferred();
-            var buffer = "";
-            var output = "";
-            var failure = _("Not a valid private key");
-            var sent_password = false;
+        proc = cockpit.script(lister, [ self.path ], { err: "message" })
+                .always(function() {
+                    proc = null;
 
-            var proc;
-            var timeout = window.setTimeout(function() {
-                failure = _("Prompting via ssh-add timed out");
-                proc.close("terminated");
-            }, 10 * 1000);
-
-            proc = cockpit.spawn(["ssh-add", name],
-                                 { pty: true, environ: [ "LC_ALL=C" ], err: "out", directory: self.path })
-                    .always(function() {
-                        window.clearInterval(timeout);
-                    })
-                    .done(function() {
-                        refresh();
-                        dfd.resolve();
-                    })
-                    .fail(function(ex) {
-                        console.log(output);
-                        if (ex.exit_status)
-                            ex = new Error(failure);
-
-                        ex.sent_password = sent_password;
-                        dfd.reject(ex);
-                    })
-                    .stream(function(data) {
-                        buffer += data;
-                        output += data;
-                        if (perm_exp.test(buffer)) {
-                            failure = _("Invalid file permissions");
-                            buffer = "";
-                        } else if (ask_exp.test(buffer)) {
-                            buffer = "";
-                            failure = _("Password not accepted");
-                            this.input(password + "\n", true);
-                            sent_password = true;
-                        } else if (bad_exp.test(buffer)) {
-                            buffer = "";
-                            this.input("\n", true);
-                        }
-                    });
-
-            return dfd.promise();
-        };
-
-        self.unload = function unload(key) {
-            var proc;
-            var options = { pty: true, err: "message", directory: self.path };
-
-            if (key.name && !key.agent_only)
-                proc = cockpit.spawn(["ssh-add", "-d", key.name], options);
-            else
-                proc = cockpit.script(remove_key, [key.data], options);
-
-            return proc.done(refresh);
-        };
-
-        self.close = function close() {
-            if (watch)
-                watch.close();
-            if (proc)
-                proc.close();
-            window.clearTimeout(timeout);
-            timeout = null;
-        };
+                    if (!timeout)
+                        timeout = window.setTimeout(refresh, 5000);
+                })
+                .done(function(data) {
+                    process(data);
+                })
+                .fail(function(ex) {
+                    console.warn("failed to list keys in home directory: " + ex.message);
+                });
     }
 
-    module.exports = {
-        keys_instance: function () {
-            return new Keys();
+    function process(data) {
+        var blocks = data.split('\v');
+        var key;
+        var items = { };
+
+        /* First block is the data from ssh agent */
+        blocks[0].trim().split("\n")
+                .forEach(function(line) {
+                    key = parse_key(line, items);
+                    if (key)
+                        key.loaded = true;
+                });
+
+        /* Next come individual triples of blocks */
+        blocks.slice(1).forEach(function(block, i) {
+            switch (i % 3) {
+            case 0:
+                key = parse_key(block, items);
+                break;
+            case 1:
+                if (key) {
+                    block = block.trim();
+                    if (block.slice(-4) === ".pub")
+                        key.name = block.slice(0, -4);
+                    else if (block)
+                        key.name = block;
+                    else
+                        key.agent_only = true;
+                }
+                break;
+            case 2:
+                if (key)
+                    parse_info(block, key);
+                break;
+            }
+        });
+
+        self.items = items;
+        $(self).triggerHandler("changed");
+    }
+
+    function parse_key(line, items) {
+        var parts = line.trim().split(" ");
+        var id, type, comment;
+
+        /* SSHv1 keys */
+        if (!isNaN(parseInt(parts[0], 10))) {
+            id = parts[2];
+            type = "RSA1";
+            comment = parts.slice(3).join(" ");
+        } else if (parts[0].indexOf("ssh-") === 0) {
+            id = parts[1];
+            type = parts[0].substring(4).toUpperCase();
+            comment = parts.slice(2).join(" ");
+        } else if (parts[0].indexOf("ecdsa-") === 0) {
+            id = parts[1];
+            type = "ECDSA";
+            comment = parts.slice(2).join(" ");
+        } else {
+            return;
         }
+
+        var key = items[id];
+        if (!key)
+            key = items[id] = { };
+
+        key.type = type;
+        key.comment = comment;
+        key.data = line;
+        return key;
+    }
+
+    function parse_info(line, key) {
+        var parts = line.trim().split(" ");
+        parts = parts.filter(function(n) {
+            return !!n;
+        });
+
+        key.size = parseInt(parts[0], 10);
+        if (isNaN(key.size))
+            key.size = null;
+
+        key.fingerprint = parts[1];
+
+        if (parts[2] && !key.name && parts[2].indexOf("/") !== -1)
+            key.name = parts[2];
+    }
+
+    self.change = function change(name, old_pass, new_pass, two_pass) {
+        var old_exps = [ /.*Enter old passphrase: $/ ];
+        var new_exps = [ /.*Enter new passphrase.*/, /.*Enter same passphrase again: $/ ];
+        var bad_exps = [ /.*failed: passphrase is too short.*/ ];
+
+        var dfd = $.Deferred();
+        var buffer = "";
+        var sent_new = false;
+        var failure = _("No such file or directory");
+        var i;
+
+        if (new_pass !== two_pass) {
+            dfd.reject(new Error(_("The passwords do not match.")));
+            return dfd.promise();
+        }
+
+        var proc;
+        var timeout = window.setTimeout(function() {
+            failure = _("Prompting via ssh-keygen timed out");
+            proc.close("terminated");
+        }, 10 * 1000);
+
+        proc = cockpit.spawn(["ssh-keygen", "-p", "-f", name],
+                             { pty: true, environ: [ "LC_ALL=C" ], err: "out", directory: self.path })
+                .always(function() {
+                    window.clearInterval(timeout);
+                })
+                .done(function() {
+                    dfd.resolve();
+                })
+                .fail(function(ex) {
+                    if (ex.exit_status)
+                        ex = new Error(failure);
+                    dfd.reject(ex);
+                })
+                .stream(function(data) {
+                    buffer += data;
+                    for (i = 0; i < old_exps.length; i++) {
+                        if (old_exps[i].test(buffer)) {
+                            buffer = "";
+                            failure = _("Old password not accepted");
+                            this.input(old_pass + "\n", true);
+                            return;
+                        }
+                    }
+
+                    for (i = 0; i < new_exps.length; i++) {
+                        if (new_exps[i].test(buffer)) {
+                            buffer = "";
+                            this.input(new_pass + "\n", true);
+                            failure = _("Failed to change password");
+                            sent_new = true;
+                            return;
+                        }
+                    }
+
+                    if (sent_new) {
+                        for (i = 0; i < bad_exps.length; i++) {
+                            if (bad_exps[i].test(buffer)) {
+                                failure = _("New password was not accepted");
+                                return;
+                            }
+                        }
+                    }
+                });
+
+        return dfd.promise();
     };
-}());
+
+    self.load = function(name, password) {
+        var ask_exp = /.*Enter passphrase for .*/;
+        var perm_exp = /.*UNPROTECTED PRIVATE KEY FILE.*/;
+        var bad_exp = /.*Bad passphrase.*/;
+
+        var dfd = $.Deferred();
+        var buffer = "";
+        var output = "";
+        var failure = _("Not a valid private key");
+        var sent_password = false;
+
+        var proc;
+        var timeout = window.setTimeout(function() {
+            failure = _("Prompting via ssh-add timed out");
+            proc.close("terminated");
+        }, 10 * 1000);
+
+        proc = cockpit.spawn(["ssh-add", name],
+                             { pty: true, environ: [ "LC_ALL=C" ], err: "out", directory: self.path })
+                .always(function() {
+                    window.clearInterval(timeout);
+                })
+                .done(function() {
+                    refresh();
+                    dfd.resolve();
+                })
+                .fail(function(ex) {
+                    console.log(output);
+                    if (ex.exit_status)
+                        ex = new Error(failure);
+
+                    ex.sent_password = sent_password;
+                    dfd.reject(ex);
+                })
+                .stream(function(data) {
+                    buffer += data;
+                    output += data;
+                    if (perm_exp.test(buffer)) {
+                        failure = _("Invalid file permissions");
+                        buffer = "";
+                    } else if (ask_exp.test(buffer)) {
+                        buffer = "";
+                        failure = _("Password not accepted");
+                        this.input(password + "\n", true);
+                        sent_password = true;
+                    } else if (bad_exp.test(buffer)) {
+                        buffer = "";
+                        this.input("\n", true);
+                    }
+                });
+
+        return dfd.promise();
+    };
+
+    self.unload = function unload(key) {
+        var proc;
+        var options = { pty: true, err: "message", directory: self.path };
+
+        if (key.name && !key.agent_only)
+            proc = cockpit.spawn(["ssh-add", "-d", key.name], options);
+        else
+            proc = cockpit.script(remove_key, [key.data], options);
+
+        return proc.done(refresh);
+    };
+
+    self.close = function close() {
+        if (watch)
+            watch.close();
+        if (proc)
+            proc.close();
+        window.clearTimeout(timeout);
+        timeout = null;
+    };
+}
+
+module.exports = {
+    keys_instance: function () {
+        return new Keys();
+    }
+};

--- a/pkg/lib/journal.js
+++ b/pkg/lib/journal.js
@@ -17,567 +17,563 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+var cockpit = require("cockpit");
+var Mustache = require("mustache");
+var day_header_template = require('raw-loader!journal_day_header.mustache');
+var line_template = require('raw-loader!journal_line.mustache');
+var reboot_template = require('raw-loader!journal_reboot.mustache');
 
-    var cockpit = require("cockpit");
-    var Mustache = require("mustache");
-    var day_header_template = require('raw-loader!journal_day_header.mustache');
-    var line_template = require('raw-loader!journal_line.mustache');
-    var reboot_template = require('raw-loader!journal_reboot.mustache');
+var _ = cockpit.gettext;
+var C_ = cockpit.gettext;
 
-    var _ = cockpit.gettext;
-    var C_ = cockpit.gettext;
+var journal = { };
 
-    var journal = { };
+/**
+ * journalctl([match, ...], [options])
+ * @match: any number of journal match strings
+ * @options: an object containing further options
+ *
+ * Load and (by default) stream journal entries as
+ * json objects. This function returns a jQuery deferred
+ * object which delivers the various journal entries.
+ *
+ * The various @match strings are journalctl matches.
+ * Zero, one or more can be specified. They must be in
+ * string format, or arrays of strings.
+ *
+ * The optional @options object can contain the following:
+ *  * "host": the host to load journal from
+ *  * "count": number of entries to load and/or pre-stream.
+ *    Default is 10
+ *  * "follow": if set to false just load entries and don't
+ *    stream further journal data. Default is true.
+ *  * "directory": optional directory to load journal files
+ *  * "boot": when set only list entries from this specific
+ *    boot id, or if null then the current boot.
+ *  * "since": if specified list entries since the date/time
+ *  * "until": if specified list entries until the date/time
+ *  * "cursor": a cursor to start listing entries from
+ *  * "after": a cursor to start listing entries after
+ *
+ * Returns a jQuery deferred promise. You can call these
+ * functions on the deferred to handle the responses. Note that
+ * there are additional non-jQuery methods.
+ *
+ *  .done(function(entries) { }): Called when done, @entries is
+ *         an array of all journal entries loaded. If .stream()
+ *         has been invoked then @entries will be empty.
+ *  .fail(funciton(ex) { }): called if the operation fails
+ *  .stream(function(entries) { }): called when we receive entries
+ *         entries. Called once per batch of journal @entries,
+ *         whether following or not.
+ *  .stop(): stop following or retrieving entries.
+ */
 
-    /**
-     * journalctl([match, ...], [options])
-     * @match: any number of journal match strings
-     * @options: an object containing further options
-     *
-     * Load and (by default) stream journal entries as
-     * json objects. This function returns a jQuery deferred
-     * object which delivers the various journal entries.
-     *
-     * The various @match strings are journalctl matches.
-     * Zero, one or more can be specified. They must be in
-     * string format, or arrays of strings.
-     *
-     * The optional @options object can contain the following:
-     *  * "host": the host to load journal from
-     *  * "count": number of entries to load and/or pre-stream.
-     *    Default is 10
-     *  * "follow": if set to false just load entries and don't
-     *    stream further journal data. Default is true.
-     *  * "directory": optional directory to load journal files
-     *  * "boot": when set only list entries from this specific
-     *    boot id, or if null then the current boot.
-     *  * "since": if specified list entries since the date/time
-     *  * "until": if specified list entries until the date/time
-     *  * "cursor": a cursor to start listing entries from
-     *  * "after": a cursor to start listing entries after
-     *
-     * Returns a jQuery deferred promise. You can call these
-     * functions on the deferred to handle the responses. Note that
-     * there are additional non-jQuery methods.
-     *
-     *  .done(function(entries) { }): Called when done, @entries is
-     *         an array of all journal entries loaded. If .stream()
-     *         has been invoked then @entries will be empty.
-     *  .fail(funciton(ex) { }): called if the operation fails
-     *  .stream(function(entries) { }): called when we receive entries
-     *         entries. Called once per batch of journal @entries,
-     *         whether following or not.
-     *  .stop(): stop following or retrieving entries.
-     */
-
-    journal.journalctl = function journalctl(/* ... */) {
-        var matches = [];
-        var i, arg;
-        var options = { follow: true };
-        for (i = 0; i < arguments.length; i++) {
-            arg = arguments[i];
-            if (typeof arg == "string") {
-                matches.push(arg);
-            } else if (typeof arg == "object") {
-                if (arg instanceof Array) {
-                    matches.push.apply(matches, arg);
-                } else {
-                    cockpit.extend(options, arg);
-                    break;
-                }
+journal.journalctl = function journalctl(/* ... */) {
+    var matches = [];
+    var i, arg;
+    var options = { follow: true };
+    for (i = 0; i < arguments.length; i++) {
+        arg = arguments[i];
+        if (typeof arg == "string") {
+            matches.push(arg);
+        } else if (typeof arg == "object") {
+            if (arg instanceof Array) {
+                matches.push.apply(matches, arg);
             } else {
-                console.warn("journal.journalctl called with invalid argument:", arg);
+                cockpit.extend(options, arg);
+                break;
             }
+        } else {
+            console.warn("journal.journalctl called with invalid argument:", arg);
         }
+    }
 
-        if (options.count === undefined) {
-            if (options.follow)
-                options.count = 10;
-            else
-                options.count = null;
-        }
-
-        var cmd = [ "journalctl", "-q", "--output=json" ];
-        if (!options.count)
-            cmd.push("--no-tail");
+    if (options.count === undefined) {
+        if (options.follow)
+            options.count = 10;
         else
-            cmd.push("--lines=" + options.count);
-        if (options.directory)
-            cmd.push("--directory=" + options.directory);
-        if (options.boot)
-            cmd.push("--boot=" + options.boot);
-        else if (options.boot !== undefined)
-            cmd.push("--boot");
-        if (options.since)
-            cmd.push("--since=" + options.since);
-        if (options.until)
-            cmd.push("--until=" + options.until);
-        if (options.cursor)
-            cmd.push("--cursor=" + options.cursor);
-        if (options.after)
-            cmd.push("--after=" + options.after);
+            options.count = null;
+    }
 
-        /* journalctl doesn't allow reverse and follow together */
-        if (options.reverse)
-            cmd.push("--reverse");
-        else if (options.follow)
-            cmd.push("--follow");
+    var cmd = [ "journalctl", "-q", "--output=json" ];
+    if (!options.count)
+        cmd.push("--no-tail");
+    else
+        cmd.push("--lines=" + options.count);
+    if (options.directory)
+        cmd.push("--directory=" + options.directory);
+    if (options.boot)
+        cmd.push("--boot=" + options.boot);
+    else if (options.boot !== undefined)
+        cmd.push("--boot");
+    if (options.since)
+        cmd.push("--since=" + options.since);
+    if (options.until)
+        cmd.push("--until=" + options.until);
+    if (options.cursor)
+        cmd.push("--cursor=" + options.cursor);
+    if (options.after)
+        cmd.push("--after=" + options.after);
 
-        cmd.push("--");
-        cmd.push.apply(cmd, matches);
+    /* journalctl doesn't allow reverse and follow together */
+    if (options.reverse)
+        cmd.push("--reverse");
+    else if (options.follow)
+        cmd.push("--follow");
 
-        var dfd = cockpit.defer();
-        var promise;
-        var buffer = "";
-        var entries = [];
-        var streamers = [];
-        var interval = null;
+    cmd.push("--");
+    cmd.push.apply(cmd, matches);
 
-        function fire_streamers() {
-            var ents, i;
-            if (streamers.length && entries.length > 0) {
-                ents = entries;
-                entries = [];
-                for (i = 0; i < streamers.length; i++)
-                    streamers[i].apply(promise, [ents]);
-            } else {
-                window.clearInterval(interval);
-                interval = null;
-            }
+    var dfd = cockpit.defer();
+    var promise;
+    var buffer = "";
+    var entries = [];
+    var streamers = [];
+    var interval = null;
+
+    function fire_streamers() {
+        var ents, i;
+        if (streamers.length && entries.length > 0) {
+            ents = entries;
+            entries = [];
+            for (i = 0; i < streamers.length; i++)
+                streamers[i].apply(promise, [ents]);
+        } else {
+            window.clearInterval(interval);
+            interval = null;
         }
+    }
 
-        var proc = cockpit.spawn(cmd, { host: options.host, batch: 8192, latency: 300, superuser: "try" })
-                .stream(function(data) {
-                    if (buffer)
-                        data = buffer + data;
-                    buffer = "";
+    var proc = cockpit.spawn(cmd, { host: options.host, batch: 8192, latency: 300, superuser: "try" })
+            .stream(function(data) {
+                if (buffer)
+                    data = buffer + data;
+                buffer = "";
 
-                    var lines = data.split("\n");
-                    var last = lines.length - 1;
-                    lines.forEach(function(line, i) {
-                        if (i == last) {
-                            buffer = line;
-                        } else if (line && line.indexOf("-- ") !== 0) {
-                            try {
-                                entries.push(JSON.parse(line));
-                            } catch (e) {
-                                console.warn(e, line);
-                            }
+                var lines = data.split("\n");
+                var last = lines.length - 1;
+                lines.forEach(function(line, i) {
+                    if (i == last) {
+                        buffer = line;
+                    } else if (line && line.indexOf("-- ") !== 0) {
+                        try {
+                            entries.push(JSON.parse(line));
+                        } catch (e) {
+                            console.warn(e, line);
                         }
-                    });
-
-                    if (streamers.length && interval === null)
-                        interval = window.setInterval(fire_streamers, 300);
-                })
-                .done(function() {
-                    fire_streamers();
-                    dfd.resolve(entries);
-                })
-                .fail(function(ex) {
-                /* The journalctl command fails when no entries are matched
-                 * so we just ignore this status code */
-                    if (ex.problem == "cancelled" ||
-                    ex.exit_status === 1) {
-                        fire_streamers();
-                        dfd.resolve(entries);
-                    } else {
-                        dfd.reject(ex);
                     }
-                })
-                .always(function() {
-                    window.clearInterval(interval);
                 });
 
-        promise = dfd.promise();
-        promise.stream = function stream(callback) {
-            streamers.push(callback);
-            return this;
-        };
-        promise.stop = function stop() {
-            proc.close("cancelled");
-        };
-        return promise;
+                if (streamers.length && interval === null)
+                    interval = window.setInterval(fire_streamers, 300);
+            })
+            .done(function() {
+                fire_streamers();
+                dfd.resolve(entries);
+            })
+            .fail(function(ex) {
+            /* The journalctl command fails when no entries are matched
+             * so we just ignore this status code */
+                if (ex.problem == "cancelled" ||
+                ex.exit_status === 1) {
+                    fire_streamers();
+                    dfd.resolve(entries);
+                } else {
+                    dfd.reject(ex);
+                }
+            })
+            .always(function() {
+                window.clearInterval(interval);
+            });
+
+    promise = dfd.promise();
+    promise.stream = function stream(callback) {
+        streamers.push(callback);
+        return this;
     };
-
-    journal.printable = function printable(value) {
-        if (value === undefined || value === null)
-            return _("[no data]");
-        else if (typeof (value) == "string")
-            return value;
-        else if (value.length !== undefined)
-            return cockpit.format(_("[$0 bytes of binary data]"), value.length);
-        else
-            return _("[binary data]");
+    promise.stop = function stop() {
+        proc.close("cancelled");
     };
+    return promise;
+};
 
-    function output_funcs_for_box(box) {
-        /* Dereference any jQuery object here */
-        if (box.jquery)
-            box = box[0];
+journal.printable = function printable(value) {
+    if (value === undefined || value === null)
+        return _("[no data]");
+    else if (typeof (value) == "string")
+        return value;
+    else if (value.length !== undefined)
+        return cockpit.format(_("[$0 bytes of binary data]"), value.length);
+    else
+        return _("[binary data]");
+};
 
-        Mustache.parse(day_header_template);
-        Mustache.parse(line_template);
-        Mustache.parse(reboot_template);
+function output_funcs_for_box(box) {
+    /* Dereference any jQuery object here */
+    if (box.jquery)
+        box = box[0];
 
-        function render_line(ident, prio, message, count, time, entry) {
-            var parts = {
-                'cursor': entry["__CURSOR"],
-                'time': time,
-                'message': message,
-                'service': ident
-            };
-            if (count > 1)
-                parts['count'] = count;
-            if (ident === 'abrt-notification') {
-                parts['problem'] = true;
-                parts['service'] = entry['PROBLEM_BINARY'];
-            } else if (prio < 4)
-                parts['warning'] = true;
-            return Mustache.render(line_template, parts);
-        }
+    Mustache.parse(day_header_template);
+    Mustache.parse(line_template);
+    Mustache.parse(reboot_template);
 
-        var reboot = _("Reboot");
-        var reboot_line = Mustache.render(reboot_template, {'message': reboot});
+    function render_line(ident, prio, message, count, time, entry) {
+        var parts = {
+            'cursor': entry["__CURSOR"],
+            'time': time,
+            'message': message,
+            'service': ident
+        };
+        if (count > 1)
+            parts['count'] = count;
+        if (ident === 'abrt-notification') {
+            parts['problem'] = true;
+            parts['service'] = entry['PROBLEM_BINARY'];
+        } else if (prio < 4)
+            parts['warning'] = true;
+        return Mustache.render(line_template, parts);
+    }
 
-        function render_reboot_separator() {
-            return reboot_line;
-        }
+    var reboot = _("Reboot");
+    var reboot_line = Mustache.render(reboot_template, {'message': reboot});
 
-        function render_day_header(day) {
-            return Mustache.render(day_header_template, {'day': day});
-        }
+    function render_reboot_separator() {
+        return reboot_line;
+    }
 
-        function parse_html(string) {
-            var div = document.createElement("div");
-            div.innerHTML = string.trim();
-            return div.children[0];
-        }
+    function render_day_header(day) {
+        return Mustache.render(day_header_template, {'day': day});
+    }
 
-        return {
-            render_line: render_line,
-            render_day_header: render_day_header,
-            render_reboot_separator: render_reboot_separator,
+    function parse_html(string) {
+        var div = document.createElement("div");
+        div.innerHTML = string.trim();
+        return div.children[0];
+    }
 
-            append: function(elt) {
-                if (typeof (elt) == "string")
-                    elt = parse_html(elt);
+    return {
+        render_line: render_line,
+        render_day_header: render_day_header,
+        render_reboot_separator: render_reboot_separator,
+
+        append: function(elt) {
+            if (typeof (elt) == "string")
+                elt = parse_html(elt);
+            box.appendChild(elt);
+        },
+        prepend: function(elt) {
+            if (typeof (elt) == "string")
+                elt = parse_html(elt);
+            if (box.firstChild)
+                box.insertBefore(elt, box.firstChild);
+            else
                 box.appendChild(elt);
-            },
-            prepend: function(elt) {
-                if (typeof (elt) == "string")
-                    elt = parse_html(elt);
-                if (box.firstChild)
-                    box.insertBefore(elt, box.firstChild);
-                else
-                    box.appendChild(elt);
-            },
-            remove_last: function() {
-                if (box.lastChild)
-                    box.removeChild(box.lastChild);
-            },
-            remove_first: function() {
-                if (box.firstChild)
-                    box.removeChild(box.firstChild);
-            },
+        },
+        remove_last: function() {
+            if (box.lastChild)
+                box.removeChild(box.lastChild);
+        },
+        remove_first: function() {
+            if (box.firstChild)
+                box.removeChild(box.firstChild);
+        },
+    };
+}
+
+var month_names = [
+    C_("month-name", 'January'),
+    C_("month-name", 'February'),
+    C_("month-name", 'March'),
+    C_("month-name", 'April'),
+    C_("month-name", 'May'),
+    C_("month-name", 'June'),
+    C_("month-name", 'July'),
+    C_("month-name", 'August'),
+    C_("month-name", 'September'),
+    C_("month-name", 'October'),
+    C_("month-name", 'November'),
+    C_("month-name", 'December')
+];
+
+/* Render the journal entries by passing suitable HTML strings back to
+   the caller via the 'output_funcs'.
+
+   Rendering is context aware.  It will insert 'reboot' markers, for
+   example, and collapse repeated lines.  You can extend the output at
+   the bottom and also at the top.
+
+   A new renderer is created by calling 'journal.renderer' like
+   so:
+
+      var renderer = journal.renderer(funcs);
+
+   You can feed new entries into the renderer by calling various
+   methods on the returned object:
+
+      - renderer.append(journal_entry)
+      - renderer.append_flush()
+      - renderer.prepend(journal_entry)
+      - renderer.prepend_flush()
+
+   A 'journal_entry' is one element of the result array returned by a
+   call to 'Query' with the 'cockpit.journal_fields' as the fields to
+   return.
+
+   Calling 'append' will append the given entry to the end of the
+   output, naturally, and 'prepend' will prepend it to the start.
+
+   The output might lag behind what has been input via 'append' and
+   'prepend', and you need to call 'append_flush' and 'prepend_flush'
+   respectively to ensure that the output is up-to-date.  Flushing a
+   renderer does not introduce discontinuities into the output.  You
+   can continue to feed entries into the renderer after flushing and
+   repeated lines will be correctly collapsed across the flush, for
+   example.
+
+   The renderer will call methods of the 'output_funcs' object to
+   produce the desired output:
+
+      - output_funcs.append(rendered)
+      - output_funcs.remove_last()
+      - output_funcs.prepend(rendered)
+      - output_funcs.remove_first()
+
+   The 'rendered' argument is the return value of one of the rendering
+   functions described below.  The 'append' and 'prepend' methods
+   should add this element to the output, naturally, and 'remove_last'
+   and 'remove_first' should remove the indicated element.
+
+   If you never call 'prepend' on the renderer, 'output_func.prepend'
+   isn't called either.  If you never call 'renderer.prepend' after
+   'renderer.prepend_flush', then 'output_func.remove_first' will
+   never be called.  The same guarantees exist for the 'append' family
+   of functions.
+
+   The actual rendering is also done by calling methods on
+   'output_funcs':
+
+      - output_funcs.render_line(ident, prio, message, count, time, cursor)
+      - output_funcs.render_day_header(day)
+      - output_funcs.render_reboot_separator()
+
+*/
+
+journal.renderer = function renderer(funcs_or_box) {
+    var output_funcs;
+    if (funcs_or_box.render_line)
+        output_funcs = funcs_or_box;
+    else
+        output_funcs = output_funcs_for_box(funcs_or_box);
+
+    function copy_object(o) {
+        var c = { }; for (var p in o) c[p] = o[p]; return c;
+    }
+
+    // A 'entry' object describes a journal entry in formatted form.
+    // It has fields 'bootid', 'ident', 'prio', 'message', 'time',
+    // 'day', all of which are strings.
+
+    function format_entry(journal_entry) {
+        function pad(n) {
+            var str = n.toFixed();
+            if (str.length == 1)
+                str = '0' + str;
+            return str;
+        }
+
+        var d = new Date(journal_entry["__REALTIME_TIMESTAMP"] / 1000);
+        return {
+            cursor: journal_entry["__CURSOR"],
+            full: journal_entry,
+            day: month_names[d.getMonth()] + ' ' + d.getDate().toFixed() + ', ' + d.getFullYear().toFixed(),
+            time: pad(d.getHours()) + ':' + pad(d.getMinutes()),
+            bootid: journal_entry["_BOOT_ID"],
+            ident: journal_entry["SYSLOG_IDENTIFIER"] || journal_entry["_COMM"],
+            prio: journal_entry["PRIORITY"],
+            message: journal.printable(journal_entry["MESSAGE"])
         };
     }
 
-    var month_names = [
-        C_("month-name", 'January'),
-        C_("month-name", 'February'),
-        C_("month-name", 'March'),
-        C_("month-name", 'April'),
-        C_("month-name", 'May'),
-        C_("month-name", 'June'),
-        C_("month-name", 'July'),
-        C_("month-name", 'August'),
-        C_("month-name", 'September'),
-        C_("month-name", 'October'),
-        C_("month-name", 'November'),
-        C_("month-name", 'December')
-    ];
+    function entry_is_equal(a, b) {
+        return (a && b &&
+                a.day == b.day &&
+                a.bootid == b.bootid &&
+                a.ident == b.ident &&
+                a.prio == b.prio &&
+                a.message == b.message);
+    }
 
-    /* Render the journal entries by passing suitable HTML strings back to
-       the caller via the 'output_funcs'.
+    // A state object describes a line that should be eventually
+    // output.  It has an 'entry' field as per description above, and
+    // also 'count', 'last_time', and 'first_time', which record
+    // repeated entries.  Additionally:
+    //
+    // line_present: When true, the line has been output already with
+    //     some preliminary data.  It needs to be removed before
+    //     outputting more recent data.
+    //
+    // header_present: The day header has been output preliminarily
+    //     before the actual log lines.  It needs to be removed before
+    //     prepending more lines.  If both line_present and
+    //     header_present are true, then the header comes first in the
+    //     output, followed by the line.
 
-       Rendering is context aware.  It will insert 'reboot' markers, for
-       example, and collapse repeated lines.  You can extend the output at
-       the bottom and also at the top.
+    function render_state_line(state) {
+        return output_funcs.render_line(state.entry.ident,
+                                        state.entry.prio,
+                                        state.entry.message,
+                                        state.count,
+                                        state.last_time,
+                                        state.entry.full);
+    }
 
-       A new renderer is created by calling 'journal.renderer' like
-       so:
+    // We keep the state of the first and last journal lines,
+    // respectively, in order to collapse repeated lines, and to
+    // insert reboot markers and day headers.
+    //
+    // Normally, there are two state objects, but if only a single
+    // line has been output so far, top_state and bottom_state point
+    // to the same object.
 
-          var renderer = journal.renderer(funcs);
+    var top_state, bottom_state;
 
-       You can feed new entries into the renderer by calling various
-       methods on the returned object:
+    top_state = bottom_state = { };
 
-          - renderer.append(journal_entry)
-          - renderer.append_flush()
-          - renderer.prepend(journal_entry)
-          - renderer.prepend_flush()
-
-       A 'journal_entry' is one element of the result array returned by a
-       call to 'Query' with the 'cockpit.journal_fields' as the fields to
-       return.
-
-       Calling 'append' will append the given entry to the end of the
-       output, naturally, and 'prepend' will prepend it to the start.
-
-       The output might lag behind what has been input via 'append' and
-       'prepend', and you need to call 'append_flush' and 'prepend_flush'
-       respectively to ensure that the output is up-to-date.  Flushing a
-       renderer does not introduce discontinuities into the output.  You
-       can continue to feed entries into the renderer after flushing and
-       repeated lines will be correctly collapsed across the flush, for
-       example.
-
-       The renderer will call methods of the 'output_funcs' object to
-       produce the desired output:
-
-          - output_funcs.append(rendered)
-          - output_funcs.remove_last()
-          - output_funcs.prepend(rendered)
-          - output_funcs.remove_first()
-
-       The 'rendered' argument is the return value of one of the rendering
-       functions described below.  The 'append' and 'prepend' methods
-       should add this element to the output, naturally, and 'remove_last'
-       and 'remove_first' should remove the indicated element.
-
-       If you never call 'prepend' on the renderer, 'output_func.prepend'
-       isn't called either.  If you never call 'renderer.prepend' after
-       'renderer.prepend_flush', then 'output_func.remove_first' will
-       never be called.  The same guarantees exist for the 'append' family
-       of functions.
-
-       The actual rendering is also done by calling methods on
-       'output_funcs':
-
-          - output_funcs.render_line(ident, prio, message, count, time, cursor)
-          - output_funcs.render_day_header(day)
-          - output_funcs.render_reboot_separator()
-
-    */
-
-    journal.renderer = function renderer(funcs_or_box) {
-        var output_funcs;
-        if (funcs_or_box.render_line)
-            output_funcs = funcs_or_box;
-        else
-            output_funcs = output_funcs_for_box(funcs_or_box);
-
-        function copy_object(o) {
-            var c = { }; for (var p in o) c[p] = o[p]; return c;
+    function start_new_line() {
+        // If we now have two lines, split the state
+        if (top_state === bottom_state && top_state.entry) {
+            top_state = copy_object(bottom_state);
         }
+    }
 
-        // A 'entry' object describes a journal entry in formatted form.
-        // It has fields 'bootid', 'ident', 'prio', 'message', 'time',
-        // 'day', all of which are strings.
-
-        function format_entry(journal_entry) {
-            function pad(n) {
-                var str = n.toFixed();
-                if (str.length == 1)
-                    str = '0' + str;
-                return str;
-            }
-
-            var d = new Date(journal_entry["__REALTIME_TIMESTAMP"] / 1000);
-            return {
-                cursor: journal_entry["__CURSOR"],
-                full: journal_entry,
-                day: month_names[d.getMonth()] + ' ' + d.getDate().toFixed() + ', ' + d.getFullYear().toFixed(),
-                time: pad(d.getHours()) + ':' + pad(d.getMinutes()),
-                bootid: journal_entry["_BOOT_ID"],
-                ident: journal_entry["SYSLOG_IDENTIFIER"] || journal_entry["_COMM"],
-                prio: journal_entry["PRIORITY"],
-                message: journal.printable(journal_entry["MESSAGE"])
-            };
+    function top_output() {
+        if (top_state.header_present) {
+            output_funcs.remove_first();
+            top_state.header_present = false;
         }
-
-        function entry_is_equal(a, b) {
-            return (a && b &&
-                    a.day == b.day &&
-                    a.bootid == b.bootid &&
-                    a.ident == b.ident &&
-                    a.prio == b.prio &&
-                    a.message == b.message);
+        if (top_state.line_present) {
+            output_funcs.remove_first();
+            top_state.line_present = false;
         }
-
-        // A state object describes a line that should be eventually
-        // output.  It has an 'entry' field as per description above, and
-        // also 'count', 'last_time', and 'first_time', which record
-        // repeated entries.  Additionally:
-        //
-        // line_present: When true, the line has been output already with
-        //     some preliminary data.  It needs to be removed before
-        //     outputting more recent data.
-        //
-        // header_present: The day header has been output preliminarily
-        //     before the actual log lines.  It needs to be removed before
-        //     prepending more lines.  If both line_present and
-        //     header_present are true, then the header comes first in the
-        //     output, followed by the line.
-
-        function render_state_line(state) {
-            return output_funcs.render_line(state.entry.ident,
-                                            state.entry.prio,
-                                            state.entry.message,
-                                            state.count,
-                                            state.last_time,
-                                            state.entry.full);
+        if (top_state.entry) {
+            output_funcs.prepend(render_state_line(top_state));
+            top_state.line_present = true;
         }
+    }
 
-        // We keep the state of the first and last journal lines,
-        // respectively, in order to collapse repeated lines, and to
-        // insert reboot markers and day headers.
-        //
-        // Normally, there are two state objects, but if only a single
-        // line has been output so far, top_state and bottom_state point
-        // to the same object.
+    function prepend(journal_entry) {
+        var entry = format_entry(journal_entry);
 
-        var top_state, bottom_state;
-
-        top_state = bottom_state = { };
-
-        function start_new_line() {
-            // If we now have two lines, split the state
-            if (top_state === bottom_state && top_state.entry) {
-                top_state = copy_object(bottom_state);
-            }
-        }
-
-        function top_output() {
-            if (top_state.header_present) {
-                output_funcs.remove_first();
-                top_state.header_present = false;
-            }
-            if (top_state.line_present) {
-                output_funcs.remove_first();
-                top_state.line_present = false;
-            }
-            if (top_state.entry) {
-                output_funcs.prepend(render_state_line(top_state));
-                top_state.line_present = true;
-            }
-        }
-
-        function prepend(journal_entry) {
-            var entry = format_entry(journal_entry);
-
-            if (entry_is_equal(top_state.entry, entry)) {
-                top_state.count += 1;
-                top_state.first_time = entry.time;
-            } else {
-                top_output();
-
-                if (top_state.entry) {
-                    if (entry.bootid != top_state.entry.bootid)
-                        output_funcs.prepend(output_funcs.render_reboot_separator());
-                    if (entry.day != top_state.entry.day)
-                        output_funcs.prepend(output_funcs.render_day_header(top_state.entry.day));
-                }
-
-                start_new_line();
-                top_state.entry = entry;
-                top_state.count = 1;
-                top_state.first_time = top_state.last_time = entry.time;
-                top_state.line_present = false;
-            }
-        }
-
-        function prepend_flush() {
+        if (entry_is_equal(top_state.entry, entry)) {
+            top_state.count += 1;
+            top_state.first_time = entry.time;
+        } else {
             top_output();
+
             if (top_state.entry) {
-                output_funcs.prepend(output_funcs.render_day_header(top_state.entry.day));
-                top_state.header_present = true;
+                if (entry.bootid != top_state.entry.bootid)
+                    output_funcs.prepend(output_funcs.render_reboot_separator());
+                if (entry.day != top_state.entry.day)
+                    output_funcs.prepend(output_funcs.render_day_header(top_state.entry.day));
             }
+
+            start_new_line();
+            top_state.entry = entry;
+            top_state.count = 1;
+            top_state.first_time = top_state.last_time = entry.time;
+            top_state.line_present = false;
         }
+    }
 
-        function bottom_output() {
-            if (bottom_state.line_present) {
-                output_funcs.remove_last();
-                bottom_state.line_present = false;
-            }
-            if (bottom_state.entry) {
-                output_funcs.append(render_state_line(bottom_state));
-                bottom_state.line_present = true;
-            }
+    function prepend_flush() {
+        top_output();
+        if (top_state.entry) {
+            output_funcs.prepend(output_funcs.render_day_header(top_state.entry.day));
+            top_state.header_present = true;
         }
+    }
 
-        function append(journal_entry) {
-            var entry = format_entry(journal_entry);
-
-            if (entry_is_equal(bottom_state.entry, entry)) {
-                bottom_state.count += 1;
-                bottom_state.last_time = entry.time;
-            } else {
-                bottom_output();
-
-                if (!bottom_state.entry || entry.day != bottom_state.entry.day) {
-                    output_funcs.append(output_funcs.render_day_header(entry.day));
-                    bottom_state.header_present = true;
-                }
-                if (bottom_state.entry && entry.bootid != bottom_state.entry.bootid)
-                    output_funcs.append(output_funcs.render_reboot_separator());
-
-                start_new_line();
-                bottom_state.entry = entry;
-                bottom_state.count = 1;
-                bottom_state.first_time = bottom_state.last_time = entry.time;
-                bottom_state.line_present = false;
-            }
+    function bottom_output() {
+        if (bottom_state.line_present) {
+            output_funcs.remove_last();
+            bottom_state.line_present = false;
         }
+        if (bottom_state.entry) {
+            output_funcs.append(render_state_line(bottom_state));
+            bottom_state.line_present = true;
+        }
+    }
 
-        function append_flush() {
+    function append(journal_entry) {
+        var entry = format_entry(journal_entry);
+
+        if (entry_is_equal(bottom_state.entry, entry)) {
+            bottom_state.count += 1;
+            bottom_state.last_time = entry.time;
+        } else {
             bottom_output();
-        }
 
-        return { prepend: prepend,
-                 prepend_flush: prepend_flush,
-                 append: append,
-                 append_flush: append_flush
-        };
-    };
-
-    journal.logbox = function logbox(match, max_entries) {
-        var entries = [ ];
-        var box = document.createElement("div");
-
-        function render() {
-            var renderer = journal.renderer(box);
-            while (box.firstChild)
-                box.removeChild(box.firstChild);
-            for (var i = 0; i < entries.length; i++) {
-                renderer.prepend(entries[i]);
+            if (!bottom_state.entry || entry.day != bottom_state.entry.day) {
+                output_funcs.append(output_funcs.render_day_header(entry.day));
+                bottom_state.header_present = true;
             }
-            renderer.prepend_flush();
-            if (entries.length > 0)
-                box.removeAttribute("hidden");
-            else
-                box.setAttribute("hidden", "hidden");
+            if (bottom_state.entry && entry.bootid != bottom_state.entry.bootid)
+                output_funcs.append(output_funcs.render_reboot_separator());
+
+            start_new_line();
+            bottom_state.entry = entry;
+            bottom_state.count = 1;
+            bottom_state.first_time = bottom_state.last_time = entry.time;
+            bottom_state.line_present = false;
         }
+    }
 
-        render();
+    function append_flush() {
+        bottom_output();
+    }
 
-        var promise = journal.journalctl(match, { count: max_entries })
-                .stream(function(tail) {
-                    entries = entries.concat(tail);
-                    if (entries.length > max_entries)
-                        entries = entries.slice(-max_entries);
-                    render();
-                })
-                .fail(function(error) {
-                    box.appendChild(document.createTextNode(error.message));
-                    box.removeAttribute("hidden");
-                });
-
-        /* Both a DOM element and a promise */
-        return promise.promise(box);
+    return { prepend: prepend,
+             prepend_flush: prepend_flush,
+             append: append,
+             append_flush: append_flush
     };
+};
 
-    module.exports = journal;
-}());
+journal.logbox = function logbox(match, max_entries) {
+    var entries = [ ];
+    var box = document.createElement("div");
+
+    function render() {
+        var renderer = journal.renderer(box);
+        while (box.firstChild)
+            box.removeChild(box.firstChild);
+        for (var i = 0; i < entries.length; i++) {
+            renderer.prepend(entries[i]);
+        }
+        renderer.prepend_flush();
+        if (entries.length > 0)
+            box.removeAttribute("hidden");
+        else
+            box.setAttribute("hidden", "hidden");
+    }
+
+    render();
+
+    var promise = journal.journalctl(match, { count: max_entries })
+            .stream(function(tail) {
+                entries = entries.concat(tail);
+                if (entries.length > max_entries)
+                    entries = entries.slice(-max_entries);
+                render();
+            })
+            .fail(function(error) {
+                box.appendChild(document.createTextNode(error.message));
+                box.removeAttribute("hidden");
+            });
+
+    /* Both a DOM element and a promise */
+    return promise.promise(box);
+};
+
+module.exports = journal;

--- a/pkg/lib/machine-dialogs.js
+++ b/pkg/lib/machine-dialogs.js
@@ -17,1048 +17,1044 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+var $ = require("jquery");
+var cockpit = require("cockpit");
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
+var mustache = require("mustache");
 
-    var mustache = require("mustache");
+var machines = require("machines");
+var credentials = require("credentials");
+require("patterns");
 
-    var machines = require("machines");
-    var credentials = require("credentials");
-    require("patterns");
+var add_tmpl = require("raw-loader!machine-add.html");
+var auth_failed_tmpl = require("raw-loader!machine-auth-failed.html");
+var change_auth_tmpl = require("raw-loader!machine-change-auth.html");
+var change_port_tmpl = require("raw-loader!machine-change-port.html");
+var color_picker_tmpl = require("raw-loader!machine-color-picker.html");
+var invalid_hostkey_tmpl = require("raw-loader!machine-invalid-hostkey.html");
+var not_supported_tmpl = require("raw-loader!machine-not-supported.html");
+var sync_users_tmpl = require("raw-loader!machine-sync-users.html");
+var unknown_hosts_tmpl = require("raw-loader!machine-unknown-hostkey.html");
 
-    var add_tmpl = require("raw-loader!machine-add.html");
-    var auth_failed_tmpl = require("raw-loader!machine-auth-failed.html");
-    var change_auth_tmpl = require("raw-loader!machine-change-auth.html");
-    var change_port_tmpl = require("raw-loader!machine-change-port.html");
-    var color_picker_tmpl = require("raw-loader!machine-color-picker.html");
-    var invalid_hostkey_tmpl = require("raw-loader!machine-invalid-hostkey.html");
-    var not_supported_tmpl = require("raw-loader!machine-not-supported.html");
-    var sync_users_tmpl = require("raw-loader!machine-sync-users.html");
-    var unknown_hosts_tmpl = require("raw-loader!machine-unknown-hostkey.html");
+var _ = cockpit.gettext;
 
-    var _ = cockpit.gettext;
+var default_codes = {
+    "no-cockpit": "not-supported",
+    "not-supported": "not-supported",
+    "protocol-error": "not-supported",
+    "authentication-not-supported": "change-auth",
+    "authentication-failed": "change-auth",
+    "no-forwarding": "change-auth",
+    "unknown-hostkey": "unknown-hostkey",
+    "invalid-hostkey": "invalid-hostkey",
+    "not-found": "add-machine",
+    "unknown-host": "unknown-host",
+    "sync-users": "sync-users"
+};
 
-    var default_codes = {
-        "no-cockpit": "not-supported",
-        "not-supported": "not-supported",
-        "protocol-error": "not-supported",
-        "authentication-not-supported": "change-auth",
-        "authentication-failed": "change-auth",
-        "no-forwarding": "change-auth",
-        "unknown-hostkey": "unknown-hostkey",
-        "invalid-hostkey": "invalid-hostkey",
-        "not-found": "add-machine",
-        "unknown-host": "unknown-host",
-        "sync-users": "sync-users"
+function translate_and_init(tmpl) {
+    var tmp = $("<div>").append(tmpl);
+    tmp.find("[translatable=\"yes\"]").each(function(i, e) {
+        var old = e.outerHTML;
+        var translated = cockpit.gettext(e.getAttribute("context"), $(e).text());
+        $(e).removeAttr("translatable")
+                .text(translated);
+        tmpl = tmpl.replace(old, e.outerHTML);
+    });
+    mustache.parse(tmpl);
+    return tmpl;
+}
+
+var templates = {
+    "add-machine" : translate_and_init(add_tmpl),
+    "auth-failed" : translate_and_init(auth_failed_tmpl),
+    "change-auth" : translate_and_init(change_auth_tmpl),
+    "change-port" : translate_and_init(change_port_tmpl),
+    "color-picker" : translate_and_init(color_picker_tmpl),
+    "invalid-hostkey" : translate_and_init(invalid_hostkey_tmpl),
+    "not-supported" : translate_and_init(not_supported_tmpl),
+    "sync-users" : translate_and_init(sync_users_tmpl),
+    "unknown-hostkey" : translate_and_init(unknown_hosts_tmpl),
+    "unknown-host" : translate_and_init(unknown_hosts_tmpl)
+};
+
+function full_address(machines_ins, address) {
+    var machine = machines_ins.lookup(address);
+    if (machine && machine.address != "localhost")
+        return machine.connection_string;
+
+    return address;
+}
+
+function Dialog(selector, address, machines_ins, codes) {
+    var self = this;
+
+    self.machines_ins = machines_ins;
+    self.codes = codes;
+    self.address = full_address(self.machines_ins, address);
+
+    var promise_callback = null;
+
+    var success_callback = null;
+
+    var current_template = null;
+    var current_instance = null;
+
+    function address_or_label() {
+        var machine = self.machines_ins.lookup(self.address);
+        var host = self.machines_ins.split_connection_string(self.address).address;
+        if (machine && machine.label)
+            host = machine.label;
+        return host;
+    }
+
+    function change_content(template, error_options) {
+        var old_instance = current_instance;
+
+        if (current_template === template)
+            return;
+
+        if (template == "add-machine")
+            current_instance = new AddMachine(self);
+        else if (template == "sync-users")
+            current_instance = new SyncUsers(self);
+        else if (template == "unknown-hostkey" || template == "unknown-host")
+            current_instance = new HostKey(self, template);
+        else if (template == "invalid-hostkey")
+            current_instance = new HostKey(self, template);
+        else if (template == "change-auth")
+            current_instance = new ChangeAuth(self);
+        else if (template == "change-port")
+            current_instance = new MachinePort(self);
+        else
+            current_instance = new Simple(self);
+
+        current_template = template;
+        current_instance.load(error_options);
+
+        if (old_instance && old_instance.close)
+            old_instance.close();
+        old_instance = null;
+    }
+
+    self.try_to_connect = function(address, options) {
+        var dfd = $.Deferred();
+        var conn_options = $.extend({ "payload": "echo",
+                                      "host": address },
+                                    options);
+
+        var machine = self.machines_ins.lookup(address);
+        if (machine && machine.host_key && !machine.on_disk) {
+            conn_options['temp-session'] = false; /* Compatiblity option */
+            conn_options['session'] = 'shared';
+            conn_options['host-key'] = machine.host_key;
+        }
+        var client = cockpit.channel(conn_options);
+        client.send("x");
+        $(client)
+                .on("message", function() {
+                    $(client).off();
+                    client.close();
+                    dfd.resolve();
+                })
+                .on("close", function(event, options) {
+                    dfd.reject(options);
+                });
+
+        return dfd.promise();
     };
 
-    function translate_and_init(tmpl) {
-        var tmp = $("<div>").append(tmpl);
-        tmp.find("[translatable=\"yes\"]").each(function(i, e) {
-            var old = e.outerHTML;
-            var translated = cockpit.gettext(e.getAttribute("context"), $(e).text());
-            $(e).removeAttr("translatable")
-                    .text(translated);
-            tmpl = tmpl.replace(old, e.outerHTML);
+    self.get_sel = function(child_selector) {
+        var ret_txt = selector;
+        if (child_selector)
+            ret_txt = ret_txt + " " + child_selector;
+        return $(ret_txt);
+    };
+
+    self.set_on_success = function (callback) {
+        success_callback = callback;
+    };
+
+    self.set_goal = function (callback) {
+        promise_callback = callback;
+    };
+
+    self.complete = function(val) {
+        if (success_callback)
+            success_callback(val);
+        else
+            $(selector).modal('hide');
+    };
+
+    self.render = function render(data, template) {
+        if (!template)
+            template = current_template;
+
+        var address_data = self.machines_ins.split_connection_string(self.address);
+        var context = $.extend({
+            'host' : address_or_label(),
+            'full_address' : self.address,
+            'context_title' : self.context_title,
+            'strong' : function() {
+                return function(text, render) {
+                    return "<strong>" + render(text) + "</strong>";
+                };
+            }
+        }, data, address_data);
+
+        var output = $(mustache.render(templates[template], context));
+        cockpit.translate(output);
+        self.get_sel(".modal-content").html(output);
+    };
+
+    self.render_error = function render_error(error) {
+        var template;
+        if (error.problem && error.command == "close")
+            template = self.codes[error.problem];
+
+        if (template && current_template !== template)
+            change_content(template, error);
+        else
+            $(selector).dialog("failure", cockpit.message(error));
+    };
+
+    self.render_template = function render_template(template) {
+        change_content(template);
+    };
+
+    self.show = function () {
+        var sel = self.get_sel();
+        sel.on('hide.bs.modal', function () {
+            self.get_sel(".model-content").empty();
         });
-        mustache.parse(tmpl);
-        return tmpl;
-    }
-
-    var templates = {
-        "add-machine" : translate_and_init(add_tmpl),
-        "auth-failed" : translate_and_init(auth_failed_tmpl),
-        "change-auth" : translate_and_init(change_auth_tmpl),
-        "change-port" : translate_and_init(change_port_tmpl),
-        "color-picker" : translate_and_init(color_picker_tmpl),
-        "invalid-hostkey" : translate_and_init(invalid_hostkey_tmpl),
-        "not-supported" : translate_and_init(not_supported_tmpl),
-        "sync-users" : translate_and_init(sync_users_tmpl),
-        "unknown-hostkey" : translate_and_init(unknown_hosts_tmpl),
-        "unknown-host" : translate_and_init(unknown_hosts_tmpl)
+        sel.modal('show');
     };
 
-    function full_address(machines_ins, address) {
-        var machine = machines_ins.lookup(address);
-        if (machine && machine.address != "localhost")
-            return machine.connection_string;
+    self.run = function (promise, failure_callback) {
+        var dialog_dfd = $.Deferred();
+        var promise_funcs = [];
 
-        return address;
-    }
-
-    function Dialog(selector, address, machines_ins, codes) {
-        var self = this;
-
-        self.machines_ins = machines_ins;
-        self.codes = codes;
-        self.address = full_address(self.machines_ins, address);
-
-        var promise_callback = null;
-
-        var success_callback = null;
-
-        var current_template = null;
-        var current_instance = null;
-
-        function address_or_label() {
-            var machine = self.machines_ins.lookup(self.address);
-            var host = self.machines_ins.split_connection_string(self.address).address;
-            if (machine && machine.label)
-                host = machine.label;
-            return host;
-        }
-
-        function change_content(template, error_options) {
-            var old_instance = current_instance;
-
-            if (current_template === template)
-                return;
-
-            if (template == "add-machine")
-                current_instance = new AddMachine(self);
-            else if (template == "sync-users")
-                current_instance = new SyncUsers(self);
-            else if (template == "unknown-hostkey" || template == "unknown-host")
-                current_instance = new HostKey(self, template);
-            else if (template == "invalid-hostkey")
-                current_instance = new HostKey(self, template);
-            else if (template == "change-auth")
-                current_instance = new ChangeAuth(self);
-            else if (template == "change-port")
-                current_instance = new MachinePort(self);
-            else
-                current_instance = new Simple(self);
-
-            current_template = template;
-            current_instance.load(error_options);
-
-            if (old_instance && old_instance.close)
-                old_instance.close();
-            old_instance = null;
-        }
-
-        self.try_to_connect = function(address, options) {
-            var dfd = $.Deferred();
-            var conn_options = $.extend({ "payload": "echo",
-                                          "host": address },
-                                        options);
-
-            var machine = self.machines_ins.lookup(address);
-            if (machine && machine.host_key && !machine.on_disk) {
-                conn_options['temp-session'] = false; /* Compatiblity option */
-                conn_options['session'] = 'shared';
-                conn_options['host-key'] = machine.host_key;
-            }
-            var client = cockpit.channel(conn_options);
-            client.send("x");
-            $(client)
-                    .on("message", function() {
-                        $(client).off();
-                        client.close();
-                        dfd.resolve();
-                    })
-                    .on("close", function(event, options) {
-                        dfd.reject(options);
-                    });
-
-            return dfd.promise();
-        };
-
-        self.get_sel = function(child_selector) {
-            var ret_txt = selector;
-            if (child_selector)
-                ret_txt = ret_txt + " " + child_selector;
-            return $(ret_txt);
-        };
-
-        self.set_on_success = function (callback) {
-            success_callback = callback;
-        };
-
-        self.set_goal = function (callback) {
-            promise_callback = callback;
-        };
-
-        self.complete = function(val) {
-            if (success_callback)
-                success_callback(val);
-            else
-                $(selector).modal('hide');
-        };
-
-        self.render = function render(data, template) {
-            if (!template)
-                template = current_template;
-
-            var address_data = self.machines_ins.split_connection_string(self.address);
-            var context = $.extend({
-                'host' : address_or_label(),
-                'full_address' : self.address,
-                'context_title' : self.context_title,
-                'strong' : function() {
-                    return function(text, render) {
-                        return "<strong>" + render(text) + "</strong>";
-                    };
-                }
-            }, data, address_data);
-
-            var output = $(mustache.render(templates[template], context));
-            cockpit.translate(output);
-            self.get_sel(".modal-content").html(output);
-        };
-
-        self.render_error = function render_error(error) {
-            var template;
-            if (error.problem && error.command == "close")
-                template = self.codes[error.problem];
-
-            if (template && current_template !== template)
-                change_content(template, error);
-            else
-                $(selector).dialog("failure", cockpit.message(error));
-        };
-
-        self.render_template = function render_template(template) {
-            change_content(template);
-        };
-
-        self.show = function () {
-            var sel = self.get_sel();
-            sel.on('hide.bs.modal', function () {
-                self.get_sel(".model-content").empty();
-            });
-            sel.modal('show');
-        };
-
-        self.run = function (promise, failure_callback) {
-            var dialog_dfd = $.Deferred();
-            var promise_funcs = [];
-
-            function next(i) {
-                promise_funcs[i]()
-                        .done(function(val) {
-                            i = i + 1;
-                            if (i < promise_funcs.length) {
-                                next(i);
-                            } else {
-                                dialog_dfd.resolve();
-                                self.complete(val);
-                            }
-                        })
-                        .fail(function(ex) {
-                            if (failure_callback)
-                                failure_callback(ex);
-                            else
-                                self.render_error(ex);
-                            dialog_dfd.reject(ex);
-                        });
-            }
-
-            promise_funcs.push(function() {
-                return promise;
-            });
-
-            self.get_sel().dialog("wait", dialog_dfd.promise());
-            if (promise_callback)
-                promise_funcs.push(promise_callback);
-
-            next(0);
-        };
-    }
-
-    function is_method_supported(methods, method) {
-        var result = methods[method];
-        return result ? result != "no-server-support" : false;
-    }
-
-    function MachineColorPicker(machines_ins) {
-        var self = this;
-
-        self.render = function(selector, address, selected_color) {
-            var machine;
-
-            if (address && !selected_color) {
-                machine = machines_ins.lookup(address);
-                if (machine)
-                    selected_color = machine.color;
-            }
-
-            if (!selected_color)
-                selected_color = machines_ins.unused_color();
-
-            var part;
-            var colors = [];
-            for (var i = 0; i < machines.colors.length; i += 6) {
-                part = machines.colors.slice(i, i + 6);
-                colors.push({"list" : part});
-            }
-
-            var text = mustache.render(templates["color-picker"], { 'colors' : colors, });
-            $(selector).html(text);
-
-            $("#host-edit-color", selector).css("background-color", selected_color);
-            $(".color-cell", selector).each(function(index) {
-                $(this).css("background-color", machines.colors[index]);
-            });
-
-            $('#host-edit-color-popover .popover-content .color-cell', selector)
-                    .click(function() {
-                        var color = $(this).css('background-color');
-                        $('#host-edit-color', selector).css('background-color', color);
-                    });
-
-            $("#host-edit-color", selector).parent()
-                    .on('show.bs.dropdown', function () {
-                        var $div = $('#host-edit-color', selector);
-                        var $pop = $('#host-edit-color-popover', selector);
-                        var div_pos = $div.position();
-                        var div_width = $div.width();
-                        var div_height = $div.height();
-                        var pop_width = $pop.width();
-                        var pop_height = $pop.height();
-
-                        var top = div_pos.top - pop_height + 10;
-                        if (top < 0) {
-                            top = div_pos.top + div_height + 10;
-                            $pop.addClass("bottom");
-                            $pop.removeClass("top");
+        function next(i) {
+            promise_funcs[i]()
+                    .done(function(val) {
+                        i = i + 1;
+                        if (i < promise_funcs.length) {
+                            next(i);
                         } else {
-                            $pop.addClass("top");
-                            $pop.removeClass("bottom");
+                            dialog_dfd.resolve();
+                            self.complete(val);
                         }
-                        $pop.css('left', div_pos.left + (div_width - pop_width) / 2);
-                        $pop.css('top', top);
-                        $pop.show();
                     })
-                    .on('hide.bs.dropdown', function () {
-                        $('#host-edit-color-popover', selector).hide();
+                    .fail(function(ex) {
+                        if (failure_callback)
+                            failure_callback(ex);
+                        else
+                            self.render_error(ex);
+                        dialog_dfd.reject(ex);
                     });
-        };
-    }
+        }
 
-    function Simple(dialog) {
-        var self = this;
-
-        self.load = function() {
-            dialog.render();
-        };
-    }
-
-    function AddMachine(dialog) {
-        var self = this;
-        var color = null;
-        var selector = dialog.get_sel();
-        var run_error = null;
-
-        var invisible = dialog.machines_ins.addresses.filter(function(addr) {
-            var m = dialog.machines_ins.lookup(addr);
-            return !m || !m.visible;
+        promise_funcs.push(function() {
+            return promise;
         });
 
-        function existing_error(address) {
-            var ex = null;
-            var machine = dialog.machines_ins.lookup(address);
-            if (machine && machine.visible && machine.on_disk) {
-                ex = new Error(_("This machine has already been added."));
-                ex.target = "#add-machine-address";
-            }
-            return ex;
+        self.get_sel().dialog("wait", dialog_dfd.promise());
+        if (promise_callback)
+            promise_funcs.push(promise_callback);
+
+        next(0);
+    };
+}
+
+function is_method_supported(methods, method) {
+    var result = methods[method];
+    return result ? result != "no-server-support" : false;
+}
+
+function MachineColorPicker(machines_ins) {
+    var self = this;
+
+    self.render = function(selector, address, selected_color) {
+        var machine;
+
+        if (address && !selected_color) {
+            machine = machines_ins.lookup(address);
+            if (machine)
+                selected_color = machine.color;
         }
 
-        function check_address(evt) {
-            var disabled = true;
-            var ex = null;
+        if (!selected_color)
+            selected_color = machines_ins.unused_color();
 
-            var addr = $('#add-machine-address').val();
-            var button = dialog.get_sel(".btn-primary");
-            if (addr === "") {
-                disabled = true;
-            } else if (!machines.allow_connection_string &&
-                       (addr.indexOf('@') > -1 || addr.indexOf(':') > -1)) {
-                ex = new Error(_("This version of cockpit-ws does not support connecting to a host with an alternate user or port"));
-            } else if (addr.search(/\s+/) === -1) {
-                ex = existing_error(addr);
-                if (!ex)
-                    disabled = false;
-            } else {
-                ex = new Error(_("The IP address or host name cannot contain whitespace."));
-            }
-
-            if (ex)
-                ex.target = "#add-machine-address";
-
-            if (run_error)
-                selector.dialog("failure", run_error, ex);
-            else
-                selector.dialog("failure", ex);
-
-            button.prop("disabled", disabled);
+        var part;
+        var colors = [];
+        for (var i = 0; i < machines.colors.length; i += 6) {
+            part = machines.colors.slice(i, i + 6);
+            colors.push({"list" : part});
         }
 
-        function add_machine() {
-            run_error = null;
-            dialog.address = $('#add-machine-address').val();
-            color = machines.colors.parse($('#add-machine-color-picker #host-edit-color').css('background-color'));
-            if (existing_error(dialog.address))
-                return;
+        var text = mustache.render(templates["color-picker"], { 'colors' : colors, });
+        $(selector).html(text);
 
-            dialog.set_goal(function() {
-                var dfp = $.Deferred();
-                dialog.machines_ins.add(dialog.address, color)
-                        .done(dfp.resolve)
-                        .fail(function (ex) {
-                            var msg = cockpit.format(_("Failed to add machine: $0"),
-                                                     cockpit.message(ex));
-                            dfp.reject(msg);
-                        });
+        $("#host-edit-color", selector).css("background-color", selected_color);
+        $(".color-cell", selector).each(function(index) {
+            $(this).css("background-color", machines.colors[index]);
+        });
 
-                return dfp.promise();
-            });
+        $('#host-edit-color-popover .popover-content .color-cell', selector)
+                .click(function() {
+                    var color = $(this).css('background-color');
+                    $('#host-edit-color', selector).css('background-color', color);
+                });
 
-            dialog.run(dialog.try_to_connect(dialog.address), function (ex) {
-                if (ex.problem == "no-host") {
-                    var host_id_port = dialog.address;
-                    var port_index = host_id_port.lastIndexOf(":");
-                    var port = "22";
-                    if (port_index === -1)
-                        host_id_port = dialog.address + ":22";
-                    else
-                        port = host_id_port.substr(port_index + 1);
-                    ex.message = cockpit.format(_("Cockpit could not contact the given host $0. Make sure it has ssh running on port $1, or specify another port in the address."), host_id_port, port);
-                    ex = cockpit.message(ex);
-                    run_error = ex;
-                }
-                dialog.render_error(ex);
-            });
+        $("#host-edit-color", selector).parent()
+                .on('show.bs.dropdown', function () {
+                    var $div = $('#host-edit-color', selector);
+                    var $pop = $('#host-edit-color-popover', selector);
+                    var div_pos = $div.position();
+                    var div_width = $div.width();
+                    var div_height = $div.height();
+                    var pop_width = $pop.width();
+                    var pop_height = $pop.height();
+
+                    var top = div_pos.top - pop_height + 10;
+                    if (top < 0) {
+                        top = div_pos.top + div_height + 10;
+                        $pop.addClass("bottom");
+                        $pop.removeClass("top");
+                    } else {
+                        $pop.addClass("top");
+                        $pop.removeClass("bottom");
+                    }
+                    $pop.css('left', div_pos.left + (div_width - pop_width) / 2);
+                    $pop.css('top', top);
+                    $pop.show();
+                })
+                .on('hide.bs.dropdown', function () {
+                    $('#host-edit-color-popover', selector).hide();
+                });
+    };
+}
+
+function Simple(dialog) {
+    var self = this;
+
+    self.load = function() {
+        dialog.render();
+    };
+}
+
+function AddMachine(dialog) {
+    var self = this;
+    var color = null;
+    var selector = dialog.get_sel();
+    var run_error = null;
+
+    var invisible = dialog.machines_ins.addresses.filter(function(addr) {
+        var m = dialog.machines_ins.lookup(addr);
+        return !m || !m.visible;
+    });
+
+    function existing_error(address) {
+        var ex = null;
+        var machine = dialog.machines_ins.lookup(address);
+        if (machine && machine.visible && machine.on_disk) {
+            ex = new Error(_("This machine has already been added."));
+            ex.target = "#add-machine-address";
         }
-
-        self.load = function() {
-            var manifest = cockpit.manifests["shell"] || {};
-            var limit = parseInt(manifest["machine-limit"], 10);
-            var color_picker = new MachineColorPicker(dialog.machines_ins);
-            if (!limit || isNaN(limit))
-                limit = 20;
-
-            dialog.render({
-                'nearlimit' : limit * 0.75 <= dialog.machines_ins.list.length,
-                'limit' : limit,
-                'placeholder' : _("Enter IP address or host name"),
-                'options' : invisible,
-            });
-
-            var button = dialog.get_sel(".btn-primary");
-            button.on("click", add_machine);
-
-            $("#add-machine-address").on("keyup", function (ev) {
-                if (ev.which === 13) {
-                    var disabled = button.prop('disabled');
-                    if (!disabled)
-                        add_machine();
-                }
-            });
-            $("#add-machine-address").on("input focus", check_address);
-            color_picker.render("#add-machine-color-picker", dialog.address, color);
-            $("#add-machine-address").focus();
-        };
+        return ex;
     }
 
-    function MachinePort(dialog) {
-        var self = this;
+    function check_address(evt) {
+        var disabled = true;
+        var ex = null;
 
-        function change_port() {
+        var addr = $('#add-machine-address').val();
+        var button = dialog.get_sel(".btn-primary");
+        if (addr === "") {
+            disabled = true;
+        } else if (!machines.allow_connection_string &&
+                   (addr.indexOf('@') > -1 || addr.indexOf(':') > -1)) {
+            ex = new Error(_("This version of cockpit-ws does not support connecting to a host with an alternate user or port"));
+        } else if (addr.search(/\s+/) === -1) {
+            ex = existing_error(addr);
+            if (!ex)
+                disabled = false;
+        } else {
+            ex = new Error(_("The IP address or host name cannot contain whitespace."));
+        }
+
+        if (ex)
+            ex.target = "#add-machine-address";
+
+        if (run_error)
+            selector.dialog("failure", run_error, ex);
+        else
+            selector.dialog("failure", ex);
+
+        button.prop("disabled", disabled);
+    }
+
+    function add_machine() {
+        run_error = null;
+        dialog.address = $('#add-machine-address').val();
+        color = machines.colors.parse($('#add-machine-color-picker #host-edit-color').css('background-color'));
+        if (existing_error(dialog.address))
+            return;
+
+        dialog.set_goal(function() {
             var dfp = $.Deferred();
-            var parts = dialog.machines_ins.split_connection_string(dialog.address);
-            parts.port = $("#edit-machine-port").val();
-            var address = dialog.machines_ins.generate_connection_string(parts.user,
-                                                                         parts.port,
-                                                                         parts.address);
-            function update_host(ex) {
-                dialog.address = address;
-                dialog.machines_ins.change(parts.address, { "port": parts.port })
-                        .done(function () {
-                        // We failed before so try to connect again
-                        // now that the machine is saved.
-                            if (ex) {
-                                dialog.try_to_connect(address)
-                                        .done(dialog.complete)
-                                        .fail(function (e) {
-                                            dfp.reject(e);
-                                        });
-                            } else {
-                                dfp.resolve();
-                            }
-                        })
-                        .fail(function (ex) {
-                            var msg = cockpit.format(_("Failed to edit machine: $0"),
-                                                     cockpit.message(ex));
-                            dfp.reject(msg);
-                        });
-            }
-
-            dialog.try_to_connect(address)
-                    .done(function () {
-                        update_host();
-                    })
+            dialog.machines_ins.add(dialog.address, color)
+                    .done(dfp.resolve)
                     .fail(function (ex) {
-                    /* any other error means progress, so save */
-                        if (ex.problem != 'no-host')
-                            update_host(ex);
-                        else
-                            dfp.reject(ex);
+                        var msg = cockpit.format(_("Failed to add machine: $0"),
+                                                 cockpit.message(ex));
+                        dfp.reject(msg);
                     });
 
-            dialog.run(dfp.promise());
-        }
+            return dfp.promise();
+        });
 
-        self.load = function() {
-            var machine = dialog.machines_ins.lookup(dialog.address);
-            if (!machine) {
-                dialog.get_sel().modal('hide');
-                return;
+        dialog.run(dialog.try_to_connect(dialog.address), function (ex) {
+            if (ex.problem == "no-host") {
+                var host_id_port = dialog.address;
+                var port_index = host_id_port.lastIndexOf(":");
+                var port = "22";
+                if (port_index === -1)
+                    host_id_port = dialog.address + ":22";
+                else
+                    port = host_id_port.substr(port_index + 1);
+                ex.message = cockpit.format(_("Cockpit could not contact the given host $0. Make sure it has ssh running on port $1, or specify another port in the address."), host_id_port, port);
+                ex = cockpit.message(ex);
+                run_error = ex;
             }
-
-            dialog.render({ 'port' : machine.port,
-                            'allow_connection_string' : machines.allow_connection_string });
-            if (machines.allow_connection_string)
-                dialog.get_sel(".btn-primary").on("click", change_port);
-        };
+            dialog.render_error(ex);
+        });
     }
 
-    function HostKey(dialog, problem) {
-        var self = this;
-        var error_options = null;
-        var key = null;
-        var allow_change = (problem == "unknown-hostkey" ||
-                            problem == "unknown-host");
+    self.load = function() {
+        var manifest = cockpit.manifests["shell"] || {};
+        var limit = parseInt(manifest["machine-limit"], 10);
+        var color_picker = new MachineColorPicker(dialog.machines_ins);
+        if (!limit || isNaN(limit))
+            limit = 20;
 
-        function add_key() {
-            var q;
-            var machine = dialog.machines_ins.lookup(dialog.address);
-            if (!machine || machine.on_disk) {
-                q = dialog.machines_ins.add_key(key);
-            } else {
-                /* When machine isn't saved to disk
-                   don't save the key either */
-                q = dialog.machines_ins.change(dialog.address, {
-                    'host_key': key
-                });
+        dialog.render({
+            'nearlimit' : limit * 0.75 <= dialog.machines_ins.list.length,
+            'limit' : limit,
+            'placeholder' : _("Enter IP address or host name"),
+            'options' : invisible,
+        });
+
+        var button = dialog.get_sel(".btn-primary");
+        button.on("click", add_machine);
+
+        $("#add-machine-address").on("keyup", function (ev) {
+            if (ev.which === 13) {
+                var disabled = button.prop('disabled');
+                if (!disabled)
+                    add_machine();
             }
+        });
+        $("#add-machine-address").on("input focus", check_address);
+        color_picker.render("#add-machine-color-picker", dialog.address, color);
+        $("#add-machine-address").focus();
+    };
+}
 
-            var promise = q.then(function () {
-                var inner = dialog.try_to_connect(dialog.address);
+function MachinePort(dialog) {
+    var self = this;
 
-                inner.fail(function(ex) {
-                    if ((ex.problem == "invalid-hostkey" ||
-                        ex.problem == "unknown-hostkey") &&
-                        machine && !machine.on_disk) {
-                        dialog.machines_ins.change(dialog.address, {
-                            'host_key': null
-                        });
-                    }
-                });
-
-                return inner;
-            });
-
-            dialog.run(promise);
-        }
-
-        function render() {
-            var promise = null;
-            var options = {};
-            var match_problem = problem;
-            var fp;
-
-            if (error_options) {
-                key = error_options["host-key"];
-                fp = error_options["host-fingerprint"];
-            }
-
-            dialog.render({
-                'context_title' : dialog.context_title,
-                'key' : fp,
-            });
-
-            if (!key) {
-                if (problem == "unknown-host") {
-                    options["session"] = "private";
-                    match_problem = "unknown-hostkey";
-                }
-
-                promise = dialog.try_to_connect(dialog.address, options)
-                        .fail(function(ex) {
-                            if (ex.problem != match_problem) {
-                                dialog.render_error(ex);
-                            } else {
-                                error_options = ex;
-                                render();
-                            }
-                        })
-
-                // Fixed already, just close
-                        .done(function (v) {
-                            dialog.complete(v);
-                        });
-
-                dialog.get_sel().dialog("wait", promise);
-            } else if (allow_change) {
-                dialog.get_sel(".btn-primary").on("click", add_key);
-            }
-        }
-
-        self.load = function(ex) {
-            error_options = ex;
-            render();
-        };
-    }
-
-    function ChangeAuth(dialog) {
-        var self = this;
-        var error_options = null;
-        var keys = null;
-        var have_ticket = null;
-        var machine = dialog.machines_ins.lookup(dialog.address);
-
-        self.user = { };
-
-        function update_available() {
-            var key_div = dialog.get_sel('.keys');
-            var have_keys = false;
-
-            if (key_div) {
-                key_div.empty();
-                for (var id in keys.items) {
-                    var key = keys.items[id];
-                    if (key.loaded) {
-                        have_keys = true;
-                        key_div.append($("<div>").text(key.name || key.comment));
-                    }
-                }
-            }
-
-            var empty_div = dialog.get_sel('.empty');
-            if (empty_div)
-                empty_div.toggleClass("hidden", have_keys);
-        }
-
-        function login() {
-            var address;
-            var options = {};
-            var dfp = $.Deferred();
-            var user = $("#login-custom-user").val();
-
-            var parts = dialog.machines_ins.split_connection_string(dialog.address);
-            parts.user = user;
-
-            address = dialog.machines_ins.generate_connection_string(parts.user,
+    function change_port() {
+        var dfp = $.Deferred();
+        var parts = dialog.machines_ins.split_connection_string(dialog.address);
+        parts.port = $("#edit-machine-port").val();
+        var address = dialog.machines_ins.generate_connection_string(parts.user,
                                                                      parts.port,
                                                                      parts.address);
-
-            if ($("#login-type button").val() != 'stored') {
-                options['password'] = $("#login-custom-password").val();
-                options["session"] = 'shared';
-                if (!user) {
-                    /* we don't want to save the default user for everyone
-                     * so we pass current user as an option, but make sure the
-                     * session isn't private
-                     */
-                    if (self.user && self.user.name)
-                        options["user"] = self.user.name;
-                    options["temp-session"] = false; /* Compatibility option */
-                }
-            }
-
-            dialog.try_to_connect(address, options)
+        function update_host(ex) {
+            dialog.address = address;
+            dialog.machines_ins.change(parts.address, { "port": parts.port })
                     .done(function () {
-                        dialog.address = address;
-                        if (machine) {
-                            dialog.machines_ins.change(machine.address, { "user" : user })
-                                    .done(dfp.resolve)
-                                    .fail(dfp.reject);
+                    // We failed before so try to connect again
+                    // now that the machine is saved.
+                        if (ex) {
+                            dialog.try_to_connect(address)
+                                    .done(dialog.complete)
+                                    .fail(function (e) {
+                                        dfp.reject(e);
+                                    });
                         } else {
                             dfp.resolve();
                         }
                     })
-                    .fail(dfp.reject);
-
-            dialog.run(dfp.promise());
+                    .fail(function (ex) {
+                        var msg = cockpit.format(_("Failed to edit machine: $0"),
+                                                 cockpit.message(ex));
+                        dfp.reject(msg);
+                    });
         }
 
-        function change_login_type(value) {
-            var stored = value != 'password';
-            var text = $("#login-type li[value=" + value + "]").text();
-            $("#login-type button").val(value);
-            $("#login-type button span").text(text);
-            $("#login-available").toggle(stored);
-            $("#login-diff-password").toggle(!stored);
+        dialog.try_to_connect(address)
+                .done(function () {
+                    update_host();
+                })
+                .fail(function (ex) {
+                /* any other error means progress, so save */
+                    if (ex.problem != 'no-host')
+                        update_host(ex);
+                    else
+                        dfp.reject(ex);
+                });
+
+        dialog.run(dfp.promise());
+    }
+
+    self.load = function() {
+        var machine = dialog.machines_ins.lookup(dialog.address);
+        if (!machine) {
+            dialog.get_sel().modal('hide');
+            return;
         }
 
-        function render() {
-            var promise = null;
-            var template = "change-auth";
-            if (!machines.allow_connection_string || !machines.has_auth_results)
-                template = "auth-failed";
+        dialog.render({ 'port' : machine.port,
+                        'allow_connection_string' : machines.allow_connection_string });
+        if (machines.allow_connection_string)
+            dialog.get_sel(".btn-primary").on("click", change_port);
+    };
+}
 
-            var no_password = false;
-            var methods = null;
-            var available = null;
+function HostKey(dialog, problem) {
+    var self = this;
+    var error_options = null;
+    var key = null;
+    var allow_change = (problem == "unknown-hostkey" ||
+                        problem == "unknown-host");
 
-            var machine_user = dialog.machines_ins.split_connection_string(dialog.address).user;
-            if (!machine_user && machine)
-                machine_user = machine.user;
+    function add_key() {
+        var q;
+        var machine = dialog.machines_ins.lookup(dialog.address);
+        if (!machine || machine.on_disk) {
+            q = dialog.machines_ins.add_key(key);
+        } else {
+            /* When machine isn't saved to disk
+               don't save the key either */
+            q = dialog.machines_ins.change(dialog.address, {
+                'host_key': key
+            });
+        }
 
-            if (error_options && machines.has_auth_results) {
-                available = {};
+        var promise = q.then(function () {
+            var inner = dialog.try_to_connect(dialog.address);
 
-                methods = error_options["auth-method-results"];
-                if (methods) {
-                    no_password = methods['password'] === "not-provided";
-                    for (var method in methods) {
-                        if (is_method_supported(methods, method)) {
-                            available[method] = true;
-                        }
-                    }
+            inner.fail(function(ex) {
+                if ((ex.problem == "invalid-hostkey" ||
+                    ex.problem == "unknown-hostkey") &&
+                    machine && !machine.on_disk) {
+                    dialog.machines_ins.change(dialog.address, {
+                        'host_key': null
+                    });
                 }
+            });
 
-                if ($.isEmptyObject(available))
-                    template = "auth-failed";
+            return inner;
+        });
+
+        dialog.run(promise);
+    }
+
+    function render() {
+        var promise = null;
+        var options = {};
+        var match_problem = problem;
+        var fp;
+
+        if (error_options) {
+            key = error_options["host-key"];
+            fp = error_options["host-fingerprint"];
+        }
+
+        dialog.render({
+            'context_title' : dialog.context_title,
+            'key' : fp,
+        });
+
+        if (!key) {
+            if (problem == "unknown-host") {
+                options["session"] = "private";
+                match_problem = "unknown-hostkey";
             }
 
-            dialog.render({
-                'supported' : methods,
-                'available' : available,
-                'machine_user' : machine_user,
-                'default_user' : self.user ? self.user.name : "",
-                'show_password' : available && available.password && !no_password,
-                'show_ticket': available && available['gssapi-mic'] && have_ticket,
-                'can_sync': !!dialog.codes['sync-users'],
-                'machines.allow_connection_string' : machines.allow_connection_string,
-                'sync_link' : function() {
-                    return function(text, render) {
-                        return '<a id="do-sync-users">' + render(text) + "</a>";
-                    };
-                }
-            }, template);
-
-            if (methods === null && machines.has_auth_results) {
-                promise = dialog.try_to_connect(dialog.address)
-                        .fail(function(ex) {
+            promise = dialog.try_to_connect(dialog.address, options)
+                    .fail(function(ex) {
+                        if (ex.problem != match_problem) {
+                            dialog.render_error(ex);
+                        } else {
                             error_options = ex;
                             render();
-                        })
-
-                // Fixed already, just close
-                        .done(function (v) {
-                            dialog.complete(v);
-                        });
-
-                dialog.get_sel().dialog("wait", promise);
-            } else if (!$.isEmptyObject(available)) {
-                $("#login-type li").on('click', function() {
-                    change_login_type($(this).attr("value"));
-                });
-                change_login_type($("#login-type li:first-child").attr("value"));
-                dialog.get_sel(".btn-primary").on("click", login);
-                dialog.get_sel("a[data-content]").popover();
-
-                update_available();
-            }
-
-            dialog.get_sel("#do-sync-users").on("click", function () {
-                dialog.render_template("sync-users");
-            });
-        }
-
-        self.load = function(ex) {
-            error_options = ex;
-            if (credentials) {
-                keys = credentials.keys_instance();
-                $(keys).on("changed", update_available);
-            }
-
-            cockpit.spawn(["klist", "-s"])
-                    .fail(function (ex) {
-                        have_ticket = false;
+                        }
                     })
-                    .done(function (done) {
-                        have_ticket = true;
-                    })
-                    .always(function () {
-                        cockpit.user()
-                                .done(function (user) {
-                                    self.user = user;
-                                })
-                                .always(function (user) {
-                                    render();
-                                });
+
+            // Fixed already, just close
+                    .done(function (v) {
+                        dialog.complete(v);
                     });
-        };
 
-        self.close = function(ex) {
-            if (keys) {
-                $(keys).off();
-                keys.close();
-            }
-            keys = null;
-        };
+            dialog.get_sel().dialog("wait", promise);
+        } else if (allow_change) {
+            dialog.get_sel(".btn-primary").on("click", add_key);
+        }
     }
 
-    function SyncUsers(dialog) {
-        var self = this;
-        var users = {};
+    self.load = function(ex) {
+        error_options = ex;
+        render();
+    };
+}
 
-        var needs_auth = false;
-        var needs_root = false;
-        var methods = null;
-        var remote_options = { "superuser": true };
+function ChangeAuth(dialog) {
+    var self = this;
+    var error_options = null;
+    var keys = null;
+    var have_ticket = null;
+    var machine = dialog.machines_ins.lookup(dialog.address);
 
-        var perm_failed = null;
+    self.user = { };
 
-        function load_users() {
-            var local = cockpit.dbus(null, { bus: "internal",
-                                             host: "localhost",
-                                             superuser: true });
-            $(local).on("close", function(event, options) {
-                perm_failed = options;
-                render();
-            });
+    function update_available() {
+        var key_div = dialog.get_sel('.keys');
+        var have_keys = false;
 
-            var proxy = local.proxy("cockpit.Setup", "/setup");
-            proxy.wait(function () {
-                if (proxy.valid) {
-                    var blank = {
-                        "t" : "(asas)",
-                        "v" : [[], []]
-                    };
-
-                    proxy.Transfer("passwd1", blank)
-                            .done(function(prepared) {
-                                var i, parts, name;
-                                var groups = prepared.v[1];
-
-                                for (i = 0; i < prepared.v[0].length; i++) {
-                                    var raw = prepared.v[0][i];
-
-                                    parts = raw.split(":");
-                                    name = parts[0];
-
-                                    users[name] = {
-                                        "username" : name,
-                                        "name" : parts[4] || name,
-                                        "raw" : raw,
-                                        "groups" : [],
-                                    };
-                                }
-
-                                for (i = 0; i < groups.length; i++) {
-                                    parts = groups[i].split(":");
-                                    name = parts[0];
-                                    var members = parts[parts.length - 1].split(",");
-                                    for (var j = 0; j < members.length; j++) {
-                                        var u = members[j];
-                                        if (users[u])
-                                            users[u].groups.push(name);
-                                    }
-                                }
-                            })
-                            .fail(function(ex) {
-                                ex.message = cockpit.gettext(ex.message);
-                                perm_failed = ex;
-                            })
-                            .always(function(ex) {
-                                $(local).off();
-                                local.close();
-                                render();
-                            });
+        if (key_div) {
+            key_div.empty();
+            for (var id in keys.items) {
+                var key = keys.items[id];
+                if (key.loaded) {
+                    have_keys = true;
+                    key_div.append($("<div>").text(key.name || key.comment));
                 }
-            });
+            }
         }
 
-        function sync_users() {
-            var client = null;
+        var empty_div = dialog.get_sel('.empty');
+        if (empty_div)
+            empty_div.toggleClass("hidden", have_keys);
+    }
 
-            var dfd = $.Deferred();
-            var promise = dfd.promise();
+    function login() {
+        var address;
+        var options = {};
+        var dfp = $.Deferred();
+        var user = $("#login-custom-user").val();
 
-            dialog.run(promise);
+        var parts = dialog.machines_ins.split_connection_string(dialog.address);
+        parts.user = user;
 
-            /* A successfull sync should close the dialog */
-            dialog.set_on_success(null);
+        address = dialog.machines_ins.generate_connection_string(parts.user,
+                                                                 parts.port,
+                                                                 parts.address);
 
-            promise.always(function () {
-                if (client) {
-                    $(client).off();
-                    client.close();
-                }
-            });
-
-            var options = { bus: "internal" };
-            if (needs_auth) {
-                options.user = $("#sync-username").val();
-                options.password = $("#sync-password").val();
+        if ($("#login-type button").val() != 'stored') {
+            options['password'] = $("#login-custom-password").val();
+            options["session"] = 'shared';
+            if (!user) {
+                /* we don't want to save the default user for everyone
+                 * so we pass current user as an option, but make sure the
+                 * session isn't private
+                 */
+                if (self.user && self.user.name)
+                    options["user"] = self.user.name;
+                options["temp-session"] = false; /* Compatibility option */
             }
-            $.extend(options, remote_options, { host: dialog.address });
-            client = cockpit.dbus(null, options);
-            $(client).on("close", function(event, ex) {
-                dfd.reject(cockpit.message(ex));
-            });
+        }
 
-            var variant = {
-                "t" : "(asas)",
-                "v" : [[]],
-            };
+        dialog.try_to_connect(address, options)
+                .done(function () {
+                    dialog.address = address;
+                    if (machine) {
+                        dialog.machines_ins.change(machine.address, { "user" : user })
+                                .done(dfp.resolve)
+                                .fail(dfp.reject);
+                    } else {
+                        dfp.resolve();
+                    }
+                })
+                .fail(dfp.reject);
 
-            var groups = {};
-            dialog.get_sel("input:checked").each(function() {
-                var u = users[$(this).attr("name")];
-                if (u) {
-                    variant.v[0].push(u.raw);
-                    for (var i = 0; i < u.groups.length; i++) {
-                        var group = u.groups[i];
-                        if (!groups[group])
-                            groups[group] = [];
+        dialog.run(dfp.promise());
+    }
 
-                        groups[group].push(u.username);
+    function change_login_type(value) {
+        var stored = value != 'password';
+        var text = $("#login-type li[value=" + value + "]").text();
+        $("#login-type button").val(value);
+        $("#login-type button span").text(text);
+        $("#login-available").toggle(stored);
+        $("#login-diff-password").toggle(!stored);
+    }
+
+    function render() {
+        var promise = null;
+        var template = "change-auth";
+        if (!machines.allow_connection_string || !machines.has_auth_results)
+            template = "auth-failed";
+
+        var no_password = false;
+        var methods = null;
+        var available = null;
+
+        var machine_user = dialog.machines_ins.split_connection_string(dialog.address).user;
+        if (!machine_user && machine)
+            machine_user = machine.user;
+
+        if (error_options && machines.has_auth_results) {
+            available = {};
+
+            methods = error_options["auth-method-results"];
+            if (methods) {
+                no_password = methods['password'] === "not-provided";
+                for (var method in methods) {
+                    if (is_method_supported(methods, method)) {
+                        available[method] = true;
                     }
                 }
-            });
-            variant.v.push(Object.keys(groups).map(function(k) {
-                return k + ":::" + groups[k].join();
-            }));
-
-            /* We assume all cockpits support the 'passwd1' mechanism */
-            var proxy = client.proxy("cockpit.Setup", "/setup");
-            proxy.wait(function() {
-                if (proxy.valid) {
-                    proxy.Commit("passwd1", variant)
-                            .fail(function(ex) {
-                                ex.message = cockpit.gettext(ex.message);
-                                dfd.reject(ex);
-                            })
-                            .done(dfd.resolve);
-                }
-            });
-        }
-
-        function toggle_button() {
-            var any = dialog.get_sel("input:checked").length > 0;
-            dialog.get_sel(".btn-primary").toggleClass("disabled", !any);
-        }
-
-        function render() {
-            function formated_groups() {
-                if (this.groups)
-                    return this.groups.join(", ");
             }
 
-            /* assume password is allowed for backwards compatibility */
-            var allows_password = true;
-            var user_list = Object.keys(users).sort()
-                    .map(function(v) {
-                        return users[v];
+            if ($.isEmptyObject(available))
+                template = "auth-failed";
+        }
+
+        dialog.render({
+            'supported' : methods,
+            'available' : available,
+            'machine_user' : machine_user,
+            'default_user' : self.user ? self.user.name : "",
+            'show_password' : available && available.password && !no_password,
+            'show_ticket': available && available['gssapi-mic'] && have_ticket,
+            'can_sync': !!dialog.codes['sync-users'],
+            'machines.allow_connection_string' : machines.allow_connection_string,
+            'sync_link' : function() {
+                return function(text, render) {
+                    return '<a id="do-sync-users">' + render(text) + "</a>";
+                };
+            }
+        }, template);
+
+        if (methods === null && machines.has_auth_results) {
+            promise = dialog.try_to_connect(dialog.address)
+                    .fail(function(ex) {
+                        error_options = ex;
+                        render();
+                    })
+
+            // Fixed already, just close
+                    .done(function (v) {
+                        dialog.complete(v);
                     });
 
-            if (machines.has_auth_results && methods)
-                allows_password = is_method_supported(methods, 'password');
-
-            var text = dialog.render({
-                'needs_auth' : needs_auth,
-                'needs_root' : needs_root,
-                'users' : user_list,
-                'perm_failed' : perm_failed ? cockpit.message(perm_failed) : null,
-                'allows_password' : allows_password,
-                'formated_groups': formated_groups,
+            dialog.get_sel().dialog("wait", promise);
+        } else if (!$.isEmptyObject(available)) {
+            $("#login-type li").on('click', function() {
+                change_login_type($(this).attr("value"));
             });
+            change_login_type($("#login-type li:first-child").attr("value"));
+            dialog.get_sel(".btn-primary").on("click", login);
+            dialog.get_sel("a[data-content]").popover();
 
-            dialog.get_sel(".modal-content").html(text);
-            dialog.get_sel(".btn-primary").on("click", sync_users);
-            dialog.get_sel("input:checkbox").on("change", function() {
-                var name = $(this).attr("name");
-                users[name].checked = $(this).is(':checked');
-                toggle_button();
-            });
-            toggle_button();
+            update_available();
         }
 
-        self.load = function(error_options) {
-            if (error_options)
-                methods = error_options['auth-method-results'];
-
-            render();
-            dialog.try_to_connect(dialog.address, remote_options).fail(function(ex) {
-                needs_auth = true;
-                if (ex.problem == "access-denied") {
-                    needs_root = true;
-                    if (!methods && machines.has_auth_results)
-                        /* TODO: We need to know if password auth is
-                         * supported but we only get that when the transport
-                         * closes. Passing an invalid username should
-                         * open new transport that fails.
-                         */
-                        dialog.try_to_connect(dialog.address, { "user" : "1" })
-                                .fail(function(ex) {
-                                    methods = ex['auth-method-results'];
-                                })
-                                .always(render);
-                } else {
-                    methods = ex['auth-method-results'];
-                    render();
-                }
-            });
-            load_users();
-        };
+        dialog.get_sel("#do-sync-users").on("click", function () {
+            dialog.render_template("sync-users");
+        });
     }
 
-    function MachineDialogManager(machines_ins, codes) {
-        var self = this;
-
-        if (!codes)
-            codes = default_codes;
-
-        var color_picker = new MachineColorPicker(machines_ins);
-
-        self.troubleshoot = function(target_id, machine) {
-            var selector = "#" + target_id;
-            if (!machine || !machine.problem)
-                return;
-
-            var template = codes[machine.problem];
-            if (machine.problem == "no-host")
-                template = "change-port";
-
-            var dialog = new Dialog(selector, machine.address, machines_ins, codes);
-            dialog.render_template(template);
-            dialog.show();
-        };
-
-        self.needs_troubleshoot = function (machine) {
-            if (!machine || !machine.problem)
-                return false;
-
-            if (machine.problem == "no-host")
-                return true;
-
-            return !!codes[machine.problem];
-        };
-
-        self.render_dialog = function (template, target_id, address) {
-            var selector = "#" + target_id;
-            var dialog = new Dialog(selector, address, machines_ins, codes);
-            dialog.render_template(template);
-            dialog.show();
-        };
-
-        self.render_color_picker = function (selector, address) {
-            color_picker.render(selector, address);
-        };
-    }
-
-    module.exports = {
-        new_manager: function (machines_ins, codes) {
-            return new MachineDialogManager(machines_ins, codes);
+    self.load = function(ex) {
+        error_options = ex;
+        if (credentials) {
+            keys = credentials.keys_instance();
+            $(keys).on("changed", update_available);
         }
+
+        cockpit.spawn(["klist", "-s"])
+                .fail(function (ex) {
+                    have_ticket = false;
+                })
+                .done(function (done) {
+                    have_ticket = true;
+                })
+                .always(function () {
+                    cockpit.user()
+                            .done(function (user) {
+                                self.user = user;
+                            })
+                            .always(function (user) {
+                                render();
+                            });
+                });
     };
-}());
+
+    self.close = function(ex) {
+        if (keys) {
+            $(keys).off();
+            keys.close();
+        }
+        keys = null;
+    };
+}
+
+function SyncUsers(dialog) {
+    var self = this;
+    var users = {};
+
+    var needs_auth = false;
+    var needs_root = false;
+    var methods = null;
+    var remote_options = { "superuser": true };
+
+    var perm_failed = null;
+
+    function load_users() {
+        var local = cockpit.dbus(null, { bus: "internal",
+                                         host: "localhost",
+                                         superuser: true });
+        $(local).on("close", function(event, options) {
+            perm_failed = options;
+            render();
+        });
+
+        var proxy = local.proxy("cockpit.Setup", "/setup");
+        proxy.wait(function () {
+            if (proxy.valid) {
+                var blank = {
+                    "t" : "(asas)",
+                    "v" : [[], []]
+                };
+
+                proxy.Transfer("passwd1", blank)
+                        .done(function(prepared) {
+                            var i, parts, name;
+                            var groups = prepared.v[1];
+
+                            for (i = 0; i < prepared.v[0].length; i++) {
+                                var raw = prepared.v[0][i];
+
+                                parts = raw.split(":");
+                                name = parts[0];
+
+                                users[name] = {
+                                    "username" : name,
+                                    "name" : parts[4] || name,
+                                    "raw" : raw,
+                                    "groups" : [],
+                                };
+                            }
+
+                            for (i = 0; i < groups.length; i++) {
+                                parts = groups[i].split(":");
+                                name = parts[0];
+                                var members = parts[parts.length - 1].split(",");
+                                for (var j = 0; j < members.length; j++) {
+                                    var u = members[j];
+                                    if (users[u])
+                                        users[u].groups.push(name);
+                                }
+                            }
+                        })
+                        .fail(function(ex) {
+                            ex.message = cockpit.gettext(ex.message);
+                            perm_failed = ex;
+                        })
+                        .always(function(ex) {
+                            $(local).off();
+                            local.close();
+                            render();
+                        });
+            }
+        });
+    }
+
+    function sync_users() {
+        var client = null;
+
+        var dfd = $.Deferred();
+        var promise = dfd.promise();
+
+        dialog.run(promise);
+
+        /* A successfull sync should close the dialog */
+        dialog.set_on_success(null);
+
+        promise.always(function () {
+            if (client) {
+                $(client).off();
+                client.close();
+            }
+        });
+
+        var options = { bus: "internal" };
+        if (needs_auth) {
+            options.user = $("#sync-username").val();
+            options.password = $("#sync-password").val();
+        }
+        $.extend(options, remote_options, { host: dialog.address });
+        client = cockpit.dbus(null, options);
+        $(client).on("close", function(event, ex) {
+            dfd.reject(cockpit.message(ex));
+        });
+
+        var variant = {
+            "t" : "(asas)",
+            "v" : [[]],
+        };
+
+        var groups = {};
+        dialog.get_sel("input:checked").each(function() {
+            var u = users[$(this).attr("name")];
+            if (u) {
+                variant.v[0].push(u.raw);
+                for (var i = 0; i < u.groups.length; i++) {
+                    var group = u.groups[i];
+                    if (!groups[group])
+                        groups[group] = [];
+
+                    groups[group].push(u.username);
+                }
+            }
+        });
+        variant.v.push(Object.keys(groups).map(function(k) {
+            return k + ":::" + groups[k].join();
+        }));
+
+        /* We assume all cockpits support the 'passwd1' mechanism */
+        var proxy = client.proxy("cockpit.Setup", "/setup");
+        proxy.wait(function() {
+            if (proxy.valid) {
+                proxy.Commit("passwd1", variant)
+                        .fail(function(ex) {
+                            ex.message = cockpit.gettext(ex.message);
+                            dfd.reject(ex);
+                        })
+                        .done(dfd.resolve);
+            }
+        });
+    }
+
+    function toggle_button() {
+        var any = dialog.get_sel("input:checked").length > 0;
+        dialog.get_sel(".btn-primary").toggleClass("disabled", !any);
+    }
+
+    function render() {
+        function formated_groups() {
+            if (this.groups)
+                return this.groups.join(", ");
+        }
+
+        /* assume password is allowed for backwards compatibility */
+        var allows_password = true;
+        var user_list = Object.keys(users).sort()
+                .map(function(v) {
+                    return users[v];
+                });
+
+        if (machines.has_auth_results && methods)
+            allows_password = is_method_supported(methods, 'password');
+
+        var text = dialog.render({
+            'needs_auth' : needs_auth,
+            'needs_root' : needs_root,
+            'users' : user_list,
+            'perm_failed' : perm_failed ? cockpit.message(perm_failed) : null,
+            'allows_password' : allows_password,
+            'formated_groups': formated_groups,
+        });
+
+        dialog.get_sel(".modal-content").html(text);
+        dialog.get_sel(".btn-primary").on("click", sync_users);
+        dialog.get_sel("input:checkbox").on("change", function() {
+            var name = $(this).attr("name");
+            users[name].checked = $(this).is(':checked');
+            toggle_button();
+        });
+        toggle_button();
+    }
+
+    self.load = function(error_options) {
+        if (error_options)
+            methods = error_options['auth-method-results'];
+
+        render();
+        dialog.try_to_connect(dialog.address, remote_options).fail(function(ex) {
+            needs_auth = true;
+            if (ex.problem == "access-denied") {
+                needs_root = true;
+                if (!methods && machines.has_auth_results)
+                    /* TODO: We need to know if password auth is
+                     * supported but we only get that when the transport
+                     * closes. Passing an invalid username should
+                     * open new transport that fails.
+                     */
+                    dialog.try_to_connect(dialog.address, { "user" : "1" })
+                            .fail(function(ex) {
+                                methods = ex['auth-method-results'];
+                            })
+                            .always(render);
+            } else {
+                methods = ex['auth-method-results'];
+                render();
+            }
+        });
+        load_users();
+    };
+}
+
+function MachineDialogManager(machines_ins, codes) {
+    var self = this;
+
+    if (!codes)
+        codes = default_codes;
+
+    var color_picker = new MachineColorPicker(machines_ins);
+
+    self.troubleshoot = function(target_id, machine) {
+        var selector = "#" + target_id;
+        if (!machine || !machine.problem)
+            return;
+
+        var template = codes[machine.problem];
+        if (machine.problem == "no-host")
+            template = "change-port";
+
+        var dialog = new Dialog(selector, machine.address, machines_ins, codes);
+        dialog.render_template(template);
+        dialog.show();
+    };
+
+    self.needs_troubleshoot = function (machine) {
+        if (!machine || !machine.problem)
+            return false;
+
+        if (machine.problem == "no-host")
+            return true;
+
+        return !!codes[machine.problem];
+    };
+
+    self.render_dialog = function (template, target_id, address) {
+        var selector = "#" + target_id;
+        var dialog = new Dialog(selector, address, machines_ins, codes);
+        dialog.render_template(template);
+        dialog.show();
+    };
+
+    self.render_color_picker = function (selector, address) {
+        color_picker.render(selector, address);
+    };
+}
+
+module.exports = {
+    new_manager: function (machines_ins, codes) {
+        return new MachineDialogManager(machines_ins, codes);
+    }
+};

--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -1,783 +1,781 @@
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
+var $ = require("jquery");
+var cockpit = require("cockpit");
 
-    var mod = { };
+var mod = { };
 
-    var known_hosts_path = "/etc/ssh/ssh_known_hosts";
-    /*
-     * We share the Machines state between multiple frames. Only
-     * one frame has the job of loading the state, usually index.js
-     * The Loader code below does all the loading.
-     *
-     * The data is stored in sessionStorage in a JSON object, like this
-     * {
-     *    content: name → info dict from bridge's /machines Machines property
-     *    overlay: extra data to augment and override on top of content
-     * }
-     *
-     * This uses sessionStorage rather than cockpit.sessionStorage
-     * because we don't ever want to write unprefixed keys.
-     */
+var known_hosts_path = "/etc/ssh/ssh_known_hosts";
+/*
+ * We share the Machines state between multiple frames. Only
+ * one frame has the job of loading the state, usually index.js
+ * The Loader code below does all the loading.
+ *
+ * The data is stored in sessionStorage in a JSON object, like this
+ * {
+ *    content: name → info dict from bridge's /machines Machines property
+ *    overlay: extra data to augment and override on top of content
+ * }
+ *
+ * This uses sessionStorage rather than cockpit.sessionStorage
+ * because we don't ever want to write unprefixed keys.
+ */
 
-    var key = cockpit.sessionStorage.prefixedKey("v2-machines.json");
-    var session_prefix = cockpit.sessionStorage.prefixedKey("v1-session-machine");
+var key = cockpit.sessionStorage.prefixedKey("v2-machines.json");
+var session_prefix = cockpit.sessionStorage.prefixedKey("v1-session-machine");
 
-    function generate_session_key(host) {
-        return session_prefix + "/" + host;
-    }
+function generate_session_key(host) {
+    return session_prefix + "/" + host;
+}
 
-    function Machines() {
-        var self = this;
+function Machines() {
+    var self = this;
 
-        var flat = null;
-        self.ready = false;
+    var flat = null;
+    self.ready = false;
 
-        /* parsed machine data */
-        var machines = { };
+    /* parsed machine data */
+    var machines = { };
 
-        /* Data shared between Machines() instances */
-        var last = {
-            content: null,
-            overlay: {
-                localhost: {
-                    visible: true,
-                    manifests: cockpit.manifests
-                }
-            }
-        };
-
-        function storage(ev) {
-            if (ev.key === key && ev.storageArea === window.sessionStorage)
-                refresh(JSON.parse(ev.newValue || "null"));
-        }
-
-        window.addEventListener("storage", storage);
-
-        window.setTimeout(function() {
-            var value = window.sessionStorage.getItem(key);
-            if (!self.ready && value)
-                refresh(JSON.parse(value));
-        });
-
-        var timeout = null;
-
-        function sync(machine, values, overlay) {
-            var desired = $.extend({ }, values || { }, overlay || { });
-            var prop;
-            for (prop in desired) {
-                if (machine[prop] !== desired[prop])
-                    machine[prop] = desired[prop];
-            }
-            for (prop in machine) {
-                if (machine[prop] !== desired[prop])
-                    delete machine[prop];
-            }
-            return machine;
-        }
-
-        function refresh(shared, push) {
-            if (!shared)
-                return;
-
-            var emit_ready = !self.ready;
-
-            self.ready = true;
-            last = shared;
-            flat = null;
-
-            if (push && !timeout) {
-                timeout = window.setTimeout(function() {
-                    timeout = null;
-                    window.sessionStorage.setItem(key, JSON.stringify(last));
-                }, 10);
-            }
-
-            var host;
-            var hosts = { };
-            var content = shared.content || { };
-            var overlay = shared.overlay || { };
-            for (host in content)
-                hosts[host] = true;
-            for (host in overlay)
-                hosts[host] = true;
-
-            var events = [];
-
-            var machine, application;
-            for (host in hosts) {
-                var old_machine = machines[host] || { };
-                var old_conns = old_machine.connection_string;
-
-                /* Invert logic for color, always respect what's on disk */
-                if (content[host] && content[host].color && overlay[host])
-                    delete overlay[host].color;
-
-                machine = sync(old_machine, content[host], overlay[host]);
-
-                /* Fill in defaults */
-                machine.key = host;
-                if (!machine.address)
-                    machine.address = host;
-
-                machine.connection_string = self.generate_connection_string(machine.user,
-                                                                            machine.port,
-                                                                            machine.address);
-
-                if (!machine.label) {
-                    if (host == "localhost" || host == "localhost.localdomain") {
-                        application = cockpit.transport.application();
-                        if (application.indexOf('cockpit+=') === 0)
-                            machine.label = application.replace('cockpit+=', '');
-                        else
-                            machine.label = window.location.hostname;
-                    } else {
-                        machine.label = host;
-                    }
-                }
-                if (!machine.avatar)
-                    machine.avatar = "../shell/images/server-small.png";
-
-                events.push([host in machines ? "updated" : "added",
-                    [machine, host, old_conns]]);
-                machines[host] = machine;
-            }
-
-            /* Remove any lost hosts */
-            for (host in machines) {
-                if (!(host in hosts)) {
-                    machine = machines[host];
-                    delete machines[host];
-                    delete overlay[host];
-                    events.push(["removed", [machine, host]]);
-                }
-            }
-
-            /* Fire off all events */
-            var i;
-            var sel = $(self);
-            var len = events.length;
-            for (i = 0; i < len; i++)
-                sel.triggerHandler(events[i][0], events[i][1]);
-            if (emit_ready)
-                $(self).triggerHandler("ready");
-        }
-
-        function update_session_machine(machine, host, values) {
-            /* We don't save the whole machine object */
-            var skey = generate_session_key(host);
-            var data = $.extend({}, machine, values);
-            window.sessionStorage.setItem(skey, JSON.stringify(data));
-            self.overlay(host, values);
-            return cockpit.when([]);
-        }
-
-        function update_saved_machine(host, values) {
-            // wrap values in variants for D-Bus call; at least values.port can
-            // be int or string, so stringify everything but the "visible" boolean
-            var values_variant = {};
-            for (var prop in values) {
-                if (values[prop] !== null) {
-                    if (prop == "visible")
-                        values_variant[prop] = cockpit.variant('b', values[prop]);
-                    else
-                        values_variant[prop] = cockpit.variant('s', values[prop].toString());
-                }
-            }
-
-            // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
-            var bridge = cockpit.dbus(null, { bus: "internal", "superuser": "try" });
-            var mod = bridge.call("/machines", "cockpit.Machines", "Update", [ "99-webui.json", host, values_variant ])
-                    .fail(function(error) {
-                        console.error("failed to call cockpit.Machines.Update(): ", error);
-                    });
-
-            return mod;
-        }
-
-        self.add_key = function(host_key) {
-            var known_hosts = cockpit.file(known_hosts_path, { superuser: "try" });
-            return known_hosts
-                    .modify(function(data) {
-                        if (!data)
-                            data = "";
-
-                        return data + "\n" + host_key;
-                    })
-                    .always(function() {
-                        known_hosts.close();
-                    });
-        };
-
-        self.add = function add(connection_string, color) {
-            var values = self.split_connection_string(connection_string);
-            var host = values['address'];
-
-            values = $.extend({
+    /* Data shared between Machines() instances */
+    var last = {
+        content: null,
+        overlay: {
+            localhost: {
                 visible: true,
-                color: color || self.unused_color(),
-            }, values);
-
-            var machine = self.lookup(host);
-            if (machine)
-                machine.on_disk = true;
-
-            return self.change(values['address'], values);
-        };
-
-        self.unused_color = function unused_color() {
-            var i;
-            var len = mod.colors.length;
-            for (i = 0; i < len; i++) {
-                if (!color_in_use(mod.colors[i]))
-                    return mod.colors[i];
-            }
-            return "gray";
-        };
-
-        function color_in_use(color) {
-            var key, machine;
-            var norm = mod.colors.parse(color);
-            for (key in machines) {
-                machine = machines[key];
-                if (machine.color && mod.colors.parse(machine.color) == norm)
-                    return true;
-            }
-            return false;
-        }
-
-        function merge(item, values) {
-            for (var prop in values) {
-                if (values[prop] === null)
-                    delete item[prop];
-                else
-                    item[prop] = values[prop];
+                manifests: cockpit.manifests
             }
         }
+    };
 
-        self.change = function change(host, values) {
-            var mod, hostnamed, call;
-            var machine = self.lookup(host);
-
-            if (values.label) {
-                var conn_to = host;
-                if (machine)
-                    conn_to = machine.connection_string;
-
-                if (!machine || machine.label !== values.label) {
-                    hostnamed = cockpit.dbus("org.freedesktop.hostname1", { host: conn_to });
-                    call = hostnamed.call("/org/freedesktop/hostname1", "org.freedesktop.hostname1",
-                                          "SetPrettyHostname", [ values.label, true ])
-                            .always(function() {
-                                hostnamed.close();
-                            })
-                            .fail(function(ex) {
-                                console.warn("couldn't set pretty host name: " + ex);
-                            });
-                }
-            }
-
-            if (machine && !machine.on_disk)
-                mod = update_session_machine(machine, host, values);
-            else
-                mod = update_saved_machine(host, values);
-
-            if (call)
-                return cockpit.all(call, mod);
-
-            return mod;
-        };
-
-        self.data = function data(content) {
-            var host;
-            var changes = {};
-
-            for (host in content) {
-                changes[host] = $.extend({ }, last.overlay[host] || { });
-                merge(changes[host], { on_disk: true });
-            }
-
-            /* It's a full reload, so data not
-             * present is no longer from disk
-             */
-            for (host in machines) {
-                if (content && !content[host]) {
-                    changes[host] = $.extend({ }, last.overlay[host] || { });
-                    merge(changes[host], { on_disk: null });
-                }
-            }
-
-            refresh({ content: content,
-                      overlay: $.extend({ }, last.overlay, changes) }, true);
-        };
-
-        self.overlay = function overlay(host, values) {
-            var changes = { };
-            changes[host] = $.extend({ }, last.overlay[host] || { });
-            merge(changes[host], values);
-            refresh({
-                content: last.content,
-                overlay: $.extend({ }, last.overlay, changes)
-            }, true);
-        };
-
-        Object.defineProperty(self, "list", {
-            enumerable: true,
-            get: function get() {
-                var key;
-                if (!flat) {
-                    flat = [];
-                    for (key in machines) {
-                        if (machines[key].visible)
-                            flat.push(machines[key]);
-                    }
-                    flat.sort(function(m1, m2) {
-                        return m1.label.localeCompare(m2.label);
-                    });
-                }
-                return flat;
-            }
-        });
-
-        Object.defineProperty(self, "addresses", {
-            enumerable: true,
-            get: function get() {
-                return Object.keys(machines);
-            }
-        });
-
-        self.lookup = function lookup(address) {
-            var parts = self.split_connection_string(address);
-            return machines[parts.address || "localhost"] || null;
-        };
-
-        self.generate_connection_string = function (user, port, addr) {
-            var address = addr;
-            if (user)
-                address = user + "@" + address;
-
-            if (port)
-                address = address + ":" + port;
-
-            return address;
-        };
-
-        self.split_connection_string = function(conn_to) {
-            var parts = {};
-            var user_spot = -1;
-            var port_spot = -1;
-
-            if (conn_to) {
-                user_spot = conn_to.lastIndexOf('@');
-                port_spot = conn_to.lastIndexOf(':');
-            }
-
-            if (user_spot > 0) {
-                parts.user = conn_to.substring(0, user_spot);
-                conn_to = conn_to.substring(user_spot + 1);
-                port_spot = conn_to.lastIndexOf(':');
-            }
-
-            if (port_spot > -1) {
-                var port = parseInt(conn_to.substring(port_spot + 1), 10);
-                if (!isNaN(port)) {
-                    parts.port = port;
-                    conn_to = conn_to.substring(0, port_spot);
-                }
-            }
-
-            parts.address = conn_to;
-            return parts;
-        };
-
-        self.close = function close() {
-            window.removeEventListener("storage", storage);
-        };
+    function storage(ev) {
+        if (ev.key === key && ev.storageArea === window.sessionStorage)
+            refresh(JSON.parse(ev.newValue || "null"));
     }
 
-    function Loader(machines, session_only) {
-        var self = this;
+    window.addEventListener("storage", storage);
 
-        /* Have we loaded from cockpit session */
-        var session_loaded = false;
+    window.setTimeout(function() {
+        var value = window.sessionStorage.getItem(key);
+        if (!self.ready && value)
+            refresh(JSON.parse(value));
+    });
 
-        /* echo channels to each machine */
-        var channels = { };
+    var timeout = null;
 
-        /* hostnamed proxies to each machine, if hostnamed available */
-        var proxies = { };
+    function sync(machine, values, overlay) {
+        var desired = $.extend({ }, values || { }, overlay || { });
+        var prop;
+        for (prop in desired) {
+            if (machine[prop] !== desired[prop])
+                machine[prop] = desired[prop];
+        }
+        for (prop in machine) {
+            if (machine[prop] !== desired[prop])
+                delete machine[prop];
+        }
+        return machine;
+    }
 
-        /* clients for the bridge D-Bus API */
-        var bridge_dbus = { };
+    function refresh(shared, push) {
+        if (!shared)
+            return;
 
-        function process_session_key(key, value) {
-            var host, values, machine;
-            var parts = key.split("/");
-            if (parts[0] == session_prefix &&
-                parts.length === 2) {
-                host = parts[1];
-                if (value) {
-                    values = JSON.parse(value);
-                    machine = machines.lookup(host);
-                    if (!machine || !machine.on_disk)
-                        machines.overlay(host, values);
-                    else if (!machine.visible)
-                        machines.change(host, { visible: true });
-                    self.connect(host);
+        var emit_ready = !self.ready;
+
+        self.ready = true;
+        last = shared;
+        flat = null;
+
+        if (push && !timeout) {
+            timeout = window.setTimeout(function() {
+                timeout = null;
+                window.sessionStorage.setItem(key, JSON.stringify(last));
+            }, 10);
+        }
+
+        var host;
+        var hosts = { };
+        var content = shared.content || { };
+        var overlay = shared.overlay || { };
+        for (host in content)
+            hosts[host] = true;
+        for (host in overlay)
+            hosts[host] = true;
+
+        var events = [];
+
+        var machine, application;
+        for (host in hosts) {
+            var old_machine = machines[host] || { };
+            var old_conns = old_machine.connection_string;
+
+            /* Invert logic for color, always respect what's on disk */
+            if (content[host] && content[host].color && overlay[host])
+                delete overlay[host].color;
+
+            machine = sync(old_machine, content[host], overlay[host]);
+
+            /* Fill in defaults */
+            machine.key = host;
+            if (!machine.address)
+                machine.address = host;
+
+            machine.connection_string = self.generate_connection_string(machine.user,
+                                                                        machine.port,
+                                                                        machine.address);
+
+            if (!machine.label) {
+                if (host == "localhost" || host == "localhost.localdomain") {
+                    application = cockpit.transport.application();
+                    if (application.indexOf('cockpit+=') === 0)
+                        machine.label = application.replace('cockpit+=', '');
+                    else
+                        machine.label = window.location.hostname;
+                } else {
+                    machine.label = host;
                 }
             }
+            if (!machine.avatar)
+                machine.avatar = "../shell/images/server-small.png";
+
+            events.push([host in machines ? "updated" : "added",
+                [machine, host, old_conns]]);
+            machines[host] = machine;
         }
 
-        function load_from_session_storage() {
-            var i;
-            session_loaded = true;
-            for (i = 0; i < window.sessionStorage.length; i++) {
-                var k = window.sessionStorage.key(i);
-                process_session_key(k, window.sessionStorage.getItem(k));
+        /* Remove any lost hosts */
+        for (host in machines) {
+            if (!(host in hosts)) {
+                machine = machines[host];
+                delete machines[host];
+                delete overlay[host];
+                events.push(["removed", [machine, host]]);
             }
         }
 
-        function process_session_machines(ev) {
-            if (ev.storageArea === window.sessionStorage)
-                process_session_key(ev.key || "", ev.newValue);
-        }
-        window.addEventListener("storage", process_session_machines);
+        /* Fire off all events */
+        var i;
+        var sel = $(self);
+        var len = events.length;
+        for (i = 0; i < len; i++)
+            sel.triggerHandler(events[i][0], events[i][1]);
+        if (emit_ready)
+            $(self).triggerHandler("ready");
+    }
 
-        function state(host, value, problem) {
-            var values = { state: value, problem: problem };
-            if (value == "connected") {
-                values.restarting = false;
-            } else if (problem) {
-                values.manifests = null;
-                values.checksum = null;
-            }
-            machines.overlay(host, values);
-        }
+    function update_session_machine(machine, host, values) {
+        /* We don't save the whole machine object */
+        var skey = generate_session_key(host);
+        var data = $.extend({}, machine, values);
+        window.sessionStorage.setItem(skey, JSON.stringify(data));
+        self.overlay(host, values);
+        return cockpit.when([]);
+    }
 
-        $(machines).on("added", updated);
-        $(machines).on("updated", updated);
-        $(machines).on("removed", removed);
-
-        function updated(ev, machine, host, old_conns) {
-            if (!machine) {
-                machine = machines.lookup(host);
-                if (!machine)
-                    return;
-            }
-
-            var props = proxies[host];
-            if (!props || !props.valid)
-                props = { };
-
-            var overlay = { };
-
-            if (!machine.color)
-                overlay.color = machines.unused_color();
-
-            var label = props.PrettyHostname || props.StaticHostname;
-            if (label && label !== machine.label)
-                overlay.label = label;
-
-            var os = props.OperatingSystemPrettyName;
-            if (os && os != machine.os)
-                overlay.os = props.OperatingSystemPrettyName;
-
-            if (!$.isEmptyObject(overlay))
-                machines.overlay(host, overlay);
-
-            /* Don't automatically reconnect failed machines */
-            if (machine.visible) {
-                if (old_conns && machine.connection_string != old_conns) {
-                    cockpit.kill(old_conns);
-                    self.disconnect(host);
-                    self.connect(host);
-                } else if (!machine.problem) {
-                    self.connect(host);
-                }
-            } else {
-                self.disconnect(host);
-            }
-        }
-
-        function removed(ev, machine, host) {
-            self.disconnect(host);
-        }
-
-        self.connect = function connect(host) {
-            var machine = machines.lookup(host);
-            if (!machine)
-                return;
-
-            var channel = channels[host];
-            if (channel)
-                return;
-
-            var options = {
-                host: machine.connection_string,
-                payload: "echo"
-            };
-
-            if (!machine.on_disk && machine.host_key) {
-                options['temp-session'] = false; /* Compatibility option */
-                options['session'] = 'shared';
-                options['host-key'] = machine.host_key;
-            }
-
-            channel = cockpit.channel(options);
-            channels[host] = channel;
-
-            var local = host === "localhost";
-
-            /* Request is null, and message is true when connected */
-            var request = null;
-            var open = local;
-            var problem = null;
-
-            var url;
-            if (!machine.manifests) {
-                if (machine.checksum)
-                    url = "../../" + machine.checksum + "/manifests.json";
+    function update_saved_machine(host, values) {
+        // wrap values in variants for D-Bus call; at least values.port can
+        // be int or string, so stringify everything but the "visible" boolean
+        var values_variant = {};
+        for (var prop in values) {
+            if (values[prop] !== null) {
+                if (prop == "visible")
+                    values_variant[prop] = cockpit.variant('b', values[prop]);
                 else
-                    url = "../../@" + encodeURI(machine.connection_string) + "/manifests.json";
+                    values_variant[prop] = cockpit.variant('s', values[prop].toString());
             }
+        }
 
-            function whirl() {
-                if (!request && open)
-                    state(host, "connected", null);
-                else if (!problem)
-                    state(host, "connecting", null);
-            }
+        // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
+        var bridge = cockpit.dbus(null, { bus: "internal", "superuser": "try" });
+        var mod = bridge.call("/machines", "cockpit.Machines", "Update", [ "99-webui.json", host, values_variant ])
+                .fail(function(error) {
+                    console.error("failed to call cockpit.Machines.Update(): ", error);
+                });
 
-            /* Here we load the machine manifests, and expect them before going to "connected" */
-            function request_manifest() {
-                request = $.ajax({ url: url, dataType: "json", cache: true })
-                        .done(function(manifests) {
-                            var overlay = { manifests: manifests };
-                            var etag = request.getResponseHeader("ETag");
-                            if (etag) /* and remove quotes */
-                                overlay.checksum = etag.replace(/^"(.+)"$/, '$1');
-                            machines.overlay(host, overlay);
+        return mod;
+    }
+
+    self.add_key = function(host_key) {
+        var known_hosts = cockpit.file(known_hosts_path, { superuser: "try" });
+        return known_hosts
+                .modify(function(data) {
+                    if (!data)
+                        data = "";
+
+                    return data + "\n" + host_key;
+                })
+                .always(function() {
+                    known_hosts.close();
+                });
+    };
+
+    self.add = function add(connection_string, color) {
+        var values = self.split_connection_string(connection_string);
+        var host = values['address'];
+
+        values = $.extend({
+            visible: true,
+            color: color || self.unused_color(),
+        }, values);
+
+        var machine = self.lookup(host);
+        if (machine)
+            machine.on_disk = true;
+
+        return self.change(values['address'], values);
+    };
+
+    self.unused_color = function unused_color() {
+        var i;
+        var len = mod.colors.length;
+        for (i = 0; i < len; i++) {
+            if (!color_in_use(mod.colors[i]))
+                return mod.colors[i];
+        }
+        return "gray";
+    };
+
+    function color_in_use(color) {
+        var key, machine;
+        var norm = mod.colors.parse(color);
+        for (key in machines) {
+            machine = machines[key];
+            if (machine.color && mod.colors.parse(machine.color) == norm)
+                return true;
+        }
+        return false;
+    }
+
+    function merge(item, values) {
+        for (var prop in values) {
+            if (values[prop] === null)
+                delete item[prop];
+            else
+                item[prop] = values[prop];
+        }
+    }
+
+    self.change = function change(host, values) {
+        var mod, hostnamed, call;
+        var machine = self.lookup(host);
+
+        if (values.label) {
+            var conn_to = host;
+            if (machine)
+                conn_to = machine.connection_string;
+
+            if (!machine || machine.label !== values.label) {
+                hostnamed = cockpit.dbus("org.freedesktop.hostname1", { host: conn_to });
+                call = hostnamed.call("/org/freedesktop/hostname1", "org.freedesktop.hostname1",
+                                      "SetPrettyHostname", [ values.label, true ])
+                        .always(function() {
+                            hostnamed.close();
                         })
                         .fail(function(ex) {
-                            console.warn("failed to load manifests from " + machine.connection_string + ": " + ex);
-                        })
-                        .always(function() {
-                            request = null;
-                            whirl();
+                            console.warn("couldn't set pretty host name: " + ex);
                         });
             }
-
-            /* Try to get change notifications via the internal
-               /packages D-Bus interface of the bridge.  Not all
-               bridges support this API, so we still get the first
-               version of the manifests via HTTP in request_manifest.
-            */
-
-            function watch_manifests() {
-                var dbus = cockpit.dbus(null, { bus: "internal",
-                                                host: machine.connection_string
-                });
-                bridge_dbus[host] = dbus;
-                dbus.subscribe({ path: "/packages",
-                                 interface: "org.freedesktop.DBus.Properties",
-                                 member: "PropertiesChanged" },
-                               function (path, iface, mamber, args) {
-                                   if (args[0] == "cockpit.Packages") {
-                                       if (args[1]["Manifests"]) {
-                                           var manifests = JSON.parse(args[1]["Manifests"].v);
-                                           machines.overlay(host, { manifests: manifests });
-                                       }
-                                   }
-                               });
-
-                /* Tell the bridge to reload the packages, but only if
-                   it hasn't just started.  Thus, nothing happens on
-                   the first login, but if you reload the shell, we
-                   will also reload the packages.
-                */
-                dbus.call("/packages", "cockpit.Packages", "ReloadHint", [ ]);
-            }
-
-            function request_hostname() {
-                if (!machine.static_hostname) {
-                    var proxy = cockpit.dbus("org.freedesktop.hostname1",
-                                             { host: machine.connection_string }).proxy();
-                    proxies[host] = proxy;
-                    proxy.wait(function() {
-                        $(proxy).on("changed", function() {
-                            updated(null, null, host);
-                        });
-                        updated(null, null, host);
-                    });
-                }
-            }
-
-            /* Send a message to the server and get back a message once connected */
-            if (!local) {
-                channel.send("x");
-
-                $(channel)
-                        .on("message", function() {
-                            open = true;
-                            if (url)
-                                request_manifest();
-                            watch_manifests();
-                            request_hostname();
-                            whirl();
-                        })
-                        .on("close", function(ev, options) {
-                            var m = machines.lookup(host);
-                            open = false;
-                            // reset to clean state when removing machine (orderly disconnect), otherwise mark as failed
-                            if (!options.problem && m && !m.visible)
-                                state(host, null, null);
-                            else
-                                state(host, "failed", options.problem || "disconnected");
-                            if (m && m.restarting) {
-                                window.setTimeout(function() {
-                                    self.connect(host);
-                                }, 10000);
-                            }
-                            self.disconnect(host);
-                        });
-            } else {
-                if (url)
-                    request_manifest();
-                watch_manifests();
-                request_hostname();
-            }
-
-            /* In case already ready, for example when local */
-            whirl();
-        };
-
-        self.disconnect = function disconnect(host) {
-            if (host === "localhost")
-                return;
-
-            var channel = channels[host];
-            delete channels[host];
-            if (channel) {
-                channel.close();
-                $(channel).off();
-            }
-
-            var proxy = proxies[host];
-            delete proxies[host];
-            if (proxy) {
-                proxy.client.close();
-                $(proxy).off();
-            }
-
-            var dbus = bridge_dbus[host];
-            delete bridge_dbus[host];
-            if (dbus) {
-                dbus.close();
-            }
-        };
-
-        self.expect_restart = function expect_restart(host) {
-            var parts = machines.split_connection_string(host);
-            machines.overlay(parts.address, { restarting: true,
-                                              problem: null });
-        };
-
-        self.close = function close() {
-            $(machines).off("added", updated);
-            $(machines).off("changed", updated);
-            $(machines).off("removed", removed);
-            machines = null;
-
-            window.removeEventListener("storage", process_session_machines);
-            var hosts = Object.keys(channels);
-            hosts.forEach(self.disconnect);
-        };
-
-        if (!session_only) {
-            var proxy = cockpit.dbus(null, { bus: "internal" }).proxy("cockpit.Machines", "/machines");
-            $(proxy).on("changed", function(data) {
-                // unwrap variants from D-Bus call
-                var wrapped = proxy.Machines;
-                var data_unwrap = {};
-                var host_props;
-                for (var host in wrapped) {
-                    host_props = {};
-                    for (var prop in wrapped[host])
-                        host_props[prop] = wrapped[host][prop].v;
-                    data_unwrap[host] = host_props;
-                }
-
-                machines.data(data_unwrap);
-                if (!session_loaded)
-                    load_from_session_storage();
-            });
-        } else {
-            load_from_session_storage();
-            machines.data({});
         }
-    }
 
-    mod.instance = function instance(loader) {
-        return new Machines();
+        if (machine && !machine.on_disk)
+            mod = update_session_machine(machine, host, values);
+        else
+            mod = update_saved_machine(host, values);
+
+        if (call)
+            return cockpit.all(call, mod);
+
+        return mod;
     };
 
-    mod.loader = function loader(machines, session_only) {
-        return new Loader(machines, session_only);
+    self.data = function data(content) {
+        var host;
+        var changes = {};
+
+        for (host in content) {
+            changes[host] = $.extend({ }, last.overlay[host] || { });
+            merge(changes[host], { on_disk: true });
+        }
+
+        /* It's a full reload, so data not
+         * present is no longer from disk
+         */
+        for (host in machines) {
+            if (content && !content[host]) {
+                changes[host] = $.extend({ }, last.overlay[host] || { });
+                merge(changes[host], { on_disk: null });
+            }
+        }
+
+        refresh({ content: content,
+                  overlay: $.extend({ }, last.overlay, changes) }, true);
     };
 
-    mod.colors = [
-        "#0099d3",
-        "#67d300",
-        "#d39e00",
-        "#d3007c",
-        "#00d39f",
-        "#00d1d3",
-        "#00618a",
-        "#4c8a00",
-        "#8a6600",
-        "#9b005b",
-        "#008a55",
-        "#008a8a",
-        "#00b9ff",
-        "#7dff00",
-        "#ffbe00",
-        "#ff0096",
-        "#00ffc0",
-        "#00fdff",
-        "#023448",
-        "#264802",
-        "#483602",
-        "#590034",
-        "#024830",
-        "#024848"
-    ];
-
-    mod.colors.parse = function parse_color(input) {
-        var div = document.createElement('div');
-        div.style.color = input;
-        var style = window.getComputedStyle(div, null);
-        return style.getPropertyValue("color") || div.style.color;
+    self.overlay = function overlay(host, values) {
+        var changes = { };
+        changes[host] = $.extend({ }, last.overlay[host] || { });
+        merge(changes[host], values);
+        refresh({
+            content: last.content,
+            overlay: $.extend({ }, last.overlay, changes)
+        }, true);
     };
 
-    mod.known_hosts_path = known_hosts_path;
-
-    cockpit.transport.wait(function() {
-        var caps = cockpit.transport.options.capabilities || [];
-        /* If cockpit-ws is handling ssh, check for each capability. Otherwise
-         * the version is new enough that is has them all */
-        if ($.inArray("ssh", caps) > -1) {
-            mod.allow_connection_string = $.inArray("connection-string", caps) != -1;
-            mod.has_auth_results = $.inArray("auth-method-results", caps) != -1;
-            known_hosts_path = "/var/lib/cockpit/known_hosts";
-            mod.known_hosts_path = known_hosts_path;
-            console.debug("Running against legacy ws with ssh, using legacy file", known_hosts_path);
-        } else {
-            mod.allow_connection_string = true;
-            mod.has_auth_results = true;
+    Object.defineProperty(self, "list", {
+        enumerable: true,
+        get: function get() {
+            var key;
+            if (!flat) {
+                flat = [];
+                for (key in machines) {
+                    if (machines[key].visible)
+                        flat.push(machines[key]);
+                }
+                flat.sort(function(m1, m2) {
+                    return m1.label.localeCompare(m2.label);
+                });
+            }
+            return flat;
         }
     });
 
-    module.exports = mod;
-}());
+    Object.defineProperty(self, "addresses", {
+        enumerable: true,
+        get: function get() {
+            return Object.keys(machines);
+        }
+    });
+
+    self.lookup = function lookup(address) {
+        var parts = self.split_connection_string(address);
+        return machines[parts.address || "localhost"] || null;
+    };
+
+    self.generate_connection_string = function (user, port, addr) {
+        var address = addr;
+        if (user)
+            address = user + "@" + address;
+
+        if (port)
+            address = address + ":" + port;
+
+        return address;
+    };
+
+    self.split_connection_string = function(conn_to) {
+        var parts = {};
+        var user_spot = -1;
+        var port_spot = -1;
+
+        if (conn_to) {
+            user_spot = conn_to.lastIndexOf('@');
+            port_spot = conn_to.lastIndexOf(':');
+        }
+
+        if (user_spot > 0) {
+            parts.user = conn_to.substring(0, user_spot);
+            conn_to = conn_to.substring(user_spot + 1);
+            port_spot = conn_to.lastIndexOf(':');
+        }
+
+        if (port_spot > -1) {
+            var port = parseInt(conn_to.substring(port_spot + 1), 10);
+            if (!isNaN(port)) {
+                parts.port = port;
+                conn_to = conn_to.substring(0, port_spot);
+            }
+        }
+
+        parts.address = conn_to;
+        return parts;
+    };
+
+    self.close = function close() {
+        window.removeEventListener("storage", storage);
+    };
+}
+
+function Loader(machines, session_only) {
+    var self = this;
+
+    /* Have we loaded from cockpit session */
+    var session_loaded = false;
+
+    /* echo channels to each machine */
+    var channels = { };
+
+    /* hostnamed proxies to each machine, if hostnamed available */
+    var proxies = { };
+
+    /* clients for the bridge D-Bus API */
+    var bridge_dbus = { };
+
+    function process_session_key(key, value) {
+        var host, values, machine;
+        var parts = key.split("/");
+        if (parts[0] == session_prefix &&
+            parts.length === 2) {
+            host = parts[1];
+            if (value) {
+                values = JSON.parse(value);
+                machine = machines.lookup(host);
+                if (!machine || !machine.on_disk)
+                    machines.overlay(host, values);
+                else if (!machine.visible)
+                    machines.change(host, { visible: true });
+                self.connect(host);
+            }
+        }
+    }
+
+    function load_from_session_storage() {
+        var i;
+        session_loaded = true;
+        for (i = 0; i < window.sessionStorage.length; i++) {
+            var k = window.sessionStorage.key(i);
+            process_session_key(k, window.sessionStorage.getItem(k));
+        }
+    }
+
+    function process_session_machines(ev) {
+        if (ev.storageArea === window.sessionStorage)
+            process_session_key(ev.key || "", ev.newValue);
+    }
+    window.addEventListener("storage", process_session_machines);
+
+    function state(host, value, problem) {
+        var values = { state: value, problem: problem };
+        if (value == "connected") {
+            values.restarting = false;
+        } else if (problem) {
+            values.manifests = null;
+            values.checksum = null;
+        }
+        machines.overlay(host, values);
+    }
+
+    $(machines).on("added", updated);
+    $(machines).on("updated", updated);
+    $(machines).on("removed", removed);
+
+    function updated(ev, machine, host, old_conns) {
+        if (!machine) {
+            machine = machines.lookup(host);
+            if (!machine)
+                return;
+        }
+
+        var props = proxies[host];
+        if (!props || !props.valid)
+            props = { };
+
+        var overlay = { };
+
+        if (!machine.color)
+            overlay.color = machines.unused_color();
+
+        var label = props.PrettyHostname || props.StaticHostname;
+        if (label && label !== machine.label)
+            overlay.label = label;
+
+        var os = props.OperatingSystemPrettyName;
+        if (os && os != machine.os)
+            overlay.os = props.OperatingSystemPrettyName;
+
+        if (!$.isEmptyObject(overlay))
+            machines.overlay(host, overlay);
+
+        /* Don't automatically reconnect failed machines */
+        if (machine.visible) {
+            if (old_conns && machine.connection_string != old_conns) {
+                cockpit.kill(old_conns);
+                self.disconnect(host);
+                self.connect(host);
+            } else if (!machine.problem) {
+                self.connect(host);
+            }
+        } else {
+            self.disconnect(host);
+        }
+    }
+
+    function removed(ev, machine, host) {
+        self.disconnect(host);
+    }
+
+    self.connect = function connect(host) {
+        var machine = machines.lookup(host);
+        if (!machine)
+            return;
+
+        var channel = channels[host];
+        if (channel)
+            return;
+
+        var options = {
+            host: machine.connection_string,
+            payload: "echo"
+        };
+
+        if (!machine.on_disk && machine.host_key) {
+            options['temp-session'] = false; /* Compatibility option */
+            options['session'] = 'shared';
+            options['host-key'] = machine.host_key;
+        }
+
+        channel = cockpit.channel(options);
+        channels[host] = channel;
+
+        var local = host === "localhost";
+
+        /* Request is null, and message is true when connected */
+        var request = null;
+        var open = local;
+        var problem = null;
+
+        var url;
+        if (!machine.manifests) {
+            if (machine.checksum)
+                url = "../../" + machine.checksum + "/manifests.json";
+            else
+                url = "../../@" + encodeURI(machine.connection_string) + "/manifests.json";
+        }
+
+        function whirl() {
+            if (!request && open)
+                state(host, "connected", null);
+            else if (!problem)
+                state(host, "connecting", null);
+        }
+
+        /* Here we load the machine manifests, and expect them before going to "connected" */
+        function request_manifest() {
+            request = $.ajax({ url: url, dataType: "json", cache: true })
+                    .done(function(manifests) {
+                        var overlay = { manifests: manifests };
+                        var etag = request.getResponseHeader("ETag");
+                        if (etag) /* and remove quotes */
+                            overlay.checksum = etag.replace(/^"(.+)"$/, '$1');
+                        machines.overlay(host, overlay);
+                    })
+                    .fail(function(ex) {
+                        console.warn("failed to load manifests from " + machine.connection_string + ": " + ex);
+                    })
+                    .always(function() {
+                        request = null;
+                        whirl();
+                    });
+        }
+
+        /* Try to get change notifications via the internal
+           /packages D-Bus interface of the bridge.  Not all
+           bridges support this API, so we still get the first
+           version of the manifests via HTTP in request_manifest.
+        */
+
+        function watch_manifests() {
+            var dbus = cockpit.dbus(null, { bus: "internal",
+                                            host: machine.connection_string
+            });
+            bridge_dbus[host] = dbus;
+            dbus.subscribe({ path: "/packages",
+                             interface: "org.freedesktop.DBus.Properties",
+                             member: "PropertiesChanged" },
+                           function (path, iface, mamber, args) {
+                               if (args[0] == "cockpit.Packages") {
+                                   if (args[1]["Manifests"]) {
+                                       var manifests = JSON.parse(args[1]["Manifests"].v);
+                                       machines.overlay(host, { manifests: manifests });
+                                   }
+                               }
+                           });
+
+            /* Tell the bridge to reload the packages, but only if
+               it hasn't just started.  Thus, nothing happens on
+               the first login, but if you reload the shell, we
+               will also reload the packages.
+            */
+            dbus.call("/packages", "cockpit.Packages", "ReloadHint", [ ]);
+        }
+
+        function request_hostname() {
+            if (!machine.static_hostname) {
+                var proxy = cockpit.dbus("org.freedesktop.hostname1",
+                                         { host: machine.connection_string }).proxy();
+                proxies[host] = proxy;
+                proxy.wait(function() {
+                    $(proxy).on("changed", function() {
+                        updated(null, null, host);
+                    });
+                    updated(null, null, host);
+                });
+            }
+        }
+
+        /* Send a message to the server and get back a message once connected */
+        if (!local) {
+            channel.send("x");
+
+            $(channel)
+                    .on("message", function() {
+                        open = true;
+                        if (url)
+                            request_manifest();
+                        watch_manifests();
+                        request_hostname();
+                        whirl();
+                    })
+                    .on("close", function(ev, options) {
+                        var m = machines.lookup(host);
+                        open = false;
+                        // reset to clean state when removing machine (orderly disconnect), otherwise mark as failed
+                        if (!options.problem && m && !m.visible)
+                            state(host, null, null);
+                        else
+                            state(host, "failed", options.problem || "disconnected");
+                        if (m && m.restarting) {
+                            window.setTimeout(function() {
+                                self.connect(host);
+                            }, 10000);
+                        }
+                        self.disconnect(host);
+                    });
+        } else {
+            if (url)
+                request_manifest();
+            watch_manifests();
+            request_hostname();
+        }
+
+        /* In case already ready, for example when local */
+        whirl();
+    };
+
+    self.disconnect = function disconnect(host) {
+        if (host === "localhost")
+            return;
+
+        var channel = channels[host];
+        delete channels[host];
+        if (channel) {
+            channel.close();
+            $(channel).off();
+        }
+
+        var proxy = proxies[host];
+        delete proxies[host];
+        if (proxy) {
+            proxy.client.close();
+            $(proxy).off();
+        }
+
+        var dbus = bridge_dbus[host];
+        delete bridge_dbus[host];
+        if (dbus) {
+            dbus.close();
+        }
+    };
+
+    self.expect_restart = function expect_restart(host) {
+        var parts = machines.split_connection_string(host);
+        machines.overlay(parts.address, { restarting: true,
+                                          problem: null });
+    };
+
+    self.close = function close() {
+        $(machines).off("added", updated);
+        $(machines).off("changed", updated);
+        $(machines).off("removed", removed);
+        machines = null;
+
+        window.removeEventListener("storage", process_session_machines);
+        var hosts = Object.keys(channels);
+        hosts.forEach(self.disconnect);
+    };
+
+    if (!session_only) {
+        var proxy = cockpit.dbus(null, { bus: "internal" }).proxy("cockpit.Machines", "/machines");
+        $(proxy).on("changed", function(data) {
+            // unwrap variants from D-Bus call
+            var wrapped = proxy.Machines;
+            var data_unwrap = {};
+            var host_props;
+            for (var host in wrapped) {
+                host_props = {};
+                for (var prop in wrapped[host])
+                    host_props[prop] = wrapped[host][prop].v;
+                data_unwrap[host] = host_props;
+            }
+
+            machines.data(data_unwrap);
+            if (!session_loaded)
+                load_from_session_storage();
+        });
+    } else {
+        load_from_session_storage();
+        machines.data({});
+    }
+}
+
+mod.instance = function instance(loader) {
+    return new Machines();
+};
+
+mod.loader = function loader(machines, session_only) {
+    return new Loader(machines, session_only);
+};
+
+mod.colors = [
+    "#0099d3",
+    "#67d300",
+    "#d39e00",
+    "#d3007c",
+    "#00d39f",
+    "#00d1d3",
+    "#00618a",
+    "#4c8a00",
+    "#8a6600",
+    "#9b005b",
+    "#008a55",
+    "#008a8a",
+    "#00b9ff",
+    "#7dff00",
+    "#ffbe00",
+    "#ff0096",
+    "#00ffc0",
+    "#00fdff",
+    "#023448",
+    "#264802",
+    "#483602",
+    "#590034",
+    "#024830",
+    "#024848"
+];
+
+mod.colors.parse = function parse_color(input) {
+    var div = document.createElement('div');
+    div.style.color = input;
+    var style = window.getComputedStyle(div, null);
+    return style.getPropertyValue("color") || div.style.color;
+};
+
+mod.known_hosts_path = known_hosts_path;
+
+cockpit.transport.wait(function() {
+    var caps = cockpit.transport.options.capabilities || [];
+    /* If cockpit-ws is handling ssh, check for each capability. Otherwise
+     * the version is new enough that is has them all */
+    if ($.inArray("ssh", caps) > -1) {
+        mod.allow_connection_string = $.inArray("connection-string", caps) != -1;
+        mod.has_auth_results = $.inArray("auth-method-results", caps) != -1;
+        known_hosts_path = "/var/lib/cockpit/known_hosts";
+        mod.known_hosts_path = known_hosts_path;
+        console.debug("Running against legacy ws with ssh, using legacy file", known_hosts_path);
+    } else {
+        mod.allow_connection_string = true;
+        mod.has_auth_results = true;
+    }
+});
+
+module.exports = mod;

--- a/pkg/lib/qunit-tests.js
+++ b/pkg/lib/qunit-tests.js
@@ -17,16 +17,14 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    /* QUnit needs to have 'window' as 'this' in order to load */
-    window.QUnit = require("qunit/qunit/qunit.js");
-    window.qunitTap = require("qunit-tap/lib/qunit-tap.js");
+/* QUnit needs to have 'window' as 'this' in order to load */
+window.QUnit = require("qunit/qunit/qunit.js");
+window.qunitTap = require("qunit-tap/lib/qunit-tap.js");
 
-    require("./qunit-config.js");
+require("./qunit-config.js");
 
-    require("qunit/qunit/qunit.css");
+require("qunit/qunit/qunit.css");
 
-    module.exports = window.QUnit;
-}());
+module.exports = window.QUnit;

--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -1,338 +1,336 @@
-(function() {
-    "use strict";
+"use strict";
 
-    var cockpit = require("cockpit");
+var cockpit = require("cockpit");
 
-    /* SERVICE MANAGEMENT API
+/* SERVICE MANAGEMENT API
+ *
+ * The "service" module lets you monitor and manage a
+ * system service on localhost in a simple way.
+ *
+ * It mainly exists because talking to the systemd D-Bus API is
+ * not trivial enough to do it directly.
+ *
+ * - proxy = service.proxy(name)
+ *
+ * Create a proxy that represents the service named NAME.
+ *
+ * The proxy has properties and methods (described below) that
+ * allow you to monitor the state of the service, and perform
+ * simple actions on it.
+ *
+ * Initially, any of the properties can be "null" until their
+ * actual values have been retrieved in the background.
+ *
+ * - $(proxy).on('changed', function (event) { ... })
+ *
+ * The 'changed' event is emitted whenever one of the properties
+ * of the proxy changes.
+ *
+ * - proxy.exists
+ *
+ * A boolean that tells whether the service is known or not.  A
+ * proxy with 'exists == false' will have 'state == undefined' and
+ * 'enabled == undefined'.
+ *
+ * - proxy.state
+ *
+ * Either 'undefined' when the state can't be retrieved, or a
+ * string that has one of the values "starting", "running",
+ * "stopping", "stopped", or "failed".
+ *
+ * - proxy.enabled
+ *
+ * Either 'undefined' when the value can't be retrieved, or a
+ * boolean that tells whether the service is started 'enabled'.
+ * What it means exactly for a service to be enabled depends on
+ * the service, but a enabled service is usually started on boot,
+ * no matter wether other services need it or not.  A disabled
+ * service is usually only started when it is needed by some other
+ * service.
+ *
+ * - proxy.unit
+ * - proxy.service
+ *
+ * The raw org.freedesktop.systemd1.Unit and Service D-Bus
+ * interface proxies for the service.
+ *
+ * - promise = proxy.start()
+ *
+ * Start the service.  The return value is a standard jQuery
+ * promise as returned from DBusClient.call.
+ *
+ * - promise =  proxy.restart()
+ *
+ * Restart the service.
+ *
+ * - promise = proxy.tryRestart()
+ *
+ * Try to restart the service if it's running or starting
+ *
+ * - promise = proxy.stop()
+ *
+ * Stop the service.
+ *
+ * - promise = proxy.enable()
+ *
+ * Enable the service.
+ *
+ * - promise = proxy.disable()
+ *
+ * Disable the service.
+ */
+
+var systemd_client;
+var systemd_manager;
+
+function wait_valid(proxy, callback) {
+    proxy.wait(function() {
+        if (proxy.valid)
+            callback();
+    });
+}
+
+function with_systemd_manager(done) {
+    if (!systemd_manager) {
+        systemd_client = cockpit.dbus("org.freedesktop.systemd1", { superuser: "try" });
+        systemd_manager = systemd_client.proxy("org.freedesktop.systemd1.Manager",
+                                               "/org/freedesktop/systemd1");
+        wait_valid(systemd_manager, function() {
+            systemd_manager.Subscribe()
+                    .fail(function (error) {
+                        if (error.name != "org.freedesktop.systemd1.AlreadySubscribed" &&
+                        error.name != "org.freedesktop.DBus.Error.FileExists")
+                            console.warn("Subscribing to systemd signals failed", error);
+                    });
+        });
+    }
+    wait_valid(systemd_manager, done);
+}
+
+function proxy(name) {
+    var self = {
+        exists: null,
+        state: null,
+        enabled: null,
+
+        wait: wait,
+
+        start: start,
+        stop: stop,
+        restart: restart,
+        tryRestart: tryRestart,
+
+        enable: enable,
+        disable: disable
+    };
+
+    cockpit.event_target(self);
+
+    var unit, service;
+    var wait_callbacks = cockpit.defer();
+
+    if (name.indexOf(".") == -1)
+        name = name + ".service";
+
+    function update_from_unit() {
+        self.exists = (unit.LoadState != "not-found" || unit.ActiveState != "inactive");
+
+        if (unit.ActiveState == "activating")
+            self.state = "starting";
+        else if (unit.ActiveState == "deactivating")
+            self.state = "stopping";
+        else if (unit.ActiveState == "active" || unit.ActiveState == "reloading")
+            self.state = "running";
+        else if (unit.ActiveState == "failed")
+            self.state = "failed";
+        else if (unit.ActiveState == "inactive" && self.exists)
+            self.state = "stopped";
+        else
+            self.state = undefined;
+
+        if (unit.UnitFileState == "enabled" || unit.UnitFileState == "linked")
+            self.enabled = true;
+        else if (unit.UnitFileState == "disabled" || unit.UnitFileState == "masked")
+            self.enabled = false;
+        else
+            self.enabled = undefined;
+
+        self.unit = unit;
+
+        self.dispatchEvent("changed");
+        wait_callbacks.resolve();
+    }
+
+    function update_from_service() {
+        self.service = service;
+        self.dispatchEvent("changed");
+    }
+
+    with_systemd_manager(function () {
+        systemd_manager.LoadUnit(name)
+                .done(function (path) {
+                    unit = systemd_client.proxy('org.freedesktop.systemd1.Unit', path);
+                    unit.addEventListener('changed', update_from_unit);
+                    wait_valid(unit, update_from_unit);
+
+                    service = systemd_client.proxy('org.freedesktop.systemd1.Service', path);
+                    service.addEventListener('changed', update_from_service);
+                    wait_valid(service, update_from_service);
+                })
+                .fail(function () {
+                    self.exists = false;
+                    self.dispatchEvent('changed');
+                });
+    });
+
+    function refresh() {
+        if (!unit || !service)
+            return;
+
+        function refresh_interface(path, iface) {
+            systemd_client.call(path,
+                                "org.freedesktop.DBus.Properties", "GetAll", [ iface ])
+                    .fail(function (error) {
+                        console.log(error);
+                    })
+                    .done(function (result) {
+                        var props = { };
+                        for (var p in result[0])
+                            props[p] = result[0][p].v;
+                        var ifaces = { };
+                        ifaces[iface] = props;
+                        var data = { };
+                        data[unit.path] = ifaces;
+                        systemd_client.notify(data);
+                    });
+        }
+
+        refresh_interface(unit.path, "org.freedesktop.systemd1.Unit");
+        refresh_interface(service.path, "org.freedesktop.systemd1.Service");
+    }
+
+    function on_job_new_removed_refresh(event, number, path, unit_id, result) {
+        if (unit_id == name)
+            refresh();
+    }
+
+    /* HACK - https://bugs.freedesktop.org/show_bug.cgi?id=69575
      *
-     * The "service" module lets you monitor and manage a
-     * system service on localhost in a simple way.
+     * We need to explicitly get new property values when getting
+     * a UnitNew signal since UnitNew doesn't carry them.
+     * However, reacting to UnitNew with GetAll could lead to an
+     * infinite loop since systemd emits a UnitNew in reaction to
+     * GetAll for units that it doesn't want to keep loaded, such
+     * as units without unit files.
      *
-     * It mainly exists because talking to the systemd D-Bus API is
-     * not trivial enough to do it directly.
-     *
-     * - proxy = service.proxy(name)
-     *
-     * Create a proxy that represents the service named NAME.
-     *
-     * The proxy has properties and methods (described below) that
-     * allow you to monitor the state of the service, and perform
-     * simple actions on it.
-     *
-     * Initially, any of the properties can be "null" until their
-     * actual values have been retrieved in the background.
-     *
-     * - $(proxy).on('changed', function (event) { ... })
-     *
-     * The 'changed' event is emitted whenever one of the properties
-     * of the proxy changes.
-     *
-     * - proxy.exists
-     *
-     * A boolean that tells whether the service is known or not.  A
-     * proxy with 'exists == false' will have 'state == undefined' and
-     * 'enabled == undefined'.
-     *
-     * - proxy.state
-     *
-     * Either 'undefined' when the state can't be retrieved, or a
-     * string that has one of the values "starting", "running",
-     * "stopping", "stopped", or "failed".
-     *
-     * - proxy.enabled
-     *
-     * Either 'undefined' when the value can't be retrieved, or a
-     * boolean that tells whether the service is started 'enabled'.
-     * What it means exactly for a service to be enabled depends on
-     * the service, but a enabled service is usually started on boot,
-     * no matter wether other services need it or not.  A disabled
-     * service is usually only started when it is needed by some other
-     * service.
-     *
-     * - proxy.unit
-     * - proxy.service
-     *
-     * The raw org.freedesktop.systemd1.Unit and Service D-Bus
-     * interface proxies for the service.
-     *
-     * - promise = proxy.start()
-     *
-     * Start the service.  The return value is a standard jQuery
-     * promise as returned from DBusClient.call.
-     *
-     * - promise =  proxy.restart()
-     *
-     * Restart the service.
-     *
-     * - promise = proxy.tryRestart()
-     *
-     * Try to restart the service if it's running or starting
-     *
-     * - promise = proxy.stop()
-     *
-     * Stop the service.
-     *
-     * - promise = proxy.enable()
-     *
-     * Enable the service.
-     *
-     * - promise = proxy.disable()
-     *
-     * Disable the service.
+     * So we ignore UnitNew and instead assume that the unit state
+     * only changes in interesting ways when there is a job for it
+     * or when the daemon is reloaded (or when we get a property
+     * change notification, of course).
      */
 
-    var systemd_client;
-    var systemd_manager;
+    // This is what we want to do:
+    // systemd_manager.addEventListener("UnitNew", function (event, unit_id, path) {
+    //     if (unit_id == name)
+    //         refresh();
+    // });
 
-    function wait_valid(proxy, callback) {
-        proxy.wait(function() {
-            if (proxy.valid)
-                callback();
-        });
+    // This is what we have to do:
+    systemd_manager.addEventListener("Reloading", function (event, reloading) {
+        if (!reloading)
+            refresh();
+    });
+
+    systemd_manager.addEventListener("JobNew", on_job_new_removed_refresh);
+    systemd_manager.addEventListener("JobRemoved", on_job_new_removed_refresh);
+
+    function wait(callback) {
+        wait_callbacks.promise.then(callback);
     }
 
-    function with_systemd_manager(done) {
-        if (!systemd_manager) {
-            systemd_client = cockpit.dbus("org.freedesktop.systemd1", { superuser: "try" });
-            systemd_manager = systemd_client.proxy("org.freedesktop.systemd1.Manager",
-                                                   "/org/freedesktop/systemd1");
-            wait_valid(systemd_manager, function() {
-                systemd_manager.Subscribe()
-                        .fail(function (error) {
-                            if (error.name != "org.freedesktop.systemd1.AlreadySubscribed" &&
-                            error.name != "org.freedesktop.DBus.Error.FileExists")
-                                console.warn("Subscribing to systemd signals failed", error);
-                        });
-            });
+    /* Actions
+     *
+     * We don't call methods on the D-Bus proxies here since they
+     * might not be ready when these functions are called.
+     */
+
+    var pending_jobs = { };
+
+    systemd_manager.addEventListener("JobRemoved", function (event, number, path, unit_id, result) {
+        if (pending_jobs[path]) {
+            if (result == "done")
+                pending_jobs[path].resolve();
+            else
+                pending_jobs[path].reject(result);
+            delete pending_jobs[path];
         }
-        wait_valid(systemd_manager, done);
+    });
+
+    function call_manager(method, args) {
+        return systemd_client.call("/org/freedesktop/systemd1",
+                                   "org.freedesktop.systemd1.Manager",
+                                   method, args);
     }
 
-    function proxy(name) {
-        var self = {
-            exists: null,
-            state: null,
-            enabled: null,
+    function call_manager_with_job(method, args) {
+        var dfd = cockpit.defer();
+        call_manager(method, args)
+                .done(function (results) {
+                    var path = results[0];
+                    pending_jobs[path] = dfd;
+                })
+                .fail(function (error) {
+                    dfd.reject(error);
+                });
+        return dfd.promise();
+    }
 
-            wait: wait,
-
-            start: start,
-            stop: stop,
-            restart: restart,
-            tryRestart: tryRestart,
-
-            enable: enable,
-            disable: disable
-        };
-
-        cockpit.event_target(self);
-
-        var unit, service;
-        var wait_callbacks = cockpit.defer();
-
-        if (name.indexOf(".") == -1)
-            name = name + ".service";
-
-        function update_from_unit() {
-            self.exists = (unit.LoadState != "not-found" || unit.ActiveState != "inactive");
-
-            if (unit.ActiveState == "activating")
-                self.state = "starting";
-            else if (unit.ActiveState == "deactivating")
-                self.state = "stopping";
-            else if (unit.ActiveState == "active" || unit.ActiveState == "reloading")
-                self.state = "running";
-            else if (unit.ActiveState == "failed")
-                self.state = "failed";
-            else if (unit.ActiveState == "inactive" && self.exists)
-                self.state = "stopped";
-            else
-                self.state = undefined;
-
-            if (unit.UnitFileState == "enabled" || unit.UnitFileState == "linked")
-                self.enabled = true;
-            else if (unit.UnitFileState == "disabled" || unit.UnitFileState == "masked")
-                self.enabled = false;
-            else
-                self.enabled = undefined;
-
-            self.unit = unit;
-
-            self.dispatchEvent("changed");
-            wait_callbacks.resolve();
-        }
-
-        function update_from_service() {
-            self.service = service;
-            self.dispatchEvent("changed");
-        }
-
-        with_systemd_manager(function () {
-            systemd_manager.LoadUnit(name)
-                    .done(function (path) {
-                        unit = systemd_client.proxy('org.freedesktop.systemd1.Unit', path);
-                        unit.addEventListener('changed', update_from_unit);
-                        wait_valid(unit, update_from_unit);
-
-                        service = systemd_client.proxy('org.freedesktop.systemd1.Service', path);
-                        service.addEventListener('changed', update_from_service);
-                        wait_valid(service, update_from_service);
-                    })
-                    .fail(function () {
-                        self.exists = false;
-                        self.dispatchEvent('changed');
-                    });
-        });
-
-        function refresh() {
-            if (!unit || !service)
-                return;
-
-            function refresh_interface(path, iface) {
-                systemd_client.call(path,
-                                    "org.freedesktop.DBus.Properties", "GetAll", [ iface ])
-                        .fail(function (error) {
-                            console.log(error);
-                        })
-                        .done(function (result) {
-                            var props = { };
-                            for (var p in result[0])
-                                props[p] = result[0][p].v;
-                            var ifaces = { };
-                            ifaces[iface] = props;
-                            var data = { };
-                            data[unit.path] = ifaces;
-                            systemd_client.notify(data);
-                        });
-            }
-
-            refresh_interface(unit.path, "org.freedesktop.systemd1.Unit");
-            refresh_interface(service.path, "org.freedesktop.systemd1.Service");
-        }
-
-        function on_job_new_removed_refresh(event, number, path, unit_id, result) {
-            if (unit_id == name)
-                refresh();
-        }
-
-        /* HACK - https://bugs.freedesktop.org/show_bug.cgi?id=69575
-         *
-         * We need to explicitly get new property values when getting
-         * a UnitNew signal since UnitNew doesn't carry them.
-         * However, reacting to UnitNew with GetAll could lead to an
-         * infinite loop since systemd emits a UnitNew in reaction to
-         * GetAll for units that it doesn't want to keep loaded, such
-         * as units without unit files.
-         *
-         * So we ignore UnitNew and instead assume that the unit state
-         * only changes in interesting ways when there is a job for it
-         * or when the daemon is reloaded (or when we get a property
-         * change notification, of course).
-         */
-
-        // This is what we want to do:
-        // systemd_manager.addEventListener("UnitNew", function (event, unit_id, path) {
-        //     if (unit_id == name)
-        //         refresh();
-        // });
-
-        // This is what we have to do:
-        systemd_manager.addEventListener("Reloading", function (event, reloading) {
-            if (!reloading)
-                refresh();
-        });
-
-        systemd_manager.addEventListener("JobNew", on_job_new_removed_refresh);
-        systemd_manager.addEventListener("JobRemoved", on_job_new_removed_refresh);
-
-        function wait(callback) {
-            wait_callbacks.promise.then(callback);
-        }
-
-        /* Actions
-         *
-         * We don't call methods on the D-Bus proxies here since they
-         * might not be ready when these functions are called.
-         */
-
-        var pending_jobs = { };
-
-        systemd_manager.addEventListener("JobRemoved", function (event, number, path, unit_id, result) {
-            if (pending_jobs[path]) {
-                if (result == "done")
-                    pending_jobs[path].resolve();
-                else
-                    pending_jobs[path].reject(result);
-                delete pending_jobs[path];
-            }
-        });
-
-        function call_manager(method, args) {
-            return systemd_client.call("/org/freedesktop/systemd1",
-                                       "org.freedesktop.systemd1.Manager",
-                                       method, args);
-        }
-
-        function call_manager_with_job(method, args) {
+    function call_manager_with_reload(method, args) {
+        return call_manager(method, args).then(function () {
             var dfd = cockpit.defer();
-            call_manager(method, args)
-                    .done(function (results) {
-                        var path = results[0];
-                        pending_jobs[path] = dfd;
-                    })
+            call_manager("Reload", [ ])
+                    .done(function () { dfd.resolve() })
                     .fail(function (error) {
-                        dfd.reject(error);
+                    // HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1560549
+                    // some systemd versions disconnect too fast from the bus
+                        if (error.name === "org.freedesktop.DBus.Error.NoReply") {
+                            refresh();
+                            dfd.resolve();
+                        } else {
+                            dfd.reject(error);
+                        }
                     });
             return dfd.promise();
-        }
-
-        function call_manager_with_reload(method, args) {
-            return call_manager(method, args).then(function () {
-                var dfd = cockpit.defer();
-                call_manager("Reload", [ ])
-                        .done(function () { dfd.resolve() })
-                        .fail(function (error) {
-                        // HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1560549
-                        // some systemd versions disconnect too fast from the bus
-                            if (error.name === "org.freedesktop.DBus.Error.NoReply") {
-                                refresh();
-                                dfd.resolve();
-                            } else {
-                                dfd.reject(error);
-                            }
-                        });
-                return dfd.promise();
-            });
-        }
-
-        function start() {
-            return call_manager_with_job("StartUnit", [ name, "replace" ]);
-        }
-
-        function stop() {
-            return call_manager_with_job("StopUnit", [ name, "replace" ]);
-        }
-
-        function restart() {
-            return call_manager_with_job("RestartUnit", [ name, "replace" ]);
-        }
-
-        function tryRestart() {
-            return call_manager_with_job("TryRestartUnit", [ name, "replace" ]);
-        }
-
-        function enable() {
-            return call_manager_with_reload("EnableUnitFiles", [ [ name ], false, false ]);
-        }
-
-        function disable() {
-            return call_manager_with_reload("DisableUnitFiles", [ [ name ], false ]);
-        }
-
-        return self;
+        });
     }
 
-    module.exports = {
-        proxy: proxy
-    };
-}());
+    function start() {
+        return call_manager_with_job("StartUnit", [ name, "replace" ]);
+    }
+
+    function stop() {
+        return call_manager_with_job("StopUnit", [ name, "replace" ]);
+    }
+
+    function restart() {
+        return call_manager_with_job("RestartUnit", [ name, "replace" ]);
+    }
+
+    function tryRestart() {
+        return call_manager_with_job("TryRestartUnit", [ name, "replace" ]);
+    }
+
+    function enable() {
+        return call_manager_with_reload("EnableUnitFiles", [ [ name ], false, false ]);
+    }
+
+    function disable() {
+        return call_manager_with_reload("DisableUnitFiles", [ [ name ], false ]);
+    }
+
+    return self;
+}
+
+module.exports = {
+    proxy: proxy
+};

--- a/pkg/networkmanager/utils.js
+++ b/pkg/networkmanager/utils.js
@@ -17,218 +17,216 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var cockpit = require("cockpit");
+var cockpit = require("cockpit");
 
-    var _ = cockpit.gettext;
+var _ = cockpit.gettext;
 
-    /* NetworkManager specific data conversions and utility functions.
-     */
+/* NetworkManager specific data conversions and utility functions.
+ */
 
-    var byteorder;
+var byteorder;
 
-    function set_byteorder(bo) {
-        byteorder = bo;
-    }
+function set_byteorder(bo) {
+    byteorder = bo;
+}
 
-    function ip_prefix_to_text(num) {
-        return num.toString();
-    }
+function ip_prefix_to_text(num) {
+    return num.toString();
+}
 
-    function ip_prefix_from_text(text) {
-        if (/^[0-9]+$/.test(text.trim()))
-            return parseInt(text, 10);
+function ip_prefix_from_text(text) {
+    if (/^[0-9]+$/.test(text.trim()))
+        return parseInt(text, 10);
 
-        throw cockpit.format(_("Invalid prefix $0"), text);
-    }
+    throw cockpit.format(_("Invalid prefix $0"), text);
+}
 
-    function ip_metric_to_text(num) {
-        return num.toString();
-    }
+function ip_metric_to_text(num) {
+    return num.toString();
+}
 
-    function ip_metric_from_text(text) {
-        if (text === "")
-            return 0;
+function ip_metric_from_text(text) {
+    if (text === "")
+        return 0;
 
-        if (/^[0-9]+$/.test(text.trim()))
-            return parseInt(text, 10);
+    if (/^[0-9]+$/.test(text.trim()))
+        return parseInt(text, 10);
 
-        throw cockpit.format(_("Invalid metric $0"), text);
-    }
+    throw cockpit.format(_("Invalid metric $0"), text);
+}
 
-    function toDec(n) {
-        return n.toString(10);
-    }
+function toDec(n) {
+    return n.toString(10);
+}
 
-    function bytes_from_nm32(num) {
-        var bytes = [];
-        var i;
-        if (byteorder == "be") {
-            for (i = 3; i >= 0; i--) {
-                bytes[i] = num & 0xFF;
-                num = num >>> 8;
-            }
-        } else {
-            for (i = 0; i < 4; i++) {
-                bytes[i] = num & 0xFF;
-                num = num >>> 8;
-            }
+function bytes_from_nm32(num) {
+    var bytes = [];
+    var i;
+    if (byteorder == "be") {
+        for (i = 3; i >= 0; i--) {
+            bytes[i] = num & 0xFF;
+            num = num >>> 8;
         }
-        return bytes;
-    }
-
-    function ip4_to_text(num, zero_is_empty) {
-        if (num === 0 && zero_is_empty)
-            return "";
-        return bytes_from_nm32(num).map(toDec)
-                .join('.');
-    }
-
-    function ip4_from_text(text, empty_is_zero) {
-        function invalid() {
-            throw cockpit.format(_("Invalid address $0"), text);
-        }
-
-        if (text === "" && empty_is_zero)
-            return 0;
-
-        var parts = text.split('.');
-        if (parts.length != 4)
-            invalid();
-
-        var bytes = parts.map(function(s) {
-            if (/^[0-9]+$/.test(s.trim()))
-                return parseInt(s, 10);
-            else
-                invalid();
-        });
-
-        var num = 0;
-        function shift(b) {
-            if (isNaN(b) || b < 0 || b > 0xFF)
-                invalid();
-            num = 0x100 * num + b;
-        }
-
-        var i;
-        if (byteorder == "be") {
-            for (i = 0; i < 4; i++) {
-                shift(bytes[i]);
-            }
-        } else {
-            for (i = 3; i >= 0; i--) {
-                shift(bytes[i]);
-            }
-        }
-
-        return num;
-    }
-
-    var text_to_prefix_bits = {
-        "255": 8, "254": 7, "252": 6, "248": 5, "240": 4, "224": 3, "192": 2, "128": 1, "0": 0
-    };
-
-    function ip4_prefix_from_text(text) {
-        function invalid() {
-            throw cockpit.format(_("Invalid prefix or netmask $0"), text);
-        }
-
-        if (/^[0-9]+$/.test(text.trim()))
-            return parseInt(text, 10);
-        var parts = text.split('.');
-        if (parts.length != 4)
-            invalid();
-        var prefix = 0;
-        var i;
+    } else {
         for (i = 0; i < 4; i++) {
-            var p = text_to_prefix_bits[parts[i].trim()];
-            if (p !== undefined) {
-                prefix += p;
-                if (p < 8)
-                    break;
-            } else
-                invalid();
+            bytes[i] = num & 0xFF;
+            num = num >>> 8;
         }
-        for (i += 1; i < 4; i++) {
-            if (/^0+$/.test(parts[i].trim()) === false)
-                invalid();
-        }
-        return prefix;
+    }
+    return bytes;
+}
+
+function ip4_to_text(num, zero_is_empty) {
+    if (num === 0 && zero_is_empty)
+        return "";
+    return bytes_from_nm32(num).map(toDec)
+            .join('.');
+}
+
+function ip4_from_text(text, empty_is_zero) {
+    function invalid() {
+        throw cockpit.format(_("Invalid address $0"), text);
     }
 
-    function ip6_to_text(data, zero_is_empty) {
-        var parts = [];
-        var bytes = cockpit.base64_decode(data);
-        for (var i = 0; i < 8; i++)
-            parts[i] = ((bytes[2 * i] << 8) + bytes[2 * i + 1]).toString(16);
-        var result = parts.join(':');
-        if (result == "0:0:0:0:0:0:0:0" && zero_is_empty)
-            return "";
-        return result;
-    }
+    if (text === "" && empty_is_zero)
+        return 0;
 
-    function ip6_from_text(text, empty_is_zero) {
-        function invalid() {
-            throw cockpit.format(_("Invalid address $0"), text);
-        }
+    var parts = text.split('.');
+    if (parts.length != 4)
+        invalid();
 
-        if (text === "" && empty_is_zero)
-            return cockpit.base64_encode([ 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0,
-            ]);
-
-        var parts = text.split(':');
-        if (parts.length < 1 || parts.length > 8)
+    var bytes = parts.map(function(s) {
+        if (/^[0-9]+$/.test(s.trim()))
+            return parseInt(s, 10);
+        else
             invalid();
+    });
 
-        if (parts[0] === "")
-            parts[0] = "0";
-        if (parts[parts.length - 1] === "")
-            parts[parts.length - 1] = "0";
+    var num = 0;
+    function shift(b) {
+        if (isNaN(b) || b < 0 || b > 0xFF)
+            invalid();
+        num = 0x100 * num + b;
+    }
 
-        var bytes = [];
-        var n, i, j;
-        var empty_seen = false;
-        for (i = 0, j = 0; i < parts.length; i++, j++) {
-            if (parts[i] === "") {
-                if (empty_seen)
-                    invalid();
-                empty_seen = true;
-                while (j < i + (8 - parts.length)) {
-                    bytes[2 * j] = bytes[2 * j + 1] = 0;
-                    j++;
-                }
-            } else {
-                if (!/^[0-9a-fA-F]+$/.test(parts[i].trim()))
-                    invalid();
-                n = parseInt(parts[i], 16);
-                if (isNaN(n) || n < 0 || n > 0xFFFF)
-                    invalid();
-                bytes[2 * j] = n >> 8;
-                bytes[2 * j + 1] = n & 0xFF;
+    var i;
+    if (byteorder == "be") {
+        for (i = 0; i < 4; i++) {
+            shift(bytes[i]);
+        }
+    } else {
+        for (i = 3; i >= 0; i--) {
+            shift(bytes[i]);
+        }
+    }
+
+    return num;
+}
+
+var text_to_prefix_bits = {
+    "255": 8, "254": 7, "252": 6, "248": 5, "240": 4, "224": 3, "192": 2, "128": 1, "0": 0
+};
+
+function ip4_prefix_from_text(text) {
+    function invalid() {
+        throw cockpit.format(_("Invalid prefix or netmask $0"), text);
+    }
+
+    if (/^[0-9]+$/.test(text.trim()))
+        return parseInt(text, 10);
+    var parts = text.split('.');
+    if (parts.length != 4)
+        invalid();
+    var prefix = 0;
+    var i;
+    for (i = 0; i < 4; i++) {
+        var p = text_to_prefix_bits[parts[i].trim()];
+        if (p !== undefined) {
+            prefix += p;
+            if (p < 8)
+                break;
+        } else
+            invalid();
+    }
+    for (i += 1; i < 4; i++) {
+        if (/^0+$/.test(parts[i].trim()) === false)
+            invalid();
+    }
+    return prefix;
+}
+
+function ip6_to_text(data, zero_is_empty) {
+    var parts = [];
+    var bytes = cockpit.base64_decode(data);
+    for (var i = 0; i < 8; i++)
+        parts[i] = ((bytes[2 * i] << 8) + bytes[2 * i + 1]).toString(16);
+    var result = parts.join(':');
+    if (result == "0:0:0:0:0:0:0:0" && zero_is_empty)
+        return "";
+    return result;
+}
+
+function ip6_from_text(text, empty_is_zero) {
+    function invalid() {
+        throw cockpit.format(_("Invalid address $0"), text);
+    }
+
+    if (text === "" && empty_is_zero)
+        return cockpit.base64_encode([ 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+        ]);
+
+    var parts = text.split(':');
+    if (parts.length < 1 || parts.length > 8)
+        invalid();
+
+    if (parts[0] === "")
+        parts[0] = "0";
+    if (parts[parts.length - 1] === "")
+        parts[parts.length - 1] = "0";
+
+    var bytes = [];
+    var n, i, j;
+    var empty_seen = false;
+    for (i = 0, j = 0; i < parts.length; i++, j++) {
+        if (parts[i] === "") {
+            if (empty_seen)
+                invalid();
+            empty_seen = true;
+            while (j < i + (8 - parts.length)) {
+                bytes[2 * j] = bytes[2 * j + 1] = 0;
+                j++;
             }
+        } else {
+            if (!/^[0-9a-fA-F]+$/.test(parts[i].trim()))
+                invalid();
+            n = parseInt(parts[i], 16);
+            if (isNaN(n) || n < 0 || n > 0xFFFF)
+                invalid();
+            bytes[2 * j] = n >> 8;
+            bytes[2 * j + 1] = n & 0xFF;
         }
-        if (j != 8)
-            invalid();
-
-        return cockpit.base64_encode(bytes);
     }
+    if (j != 8)
+        invalid();
 
-    module.exports = {
-        set_byteorder: set_byteorder,
+    return cockpit.base64_encode(bytes);
+}
 
-        ip_prefix_to_text: ip_prefix_to_text,
-        ip_prefix_from_text: ip_prefix_from_text,
-        ip_metric_to_text: ip_metric_to_text,
-        ip_metric_from_text: ip_metric_from_text,
+module.exports = {
+    set_byteorder: set_byteorder,
 
-        ip4_to_text: ip4_to_text,
-        ip4_from_text: ip4_from_text,
-        ip4_prefix_from_text: ip4_prefix_from_text,
+    ip_prefix_to_text: ip_prefix_to_text,
+    ip_prefix_from_text: ip_prefix_from_text,
+    ip_metric_to_text: ip_metric_to_text,
+    ip_metric_from_text: ip_metric_from_text,
 
-        ip6_to_text: ip6_to_text,
-        ip6_from_text: ip6_from_text
-    };
-})();
+    ip4_to_text: ip4_to_text,
+    ip4_from_text: ip4_from_text,
+    ip4_prefix_from_text: ip4_prefix_from_text,
+
+    ip6_to_text: ip6_to_text,
+    ip6_from_text: ip6_from_text
+};

--- a/pkg/playground/react-demo-dialog.jsx
+++ b/pkg/playground/react-demo-dialog.jsx
@@ -20,89 +20,85 @@
 import React from "react";
 import * as Select from "cockpit-components-select.jsx";
 
-(function() {
-    "use strict";
-
-    /* Sample dialog body
-     */
-    class PatternDialogBody extends React.Component {
-        selectChanged(value) {
-            console.log("new value: " + value);
-        }
-
-        render() {
-            return (
-                <div className="modal-body">
-                    <table className="form-table-ct">
-                        <tbody>
-                            <tr>
-                                <td className="top">
-                                    <label className="control-label" htmlFor="control-1">
-                                        Label
-                                    </label>
-                                </td>
-                                <td>
-                                    <input id="control-1" className="form-control" type="text" />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="top">
-                                    <label className="control-label">
-                                        Select
-                                    </label>
-                                </td>
-                                <td>
-                                    <Select.Select onChange={this.selectChanged} id="primary-select">
-                                        <Select.SelectEntry data='one'>One</Select.SelectEntry>
-                                        <Select.SelectEntry data='two'>Two</Select.SelectEntry>
-                                        <Select.SelectEntry data='three'>Three</Select.SelectEntry>
-                                        <Select.SelectEntry data='four' />
-                                    </Select.Select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="top">
-                                    <label className="control-label">
-                                        Preselected
-                                    </label>
-                                </td>
-                                <td>
-                                    <Select.Select initial="two">
-                                        <Select.SelectEntry data="one">One</Select.SelectEntry>
-                                        <Select.SelectEntry data="two">Two</Select.SelectEntry>
-                                        <Select.SelectEntry data="three">Three</Select.SelectEntry>
-                                    </Select.Select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="top">
-                                    <label className="control-label">
-                                        Empty Select
-                                    </label>
-                                </td>
-                                <td>
-                                    <Select.Select />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="top">
-                                    <label className="control-label">
-                                        Nested dialog
-                                    </label>
-                                </td>
-                                <td>
-                                    <button id="open-nested" onClick={ this.props.clickNested }>
-                                        Try to nest dialog
-                                    </button>
-                                    <span>Doesn't open a dialog, only shows a warning in the console.</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            );
-        }
+/* Sample dialog body
+ */
+class PatternDialogBody extends React.Component {
+    selectChanged(value) {
+        console.log("new value: " + value);
     }
 
-    module.exports = PatternDialogBody;
-}());
+    render() {
+        return (
+            <div className="modal-body">
+                <table className="form-table-ct">
+                    <tbody>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label" htmlFor="control-1">
+                                    Label
+                                </label>
+                            </td>
+                            <td>
+                                <input id="control-1" className="form-control" type="text" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label">
+                                    Select
+                                </label>
+                            </td>
+                            <td>
+                                <Select.Select onChange={this.selectChanged} id="primary-select">
+                                    <Select.SelectEntry data='one'>One</Select.SelectEntry>
+                                    <Select.SelectEntry data='two'>Two</Select.SelectEntry>
+                                    <Select.SelectEntry data='three'>Three</Select.SelectEntry>
+                                    <Select.SelectEntry data='four' />
+                                </Select.Select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label">
+                                    Preselected
+                                </label>
+                            </td>
+                            <td>
+                                <Select.Select initial="two">
+                                    <Select.SelectEntry data="one">One</Select.SelectEntry>
+                                    <Select.SelectEntry data="two">Two</Select.SelectEntry>
+                                    <Select.SelectEntry data="three">Three</Select.SelectEntry>
+                                </Select.Select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label">
+                                    Empty Select
+                                </label>
+                            </td>
+                            <td>
+                                <Select.Select />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="top">
+                                <label className="control-label">
+                                    Nested dialog
+                                </label>
+                            </td>
+                            <td>
+                                <button id="open-nested" onClick={ this.props.clickNested }>
+                                    Try to nest dialog
+                                </button>
+                                <span>Doesn't open a dialog, only shows a warning in the console.</span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        );
+    }
+}
+
+module.exports = PatternDialogBody;

--- a/pkg/playground/react-demo-listing.jsx
+++ b/pkg/playground/react-demo-listing.jsx
@@ -23,131 +23,127 @@ import PropTypes from "prop-types";
 
 import * as cockpitListing from "cockpit-components-listing.jsx";
 
-(function() {
-    "use strict";
-
-    /* Sample tab renderer for listing pattern
-     * Shows a caption and the time it was instantiated
-     */
-    class DemoListingTab extends React.Component {
-        constructor(props) {
-            super(props);
-            this.state = {
-                initTime: new Date().toLocaleString(),
-            };
-        }
-
-        render() {
-            return (<div>
-                <span>This is a listing tab</span><br />
-                <span>{this.props.description}</span><br />
-                <span>Initialized at: {this.state.initTime}</span>
-            </div>
-            );
-        }
+/* Sample tab renderer for listing pattern
+ * Shows a caption and the time it was instantiated
+ */
+class DemoListingTab extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            initTime: new Date().toLocaleString(),
+        };
     }
-    DemoListingTab.propTypes = {
-        description: PropTypes.string.isRequired,
-    };
 
-    var showListingDemo = function(rootElement, rootElementSelectable, rootElementEmptyList) {
-        var navigateToItem = function(msg) {
-            window.alert("navigated to item: " + msg);
-        };
-
-        var handleAddClick = function(event) {
-            if (event.button !== 0)
-                return;
-
-            window.alert('This link could open a dialog to create a new entry');
-        };
-
-        var handlePlayClick = function(event) {
-            if (event.button !== 0)
-                return;
-
-            window.alert('This is a row-specific action');
-            event.stopPropagation();
-        };
-
-        var tabRenderers = [
-            {
-                name: 'onlyActive',
-                renderer: DemoListingTab,
-                data: { description: "Tab should only stay loaded when active" },
-                presence: 'onlyActive',
-            },
-            {
-                name: 'default',
-                renderer: DemoListingTab,
-                data: { description: "standard behavior tab" },
-            },
-            {
-                name: 'always',
-                renderer: DemoListingTab,
-                data: { description: "Tab should always stay loaded while row is expanded" },
-                presence: 'always',
-            },
-            {
-                name: 'loadOnDemand',
-                renderer: DemoListingTab,
-                data: { description: "Tab is loaded on demand, then stays active until row is collapsed" },
-                presence: 'loadOnDemand',
-            },
-        ];
-
-        var addLink = <a className="pull-right" role="link" tabIndex="0" onClick={handleAddClick}>Add Row</a>;
-
-        var rowAction = {
-            element: <button className="btn btn-default btn-control fa fa-play" onClick={handlePlayClick} />,
-            tight: true
-        };
-
-        // create the listings
-        var listing = (
-            <cockpitListing.Listing title="Demo Listing Pattern with expandable rows"
-                actions={addLink}
-                columnTitles={['Name', 'Random', 'IP', 'State']}>
-                <cockpitListing.ListingRow
-                    columns={ [ { name: 'standard', 'header': true }, 'aoeuaoeu', '127.30.168.10', 'Running' ] }
-                    tabRenderers={tabRenderers}
-                    navigateToItem={navigateToItem.bind(this, 'frontend')} />
-                <cockpitListing.ListingRow
-                    columns={ [ { name: "can't navigate", 'header': true }, 'aoeuaoeu', '127.30.168.10', 'Running' ] }
-                    tabRenderers={tabRenderers} />
-                <cockpitListing.ListingRow
-                    columns={ [ { name: "with button", 'header': true }, 'aoeuaoeu', '127.30.168.10', rowAction ] }
-                    tabRenderers={tabRenderers} />
-                <cockpitListing.ListingRow
-                    columns={ [ { name: "initially expanded", 'header': true }, 'aoeuaoeu', '127.30.168.12', rowAction ] }
-                    tabRenderers={tabRenderers} initiallyExpanded />
-                <cockpitListing.ListingRow
-                    columns={ [ { name: 'nothing to expand', 'header': true }, 'some text', '127.30.168.11', 'some state' ] } />
-            </cockpitListing.Listing>
+    render() {
+        return (<div>
+            <span>This is a listing tab</span><br />
+            <span>{this.props.description}</span><br />
+            <span>Initialized at: {this.state.initTime}</span>
+        </div>
         );
-        ReactDOM.render(listing, rootElement);
+    }
+}
+DemoListingTab.propTypes = {
+    description: PropTypes.string.isRequired,
+};
 
-        listing = (
-            <cockpitListing.Listing title="Demo Listing Pattern with selectable rows"
-                actions={addLink}
-                columnTitles={['Name', 'Random', 'IP', 'State']}>
-                <cockpitListing.ListingRow
-                    columns={ [ { name: 'selected by default', 'header': true }, 'aoeuaoeu', '127.30.168.10', 'Running' ] }
-                    selected />
-                <cockpitListing.ListingRow
-                    columns={ [ { name: "not selected by default", 'header': true }, 'aoeuaoeu', '127.30.168.11', 'Running' ] }
-                    selected={false} />
-                <cockpitListing.ListingRow
-                    columns={ [ { name: "not selectable", 'header': true }, 'aoeuaoeu', '127.30.168.12', rowAction ] } />
-            </cockpitListing.Listing>
-        );
-        ReactDOM.render(listing, rootElementSelectable);
-
-        var emptyListing = <cockpitListing.Listing title="Demo Empty Listing Pattern" emptyCaption="No Entries" />;
-        ReactDOM.render(emptyListing, rootElementEmptyList);
+var showListingDemo = function(rootElement, rootElementSelectable, rootElementEmptyList) {
+    var navigateToItem = function(msg) {
+        window.alert("navigated to item: " + msg);
     };
 
-    module.exports = {
-        demo: showListingDemo,
+    var handleAddClick = function(event) {
+        if (event.button !== 0)
+            return;
+
+        window.alert('This link could open a dialog to create a new entry');
     };
-}());
+
+    var handlePlayClick = function(event) {
+        if (event.button !== 0)
+            return;
+
+        window.alert('This is a row-specific action');
+        event.stopPropagation();
+    };
+
+    var tabRenderers = [
+        {
+            name: 'onlyActive',
+            renderer: DemoListingTab,
+            data: { description: "Tab should only stay loaded when active" },
+            presence: 'onlyActive',
+        },
+        {
+            name: 'default',
+            renderer: DemoListingTab,
+            data: { description: "standard behavior tab" },
+        },
+        {
+            name: 'always',
+            renderer: DemoListingTab,
+            data: { description: "Tab should always stay loaded while row is expanded" },
+            presence: 'always',
+        },
+        {
+            name: 'loadOnDemand',
+            renderer: DemoListingTab,
+            data: { description: "Tab is loaded on demand, then stays active until row is collapsed" },
+            presence: 'loadOnDemand',
+        },
+    ];
+
+    var addLink = <a className="pull-right" role="link" tabIndex="0" onClick={handleAddClick}>Add Row</a>;
+
+    var rowAction = {
+        element: <button className="btn btn-default btn-control fa fa-play" onClick={handlePlayClick} />,
+        tight: true
+    };
+
+    // create the listings
+    var listing = (
+        <cockpitListing.Listing title="Demo Listing Pattern with expandable rows"
+            actions={addLink}
+            columnTitles={['Name', 'Random', 'IP', 'State']}>
+            <cockpitListing.ListingRow
+                columns={ [ { name: 'standard', 'header': true }, 'aoeuaoeu', '127.30.168.10', 'Running' ] }
+                tabRenderers={tabRenderers}
+                navigateToItem={navigateToItem.bind(this, 'frontend')} />
+            <cockpitListing.ListingRow
+                columns={ [ { name: "can't navigate", 'header': true }, 'aoeuaoeu', '127.30.168.10', 'Running' ] }
+                tabRenderers={tabRenderers} />
+            <cockpitListing.ListingRow
+                columns={ [ { name: "with button", 'header': true }, 'aoeuaoeu', '127.30.168.10', rowAction ] }
+                tabRenderers={tabRenderers} />
+            <cockpitListing.ListingRow
+                columns={ [ { name: "initially expanded", 'header': true }, 'aoeuaoeu', '127.30.168.12', rowAction ] }
+                tabRenderers={tabRenderers} initiallyExpanded />
+            <cockpitListing.ListingRow
+                columns={ [ { name: 'nothing to expand', 'header': true }, 'some text', '127.30.168.11', 'some state' ] } />
+        </cockpitListing.Listing>
+    );
+    ReactDOM.render(listing, rootElement);
+
+    listing = (
+        <cockpitListing.Listing title="Demo Listing Pattern with selectable rows"
+            actions={addLink}
+            columnTitles={['Name', 'Random', 'IP', 'State']}>
+            <cockpitListing.ListingRow
+                columns={ [ { name: 'selected by default', 'header': true }, 'aoeuaoeu', '127.30.168.10', 'Running' ] }
+                selected />
+            <cockpitListing.ListingRow
+                columns={ [ { name: "not selected by default", 'header': true }, 'aoeuaoeu', '127.30.168.11', 'Running' ] }
+                selected={false} />
+            <cockpitListing.ListingRow
+                columns={ [ { name: "not selectable", 'header': true }, 'aoeuaoeu', '127.30.168.12', rowAction ] } />
+        </cockpitListing.Listing>
+    );
+    ReactDOM.render(listing, rootElementSelectable);
+
+    var emptyListing = <cockpitListing.Listing title="Demo Empty Listing Pattern" emptyCaption="No Entries" />;
+    ReactDOM.render(emptyListing, rootElementEmptyList);
+};
+
+module.exports = {
+    demo: showListingDemo,
+};

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -17,984 +17,982 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
+var $ = require("jquery");
+var cockpit = require("cockpit");
 
-    var shell_embedded = window.location.pathname.indexOf(".html") !== -1;
-    var _ = cockpit.gettext;
+var shell_embedded = window.location.pathname.indexOf(".html") !== -1;
+var _ = cockpit.gettext;
 
-    function component_checksum(machine, component) {
-        var parts = component.split("/");
-        var pkg = parts[0];
-        if (machine.manifests && machine.manifests[pkg] && machine.manifests[pkg][".checksum"])
-            return "$" + machine.manifests[pkg][".checksum"];
+function component_checksum(machine, component) {
+    var parts = component.split("/");
+    var pkg = parts[0];
+    if (machine.manifests && machine.manifests[pkg] && machine.manifests[pkg][".checksum"])
+        return "$" + machine.manifests[pkg][".checksum"];
+}
+
+function Frames(index) {
+    var self = this;
+
+    /* Lists of frames, by host */
+    self.iframes = { };
+
+    function remove_frame(frame) {
+        $(frame.contentWindow).off();
+        $(frame).remove();
     }
 
-    function Frames(index) {
-        var self = this;
+    self.remove = function remove(machine, component) {
+        var address;
+        if (typeof machine == "string")
+            address = machine;
+        else if (machine)
+            address = machine.address;
+        if (!address)
+            address = "localhost";
+        var list = self.iframes[address] || { };
+        if (!component)
+            delete self.iframes[address];
+        Object.keys(list).forEach(function(key) {
+            if (!component || component == key) {
+                remove_frame(list[key]);
+                delete list[component];
+            }
+        });
+    };
 
-        /* Lists of frames, by host */
-        self.iframes = { };
+    function frame_ready(frame, count) {
+        var ready = false;
 
-        function remove_frame(frame) {
-            $(frame.contentWindow).off();
-            $(frame).remove();
+        window.clearTimeout(frame.timer);
+        frame.timer = null;
+
+        try {
+            ready = $("body", frame.contentWindow.document).is(":visible");
+        } catch (ex) {
+            ready = true;
         }
 
-        self.remove = function remove(machine, component) {
-            var address;
-            if (typeof machine == "string")
-                address = machine;
-            else if (machine)
-                address = machine.address;
-            if (!address)
-                address = "localhost";
-            var list = self.iframes[address] || { };
-            if (!component)
-                delete self.iframes[address];
-            Object.keys(list).forEach(function(key) {
-                if (!component || component == key) {
-                    remove_frame(list[key]);
-                    delete list[component];
-                }
-            });
-        };
+        if (!count)
+            count = 0;
+        count += 1;
+        if (count > 50)
+            ready = true;
 
-        function frame_ready(frame, count) {
-            var ready = false;
-
-            window.clearTimeout(frame.timer);
-            frame.timer = null;
-
-            try {
-                ready = $("body", frame.contentWindow.document).is(":visible");
-            } catch (ex) {
-                ready = true;
+        if (ready) {
+            if (frame.getAttribute("data-ready") != "1") {
+                frame.setAttribute("data-ready", "1");
+                if (count > 0)
+                    index.navigate();
             }
+        } else {
+            frame.timer = window.setTimeout(function() {
+                frame_ready(frame, count + 1);
+            }, 100);
+        }
+    }
 
-            if (!count)
-                count = 0;
-            count += 1;
-            if (count > 50)
-                ready = true;
+    self.lookup = function lookup(machine, component, hash) {
+        var host;
+        var address;
+        var new_frame = false;
 
-            if (ready) {
-                if (frame.getAttribute("data-ready") != "1") {
-                    frame.setAttribute("data-ready", "1");
-                    if (count > 0)
-                        index.navigate();
-                }
-            } else {
-                frame.timer = window.setTimeout(function() {
-                    frame_ready(frame, count + 1);
-                }, 100);
-            }
+        if (typeof machine == "string") {
+            address = host = machine;
+        } else if (machine) {
+            host = machine.connection_string;
+            address = machine.address;
         }
 
-        self.lookup = function lookup(machine, component, hash) {
-            var host;
-            var address;
-            var new_frame = false;
+        if (!host)
+            host = "localhost";
+        if (!address)
+            address = host;
 
-            if (typeof machine == "string") {
-                address = host = machine;
-            } else if (machine) {
-                host = machine.connection_string;
-                address = machine.address;
-            }
+        var list = self.iframes[address];
+        if (!list)
+            self.iframes[address] = list = { };
 
-            if (!host)
-                host = "localhost";
-            if (!address)
-                address = host;
+        var name = "cockpit1:" + host + "/" + component;
+        var frame = list[component];
+        if (frame && frame.getAttribute("name") != name) {
+            remove_frame(frame);
+            frame = null;
+        }
 
-            var list = self.iframes[address];
-            if (!list)
-                self.iframes[address] = list = { };
+        var wind, src;
 
-            var name = "cockpit1:" + host + "/" + component;
-            var frame = list[component];
-            if (frame && frame.getAttribute("name") != name) {
-                remove_frame(frame);
-                frame = null;
-            }
-
-            var wind, src;
-
-            /* A preloaded frame */
-            if (!frame) {
-                wind = window.frames[name];
-                if (wind)
-                    frame = wind.frameElement;
-                if (frame) {
-                    src = frame.getAttribute('src');
-                    frame.url = src.split("#")[0];
-                    list[component] = frame;
-                }
-            }
-
-            /* Need to create a new frame */
-            if (!frame) {
-                new_frame = true;
-                frame = document.createElement("iframe");
-                frame.setAttribute("class", "container-frame");
-                frame.setAttribute("name", name);
-                frame.style.display = "none";
-
-                var base, checksum;
-                if (machine) {
-                    if (machine.manifests && machine.manifests[".checksum"])
-                        checksum = "$" + machine.manifests[".checksum"];
-                    else
-                        checksum = machine.checksum;
-                }
-
-                if (checksum && checksum == component_checksum(machine, component)) {
-                    if (host === "localhost")
-                        base = "..";
-                    else
-                        base = "../../" + checksum;
-                } else {
-                    /* If we don't have any checksums, or if the component specifies a different
-                       checksum than the machine, load it via a non-caching @<host> path.  This
-                       makes sure that we get the right files, and also that we don't poisen the
-                       cache with wrong files.
-
-                       We can't use a $<component-checksum> path since cockpit-ws only knows how to
-                       route the machine checksum.
-
-                       TODO - make it possible to use $<component-checksum>.
-                    */
-                    base = "../../@" + host;
-                }
-
-                frame.url = base + "/" + component;
-                if (component.indexOf("/") === -1)
-                    frame.url += "/index";
-                frame.url += ".html";
-            }
-
-            if (!hash)
-                hash = "/";
-            src = frame.url + "#" + hash;
-            if (frame.getAttribute('src') != src)
-                frame.setAttribute('src', src);
-
-            /* Store frame only when fully setup */
-            if (new_frame) {
+        /* A preloaded frame */
+        if (!frame) {
+            wind = window.frames[name];
+            if (wind)
+                frame = wind.frameElement;
+            if (frame) {
+                src = frame.getAttribute('src');
+                frame.url = src.split("#")[0];
                 list[component] = frame;
-                $("#content").append(frame);
             }
-            frame_ready(frame);
-            return frame;
-        };
-    }
+        }
 
-    function Router(index) {
-        var self = this;
+        /* Need to create a new frame */
+        if (!frame) {
+            new_frame = true;
+            frame = document.createElement("iframe");
+            frame.setAttribute("class", "container-frame");
+            frame.setAttribute("name", name);
+            frame.style.display = "none";
 
-        var unique_id = 0;
-        var origin = cockpit.transport.origin;
-        var source_by_seed = { };
-        var source_by_name = { };
+            var base, checksum;
+            if (machine) {
+                if (machine.manifests && machine.manifests[".checksum"])
+                    checksum = "$" + machine.manifests[".checksum"];
+                else
+                    checksum = machine.checksum;
+            }
 
-        cockpit.transport.filter(function(message, channel, control) {
-            var seed, source, pos;
+            if (checksum && checksum == component_checksum(machine, component)) {
+                if (host === "localhost")
+                    base = "..";
+                else
+                    base = "../../" + checksum;
+            } else {
+                /* If we don't have any checksums, or if the component specifies a different
+                   checksum than the machine, load it via a non-caching @<host> path.  This
+                   makes sure that we get the right files, and also that we don't poisen the
+                   cache with wrong files.
 
-            /* Only control messages with a channel are forwardable */
-            if (control) {
-                if (control.channel !== undefined) {
-                    for (seed in source_by_seed) {
-                        source = source_by_seed[seed];
-                        if (!source.window.closed)
-                            source.window.postMessage(message, origin);
-                    }
-                } else if (control.command == "hint") {
-                    if (control.credential) {
-                        if (index.privileges)
-                            index.privileges.update(control);
-                    }
-                }
+                   We can't use a $<component-checksum> path since cockpit-ws only knows how to
+                   route the machine checksum.
 
-            /* Forward message to relevant frame */
-            } else if (channel) {
-                pos = channel.indexOf('!');
-                if (pos !== -1) {
-                    seed = channel.substring(0, pos + 1);
+                   TODO - make it possible to use $<component-checksum>.
+                */
+                base = "../../@" + host;
+            }
+
+            frame.url = base + "/" + component;
+            if (component.indexOf("/") === -1)
+                frame.url += "/index";
+            frame.url += ".html";
+        }
+
+        if (!hash)
+            hash = "/";
+        src = frame.url + "#" + hash;
+        if (frame.getAttribute('src') != src)
+            frame.setAttribute('src', src);
+
+        /* Store frame only when fully setup */
+        if (new_frame) {
+            list[component] = frame;
+            $("#content").append(frame);
+        }
+        frame_ready(frame);
+        return frame;
+    };
+}
+
+function Router(index) {
+    var self = this;
+
+    var unique_id = 0;
+    var origin = cockpit.transport.origin;
+    var source_by_seed = { };
+    var source_by_name = { };
+
+    cockpit.transport.filter(function(message, channel, control) {
+        var seed, source, pos;
+
+        /* Only control messages with a channel are forwardable */
+        if (control) {
+            if (control.channel !== undefined) {
+                for (seed in source_by_seed) {
                     source = source_by_seed[seed];
-                    if (source) {
-                        if (!source.window.closed)
-                            source.window.postMessage(message, origin);
-                        return false; /* Stop delivery */
-                    }
+                    if (!source.window.closed)
+                        source.window.postMessage(message, origin);
+                }
+            } else if (control.command == "hint") {
+                if (control.credential) {
+                    if (index.privileges)
+                        index.privileges.update(control);
                 }
             }
 
-            /* Still deliver the message locally */
-            return true;
-        }, false);
-
-        function perform_jump(child, control) {
-            var current_frame = index.current_frame();
-            if (child !== window) {
-                if (!current_frame || current_frame.contentWindow != child)
-                    return;
-            }
-            var str = control.location || "";
-            if (str[0] != "/")
-                str = "/" + str;
-            if (control.host)
-                str = "/@" + encodeURIComponent(control.host) + str;
-            index.jump(str);
-        }
-
-        function perform_track(child) {
-            var hash;
-            var current_frame = index.current_frame();
-            /* Note that we ignore tracknig for old shell code */
-            if (current_frame && current_frame.contentWindow === child &&
-                child.name && child.name.indexOf("/shell/shell") === -1) {
-                hash = child.location.hash;
-                if (hash.indexOf("#") === 0)
-                    hash = hash.substring(1);
-                if (hash === "/")
-                    hash = "";
-                index.jump({ hash: hash });
-            }
-        }
-
-        function on_unload(ev) {
-            var source;
-            if (ev.target.defaultView)
-                source = source_by_name[ev.target.defaultView.name];
-            else if (ev.view)
-                source = source_by_name[ev.view.name];
-            if (source)
-                unregister(source);
-        }
-
-        function on_hashchange(ev) {
-            var source = source_by_name[ev.target.name];
-            if (source)
-                perform_track(source.window);
-        }
-
-        function on_load(ev) {
-            var source = source_by_name[ev.target.contentWindow.name];
-            if (source)
-                perform_track(source.window);
-        }
-
-        function unregister(source) {
-            var child = source.window;
-            cockpit.kill(null, child.name);
-            var frame = child.frameElement;
-            if (frame)
-                frame.removeEventListener("load", on_load);
-            /* This is often invalid when the window is closed */
-            if (child.removeEventListener) {
-                child.removeEventListener("unload", on_unload);
-                child.removeEventListener("hashchange", on_hashchange);
-            }
-            delete source_by_seed[source.channel_seed];
-            delete source_by_name[source.name];
-        }
-
-        function register(child) {
-            var host;
-            var name = child.name || "";
-            if (name.indexOf("cockpit1:") === 0)
-                host = name.substring(9).split("/")[0];
-            if (!name || !host) {
-                console.warn("invalid child window name", child, name);
-                return;
-            }
-
-            unique_id += 1;
-            var seed = (cockpit.transport.options["channel-seed"] || "undefined:") + unique_id + "!";
-            var source = {
-                name: name,
-                window: child,
-                channel_seed: seed,
-                default_host: host,
-                inited: false,
-            };
-            source_by_seed[seed] = source;
-            source_by_name[name] = source;
-
-            var frame = child.frameElement;
-            frame.addEventListener("load", on_load);
-            child.addEventListener("unload", on_unload);
-            child.addEventListener("hashchange", on_hashchange);
-
-            /*
-             * Setting the "data-loaded" attribute helps the testsuite
-             * know when it can switch into the frame and inject its
-             * own additions.
-             */
-            frame.setAttribute('data-loaded', '1');
-
-            perform_track(child);
-
-            index.navigate();
-            return source;
-        }
-
-        function message_handler(event) {
-            if (event.origin !== origin)
-                return;
-
-            var forward_command = false;
-            var data = event.data;
-            var child = event.source;
-            if (!child)
-                return;
-
-            /* If it's binary data just send it.
-             * TODO: Once we start restricting what frames can
-             * talk to which hosts, we need to parse control
-             * messages here, and cross check channels */
-            if (data instanceof window.ArrayBuffer) {
-                cockpit.transport.inject(data, true);
-                return;
-            }
-
-            if (typeof data !== "string")
-                return;
-
-            var source, control;
-
-            /*
-             * On Internet Explorer we see Access Denied when non Cockpit
-             * frames send messages (such as Javascript console). This also
-             * happens when the window is closed.
-             */
-            try {
-                source = source_by_name[child.name];
-            } catch (ex) {
-                console.log("received message from child with in accessible name: ", ex);
-                return;
-            }
-
-            /* Closing the transport */
-            if (data.length === 0) {
-                if (source)
-                    unregister(source);
-                return;
-            }
-
-            /* A control message */
-            if (data[0] == '\n') {
-                control = JSON.parse(data.substring(1));
-                if (control.command === "init") {
-                    if (source)
-                        unregister(source);
-                    if (control.problem) {
-                        console.warn("child frame failed to init: " + control.problem);
-                        source = null;
-                    } else {
-                        source = register(child);
-                    }
-                    if (source) {
-                        var reply = $.extend({ }, cockpit.transport.options,
-                                             { command: "init", "host": source.default_host, "channel-seed": source.channel_seed }
-                        );
-                        child.postMessage("\n" + JSON.stringify(reply), origin);
-                        source.inited = true;
-
-                        /* If this new frame is not the current one, tell it */
-                        if (child.frameElement != index.current_frame())
-                            self.hint(child.frameElement.contentWindow, { "hidden": true });
-                    }
-                } else if (control.command === "jump") {
-                    perform_jump(child, control);
-                    return;
-                } else if (control.command == "logout" || control.command == "kill") {
-                    forward_command = true;
-                } else if (control.command === "hint") {
-                    if (control.hint == "restart") {
-                        /* watchdog handles current host for now */
-                        if (control.host != cockpit.transport.host)
-                            index.expect_restart(control.host);
-                    } else
-                        cockpit.hint(control.hint, control);
-                    return;
-                } else if (control.command == "oops") {
-                    index.show_oops();
-                    return;
-
-                /* Only control messages with a channel are forwardable */
-                } else if (control.channel === undefined && !forward_command) {
-                    return;
-
-                /* Add the child's group to all open channel messages */
-                } else if (control.command == "open") {
-                    control.group = child.name;
-                    data = "\n" + JSON.stringify(control);
+        /* Forward message to relevant frame */
+        } else if (channel) {
+            pos = channel.indexOf('!');
+            if (pos !== -1) {
+                seed = channel.substring(0, pos + 1);
+                source = source_by_seed[seed];
+                if (source) {
+                    if (!source.window.closed)
+                        source.window.postMessage(message, origin);
+                    return false; /* Stop delivery */
                 }
             }
-
-            if (!source) {
-                console.warn("child frame " + child.name + " sending data without init");
-                return;
-            }
-
-            /* Everything else gets forwarded */
-            cockpit.transport.inject(data, true);
         }
 
-        self.start = function start(messages) {
-            window.addEventListener("message", message_handler, false);
-            for (var i = 0, len = messages.length; i < len; i++)
-                message_handler(messages[i]);
-        };
+        /* Still deliver the message locally */
+        return true;
+    }, false);
 
-        self.hint = function hint(child, data) {
-            var message;
-            var source = source_by_name[child.name];
-            /* This is often invalid when the window is closed */
-            if (source && source.inited && !source.window.closed) {
-                data.command = "hint";
-                message = "\n" + JSON.stringify(data);
-                source.window.postMessage(message, origin);
-            }
-        };
+    function perform_jump(child, control) {
+        var current_frame = index.current_frame();
+        if (child !== window) {
+            if (!current_frame || current_frame.contentWindow != child)
+                return;
+        }
+        var str = control.location || "";
+        if (str[0] != "/")
+            str = "/" + str;
+        if (control.host)
+            str = "/@" + encodeURIComponent(control.host) + str;
+        index.jump(str);
     }
 
-    /*
-     * New instances of Index must be created by new_index_from_proto
-     * and the caller must include a navigation function in the given
-     * prototype. That function will be called by Frames and
-     * Router to actually perform any navigation action.
-     *
-     * As a convenience, common menu items can be setup by adding the
-     * selector to be used to hook them up. The accepted selectors
-     * are.
-     * oops_sel, logout_sel, language_sel, brand_sel, about_sel,
-     * user_sel, account_sel
-     *
-     * Emits "disconnect" and "expect_restart" signals, that should be
-     * handled by the caller.
-     */
-    function Index() {
-        var self = this;
-        var current_frame;
+    function perform_track(child) {
+        var hash;
+        var current_frame = index.current_frame();
+        /* Note that we ignore tracknig for old shell code */
+        if (current_frame && current_frame.contentWindow === child &&
+            child.name && child.name.indexOf("/shell/shell") === -1) {
+            hash = child.location.hash;
+            if (hash.indexOf("#") === 0)
+                hash = hash.substring(1);
+            if (hash === "/")
+                hash = "";
+            index.jump({ hash: hash });
+        }
+    }
 
-        if (typeof self.navigate !== "function")
-            throw Error("Index requires a prototype with a navigate function");
+    function on_unload(ev) {
+        var source;
+        if (ev.target.defaultView)
+            source = source_by_name[ev.target.defaultView.name];
+        else if (ev.view)
+            source = source_by_name[ev.view.name];
+        if (source)
+            unregister(source);
+    }
 
-        self.frames = new Frames(self);
-        self.router = new Router(self);
+    function on_hashchange(ev) {
+        var source = source_by_name[ev.target.name];
+        if (source)
+            perform_track(source.window);
+    }
 
-        /* Watchdog for disconnect */
-        var watchdog = cockpit.channel({ "payload": "null" });
-        $(watchdog).on("close", function(event, options) {
-            var watchdog_problem = options.problem || "disconnected";
-            console.warn("transport closed: " + watchdog_problem);
-            $(self).triggerHandler("disconnect", watchdog_problem);
-        });
+    function on_load(ev) {
+        var source = source_by_name[ev.target.contentWindow.name];
+        if (source)
+            perform_track(source.window);
+    }
 
-        /* Handles an href link as seen below */
-        $(document).on("click", "a[href]", function(ev) {
-            var a = this;
-            if (!a.host || window.location.host === a.host) {
-                self.jump(a.getAttribute('href'));
-                ev.preventDefault();
-            }
-        });
+    function unregister(source) {
+        var child = source.window;
+        cockpit.kill(null, child.name);
+        var frame = child.frameElement;
+        if (frame)
+            frame.removeEventListener("load", on_load);
+        /* This is often invalid when the window is closed */
+        if (child.removeEventListener) {
+            child.removeEventListener("unload", on_unload);
+            child.removeEventListener("hashchange", on_hashchange);
+        }
+        delete source_by_seed[source.channel_seed];
+        delete source_by_name[source.name];
+    }
 
-        var old_onerror = window.onerror;
-        window.onerror = function cockpit_error_handler(msg, url, line) {
-            self.show_oops();
-            if (old_onerror)
-                return old_onerror(msg, url, line);
-            return false;
+    function register(child) {
+        var host;
+        var name = child.name || "";
+        if (name.indexOf("cockpit1:") === 0)
+            host = name.substring(9).split("/")[0];
+        if (!name || !host) {
+            console.warn("invalid child window name", child, name);
+            return;
+        }
+
+        unique_id += 1;
+        var seed = (cockpit.transport.options["channel-seed"] || "undefined:") + unique_id + "!";
+        var source = {
+            name: name,
+            window: child,
+            channel_seed: seed,
+            default_host: host,
+            inited: false,
         };
+        source_by_seed[seed] = source;
+        source_by_name[name] = source;
+
+        var frame = child.frameElement;
+        frame.addEventListener("load", on_load);
+        child.addEventListener("unload", on_unload);
+        child.addEventListener("hashchange", on_hashchange);
 
         /*
-         * Navigation is driven by state objects, which are used with pushState()
-         * and friends. The state is the canonical navigation location, and not
-         * the URL. Only when no state has been pushed or we are arriving from
-         * a link, do we parse the state from the URL.
-         *
-         * Each state object has:
-         *   host: a machine host
-         *   component: the stripped component to load
-         *   hash: the hash to pass to the component
-         *   sidebar: set to true to hint that we want a component with a sidebar
-         *
-         * If state.sidebar is set, and no component has yet been chosen for the
-         * given state, then we try to find one that would show a sidebar.
+         * Setting the "data-loaded" attribute helps the testsuite
+         * know when it can switch into the frame and inject its
+         * own additions.
          */
+        frame.setAttribute('data-loaded', '1');
 
-        /* Encode navigate state into a string
-         * If with_root is true the configured
-         * url root will be added to the generated
-         * url. with_root should be used when
-         * navigating to a new url or updating
-         * history, but is not needed when simply
-         * generating a string for a link.
+        perform_track(child);
+
+        index.navigate();
+        return source;
+    }
+
+    function message_handler(event) {
+        if (event.origin !== origin)
+            return;
+
+        var forward_command = false;
+        var data = event.data;
+        var child = event.source;
+        if (!child)
+            return;
+
+        /* If it's binary data just send it.
+         * TODO: Once we start restricting what frames can
+         * talk to which hosts, we need to parse control
+         * messages here, and cross check channels */
+        if (data instanceof window.ArrayBuffer) {
+            cockpit.transport.inject(data, true);
+            return;
+        }
+
+        if (typeof data !== "string")
+            return;
+
+        var source, control;
+
+        /*
+         * On Internet Explorer we see Access Denied when non Cockpit
+         * frames send messages (such as Javascript console). This also
+         * happens when the window is closed.
          */
-        function encode(state, sidebar, with_root) {
-            var path = [];
-            if (state.host && (sidebar || state.host !== "localhost"))
-                path.push("@" + state.host);
-            if (state.component)
-                path.push.apply(path, state.component.split("/"));
-            var string = cockpit.location.encode(path, null, with_root);
-            if (state.hash && state.hash !== "/")
-                string += "#" + state.hash;
-            return string;
+        try {
+            source = source_by_name[child.name];
+        } catch (ex) {
+            console.log("received message from child with in accessible name: ", ex);
+            return;
         }
 
-        /* Decodes navigate state from a string */
-        function decode(string) {
-            var state = { version: "v1", hash: "" };
-            var pos = string.indexOf("#");
-            if (pos !== -1) {
-                state.hash = string.substring(pos + 1);
-                string = string.substring(0, pos);
-            }
-            if (string[0] != '/')
-                string = "/" + string;
-            var path = cockpit.location.decode(string);
-            if (path[0] && path[0][0] == "@") {
-                state.host = path.shift().substring(1);
-                state.sidebar = true;
-            } else {
-                state.host = "localhost";
-            }
-            if (path.length && path[path.length - 1] == "index")
-                path.pop();
-            state.component = path.join("/");
-            return state;
+        /* Closing the transport */
+        if (data.length === 0) {
+            if (source)
+                unregister(source);
+            return;
         }
 
-        function build_navbar() {
-            var navbar = $("#main-navbar");
-            navbar.on("click", function () {
-                navbar.parent().toggleClass("clicked", true);
-            });
-
-            navbar.on("mouseout", function () {
-                navbar.parent().toggleClass("clicked", false);
-            });
-
-            function links(component) {
-                var sm = $("<span class='fa'>")
-                        .attr("data-toggle", "tooltip")
-                        .attr("role", "presentation")
-                        .attr("title", "")
-                        .attr("data-original-title", component.label);
-
-                if (component.icon)
-                    sm.addClass(component.icon);
-                else
-                    sm.addClass("first-letter").text(component.label);
-
-                var value = $("<span class='list-group-item-value'>")
-                        .text(component.label);
-
-                var a = $("<a>")
-                        .attr("href", self.href({ host: "localhost", component: component.path }))
-                        .append(sm)
-                        .append(value);
-
-                return $("<li class='dashboard-link list-group-item'>")
-                        .attr("data-component", component.path)
-                        .append(a);
-            }
-
-            var local_compiled = new CompiledComponents();
-            local_compiled.load(cockpit.manifests, "dashboard");
-            navbar.append(local_compiled.ordered("dashboard").map(links));
-        }
-
-        self.retrieve_state = function() {
-            var state = window.history.state;
-            if (!state || state.version !== "v1") {
-                if (shell_embedded)
-                    state = decode("/" + window.location.hash);
-                else
-                    state = decode(window.location.pathname + window.location.hash);
-            }
-            return state;
-        };
-
-        function lookup_component_hash(address, component) {
-            var iframe, src;
-
-            if (!address)
-                address = "localhost";
-
-            var list = self.frames.iframes[address];
-            if (list)
-                iframe = list[component];
-
-            if (iframe) {
-                src = iframe.getAttribute('src');
-                if (src)
-                    return src.split("#")[1];
-            }
-
-            return null;
-        }
-
-        /* Jumps to a given navigate state */
-        self.jump = function (state, replace) {
-            if (typeof (state) === "string")
-                state = decode(state);
-
-            var current = self.retrieve_state();
-
-            /* Make sure we have the data we need */
-            if (!state.host)
-                state.host = current.host || "localhost";
-            if (!("component" in state))
-                state.component = current.component || "";
-
-            var target;
-            var history = window.history;
-            var frame_change = (state.host !== current.host ||
-                                state.component !== current.component);
-
-            if (frame_change && !state.hash)
-                state.hash = lookup_component_hash(state.host, state.component);
-
-            if (shell_embedded)
-                target = window.location;
-            else
-                target = encode(state, null, true);
-
-            if (replace) {
-                history.replaceState(state, "", target);
-                return false;
-            }
-
-            if (frame_change || state.hash !== current.hash) {
-                history.pushState(state, "", target);
-                self.navigate(state, true);
-                return true;
-            }
-
-            return false;
-        };
-
-        /* Build an href for use in an <a> */
-        self.href = function (state, sidebar) {
-            return encode(state, sidebar);
-        };
-
-        self.show_oops = function () {
-            if (self.oops_sel)
-                $(self.oops_sel).show();
-        };
-
-        self.current_frame = function (frame) {
-            if (frame !== undefined) {
-                if (current_frame !== frame) {
-                    if (current_frame && current_frame.contentWindow)
-                        self.router.hint(current_frame.contentWindow, { "hidden": true });
-                    if (frame && frame.contentWindow)
-                        self.router.hint(frame.contentWindow, { "hidden": false });
+        /* A control message */
+        if (data[0] == '\n') {
+            control = JSON.parse(data.substring(1));
+            if (control.command === "init") {
+                if (source)
+                    unregister(source);
+                if (control.problem) {
+                    console.warn("child frame failed to init: " + control.problem);
+                    source = null;
+                } else {
+                    source = register(child);
                 }
-                current_frame = frame;
-            }
-            return current_frame;
-        };
+                if (source) {
+                    var reply = $.extend({ }, cockpit.transport.options,
+                                         { command: "init", "host": source.default_host, "channel-seed": source.channel_seed }
+                    );
+                    child.postMessage("\n" + JSON.stringify(reply), origin);
+                    source.inited = true;
 
-        self.start = function() {
-            /* window.messages is initialized in shell/bundle.js */
-            var messages = window.messages;
-            if (messages)
-                messages.cancel();
-            self.router.start(messages || []);
-        };
-
-        self.ready = function () {
-            $(window).on("popstate", function(ev) {
-                self.navigate(ev.state, true);
-            });
-
-            build_navbar();
-            self.navigate();
-            cockpit.translate();
-            $("body").show();
-        };
-
-        self.expect_restart = function (host) {
-            $(self).triggerHandler("expect_restart", host);
-        };
-
-        /* Menu items */
-        /* The oops bar */
-        function setup_oops(id) {
-            var oops = $(id);
-            if (!oops)
+                    /* If this new frame is not the current one, tell it */
+                    if (child.frameElement != index.current_frame())
+                        self.hint(child.frameElement.contentWindow, { "hidden": true });
+                }
+            } else if (control.command === "jump") {
+                perform_jump(child, control);
                 return;
-            oops.children("a").on("click", function() {
-                $("#error-popup-title").text(_("Unexpected error"));
-                var details = _("Cockpit had an unexpected internal error. <br/><br/>You can try restarting Cockpit by pressing refresh in your browser. The javascript console contains details about this error (<b>Ctrl-Shift-J</b> in most browsers).");
-                $("#error-popup-message").html(details);
-                $('#error-popup').modal('show');
-            });
-        }
-
-        function css_content(elt) {
-            var styles, i;
-            var style, content;
-            var el_style, el_content;
-
-            if (elt)
-                style = window.getComputedStyle(elt, ":before");
-            if (!style)
+            } else if (control.command == "logout" || control.command == "kill") {
+                forward_command = true;
+            } else if (control.command === "hint") {
+                if (control.hint == "restart") {
+                    /* watchdog handles current host for now */
+                    if (control.host != cockpit.transport.host)
+                        index.expect_restart(control.host);
+                } else
+                    cockpit.hint(control.hint, control);
+                return;
+            } else if (control.command == "oops") {
+                index.show_oops();
                 return;
 
-            content = style.content;
-            // Old branding had style on the element itself
-            if (!content) {
-                el_style = window.getComputedStyle(elt);
-                if (el_style)
-                    el_content = el_style.content;
-            }
+            /* Only control messages with a channel are forwardable */
+            } else if (control.channel === undefined && !forward_command) {
+                return;
 
-            // getComputedStyle is broken for pseudo elements
-            // in Phantomjs and some old browsers
-            // those support the depricated getMatchedCSSRules
-            if (!content && style.length === 0 && window.getMatchedCSSRules) {
-                styles = window.getMatchedCSSRules(elt, ":before") || [];
-                for (i = 0; i < styles.length; i++) {
-                    if (styles[i].style.content) {
-                        content = styles[i].style.content;
-                        break;
-                    }
-                }
-            }
-
-            return content || el_content;
-        }
-
-        /* Branding */
-        function setup_brand(id, default_title) {
-            var elt = $(id)[0];
-            var os_release = {};
-            try {
-                os_release = JSON.parse(window.localStorage['os-release'] || "{}");
-            } catch (ex) {
-                console.warn("Couldn't parse os-release", ex);
-            }
-
-            var len;
-            var content = css_content(elt);
-            if (content && content != "none" && content != "normal") {
-                len = content.length;
-                if ((content[0] === '"' || content[0] === '\'') &&
-                    len > 2 && content[len - 1] === content[0])
-                    content = content.substr(1, len - 2);
-                elt.innerHTML = cockpit.format(content, os_release) || default_title;
-                return $(elt).text();
-            } else {
-                elt.removeAttribute("class");
+            /* Add the child's group to all open channel messages */
+            } else if (control.command == "open") {
+                control.group = child.name;
+                data = "\n" + JSON.stringify(control);
             }
         }
 
-        /* Logout link */
-        function setup_logout(id) {
-            $(id).on("click", function() {
-                cockpit.logout();
-            });
+        if (!source) {
+            console.warn("child frame " + child.name + " sending data without init");
+            return;
         }
 
-        /* Display language dialog */
-        function setup_language(id) {
-            /*
-             * Note that we don't go ahead and load all the po files in order
-             * to produce this list. Perhaps we would include it somewhere in a
-             * separate automatically generated file. Need to see.
-             */
-            var manifest = cockpit.manifests["shell"] || { };
-            $(".display-language-menu").toggle(!!manifest.locales);
-            var language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1");
-            if (!language)
-                language = "en-us";
-
-            $('html').attr('lang', language);
-
-            $.each(manifest.locales || { }, function(code, name) {
-                var el = $("<option>").text(name)
-                        .val(code);
-                if (code == language)
-                    el.attr("selected", "true");
-                $("#display-language-list").append(el);
-            });
-
-            $("#display-language-select-button").on("click", function(event) {
-                var code_to_select = $("#display-language-list").val();
-                var cookie = "CockpitLang=" + encodeURIComponent(code_to_select) +
-                             "; path=/; expires=Sun, 16 Jul 3567 06:23:41 GMT";
-                document.cookie = cookie;
-                window.localStorage.setItem("cockpit.lang", code_to_select);
-                window.location.reload(true);
-                return false;
-            });
-
-            $(id).on("shown.bs.modal", function() {
-                $("display-language-list").focus();
-            });
-        }
-
-        /* About dialog */
-        function setup_about(id) {
-            $(cockpit.info).on("changed", function() {
-                $(id).text(cockpit.info.version);
-            });
-        }
-
-        /* Account link */
-        function setup_account(id, user) {
-            $(id).on("click", function() {
-                self.jump({ host: "localhost", component: "users", hash: "/" + user.name });
-            })
-                    .show();
-        }
-
-        function setup_killer(id) {
-            $(id).on("click", function(ev) {
-                if (ev && ev.button === 0)
-                    require("./active-pages").showDialog(self.frames);
-            });
-        }
-
-        /* User information */
-        function setup_user(id, user) {
-            $(id).text(user.full_name || user.name || '???');
-        }
-
-        if (self.oops_sel)
-            setup_oops(self.oops_sel);
-
-        if (self.logout_sel)
-            setup_logout(self.logout_sel);
-
-        if (self.language_sel)
-            setup_language(self.language_sel);
-
-        var cal_title;
-        if (self.brand_sel) {
-            cal_title = setup_brand(self.brand_sel, self.default_title);
-            if (cal_title && !self.skip_brand_title)
-                self.default_title = cal_title;
-        }
-
-        if (self.about_sel)
-            setup_about(self.about_sel);
-        if (self.killer_sel)
-            setup_killer(self.killer_sel);
-
-        if (self.user_sel || self.account_sel) {
-            cockpit.user().done(function (user) {
-                if (self.user_sel)
-                    setup_user(self.user_sel, user);
-                if (self.account_sel)
-                    setup_account(self.account_sel, user);
-            });
-        }
+        /* Everything else gets forwarded */
+        cockpit.transport.inject(data, true);
     }
 
-    function CompiledComponents() {
-        var self = this;
-        self.items = {};
+    self.start = function start(messages) {
+        window.addEventListener("message", message_handler, false);
+        for (var i = 0, len = messages.length; i < len; i++)
+            message_handler(messages[i]);
+    };
 
-        self.load = function(manifests, section) {
-            $.each(manifests || { }, function(name, manifest) {
-                $.each(manifest[section] || { }, function(prop, info) {
-                    var item = {
-                        section: section,
-                        label: cockpit.gettext(info.label) || prop,
-                        order: info.order === undefined ? 1000 : info.order,
-                        icon: info.icon,
-                        wants: info.wants
-                    };
-                    if (info.path)
-                        item.path = info.path.replace(/\.html$/, "");
-                    else
-                        item.path = name + "/" + prop;
-
-                    /* Split out any hash in the path */
-                    var pos = item.path.indexOf("#");
-                    if (pos !== -1) {
-                        item.hash = item.path.substr(pos + 1);
-                        item.path = item.path.substr(0, pos);
-                    }
-
-                    /* Fix component for compatibility and normalize it */
-                    if (item.path.indexOf("/") === -1)
-                        item.path = name + "/" + item.path;
-                    if (item.path.slice(-6) == "/index")
-                        item.path = item.path.slice(0, -6);
-                    self.items[item.path] = item;
-                });
-            });
-        };
-
-        self.ordered = function(section) {
-            var x;
-            var list = [];
-            for (x in self.items) {
-                if (!section || self.items[x].section === section)
-                    list.push(self.items[x]);
-            }
-            list.sort(function(a, b) {
-                var ret = a.order - b.order;
-                if (ret === 0)
-                    ret = a.label.localeCompare(b.label);
-                return ret;
-            });
-            return list;
-        };
-
-        self.search = function(prop, value) {
-            var x;
-            for (x in self.items) {
-                if (self.items[x][prop] === value)
-                    return self.items[x];
-            }
-        };
-    }
-
-    function follow(arg) {
-        /* A promise of some sort */
-        if (arguments.length == 1 && typeof arg.then == "function") {
-            arg.then(function() { console.log.apply(console, arguments) },
-                     function() { console.error.apply(console, arguments) });
-            if (typeof arg.stream == "function")
-                arg.stream(function() { console.log.apply(console, arguments) });
+    self.hint = function hint(child, data) {
+        var message;
+        var source = source_by_name[child.name];
+        /* This is often invalid when the window is closed */
+        if (source && source.inited && !source.window.closed) {
+            data.command = "hint";
+            message = "\n" + JSON.stringify(data);
+            source.window.postMessage(message, origin);
         }
-    }
+    };
+}
 
-    var zz_value;
+/*
+ * New instances of Index must be created by new_index_from_proto
+ * and the caller must include a navigation function in the given
+ * prototype. That function will be called by Frames and
+ * Router to actually perform any navigation action.
+ *
+ * As a convenience, common menu items can be setup by adding the
+ * selector to be used to hook them up. The accepted selectors
+ * are.
+ * oops_sel, logout_sel, language_sel, brand_sel, about_sel,
+ * user_sel, account_sel
+ *
+ * Emits "disconnect" and "expect_restart" signals, that should be
+ * handled by the caller.
+ */
+function Index() {
+    var self = this;
+    var current_frame;
 
-    /* For debugging utility in the index window */
-    Object.defineProperties(window, {
-        cockpit: { value: cockpit },
-        zz: {
-            get: function() { return zz_value },
-            set: function(val) { zz_value = val; follow(val) }
+    if (typeof self.navigate !== "function")
+        throw Error("Index requires a prototype with a navigate function");
+
+    self.frames = new Frames(self);
+    self.router = new Router(self);
+
+    /* Watchdog for disconnect */
+    var watchdog = cockpit.channel({ "payload": "null" });
+    $(watchdog).on("close", function(event, options) {
+        var watchdog_problem = options.problem || "disconnected";
+        console.warn("transport closed: " + watchdog_problem);
+        $(self).triggerHandler("disconnect", watchdog_problem);
+    });
+
+    /* Handles an href link as seen below */
+    $(document).on("click", "a[href]", function(ev) {
+        var a = this;
+        if (!a.host || window.location.host === a.host) {
+            self.jump(a.getAttribute('href'));
+            ev.preventDefault();
         }
     });
 
-    module.exports = {
-        new_index_from_proto: function (proto) {
-            var o = new Object(proto); // eslint-disable-line no-new-object
-            Index.call(o);
-            return o;
-        },
-
-        new_compiled: function () {
-            return new CompiledComponents();
-        },
+    var old_onerror = window.onerror;
+    window.onerror = function cockpit_error_handler(msg, url, line) {
+        self.show_oops();
+        if (old_onerror)
+            return old_onerror(msg, url, line);
+        return false;
     };
-}());
+
+    /*
+     * Navigation is driven by state objects, which are used with pushState()
+     * and friends. The state is the canonical navigation location, and not
+     * the URL. Only when no state has been pushed or we are arriving from
+     * a link, do we parse the state from the URL.
+     *
+     * Each state object has:
+     *   host: a machine host
+     *   component: the stripped component to load
+     *   hash: the hash to pass to the component
+     *   sidebar: set to true to hint that we want a component with a sidebar
+     *
+     * If state.sidebar is set, and no component has yet been chosen for the
+     * given state, then we try to find one that would show a sidebar.
+     */
+
+    /* Encode navigate state into a string
+     * If with_root is true the configured
+     * url root will be added to the generated
+     * url. with_root should be used when
+     * navigating to a new url or updating
+     * history, but is not needed when simply
+     * generating a string for a link.
+     */
+    function encode(state, sidebar, with_root) {
+        var path = [];
+        if (state.host && (sidebar || state.host !== "localhost"))
+            path.push("@" + state.host);
+        if (state.component)
+            path.push.apply(path, state.component.split("/"));
+        var string = cockpit.location.encode(path, null, with_root);
+        if (state.hash && state.hash !== "/")
+            string += "#" + state.hash;
+        return string;
+    }
+
+    /* Decodes navigate state from a string */
+    function decode(string) {
+        var state = { version: "v1", hash: "" };
+        var pos = string.indexOf("#");
+        if (pos !== -1) {
+            state.hash = string.substring(pos + 1);
+            string = string.substring(0, pos);
+        }
+        if (string[0] != '/')
+            string = "/" + string;
+        var path = cockpit.location.decode(string);
+        if (path[0] && path[0][0] == "@") {
+            state.host = path.shift().substring(1);
+            state.sidebar = true;
+        } else {
+            state.host = "localhost";
+        }
+        if (path.length && path[path.length - 1] == "index")
+            path.pop();
+        state.component = path.join("/");
+        return state;
+    }
+
+    function build_navbar() {
+        var navbar = $("#main-navbar");
+        navbar.on("click", function () {
+            navbar.parent().toggleClass("clicked", true);
+        });
+
+        navbar.on("mouseout", function () {
+            navbar.parent().toggleClass("clicked", false);
+        });
+
+        function links(component) {
+            var sm = $("<span class='fa'>")
+                    .attr("data-toggle", "tooltip")
+                    .attr("role", "presentation")
+                    .attr("title", "")
+                    .attr("data-original-title", component.label);
+
+            if (component.icon)
+                sm.addClass(component.icon);
+            else
+                sm.addClass("first-letter").text(component.label);
+
+            var value = $("<span class='list-group-item-value'>")
+                    .text(component.label);
+
+            var a = $("<a>")
+                    .attr("href", self.href({ host: "localhost", component: component.path }))
+                    .append(sm)
+                    .append(value);
+
+            return $("<li class='dashboard-link list-group-item'>")
+                    .attr("data-component", component.path)
+                    .append(a);
+        }
+
+        var local_compiled = new CompiledComponents();
+        local_compiled.load(cockpit.manifests, "dashboard");
+        navbar.append(local_compiled.ordered("dashboard").map(links));
+    }
+
+    self.retrieve_state = function() {
+        var state = window.history.state;
+        if (!state || state.version !== "v1") {
+            if (shell_embedded)
+                state = decode("/" + window.location.hash);
+            else
+                state = decode(window.location.pathname + window.location.hash);
+        }
+        return state;
+    };
+
+    function lookup_component_hash(address, component) {
+        var iframe, src;
+
+        if (!address)
+            address = "localhost";
+
+        var list = self.frames.iframes[address];
+        if (list)
+            iframe = list[component];
+
+        if (iframe) {
+            src = iframe.getAttribute('src');
+            if (src)
+                return src.split("#")[1];
+        }
+
+        return null;
+    }
+
+    /* Jumps to a given navigate state */
+    self.jump = function (state, replace) {
+        if (typeof (state) === "string")
+            state = decode(state);
+
+        var current = self.retrieve_state();
+
+        /* Make sure we have the data we need */
+        if (!state.host)
+            state.host = current.host || "localhost";
+        if (!("component" in state))
+            state.component = current.component || "";
+
+        var target;
+        var history = window.history;
+        var frame_change = (state.host !== current.host ||
+                            state.component !== current.component);
+
+        if (frame_change && !state.hash)
+            state.hash = lookup_component_hash(state.host, state.component);
+
+        if (shell_embedded)
+            target = window.location;
+        else
+            target = encode(state, null, true);
+
+        if (replace) {
+            history.replaceState(state, "", target);
+            return false;
+        }
+
+        if (frame_change || state.hash !== current.hash) {
+            history.pushState(state, "", target);
+            self.navigate(state, true);
+            return true;
+        }
+
+        return false;
+    };
+
+    /* Build an href for use in an <a> */
+    self.href = function (state, sidebar) {
+        return encode(state, sidebar);
+    };
+
+    self.show_oops = function () {
+        if (self.oops_sel)
+            $(self.oops_sel).show();
+    };
+
+    self.current_frame = function (frame) {
+        if (frame !== undefined) {
+            if (current_frame !== frame) {
+                if (current_frame && current_frame.contentWindow)
+                    self.router.hint(current_frame.contentWindow, { "hidden": true });
+                if (frame && frame.contentWindow)
+                    self.router.hint(frame.contentWindow, { "hidden": false });
+            }
+            current_frame = frame;
+        }
+        return current_frame;
+    };
+
+    self.start = function() {
+        /* window.messages is initialized in shell/bundle.js */
+        var messages = window.messages;
+        if (messages)
+            messages.cancel();
+        self.router.start(messages || []);
+    };
+
+    self.ready = function () {
+        $(window).on("popstate", function(ev) {
+            self.navigate(ev.state, true);
+        });
+
+        build_navbar();
+        self.navigate();
+        cockpit.translate();
+        $("body").show();
+    };
+
+    self.expect_restart = function (host) {
+        $(self).triggerHandler("expect_restart", host);
+    };
+
+    /* Menu items */
+    /* The oops bar */
+    function setup_oops(id) {
+        var oops = $(id);
+        if (!oops)
+            return;
+        oops.children("a").on("click", function() {
+            $("#error-popup-title").text(_("Unexpected error"));
+            var details = _("Cockpit had an unexpected internal error. <br/><br/>You can try restarting Cockpit by pressing refresh in your browser. The javascript console contains details about this error (<b>Ctrl-Shift-J</b> in most browsers).");
+            $("#error-popup-message").html(details);
+            $('#error-popup').modal('show');
+        });
+    }
+
+    function css_content(elt) {
+        var styles, i;
+        var style, content;
+        var el_style, el_content;
+
+        if (elt)
+            style = window.getComputedStyle(elt, ":before");
+        if (!style)
+            return;
+
+        content = style.content;
+        // Old branding had style on the element itself
+        if (!content) {
+            el_style = window.getComputedStyle(elt);
+            if (el_style)
+                el_content = el_style.content;
+        }
+
+        // getComputedStyle is broken for pseudo elements
+        // in Phantomjs and some old browsers
+        // those support the depricated getMatchedCSSRules
+        if (!content && style.length === 0 && window.getMatchedCSSRules) {
+            styles = window.getMatchedCSSRules(elt, ":before") || [];
+            for (i = 0; i < styles.length; i++) {
+                if (styles[i].style.content) {
+                    content = styles[i].style.content;
+                    break;
+                }
+            }
+        }
+
+        return content || el_content;
+    }
+
+    /* Branding */
+    function setup_brand(id, default_title) {
+        var elt = $(id)[0];
+        var os_release = {};
+        try {
+            os_release = JSON.parse(window.localStorage['os-release'] || "{}");
+        } catch (ex) {
+            console.warn("Couldn't parse os-release", ex);
+        }
+
+        var len;
+        var content = css_content(elt);
+        if (content && content != "none" && content != "normal") {
+            len = content.length;
+            if ((content[0] === '"' || content[0] === '\'') &&
+                len > 2 && content[len - 1] === content[0])
+                content = content.substr(1, len - 2);
+            elt.innerHTML = cockpit.format(content, os_release) || default_title;
+            return $(elt).text();
+        } else {
+            elt.removeAttribute("class");
+        }
+    }
+
+    /* Logout link */
+    function setup_logout(id) {
+        $(id).on("click", function() {
+            cockpit.logout();
+        });
+    }
+
+    /* Display language dialog */
+    function setup_language(id) {
+        /*
+         * Note that we don't go ahead and load all the po files in order
+         * to produce this list. Perhaps we would include it somewhere in a
+         * separate automatically generated file. Need to see.
+         */
+        var manifest = cockpit.manifests["shell"] || { };
+        $(".display-language-menu").toggle(!!manifest.locales);
+        var language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1");
+        if (!language)
+            language = "en-us";
+
+        $('html').attr('lang', language);
+
+        $.each(manifest.locales || { }, function(code, name) {
+            var el = $("<option>").text(name)
+                    .val(code);
+            if (code == language)
+                el.attr("selected", "true");
+            $("#display-language-list").append(el);
+        });
+
+        $("#display-language-select-button").on("click", function(event) {
+            var code_to_select = $("#display-language-list").val();
+            var cookie = "CockpitLang=" + encodeURIComponent(code_to_select) +
+                         "; path=/; expires=Sun, 16 Jul 3567 06:23:41 GMT";
+            document.cookie = cookie;
+            window.localStorage.setItem("cockpit.lang", code_to_select);
+            window.location.reload(true);
+            return false;
+        });
+
+        $(id).on("shown.bs.modal", function() {
+            $("display-language-list").focus();
+        });
+    }
+
+    /* About dialog */
+    function setup_about(id) {
+        $(cockpit.info).on("changed", function() {
+            $(id).text(cockpit.info.version);
+        });
+    }
+
+    /* Account link */
+    function setup_account(id, user) {
+        $(id).on("click", function() {
+            self.jump({ host: "localhost", component: "users", hash: "/" + user.name });
+        })
+                .show();
+    }
+
+    function setup_killer(id) {
+        $(id).on("click", function(ev) {
+            if (ev && ev.button === 0)
+                require("./active-pages").showDialog(self.frames);
+        });
+    }
+
+    /* User information */
+    function setup_user(id, user) {
+        $(id).text(user.full_name || user.name || '???');
+    }
+
+    if (self.oops_sel)
+        setup_oops(self.oops_sel);
+
+    if (self.logout_sel)
+        setup_logout(self.logout_sel);
+
+    if (self.language_sel)
+        setup_language(self.language_sel);
+
+    var cal_title;
+    if (self.brand_sel) {
+        cal_title = setup_brand(self.brand_sel, self.default_title);
+        if (cal_title && !self.skip_brand_title)
+            self.default_title = cal_title;
+    }
+
+    if (self.about_sel)
+        setup_about(self.about_sel);
+    if (self.killer_sel)
+        setup_killer(self.killer_sel);
+
+    if (self.user_sel || self.account_sel) {
+        cockpit.user().done(function (user) {
+            if (self.user_sel)
+                setup_user(self.user_sel, user);
+            if (self.account_sel)
+                setup_account(self.account_sel, user);
+        });
+    }
+}
+
+function CompiledComponents() {
+    var self = this;
+    self.items = {};
+
+    self.load = function(manifests, section) {
+        $.each(manifests || { }, function(name, manifest) {
+            $.each(manifest[section] || { }, function(prop, info) {
+                var item = {
+                    section: section,
+                    label: cockpit.gettext(info.label) || prop,
+                    order: info.order === undefined ? 1000 : info.order,
+                    icon: info.icon,
+                    wants: info.wants
+                };
+                if (info.path)
+                    item.path = info.path.replace(/\.html$/, "");
+                else
+                    item.path = name + "/" + prop;
+
+                /* Split out any hash in the path */
+                var pos = item.path.indexOf("#");
+                if (pos !== -1) {
+                    item.hash = item.path.substr(pos + 1);
+                    item.path = item.path.substr(0, pos);
+                }
+
+                /* Fix component for compatibility and normalize it */
+                if (item.path.indexOf("/") === -1)
+                    item.path = name + "/" + item.path;
+                if (item.path.slice(-6) == "/index")
+                    item.path = item.path.slice(0, -6);
+                self.items[item.path] = item;
+            });
+        });
+    };
+
+    self.ordered = function(section) {
+        var x;
+        var list = [];
+        for (x in self.items) {
+            if (!section || self.items[x].section === section)
+                list.push(self.items[x]);
+        }
+        list.sort(function(a, b) {
+            var ret = a.order - b.order;
+            if (ret === 0)
+                ret = a.label.localeCompare(b.label);
+            return ret;
+        });
+        return list;
+    };
+
+    self.search = function(prop, value) {
+        var x;
+        for (x in self.items) {
+            if (self.items[x][prop] === value)
+                return self.items[x];
+        }
+    };
+}
+
+function follow(arg) {
+    /* A promise of some sort */
+    if (arguments.length == 1 && typeof arg.then == "function") {
+        arg.then(function() { console.log.apply(console, arguments) },
+                 function() { console.error.apply(console, arguments) });
+        if (typeof arg.stream == "function")
+            arg.stream(function() { console.log.apply(console, arguments) });
+    }
+}
+
+var zz_value;
+
+/* For debugging utility in the index window */
+Object.defineProperties(window, {
+    cockpit: { value: cockpit },
+    zz: {
+        get: function() { return zz_value },
+        set: function(val) { zz_value = val; follow(val) }
+    }
+});
+
+module.exports = {
+    new_index_from_proto: function (proto) {
+        var o = new Object(proto); // eslint-disable-line no-new-object
+        Index.call(o);
+        return o;
+    },
+
+    new_compiled: function () {
+        return new CompiledComponents();
+    },
+};

--- a/pkg/shell/credentials.js
+++ b/pkg/shell/credentials.js
@@ -17,313 +17,311 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var sshFile = require("./ssh-file-autocomplete.jsx");
-    var credentials = require("credentials");
-    var $ = require("jquery");
+var sshFile = require("./ssh-file-autocomplete.jsx");
+var credentials = require("credentials");
+var $ = require("jquery");
 
-    require("listing.less");
-    require("patterns");
+require("listing.less");
+require("patterns");
 
-    function setup() {
-        var keys;
+function setup() {
+    var keys;
 
-        function hide_add_key() {
-            $("tbody.ssh-add-key-body").attr("data-name", "");
-            $("tbody.ssh-add-key-body").toggleClass("unlock", false);
-            $("#credentials-dialog tr.load-custom-key").toggleClass("hidden", true);
-            $("#credentials-dialog tr.load-custom-key td").toggleClass("has-error", false);
-            sshFile.remove(document.getElementById('ssh-file-container'));
-        }
+    function hide_add_key() {
+        $("tbody.ssh-add-key-body").attr("data-name", "");
+        $("tbody.ssh-add-key-body").toggleClass("unlock", false);
+        $("#credentials-dialog tr.load-custom-key").toggleClass("hidden", true);
+        $("#credentials-dialog tr.load-custom-key td").toggleClass("has-error", false);
+        sshFile.remove(document.getElementById('ssh-file-container'));
+    }
 
-        function show_pending(val) {
-            var body = $("tbody.ssh-add-key-body");
-            body.attr("data-name", val);
-            body.find("th.credential-label").text(val);
-            body.addClass("unlock");
-            body.find(".alert").hide();
-        }
+    function show_pending(val) {
+        var body = $("tbody.ssh-add-key-body");
+        body.attr("data-name", val);
+        body.find("th.credential-label").text(val);
+        body.addClass("unlock");
+        body.find(".alert").hide();
+    }
 
-        function add_custom_key() {
-            var tr = $("#credentials-dialog tr.load-custom-key");
-            var val = tr.find("input").val();
-            keys.load(val)
-                    .done(function () {
+    function add_custom_key() {
+        var tr = $("#credentials-dialog tr.load-custom-key");
+        var val = tr.find("input").val();
+        keys.load(val)
+                .done(function () {
+                    hide_add_key();
+                })
+                .fail(function(ex) {
+                    if (!ex.sent_password) {
+                        tr.find("td").toggleClass("has-error", true);
+                        tr.find("td div.dialog-error").text(ex.message);
+                    } else {
                         hide_add_key();
-                    })
-                    .fail(function(ex) {
-                        if (!ex.sent_password) {
-                            tr.find("td").toggleClass("has-error", true);
-                            tr.find("td div.dialog-error").text(ex.message);
-                        } else {
-                            hide_add_key();
-                            show_pending(val);
-                        }
-                    });
-        }
-
-        $("#credentials-dialog")
-
-        /* Show and hide panels */
-                .on("click", "#credential-keys a", function(ev) {
-                    hide_add_key();
-                    sshFile.render(document.getElementById('ssh-file-container'));
-                    $("#credentials-dialog tr.load-custom-key").toggleClass("hidden", false);
-                    $("#credentials-dialog tr.load-custom-key input").focus();
-                    ev.preventDefault();
-                    ev.stopPropagation();
-                })
-
-                .on("click", "tr.load-custom-key button", function(ev) {
-                    add_custom_key();
-                    ev.preventDefault();
-                    ev.stopPropagation();
-                })
-
-                .on("keypress", "tr.load-custom-key button", function(ev) {
-                    if (ev.which == 13)
-                        add_custom_key();
-                })
-
-                .on("keypress", "tr.load-custom-key input", function(ev) {
-                    if (ev.which == 13) {
-                        $("#credentials-dialog tr.load-custom-key button").focus();
-                        add_custom_key();
+                        show_pending(val);
                     }
-                })
-
-        /* Show and hide panels */
-                .on("click", "tr.listing-ct-item", function(ev) {
-                    var body;
-                    hide_add_key();
-                    if ($(ev.target).parents(".listing-ct-actions, ul").length === 0) {
-                        body = $(ev.target).parents("tbody");
-                        body.toggleClass("open").removeClass("unlock");
-                        body.find(".alert").hide();
-                        ev.preventDefault();
-                        ev.stopPropagation();
-                    }
-                })
-
-        /* Highlighting */
-                .on("mouseenter", ".listing-ct-item", function(ev) {
-                    $(ev.target).parents("tbody")
-                            .find(".listing-ct-item")
-                            .addClass("highlight-ct");
-                })
-                .on("mouseleave", ".listing-ct-item", function(ev) {
-                    $(ev.target).parents("tbody")
-                            .find(".listing-ct-item")
-                            .removeClass("highlight-ct");
-                })
-
-        /* Load and unload keys */
-                .on("change", ".btn-group", function(ev) {
-                    var body = $(this).parents("tbody");
-                    var id = body.attr("data-id");
-                    var key = keys.items[id];
-                    if (!key || !key.name)
-                        return;
-
-                    hide_add_key();
-                    var value = $(this).onoff("value");
-                    body.find(".alert").hide();
-
-                    /* Key needs to be loaded, show load UI */
-                    if (value && !key.loaded) {
-                        body.addClass("open").addClass("unlock");
-
-                        /* Key needs to be unloaded, do that directly */
-                    } else if (!value && key.loaded) {
-                        keys.unload(key)
-                                .done(function(ex) {
-                                    body.removeClass("open");
-                                })
-                                .fail(function(ex) {
-                                    console.log(ex);
-                                    body.addClass("open").removeClass("unlock");
-                                    body.find(".alert").show()
-                                            .find(".credential-alert")
-                                            .text(ex.message);
-                                });
-                    }
-                })
-
-        /* Load key */
-                .on("click", ".credential-unlock button", function(ev) {
-                    var body = $(this).parents("tbody");
-                    var id = body.attr("data-id");
-                    var key = keys.items[id];
-                    var name;
-
-                    if (key)
-                        name = key.name;
-                    if (body.hasClass("ssh-add-key-body"))
-                        name = body.attr("data-name");
-
-                    if (!name)
-                        return;
-
-                    body.find("input button").prop("disabled", true);
-                    body.find(".alert").hide();
-
-                    var password = body.find(".credential-password").val();
-                    keys.load(name, password)
-                            .always(function(ex) {
-                                body.find("input button").prop("disabled", false);
-                            })
-                            .done(function(ex) {
-                                body.find(".credential-password").val("");
-                                body.removeClass("unlock");
-                                hide_add_key();
-                                body.find(".alert").hide();
-                            })
-                            .fail(function(ex) {
-                                body.find(".alert").show()
-                                        .find("span")
-                                        .text(ex.message);
-                                console.warn("loading key failed: ", ex.message);
-                            });
-                    ev.preventDefault();
-                    ev.stopPropagation();
-                })
-
-        /* Change key */
-                .on("click", ".credential-change", function(ev) {
-                    var body = $(this).parents("tbody");
-                    var id = body.attr("data-id");
-                    var key = keys.items[id];
-                    if (!key || !key.name)
-                        return;
-
-                    hide_add_key();
-
-                    body.find("input button").prop("disabled", true);
-                    body.find(".alert").hide();
-
-                    var old_pass = body.find(".credential-old").val();
-                    var new_pass = body.find(".credential-new").val();
-                    var two_pass = body.find(".credential-two").val();
-                    if (old_pass === undefined || new_pass === undefined || two_pass === undefined)
-                        throw Error("invalid password fields");
-
-                    keys.change(key.name, old_pass, new_pass, two_pass)
-                            .always(function(ex) {
-                                body.find("input button").prop("disabled", false);
-                            })
-                            .done(function() {
-                                body.find(".credential-old").val("");
-                                body.find(".credential-new").val("");
-                                body.find(".credential-two").val("");
-                                body.find("li a").first()
-                                        .click();
-                            })
-                            .fail(function(ex) {
-                                body.find(".alert").show()
-                                        .find("span")
-                                        .text(ex.message);
-                            });
-                    ev.preventDefault();
-                    ev.stopPropagation();
-                })
-
-                .on("change keypress", "input", function(ev) {
-                    var body = $(this).parents("tbody");
-                    if (ev.type == "keypress" && ev.keyCode == 13)
-                        $(this).parents("dl")
-                                .find(".btn-primary")
-                                .click();
-                    body.find(".alert").hide();
-                })
-
-        /* Change tabs */
-                .on("click", "tr.credential-panel ul > li > a", function(ev) {
-                    var li = $(this).parent();
-                    var index = li.index();
-                    li.parent().children()
-                            .removeClass("active");
-                    li.addClass("active");
-                    var body = $(this).parents("tbody");
-                    body.find(".credential-tab").hide()
-                            .eq(index)
-                            .show();
-                    body.find(".alert").hide();
-                    ev.preventDefault();
-                    ev.stopPropagation();
-                })
-
-        /* Popover help */
-                .on("click", "[data-toggle='popover']", function() {
-                    $(this).popover('toggle');
-                })
-
-        /* Dialog is hidden */
-                .on("hide.bs.modal", function() {
-                    if (keys) {
-                        $(keys).off();
-                        keys.close();
-                        keys = null;
-                    }
-                    hide_add_key();
-                })
-
-        /* Dialog is shown */
-                .on("show.bs.modal", function() {
-                    keys = credentials.keys_instance();
-
-                    $(keys).on("changed", function() {
-                        var key, id, row;
-                        var rows = { };
-                        var table = $("#credentials-dialog table.credential-listing");
-
-                        table.find("tbody[data-id]").each(function(i, el) {
-                            row = $(el);
-                            rows[row.attr("data-id")] = row;
-                        });
-
-                        var body = table.find("tbody.ssh-key-body").first();
-                        for (id in keys.items) {
-                            if (!(id in rows)) {
-                                row = rows[id] = body.clone();
-                                row.attr("data-id", id)
-                                        .removeAttr("hidden")
-                                        .onoff();
-                                table.append(row);
-                            }
-                        }
-
-                        function text(row, field, string) {
-                            var sel = row.find(field);
-                            string = string || "";
-                            if (sel.text() !== string)
-                                sel.text(string);
-                        }
-
-                        for (id in rows) {
-                            row = rows[id];
-                            key = keys.items[id];
-                            if (key) {
-                                text(row, ".credential-label", key.name || key.comment);
-                                text(row, ".credential-type", key.type);
-                                text(row, ".credential-fingerprint", key.fingerprint);
-                                text(row, ".credential-comment", key.comment);
-                                text(row, ".credential-data", key.data);
-                                row.attr("data-name", key.name)
-                                        .attr("data-loaded", key.loaded ? "1" : "0")
-                                        .find(".btn-onoff-ct")
-                                        .onoff("value", key.loaded || row.hasClass("unlock"))
-                                        .onoff("disabled", !key.name);
-                            } else if (id !== "adding") {
-                                row.remove();
-                            }
-                        }
-                    });
                 });
     }
 
-    module.exports = {
-        setup: setup
-    };
-}());
+    $("#credentials-dialog")
+
+    /* Show and hide panels */
+            .on("click", "#credential-keys a", function(ev) {
+                hide_add_key();
+                sshFile.render(document.getElementById('ssh-file-container'));
+                $("#credentials-dialog tr.load-custom-key").toggleClass("hidden", false);
+                $("#credentials-dialog tr.load-custom-key input").focus();
+                ev.preventDefault();
+                ev.stopPropagation();
+            })
+
+            .on("click", "tr.load-custom-key button", function(ev) {
+                add_custom_key();
+                ev.preventDefault();
+                ev.stopPropagation();
+            })
+
+            .on("keypress", "tr.load-custom-key button", function(ev) {
+                if (ev.which == 13)
+                    add_custom_key();
+            })
+
+            .on("keypress", "tr.load-custom-key input", function(ev) {
+                if (ev.which == 13) {
+                    $("#credentials-dialog tr.load-custom-key button").focus();
+                    add_custom_key();
+                }
+            })
+
+    /* Show and hide panels */
+            .on("click", "tr.listing-ct-item", function(ev) {
+                var body;
+                hide_add_key();
+                if ($(ev.target).parents(".listing-ct-actions, ul").length === 0) {
+                    body = $(ev.target).parents("tbody");
+                    body.toggleClass("open").removeClass("unlock");
+                    body.find(".alert").hide();
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                }
+            })
+
+    /* Highlighting */
+            .on("mouseenter", ".listing-ct-item", function(ev) {
+                $(ev.target).parents("tbody")
+                        .find(".listing-ct-item")
+                        .addClass("highlight-ct");
+            })
+            .on("mouseleave", ".listing-ct-item", function(ev) {
+                $(ev.target).parents("tbody")
+                        .find(".listing-ct-item")
+                        .removeClass("highlight-ct");
+            })
+
+    /* Load and unload keys */
+            .on("change", ".btn-group", function(ev) {
+                var body = $(this).parents("tbody");
+                var id = body.attr("data-id");
+                var key = keys.items[id];
+                if (!key || !key.name)
+                    return;
+
+                hide_add_key();
+                var value = $(this).onoff("value");
+                body.find(".alert").hide();
+
+                /* Key needs to be loaded, show load UI */
+                if (value && !key.loaded) {
+                    body.addClass("open").addClass("unlock");
+
+                    /* Key needs to be unloaded, do that directly */
+                } else if (!value && key.loaded) {
+                    keys.unload(key)
+                            .done(function(ex) {
+                                body.removeClass("open");
+                            })
+                            .fail(function(ex) {
+                                console.log(ex);
+                                body.addClass("open").removeClass("unlock");
+                                body.find(".alert").show()
+                                        .find(".credential-alert")
+                                        .text(ex.message);
+                            });
+                }
+            })
+
+    /* Load key */
+            .on("click", ".credential-unlock button", function(ev) {
+                var body = $(this).parents("tbody");
+                var id = body.attr("data-id");
+                var key = keys.items[id];
+                var name;
+
+                if (key)
+                    name = key.name;
+                if (body.hasClass("ssh-add-key-body"))
+                    name = body.attr("data-name");
+
+                if (!name)
+                    return;
+
+                body.find("input button").prop("disabled", true);
+                body.find(".alert").hide();
+
+                var password = body.find(".credential-password").val();
+                keys.load(name, password)
+                        .always(function(ex) {
+                            body.find("input button").prop("disabled", false);
+                        })
+                        .done(function(ex) {
+                            body.find(".credential-password").val("");
+                            body.removeClass("unlock");
+                            hide_add_key();
+                            body.find(".alert").hide();
+                        })
+                        .fail(function(ex) {
+                            body.find(".alert").show()
+                                    .find("span")
+                                    .text(ex.message);
+                            console.warn("loading key failed: ", ex.message);
+                        });
+                ev.preventDefault();
+                ev.stopPropagation();
+            })
+
+    /* Change key */
+            .on("click", ".credential-change", function(ev) {
+                var body = $(this).parents("tbody");
+                var id = body.attr("data-id");
+                var key = keys.items[id];
+                if (!key || !key.name)
+                    return;
+
+                hide_add_key();
+
+                body.find("input button").prop("disabled", true);
+                body.find(".alert").hide();
+
+                var old_pass = body.find(".credential-old").val();
+                var new_pass = body.find(".credential-new").val();
+                var two_pass = body.find(".credential-two").val();
+                if (old_pass === undefined || new_pass === undefined || two_pass === undefined)
+                    throw Error("invalid password fields");
+
+                keys.change(key.name, old_pass, new_pass, two_pass)
+                        .always(function(ex) {
+                            body.find("input button").prop("disabled", false);
+                        })
+                        .done(function() {
+                            body.find(".credential-old").val("");
+                            body.find(".credential-new").val("");
+                            body.find(".credential-two").val("");
+                            body.find("li a").first()
+                                    .click();
+                        })
+                        .fail(function(ex) {
+                            body.find(".alert").show()
+                                    .find("span")
+                                    .text(ex.message);
+                        });
+                ev.preventDefault();
+                ev.stopPropagation();
+            })
+
+            .on("change keypress", "input", function(ev) {
+                var body = $(this).parents("tbody");
+                if (ev.type == "keypress" && ev.keyCode == 13)
+                    $(this).parents("dl")
+                            .find(".btn-primary")
+                            .click();
+                body.find(".alert").hide();
+            })
+
+    /* Change tabs */
+            .on("click", "tr.credential-panel ul > li > a", function(ev) {
+                var li = $(this).parent();
+                var index = li.index();
+                li.parent().children()
+                        .removeClass("active");
+                li.addClass("active");
+                var body = $(this).parents("tbody");
+                body.find(".credential-tab").hide()
+                        .eq(index)
+                        .show();
+                body.find(".alert").hide();
+                ev.preventDefault();
+                ev.stopPropagation();
+            })
+
+    /* Popover help */
+            .on("click", "[data-toggle='popover']", function() {
+                $(this).popover('toggle');
+            })
+
+    /* Dialog is hidden */
+            .on("hide.bs.modal", function() {
+                if (keys) {
+                    $(keys).off();
+                    keys.close();
+                    keys = null;
+                }
+                hide_add_key();
+            })
+
+    /* Dialog is shown */
+            .on("show.bs.modal", function() {
+                keys = credentials.keys_instance();
+
+                $(keys).on("changed", function() {
+                    var key, id, row;
+                    var rows = { };
+                    var table = $("#credentials-dialog table.credential-listing");
+
+                    table.find("tbody[data-id]").each(function(i, el) {
+                        row = $(el);
+                        rows[row.attr("data-id")] = row;
+                    });
+
+                    var body = table.find("tbody.ssh-key-body").first();
+                    for (id in keys.items) {
+                        if (!(id in rows)) {
+                            row = rows[id] = body.clone();
+                            row.attr("data-id", id)
+                                    .removeAttr("hidden")
+                                    .onoff();
+                            table.append(row);
+                        }
+                    }
+
+                    function text(row, field, string) {
+                        var sel = row.find(field);
+                        string = string || "";
+                        if (sel.text() !== string)
+                            sel.text(string);
+                    }
+
+                    for (id in rows) {
+                        row = rows[id];
+                        key = keys.items[id];
+                        if (key) {
+                            text(row, ".credential-label", key.name || key.comment);
+                            text(row, ".credential-type", key.type);
+                            text(row, ".credential-fingerprint", key.fingerprint);
+                            text(row, ".credential-comment", key.comment);
+                            text(row, ".credential-data", key.data);
+                            row.attr("data-name", key.name)
+                                    .attr("data-loaded", key.loaded ? "1" : "0")
+                                    .find(".btn-onoff-ct")
+                                    .onoff("value", key.loaded || row.hasClass("unlock"))
+                                    .onoff("disabled", !key.name);
+                        } else if (id !== "adding") {
+                            row.remove();
+                        }
+                    }
+                });
+            });
+}
+
+module.exports = {
+    setup: setup
+};

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -17,701 +17,699 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var $ = require("jquery");
-    var cockpit = require("cockpit");
+var $ = require("jquery");
+var cockpit = require("cockpit");
 
-    var base_index = require("./base_index");
+var base_index = require("./base_index");
 
-    var _ = cockpit.gettext;
+var _ = cockpit.gettext;
 
-    var shell_embedded = window.location.pathname.indexOf(".html") !== -1;
+var shell_embedded = window.location.pathname.indexOf(".html") !== -1;
 
-    function MachinesIndex(index_options, machines, loader, mdialogs) {
-        if (!index_options)
-            index_options = {};
+function MachinesIndex(index_options, machines, loader, mdialogs) {
+    if (!index_options)
+        index_options = {};
 
-        index_options.navigate = function (state, sidebar) {
-            return navigate(state, sidebar);
-        };
-        var index = base_index.new_index_from_proto(index_options);
+    index_options.navigate = function (state, sidebar) {
+        return navigate(state, sidebar);
+    };
+    var index = base_index.new_index_from_proto(index_options);
 
-        /* Restarts */
-        $(index).on("expect_restart", function (ev, host) {
-            loader.expect_restart(host);
-        });
+    /* Restarts */
+    $(index).on("expect_restart", function (ev, host) {
+        loader.expect_restart(host);
+    });
 
-        /* Disconnection Dialog */
-        var watchdog_problem = null;
-        $(index).on("disconnect", function (ev, problem) {
-            watchdog_problem = problem;
-            show_disconnected();
-        });
+    /* Disconnection Dialog */
+    var watchdog_problem = null;
+    $(index).on("disconnect", function (ev, problem) {
+        watchdog_problem = problem;
+        show_disconnected();
+    });
 
-        /* Is troubleshooting dialog open */
-        var troubleshooting = false;
-        var machines_timer = null;
+    /* Is troubleshooting dialog open */
+    var troubleshooting = false;
+    var machines_timer = null;
 
-        $("#machine-dropdown").on("hide.bs.dropdown", function () {
-            $("#find-machine").val("");
-            $("#machine-dropdown ul li").toggleClass("hidden", false);
-        });
+    $("#machine-dropdown").on("hide.bs.dropdown", function () {
+        $("#find-machine").val("");
+        $("#machine-dropdown ul li").toggleClass("hidden", false);
+    });
 
-        $("#find-machine").on("keyup", function (ev) {
-            if (machines_timer)
-                window.clearTimeout(machines_timer);
+    $("#find-machine").on("keyup", function (ev) {
+        if (machines_timer)
+            window.clearTimeout(machines_timer);
 
-            machines_timer = window.setTimeout(function () {
-                filter_machines();
-                machines_timer = null;
-            }, 250);
-        });
+        machines_timer = window.setTimeout(function () {
+            filter_machines();
+            machines_timer = null;
+        }, 250);
+    });
 
-        $("#host-nav-item").on("click", function (ev) {
-            if ($(this).hasClass("active")) {
-                $(this).toggleClass("menu-visible");
-                $("#host-nav").toggleClass("interact");
-                ev.preventDefault();
-                return false;
-            } else {
-                $(this).toggleClass("menu-visible", true);
-                $("#host-nav").toggleClass("interact", true);
-            }
-        });
-
-        /* Reconnect button */
-        $("#machine-reconnect").on("click", function(ev) {
-            if (watchdog_problem) {
-                cockpit.sessionStorage.clear();
-                window.location.reload(true);
-            } else {
-                navigate(null, true);
-            }
-        });
-
-        /* Troubleshoot pause navigation */
-        $("#troubleshoot-dialog").on("show.bs.modal", function(ev) {
-            troubleshooting = true;
-        });
-
-        /* Troubleshoot dialog close */
-        $("#troubleshoot-dialog").on("hide.bs.modal", function(ev) {
-            troubleshooting = false;
-            navigate(null, true);
-        });
-
-        /* Navigation */
-        var ready = false;
-        function on_ready() {
-            ready = true;
-            index.ready();
+    $("#host-nav-item").on("click", function (ev) {
+        if ($(this).hasClass("active")) {
+            $(this).toggleClass("menu-visible");
+            $("#host-nav").toggleClass("interact");
+            ev.preventDefault();
+            return false;
+        } else {
+            $(this).toggleClass("menu-visible", true);
+            $("#host-nav").toggleClass("interact", true);
         }
-
-        /* When the machine list is ready we start processing navigation */
-        $(machines)
-                .on("ready", on_ready)
-                .on("added updated", function(ev, machine) {
-                    if (!machine.visible)
-                        index.frames.remove(machine);
-                    else if (machine.problem)
-                        index.frames.remove(machine);
-
-                    update_machines();
-                    if (ready)
-                        navigate();
-                })
-                .on("removed", function(ev, machine) {
-                    index.frames.remove(machine);
-                    update_machines();
-                });
-
-        if (machines.ready)
-            on_ready();
-
-        /* When only one machine this operates as a link */
-        $("#machine-link").on("click", function(ev) {
-            if (machines.list.length == 1) {
-                index.jump({ host: machines.list[0].address, sidebar: true, component: "" });
-                ev.preventDefault();
-                return false;
-            }
-        });
-
-        function show_disconnected() {
-            var current_frame = index.current_frame();
-
-            if (current_frame)
-                $(current_frame).hide();
-
-            $(".curtains-ct .spinner").toggle(false);
-            $("#machine-reconnect").toggle(true);
-            $("#machine-troubleshoot").toggle(false);
-            $(".curtains-ct i").toggle(true);
-            $(".curtains-ct h1").text(_("Disconnected"));
-            $(".curtains-ct p").text(cockpit.message(watchdog_problem));
-            $(".curtains-ct").show();
-            $("#navbar-dropdown").addClass("disabled");
-        }
-
-        /* Handles navigation */
-        function navigate(state, reconnect) {
-            var machine;
-            $('#host-nav-item').toggleClass("menu-visible", false);
-            $("#host-nav").toggleClass("interact", false);
-
-            /* If this is a watchdog problem or we are troubleshooting
-             * let the dialog handle it */
-            if (watchdog_problem || troubleshooting)
-                return;
-
-            /* phantomjs has a problem retrieving state, so we allow it to be passed in */
-            if (!state)
-                state = index.retrieve_state();
-            machine = machines.lookup(state.host);
-
-            /* No such machine */
-            if (!machine) {
-                machine = {
-                    key: state.host,
-                    address: state.host,
-                    label: state.host,
-                    state: "failed",
-                    problem: "not-found",
-                };
-
-            /* Asked to reconnect to the machine */
-            } else if (!machine.visible) {
-                machine.state = "failed";
-                machine.problem = "not-found";
-            } else if (reconnect && machine.state !== "connected") {
-                loader.connect(state.host);
-            }
-
-            var compiled = compile(machine);
-            if (machine.manifests && !state.component)
-                state.component = choose_component(state, compiled);
-
-            update_navbar(machine, state, compiled);
-            update_frame(machine, state, compiled);
-
-            /* Just replace the state, and URL */
-            index.jump(state, true);
-        }
-
-        function choose_component(state, compiled) {
-            var item, menu_items;
-            var single_host = machines.list.length <= 1;
-            var dashboards = compiled.ordered("dashboard");
-
-            if (shell_embedded)
-                state.sidebar = true;
-
-            /* See if we should show a dashboard */
-            if (!state.sidebar && dashboards.length > 0) {
-                item = dashboards[0];
-                /* Don't chose a dashboard as a single host unless
-                 * it specifically supports that.
-                 */
-                if (item && (!single_host || item.wants !== "multiple-machines"))
-                    return item.path;
-                else
-                    item = null;
-            }
-
-            /* See if we can find something with currently selected label */
-            var label = $("#sidebar li.active a").text();
-            if (label) {
-                item = compiled.search("label", label);
-                if (item)
-                    return item.path;
-            }
-
-            /* Go for the first item */
-            menu_items = compiled.ordered("menu");
-            if (menu_items.length > 0 && menu_items[0]) {
-                return menu_items[0].path;
-
-            /* If there is no menu items use a dashboard */
-            } else if (dashboards.length > 0) {
-                item = dashboards[0];
-                if (item) {
-                    state.sidebar = false;
-                    return item.path;
-                }
-            }
-
-            return "system";
-        }
-
-        function default_machine() {
-            /* Default to localhost if it has anything.
-             * Otherwise find the first non local machine.
-             */
-            var i;
-            var machine = machines.lookup("localhost");
-            var compiled = compile(machine);
-            if (compiled.ordered("menu").length || compiled.ordered("tools").length)
-                return machine;
-
-            for (i = 0; i < machines.list.length; i++) {
-                if (machines.list[i].address != "localhost")
-                    return machines.list[i];
-            }
-        }
-
-        function update_sidebar(machine, state, compiled) {
-            function links(component) {
-                var active = state.component === component.path;
-                var listItem;
-
-                listItem = $("<li class='list-group-item'>")
-                        .toggleClass("active", active)
-                        .append($("<a>")
-                                .attr("href", index.href({ host: machine.address, component: component.path, hash: component.hash }))
-                                .append($("<span>").text(component.label)));
-
-                if (active)
-                    listItem.find('a').attr("aria-current", "page");
-
-                return listItem;
-            }
-
-            var menu = compiled.ordered("menu").map(links);
-            $("#sidebar-menu").empty()
-                    .append(menu);
-
-            var tools = compiled.ordered("tools").map(links);
-            $("#sidebar-tools").empty()
-                    .append(tools);
-
-            $("#machine-avatar").attr("src", machine && machine.avatar ? encodeURI(machine.avatar)
-                : "../shell/images/server-small.png");
-
-            var color = machine ? machine.color : "";
-            $("#host-nav-item span.pficon-container-node").css("color", color);
-
-            if (machine) {
-                $("#machine-link span").text(machine.label);
-                $("#machine-link").attr("title", machine.label);
-            } else {
-                $("#machine-link span").text(_("Machines"));
-                $("#machine-link").attr("title", "");
-            }
-        }
-
-        function update_active_machine (address) {
-            var active_sel;
-            $("#machine-dropdown ul li").toggleClass("active", false)
-                    .find("a")
-                    .removeAttr("aria-current");
-            if (address) {
-                active_sel = "#machine-dropdown ul li[data-address='" + address + "']";
-                $(active_sel).toggleClass("active", true)
-                        .find("a")
-                        .attr("aria-current", "page");
-            }
-        }
-
-        function update_machine_links(machine, showing_sidebar, state) {
-            var data = $("#host-nav-link").attr("data-machine");
-
-            // If we are already setup we will bail early
-            if (data && (!machine || machine.address === data)) {
-                // If showing the sidebar, save our place
-                if (showing_sidebar) {
-                    $("#host-nav-link").attr("href", index.href(state));
-                    update_active_machine(data);
-                }
-                return;
-            }
-
-            if (!machine && data)
-                machine = machines.lookup(data);
-            if (!machine)
-                machine = default_machine();
-
-            $("#host-nav-link span.list-group-item-value").text(machine ? machine.label : "");
-            $("#host-nav-link")
-                    .attr("aria-label", _("Host"))
-                    .attr("data-machine", machine ? machine.address : "")
-                    .attr("href", index.href({ host: machine ? machine.address : undefined }, true));
-
-            // Only show the hosts icon in the main nav if we have a machine
-            $("#host-nav-item").toggleClass("dashboard-link", !!machine);
-
-            update_active_machine(machine ? machine.address : null);
-        }
-
-        function update_navbar(machine, state, compiled) {
-            /* When a dashboard no machine or sidebar */
-            var item = compiled.items[state.component];
-            if (item && item.section == "dashboard") {
-                delete state.sidebar;
-                machine = null;
-            }
-
-            $(".dashboard-link").each(function() {
-                var el = $(this);
-                var data = el.attr("data-component");
-                // Mark active component and save our place
-                if (data && data === state.component) {
-                    el.attr("href", index.href(state))
-                            .toggleClass("active", true)
-                            .find("a")
-                            .attr("aria-current", "page");
-                } else {
-                    el.toggleClass("active", false)
-                            .find("a")
-                            .removeAttr("aria-current");
-                }
-            });
-
-            $("#host-nav-item").toggleClass("active", !!machine);
-            if (machine)
-                update_sidebar(machine, state, compiled);
-
-            $("#host-nav").toggleClass("hidden", !machine);
-            update_machine_links(machine, !!machine, state);
-            $('.area-ct-body').toggleClass("single-nav", $(".dashboard-link").length < 2);
-        }
-
-        function update_title(label, machine) {
-            var compiled;
-            if (label)
-                label += " - ";
-            else
-                label = "";
-            var suffix = index.default_title;
-
-            if (machine) {
-                if (machine.address === "localhost") {
-                    compiled = compile(machine);
-                    if (compiled.ordered("menu").length || compiled.ordered("tools").length)
-                        suffix = machine.label;
-                } else {
-                    suffix = machine.label;
-                }
-            }
-            document.title = label + suffix;
-        }
-
-        function update_frame(machine, state, compiled) {
-            var title, message, connecting, restarting;
-            var current_frame = index.current_frame();
-
-            if (machine.state != "connected") {
-                $(current_frame).hide();
-                current_frame = null;
-                index.current_frame(current_frame);
-
-                connecting = (machine.state == "connecting");
-                if (machine.restarting) {
-                    title = _("The machine is restarting");
-                    message = "";
-                } else if (connecting) {
-                    title = _("Connecting to the machine");
-                    message = "";
-                } else {
-                    title = _("Couldn't connect to the machine");
-                    if (machine.problem == "not-found") {
-                        message = _("Cannot connect to an unknown machine");
-                    } else {
-                        var error = machine.problem || machine.state;
-                        if (error)
-                            message = cockpit.message(error);
-                        else
-                            message = "";
-                    }
-                }
-
-                if (!machine.restarting && mdialogs.needs_troubleshoot(machine)) {
-                    $("#machine-troubleshoot").off()
-                            .on("click", function () {
-                                mdialogs.troubleshoot("troubleshoot-dialog", machine);
-                            });
-                    $("#machine-troubleshoot").show();
-                } else {
-                    $("#machine-troubleshoot").hide();
-                }
-
-                restarting = !!machine.restarting;
-                $(".curtains-ct").show();
-                $(".curtains-ct .spinner").toggle(connecting || restarting);
-                $("#machine-reconnect").toggle(!connecting && machine.problem != "not-found");
-                $(".curtains-ct i").toggle(!connecting && !restarting);
-                $(".curtains-ct h1").text(title);
-                $(".curtains-ct p").text(message);
-
-                $("#machine-spinner").hide();
-
-                update_title(null, machine);
-
-                /* Fall through when connecting, and allow frame to load at same time */
-                if (!connecting)
-                    return;
-            }
-
-            var hash = state.hash;
-            var component = state.component;
-
-            /* Old cockpit packages, used to be in shell/shell.html */
-            var compat;
-            if (machine && compiled.compat) {
-                compat = compiled.compat[component];
-                if (compat) {
-                    component = "shell/shell";
-                    hash = compat;
-                }
-            }
-
-            var frame;
-            if (component)
-                frame = index.frames.lookup(machine, component, hash);
-            if (frame != current_frame) {
-                $(current_frame).css('display', 'none');
-                index.current_frame(frame);
-            }
-
-            var label, item;
-            if (machine.state == "connected") {
-                $(".curtains-ct").hide();
-                $("#machine-spinner").toggle(frame && !$(frame).attr("data-ready"));
-                $(frame).css('display', 'block');
-                item = compiled.items[state.component];
-                label = item ? item.label : "";
-                update_title(label, machine);
-            }
-        }
-
-        function update_machines() {
-            $("#machine-dropdown .caret")
-                    .toggle(machines.list.length > 1);
-
-            var machine_link = $("#machine-link");
-            if (machines.list.length > 1)
-                machine_link.attr("data-toggle", "dropdown");
-            else
-                machine_link.removeAttr("data-toggle");
-
-            var list = $("#machine-dropdown ul");
-            var links = machines.list.map(function(machine) {
-                var text = $("<span>")
-                        .text(machine.label)
-                        .prepend($("<i>")
-                                .attr("class", "fa-li fa fa-circle")
-                                .css("color", machine.color || ""));
-                return $("<li role='presentation'>")
-                        .attr("data-address", machine.address)
-                        .append($("<a>")
-                                .attr("role", "menuitem")
-                                .attr("tabindex", "-1")
-                                .attr("data-address", machine.address)
-                                .attr("href", index.href({ host: machine.address }, true))
-                                .append(text));
-            });
-            list.empty().append(links);
-        }
-
-        function filter_machines () {
-            var val = $("#find-machine").val()
-                    .toLowerCase();
-            $("#machine-dropdown ul li").each(function() {
-                var el = $(this);
-                var a = el.find('a').first();
-                var txt = a.text().toLowerCase();
-                var addr = a.attr("data-address") ? a.attr("data-address").toLowerCase() : "";
-                var hide = !!val && txt.indexOf(val) !== 0 && addr.indexOf(val) !== 0;
-                el.toggleClass("hidden", hide);
-            });
-        }
-
-        function compatibility(machine) {
-            if (!machine.manifests || machine.address === "localhost")
-                return null;
-
-            var shell = machine.manifests["shell"] || { };
-            var menu = shell["menu"] || { };
-            var tools = shell["tools"] || { };
-
-            var mapping = { };
-
-            /* The following were included in shell/shell.html in old versions */
-            if ("_host_" in menu)
-                mapping["system/host"] = "/server";
-            if ("_init_" in menu)
-                mapping["system/init"] = "/services";
-            if ("_network_" in menu)
-                mapping["network/interfaces"] = "/networking";
-            if ("_storage_" in menu)
-                mapping["storage/devices"] = "/storage";
-            if ("_users_" in tools)
-                mapping["users/local"] = "/accounts";
-
-            /* For Docker we have to guess ... some heuristics */
-            if ("_storage_" in menu || "_init_" in menu)
-                mapping["docker/containers"] = "/containers";
-
-            return mapping;
-        }
-
-        function compile(machine) {
-            var compiled = base_index.new_compiled();
-            compiled.load(machine.manifests, "tools");
-            compiled.load(machine.manifests, "dashboard");
-            compiled.load(machine.manifests, "menu");
-            compiled.compat = compatibility(machine);
-            return compiled;
-        }
-
-        cockpit.transport.wait(function() {
-            index.start();
-        });
-    }
-
-    function SimpleIndex(index_options) {
-        if (!index_options)
-            index_options = {};
-
-        index_options.navigate = function (state, sidebar) {
-            return navigate(state, sidebar);
-        };
-        var default_title = index_options.default_title || "Cockpit";
-        var index = base_index.new_index_from_proto(index_options);
-        var compiled = base_index.new_compiled();
-
-        compiled.load(cockpit.manifests, "dashboard");
-
-        /* Disconnection Dialog */
-        var watchdog_problem = null;
-        $(index).on("disconnect", function (ev, problem) {
-            watchdog_problem = problem;
-            show_disconnected();
-        });
-
-        /* Reconnect button */
-        $("#machine-reconnect").on("click", function(ev) {
+    });
+
+    /* Reconnect button */
+    $("#machine-reconnect").on("click", function(ev) {
+        if (watchdog_problem) {
             cockpit.sessionStorage.clear();
             window.location.reload(true);
-        });
-
-        function show_disconnected() {
-            var current_frame = index.current_frame();
-            if (current_frame)
-                $(current_frame).hide();
-
-            $(".curtains-ct .spinner").toggle(false);
-            $("#machine-reconnect").toggle(true);
-            $(".curtains-ct i").toggle(true);
-            $(".curtains-ct h1").text(_("Disconnected"));
-            $(".curtains-ct p").text(cockpit.message(watchdog_problem));
-            $(".curtains-ct").show();
-            $("#navbar-dropdown").addClass("disabled");
+        } else {
+            navigate(null, true);
         }
+    });
 
+    /* Troubleshoot pause navigation */
+    $("#troubleshoot-dialog").on("show.bs.modal", function(ev) {
+        troubleshooting = true;
+    });
+
+    /* Troubleshoot dialog close */
+    $("#troubleshoot-dialog").on("hide.bs.modal", function(ev) {
+        troubleshooting = false;
+        navigate(null, true);
+    });
+
+    /* Navigation */
+    var ready = false;
+    function on_ready() {
+        ready = true;
         index.ready();
+    }
 
-        /* Handles navigation */
-        function navigate(state, reconnect) {
-            var dashboards = compiled.ordered("dashboard");
+    /* When the machine list is ready we start processing navigation */
+    $(machines)
+            .on("ready", on_ready)
+            .on("added updated", function(ev, machine) {
+                if (!machine.visible)
+                    index.frames.remove(machine);
+                else if (machine.problem)
+                    index.frames.remove(machine);
 
-            /* If this is a watchdog problem or we are troubleshooting
-             * let the dialog handle it */
-            if (watchdog_problem)
-                return;
-
-            /* phantomjs has a problem retrieving state, so we allow it to be passed in */
-            if (!state)
-                state = index.retrieve_state();
-
-            if (!state.component && dashboards.length > 0) {
-                state.component = dashboards[0].path;
-            }
-            update_navbar(state);
-            update_frame(state);
-
-            /* Just replace the state, and URL */
-            index.jump(state, true);
-        }
-
-        function update_navbar(state) {
-            $("#host-nav-item").toggleClass("dashboard-link", false);
-            $(".dashboard-link").each(function() {
-                var el = $(this);
-                el.toggleClass("active", el.attr("data-component") === state.component);
+                update_machines();
+                if (ready)
+                    navigate();
+            })
+            .on("removed", function(ev, machine) {
+                index.frames.remove(machine);
+                update_machines();
             });
 
-            var item = compiled.items[state.component];
-            if (item && item.section == "dashboard")
-                delete state.sidebar;
+    if (machines.ready)
+        on_ready();
 
-            $('.area-ct-body').toggleClass("single-nav", $(".dashboard-link").length < 2);
+    /* When only one machine this operates as a link */
+    $("#machine-link").on("click", function(ev) {
+        if (machines.list.length == 1) {
+            index.jump({ host: machines.list[0].address, sidebar: true, component: "" });
+            ev.preventDefault();
+            return false;
+        }
+    });
+
+    function show_disconnected() {
+        var current_frame = index.current_frame();
+
+        if (current_frame)
+            $(current_frame).hide();
+
+        $(".curtains-ct .spinner").toggle(false);
+        $("#machine-reconnect").toggle(true);
+        $("#machine-troubleshoot").toggle(false);
+        $(".curtains-ct i").toggle(true);
+        $(".curtains-ct h1").text(_("Disconnected"));
+        $(".curtains-ct p").text(cockpit.message(watchdog_problem));
+        $(".curtains-ct").show();
+        $("#navbar-dropdown").addClass("disabled");
+    }
+
+    /* Handles navigation */
+    function navigate(state, reconnect) {
+        var machine;
+        $('#host-nav-item').toggleClass("menu-visible", false);
+        $("#host-nav").toggleClass("interact", false);
+
+        /* If this is a watchdog problem or we are troubleshooting
+         * let the dialog handle it */
+        if (watchdog_problem || troubleshooting)
+            return;
+
+        /* phantomjs has a problem retrieving state, so we allow it to be passed in */
+        if (!state)
+            state = index.retrieve_state();
+        machine = machines.lookup(state.host);
+
+        /* No such machine */
+        if (!machine) {
+            machine = {
+                key: state.host,
+                address: state.host,
+                label: state.host,
+                state: "failed",
+                problem: "not-found",
+            };
+
+        /* Asked to reconnect to the machine */
+        } else if (!machine.visible) {
+            machine.state = "failed";
+            machine.problem = "not-found";
+        } else if (reconnect && machine.state !== "connected") {
+            loader.connect(state.host);
         }
 
-        function update_title(label) {
-            if (label)
-                label += " - ";
+        var compiled = compile(machine);
+        if (machine.manifests && !state.component)
+            state.component = choose_component(state, compiled);
+
+        update_navbar(machine, state, compiled);
+        update_frame(machine, state, compiled);
+
+        /* Just replace the state, and URL */
+        index.jump(state, true);
+    }
+
+    function choose_component(state, compiled) {
+        var item, menu_items;
+        var single_host = machines.list.length <= 1;
+        var dashboards = compiled.ordered("dashboard");
+
+        if (shell_embedded)
+            state.sidebar = true;
+
+        /* See if we should show a dashboard */
+        if (!state.sidebar && dashboards.length > 0) {
+            item = dashboards[0];
+            /* Don't chose a dashboard as a single host unless
+             * it specifically supports that.
+             */
+            if (item && (!single_host || item.wants !== "multiple-machines"))
+                return item.path;
             else
-                label = "";
-            document.title = label + default_title;
+                item = null;
         }
 
-        function update_frame(state) {
-            var current_frame = index.current_frame();
+        /* See if we can find something with currently selected label */
+        var label = $("#sidebar li.active a").text();
+        if (label) {
+            item = compiled.search("label", label);
+            if (item)
+                return item.path;
+        }
 
-            var hash = state.hash;
-            var component = state.component;
+        /* Go for the first item */
+        menu_items = compiled.ordered("menu");
+        if (menu_items.length > 0 && menu_items[0]) {
+            return menu_items[0].path;
 
-            var frame;
-            if (component)
-                frame = index.frames.lookup(null, component, hash);
-            if (frame != current_frame) {
-                $(current_frame).css('display', 'none');
-                index.current_frame(frame);
+        /* If there is no menu items use a dashboard */
+        } else if (dashboards.length > 0) {
+            item = dashboards[0];
+            if (item) {
+                state.sidebar = false;
+                return item.path;
+            }
+        }
+
+        return "system";
+    }
+
+    function default_machine() {
+        /* Default to localhost if it has anything.
+         * Otherwise find the first non local machine.
+         */
+        var i;
+        var machine = machines.lookup("localhost");
+        var compiled = compile(machine);
+        if (compiled.ordered("menu").length || compiled.ordered("tools").length)
+            return machine;
+
+        for (i = 0; i < machines.list.length; i++) {
+            if (machines.list[i].address != "localhost")
+                return machines.list[i];
+        }
+    }
+
+    function update_sidebar(machine, state, compiled) {
+        function links(component) {
+            var active = state.component === component.path;
+            var listItem;
+
+            listItem = $("<li class='list-group-item'>")
+                    .toggleClass("active", active)
+                    .append($("<a>")
+                            .attr("href", index.href({ host: machine.address, component: component.path, hash: component.hash }))
+                            .append($("<span>").text(component.label)));
+
+            if (active)
+                listItem.find('a').attr("aria-current", "page");
+
+            return listItem;
+        }
+
+        var menu = compiled.ordered("menu").map(links);
+        $("#sidebar-menu").empty()
+                .append(menu);
+
+        var tools = compiled.ordered("tools").map(links);
+        $("#sidebar-tools").empty()
+                .append(tools);
+
+        $("#machine-avatar").attr("src", machine && machine.avatar ? encodeURI(machine.avatar)
+            : "../shell/images/server-small.png");
+
+        var color = machine ? machine.color : "";
+        $("#host-nav-item span.pficon-container-node").css("color", color);
+
+        if (machine) {
+            $("#machine-link span").text(machine.label);
+            $("#machine-link").attr("title", machine.label);
+        } else {
+            $("#machine-link span").text(_("Machines"));
+            $("#machine-link").attr("title", "");
+        }
+    }
+
+    function update_active_machine (address) {
+        var active_sel;
+        $("#machine-dropdown ul li").toggleClass("active", false)
+                .find("a")
+                .removeAttr("aria-current");
+        if (address) {
+            active_sel = "#machine-dropdown ul li[data-address='" + address + "']";
+            $(active_sel).toggleClass("active", true)
+                    .find("a")
+                    .attr("aria-current", "page");
+        }
+    }
+
+    function update_machine_links(machine, showing_sidebar, state) {
+        var data = $("#host-nav-link").attr("data-machine");
+
+        // If we are already setup we will bail early
+        if (data && (!machine || machine.address === data)) {
+            // If showing the sidebar, save our place
+            if (showing_sidebar) {
+                $("#host-nav-link").attr("href", index.href(state));
+                update_active_machine(data);
+            }
+            return;
+        }
+
+        if (!machine && data)
+            machine = machines.lookup(data);
+        if (!machine)
+            machine = default_machine();
+
+        $("#host-nav-link span.list-group-item-value").text(machine ? machine.label : "");
+        $("#host-nav-link")
+                .attr("aria-label", _("Host"))
+                .attr("data-machine", machine ? machine.address : "")
+                .attr("href", index.href({ host: machine ? machine.address : undefined }, true));
+
+        // Only show the hosts icon in the main nav if we have a machine
+        $("#host-nav-item").toggleClass("dashboard-link", !!machine);
+
+        update_active_machine(machine ? machine.address : null);
+    }
+
+    function update_navbar(machine, state, compiled) {
+        /* When a dashboard no machine or sidebar */
+        var item = compiled.items[state.component];
+        if (item && item.section == "dashboard") {
+            delete state.sidebar;
+            machine = null;
+        }
+
+        $(".dashboard-link").each(function() {
+            var el = $(this);
+            var data = el.attr("data-component");
+            // Mark active component and save our place
+            if (data && data === state.component) {
+                el.attr("href", index.href(state))
+                        .toggleClass("active", true)
+                        .find("a")
+                        .attr("aria-current", "page");
+            } else {
+                el.toggleClass("active", false)
+                        .find("a")
+                        .removeAttr("aria-current");
+            }
+        });
+
+        $("#host-nav-item").toggleClass("active", !!machine);
+        if (machine)
+            update_sidebar(machine, state, compiled);
+
+        $("#host-nav").toggleClass("hidden", !machine);
+        update_machine_links(machine, !!machine, state);
+        $('.area-ct-body').toggleClass("single-nav", $(".dashboard-link").length < 2);
+    }
+
+    function update_title(label, machine) {
+        var compiled;
+        if (label)
+            label += " - ";
+        else
+            label = "";
+        var suffix = index.default_title;
+
+        if (machine) {
+            if (machine.address === "localhost") {
+                compiled = compile(machine);
+                if (compiled.ordered("menu").length || compiled.ordered("tools").length)
+                    suffix = machine.label;
+            } else {
+                suffix = machine.label;
+            }
+        }
+        document.title = label + suffix;
+    }
+
+    function update_frame(machine, state, compiled) {
+        var title, message, connecting, restarting;
+        var current_frame = index.current_frame();
+
+        if (machine.state != "connected") {
+            $(current_frame).hide();
+            current_frame = null;
+            index.current_frame(current_frame);
+
+            connecting = (machine.state == "connecting");
+            if (machine.restarting) {
+                title = _("The machine is restarting");
+                message = "";
+            } else if (connecting) {
+                title = _("Connecting to the machine");
+                message = "";
+            } else {
+                title = _("Couldn't connect to the machine");
+                if (machine.problem == "not-found") {
+                    message = _("Cannot connect to an unknown machine");
+                } else {
+                    var error = machine.problem || machine.state;
+                    if (error)
+                        message = cockpit.message(error);
+                    else
+                        message = "";
+                }
             }
 
-            var label, item;
+            if (!machine.restarting && mdialogs.needs_troubleshoot(machine)) {
+                $("#machine-troubleshoot").off()
+                        .on("click", function () {
+                            mdialogs.troubleshoot("troubleshoot-dialog", machine);
+                        });
+                $("#machine-troubleshoot").show();
+            } else {
+                $("#machine-troubleshoot").hide();
+            }
+
+            restarting = !!machine.restarting;
+            $(".curtains-ct").show();
+            $(".curtains-ct .spinner").toggle(connecting || restarting);
+            $("#machine-reconnect").toggle(!connecting && machine.problem != "not-found");
+            $(".curtains-ct i").toggle(!connecting && !restarting);
+            $(".curtains-ct h1").text(title);
+            $(".curtains-ct p").text(message);
+
+            $("#machine-spinner").hide();
+
+            update_title(null, machine);
+
+            /* Fall through when connecting, and allow frame to load at same time */
+            if (!connecting)
+                return;
+        }
+
+        var hash = state.hash;
+        var component = state.component;
+
+        /* Old cockpit packages, used to be in shell/shell.html */
+        var compat;
+        if (machine && compiled.compat) {
+            compat = compiled.compat[component];
+            if (compat) {
+                component = "shell/shell";
+                hash = compat;
+            }
+        }
+
+        var frame;
+        if (component)
+            frame = index.frames.lookup(machine, component, hash);
+        if (frame != current_frame) {
+            $(current_frame).css('display', 'none');
+            index.current_frame(frame);
+        }
+
+        var label, item;
+        if (machine.state == "connected") {
+            $(".curtains-ct").hide();
+            $("#machine-spinner").toggle(frame && !$(frame).attr("data-ready"));
             $(frame).css('display', 'block');
             item = compiled.items[state.component];
             label = item ? item.label : "";
-            update_title(label);
+            update_title(label, machine);
         }
+    }
 
-        cockpit.transport.wait(function() {
-            index.start();
+    function update_machines() {
+        $("#machine-dropdown .caret")
+                .toggle(machines.list.length > 1);
+
+        var machine_link = $("#machine-link");
+        if (machines.list.length > 1)
+            machine_link.attr("data-toggle", "dropdown");
+        else
+            machine_link.removeAttr("data-toggle");
+
+        var list = $("#machine-dropdown ul");
+        var links = machines.list.map(function(machine) {
+            var text = $("<span>")
+                    .text(machine.label)
+                    .prepend($("<i>")
+                            .attr("class", "fa-li fa fa-circle")
+                            .css("color", machine.color || ""));
+            return $("<li role='presentation'>")
+                    .attr("data-address", machine.address)
+                    .append($("<a>")
+                            .attr("role", "menuitem")
+                            .attr("tabindex", "-1")
+                            .attr("data-address", machine.address)
+                            .attr("href", index.href({ host: machine.address }, true))
+                            .append(text));
+        });
+        list.empty().append(links);
+    }
+
+    function filter_machines () {
+        var val = $("#find-machine").val()
+                .toLowerCase();
+        $("#machine-dropdown ul li").each(function() {
+            var el = $(this);
+            var a = el.find('a').first();
+            var txt = a.text().toLowerCase();
+            var addr = a.attr("data-address") ? a.attr("data-address").toLowerCase() : "";
+            var hide = !!val && txt.indexOf(val) !== 0 && addr.indexOf(val) !== 0;
+            el.toggleClass("hidden", hide);
         });
     }
 
-    module.exports = {
-        simple_index: function (options) {
-            return new SimpleIndex(options);
-        },
-        machines_index: function (options, machines_ins, loader, mdialogs) {
-            return new MachinesIndex(options, machines_ins, loader, mdialogs);
+    function compatibility(machine) {
+        if (!machine.manifests || machine.address === "localhost")
+            return null;
+
+        var shell = machine.manifests["shell"] || { };
+        var menu = shell["menu"] || { };
+        var tools = shell["tools"] || { };
+
+        var mapping = { };
+
+        /* The following were included in shell/shell.html in old versions */
+        if ("_host_" in menu)
+            mapping["system/host"] = "/server";
+        if ("_init_" in menu)
+            mapping["system/init"] = "/services";
+        if ("_network_" in menu)
+            mapping["network/interfaces"] = "/networking";
+        if ("_storage_" in menu)
+            mapping["storage/devices"] = "/storage";
+        if ("_users_" in tools)
+            mapping["users/local"] = "/accounts";
+
+        /* For Docker we have to guess ... some heuristics */
+        if ("_storage_" in menu || "_init_" in menu)
+            mapping["docker/containers"] = "/containers";
+
+        return mapping;
+    }
+
+    function compile(machine) {
+        var compiled = base_index.new_compiled();
+        compiled.load(machine.manifests, "tools");
+        compiled.load(machine.manifests, "dashboard");
+        compiled.load(machine.manifests, "menu");
+        compiled.compat = compatibility(machine);
+        return compiled;
+    }
+
+    cockpit.transport.wait(function() {
+        index.start();
+    });
+}
+
+function SimpleIndex(index_options) {
+    if (!index_options)
+        index_options = {};
+
+    index_options.navigate = function (state, sidebar) {
+        return navigate(state, sidebar);
+    };
+    var default_title = index_options.default_title || "Cockpit";
+    var index = base_index.new_index_from_proto(index_options);
+    var compiled = base_index.new_compiled();
+
+    compiled.load(cockpit.manifests, "dashboard");
+
+    /* Disconnection Dialog */
+    var watchdog_problem = null;
+    $(index).on("disconnect", function (ev, problem) {
+        watchdog_problem = problem;
+        show_disconnected();
+    });
+
+    /* Reconnect button */
+    $("#machine-reconnect").on("click", function(ev) {
+        cockpit.sessionStorage.clear();
+        window.location.reload(true);
+    });
+
+    function show_disconnected() {
+        var current_frame = index.current_frame();
+        if (current_frame)
+            $(current_frame).hide();
+
+        $(".curtains-ct .spinner").toggle(false);
+        $("#machine-reconnect").toggle(true);
+        $(".curtains-ct i").toggle(true);
+        $(".curtains-ct h1").text(_("Disconnected"));
+        $(".curtains-ct p").text(cockpit.message(watchdog_problem));
+        $(".curtains-ct").show();
+        $("#navbar-dropdown").addClass("disabled");
+    }
+
+    index.ready();
+
+    /* Handles navigation */
+    function navigate(state, reconnect) {
+        var dashboards = compiled.ordered("dashboard");
+
+        /* If this is a watchdog problem or we are troubleshooting
+         * let the dialog handle it */
+        if (watchdog_problem)
+            return;
+
+        /* phantomjs has a problem retrieving state, so we allow it to be passed in */
+        if (!state)
+            state = index.retrieve_state();
+
+        if (!state.component && dashboards.length > 0) {
+            state.component = dashboards[0].path;
         }
+        update_navbar(state);
+        update_frame(state);
+
+        /* Just replace the state, and URL */
+        index.jump(state, true);
+    }
+
+    function update_navbar(state) {
+        $("#host-nav-item").toggleClass("dashboard-link", false);
+        $(".dashboard-link").each(function() {
+            var el = $(this);
+            el.toggleClass("active", el.attr("data-component") === state.component);
+        });
+
+        var item = compiled.items[state.component];
+        if (item && item.section == "dashboard")
+            delete state.sidebar;
+
+        $('.area-ct-body').toggleClass("single-nav", $(".dashboard-link").length < 2);
+    }
+
+    function update_title(label) {
+        if (label)
+            label += " - ";
+        else
+            label = "";
+        document.title = label + default_title;
+    }
+
+    function update_frame(state) {
+        var current_frame = index.current_frame();
+
+        var hash = state.hash;
+        var component = state.component;
+
+        var frame;
+        if (component)
+            frame = index.frames.lookup(null, component, hash);
+        if (frame != current_frame) {
+            $(current_frame).css('display', 'none');
+            index.current_frame(frame);
+        }
+
+        var label, item;
+        $(frame).css('display', 'block');
+        item = compiled.items[state.component];
+        label = item ? item.label : "";
+        update_title(label);
+    }
+
+    cockpit.transport.wait(function() {
+        index.start();
+    });
+}
+
+function message_queue(event) {
+    window.messages.push(event);
+}
+
+/* When we're being loaded into the index window we have additional duties */
+if (document.documentElement.getAttribute("class") === "index-page") {
+    /* Indicates to child frames that we are a cockpit1 router frame */
+    window.name = "cockpit1";
+
+    /* The same thing as above, but compatibility with old cockpit */
+    window.options = { sink: true, protocol: "cockpit1" };
+
+    /* While the index is initializing, snag any messages we receive from frames */
+    window.messages = [ ];
+
+    window.messages.cancel = function() {
+        window.removeEventListener("message", message_queue, false);
+        window.messages = null;
     };
 
-    function message_queue(event) {
-        window.messages.push(event);
+    window.addEventListener("message", message_queue, false);
+}
+
+module.exports = {
+    simple_index: function (options) {
+        return new SimpleIndex(options);
+    },
+    machines_index: function (options, machines_ins, loader, mdialogs) {
+        return new MachinesIndex(options, machines_ins, loader, mdialogs);
     }
-
-    /* When we're being loaded into the index window we have additional duties */
-    if (document.documentElement.getAttribute("class") === "index-page") {
-        /* Indicates to child frames that we are a cockpit1 router frame */
-        window.name = "cockpit1";
-
-        /* The same thing as above, but compatibility with old cockpit */
-        window.options = { sink: true, protocol: "cockpit1" };
-
-        /* While the index is initializing, snag any messages we receive from frames */
-        window.messages = [ ];
-
-        window.messages.cancel = function() {
-            window.removeEventListener("message", message_queue, false);
-            window.messages = null;
-        };
-
-        window.addEventListener("message", message_queue, false);
-    }
-}());
+};

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -17,863 +17,859 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+var $ = require('jquery');
+var cockpit = require('cockpit');
+var PK = require('packagekit.js');
 
-    var $ = require('jquery');
-    var cockpit = require('cockpit');
-    var PK = require('packagekit.js');
+var utils = require('./utils');
 
-    var utils = require('./utils');
+var python = require("python.js");
+var inotify_py = require("raw-loader!inotify.py");
+var nfs_mounts_py = require("raw-loader!./nfs-mounts.py");
+var vdo_monitor_py = require("raw-loader!./vdo-monitor.py");
 
-    var python = require("python.js");
-    var inotify_py = require("raw-loader!inotify.py");
-    var nfs_mounts_py = require("raw-loader!./nfs-mounts.py");
-    var vdo_monitor_py = require("raw-loader!./vdo-monitor.py");
+/* STORAGED CLIENT
+ */
 
-    /* STORAGED CLIENT
-     */
+/* HACK: https://github.com/storaged-project/storaged/pull/68 */
+var hacks = { };
+if (cockpit.manifests["storage"] && cockpit.manifests["storage"]["hacks"])
+    hacks = cockpit.manifests["storage"]["hacks"];
 
-    /* HACK: https://github.com/storaged-project/storaged/pull/68 */
-    var hacks = { };
-    if (cockpit.manifests["storage"] && cockpit.manifests["storage"]["hacks"])
-        hacks = cockpit.manifests["storage"]["hacks"];
+var client = { };
 
-    var client = { };
+cockpit.event_target(client);
 
-    cockpit.event_target(client);
+/* Metrics
+ */
 
-    /* Metrics
-     */
+function instance_sampler(metrics, source) {
+    var instances;
+    var self = {
+        data: { },
+        close: close
+    };
 
-    function instance_sampler(metrics, source) {
-        var instances;
-        var self = {
-            data: { },
-            close: close
-        };
+    cockpit.event_target(self);
 
-        cockpit.event_target(self);
-
-        function handle_meta(msg) {
-            self.data = { };
-            instances = [ ];
-            for (var m = 0; m < msg.metrics.length; m++) {
-                instances[m] = msg.metrics[m].instances;
-                for (var i = 0; i < instances[m].length; i++)
-                    self.data[instances[m][i]] = [ ];
-            }
+    function handle_meta(msg) {
+        self.data = { };
+        instances = [ ];
+        for (var m = 0; m < msg.metrics.length; m++) {
+            instances[m] = msg.metrics[m].instances;
+            for (var i = 0; i < instances[m].length; i++)
+                self.data[instances[m][i]] = [ ];
         }
+    }
 
-        function handle_data(msg) {
-            var changed = false;
-            for (var s = 0; s < msg.length; s++) {
-                var metrics = msg[s];
-                for (var m = 0; m < metrics.length; m++) {
-                    var inst = metrics[m];
-                    for (var i = 0; i < inst.length; i++) {
-                        if (inst[i] !== null) {
-                            changed = true;
-                            self.data[instances[m][i]][m] = inst[i];
-                        }
+    function handle_data(msg) {
+        var changed = false;
+        for (var s = 0; s < msg.length; s++) {
+            var metrics = msg[s];
+            for (var m = 0; m < metrics.length; m++) {
+                var inst = metrics[m];
+                for (var i = 0; i < inst.length; i++) {
+                    if (inst[i] !== null) {
+                        changed = true;
+                        self.data[instances[m][i]][m] = inst[i];
                     }
                 }
             }
-            if (changed)
-                self.dispatchEvent('changed');
         }
-
-        var channel = cockpit.channel({ payload: "metrics1",
-                                        source: source || "internal",
-                                        metrics: metrics
-        });
-        $(channel).on("closed", function (event, error) {
-            console.log("closed", error);
-        });
-        $(channel).on("message", function (event, message) {
-            var msg = JSON.parse(message);
-            if (msg.length)
-                handle_data(msg);
-            else
-                handle_meta(msg);
-        });
-
-        function close() {
-            channel.close();
-        }
-
-        return self;
+        if (changed)
+            self.dispatchEvent('changed');
     }
 
-    /* D-Bus proxies
+    var channel = cockpit.channel({ payload: "metrics1",
+                                    source: source || "internal",
+                                    metrics: metrics
+    });
+    $(channel).on("closed", function (event, error) {
+        console.log("closed", error);
+    });
+    $(channel).on("message", function (event, message) {
+        var msg = JSON.parse(message);
+        if (msg.length)
+            handle_data(msg);
+        else
+            handle_meta(msg);
+    });
+
+    function close() {
+        channel.close();
+    }
+
+    return self;
+}
+
+/* D-Bus proxies
+ */
+
+var STORAGED_SERVICE;
+var STORAGED_OPATH_PFX;
+var STORAGED_IFACE_PFX;
+
+client.time_offset = undefined; /* Number of milliseconds that the server is ahead of us. */
+client.features = undefined;
+
+client.storaged_client = undefined;
+
+function proxy(iface, path) {
+    return client.storaged_client.proxy(STORAGED_IFACE_PFX + "." + iface,
+                                        STORAGED_OPATH_PFX + "/" + path,
+                                        { watch: true });
+}
+
+function proxies(iface) {
+    /* We create the proxies here with 'watch' set to false and
+     * establish a general watch for all of them.  This is more
+     * efficient since it reduces the number of D-Bus calls done
+     * by the cache.
      */
+    return client.storaged_client.proxies(STORAGED_IFACE_PFX + "." + iface,
+                                          STORAGED_OPATH_PFX,
+                                          { watch: false });
+}
 
-    var STORAGED_SERVICE;
-    var STORAGED_OPATH_PFX;
-    var STORAGED_IFACE_PFX;
+client.call = function call(path, iface, method, args, options) {
+    return client.storaged_client.call(path, STORAGED_IFACE_PFX + "." + iface, method, args, options);
+};
 
-    client.time_offset = undefined; /* Number of milliseconds that the server is ahead of us. */
-    client.features = undefined;
+function init_proxies () {
+    client.storaged_client.watch({ path_namespace: STORAGED_OPATH_PFX });
 
-    client.storaged_client = undefined;
+    client.mdraids = proxies("MDRaid");
+    client.vgroups = proxies("VolumeGroup");
+    client.lvols = proxies("LogicalVolume");
+    client.drives = proxies("Drive");
+    client.drives_ata = proxies("Drive.Ata");
+    client.blocks = proxies("Block");
+    client.blocks_ptable = proxies("PartitionTable");
+    client.blocks_part = proxies("Partition");
+    client.blocks_lvm2 = proxies("Block.LVM2");
+    client.blocks_pvol = proxies("PhysicalVolume");
+    client.blocks_fsys = proxies("Filesystem");
+    client.blocks_crypto = proxies("Encrypted");
+    client.blocks_swap = proxies("Swapspace");
+    client.iscsi_sessions = proxies("ISCSI.Session");
+    client.jobs = proxies("Job");
+}
 
-    function proxy(iface, path) {
-        return client.storaged_client.proxy(STORAGED_IFACE_PFX + "." + iface,
-                                            STORAGED_OPATH_PFX + "/" + path,
-                                            { watch: true });
+/* Monitors
+ */
+
+client.fsys_sizes = instance_sampler([ { name: "mount.used" },
+    { name: "mount.total" }
+]);
+
+client.swap_sizes = instance_sampler([ { name: "swapdev.length" },
+    { name: "swapdev.free" },
+], "direct");
+
+client.blockdev_io = instance_sampler([ { name: "block.device.read", derive: "rate" },
+    { name: "block.device.written", derive: "rate" }
+]);
+
+/* Derived indices.
+ */
+
+function is_multipath_master(block) {
+    // The master has "mpath" in its device mapper UUID.  In the
+    // future, storaged will hopefully provide this information
+    // directly.
+    if (block.Symlinks && block.Symlinks.length) {
+        for (var i = 0; i < block.Symlinks.length; i++)
+            if (utils.decode_filename(block.Symlinks[i]).indexOf("/dev/disk/by-id/dm-uuid-mpath-") === 0)
+                return true;
     }
+    return false;
+}
 
-    function proxies(iface) {
-        /* We create the proxies here with 'watch' set to false and
-         * establish a general watch for all of them.  This is more
-         * efficient since it reduces the number of D-Bus calls done
-         * by the cache.
+function update_indices() {
+    var path, block, mdraid, vgroup, pvol, lvol, part, i;
+
+    client.broken_multipath_present = false;
+    client.drives_multipath_blocks = { };
+    client.drives_block = { };
+    for (path in client.drives) {
+        client.drives_multipath_blocks[path] = [ ];
+    }
+    for (path in client.blocks) {
+        block = client.blocks[path];
+        if (!client.blocks_part[path] && client.drives_multipath_blocks[block.Drive] !== undefined) {
+            if (is_multipath_master(block))
+                client.drives_block[block.Drive] = block;
+            else
+                client.drives_multipath_blocks[block.Drive].push(block);
+        }
+    }
+    for (path in client.drives_multipath_blocks) {
+        /* If there is no multipath master and only a single
+         * member, then this is actually a normal singlepath
+         * device.
          */
-        return client.storaged_client.proxies(STORAGED_IFACE_PFX + "." + iface,
-                                              STORAGED_OPATH_PFX,
-                                              { watch: false });
+
+        if (!client.drives_block[path] && client.drives_multipath_blocks[path].length == 1) {
+            client.drives_block[path] = client.drives_multipath_blocks[path][0];
+            client.drives_multipath_blocks[path] = [ ];
+        } else {
+            client.drives_multipath_blocks[path].sort(utils.block_cmp);
+            if (!client.drives_block[path])
+                client.broken_multipath_present = true;
+        }
     }
 
-    client.call = function call(path, iface, method, args, options) {
-        return client.storaged_client.call(path, STORAGED_IFACE_PFX + "." + iface, method, args, options);
+    client.mdraids_block = { };
+    for (path in client.blocks) {
+        block = client.blocks[path];
+        if (block.MDRaid != "/")
+            client.mdraids_block[block.MDRaid] = block;
+    }
+
+    client.mdraids_members = { };
+    for (path in client.mdraids) {
+        client.mdraids_members[path] = [ ];
+    }
+    for (path in client.blocks) {
+        block = client.blocks[path];
+        if (client.mdraids_members[block.MDRaidMember] !== undefined)
+            client.mdraids_members[block.MDRaidMember].push(block);
+    }
+    for (path in client.mdraids_members) {
+        client.mdraids_members[path].sort(utils.block_cmp);
+    }
+
+    client.slashdevs_block = { };
+    function enter_slashdev(block, enc) {
+        client.slashdevs_block[utils.decode_filename(enc)] = block;
+    }
+    for (path in client.blocks) {
+        block = client.blocks[path];
+        enter_slashdev(block, block.Device);
+        enter_slashdev(block, block.PreferredDevice);
+        for (i = 0; i < block.Symlinks.length; i++)
+            enter_slashdev(block, block.Symlinks[i]);
+    }
+
+    client.uuids_mdraid = { };
+    for (path in client.mdraids) {
+        mdraid = client.mdraids[path];
+        client.uuids_mdraid[mdraid.UUID] = mdraid;
+    }
+
+    client.vgnames_vgroup = { };
+    for (path in client.vgroups) {
+        vgroup = client.vgroups[path];
+        client.vgnames_vgroup[vgroup.Name] = vgroup;
+    }
+
+    client.vgroups_pvols = { };
+    for (path in client.vgroups) {
+        client.vgroups_pvols[path] = [ ];
+    }
+    for (path in client.blocks_pvol) {
+        pvol = client.blocks_pvol[path];
+        if (client.vgroups_pvols[pvol.VolumeGroup] !== undefined)
+            client.vgroups_pvols[pvol.VolumeGroup].push(pvol);
+    }
+    function cmp_pvols(a, b) {
+        return utils.block_cmp(client.blocks[a.path], client.blocks[b.path]);
+    }
+    for (path in client.vgroups_pvols) {
+        client.vgroups_pvols[path].sort(cmp_pvols);
+    }
+
+    client.vgroups_lvols = { };
+    for (path in client.vgroups) {
+        client.vgroups_lvols[path] = [ ];
+    }
+    for (path in client.lvols) {
+        lvol = client.lvols[path];
+        if (client.vgroups_lvols[lvol.VolumeGroup] !== undefined)
+            client.vgroups_lvols[lvol.VolumeGroup].push(lvol);
+    }
+    for (path in client.vgroups_lvols) {
+        client.vgroups_lvols[path].sort(function (a, b) { return a.Name.localeCompare(b.Name) });
+    }
+
+    client.lvols_block = { };
+    for (path in client.blocks_lvm2) {
+        client.lvols_block[client.blocks_lvm2[path].LogicalVolume] = client.blocks[path];
+    }
+
+    client.lvols_pool_members = { };
+    for (path in client.lvols) {
+        if (client.lvols[path].Type == "pool")
+            client.lvols_pool_members[path] = [ ];
+    }
+    for (path in client.lvols) {
+        lvol = client.lvols[path];
+        if (client.lvols_pool_members[lvol.ThinPool] !== undefined)
+            client.lvols_pool_members[lvol.ThinPool].push(lvol);
+    }
+    for (path in client.lvols_pool_members) {
+        client.lvols_pool_members[path].sort(function (a, b) { return a.Name.localeCompare(b.Name) });
+    }
+
+    client.blocks_cleartext = { };
+    for (path in client.blocks) {
+        block = client.blocks[path];
+        if (block.CryptoBackingDevice != "/")
+            client.blocks_cleartext[block.CryptoBackingDevice] = block;
+    }
+
+    client.blocks_partitions = { };
+    for (path in client.blocks_ptable) {
+        client.blocks_partitions[path] = [ ];
+    }
+    for (path in client.blocks_part) {
+        part = client.blocks_part[path];
+        if (client.blocks_partitions[part.Table] !== undefined)
+            client.blocks_partitions[part.Table].push(part);
+    }
+    for (path in client.blocks_partitions) {
+        client.blocks_partitions[path].sort(function (a, b) { return a.Offset - b.Offset });
+    }
+
+    client.path_jobs = { };
+    function enter_job(job) {
+        if (!job.Objects || !job.Objects.length)
+            return;
+        job.Objects.forEach(function (path) {
+            client.path_jobs[path] = job;
+            var parent = utils.get_parent(client, path);
+            while (parent) {
+                path = parent;
+                parent = utils.get_parent(client, path);
+            }
+            client.path_jobs[path] = job;
+        });
+    }
+    for (path in client.jobs) {
+        enter_job(client.jobs[path]);
+    }
+}
+
+function init_model(callback) {
+    function wait_all(objects, callback) {
+        var obj = objects.pop();
+        if (obj) {
+            obj.wait(function () {
+                wait_all(objects, callback);
+            });
+        } else {
+            callback();
+        }
+    }
+
+    function pull_time() {
+        return cockpit.spawn(["date", "+%s"])
+                .then(function (now) {
+                    client.time_offset = parseInt(now, 10) * 1000 - new Date().getTime();
+                });
+    }
+
+    function enable_udisks_features() {
+        if (!client.manager.valid)
+            return cockpit.resolve();
+        if (!client.manager.EnableModules)
+            return cockpit.resolve();
+        return client.manager.EnableModules(true).then(
+            function() {
+                var defer = cockpit.defer();
+                client.manager_lvm2 = proxy("Manager.LVM2", "Manager");
+                client.manager_iscsi = proxy("Manager.ISCSI.Initiator", "Manager");
+                wait_all([ client.manager_lvm2, client.manager_iscsi ],
+                         function () {
+                             client.features.lvm2 = client.manager_lvm2.valid;
+                             client.features.iscsi = (hacks.with_storaged_iscsi_sessions != "no" &&
+                                                     client.manager_iscsi.valid &&
+                                                     client.manager_iscsi.SessionsSupported !== false);
+                             defer.resolve();
+                         });
+                return defer.promise;
+            }, function(error) {
+                console.warn("Can't enable storaged modules", error.toString());
+                return cockpit.resolve();
+            });
+    }
+
+    function enable_vdo_features() {
+        return client.vdo_overlay.start()
+                .then(function (success) {
+                    client.features.vdo = success;
+                    return cockpit.resolve();
+                })
+                .fail(function () {
+                    return cockpit.resolve();
+                });
+    }
+
+    function enable_clevis_features() {
+        return cockpit.spawn([ "which", "clevis-luks-bind" ], { err: "ignore" }).then(
+            function () {
+                client.features.clevis = true;
+                return cockpit.resolve();
+            },
+            function () {
+                return cockpit.resolve();
+            });
+    }
+
+    function enable_nfs_features() {
+        return cockpit.spawn([ "which", "mount.nfs" ], { err: "ignore" }).then(
+            function () {
+                client.features.nfs = true;
+                client.nfs.start();
+                return cockpit.resolve();
+            },
+            function () {
+                return cockpit.resolve();
+            });
+    }
+
+    function enable_pk_features() {
+        return PK.detect().then(function (available) { client.features.packagekit = available });
+    }
+
+    function enable_features() {
+        client.features = { };
+        return (enable_udisks_features()
+                .then(enable_vdo_features)
+                .then(enable_clevis_features)
+                .then(enable_nfs_features)
+                .then(enable_pk_features));
+    }
+
+    function query_fsys_info() {
+        var info = {
+            xfs: {
+                can_format: true,
+                can_shrink: false,
+                can_grow: true,
+                grow_needs_unmount: false
+            },
+
+            ext4: {
+                can_format: true,
+                can_shrink: true,
+                shrink_needs_unmount: true,
+                can_grow: true,
+                grow_needs_unmount: false
+            },
+        };
+
+        if (client.manager.SupportedFilesystems && client.manager.CanResize) {
+            return cockpit.all(client.manager.SupportedFilesystems.map(function (fs) {
+                return client.manager.CanFormat(fs).then(
+                    function (canformat_result) {
+                        info[fs] = {
+                            can_format: canformat_result[0],
+                            can_shrink: false,
+                            can_grow: false
+                        };
+                        return client.manager.CanResize(fs).then(
+                            function (canresize_result) {
+                                // We assume that all filesystems support
+                                // offline shrinking/growing if they
+                                // support shrinking or growing at all.
+                                // The actual resizing utility will
+                                // temporarily mount the fs if necessary,
+                                if (canresize_result[0]) {
+                                    info[fs].can_shrink = !!(canresize_result[1] & 2);
+                                    info[fs].shrink_needs_unmount = !(canresize_result[1] & 8);
+                                    info[fs].can_grow = !!(canresize_result[1] & 4);
+                                    info[fs].grow_needs_unmount = !(canresize_result[1] & 16);
+                                }
+                            },
+                            function () {
+                                // ignore unsupported filesystems
+                            });
+                    });
+            })).then(function () {
+                return info;
+            });
+        } else {
+            return cockpit.resolve(info);
+        }
+    }
+
+    wait_all([ client.manager,
+        client.mdraids, client.vgroups, client.drives,
+        client.blocks, client.blocks_ptable, client.blocks_lvm2, client.blocks_fsys
+    ], function () {
+        pull_time().then(function() {
+            enable_features().then(function() {
+                query_fsys_info().then(function(fsys_info) {
+                    client.fsys_info = fsys_info;
+                    callback();
+                });
+            });
+
+            $(client.storaged_client).on('notify', function () {
+                update_indices();
+                client.dispatchEvent("changed");
+            });
+            update_indices();
+        });
+    });
+}
+
+client.older_than = function older_than(version) {
+    return utils.compare_versions(this.manager.Version, version) < 0;
+};
+
+/* NFS mounts
+ */
+
+function nfs_mounts() {
+    var self = {
+        entries: [ ],
+        fsys_sizes: { },
+
+        start: start,
+
+        get_fsys_size: get_fsys_size,
+        entry_users: entry_users,
+
+        update_entry: update_entry,
+        add_entry: add_entry,
+        remove_entry: remove_entry,
+
+        mount_entry: mount_entry,
+        unmount_entry: unmount_entry,
+        stop_and_unmount_entry: stop_and_unmount_entry,
+        stop_and_remove_entry: stop_and_remove_entry,
+
+        find_entry: find_entry
     };
 
-    function init_proxies () {
-        client.storaged_client.watch({ path_namespace: STORAGED_OPATH_PFX });
-
-        client.mdraids = proxies("MDRaid");
-        client.vgroups = proxies("VolumeGroup");
-        client.lvols = proxies("LogicalVolume");
-        client.drives = proxies("Drive");
-        client.drives_ata = proxies("Drive.Ata");
-        client.blocks = proxies("Block");
-        client.blocks_ptable = proxies("PartitionTable");
-        client.blocks_part = proxies("Partition");
-        client.blocks_lvm2 = proxies("Block.LVM2");
-        client.blocks_pvol = proxies("PhysicalVolume");
-        client.blocks_fsys = proxies("Filesystem");
-        client.blocks_crypto = proxies("Encrypted");
-        client.blocks_swap = proxies("Swapspace");
-        client.iscsi_sessions = proxies("ISCSI.Session");
-        client.jobs = proxies("Job");
+    function spawn_nfs_mounts(args) {
+        return python.spawn([ inotify_py, nfs_mounts_py ], args, { superuser: "try", err: "message" });
     }
 
-    /* Monitors
-     */
+    function start() {
+        var buf = "";
+        spawn_nfs_mounts([ "monitor" ])
+                .stream(function (output) {
+                    var lines;
 
-    client.fsys_sizes = instance_sampler([ { name: "mount.used" },
-        { name: "mount.total" }
-    ]);
-
-    client.swap_sizes = instance_sampler([ { name: "swapdev.length" },
-        { name: "swapdev.free" },
-    ], "direct");
-
-    client.blockdev_io = instance_sampler([ { name: "block.device.read", derive: "rate" },
-        { name: "block.device.written", derive: "rate" }
-    ]);
-
-    /* Derived indices.
-     */
-
-    function is_multipath_master(block) {
-        // The master has "mpath" in its device mapper UUID.  In the
-        // future, storaged will hopefully provide this information
-        // directly.
-        if (block.Symlinks && block.Symlinks.length) {
-            for (var i = 0; i < block.Symlinks.length; i++)
-                if (utils.decode_filename(block.Symlinks[i]).indexOf("/dev/disk/by-id/dm-uuid-mpath-") === 0)
-                    return true;
-        }
-        return false;
-    }
-
-    function update_indices() {
-        var path, block, mdraid, vgroup, pvol, lvol, part, i;
-
-        client.broken_multipath_present = false;
-        client.drives_multipath_blocks = { };
-        client.drives_block = { };
-        for (path in client.drives) {
-            client.drives_multipath_blocks[path] = [ ];
-        }
-        for (path in client.blocks) {
-            block = client.blocks[path];
-            if (!client.blocks_part[path] && client.drives_multipath_blocks[block.Drive] !== undefined) {
-                if (is_multipath_master(block))
-                    client.drives_block[block.Drive] = block;
-                else
-                    client.drives_multipath_blocks[block.Drive].push(block);
-            }
-        }
-        for (path in client.drives_multipath_blocks) {
-            /* If there is no multipath master and only a single
-             * member, then this is actually a normal singlepath
-             * device.
-             */
-
-            if (!client.drives_block[path] && client.drives_multipath_blocks[path].length == 1) {
-                client.drives_block[path] = client.drives_multipath_blocks[path][0];
-                client.drives_multipath_blocks[path] = [ ];
-            } else {
-                client.drives_multipath_blocks[path].sort(utils.block_cmp);
-                if (!client.drives_block[path])
-                    client.broken_multipath_present = true;
-            }
-        }
-
-        client.mdraids_block = { };
-        for (path in client.blocks) {
-            block = client.blocks[path];
-            if (block.MDRaid != "/")
-                client.mdraids_block[block.MDRaid] = block;
-        }
-
-        client.mdraids_members = { };
-        for (path in client.mdraids) {
-            client.mdraids_members[path] = [ ];
-        }
-        for (path in client.blocks) {
-            block = client.blocks[path];
-            if (client.mdraids_members[block.MDRaidMember] !== undefined)
-                client.mdraids_members[block.MDRaidMember].push(block);
-        }
-        for (path in client.mdraids_members) {
-            client.mdraids_members[path].sort(utils.block_cmp);
-        }
-
-        client.slashdevs_block = { };
-        function enter_slashdev(block, enc) {
-            client.slashdevs_block[utils.decode_filename(enc)] = block;
-        }
-        for (path in client.blocks) {
-            block = client.blocks[path];
-            enter_slashdev(block, block.Device);
-            enter_slashdev(block, block.PreferredDevice);
-            for (i = 0; i < block.Symlinks.length; i++)
-                enter_slashdev(block, block.Symlinks[i]);
-        }
-
-        client.uuids_mdraid = { };
-        for (path in client.mdraids) {
-            mdraid = client.mdraids[path];
-            client.uuids_mdraid[mdraid.UUID] = mdraid;
-        }
-
-        client.vgnames_vgroup = { };
-        for (path in client.vgroups) {
-            vgroup = client.vgroups[path];
-            client.vgnames_vgroup[vgroup.Name] = vgroup;
-        }
-
-        client.vgroups_pvols = { };
-        for (path in client.vgroups) {
-            client.vgroups_pvols[path] = [ ];
-        }
-        for (path in client.blocks_pvol) {
-            pvol = client.blocks_pvol[path];
-            if (client.vgroups_pvols[pvol.VolumeGroup] !== undefined)
-                client.vgroups_pvols[pvol.VolumeGroup].push(pvol);
-        }
-        function cmp_pvols(a, b) {
-            return utils.block_cmp(client.blocks[a.path], client.blocks[b.path]);
-        }
-        for (path in client.vgroups_pvols) {
-            client.vgroups_pvols[path].sort(cmp_pvols);
-        }
-
-        client.vgroups_lvols = { };
-        for (path in client.vgroups) {
-            client.vgroups_lvols[path] = [ ];
-        }
-        for (path in client.lvols) {
-            lvol = client.lvols[path];
-            if (client.vgroups_lvols[lvol.VolumeGroup] !== undefined)
-                client.vgroups_lvols[lvol.VolumeGroup].push(lvol);
-        }
-        for (path in client.vgroups_lvols) {
-            client.vgroups_lvols[path].sort(function (a, b) { return a.Name.localeCompare(b.Name) });
-        }
-
-        client.lvols_block = { };
-        for (path in client.blocks_lvm2) {
-            client.lvols_block[client.blocks_lvm2[path].LogicalVolume] = client.blocks[path];
-        }
-
-        client.lvols_pool_members = { };
-        for (path in client.lvols) {
-            if (client.lvols[path].Type == "pool")
-                client.lvols_pool_members[path] = [ ];
-        }
-        for (path in client.lvols) {
-            lvol = client.lvols[path];
-            if (client.lvols_pool_members[lvol.ThinPool] !== undefined)
-                client.lvols_pool_members[lvol.ThinPool].push(lvol);
-        }
-        for (path in client.lvols_pool_members) {
-            client.lvols_pool_members[path].sort(function (a, b) { return a.Name.localeCompare(b.Name) });
-        }
-
-        client.blocks_cleartext = { };
-        for (path in client.blocks) {
-            block = client.blocks[path];
-            if (block.CryptoBackingDevice != "/")
-                client.blocks_cleartext[block.CryptoBackingDevice] = block;
-        }
-
-        client.blocks_partitions = { };
-        for (path in client.blocks_ptable) {
-            client.blocks_partitions[path] = [ ];
-        }
-        for (path in client.blocks_part) {
-            part = client.blocks_part[path];
-            if (client.blocks_partitions[part.Table] !== undefined)
-                client.blocks_partitions[part.Table].push(part);
-        }
-        for (path in client.blocks_partitions) {
-            client.blocks_partitions[path].sort(function (a, b) { return a.Offset - b.Offset });
-        }
-
-        client.path_jobs = { };
-        function enter_job(job) {
-            if (!job.Objects || !job.Objects.length)
-                return;
-            job.Objects.forEach(function (path) {
-                client.path_jobs[path] = job;
-                var parent = utils.get_parent(client, path);
-                while (parent) {
-                    path = parent;
-                    parent = utils.get_parent(client, path);
-                }
-                client.path_jobs[path] = job;
-            });
-        }
-        for (path in client.jobs) {
-            enter_job(client.jobs[path]);
-        }
-    }
-
-    function init_model(callback) {
-        function wait_all(objects, callback) {
-            var obj = objects.pop();
-            if (obj) {
-                obj.wait(function () {
-                    wait_all(objects, callback);
+                    buf += output;
+                    lines = buf.split("\n");
+                    buf = lines[lines.length - 1];
+                    if (lines.length >= 2) {
+                        self.entries = JSON.parse(lines[lines.length - 2]);
+                        self.fsys_sizes = { };
+                        client.dispatchEvent('changed');
+                    }
+                })
+                .fail(function (error) {
+                    if (error != "closed") {
+                        console.warn(error);
+                    }
                 });
-            } else {
-                callback();
-            }
-        }
+    }
 
-        function pull_time() {
-            return cockpit.spawn(["date", "+%s"])
-                    .then(function (now) {
-                        client.time_offset = parseInt(now, 10) * 1000 - new Date().getTime();
-                    });
-        }
+    function get_fsys_size(entry) {
+        var path = entry.fields[1];
+        if (self.fsys_sizes[path])
+            return self.fsys_sizes[path];
 
-        function enable_udisks_features() {
-            if (!client.manager.valid)
-                return cockpit.resolve();
-            if (!client.manager.EnableModules)
-                return cockpit.resolve();
-            return client.manager.EnableModules(true).then(
-                function() {
-                    var defer = cockpit.defer();
-                    client.manager_lvm2 = proxy("Manager.LVM2", "Manager");
-                    client.manager_iscsi = proxy("Manager.ISCSI.Initiator", "Manager");
-                    wait_all([ client.manager_lvm2, client.manager_iscsi ],
-                             function () {
-                                 client.features.lvm2 = client.manager_lvm2.valid;
-                                 client.features.iscsi = (hacks.with_storaged_iscsi_sessions != "no" &&
-                                                         client.manager_iscsi.valid &&
-                                                         client.manager_iscsi.SessionsSupported !== false);
-                                 defer.resolve();
+        if (self.fsys_sizes[path] === false)
+            return null;
+
+        self.fsys_sizes[path] = false;
+        cockpit.spawn([ "stat", "-f", "-c", "[ %S, %f, %b ]", path ], { err: "message" })
+                .done(function (output) {
+                    var data = JSON.parse(output);
+                    self.fsys_sizes[path] = [ (data[2] - data[1]) * data[0], data[2] * data[0] ];
+                    client.dispatchEvent('changed');
+                })
+                .fail(function () {
+                    self.fsys_sizes[path] = [ 0, 0 ];
+                    client.dispatchEvent('changed');
+                });
+
+        return null;
+    }
+
+    function update_entry(entry, new_fields) {
+        return spawn_nfs_mounts([ "update", JSON.stringify(entry), JSON.stringify(new_fields) ]);
+    }
+
+    function add_entry(fields) {
+        return spawn_nfs_mounts([ "add", JSON.stringify(fields) ]);
+    }
+
+    function remove_entry(entry) {
+        return spawn_nfs_mounts([ "remove", JSON.stringify(entry) ]);
+    }
+
+    function mount_entry(entry) {
+        return spawn_nfs_mounts([ "mount", JSON.stringify(entry) ]);
+    }
+
+    function unmount_entry(entry) {
+        return spawn_nfs_mounts([ "unmount", JSON.stringify(entry) ]);
+    }
+
+    function stop_and_unmount_entry(users, entry) {
+        var units = users.map(function (u) { return u.unit });
+        return spawn_nfs_mounts([ "stop-and-unmount", JSON.stringify(units), JSON.stringify(entry) ]);
+    }
+
+    function stop_and_remove_entry(users, entry) {
+        var units = users.map(function (u) { return u.unit });
+        return spawn_nfs_mounts([ "stop-and-remove", JSON.stringify(units), JSON.stringify(entry) ]);
+    }
+
+    function entry_users(entry) {
+        return spawn_nfs_mounts([ "users", JSON.stringify(entry) ]).then(JSON.parse);
+    }
+
+    function find_entry(remote, local) {
+        for (var i = 0; i < self.entries.length; i++) {
+            if (self.entries[i].fields[0] == remote && self.entries[i].fields[1] == local)
+                return self.entries[i];
+        }
+    }
+
+    return self;
+}
+
+client.nfs = nfs_mounts();
+
+/* VDO */
+
+function vdo_overlay() {
+    var self = {
+        start: start,
+
+        volumes: [ ],
+
+        by_name: { },
+        by_dev: { },
+        by_backing_dev: { },
+
+        find_by_block: find_by_block,
+        find_by_backing_block: find_by_backing_block,
+
+        create: create
+    };
+
+    function cmd(args) {
+        return cockpit.spawn([ "vdo" ].concat(args),
+                             { superuser: true,
+                               err: "message"
                              });
-                    return defer.promise;
-                }, function(error) {
-                    console.warn("Can't enable storaged modules", error.toString());
-                    return cockpit.resolve();
-                });
-        }
+    }
 
-        function enable_vdo_features() {
-            return client.vdo_overlay.start()
-                    .then(function (success) {
-                        client.features.vdo = success;
-                        return cockpit.resolve();
-                    })
-                    .fail(function () {
-                        return cockpit.resolve();
-                    });
-        }
+    function update(data) {
+        self.by_name = { };
+        self.by_dev = { };
+        self.by_backing_dev = { };
 
-        function enable_clevis_features() {
-            return cockpit.spawn([ "which", "clevis-luks-bind" ], { err: "ignore" }).then(
-                function () {
-                    client.features.clevis = true;
-                    return cockpit.resolve();
-                },
-                function () {
-                    return cockpit.resolve();
-                });
-        }
+        self.volumes = data.map(function (vol, index) {
+            var name = vol.name;
 
-        function enable_nfs_features() {
-            return cockpit.spawn([ "which", "mount.nfs" ], { err: "ignore" }).then(
-                function () {
-                    client.features.nfs = true;
-                    client.nfs.start();
-                    return cockpit.resolve();
-                },
-                function () {
-                    return cockpit.resolve();
-                });
-        }
+            function volcmd(args) {
+                return cmd(args.concat([ "--name", name ]));
+            }
 
-        function enable_pk_features() {
-            return PK.detect().then(function (available) { client.features.packagekit = available });
-        }
+            var v = { name: name,
+                      broken: vol.broken,
+                      dev: "/dev/mapper/" + name,
+                      backing_dev: vol.device,
+                      logical_size: vol.logical_size,
+                      physical_size: vol.physical_size,
+                      index_mem: vol.index_mem,
+                      compression: vol.compression,
+                      deduplication: vol.deduplication,
+                      activated: vol.activated,
 
-        function enable_features() {
-            client.features = { };
-            return (enable_udisks_features()
-                    .then(enable_vdo_features)
-                    .then(enable_clevis_features)
-                    .then(enable_nfs_features)
-                    .then(enable_pk_features));
-        }
+                      set_compression: function(val) {
+                          return volcmd([ val ? "enableCompression" : "disableCompression" ]);
+                      },
 
-        function query_fsys_info() {
-            var info = {
-                xfs: {
-                    can_format: true,
-                    can_shrink: false,
-                    can_grow: true,
-                    grow_needs_unmount: false
-                },
+                      set_deduplication: function(val) {
+                          return volcmd([ val ? "enableDeduplication" : "disableDeduplication" ]);
+                      },
 
-                ext4: {
-                    can_format: true,
-                    can_shrink: true,
-                    shrink_needs_unmount: true,
-                    can_grow: true,
-                    grow_needs_unmount: false
-                },
+                      set_activate: function(val) {
+                          return volcmd([ val ? "activate" : "deactivate" ]);
+                      },
+
+                      start: function() {
+                          return volcmd([ "start" ]);
+                      },
+
+                      stop: function() {
+                          return volcmd([ "stop" ]);
+                      },
+
+                      remove: function() {
+                          return volcmd([ "remove" ]);
+                      },
+
+                      force_remove: function() {
+                          return volcmd([ "remove", "--force" ]);
+                      },
+
+                      grow_physical: function() {
+                          return volcmd([ "growPhysical" ]);
+                      },
+
+                      grow_logical: function(lsize) {
+                          return volcmd([ "growLogical", "--vdoLogicalSize", lsize + "B" ]);
+                      }
             };
 
-            if (client.manager.SupportedFilesystems && client.manager.CanResize) {
-                return cockpit.all(client.manager.SupportedFilesystems.map(function (fs) {
-                    return client.manager.CanFormat(fs).then(
-                        function (canformat_result) {
-                            info[fs] = {
-                                can_format: canformat_result[0],
-                                can_shrink: false,
-                                can_grow: false
-                            };
-                            return client.manager.CanResize(fs).then(
-                                function (canresize_result) {
-                                    // We assume that all filesystems support
-                                    // offline shrinking/growing if they
-                                    // support shrinking or growing at all.
-                                    // The actual resizing utility will
-                                    // temporarily mount the fs if necessary,
-                                    if (canresize_result[0]) {
-                                        info[fs].can_shrink = !!(canresize_result[1] & 2);
-                                        info[fs].shrink_needs_unmount = !(canresize_result[1] & 8);
-                                        info[fs].can_grow = !!(canresize_result[1] & 4);
-                                        info[fs].grow_needs_unmount = !(canresize_result[1] & 16);
-                                    }
-                                },
-                                function () {
-                                    // ignore unsupported filesystems
-                                });
-                        });
-                })).then(function () {
-                    return info;
-                });
-            } else {
-                return cockpit.resolve(info);
-            }
-        }
+            self.by_name[v.name] = v;
+            self.by_dev[v.dev] = v;
+            self.by_backing_dev[v.backing_dev] = v;
 
-        wait_all([ client.manager,
-            client.mdraids, client.vgroups, client.drives,
-            client.blocks, client.blocks_ptable, client.blocks_lvm2, client.blocks_fsys
-        ], function () {
-            pull_time().then(function() {
-                enable_features().then(function() {
-                    query_fsys_info().then(function(fsys_info) {
-                        client.fsys_info = fsys_info;
-                        callback();
-                    });
-                });
-
-                $(client.storaged_client).on('notify', function () {
-                    update_indices();
-                    client.dispatchEvent("changed");
-                });
-                update_indices();
-            });
+            return v;
         });
+
+        // We trigger a change on the client right away and not
+        // just on the vdo_overlay since this data is used all
+        // over the place...
+
+        client.dispatchEvent("changed");
     }
 
-    client.older_than = function older_than(version) {
-        return utils.compare_versions(this.manager.Version, version) < 0;
-    };
+    function start() {
+        var buf = "";
 
-    /* NFS mounts
+        return cockpit.spawn([ "/bin/sh", "-c", "head -1 $(which vdo || echo /dev/null)" ],
+                             { err: "ignore" })
+                .then(function (shebang) {
+                    if (shebang != "") {
+                        self.python = shebang.replace(/#! */, "").trim("\n");
+                        cockpit.spawn([ self.python, "--", "-" ], { superuser: "try", err: "message" })
+                                .input(inotify_py + vdo_monitor_py)
+                                .stream(function (output) {
+                                    var lines;
+
+                                    buf += output;
+                                    lines = buf.split("\n");
+                                    buf = lines[lines.length - 1];
+                                    if (lines.length >= 2) {
+                                        self.entries = JSON.parse(lines[lines.length - 2]);
+                                        self.fsys_sizes = { };
+                                        $(self).triggerHandler('changed');
+                                        update(JSON.parse(lines[lines.length - 2]));
+                                    }
+                                })
+                                .fail(function (error) {
+                                    if (error != "closed") {
+                                        console.warn(error);
+                                    }
+                                });
+                        return true;
+                    } else {
+                        return false;
+                    }
+                });
+    }
+
+    function some(array, func) {
+        var i;
+        for (i = 0; i < array.length; i++) {
+            var val = func(array[i]);
+            if (val)
+                return val;
+        }
+        return null;
+    }
+
+    function find_by_block(block) {
+        function check(encoded) { return self.by_dev[utils.decode_filename(encoded)] }
+        return check(block.Device) || some(block.Symlinks, check);
+    }
+
+    function find_by_backing_block(block) {
+        function check(encoded) { return self.by_backing_dev[utils.decode_filename(encoded)] }
+        return check(block.Device) || some(block.Symlinks, check);
+    }
+
+    function create(options) {
+        var args = [ "create", "--name", options.name,
+            "--device", utils.decode_filename(options.block.PreferredDevice) ];
+        if (options.logical_size !== undefined)
+            args.push("--vdoLogicalSize", options.logical_size + "B");
+        if (options.index_mem !== undefined)
+            args.push("--indexMem", options.index_mem / (1024 * 1024 * 1024));
+        if (options.compression !== undefined)
+            args.push("--compression", options.compression ? "enabled" : "disabled");
+        if (options.deduplication !== undefined)
+            args.push("--deduplication", options.deduplication ? "enabled" : "disabled");
+        if (options.emulate_512 !== undefined)
+            args.push("--emulate512", options.emulate_512 ? "enabled" : "disabled");
+        return cmd(args);
+    }
+
+    return self;
+}
+
+client.vdo_overlay = vdo_overlay();
+
+function init_manager() {
+    /* Storaged 2.6 and later uses the UDisks2 API names, but try the
+     * older storaged API first as a fallback.
      */
 
-    function nfs_mounts() {
-        var self = {
-            entries: [ ],
-            fsys_sizes: { },
-
-            start: start,
-
-            get_fsys_size: get_fsys_size,
-            entry_users: entry_users,
-
-            update_entry: update_entry,
-            add_entry: add_entry,
-            remove_entry: remove_entry,
-
-            mount_entry: mount_entry,
-            unmount_entry: unmount_entry,
-            stop_and_unmount_entry: stop_and_unmount_entry,
-            stop_and_remove_entry: stop_and_remove_entry,
-
-            find_entry: find_entry
-        };
-
-        function spawn_nfs_mounts(args) {
-            return python.spawn([ inotify_py, nfs_mounts_py ], args, { superuser: "try", err: "message" });
-        }
-
-        function start() {
-            var buf = "";
-            spawn_nfs_mounts([ "monitor" ])
-                    .stream(function (output) {
-                        var lines;
-
-                        buf += output;
-                        lines = buf.split("\n");
-                        buf = lines[lines.length - 1];
-                        if (lines.length >= 2) {
-                            self.entries = JSON.parse(lines[lines.length - 2]);
-                            self.fsys_sizes = { };
-                            client.dispatchEvent('changed');
-                        }
-                    })
-                    .fail(function (error) {
-                        if (error != "closed") {
-                            console.warn(error);
-                        }
-                    });
-        }
-
-        function get_fsys_size(entry) {
-            var path = entry.fields[1];
-            if (self.fsys_sizes[path])
-                return self.fsys_sizes[path];
-
-            if (self.fsys_sizes[path] === false)
-                return null;
-
-            self.fsys_sizes[path] = false;
-            cockpit.spawn([ "stat", "-f", "-c", "[ %S, %f, %b ]", path ], { err: "message" })
-                    .done(function (output) {
-                        var data = JSON.parse(output);
-                        self.fsys_sizes[path] = [ (data[2] - data[1]) * data[0], data[2] * data[0] ];
-                        client.dispatchEvent('changed');
-                    })
-                    .fail(function () {
-                        self.fsys_sizes[path] = [ 0, 0 ];
-                        client.dispatchEvent('changed');
-                    });
-
-            return null;
-        }
-
-        function update_entry(entry, new_fields) {
-            return spawn_nfs_mounts([ "update", JSON.stringify(entry), JSON.stringify(new_fields) ]);
-        }
-
-        function add_entry(fields) {
-            return spawn_nfs_mounts([ "add", JSON.stringify(fields) ]);
-        }
-
-        function remove_entry(entry) {
-            return spawn_nfs_mounts([ "remove", JSON.stringify(entry) ]);
-        }
-
-        function mount_entry(entry) {
-            return spawn_nfs_mounts([ "mount", JSON.stringify(entry) ]);
-        }
-
-        function unmount_entry(entry) {
-            return spawn_nfs_mounts([ "unmount", JSON.stringify(entry) ]);
-        }
-
-        function stop_and_unmount_entry(users, entry) {
-            var units = users.map(function (u) { return u.unit });
-            return spawn_nfs_mounts([ "stop-and-unmount", JSON.stringify(units), JSON.stringify(entry) ]);
-        }
-
-        function stop_and_remove_entry(users, entry) {
-            var units = users.map(function (u) { return u.unit });
-            return spawn_nfs_mounts([ "stop-and-remove", JSON.stringify(units), JSON.stringify(entry) ]);
-        }
-
-        function entry_users(entry) {
-            return spawn_nfs_mounts([ "users", JSON.stringify(entry) ]).then(JSON.parse);
-        }
-
-        function find_entry(remote, local) {
-            for (var i = 0; i < self.entries.length; i++) {
-                if (self.entries[i].fields[0] == remote && self.entries[i].fields[1] == local)
-                    return self.entries[i];
-            }
-        }
-
-        return self;
-    }
-
-    client.nfs = nfs_mounts();
-
-    /* VDO */
-
-    function vdo_overlay() {
-        var self = {
-            start: start,
-
-            volumes: [ ],
-
-            by_name: { },
-            by_dev: { },
-            by_backing_dev: { },
-
-            find_by_block: find_by_block,
-            find_by_backing_block: find_by_backing_block,
-
-            create: create
-        };
-
-        function cmd(args) {
-            return cockpit.spawn([ "vdo" ].concat(args),
-                                 { superuser: true,
-                                   err: "message"
-                                 });
-        }
-
-        function update(data) {
-            self.by_name = { };
-            self.by_dev = { };
-            self.by_backing_dev = { };
-
-            self.volumes = data.map(function (vol, index) {
-                var name = vol.name;
-
-                function volcmd(args) {
-                    return cmd(args.concat([ "--name", name ]));
-                }
-
-                var v = { name: name,
-                          broken: vol.broken,
-                          dev: "/dev/mapper/" + name,
-                          backing_dev: vol.device,
-                          logical_size: vol.logical_size,
-                          physical_size: vol.physical_size,
-                          index_mem: vol.index_mem,
-                          compression: vol.compression,
-                          deduplication: vol.deduplication,
-                          activated: vol.activated,
-
-                          set_compression: function(val) {
-                              return volcmd([ val ? "enableCompression" : "disableCompression" ]);
-                          },
-
-                          set_deduplication: function(val) {
-                              return volcmd([ val ? "enableDeduplication" : "disableDeduplication" ]);
-                          },
-
-                          set_activate: function(val) {
-                              return volcmd([ val ? "activate" : "deactivate" ]);
-                          },
-
-                          start: function() {
-                              return volcmd([ "start" ]);
-                          },
-
-                          stop: function() {
-                              return volcmd([ "stop" ]);
-                          },
-
-                          remove: function() {
-                              return volcmd([ "remove" ]);
-                          },
-
-                          force_remove: function() {
-                              return volcmd([ "remove", "--force" ]);
-                          },
-
-                          grow_physical: function() {
-                              return volcmd([ "growPhysical" ]);
-                          },
-
-                          grow_logical: function(lsize) {
-                              return volcmd([ "growLogical", "--vdoLogicalSize", lsize + "B" ]);
-                          }
-                };
-
-                self.by_name[v.name] = v;
-                self.by_dev[v.dev] = v;
-                self.by_backing_dev[v.backing_dev] = v;
-
-                return v;
-            });
-
-            // We trigger a change on the client right away and not
-            // just on the vdo_overlay since this data is used all
-            // over the place...
-
-            client.dispatchEvent("changed");
-        }
-
-        function start() {
-            var buf = "";
-
-            return cockpit.spawn([ "/bin/sh", "-c", "head -1 $(which vdo || echo /dev/null)" ],
-                                 { err: "ignore" })
-                    .then(function (shebang) {
-                        if (shebang != "") {
-                            self.python = shebang.replace(/#! */, "").trim("\n");
-                            cockpit.spawn([ self.python, "--", "-" ], { superuser: "try", err: "message" })
-                                    .input(inotify_py + vdo_monitor_py)
-                                    .stream(function (output) {
-                                        var lines;
-
-                                        buf += output;
-                                        lines = buf.split("\n");
-                                        buf = lines[lines.length - 1];
-                                        if (lines.length >= 2) {
-                                            self.entries = JSON.parse(lines[lines.length - 2]);
-                                            self.fsys_sizes = { };
-                                            $(self).triggerHandler('changed');
-                                            update(JSON.parse(lines[lines.length - 2]));
-                                        }
-                                    })
-                                    .fail(function (error) {
-                                        if (error != "closed") {
-                                            console.warn(error);
-                                        }
-                                    });
-                            return true;
-                        } else {
-                            return false;
-                        }
-                    });
-        }
-
-        function some(array, func) {
-            var i;
-            for (i = 0; i < array.length; i++) {
-                var val = func(array[i]);
-                if (val)
-                    return val;
-            }
-            return null;
-        }
-
-        function find_by_block(block) {
-            function check(encoded) { return self.by_dev[utils.decode_filename(encoded)] }
-            return check(block.Device) || some(block.Symlinks, check);
-        }
-
-        function find_by_backing_block(block) {
-            function check(encoded) { return self.by_backing_dev[utils.decode_filename(encoded)] }
-            return check(block.Device) || some(block.Symlinks, check);
-        }
-
-        function create(options) {
-            var args = [ "create", "--name", options.name,
-                "--device", utils.decode_filename(options.block.PreferredDevice) ];
-            if (options.logical_size !== undefined)
-                args.push("--vdoLogicalSize", options.logical_size + "B");
-            if (options.index_mem !== undefined)
-                args.push("--indexMem", options.index_mem / (1024 * 1024 * 1024));
-            if (options.compression !== undefined)
-                args.push("--compression", options.compression ? "enabled" : "disabled");
-            if (options.deduplication !== undefined)
-                args.push("--deduplication", options.deduplication ? "enabled" : "disabled");
-            if (options.emulate_512 !== undefined)
-                args.push("--emulate512", options.emulate_512 ? "enabled" : "disabled");
-            return cmd(args);
-        }
-
-        return self;
-    }
-
-    client.vdo_overlay = vdo_overlay();
-
-    function init_manager() {
-        /* Storaged 2.6 and later uses the UDisks2 API names, but try the
-         * older storaged API first as a fallback.
-         */
-
-        var storaged_service = "org.storaged.Storaged";
-        var storaged_opath_pfx = "/org/storaged/Storaged";
-        var storaged_iface_pfx = "org.storaged.Storaged";
-
-        var storaged = cockpit.dbus(storaged_service);
-        var storaged_manager = storaged.proxy(storaged_iface_pfx + ".Manager",
-                                              storaged_opath_pfx + "/Manager", { watch: true });
-
-        function fallback_udisks() {
-            STORAGED_SERVICE = "org.freedesktop.UDisks2";
-            STORAGED_OPATH_PFX = "/org/freedesktop/UDisks2";
-            STORAGED_IFACE_PFX = "org.freedesktop.UDisks2";
-
-            var udisks = cockpit.dbus(STORAGED_SERVICE);
-            var udisks_manager = udisks.proxy(STORAGED_IFACE_PFX + ".Manager",
-                                              STORAGED_OPATH_PFX + "/Manager", { watch: true });
-
-            return udisks_manager.wait().then(function () {
-                return udisks_manager;
-            });
-        }
-
-        return storaged_manager.wait().then(function() {
-            if (storaged_manager.valid) {
-                console.log("Using older 'storaged' API: " + storaged_service);
-                STORAGED_SERVICE = storaged_service;
-                STORAGED_OPATH_PFX = storaged_opath_pfx;
-                STORAGED_IFACE_PFX = storaged_iface_pfx;
-                return storaged_manager;
-            } else {
-                return fallback_udisks();
-            }
-        }, fallback_udisks);
-    }
-
-    client.init = function init_storaged(callback) {
-        init_manager().then(function(manager) {
-            client.storaged_client = manager.client;
-            client.manager = manager;
-
-            // The first storaged version with the UDisks2 API names was 2.6
-            client.is_old_udisks2 = (STORAGED_SERVICE == "org.freedesktop.UDisks2" && client.older_than("2.6"));
-            if (client.is_old_udisks2)
-                console.log("Using older 'udisks2' implementation: " + manager.Version);
-
-            init_proxies();
-            init_model(callback);
-        }, function() {
-            client.features = false;
-            callback();
+    var storaged_service = "org.storaged.Storaged";
+    var storaged_opath_pfx = "/org/storaged/Storaged";
+    var storaged_iface_pfx = "org.storaged.Storaged";
+
+    var storaged = cockpit.dbus(storaged_service);
+    var storaged_manager = storaged.proxy(storaged_iface_pfx + ".Manager",
+                                          storaged_opath_pfx + "/Manager", { watch: true });
+
+    function fallback_udisks() {
+        STORAGED_SERVICE = "org.freedesktop.UDisks2";
+        STORAGED_OPATH_PFX = "/org/freedesktop/UDisks2";
+        STORAGED_IFACE_PFX = "org.freedesktop.UDisks2";
+
+        var udisks = cockpit.dbus(STORAGED_SERVICE);
+        var udisks_manager = udisks.proxy(STORAGED_IFACE_PFX + ".Manager",
+                                          STORAGED_OPATH_PFX + "/Manager", { watch: true });
+
+        return udisks_manager.wait().then(function () {
+            return udisks_manager;
         });
-    };
+    }
 
-    module.exports = client;
-}());
+    return storaged_manager.wait().then(function() {
+        if (storaged_manager.valid) {
+            console.log("Using older 'storaged' API: " + storaged_service);
+            STORAGED_SERVICE = storaged_service;
+            STORAGED_OPATH_PFX = storaged_opath_pfx;
+            STORAGED_IFACE_PFX = storaged_iface_pfx;
+            return storaged_manager;
+        } else {
+            return fallback_udisks();
+        }
+    }, fallback_udisks);
+}
+
+client.init = function init_storaged(callback) {
+    init_manager().then(function(manager) {
+        client.storaged_client = manager.client;
+        client.manager = manager;
+
+        // The first storaged version with the UDisks2 API names was 2.6
+        client.is_old_udisks2 = (STORAGED_SERVICE == "org.freedesktop.UDisks2" && client.older_than("2.6"));
+        if (client.is_old_udisks2)
+            console.log("Using older 'udisks2' implementation: " + manager.Version);
+
+        init_proxies();
+        init_model(callback);
+    }, function() {
+        client.features = false;
+        callback();
+    });
+};
+
+module.exports = client;

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -17,730 +17,728 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-(function() {
-    "use strict";
+"use strict";
 
-    var cockpit = require("cockpit");
+var cockpit = require("cockpit");
 
-    var service = require("service");
-    var moment = require("moment");
-    moment.locale(cockpit.language);
+var service = require("service");
+var moment = require("moment");
+moment.locale(cockpit.language);
 
-    var _ = cockpit.gettext;
-    var C_ = cockpit.gettext;
+var _ = cockpit.gettext;
+var C_ = cockpit.gettext;
 
-    /* UTILITIES
-     */
+/* UTILITIES
+ */
 
-    var utils = { };
+var utils = { };
 
-    utils.compare_versions = function compare_versions(a, b) {
-        function to_ints(str) {
-            return str.split(".").map(function (s) { return s ? parseInt(s, 10) : 0 });
-        }
-
-        var a_ints = to_ints(a);
-        var b_ints = to_ints(b);
-        var len = Math.min(a_ints.length, b_ints.length);
-        var i;
-
-        for (i = 0; i < len; i++) {
-            if (a_ints[i] == b_ints[i])
-                continue;
-            return a_ints[i] - b_ints[i];
-        }
-
-        return a_ints.length - b_ints.length;
-    };
-
-    utils.hostnamed = cockpit.dbus("org.freedesktop.hostname1").proxy();
-
-    utils.array_find = function array_find(array, pred) {
-        for (var i = 0; i < array.length; i++)
-            if (pred(array[i]))
-                return array[i];
-        return undefined;
-    };
-
-    utils.flatten = function flatten(array_of_arrays) {
-        if (array_of_arrays.length > 0)
-            return Array.prototype.concat.apply([], array_of_arrays);
-        else
-            return [ ];
-    };
-
-    utils.decode_filename = function decode_filename(encoded) {
-        return cockpit.utf8_decoder().decode(cockpit.base64_decode(encoded).slice(0, -1));
-    };
-
-    utils.encode_filename = function encode_filename(decoded) {
-        return cockpit.base64_encode(cockpit.utf8_encoder().encode(decoded)
-                .concat([0]));
-    };
-
-    utils.fmt_size = function fmt_size(bytes) {
-        return cockpit.format_bytes(bytes, 1024);
-    };
-
-    utils.fmt_size_long = function fmt_size_long(bytes) {
-        var with_binary_unit = cockpit.format_bytes(bytes, 1024);
-        var with_decimal_unit = cockpit.format_bytes(bytes, 1000);
-        /* Translators: Used in "..." */
-        return with_binary_unit + ", " + with_decimal_unit + ", " + bytes + " " + C_("format-bytes", "bytes");
-    };
-
-    utils.fmt_rate = function fmt_rate(bytes_per_sec) {
-        return cockpit.format_bytes_per_sec(bytes_per_sec, 1024);
-    };
-
-    utils.format_temperature = function format_temperature(kelvin) {
-        var celcius = kelvin - 273.15;
-        var fahrenheit = 9.0 * celcius / 5.0 + 32.0;
-        return celcius.toFixed(1) + "° C / " + fahrenheit.toFixed(1) + "° F";
-    };
-
-    utils.format_fsys_usage = function format_fsys_usage(used, total) {
-        var text = "";
-        var units = 1024;
-        var parts = cockpit.format_bytes(total, units, true);
-        text = " / " + parts.join(" ");
-        units = parts[1];
-
-        parts = cockpit.format_bytes(used, units, true);
-        return parts[0] + text;
-    };
-
-    utils.format_delay = function format_delay(d) {
-        return moment.duration(d).humanize();
-    };
-
-    utils.format_size_and_text = function format_size_and_text(size, text) {
-        return cockpit.format(_("${size} ${desc}"), { size: utils.fmt_size(size), desc: text });
-    };
-
-    utils.validate_lvm2_name = function validate_lvm2_name(name) {
-        if (name === "")
-            return _("Name cannot be empty.");
-        if (name.length > 127)
-            return _("Name cannot be longer than 127 characters.");
-        var m = name.match(/[^a-zA-Z0-9+._-]/);
-        if (m) {
-            if (m[0].search(/\s+/) === -1)
-                return cockpit.format(_("Name cannot contain the character '$0'."), m[0]);
-            else
-                return cockpit.format(_("Name cannot contain whitespace."), m[0]);
-        }
-    };
-
-    utils.validate_fsys_label = function validate_fsys_label(label, type) {
-        var fs_label_max = {
-            "xfs":   12,
-            "ext4":  16,
-            "vfat":  11,
-            "ntfs": 128,
-        };
-
-        var limit = fs_label_max[type.replace("luks+", "")];
-        var bytes = cockpit.utf8_encoder().encode(label);
-        if (limit && bytes.length > limit) {
-            // Let's not confuse people with encoding issues unless
-            // they use funny characters.
-            if (bytes.length == label.length)
-                return cockpit.format(_("Name cannot be longer than $0 characters"), limit);
-            else
-                return cockpit.format(_("Name cannot be longer than $0 bytes"), limit);
-        }
-    };
-
-    utils.block_name = function block_name(block) {
-        return utils.decode_filename(block.PreferredDevice);
-    };
-
-    utils.mdraid_name = function mdraid_name(mdraid) {
-        if (!mdraid.Name)
-            return "";
-
-        var parts = mdraid.Name.split(":");
-
-        if (parts.length != 2)
-            return mdraid.Name;
-
-        /* if we call hostnamed too early, before the dbus.proxy() promise is fulfilled,
-         * it will not be valid yet; it's too inconvenient to make this
-         * function asynchronous, so just don't show the host name in this case */
-        if (utils.hostnamed.StaticHostname === undefined || parts[0] == utils.hostnamed.StaticHostname)
-            return parts[1];
-        else
-            return cockpit.format(_("$name (from $host)"),
-                                  { name: parts[1],
-                                    host: parts[0]
-                                  });
-    };
-
-    utils.lvol_name = function lvol_name(lvol) {
-        var type;
-        if (lvol.Type == "pool")
-            type = _("Pool for Thin Logical Volumes");
-        else if (lvol.ThinPool != "/")
-            type = _("Thin Logical Volume");
-        else if (lvol.Origin != "/")
-            type = _("Logical Volume (Snapshot)");
-        else
-            type = _("Logical Volume");
-        return cockpit.format('$0 "$1"', type, lvol.Name);
-    };
-
-    utils.drive_name = function drive_name(drive) {
-        var name_parts = [ ];
-        if (drive.Vendor)
-            name_parts.push(drive.Vendor);
-        if (drive.Model)
-            name_parts.push(drive.Model);
-
-        var name = name_parts.join(" ");
-        if (drive.Serial)
-            name += " (" + drive.Serial + ")";
-        else if (drive.WWN)
-            name += " (" + drive.WWN + ")";
-
-        return name;
-    };
-
-    utils.get_block_link_parts = function get_block_link_parts(client, path) {
-        var is_part, is_crypt, is_lvol;
-
-        while (true) {
-            if (client.blocks_part[path] && client.blocks_ptable[client.blocks_part[path].Table]) {
-                is_part = true;
-                path = client.blocks_part[path].Table;
-            } else if (client.blocks[path] && client.blocks[client.blocks[path].CryptoBackingDevice]) {
-                is_crypt = true;
-                path = client.blocks[path].CryptoBackingDevice;
-            } else
-                break;
-        }
-
-        if (client.blocks_lvm2[path] && client.lvols[client.blocks_lvm2[path].LogicalVolume])
-            is_lvol = true;
-
-        var block = client.blocks[path];
-        if (!block)
-            return;
-
-        var location, link;
-        if (client.mdraids[block.MDRaid]) {
-            location = [ "mdraid", client.mdraids[block.MDRaid].UUID ];
-            link = cockpit.format(_("RAID Device $0"), utils.mdraid_name(client.mdraids[block.MDRaid]));
-        } else if (client.blocks_lvm2[path] &&
-                   client.lvols[client.blocks_lvm2[path].LogicalVolume] &&
-                   client.vgroups[client.lvols[client.blocks_lvm2[path].LogicalVolume].VolumeGroup]) {
-            var target = client.vgroups[client.lvols[client.blocks_lvm2[path].LogicalVolume].VolumeGroup].Name;
-            location = [ "vg", target ];
-            link = cockpit.format(_("Volume Group $0"), target);
-        } else {
-            var vdo = client.vdo_overlay.find_by_block(block);
-            if (vdo) {
-                location = [ "vdo", vdo.name ];
-                link = cockpit.format(_("VDO Device $0"), vdo.name);
-            } else {
-                location = [ utils.block_name(block).replace(/^\/dev\//, "") ];
-                if (client.drives[block.Drive])
-                    link = utils.drive_name(client.drives[block.Drive]);
-                else
-                    link = utils.block_name(block);
-            }
-        }
-
-        // Partitions of logical volumes are shown as just logical volumes.
-        var format;
-        if (is_lvol && is_crypt)
-            format = _("Encrypted Logical Volume of $0");
-        else if (is_part && is_crypt)
-            format = _("Encrypted Partition of $0");
-        else if (is_lvol)
-            format = _("Logical Volume of $0");
-        else if (is_part)
-            format = _("Partition of $0");
-        else if (is_crypt)
-            format = _("Encrypted $0");
-        else
-            format = "$0";
-
-        return {
-            location: location,
-            format: format,
-            link: link
-        };
-    };
-
-    utils.go_to_block = function (client, path) {
-        var parts = utils.get_block_link_parts(client, path);
-        cockpit.location.go(parts.location);
-    };
-
-    utils.get_partitions = function get_partitions(client, block) {
-        var partitions = client.blocks_partitions[block.path];
-
-        function process_level(level, container_start, container_size) {
-            var n;
-            var last_end = container_start;
-            var total_end = container_start + container_size;
-            var block, start, size, is_container, is_contained;
-
-            var result = [ ];
-
-            function append_free_space(start, size) {
-                // There is a lot of rounding and aligning going on in
-                // the storage stack.  All of udisks2, libblockdev,
-                // and libparted seem to contribute their own ideas of
-                // where a partition really should start.
-                //
-                // The start of partitions are aggressively rounded
-                // up, sometimes twice, but the end is not aligned in
-                // the same way.  This means that a few megabytes of
-                // free space will show up between partitions.
-                //
-                // We hide these small free spaces because they are
-                // unexpected and can't be used for anything anyway.
-                //
-                // "Small" is anything less than 3 MiB, which seems to
-                // work okay.  (The worst case is probably creating
-                // the first logical partition inside a extended
-                // partition with udisks+libblockdev.  It leads to a 2
-                // MiB gap.)
-
-                if (size >= 3 * 1024 * 1024) {
-                    result.push({ type: 'free', start: start, size: size });
-                }
-            }
-
-            for (n = 0; n < partitions.length; n++) {
-                block = client.blocks[partitions[n].path];
-                start = partitions[n].Offset;
-                size = partitions[n].Size;
-                is_container = partitions[n].IsContainer;
-                is_contained = partitions[n].IsContained;
-
-                if (block === null)
-                    continue;
-
-                if (level === 0 && is_contained)
-                    continue;
-
-                if (level == 1 && !is_contained)
-                    continue;
-
-                if (start < container_start || start + size > container_start + container_size)
-                    continue;
-
-                append_free_space(last_end, start - last_end);
-                if (is_container) {
-                    result.push({ type: 'container', block: block, size: size,
-                                  partitions: process_level(level + 1, start, size) });
-                } else {
-                    result.push({ type: 'block', block: block });
-                }
-                last_end = start + size;
-            }
-
-            append_free_space(last_end, total_end - last_end);
-
-            return result;
-        }
-
-        return process_level(0, 0, block.Size);
-    };
-
-    utils.get_available_spaces = function get_available_spaces(client) {
-        function is_free(path) {
-            var block = client.blocks[path];
-            var block_ptable = client.blocks_ptable[path];
-            var block_part = client.blocks_part[path];
-            var block_pvol = client.blocks_pvol[path];
-
-            function has_fs_label() {
-                if (!block.IdUsage)
-                    return false;
-                // Devices with a LVM2_member label need to actually be
-                // associated with a volume group.
-                if (block.IdType == 'LVM2_member' && (!block_pvol || !client.vgroups[block_pvol.VolumeGroup]))
-                    return false;
-                return true;
-            }
-
-            function is_mpath_member() {
-                if (!client.drives[block.Drive])
-                    return false;
-                if (!client.drives_block[block.Drive]) {
-                    // Broken multipath drive
-                    return true;
-                }
-                var members = client.drives_multipath_blocks[block.Drive];
-                for (var i = 0; i < members.length; i++) {
-                    if (members[i] == block)
-                        return true;
-                }
-                return false;
-            }
-
-            function is_vdo_backing_dev() {
-                return !!client.vdo_overlay.find_by_backing_block(block);
-            }
-
-            return (!block.HintIgnore &&
-                    block.Size > 0 &&
-                    !has_fs_label() &&
-                    !is_mpath_member() &&
-                    !is_vdo_backing_dev() &&
-                    !block_ptable &&
-                    !(block_part && block_part.IsContainer));
-        }
-
-        function make(path) {
-            var block = client.blocks[path];
-            var parts = utils.get_block_link_parts(client, path);
-            var text = cockpit.format(parts.format, parts.link);
-            return { type: 'block', block: block, size: block.Size, desc: text };
-        }
-
-        var spaces = Object.keys(client.blocks).filter(is_free)
-                .sort(utils.make_block_path_cmp(client))
-                .map(make);
-
-        function add_free_spaces(block) {
-            var parts = utils.get_partitions(client, block);
-            var i, p, link_parts, text;
-            for (i in parts) {
-                p = parts[i];
-                if (p.type == 'free') {
-                    link_parts = utils.get_block_link_parts(client, block.path);
-                    text = cockpit.format(link_parts.format, link_parts.link);
-                    spaces.push({ type: 'free', block: block, start: p.start, size: p.size,
-                                  desc: cockpit.format(_("unpartitioned space on $0"), text) });
-                }
-            }
-        }
-
-        for (var p in client.blocks_ptable)
-            add_free_spaces(client.blocks[p]);
-
-        return spaces;
-    };
-
-    utils.prepare_available_spaces = function prepare_available_spaces(client, spcs) {
-        function prepare(spc) {
-            if (spc.type == 'block')
-                return cockpit.resolve(spc.block.path);
-            else if (spc.type == 'free') {
-                var block_ptable = client.blocks_ptable[spc.block.path];
-                return block_ptable.CreatePartition(spc.start, spc.size, "", "", { });
-            }
-        }
-        return cockpit.all(spcs.map(prepare));
-    };
-
-    /* Comparison function for sorting lists of block devices.
-
-       We sort by major:minor numbers to get the expected order when
-       there are more than 10 devices of a kind.  For example, if you
-       have 20 loopback devices named loop0 to loop19, sorting them
-       alphabetically would put them in the wrong order
-
-           loop0, loop1, loop10, loop11, ..., loop2, ...
-
-       Sorting by major:minor is an easy way to do the right thing.
-    */
-
-    utils.block_cmp = function block_cmp(a, b) {
-        return a.DeviceNumber - b.DeviceNumber;
-    };
-
-    utils.make_block_path_cmp = function(client) {
-        return function(path_a, path_b) {
-            return utils.block_cmp(client.blocks[path_a], client.blocks[path_b]);
-        };
-    };
-
-    var multipathd_service;
-
-    utils.get_multipathd_service = function() {
-        if (!multipathd_service)
-            multipathd_service = service.proxy("multipathd");
-        return multipathd_service;
-    };
-
-    utils.get_parent = function(client, path) {
-        if (client.blocks_part[path] && client.blocks[client.blocks_part[path].Table])
-            return client.blocks_part[path].Table;
-        if (client.blocks[path] && client.blocks[client.blocks[path].CryptoBackingDevice])
-            return client.blocks[path].CryptoBackingDevice;
-        if (client.blocks[path] && client.drives[client.blocks[path].Drive])
-            return client.blocks[path].Drive;
-        if (client.blocks[path] && client.mdraids[client.blocks[path].MDRaid])
-            return client.blocks[path].MDRaid;
-        if (client.blocks_lvm2[path] && client.lvols[client.blocks_lvm2[path].LogicalVolume])
-            return client.blocks_lvm2[path].LogicalVolume;
-        if (client.lvols[path] && client.vgroups[client.lvols[path].VolumeGroup])
-            return client.lvols[path].VolumeGroup;
-    };
-
-    utils.get_direct_parent_blocks = function(client, path) {
-        var parent = utils.get_parent(client, path);
-        if (!parent)
-            return [ ];
-        if (client.blocks[parent])
-            return [ parent ];
-        if (client.mdraids[parent])
-            return client.mdraids_members[parent].map(function (m) { return m.path });
-        if (client.lvols[parent])
-            parent = client.lvols[parent].VolumeGroup;
-        if (client.vgroups[parent])
-            return client.vgroups_pvols[parent].map(function (pv) { return pv.path });
-        return [ ];
-    };
-
-    utils.get_parent_blocks = function(client, path) {
-        var direct_parents = utils.get_direct_parent_blocks(client, path);
-        var direct_and_indirect_parents = utils.flatten(direct_parents.map(function (p) {
-            return utils.get_parent_blocks(client, p);
-        }));
-        return [ path ].concat(direct_and_indirect_parents);
-    };
-
-    utils.is_netdev = function(client, path) {
-        var block = client.blocks[path];
-        var drive = block && client.drives[block.Drive];
-        if (drive && drive.Vendor == "LIO-ORG")
-            return true;
-        if (block && block.Major == 43) // NBD
-            return true;
-        return false;
-    };
-
-    function get_children(client, path) {
-        var children = [ ];
-
-        if (client.blocks_cleartext[path]) {
-            children.push(client.blocks_cleartext[path].path);
-        }
-
-        if (client.blocks_ptable[path]) {
-            client.blocks_partitions[path].forEach(function (part) {
-                if (!part.IsContainer)
-                    children.push(part.path);
-            });
-        }
-
-        if (client.blocks_part[path] && client.blocks_part[path].IsContainer) {
-            var ptable_path = client.blocks_part[path].Table;
-            client.blocks_partitions[ptable_path].forEach(function (part) {
-                if (part.IsContained)
-                    children.push(part.path);
-            });
-        }
-
-        if (client.vgroups[path]) {
-            client.vgroups_lvols[path].forEach(function (lvol) {
-                if (client.lvols_block[lvol.path])
-                    children.push(client.lvols_block[lvol.path].path);
-            });
-        }
-
-        return children;
+utils.compare_versions = function compare_versions(a, b) {
+    function to_ints(str) {
+        return str.split(".").map(function (s) { return s ? parseInt(s, 10) : 0 });
     }
 
-    utils.get_active_usage = function get_active_usage(client, path) {
-        function get_usage(path) {
-            var block = client.blocks[path];
-            var fsys = client.blocks_fsys[path];
-            var mdraid = block && client.mdraids[block.MDRaidMember];
-            var pvol = client.blocks_pvol[path];
-            var vgroup = pvol && client.vgroups[pvol.VolumeGroup];
-            var vdo = block && client.vdo_overlay.find_by_backing_block(block);
+    var a_ints = to_ints(a);
+    var b_ints = to_ints(b);
+    var len = Math.min(a_ints.length, b_ints.length);
+    var i;
 
-            var usage = utils.flatten(get_children(client, path).map(get_usage));
+    for (i = 0; i < len; i++) {
+        if (a_ints[i] == b_ints[i])
+            continue;
+        return a_ints[i] - b_ints[i];
+    }
 
-            if (fsys && fsys.MountPoints.length > 0)
-                usage.push({ usage: 'mounted',
-                             block: block,
-                             fsys: fsys
-                });
+    return a_ints.length - b_ints.length;
+};
 
-            if (mdraid)
-                usage.push({ usage: 'mdraid-member',
-                             block: block,
-                             mdraid: mdraid
-                });
+utils.hostnamed = cockpit.dbus("org.freedesktop.hostname1").proxy();
 
-            if (vgroup)
-                usage.push({ usage: 'pvol',
-                             block: block,
-                             pvol: pvol,
-                             vgroup: vgroup
-                });
+utils.array_find = function array_find(array, pred) {
+    for (var i = 0; i < array.length; i++)
+        if (pred(array[i]))
+            return array[i];
+    return undefined;
+};
 
-            if (vdo)
-                usage.push({ usage: 'vdo-backing',
-                             block: block,
-                             vdo: vdo
-                });
+utils.flatten = function flatten(array_of_arrays) {
+    if (array_of_arrays.length > 0)
+        return Array.prototype.concat.apply([], array_of_arrays);
+    else
+        return [ ];
+};
 
-            return usage;
-        }
+utils.decode_filename = function decode_filename(encoded) {
+    return cockpit.utf8_decoder().decode(cockpit.base64_decode(encoded).slice(0, -1));
+};
 
-        // Prepare the result for the dialogs
+utils.encode_filename = function encode_filename(decoded) {
+    return cockpit.base64_encode(cockpit.utf8_encoder().encode(decoded)
+            .concat([0]));
+};
 
-        var usage = get_usage(path);
+utils.fmt_size = function fmt_size(bytes) {
+    return cockpit.format_bytes(bytes, 1024);
+};
 
-        var res = {
-            raw: usage,
-            Teardown: {
-                Mounts: [ ],
-                MDRaidMembers: [ ],
-                PhysicalVolumes: [ ]
-            },
-            Blocking: {
-                Mounts: [ ],
-                MDRaidMembers: [ ],
-                PhysicalVolumes: [ ],
-                VDOs: [ ]
-            }
-        };
+utils.fmt_size_long = function fmt_size_long(bytes) {
+    var with_binary_unit = cockpit.format_bytes(bytes, 1024);
+    var with_decimal_unit = cockpit.format_bytes(bytes, 1000);
+    /* Translators: Used in "..." */
+    return with_binary_unit + ", " + with_decimal_unit + ", " + bytes + " " + C_("format-bytes", "bytes");
+};
 
-        usage.forEach(function (use) {
-            var entry, active_state;
+utils.fmt_rate = function fmt_rate(bytes_per_sec) {
+    return cockpit.format_bytes_per_sec(bytes_per_sec, 1024);
+};
 
-            if (use.usage == 'mounted') {
-                res.Teardown.Mounts.push({
-                    Name: utils.block_name(use.block),
-                    MountPoint: utils.decode_filename(use.fsys.MountPoints[0])
-                });
-            } else if (use.usage == 'mdraid-member') {
-                entry = {
-                    Name: utils.block_name(use.block),
-                    MDRaid: utils.mdraid_name(use.mdraid)
-                };
-                active_state = utils.array_find(use.mdraid.ActiveDevices, function (as) {
-                    return as[0] == use.block.path;
-                });
-                if (active_state && active_state[1] < 0)
-                    res.Teardown.MDRaidMembers.push(entry);
-                else
-                    res.Blocking.MDRaidMembers.push(entry);
-            } else if (use.usage == 'pvol') {
-                entry = {
-                    Name: utils.block_name(use.block),
-                    VGroup: use.vgroup.Name
-                };
-                if (use.pvol.FreeSize == use.pvol.Size) {
-                    res.Teardown.PhysicalVolumes.push(entry);
-                } else {
-                    res.Blocking.PhysicalVolumes.push(entry);
-                }
-            } else if (use.usage == 'vdo-backing') {
-                entry = {
-                    Name: utils.block_name(use.block),
-                    VDO: use.vdo.name
-                };
-                res.Blocking.VDOs.push(entry);
-            }
-        });
+utils.format_temperature = function format_temperature(kelvin) {
+    var celcius = kelvin - 273.15;
+    var fahrenheit = 9.0 * celcius / 5.0 + 32.0;
+    return celcius.toFixed(1) + "° C / " + fahrenheit.toFixed(1) + "° F";
+};
 
-        res.Teardown.HasMounts = res.Teardown.Mounts.length > 0;
-        res.Teardown.HasMDRaidMembers = res.Teardown.MDRaidMembers.length > 0;
-        res.Teardown.HasPhysicalVolumes = res.Teardown.PhysicalVolumes.length > 0;
+utils.format_fsys_usage = function format_fsys_usage(used, total) {
+    var text = "";
+    var units = 1024;
+    var parts = cockpit.format_bytes(total, units, true);
+    text = " / " + parts.join(" ");
+    units = parts[1];
 
-        if (!res.Teardown.HasMounts && !res.Teardown.HasMDRaidMembers && !res.Teardown.HasPhysicalVolumes)
-            res.Teardown = null;
+    parts = cockpit.format_bytes(used, units, true);
+    return parts[0] + text;
+};
 
-        res.Blocking.HasMounts = res.Blocking.Mounts.length > 0;
-        res.Blocking.HasMDRaidMembers = res.Blocking.MDRaidMembers.length > 0;
-        res.Blocking.HasPhysicalVolumes = res.Blocking.PhysicalVolumes.length > 0;
-        res.Blocking.HasVDOs = res.Blocking.VDOs.length > 0;
+utils.format_delay = function format_delay(d) {
+    return moment.duration(d).humanize();
+};
 
-        if (!res.Blocking.HasMounts && !res.Blocking.HasMDRaidMembers && !res.Blocking.HasPhysicalVolumes &&
-            !res.Blocking.HasVDOs)
-            res.Blocking = null;
+utils.format_size_and_text = function format_size_and_text(size, text) {
+    return cockpit.format(_("${size} ${desc}"), { size: utils.fmt_size(size), desc: text });
+};
 
-        return res;
+utils.validate_lvm2_name = function validate_lvm2_name(name) {
+    if (name === "")
+        return _("Name cannot be empty.");
+    if (name.length > 127)
+        return _("Name cannot be longer than 127 characters.");
+    var m = name.match(/[^a-zA-Z0-9+._-]/);
+    if (m) {
+        if (m[0].search(/\s+/) === -1)
+            return cockpit.format(_("Name cannot contain the character '$0'."), m[0]);
+        else
+            return cockpit.format(_("Name cannot contain whitespace."), m[0]);
+    }
+};
+
+utils.validate_fsys_label = function validate_fsys_label(label, type) {
+    var fs_label_max = {
+        "xfs":   12,
+        "ext4":  16,
+        "vfat":  11,
+        "ntfs": 128,
     };
 
-    utils.teardown_active_usage = function teardown_active_usage(client, usage) {
-        // The code below is complicated by the fact that the last
-        // physical volume of a volume group can not be removed
-        // directly (even if it is completely empty).  We want to
-        // remove the whole volume group instead in this case.
-        //
-        // However, we might be removing the last two (or more)
-        // physical volumes here, and it is easiest to catch this
-        // condition upfront by reshuffling the data structures.
+    var limit = fs_label_max[type.replace("luks+", "")];
+    var bytes = cockpit.utf8_encoder().encode(label);
+    if (limit && bytes.length > limit) {
+        // Let's not confuse people with encoding issues unless
+        // they use funny characters.
+        if (bytes.length == label.length)
+            return cockpit.format(_("Name cannot be longer than $0 characters"), limit);
+        else
+            return cockpit.format(_("Name cannot be longer than $0 bytes"), limit);
+    }
+};
 
-        function unmount(mounteds) {
-            return cockpit.all(mounteds.map(function (m) {
-                if (m.fsys.MountPoints.length > 0)
-                    return m.fsys.Unmount({});
-                else
-                    return cockpit.resolve();
-            }));
+utils.block_name = function block_name(block) {
+    return utils.decode_filename(block.PreferredDevice);
+};
+
+utils.mdraid_name = function mdraid_name(mdraid) {
+    if (!mdraid.Name)
+        return "";
+
+    var parts = mdraid.Name.split(":");
+
+    if (parts.length != 2)
+        return mdraid.Name;
+
+    /* if we call hostnamed too early, before the dbus.proxy() promise is fulfilled,
+     * it will not be valid yet; it's too inconvenient to make this
+     * function asynchronous, so just don't show the host name in this case */
+    if (utils.hostnamed.StaticHostname === undefined || parts[0] == utils.hostnamed.StaticHostname)
+        return parts[1];
+    else
+        return cockpit.format(_("$name (from $host)"),
+                              { name: parts[1],
+                                host: parts[0]
+                              });
+};
+
+utils.lvol_name = function lvol_name(lvol) {
+    var type;
+    if (lvol.Type == "pool")
+        type = _("Pool for Thin Logical Volumes");
+    else if (lvol.ThinPool != "/")
+        type = _("Thin Logical Volume");
+    else if (lvol.Origin != "/")
+        type = _("Logical Volume (Snapshot)");
+    else
+        type = _("Logical Volume");
+    return cockpit.format('$0 "$1"', type, lvol.Name);
+};
+
+utils.drive_name = function drive_name(drive) {
+    var name_parts = [ ];
+    if (drive.Vendor)
+        name_parts.push(drive.Vendor);
+    if (drive.Model)
+        name_parts.push(drive.Model);
+
+    var name = name_parts.join(" ");
+    if (drive.Serial)
+        name += " (" + drive.Serial + ")";
+    else if (drive.WWN)
+        name += " (" + drive.WWN + ")";
+
+    return name;
+};
+
+utils.get_block_link_parts = function get_block_link_parts(client, path) {
+    var is_part, is_crypt, is_lvol;
+
+    while (true) {
+        if (client.blocks_part[path] && client.blocks_ptable[client.blocks_part[path].Table]) {
+            is_part = true;
+            path = client.blocks_part[path].Table;
+        } else if (client.blocks[path] && client.blocks[client.blocks[path].CryptoBackingDevice]) {
+            is_crypt = true;
+            path = client.blocks[path].CryptoBackingDevice;
+        } else
+            break;
+    }
+
+    if (client.blocks_lvm2[path] && client.lvols[client.blocks_lvm2[path].LogicalVolume])
+        is_lvol = true;
+
+    var block = client.blocks[path];
+    if (!block)
+        return;
+
+    var location, link;
+    if (client.mdraids[block.MDRaid]) {
+        location = [ "mdraid", client.mdraids[block.MDRaid].UUID ];
+        link = cockpit.format(_("RAID Device $0"), utils.mdraid_name(client.mdraids[block.MDRaid]));
+    } else if (client.blocks_lvm2[path] &&
+               client.lvols[client.blocks_lvm2[path].LogicalVolume] &&
+               client.vgroups[client.lvols[client.blocks_lvm2[path].LogicalVolume].VolumeGroup]) {
+        var target = client.vgroups[client.lvols[client.blocks_lvm2[path].LogicalVolume].VolumeGroup].Name;
+        location = [ "vg", target ];
+        link = cockpit.format(_("Volume Group $0"), target);
+    } else {
+        var vdo = client.vdo_overlay.find_by_block(block);
+        if (vdo) {
+            location = [ "vdo", vdo.name ];
+            link = cockpit.format(_("VDO Device $0"), vdo.name);
+        } else {
+            location = [ utils.block_name(block).replace(/^\/dev\//, "") ];
+            if (client.drives[block.Drive])
+                link = utils.drive_name(client.drives[block.Drive]);
+            else
+                link = utils.block_name(block);
+        }
+    }
+
+    // Partitions of logical volumes are shown as just logical volumes.
+    var format;
+    if (is_lvol && is_crypt)
+        format = _("Encrypted Logical Volume of $0");
+    else if (is_part && is_crypt)
+        format = _("Encrypted Partition of $0");
+    else if (is_lvol)
+        format = _("Logical Volume of $0");
+    else if (is_part)
+        format = _("Partition of $0");
+    else if (is_crypt)
+        format = _("Encrypted $0");
+    else
+        format = "$0";
+
+    return {
+        location: location,
+        format: format,
+        link: link
+    };
+};
+
+utils.go_to_block = function (client, path) {
+    var parts = utils.get_block_link_parts(client, path);
+    cockpit.location.go(parts.location);
+};
+
+utils.get_partitions = function get_partitions(client, block) {
+    var partitions = client.blocks_partitions[block.path];
+
+    function process_level(level, container_start, container_size) {
+        var n;
+        var last_end = container_start;
+        var total_end = container_start + container_size;
+        var block, start, size, is_container, is_contained;
+
+        var result = [ ];
+
+        function append_free_space(start, size) {
+            // There is a lot of rounding and aligning going on in
+            // the storage stack.  All of udisks2, libblockdev,
+            // and libparted seem to contribute their own ideas of
+            // where a partition really should start.
+            //
+            // The start of partitions are aggressively rounded
+            // up, sometimes twice, but the end is not aligned in
+            // the same way.  This means that a few megabytes of
+            // free space will show up between partitions.
+            //
+            // We hide these small free spaces because they are
+            // unexpected and can't be used for anything anyway.
+            //
+            // "Small" is anything less than 3 MiB, which seems to
+            // work okay.  (The worst case is probably creating
+            // the first logical partition inside a extended
+            // partition with udisks+libblockdev.  It leads to a 2
+            // MiB gap.)
+
+            if (size >= 3 * 1024 * 1024) {
+                result.push({ type: 'free', start: start, size: size });
+            }
         }
 
-        function mdraid_remove(members) {
-            return cockpit.all(members.map(function (m) {
-                return m.mdraid.RemoveDevice(m.block.path, { wipe: { t: 'b', v: true } });
-            }));
+        for (n = 0; n < partitions.length; n++) {
+            block = client.blocks[partitions[n].path];
+            start = partitions[n].Offset;
+            size = partitions[n].Size;
+            is_container = partitions[n].IsContainer;
+            is_contained = partitions[n].IsContained;
+
+            if (block === null)
+                continue;
+
+            if (level === 0 && is_contained)
+                continue;
+
+            if (level == 1 && !is_contained)
+                continue;
+
+            if (start < container_start || start + size > container_start + container_size)
+                continue;
+
+            append_free_space(last_end, start - last_end);
+            if (is_container) {
+                result.push({ type: 'container', block: block, size: size,
+                              partitions: process_level(level + 1, start, size) });
+            } else {
+                result.push({ type: 'block', block: block });
+            }
+            last_end = start + size;
         }
 
-        function pvol_remove(pvols) {
-            var by_vgroup = { };
-            var p;
-            pvols.forEach(function (p) {
-                if (!by_vgroup[p.vgroup.path])
-                    by_vgroup[p.vgroup.path] = [ ];
-                by_vgroup[p.vgroup.path].push(p.block);
+        append_free_space(last_end, total_end - last_end);
+
+        return result;
+    }
+
+    return process_level(0, 0, block.Size);
+};
+
+utils.get_available_spaces = function get_available_spaces(client) {
+    function is_free(path) {
+        var block = client.blocks[path];
+        var block_ptable = client.blocks_ptable[path];
+        var block_part = client.blocks_part[path];
+        var block_pvol = client.blocks_pvol[path];
+
+        function has_fs_label() {
+            if (!block.IdUsage)
+                return false;
+            // Devices with a LVM2_member label need to actually be
+            // associated with a volume group.
+            if (block.IdType == 'LVM2_member' && (!block_pvol || !client.vgroups[block_pvol.VolumeGroup]))
+                return false;
+            return true;
+        }
+
+        function is_mpath_member() {
+            if (!client.drives[block.Drive])
+                return false;
+            if (!client.drives_block[block.Drive]) {
+                // Broken multipath drive
+                return true;
+            }
+            var members = client.drives_multipath_blocks[block.Drive];
+            for (var i = 0; i < members.length; i++) {
+                if (members[i] == block)
+                    return true;
+            }
+            return false;
+        }
+
+        function is_vdo_backing_dev() {
+            return !!client.vdo_overlay.find_by_backing_block(block);
+        }
+
+        return (!block.HintIgnore &&
+                block.Size > 0 &&
+                !has_fs_label() &&
+                !is_mpath_member() &&
+                !is_vdo_backing_dev() &&
+                !block_ptable &&
+                !(block_part && block_part.IsContainer));
+    }
+
+    function make(path) {
+        var block = client.blocks[path];
+        var parts = utils.get_block_link_parts(client, path);
+        var text = cockpit.format(parts.format, parts.link);
+        return { type: 'block', block: block, size: block.Size, desc: text };
+    }
+
+    var spaces = Object.keys(client.blocks).filter(is_free)
+            .sort(utils.make_block_path_cmp(client))
+            .map(make);
+
+    function add_free_spaces(block) {
+        var parts = utils.get_partitions(client, block);
+        var i, p, link_parts, text;
+        for (i in parts) {
+            p = parts[i];
+            if (p.type == 'free') {
+                link_parts = utils.get_block_link_parts(client, block.path);
+                text = cockpit.format(link_parts.format, link_parts.link);
+                spaces.push({ type: 'free', block: block, start: p.start, size: p.size,
+                              desc: cockpit.format(_("unpartitioned space on $0"), text) });
+            }
+        }
+    }
+
+    for (var p in client.blocks_ptable)
+        add_free_spaces(client.blocks[p]);
+
+    return spaces;
+};
+
+utils.prepare_available_spaces = function prepare_available_spaces(client, spcs) {
+    function prepare(spc) {
+        if (spc.type == 'block')
+            return cockpit.resolve(spc.block.path);
+        else if (spc.type == 'free') {
+            var block_ptable = client.blocks_ptable[spc.block.path];
+            return block_ptable.CreatePartition(spc.start, spc.size, "", "", { });
+        }
+    }
+    return cockpit.all(spcs.map(prepare));
+};
+
+/* Comparison function for sorting lists of block devices.
+
+   We sort by major:minor numbers to get the expected order when
+   there are more than 10 devices of a kind.  For example, if you
+   have 20 loopback devices named loop0 to loop19, sorting them
+   alphabetically would put them in the wrong order
+
+       loop0, loop1, loop10, loop11, ..., loop2, ...
+
+   Sorting by major:minor is an easy way to do the right thing.
+*/
+
+utils.block_cmp = function block_cmp(a, b) {
+    return a.DeviceNumber - b.DeviceNumber;
+};
+
+utils.make_block_path_cmp = function(client) {
+    return function(path_a, path_b) {
+        return utils.block_cmp(client.blocks[path_a], client.blocks[path_b]);
+    };
+};
+
+var multipathd_service;
+
+utils.get_multipathd_service = function() {
+    if (!multipathd_service)
+        multipathd_service = service.proxy("multipathd");
+    return multipathd_service;
+};
+
+utils.get_parent = function(client, path) {
+    if (client.blocks_part[path] && client.blocks[client.blocks_part[path].Table])
+        return client.blocks_part[path].Table;
+    if (client.blocks[path] && client.blocks[client.blocks[path].CryptoBackingDevice])
+        return client.blocks[path].CryptoBackingDevice;
+    if (client.blocks[path] && client.drives[client.blocks[path].Drive])
+        return client.blocks[path].Drive;
+    if (client.blocks[path] && client.mdraids[client.blocks[path].MDRaid])
+        return client.blocks[path].MDRaid;
+    if (client.blocks_lvm2[path] && client.lvols[client.blocks_lvm2[path].LogicalVolume])
+        return client.blocks_lvm2[path].LogicalVolume;
+    if (client.lvols[path] && client.vgroups[client.lvols[path].VolumeGroup])
+        return client.lvols[path].VolumeGroup;
+};
+
+utils.get_direct_parent_blocks = function(client, path) {
+    var parent = utils.get_parent(client, path);
+    if (!parent)
+        return [ ];
+    if (client.blocks[parent])
+        return [ parent ];
+    if (client.mdraids[parent])
+        return client.mdraids_members[parent].map(function (m) { return m.path });
+    if (client.lvols[parent])
+        parent = client.lvols[parent].VolumeGroup;
+    if (client.vgroups[parent])
+        return client.vgroups_pvols[parent].map(function (pv) { return pv.path });
+    return [ ];
+};
+
+utils.get_parent_blocks = function(client, path) {
+    var direct_parents = utils.get_direct_parent_blocks(client, path);
+    var direct_and_indirect_parents = utils.flatten(direct_parents.map(function (p) {
+        return utils.get_parent_blocks(client, p);
+    }));
+    return [ path ].concat(direct_and_indirect_parents);
+};
+
+utils.is_netdev = function(client, path) {
+    var block = client.blocks[path];
+    var drive = block && client.drives[block.Drive];
+    if (drive && drive.Vendor == "LIO-ORG")
+        return true;
+    if (block && block.Major == 43) // NBD
+        return true;
+    return false;
+};
+
+function get_children(client, path) {
+    var children = [ ];
+
+    if (client.blocks_cleartext[path]) {
+        children.push(client.blocks_cleartext[path].path);
+    }
+
+    if (client.blocks_ptable[path]) {
+        client.blocks_partitions[path].forEach(function (part) {
+            if (!part.IsContainer)
+                children.push(part.path);
+        });
+    }
+
+    if (client.blocks_part[path] && client.blocks_part[path].IsContainer) {
+        var ptable_path = client.blocks_part[path].Table;
+        client.blocks_partitions[ptable_path].forEach(function (part) {
+            if (part.IsContained)
+                children.push(part.path);
+        });
+    }
+
+    if (client.vgroups[path]) {
+        client.vgroups_lvols[path].forEach(function (lvol) {
+            if (client.lvols_block[lvol.path])
+                children.push(client.lvols_block[lvol.path].path);
+        });
+    }
+
+    return children;
+}
+
+utils.get_active_usage = function get_active_usage(client, path) {
+    function get_usage(path) {
+        var block = client.blocks[path];
+        var fsys = client.blocks_fsys[path];
+        var mdraid = block && client.mdraids[block.MDRaidMember];
+        var pvol = client.blocks_pvol[path];
+        var vgroup = pvol && client.vgroups[pvol.VolumeGroup];
+        var vdo = block && client.vdo_overlay.find_by_backing_block(block);
+
+        var usage = utils.flatten(get_children(client, path).map(get_usage));
+
+        if (fsys && fsys.MountPoints.length > 0)
+            usage.push({ usage: 'mounted',
+                         block: block,
+                         fsys: fsys
             });
 
-            function handle_vg(p) {
-                var vg = client.vgroups[p];
-                var pvs = by_vgroup[p];
-                // If we would remove all physical volumes of a volume
-                // group, remove the whole volume group instead.
-                if (pvs.length == client.vgroups_pvols[p].length) {
-                    return vg.Delete({ 'tear-down': { t: 'b', v: true }
-                    });
-                } else {
-                    return cockpit.all(pvs.map(function (pv) {
-                        return vg.RemoveDevice(pv.path, true, {});
-                    }));
-                }
+        if (mdraid)
+            usage.push({ usage: 'mdraid-member',
+                         block: block,
+                         mdraid: mdraid
+            });
+
+        if (vgroup)
+            usage.push({ usage: 'pvol',
+                         block: block,
+                         pvol: pvol,
+                         vgroup: vgroup
+            });
+
+        if (vdo)
+            usage.push({ usage: 'vdo-backing',
+                         block: block,
+                         vdo: vdo
+            });
+
+        return usage;
+    }
+
+    // Prepare the result for the dialogs
+
+    var usage = get_usage(path);
+
+    var res = {
+        raw: usage,
+        Teardown: {
+            Mounts: [ ],
+            MDRaidMembers: [ ],
+            PhysicalVolumes: [ ]
+        },
+        Blocking: {
+            Mounts: [ ],
+            MDRaidMembers: [ ],
+            PhysicalVolumes: [ ],
+            VDOs: [ ]
+        }
+    };
+
+    usage.forEach(function (use) {
+        var entry, active_state;
+
+        if (use.usage == 'mounted') {
+            res.Teardown.Mounts.push({
+                Name: utils.block_name(use.block),
+                MountPoint: utils.decode_filename(use.fsys.MountPoints[0])
+            });
+        } else if (use.usage == 'mdraid-member') {
+            entry = {
+                Name: utils.block_name(use.block),
+                MDRaid: utils.mdraid_name(use.mdraid)
+            };
+            active_state = utils.array_find(use.mdraid.ActiveDevices, function (as) {
+                return as[0] == use.block.path;
+            });
+            if (active_state && active_state[1] < 0)
+                res.Teardown.MDRaidMembers.push(entry);
+            else
+                res.Blocking.MDRaidMembers.push(entry);
+        } else if (use.usage == 'pvol') {
+            entry = {
+                Name: utils.block_name(use.block),
+                VGroup: use.vgroup.Name
+            };
+            if (use.pvol.FreeSize == use.pvol.Size) {
+                res.Teardown.PhysicalVolumes.push(entry);
+            } else {
+                res.Blocking.PhysicalVolumes.push(entry);
             }
+        } else if (use.usage == 'vdo-backing') {
+            entry = {
+                Name: utils.block_name(use.block),
+                VDO: use.vdo.name
+            };
+            res.Blocking.VDOs.push(entry);
+        }
+    });
 
-            for (p in by_vgroup)
-                handle_vg(p);
+    res.Teardown.HasMounts = res.Teardown.Mounts.length > 0;
+    res.Teardown.HasMDRaidMembers = res.Teardown.MDRaidMembers.length > 0;
+    res.Teardown.HasPhysicalVolumes = res.Teardown.PhysicalVolumes.length > 0;
+
+    if (!res.Teardown.HasMounts && !res.Teardown.HasMDRaidMembers && !res.Teardown.HasPhysicalVolumes)
+        res.Teardown = null;
+
+    res.Blocking.HasMounts = res.Blocking.Mounts.length > 0;
+    res.Blocking.HasMDRaidMembers = res.Blocking.MDRaidMembers.length > 0;
+    res.Blocking.HasPhysicalVolumes = res.Blocking.PhysicalVolumes.length > 0;
+    res.Blocking.HasVDOs = res.Blocking.VDOs.length > 0;
+
+    if (!res.Blocking.HasMounts && !res.Blocking.HasMDRaidMembers && !res.Blocking.HasPhysicalVolumes &&
+        !res.Blocking.HasVDOs)
+        res.Blocking = null;
+
+    return res;
+};
+
+utils.teardown_active_usage = function teardown_active_usage(client, usage) {
+    // The code below is complicated by the fact that the last
+    // physical volume of a volume group can not be removed
+    // directly (even if it is completely empty).  We want to
+    // remove the whole volume group instead in this case.
+    //
+    // However, we might be removing the last two (or more)
+    // physical volumes here, and it is easiest to catch this
+    // condition upfront by reshuffling the data structures.
+
+    function unmount(mounteds) {
+        return cockpit.all(mounteds.map(function (m) {
+            if (m.fsys.MountPoints.length > 0)
+                return m.fsys.Unmount({});
+            else
+                return cockpit.resolve();
+        }));
+    }
+
+    function mdraid_remove(members) {
+        return cockpit.all(members.map(function (m) {
+            return m.mdraid.RemoveDevice(m.block.path, { wipe: { t: 'b', v: true } });
+        }));
+    }
+
+    function pvol_remove(pvols) {
+        var by_vgroup = { };
+        var p;
+        pvols.forEach(function (p) {
+            if (!by_vgroup[p.vgroup.path])
+                by_vgroup[p.vgroup.path] = [ ];
+            by_vgroup[p.vgroup.path].push(p.block);
+        });
+
+        function handle_vg(p) {
+            var vg = client.vgroups[p];
+            var pvs = by_vgroup[p];
+            // If we would remove all physical volumes of a volume
+            // group, remove the whole volume group instead.
+            if (pvs.length == client.vgroups_pvols[p].length) {
+                return vg.Delete({ 'tear-down': { t: 'b', v: true }
+                });
+            } else {
+                return cockpit.all(pvs.map(function (pv) {
+                    return vg.RemoveDevice(pv.path, true, {});
+                }));
+            }
         }
 
-        return cockpit.all([ unmount(usage.raw.filter(function(use) { return use.usage == "mounted" })),
-            mdraid_remove(usage.raw.filter(function(use) { return use.usage == "mdraid-member" })),
-            pvol_remove(usage.raw.filter(function(use) { return use.usage == "pvol" }))
-        ]);
-    };
+        for (p in by_vgroup)
+            handle_vg(p);
+    }
 
-    utils.get_config = function get_config(name, def) {
-        if (cockpit.manifests["storage"] && cockpit.manifests["storage"]["config"]) {
-            var val = cockpit.manifests["storage"]["config"][name];
-            return val !== undefined ? val : def;
-        } else {
-            return def;
-        }
-    };
+    return cockpit.all([ unmount(usage.raw.filter(function(use) { return use.usage == "mounted" })),
+        mdraid_remove(usage.raw.filter(function(use) { return use.usage == "mdraid-member" })),
+        pvol_remove(usage.raw.filter(function(use) { return use.usage == "pvol" }))
+    ]);
+};
 
-    // TODO - generalize this to arbitrary number of arguments (when needed)
-    utils.fmt_to_array = function fmt_to_array(fmt, arg) {
-        var index = fmt.indexOf("$0");
-        if (index >= 0)
-            return [ fmt.slice(0, index), arg, fmt.slice(index + 2) ];
-        else
-            return [ fmt ];
-    };
+utils.get_config = function get_config(name, def) {
+    if (cockpit.manifests["storage"] && cockpit.manifests["storage"]["config"]) {
+        var val = cockpit.manifests["storage"]["config"][name];
+        return val !== undefined ? val : def;
+    } else {
+        return def;
+    }
+};
 
-    module.exports = utils;
-}());
+// TODO - generalize this to arbitrary number of arguments (when needed)
+utils.fmt_to_array = function fmt_to_array(fmt, arg) {
+    var index = fmt.indexOf("$0");
+    if (index >= 0)
+        return [ fmt.slice(0, index), arg, fmt.slice(index + 2) ];
+    else
+        return [ fmt ];
+};
+
+module.exports = utils;


### PR DESCRIPTION
They are entirely pointless, as only explicit `module.exports` symbols
are exposed to other modules. Drop the redundant `use strict` from
these, as we already pipe everything through strict-loader, and this
flag is only valid as the very first statement in a source file or block.

This paves the way for using the preferred `export` syntax and Babel 7
in the future.