### PR TITLE
realmd: Disable changing host name when machine is joined to a domain

### DIFF
--- a/pkg/realmd/operation.js
+++ b/pkg/realmd/operation.js
@@ -521,6 +521,7 @@ function setup() {
     var element = $("<span>");
     var link = $("<a>");
     element.append(link);
+    var hostname_link = $("#system_information_hostname_button");
 
     var realmd = null;
     var realms = null;
@@ -547,10 +548,14 @@ function setup() {
                 joined.push(realm);
         }
 
-        if (!joined || !joined.length)
+        if (!joined || !joined.length) {
             text = _("Join Domain");
-        else
+            hostname_link.removeAttr('disabled');
+        } else {
             text = joined.map(function(x) { return x.Name }).join(", ");
+            hostname_link.attr('disabled', 'disabled');
+            hostname_link.attr('title', _("Host name should not be changed in a domain")).tooltip('fixTitle');
+        }
         link.text(text);
     }
 

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -247,7 +247,12 @@ PageServer.prototype = {
             cockpit.jump("/updates", cockpit.transport.host);
         });
 
-        $('#system_information_hostname_button').on('click', function() {
+        $('#system_information_hostname_button').on('click', function(ev) {
+            // you can't disable standard links, so implement this manually; realmd might disable host name changing
+            if (ev.target.getAttribute("disabled")) {
+                ev.preventDefault();
+                return;
+            }
             PageSystemInformationChangeHostname.client = self.client;
             $('#system_information_change_hostname').modal('show');
         });
@@ -708,10 +713,13 @@ PageServer.prototype = {
 
             if (!str)
                 str = _("Set Host name");
-            $("#system_information_hostname_button").text(str);
-            $("#system_information_hostname_button")
-                    .attr("title", str)
-                    .tooltip('fixTitle');
+            var hostname_button = $("#system_information_hostname_button");
+            hostname_button.text(str);
+            if (!hostname_button.attr("disabled")) {
+                hostname_button
+                        .attr("title", str)
+                        .tooltip('fixTitle');
+            }
             $("#system_information_os_text").text(self.hostname_proxy.OperatingSystemPrettyName || "");
         }
 

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -709,7 +709,9 @@ PageServer.prototype = {
             if (!str)
                 str = _("Set Host name");
             $("#system_information_hostname_button").text(str);
-            $("#system_information_hostname_button").attr("title", str);
+            $("#system_information_hostname_button")
+                    .attr("title", str)
+                    .tooltip('fixTitle');
             $("#system_information_os_text").text(self.hostname_proxy.OperatingSystemPrettyName || "");
         }
 

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -124,6 +124,16 @@ class TestRealms(MachineCase):
             # Check that this has worked
             wait_number_domains(1)
 
+        # when joined to a domain, changing the hostname is fatal, so should be disabled
+        if m.image != "rhel-7-6-distropkg":
+            # fixed in Cockpit 186
+            b.wait_present("#system_information_hostname_button[disabled]")
+            b.mouse("#system_information_hostname_button", "mouseover")
+            b.wait_present(".tooltip-inner")
+            b.wait_in_text(".tooltip-inner", "Host name should not be changed in a domain")
+            b.mouse("#system_information_hostname_button", "mouseout")
+            b.wait_not_present(".tooltip-inner")
+
         # should not have any leftover tickets from the joining
         m.execute("! klist")
         m.execute("! su -c klist admin")
@@ -211,6 +221,8 @@ class TestRealms(MachineCase):
         b.click(".realms-op-apply")
         b.wait_popdown("realms-op")
         wait_number_domains(0)
+        # re-enables hostname changing
+        b.wait_present("#system_information_hostname_button:not([disabled])")
 
         # should have cleaned up ws keytab
         m.execute("! klist -k /etc/cockpit/krb5.keytab | grep COCKPIT.LAN")


### PR DESCRIPTION
Changing the hostname breaks pretty well everything on an IPA/AD joined
machine, so disable this and change the tooltip accordingly.

As `<a>` links don't have a native handling of `disabled`, update the 
host name link's event handler to ignore clicks while the link is
disabled.

Fixes #125