### PR TITLE
package.json: Drop html-minifier

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,8 +88,7 @@ CLEAN_CSS = $(srcdir)/node_modules/.bin/cleancss
 MIN_JS_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	$(srcdir)/tools/missing $(UGLIFY_JS) $(filter-out %.deps, $^) --mangle --comments 'preserve' --beautify \
-		--source-map $@.map --source-map-url $(notdir $@).map --source-map-include-sources > $@.tmp && \
-	$(MV) $@.tmp $@
+		--source-map url=$(notdir $@).map,includeSources --output $@
 
 MIN_CSS_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "exports-loader": "~0.6.3",
     "extend": "~3.0.0",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
-    "html-minifier": "~0.7.2",
     "html-webpack-plugin": "^3.2.0",
     "htmlparser": "~1.7.7",
     "imports-loader": "~0.6.5",
@@ -80,6 +79,7 @@
     "stdio": "~0.2.7",
     "strict-loader": "~1.1.0",
     "style-loader": "~0.13.1",
+    "uglify-js": "^3.4.9",
     "webpack": "^4.17.1",
     "webpack-cli": "^3.1.0"
   },


### PR DESCRIPTION
html-minifier hasn't been used for years. The outdated dependency pulled
in outdated versions of cli, minimatch, and uglifyjs.  Of these we only
use the latter, so directly depend on a current version, move to the
current project name "uglify-js", and adjust its call to the current
CLI.

This fixes three vulnerabilities in `npm audit`:

 - https://www.npmjs.com/advisories/118
 - https://www.npmjs.com/advisories/95
 - https://www.npmjs.com/advisories/48