### PR TITLE
naughty: Close 6359: Changing OpenShift TLS certificates/kube config does not work

### DIFF
--- a/bots/naughty/rhel-7/6359-glib-networking-change-cert
+++ b/bots/naughty/rhel-7/6359-glib-networking-change-cert
@@ -1,5 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-openshift", line *, in testReconnectChangeCert
-    b.wait_present("#service-list")
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 21 days

Changing OpenShift TLS certificates/kube config does not work

Fixes #6359