### PR TITLE
networkmanager: Connect to firewalld as superuser

### DIFF
--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -34,7 +34,7 @@ const firewalld_service = service.proxy('firewalld');
 var firewalld_dbus = null;
 
 function initFirewalldDbus() {
-    firewalld_dbus = cockpit.dbus('org.fedoraproject.FirewallD1');
+    firewalld_dbus = cockpit.dbus('org.fedoraproject.FirewallD1', { superuser: "try" });
 
     firewalld_dbus.addEventListener('owner', (event, owner) => {
         firewall.enabled = !!owner;


### PR DESCRIPTION
This makes the page work when connecting as a user which has sudo, but
not polkit privileges. (I. e. when they are not in the `wheel` group,
but have an explicit user sudo rule).

https://bugzilla.redhat.com/show_bug.cgi?id=1664158