### PR TITLE
webpack: Move to babel preset-env and adjust to supported browsers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    ["env", {
+      "targets": {
+          "chrome": "57",
+          "firefox": "52",
+          "safari": "10.3",
+          "edge": "16",
+          "opera": "44"
+      }
+    }],
+    "react"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -46,9 +46,8 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.1.5",
-    "babel-plugin-transform-async-to-generator": "~6.24.1",
     "babel-plugin-transform-regenerator": "6.26.0",
-    "babel-preset-es2015": "~6.24.1",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-react": "~6.24.1",
     "chrome-remote-interface": "^0.25.2",
     "clean-css": "~3.4.20",
@@ -87,14 +86,5 @@
   "scripts": {
     "eslint": "eslint --ext .js --ext .jsx pkg/",
     "eslint:fix": "eslint --fix --ext .js --ext .jsx pkg/"
-  },
-  "babel": {
-    "presets": [
-      "react",
-      "es2015"
-    ],
-    "plugins": [
-      "transform-async-to-generator"
-    ]
   }
 }


### PR DESCRIPTION
preset-es2015 has been obsolete for a fair while (yelling loudly in npm 
install, with the recommendation to move to preset-env.

Configure supported browser versions according to
<https://cockpit-project.org/running.html>. This will make use of some
ES6 features which browsers support natively, and thus reduce babel work
and the code size a bit.

Drop transform-async-to-generator, as we don't use async in our code.

 - [x] Move to webpack 4