### PR TITLE
Remove temporary hack from css which fixes overflowing alerts

### DIFF
--- a/pkg/lib/page.css
+++ b/pkg/lib/page.css
@@ -178,13 +178,10 @@ a.disabled:hover {
 /* Small list inside a dialog */
 /* Alert fixups */
 
-/* HACK: word-wrap workaround for long alerts https://github.com/patternfly/patternfly/issues/491 */
-
 .modal-content .alert {
     text-align: left;
     padding-top: 5px;
     padding-bottom: 5px;
-    word-wrap: break-word;
 }
 
 .modal-content .alert .fa {

--- a/src/base1/cockpit.css
+++ b/src/base1/cockpit.css
@@ -280,13 +280,10 @@ a {
 
 /* Alert fixups */
 
-/* HACK: word-wrap workaround for long alerts https://github.com/patternfly/patternfly/issues/491 */
-
 .modal-content .alert {
     text-align: left;
     padding-top: 5px;
     padding-bottom: 5px;
-    word-wrap: break-word;
 }
 
 .modal-content .alert .fa {


### PR DESCRIPTION
Fix is merged into patternfly code.
https://github.com/patternfly/patternfly/issues/491

Fixes #5903