### PR TITLE
package.json: Fix @babel/polyfill version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "angular-bootstrap-npm": "0.13.4",
     "angular-gettext": "2.3.11",
     "angular-route": "1.3.20",
-    "@babel/polyfill": "^7.0.0",
+    "@babel/polyfill": "7.2.3",
     "bootstrap": "3.3.7",
     "bootstrap-datepicker": "1.8.0",
     "c3": "0.4.23",


### PR DESCRIPTION
This is a runtime dependency, so it should be controlled by
bots/npm-update.

This was introduced in commit cb00db034f4.