### PR TITLE
storage: Always round dialog size slider input

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -807,6 +807,9 @@ class SizeSliderElement extends React.Component {
                     value = round(value);
                 else
                     value = Math.round(value / round) * round;
+            } else {
+                // Only produce integers by default
+                value = Math.round(value);
             }
 
             onChange(Math.max(min, value));

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -201,11 +201,11 @@ class Browser:
         #    hash = "/@" + host + hash
         self.call_js_func('ph_go', hash)
 
-    def mouse(self, selector, type_):
-        self.eval_js("ph_mouse_event(ph_find('%s'), '%s')" % (selector, type_))
+    def mouse(self, selector, type, x=0, y=0, btn=0, force=False):
+        self.call_js_func('ph_mouse', selector, type, x, y, btn, force)
 
     def click(self, selector, force=False):
-        self.call_js_func('ph_click', selector, force)
+        self.mouse(selector, "click", 0, 0, 0, force)
 
     def val(self, selector):
         return self.call_js_func('ph_val', selector)

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -61,6 +61,45 @@ class TestStorage(StorageCase):
         self.confirm()
         self.content_row_wait_in_col(1, 1, "Free Space")
 
+    def testSizeSlider(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+        b.wait_in_text("#drives", "VirtIO")
+
+        m.add_disk("50M", serial="DISK1")
+        b.wait_in_text("#drives", "DISK1")
+        b.click('#drives tr:contains("DISK1")')
+        b.wait_present('#storage-detail')
+
+        b.wait_visible('button:contains(Create partition table)')
+        b.click('button:contains(Create partition table)')
+        self.dialog({"type": "gpt"})
+        self.content_row_wait_in_col(1, 1, "Free Space")
+
+        self.content_row_action(1, "Create Partition")
+        self.dialog_wait_open()
+        self.dialog_set_val("type", "empty")
+
+        slider = self.dialog_field("size") + " .slider"
+
+        # Move the slider one pixel past the middle, this should give a fractional size.
+        # See https://github.com/cockpit-project/cockpit/pull/10968 for more about this.
+        width = b.call_js_func('(function (sel) { return ph_find(sel).offsetWidth; })', slider)
+        about_half_way = width / 2 + 1
+
+        b.mouse(slider, "mousedown", about_half_way, 0)
+        b.mouse(slider, "mouseup", about_half_way, 0)
+        self.dialog_wait_val("size", 25.1)
+
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        # With old Udisks2 versions, the partition will end up being
+        # 25.1M while newer versions give us 26M.
+        wait(lambda: m.execute("lsblk -no SIZE /dev/sda1").strip() in ["25.1M", "26M"])
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Otherwise we will very likely pass a non-integer number to the D-Bus
call, which will fail.

This affects the size slider for new partitions, and without this fix,
setting a size for a new partition with the slider will cause a
unhelpful error message.