### PR TITLE
bots: Add issues-review script

### DIFF
--- a/bots/issues-review
+++ b/bots/issues-review
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import argparse
+import time
+
+from task import github
+
+def issues_review(api, opts):
+    now = time.time()
+    treshold = opts.age * 86400
+    count = 100
+    page = 1
+    while count == 100:
+        issues = api.get("issues?filter=all&page=%i&per_page=%i" % (page, count))
+        page += 1
+        count = len(issues)
+        for issue in issues:
+            age = now - time.mktime(time.strptime(issue["updated_at"], "%Y-%m-%dT%H:%M:%SZ"))
+            if age >= treshold:
+                print("Labelling #%i last updated at %s" % (issue["number"], issue["updated_at"]))
+                api.post("issues/%i/labels" % issue["number"], [opts.label])
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Add review label to stale issues')
+    parser.add_argument('-a', '--age', metavar='DAYS', default=90,
+                        help='Label issues whose last update is older than given number of days (default: %(default)s)')
+    parser.add_argument('-l', '--label', default=time.strftime('review-%Y-%m'),
+                        help='Label name (default: %(default)s)')
+    parser.add_argument('--repo', help='Work on this GitHub repository (owner/name)')
+    opts = parser.parse_args()
+
+    api = github.GitHub(repo=opts.repo)
+    issues_review(api, opts)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script adds a "review-YYYY-MM" label to all issues of a given
repository (defaulting to cockpit-project/cockpit) that have not been
updated in a given number of days (default 90).

This helps with organizing distributed issue review "spring clean"
activity, to be able to tell apart which bugs still need to be reviewed.
A reviewer updates the issue and then removes the label, that way the
issue list for that review label can be effectively driven to zero.