### PR TITLE
machines: fix preparation of disk data for disks of type volume

### DIFF
--- a/pkg/machines/components/vmDisksTabLibvirt.jsx
+++ b/pkg/machines/components/vmDisksTabLibvirt.jsx
@@ -118,12 +118,13 @@ class VmDisksTabLibvirt extends React.Component {
         const idPrefix = `${vmId(vm.name)}-disks`;
         const areDiskStatsSupported = this.getDiskStatsSupport(vm);
 
+        const filteredStoragePools = storagePools.filter(pool => pool.connectionName == vm.connectionName);
         const disks = Object.getOwnPropertyNames(vm.disks)
                 .sort() // by 'target'
                 .map(target => this.prepareDiskData(vm.disks[target],
                                                     vm.disksStats && vm.disksStats[target],
                                                     `${idPrefix}-${target}`,
-                                                    storagePools));
+                                                    filteredStoragePools));
         let actions = [];
 
         if (config.provider.name != 'oVirt')


### PR DESCRIPTION
When filtering storage pools by name to match a pool that a disk resides
on we need to take into consideration the connection as well, because there
can be pools with same name on system and session connection.

https://bugzilla.redhat.com/show_bug.cgi?id=1661897