### PR TITLE
ws/session: Use session type "web"

### DIFF
--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -559,6 +559,7 @@ open_session (pam_handle_t *pamh)
       debug ("opening pam session for %s", name);
 
       pam_putenv (pamh, "XDG_SESSION_CLASS=user");
+      pam_putenv (pamh, "XDG_SESSION_TYPE=web");
 
       res = pam_setcred (pamh, PAM_ESTABLISH_CRED);
       if (res != PAM_SUCCESS)

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -50,6 +50,11 @@ class TestSession(MachineCase):
         self.login_and_go("/system")
         wait_session(True)
 
+        # Check session type (fixed in PR #10963)
+        if not m.atomic_image and m.image != "rhel-7-6-distropkg":
+            id = m.execute("loginctl list-sessions | awk '/admin/ {print $1}'").strip()
+            self.assertEqual(m.execute("loginctl show-session -p Type %s" % id).strip(), "Type=web")
+
         # Logout
         b.logout()
         b.wait_visible("#login")


### PR DESCRIPTION
Systemd understands this type since 2014 (although it is not
documented).

Fixes #1098