### PR TITLE
base1: Fix cockpit's handling of es2015 Promise

### DIFF
--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -115,6 +115,7 @@ base_QUNIT_TESTS = \
 	dist/base1/test-websocket.html \
 	dist/base1/test-stub.html \
 	dist/base1/test-browser-storage.html \
+	dist/base1/test-promise.html \
 	$(NULL)
 
 base_QUNIT_DEPS = \

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -1310,7 +1310,7 @@ function factory() {
             then = values[0] && values[0].then;
         if (is_function(then)) {
             state.status = -1;
-            then.call(values, function(/* ... */) {
+            then.call(values[0], function(/* ... */) {
                 if (done)
                     return;
                 done = true;

--- a/src/base1/test-promise.js
+++ b/src/base1/test-promise.js
@@ -1,0 +1,20 @@
+/* global QUnit, cockpit */
+
+QUnit.test("should be able to dispatch es2015 promises", function (assert) {
+    // https://github.com/cockpit-project/cockpit/issues/10956
+
+    assert.expect(1);
+
+    let done = assert.async();
+    let dfd = cockpit.defer();
+
+    dfd.promise.then(() => Promise.resolve(42))
+            .then(result => {
+                assert.equal(result, 42);
+                done();
+            });
+
+    dfd.resolve();
+});
+
+QUnit.start();


### PR DESCRIPTION
Pass the correct `this` when calling the `then()` method of a promise,
otherwise es2015 promises fail with a `TypeError`.

This is not an issue for cockpit's own promises, because
`create_promise()` is a closure which never touches its `this`.

Fixes #10956