### PR TITLE
machines: Add bootorder option

### DIFF
--- a/pkg/machines/actions/provider-actions.js
+++ b/pkg/machines/actions/provider-actions.js
@@ -23,6 +23,7 @@ import { logDebug } from '../helpers.js';
 import { virt } from '../provider.js';
 import {
     ATTACH_DISK,
+    CHANGE_BOOT_ORDER,
     CHANGE_NETWORK_SETTINGS,
     CHANGE_NETWORK_STATE,
     CHANGE_VM_AUTOSTART,
@@ -73,6 +74,14 @@ import {
  */
 export function attachDisk({ connectionName, poolName, volumeName, format, target, permanent, hotplug, vmName, vmId }) {
     return virt(ATTACH_DISK, { connectionName, poolName, volumeName, format, target, permanent, hotplug, vmName, vmId });
+}
+
+export function changeBootOrder({ vm, devices }) {
+    return virt(CHANGE_BOOT_ORDER, {
+        id: vm.id,
+        connectionName: vm.connectionName,
+        devices,
+    });
 }
 
 export function changeNetworkSettings({ vm, macAddress, networkType, networkSource, networkModel }) {

--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -133,7 +133,8 @@ class App extends React.Component {
                     networks={networks}
                     actions={createVmAction}
                     resourceHasError={this.state.resourceHasError}
-                    onAddErrorNotification={this.onAddErrorNotification} />
+                    onAddErrorNotification={this.onAddErrorNotification}
+                    nodeDevices={nodeDevices} />
                 }
                 { this.state.activeTab == 2 && <StoragePoolList storagePools={storagePools}
                     dispatch={dispatch}

--- a/pkg/machines/components/vm/bootOrderModal.css
+++ b/pkg/machines/components/vm/bootOrderModal.css
@@ -1,0 +1,73 @@
+.boot-order .list-group {
+    --machines-boot-list-offset: 15rem;
+    max-height: calc(100vh - var(--machines-boot-list-offset));
+}
+
+.boot-order-list-view {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.boot-order .pficon-pending {
+    margin-left: 0.5rem;
+}
+
+/* Overriding Patternfly's ListView */
+.boot-order .list-view-pf-body {
+    align-items: baseline;
+    min-height: 26px;
+}
+
+.boot-order .list-group-item {
+    padding: 1rem 1.5rem;
+}
+
+.boot-order .list-view-pf-main-info,
+.boot-order .list-view-pf-checkbox,
+.boot-order .list-view-pf-actions {
+    align-self: baseline;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+.boot-order .list-view-pf-checkbox {
+    position: relative;
+    top: 3px;
+}
+
+.boot-order .list-view-pf-description {
+    flex: 1 0 30%;
+    flex-basis: 30%;
+}
+
+.boot-order .list-view-pf-additional-info {
+    flex-basis: 70%;
+}
+
+.boot-order .list-group-item:not(.is-checked) .list-view-pf-actions {
+    display: none;
+}
+
+.boot-order .ct-form-layout + .ct-form-layout {
+    margin-left: 1rem;
+}
+
+@media screen and (min-width: 769px) {
+    /* Standard dialog is too narrow */
+    .boot-order > .modal-dialog {
+        min-width: 70rem;
+    }
+
+    /* Adjust the spacing offset */
+    .boot-order .list-group {
+        --machines-boot-list-offset: 22rem;
+    }
+
+    /* Add spacer when list-view actions are not visible */
+    .boot-order .list-group-item:not(.is-checked) .list-view-pf-main-info {
+        /* Size of action arrows (26px x 2 - 1px) + padding-left (20px) */
+        margin-right: 71px;
+    }
+}

--- a/pkg/machines/components/vm/bootOrderModal.jsx
+++ b/pkg/machines/components/vm/bootOrderModal.jsx
@@ -1,0 +1,347 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import cockpit from 'cockpit';
+import {
+    Button,
+    ButtonGroup,
+    Icon,
+    ListView,
+    ListViewItem,
+    Modal
+} from 'patternfly-react';
+
+import { ModalError } from './../notification/inlineNotification.jsx';
+import {
+    findHostNodeDevice,
+    getSortedBootOrderDevices,
+    rephraseUI,
+    vmId
+} from '../../helpers.js';
+import {
+    changeBootOrder,
+    getVm
+} from '../../actions/provider-actions.js';
+
+import './bootOrderModal.css';
+
+const _ = cockpit.gettext;
+
+/**
+ * Return an array of devices, which can assigned boot order, with added properties needed for UI.
+ *
+ * @param {object} vm
+ * @returns {array}
+ */
+function getUIBootOrderDevices(vm) {
+    const devices = getSortedBootOrderDevices(vm.inactiveXML);
+
+    devices.forEach(dev => {
+        dev.checked = typeof dev.bootOrder !== 'undefined';
+        dev.initialOrder = parseInt(dev.bootOrder);
+    });
+
+    return devices;
+}
+
+const DeviceInfo = ({ descr, value }) => {
+    return (
+        <div className='ct-form-layout'>
+            <label className='control-label' htmlFor={value}>
+                <output>
+                    {descr}
+                </output>
+            </label>
+            <span id={value}>
+                {value}
+            </span>
+        </div>
+    );
+};
+
+const DeviceRow = ({ idPrefix, device, index, onToggle, upDisabled, downDisabled, moveUp, moveDown, nodeDevices }) => {
+    let heading;
+    let additionalInfo = [];
+
+    const addOptional = (additionalInfo, value, descr) => {
+        if (value) {
+            additionalInfo.push(
+                <DeviceInfo descr={descr} value={value} key={index + descr} />
+            );
+        }
+    };
+
+    switch (device.type) {
+    case "disk": {
+        heading = rephraseUI("bootableDisk", "disk");
+        addOptional(additionalInfo, device.device.source.file, _("File"));
+        addOptional(additionalInfo, device.device.source.dev, _("Device"));
+        addOptional(additionalInfo, device.device.source.protocol, _("Protocol"));
+        addOptional(additionalInfo, device.device.source.pool, _("Pool"));
+        addOptional(additionalInfo, device.device.source.volume, _("Volume"));
+        addOptional(additionalInfo, device.device.source.host.name, _("Host"));
+        addOptional(additionalInfo, device.device.source.host.port, _("Port"));
+        break;
+    }
+    case "network": {
+        heading = rephraseUI("bootableDisk", "network");
+        addOptional(additionalInfo, device.device.mac, _("Mac"));
+        break;
+    }
+    case "redirdev": {
+        heading = rephraseUI("bootableDisk", "redirdev");
+        addOptional(additionalInfo, device.device.type, _("Type"));
+        addOptional(additionalInfo, device.device.bus, _("Bus"));
+        addOptional(additionalInfo, device.device.address.port, _("Port"));
+        break;
+    }
+    case "hostdev": {
+        heading = rephraseUI("bootableDisk", "hostdev");
+        const nodeDev = findHostNodeDevice(device.device, nodeDevices);
+        if (nodeDev) {
+            switch (device.device.type) {
+            case "usb": {
+                addOptional(additionalInfo, device.device.type, _("Type"));
+                addOptional(additionalInfo, nodeDev.capability.vendor._value, _("Vendor"));
+                addOptional(additionalInfo, nodeDev.capability.product._value, _("Product"));
+                break;
+            }
+            case "pci": {
+                addOptional(additionalInfo, device.device.type, _("Type"));
+                addOptional(additionalInfo, nodeDev.capability.vendor._value, _("Vendor"));
+                addOptional(additionalInfo, nodeDev.capability.product._value, _("Product"));
+                break;
+            }
+            case "scsi": {
+                addOptional(additionalInfo, device.device.type, _("Type"));
+                addOptional(additionalInfo, device.device.source.address.bus, _("Bus"));
+                addOptional(additionalInfo, device.device.source.address.target, _("Target"));
+                addOptional(additionalInfo, device.device.source.address.unit, _("Unit"));
+                break;
+            }
+            case "scsi_host": {
+                addOptional(additionalInfo, device.device.type, _("Type"));
+                addOptional(additionalInfo, device.device.source.protocol, _("Protocol"));
+                addOptional(additionalInfo, device.device.source.wwpn, _("WWPN"));
+                break;
+            }
+            case "mdev": {
+                addOptional(additionalInfo, device.device.type, _("Type"));
+                addOptional(additionalInfo, nodeDev.capability.type.id, _("Type ID"));
+                break;
+            }
+            }
+        }
+        break;
+    }
+    }
+
+    const upArrow = <Button disabled={upDisabled} onClick={moveUp}><Icon id={`${idPrefix}-up`} type="fa" name="angle-up" /></Button>;
+    const downArrow = <Button disabled={downDisabled} onClick={moveDown}><Icon id={`${idPrefix}-down`} type="fa" name="angle-down" /></Button>;
+
+    const actions = (
+        <ButtonGroup>
+            {upArrow}
+            {downArrow}
+        </ButtonGroup>
+    );
+
+    const checkbox = (
+        <label htmlFor={`${idPrefix}-device-row-${index}-checkbox`}>
+            <input id={`${idPrefix}-device-row-${index}-checkbox`} type="checkbox" checked={device.checked} onChange={onToggle} />
+        </label>
+    );
+
+    return (
+        <ListViewItem
+            id={`${idPrefix}-device-row-${index}`}
+            className={ device.checked ? "is-checked" : "" }
+            checkboxInput={checkbox}
+            heading={heading}
+            additionalInfo={additionalInfo}
+            actions={actions}
+        />
+    );
+};
+
+export class BootOrderModal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            devices: getUIBootOrderDevices(props.vm),
+        };
+        this.dialogErrorSet = this.dialogErrorSet.bind(this);
+        this.close = props.close;
+        this.save = this.save.bind(this);
+        this.onToggleDevice = this.onToggleDevice.bind(this);
+        this.moveUp = this.moveUp.bind(this);
+        this.moveDown = this.moveDown.bind(this);
+    }
+
+    dialogErrorSet(text, detail) {
+        this.setState({ dialogError: text, dialogErrorDetail: detail });
+    }
+
+    save() {
+        const { dispatch, vm } = this.props;
+        const devices = this.state.devices.filter((device) => device.checked);
+
+        dispatch(changeBootOrder({
+            vm,
+            devices,
+        }))
+                .fail(exc => this.dialogErrorSet(_("Boot order settings could not be saved"), exc.message))
+                .then(() => {
+                    dispatch(getVm({ connectionName: vm.connectionName, id: vm.id }));
+                    this.close();
+                });
+    }
+
+    onToggleDevice(device) {
+        // create new array so we don't edit state
+        const devices = [...this.state.devices];
+
+        devices[devices.indexOf(device)].checked = !devices[devices.indexOf(device)].checked;
+
+        this.setState({ devices: devices });
+    }
+
+    moveUp(device) {
+        const direction = -1;
+        // create new array so we don't edit state
+        const devices = [...this.state.devices];
+
+        const index = devices.indexOf(device);
+        const tmp = devices[index + direction];
+        devices[index + direction] = devices[index];
+        devices[index] = tmp;
+
+        this.setState({ devices: devices });
+    }
+
+    moveDown(device) {
+        const direction = 1;
+        // create new array so we don't edit state
+        const devices = [...this.state.devices];
+
+        const index = devices.indexOf(device);
+        const tmp = devices[index + direction];
+        devices[index + direction] = devices[index];
+        devices[index] = tmp;
+
+        this.setState({ devices: devices });
+    }
+
+    render() {
+        const { nodeDevices, vm } = this.props;
+        const idPrefix = vmId(vm.name) + '-order-modal';
+
+        /**
+         * Returns whetever state of device represented in UI has changed
+         *
+         * @param {object} device
+         * @param {number} index order of device in list
+         * @returns {boolean}
+         */
+        function deviceStateHasChanged(device, index) {
+            // device was selected
+            if (device.checked && !device.initialOrder)
+                return true;
+
+            // device was unselected
+            if (!device.checked && device.initialOrder)
+                return true;
+
+            // device was moved in boot order list
+            if (device.initialOrder && device.initialOrder !== index + 1)
+                return true;
+
+            return false;
+        }
+
+        const showFooterWarning = () => {
+            if (vm.state === "running" &&
+                this.state.devices.some((device, index) => deviceStateHasChanged(device, index))) {
+                return (
+                    <div className="idle-message">
+                        <i className='pficon pficon-pending' />
+                        <span id={`${idPrefix}-min-message`}>{_("Changes will take effect after shutting down the VM")}</span>
+                    </div>
+                );
+            }
+        };
+
+        const defaultBody = (
+            <div className="list-group dialog-list-ct">
+                <ListView className="boot-order-list-view">
+                    {this.state.devices.map((device, index) => {
+                        const nextDevice = this.state.devices[index + 1];
+                        return <DeviceRow
+                                    key={index}
+                                    idPrefix={idPrefix}
+                                    index={index}
+                                    device={device}
+                                    onClick={() => this.onToggleDevice(device)}
+                                    onToggle={() => this.onToggleDevice(device)}
+                                    upDisabled={!index || !device.checked}
+                                    downDisabled={index + 1 == this.state.devices.length || !nextDevice.checked}
+                                    moveUp={() => this.moveUp(device)}
+                                    moveDown={() => this.moveDown(device)}
+                                    nodeDevices={nodeDevices}
+                        />;
+                    })}
+                </ListView>
+            </div>
+        );
+
+        const title = _("Boot Order");
+
+        return (
+            <Modal id={`${idPrefix}-window`} show onHide={this.close} className='boot-order'>
+                <Modal.Header>
+                    <Modal.CloseButton onClick={this.close} />
+                    <Modal.Title> {`${vm.name} ${title}`} </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {defaultBody}
+                </Modal.Body>
+                <Modal.Footer>
+                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                    {showFooterWarning()}
+                    <Button id={`${idPrefix}-cancel`} bsStyle='default' onClick={this.close}>
+                        {_("Cancel")}
+                    </Button>
+                    <Button id={`${idPrefix}-save`} bsStyle='primary' onClick={this.save}>
+                        {_("Save")}
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+BootOrderModal.propTypes = {
+    close: PropTypes.func.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    vm: PropTypes.object.isRequired,
+    nodeDevices: PropTypes.array.isRequired,
+};
+
+export default BootOrderModal;

--- a/pkg/machines/components/vm/vm.jsx
+++ b/pkg/machines/components/vm/vm.jsx
@@ -40,7 +40,7 @@ const _ = cockpit.gettext;
 /** One VM in the list (a row)
  */
 const Vm = ({ vm, config, hostDevices, storagePools, onStart, onInstall, onShutdown, onPause, onResume, onForceoff, onReboot, onForceReboot,
-              onUsageStartPolling, onUsageStopPolling, onSendNMI, dispatch, networks, resourceHasError, onAddErrorNotification }) => {
+              onUsageStartPolling, onUsageStopPolling, onSendNMI, dispatch, networks, nodeDevices, resourceHasError, onAddErrorNotification }) => {
     const stateAlert = resourceHasError[vm.id] ? <span className='pficon-warning-triangle-o machines-status-alert' /> : null;
     const stateIcon = (<StateIcon state={vm.state} config={config} valueId={`${vmId(vm.name)}-state`} extra={stateAlert} />);
 
@@ -51,7 +51,7 @@ const Vm = ({ vm, config, hostDevices, storagePools, onStart, onInstall, onShutd
     const consolesTabName = (<div id={`${vmId(vm.name)}-consoles`}>{_("Consoles")}</div>);
 
     let tabRenderers = [
-        { name: overviewTabName, renderer: VmOverviewTab, data: { vm, config, dispatch } },
+        { name: overviewTabName, renderer: VmOverviewTab, data: { vm, config, dispatch, nodeDevices } },
         { name: usageTabName, renderer: VmUsageTab, data: { vm, onUsageStartPolling, onUsageStopPolling }, presence: 'onlyActive' },
         { name: disksTabName, renderer: VmDisksTab, data: { vm, config, storagePools, onUsageStartPolling, onUsageStopPolling, dispatch, onAddErrorNotification }, presence: 'onlyActive' },
         { name: networkTabName, renderer: VmNetworkTab, data: { vm, dispatch, config, hostDevices, networks, onAddErrorNotification } },
@@ -131,6 +131,7 @@ Vm.propTypes = {
     networks: PropTypes.array.isRequired,
     resourceHasError: PropTypes.object.isRequired,
     onAddErrorNotification: PropTypes.func.isRequired,
+    nodeDevices: PropTypes.array.isRequired,
 };
 
 export default Vm;

--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -18,27 +18,19 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { OverlayTrigger, Tooltip } from "patternfly-react";
 
 import cockpit from 'cockpit';
 import { changeNetworkState, getVm } from "../actions/provider-actions.js";
 import { Listing, ListingRow } from 'cockpit-components-listing.jsx';
 import { rephraseUI, vmId } from "../helpers.js";
 import EditNICAction from './nicEdit.jsx';
+import WarningInactive from './warningInactive.jsx';
 import './nicEdit.css';
 
 const _ = cockpit.gettext;
 
 const VmNetworkTab = function ({ vm, dispatch, config, hostDevices, networks, onAddErrorNotification }) {
     const id = vmId(vm.name);
-
-    const warningInactive = (id) => {
-        return (
-            <OverlayTrigger overlay={ <Tooltip id="tip-network">{ _("Changes will take effect after shutting down the VM") }</Tooltip> } placement='top'>
-                <i id={id} className='pficon pficon-pending' />
-            </OverlayTrigger>
-        );
-    };
 
     const nicLookupByMAC = (interfacesList, mac) => {
         return interfacesList.filter(iface => iface.mac == mac)[0];
@@ -94,7 +86,7 @@ const VmNetworkTab = function ({ vm, dispatch, config, hostDevices, networks, on
             return (
                 <div id={`${id}-network-${networkId}-type`}>
                     {network.type}
-                    {inactiveNIC && inactiveNIC.type !== network.type && warningInactive(`${id}-network-${networkId}-type-tooltip`)}
+                    {inactiveNIC && inactiveNIC.type !== network.type && <WarningInactive iconId={`${id}-network-${networkId}-type-tooltip`} tooltipId="tip-network" />}
                 </div>
             );
         } },
@@ -103,7 +95,7 @@ const VmNetworkTab = function ({ vm, dispatch, config, hostDevices, networks, on
             return (
                 <div id={`${id}-network-${networkId}-model`}>
                     {network.model}
-                    {inactiveNIC && inactiveNIC.model !== network.model && warningInactive(`${id}-network-${networkId}-model-tooltip`)}
+                    {inactiveNIC && inactiveNIC.model !== network.model && <WarningInactive iconId={`${id}-network-${networkId}-model-tooltip`} tooltipId="tip-network" />}
                 </div>
             );
         } },
@@ -124,7 +116,7 @@ const VmNetworkTab = function ({ vm, dispatch, config, hostDevices, networks, on
                 return (
                     <div id={`${id}-network-${networkId}-source`}>
                         {mapSource[network.type](network.source, networkId)}
-                        {inactiveNIC && inactiveNIC.source[inactiveNIC.type] !== network.source[network.type] && warningInactive(`${id}-network-${networkId}-source-tooltip`)}
+                        {inactiveNIC && inactiveNIC.source[inactiveNIC.type] !== network.source[network.type] && <WarningInactive iconId={`${id}-network-${networkId}-source-tooltip`} tooltipId="tip-network" />}
 
                     </div>
                 );

--- a/pkg/machines/components/warningInactive.css
+++ b/pkg/machines/components/warningInactive.css
@@ -1,0 +1,3 @@
+.pficon-pending {
+    margin-left: 0.5rem;
+}

--- a/pkg/machines/components/warningInactive.jsx
+++ b/pkg/machines/components/warningInactive.jsx
@@ -1,0 +1,22 @@
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cockpit from 'cockpit';
+import { OverlayTrigger, Tooltip } from "patternfly-react";
+
+const _ = cockpit.gettext;
+
+const WarningInactive = ({ iconId, tooltipId }) => {
+    return (
+        <OverlayTrigger overlay={ <Tooltip id={tooltipId}>{ _("Changes will take effect after shutting down the VM") }</Tooltip> } placement='top'>
+            <i id={iconId} className='pficon pficon-pending' />
+        </OverlayTrigger>
+    );
+};
+
+WarningInactive.propTypes = {
+    iconId: PropTypes.string.isRequired,
+    tooltipId: PropTypes.string.isRequired,
+};
+
+export default WarningInactive;

--- a/pkg/machines/constants/provider-action-types.js
+++ b/pkg/machines/constants/provider-action-types.js
@@ -19,6 +19,7 @@
 
 // --- Provider actions -----------------------------------------
 export const ATTACH_DISK = "ATTACH_DISK";
+export const CHANGE_BOOT_ORDER = "CHANGE_BOOT_ORDER";
 export const CHANGE_NETWORK_SETTINGS = "CHANGE_NETWORK_SETTINGS";
 export const CHANGE_NETWORK_STATE = "CHANGE_NETWORK_STATE";
 export const CHANGE_VM_AUTOSTART = "CHANGE_VM_AUTOSTART";

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -73,7 +73,7 @@ class HostVmsList extends React.Component {
     }
 
     render() {
-        const { vms, config, ui, storagePools, dispatch, actions, networks } = this.props;
+        const { vms, config, ui, storagePools, dispatch, actions, networks, nodeDevices } = this.props;
         const combinedVms = [...vms, ...this.asDummVms(vms, ui.vms)];
 
         const sortFunction = (vmA, vmB) => vmA.name.localeCompare(vmB.name);
@@ -155,6 +155,7 @@ class HostVmsList extends React.Component {
                                     onUsageStopPolling={() => dispatch(usageStopPolling(vm))}
                                     dispatch={dispatch}
                                     networks={networks}
+                                    nodeDevices={nodeDevices}
                                     key={`${vmId(vm.name)}`}
                                 />);
                         })}
@@ -172,6 +173,7 @@ HostVmsList.propTypes = {
     networks: PropTypes.array.isRequired,
     resourceHasError: PropTypes.object.isRequired,
     onAddErrorNotification: PropTypes.func.isRequired,
+    nodeDevices: PropTypes.array.isRequired,
 };
 
 export default HostVmsList;

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -88,6 +88,7 @@ import {
     resolveUiState,
     serialConsoleCommand,
     unknownConnectionName,
+    updateBootOrder,
     updateVCPUSettings,
     CONSOLE_VM,
     CHECK_LIBVIRT_STATUS,
@@ -198,6 +199,18 @@ LIBVIRT_DBUS_PROVIDER = {
 
         // Error handling is done from the calling side
         return () => call(connectionName, vmId, 'org.libvirt.Domain', 'AttachDevice', [xmlDesc, flags], TIMEOUT);
+    },
+
+    CHANGE_BOOT_ORDER({
+        id: objPath,
+        connectionName,
+        devices,
+    }) {
+        return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [0], TIMEOUT)
+                .then(domXml => {
+                    let updatedXML = updateBootOrder(domXml, devices);
+                    return call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'DomainDefineXML', [updatedXML], TIMEOUT);
+                });
     },
 
     CHANGE_NETWORK_SETTINGS({

--- a/pkg/ovirt/components/App.jsx
+++ b/pkg/ovirt/components/App.jsx
@@ -135,6 +135,7 @@ const HostVmsListDecorated = ({ vms, config, systemInfo, ui, dispatch, host }) =
                          config={config}
                          systemInfo={systemInfo}
                          ui={ui}
+                         nodeDevices={[]}
                          storagePools={[]}
                          dispatch={dispatch}
                          networks={[]}

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -129,6 +129,72 @@ class TestMachinesDBus(machineslib.TestMachines):
         autostartState = m.execute("virsh dominfo subVmTest1 | grep 'Autostart:' | awk '{print $2}'").strip()
         self.assertEqual(autostartState, "enable")
 
+    def testBootOrder(self):
+        b = self.browser
+
+        self.startVm("subVmTest1")
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual Machines")
+        b.wait_present("tbody tr th")
+        b.wait_in_text("tbody tr th", "subVmTest1")
+
+        b.click("tbody tr th") # click on the row header
+        b.wait_present("#vm-subVmTest1-state")
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+
+        # Wait for the edit button
+        b.wait_present("#vm-subVmTest1-boot-order")
+        bootOrder = b.text("#vm-subVmTest1-boot-order")
+
+        # Open dialog
+        b.click("#vm-subVmTest1-boot-order")
+        b.wait_present("#vm-subVmTest1-order-modal-window")
+        # Make sure the footer warning does not appear
+        b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
+        # Move first device down and check whetever succeeded
+        row = b.text("#vm-subVmTest1-order-modal-device-row-1 .list-view-pf-additional-info")
+        b.click("#vm-subVmTest1-order-modal-device-row-0 #vm-subVmTest1-order-modal-down")
+        b.wait_in_text("#vm-subVmTest1-order-modal-device-row-0 .list-view-pf-additional-info", row)
+        # Make sure the footer warning does appear
+        b.wait_present("#vm-subVmTest1-order-modal-min-message")
+
+        # Save
+        b.click("#vm-subVmTest1-order-modal-save")
+        b.wait_not_present("#vm-subVmTest1-order-modal-window")
+        # Make sure warning next to boot order appears
+        b.wait_present("#boot-order-tooltip")
+
+        # Shut off domain and check changes are applied
+        b.click("#vm-subVmTest1-off-caret")
+        b.wait_visible("#vm-subVmTest1-forceOff")
+        b.click("#vm-subVmTest1-forceOff")
+        b.wait_in_text("#vm-subVmTest1-state", "shut off")
+
+        # Check boot order has changed and no warning is shown
+        b.wait_not_in_text("#vm-subVmTest1-boot-order", bootOrder)
+        b.wait_not_present("#boot-order-tooltip")
+
+        bootOrder = b.text("#vm-subVmTest1-boot-order")
+
+        # Open dialog
+        b.click("#vm-subVmTest1-boot-order")
+        b.wait_present("#vm-subVmTest1-order-modal-window")
+        # Make sure the footer warning does not appear
+        b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
+        # Unselect second device
+        b.click("#vm-subVmTest1-order-modal-device-row-1 input")
+        # Make sure the footer warning still does not appear, since machine is shut down
+        b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
+
+        # Save
+        b.click("#vm-subVmTest1-order-modal-save")
+        b.wait_not_present("#vm-subVmTest1-order-modal-window")
+
+        # Check boot order has changed and no warning is shown
+        b.wait_not_in_text("#vm-subVmTest1-boot-order", bootOrder)
+        b.wait_not_present("#boot-order-tooltip")
+
     def testDetachDisk(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Boot order defines order, in which devices will be booted. You can select which specific devices should be bootable. Right now, only disks and networks are supported as bootable devices.