### PR TITLE
naughty: Close 9918:  cockpit-ssh crashes on a FIPS 140-2 compliant system

### DIFF
--- a/bots/naughty/rhel-7/9918-cockpit-ssh-crash-md5
+++ b/bots/naughty/rhel-7/9918-cockpit-ssh-crash-md5
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-multi-machine", line *, in testFIPS
-    add_machine(b, "10.111.113.2")
-  File "test/verify/check-multi-machine", line *, in start_machine_troubleshoot
-    b.wait_in_text('#troubleshoot-dialog', "Fingerprint")
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 21 days

 cockpit-ssh crashes on a FIPS 140-2 compliant system

Fixes #9918