### PR TITLE
users: Always create home directory for created users

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -490,7 +490,7 @@ PageAccountsCreate.prototype = {
     create: function() {
         var tasks = [
             function create_user() {
-                var prog = ["/usr/sbin/useradd", "-s", "/bin/bash"];
+                var prog = ["/usr/sbin/useradd", "--create-home", "-s", "/bin/bash"];
                 if ($('#accounts-create-real-name').val()) {
                     prog.push('-c');
                     prog.push($('#accounts-create-real-name').val());

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -89,6 +89,10 @@ class TestAccounts(MachineCase):
         b.wait_popdown('accounts-create-dialog')
         b.wait_in_text('#accounts-list', "Berta Bestimmt")
 
+        # Check home directory
+        self.assertIn(":/home/berta:", m.execute("getent passwd berta"))
+        self.assertEqual(m.execute("stat -c '%U' /home/berta").strip(), "berta")
+
         # Delete it externally
         m.execute("userdel berta")
         b.wait_not_in_text('#accounts-list', "Berta Bestimmt")


### PR DESCRIPTION
useradd's `--create-home` is the default on Fedora/Red Hat, but not on
Debian/Ubuntu.

Fixes #9744