### PR TITLE
machines: add disk format field when creating new disk xml

### DIFF
--- a/pkg/machines/actions/provider-actions.js
+++ b/pkg/machines/actions/provider-actions.js
@@ -66,8 +66,8 @@ import {
  *  The naming convention for action creator names is: <verb><Noun>
  *  with the present tense.
  */
-export function attachDisk({ connectionName, poolName, volumeName, target, permanent, hotplug, vmName, vmId }) {
-    return virt(ATTACH_DISK, { connectionName, poolName, volumeName, target, permanent, hotplug, vmName, vmId });
+export function attachDisk({ connectionName, poolName, volumeName, format, target, permanent, hotplug, vmName, vmId }) {
+    return virt(ATTACH_DISK, { connectionName, poolName, volumeName, format, target, permanent, hotplug, vmName, vmId });
 }
 
 export function changeNetworkSettings({ vm, macAddress, networkType, networkSource, networkModel }) {

--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -390,6 +390,7 @@ class AddDiskModalBody extends React.Component {
         return dispatch(attachDisk({ connectionName: vm.connectionName,
                                      poolName: this.state.storagePoolName,
                                      volumeName: this.state.existingVolumeName,
+                                     format: this.state.diskFileFormat,
                                      target: this.state.target,
                                      permanent: this.state.permanent,
                                      hotplug: this.state.hotplug,

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -164,6 +164,7 @@ LIBVIRT_DBUS_PROVIDER = {
         connectionName,
         poolName,
         volumeName,
+        format,
         target,
         vmId,
         vmName,
@@ -176,7 +177,7 @@ LIBVIRT_DBUS_PROVIDER = {
         if (permanent)
             flags |= Enum.VIR_DOMAIN_AFFECT_CONFIG;
 
-        let xmlDesc = getDiskXML(poolName, volumeName, target);
+        let xmlDesc = getDiskXML(poolName, volumeName, format, target);
 
         // Error handling is done from the calling side
         return () => call(connectionName, vmId, 'org.libvirt.Domain', 'AttachDevice', [xmlDesc, flags], TIMEOUT);
@@ -272,7 +273,7 @@ LIBVIRT_DBUS_PROVIDER = {
                     return call(connectionName, storagePoolPath[0], 'org.libvirt.StoragePool', 'StorageVolCreateXML', [volXmlDesc, 0], TIMEOUT);
                 })
                 .then((volPath) => {
-                    return dispatch(attachDisk({ connectionName, poolName, volumeName, target, vmId, permanent, hotplug }));
+                    return dispatch(attachDisk({ connectionName, poolName, volumeName, format, target, vmId, permanent, hotplug }));
                 });
     },
 

--- a/pkg/machines/libvirt-virsh.js
+++ b/pkg/machines/libvirt-virsh.js
@@ -276,11 +276,11 @@ LIBVIRT_PROVIDER = {
         return dispatch => cockpit.script(command, null, {err: "message", environ: ['LC_ALL=en_US.UTF-8']})
                 .then(() => {
                     logDebug('Storage volume created, poolName: ', poolName, ', volumeName: ', volumeName);
-                    return dispatch(attachDisk({ connectionName, poolName, volumeName, target, vmName, permanent, hotplug }));
+                    return dispatch(attachDisk({ connectionName, poolName, volumeName, format, target, vmName, permanent, hotplug }));
                 });
     },
 
-    ATTACH_DISK({ connectionName, poolName, volumeName, target, vmName, permanent, hotplug }) {
+    ATTACH_DISK({ connectionName, poolName, volumeName, format, target, vmName, permanent, hotplug }) {
         logDebug(`${this.name}.ATTACH_DISK("`, connectionName, '", "', poolName, '", "', volumeName, '", "', target, '", "', vmName, '"');
         const connection = VMS_CONFIG.Virsh.connections[connectionName].params.join(' ');
         const volpathCommand = `virsh ${connection} vol-path --pool ${poolName} ${volumeName}`;
@@ -289,7 +289,7 @@ LIBVIRT_PROVIDER = {
                 .then((volPath) => {
                     let scope = permanent ? '--config' : '';
                     scope = scope + (hotplug ? ' --live' : '');
-                    const command = `virsh ${connection} attach-disk ${vmName} ${volPath.trim()} ${target} ${scope}`;
+                    const command = `virsh ${connection} attach-disk ${vmName} --driver qemu --subdriver ${format} ${volPath.trim()} ${target} ${scope}`;
 
                     logDebug('ATTACH_DISK command: ', command);
                     return cockpit.script(command, null, {err: "message", environ: ['LC_ALL=en_US.UTF-8']});

--- a/pkg/machines/xmlCreator.js
+++ b/pkg/machines/xmlCreator.js
@@ -1,9 +1,14 @@
-export function getDiskXML(poolName, volumeName, target) {
+export function getDiskXML(poolName, volumeName, format, target) {
     var doc = document.implementation.createDocument('', '', null);
 
     var diskElem = doc.createElement('disk');
     diskElem.setAttribute('type', 'volume');
     diskElem.setAttribute('device', 'disk');
+
+    var driverElem = doc.createElement('driver');
+    driverElem.setAttribute('name', 'qemu');
+    driverElem.setAttribute('type', format);
+    diskElem.appendChild(driverElem);
 
     var sourceElem = doc.createElement('source');
     sourceElem.setAttribute('volume', volumeName);

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -624,6 +624,12 @@ class TestMachines(MachineCase):
         b.wait_in_text("#vm-subVmTest1-disks-vdd-device", "disk")
         b.wait_in_text("#vm-subVmTest1-disks-vdd-source", "mydiskofpooltwo_permanent")
 
+        detect_format_cmd = "virsh dumpxml subVmTest1 | xmllint --xpath '/domain/devices/disk[@type=\"{0}\"]/driver[@type=\"qcow2\"]' -"
+        if self.provider == "libvirt-dbus":
+            m.execute(detect_format_cmd.format("volume"))
+        else:
+            m.execute(detect_format_cmd.format("file"))
+
         # FIXME: This causes either "unable to execute QEMU command 'device_add': Failed to get "write" lock"
         # or adding the _temporary volume results in showing that the _permanent one actually gets added
         # See https://github.com/cockpit-project/cockpit/issues/9945


### PR DESCRIPTION
When creating new disk xml pass explicitly the driver name and type.
Libvirt is not filling these information from the storage volume.

https://bugzilla.redhat.com/show_bug.cgi?id=1662213