### PR TITLE
storage: Correctly pick up initial navigation location

### DIFF
--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -37,7 +37,7 @@ const _ = cockpit.gettext;
 class StoragePage extends React.Component {
     constructor() {
         super();
-        this.state = { path: [ ] };
+        this.state = { path: cockpit.location.path };
         this.on_client_changed = () => { this.setState({}) };
         this.on_navigate = () => { this.setState({ path: cockpit.location.path }) };
     }


### PR DESCRIPTION
The page would always show the overview, even if loaded with a hash
part in the URL that should make it show the details.