### PR TITLE
README.md: Drop obsolete link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ accessible via SSH.
 ### Development
 
  * [Making changes to Cockpit](HACKING.md)
- * [Adding a new part of Cockpit](https://github.com/cockpit-project/cockpit/wiki/Hackfest)
+ * [How to contribute, developer documentation](https://github.com/cockpit-project/cockpit/wiki/Contributing)
  * IRC Channel: #cockpit on FreeNode
  * [Mailing List](https://lists.fedorahosted.org/admin/lists/cockpit-devel.lists.fedorahosted.org/)
  * [Guiding Principles](https://cockpit-project.org/ideals.html)


### PR DESCRIPTION
The hackfest wiki page is severely out of date and has lots of broken
links. Our canonical place to maintain developer docs is the
"Contributing" wiki page, so point to that one.