### PR TITLE
naughty: Close 10700: subscription-manager crashes: the 'dbus-python' distribution was not found

### DIFF
--- a/bots/naughty/rhel-8-0/10700-rhsm-dbus-python
+++ b/bots/naughty/rhel-8-0/10700-rhsm-dbus-python
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-packagekit", line *, in testNoUpdates
-    b.wait_in_text("#system_information_updates_text", "Not Registered")
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 26 days

subscription-manager crashes: the 'dbus-python' distribution was not found

Fixes #10700