### PR TITLE
systemd: Port System overview to ct-form-layout

### DIFF
--- a/pkg/realmd/operation.js
+++ b/pkg/realmd/operation.js
@@ -660,7 +660,8 @@ function setup() {
 jQuery(function() {
     var placeholder = jQuery("#system-info-domain");
     if (placeholder.length) {
-        placeholder.find(".button-location").append(setup());
+        placeholder.append(setup());
         placeholder.removeAttr('hidden');
+        placeholder.prev().removeAttr('hidden');
     }
 });

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -629,12 +629,6 @@ thead.credential-lock.credential-unlocked > *:last-child {
 
 /* System information */
 
-#system-info-domain-list {
-    padding:0px;
-    padding-top:15px;
-    border: none;
-}
-
 #systime-date-input {
     display: inline;
     width: 150px;

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -236,7 +236,7 @@ a.disabled {
     word-wrap: break-word;
 }
 
-#system_information_machine_id_row .tooltip-inner {
+.system_information_machine_id_tooltip .tooltip-inner {
     font-family: monospace;
     max-width: 35em;
 }

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -20,6 +20,48 @@ a.disabled {
     white-space: nowrap;
 }
 
+body {
+  /* Work around a pesky scrollbar on the page, due to 100% height */
+  height: auto;
+}
+
+.server-overview {
+    display: grid;
+    grid-gap: 0 2rem;
+    /* By default, horizontally stack the grid elements */
+    grid-template-areas: "motd" "info" "graphs";
+    grid-template-columns: 1fr;
+    margin: 2rem;
+    padding: 0;
+}
+
+@media screen and (min-width: 640px) {
+    /* Lay out overview in a grid, if there's enough width */
+    .server-overview {
+        grid-template-areas: "motd motd" "info graphs";
+        grid-template-columns: auto 1fr;
+    }
+}
+
+.server-overview > .info-table-ct-container {
+    grid-area: info;
+}
+
+.server-overview > .server-graphs {
+    grid-area: graphs;
+}
+
+.server-overview > .motd-box {
+    grid-area: motd;
+}
+
+/* Flot needs a little coaxing to behave */
+.server-graphs canvas,
+.server-graphs .flot-text {
+  max-width: 100%;
+  overflow: hidden;
+}
+
 .systime-inline form .pficon-close,
 .systime-inline form .fa-plus {
     height: 26px;

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -278,9 +278,10 @@ body {
     word-wrap: break-word;
 }
 
-.system_information_machine_id_tooltip .tooltip-inner {
+#system_machine_id {
+    display: inline-block;
     font-family: monospace;
-    max-width: 35em;
+    word-break: break-all;
 }
 
 @media (min-width: 500px) {

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -518,9 +518,7 @@ PageServer.prototype = {
         var machine_id = cockpit.file("/etc/machine-id");
         machine_id.read()
                 .done(function(content) {
-                    $("#system_machine_id")
-                            .text(content)
-                            .tooltip({ title: content, placement: "bottom" });
+                    $("#system_machine_id").text(content);
                 })
                 .fail(function(ex) {
                     console.error("Error reading machine id", ex);

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -29,6 +29,8 @@ import * as service from "service.js";
 import { shutdown } from "./shutdown.js";
 import host_keys_script from "raw-loader!./ssh-list-host-keys.sh";
 
+import "form-layout.less";
+
 /* These add themselves to jQuery so just including is enough */
 import "patterns";
 import "bootstrap-datepicker/dist/js/bootstrap-datepicker";
@@ -239,7 +241,9 @@ PageServer.prototype = {
             $('#motd-box').hide();
         });
 
-        $('#shutdown-group [data-action]').on("click", function() {
+        $('#shutdown-group [data-action]').on("click", function(ev) {
+            // don't let the click "fall through" to the dialog that we are about to open
+            ev.preventDefault();
             self.shutdown($(this).attr('data-action'));
         });
 
@@ -352,13 +356,17 @@ PageServer.prototype = {
         var packagekit_exists = false;
 
         function update_pmlogger_row() {
+            var logger_switch = $("#server-pmlogger-switch");
+            var enable_pcp = $('#system-information-enable-pcp-link');
             if (!pmlogger_exists) {
-                $('#system-information-enable-pcp').toggle(packagekit_exists);
-                $('#server-pmlogger-onoff-row').hide();
+                enable_pcp.toggle(packagekit_exists);
+                logger_switch.hide();
+                logger_switch.prev().hide();
             } else if (!pmlogger_promise) {
-                $('#system-information-enable-pcp').hide();
-                $("#server-pmlogger-switch").onoff('value', pmlogger_service.enabled);
-                $('#server-pmlogger-onoff-row').show();
+                enable_pcp.hide();
+                logger_switch.onoff('value', pmlogger_service.enabled);
+                logger_switch.show();
+                logger_switch.prev().show();
             }
         }
 
@@ -691,9 +699,10 @@ PageServer.prototype = {
                             .tooltip({ title: _("Click to see system hardware information"), placement: "bottom" })
                             .text(fields.sys_vendor + " " + fields.product_name);
                     var present = !!(fields.product_serial || fields.chassis_serial);
-                    $("#system_information_asset_tag_text")
-                            .text(fields.product_serial || fields.chassis_serial);
-                    $("#system-info-asset-row").toggle(present);
+                    let text = $("#system_information_asset_tag_text");
+                    text.text(fields.product_serial || fields.chassis_serial);
+                    text.toggle(present);
+                    text.prev().toggle(present);
                 })
                 .fail(function(ex) {
                     debug("couldn't read dmi info: " + ex);
@@ -851,6 +860,7 @@ PageServer.prototype = {
 
     sysroot_changed: function() {
         var self = this;
+        var link = $("#system-ostree-version-link");
 
         if (self.sysroot.Booted && self.ostree_client) {
             var version = "";
@@ -868,12 +878,13 @@ PageServer.prototype = {
                         console.log(ex);
                     })
                     .always(function() {
-                        $("#system-ostree-version").toggleClass("hidden", !version);
-                        $("#system-ostree-version-link").text(version);
+                        link.toggleClass("hidden", !version);
+                        link.prev().toggleClass("hidden", !version);
+                        link.text(version);
                     });
         } else {
-            $("#system-ostree-version").toggleClass("hidden", true);
-            $("#system-ostree-version-link").text("");
+            link.toggleClass("hidden", true);
+            link.text("");
         }
     },
 

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -71,18 +71,18 @@
       {{/SubStatus}}
     </script>
 
-    <div id="motd-box" class="container-fluid page-ct" hidden>
-      <div class="alert alert-info">
-        <button type="button" class="close" aria-hidden="true">
-          <span class="pficon pficon-close"></span>
-        </button>
-        <span class="pficon pficon-info"></span>
-        <pre id="motd"></pre>
-      </div>
-    </div>
+    <div id="server" class="container-fluid page-ct server-overview">
+        <div id="motd-box" class="motd-box" hidden>
+          <div class="alert alert-info">
+            <button type="button" class="close" aria-hidden="true">
+              <span class="pficon pficon-close"></span>
+            </button>
+            <span class="pficon pficon-info"></span>
+            <pre id="motd"></pre>
+          </div>
+        </div>
 
-    <div id="server" class="container-fluid page-ct">
-        <div class="col-md-4 col-lg-3 info-table-ct-container">
+        <div class="info-table-ct-container">
             <form class="ct-form-layout">
                 <label class="control-label" for="system_information_hardware_text" translatable="yes">Hardware</label>
                 <span> <!-- wrap the <a> so that it doesn't stretch to the whole page width; otherwise tooltip looks bad -->
@@ -173,7 +173,7 @@
             </form>
         </div>
 
-        <div id="server-graph-columns" class="col-md-8 col-lg-9" role="presentation">
+        <div id="server-graph-columns" class="server-graphs" role="presentation">
             <div id="server-graph-toolbar" class="zoom-controls standard-zoom-controls">
                 <div class="dropdown">
                     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -83,113 +83,96 @@
 
     <div id="server" class="container-fluid page-ct">
         <div class="col-md-4 col-lg-3 info-table-ct-container">
-            <table class="info-table-ct">
-                <tr>
-                    <td translatable="yes">Hardware</td>
-                    <td><a id="system_information_hardware_text"></a></td>
-                </tr>
-                <tr id="system-info-asset-row">
-                    <td translatable="yes">Asset Tag</td>
-                    <td id="system_information_asset_tag_text"></td>
-                </tr>
-                <tr id="system_information_machine_id_row">
-                    <td translatable="yes">Machine ID</td>
-                    <td><span id="system_machine_id"></span></td>
-                </tr>
-                <tr id="system_information_os">
-                    <td translatable="yes">Operating System</td>
-                    <td id="system_information_os_text"></td>
-                </tr>
-                <tr id="system_information_updates">
-                    <td>
-                        <span id="system_information_updates_icon" hidden></span>
-                    </td>
-                    <td id="system_information_updates_text"></td>
-                </tr>
-                <tr id="system-ssh-keys">
-                    <td translatable="yes">Secure Shell Keys</td>
-                    <td><a id="system-ssh-keys-link" translatable="yes" data-toggle="modal"
-                           data-target="#system_information_ssh_keys">Show fingerprints</a></td>
-                </tr>
-                <tr id="system-ostree-version" class="hidden">
-                    <td translatable="yes">Version</td>
-                    <td><a id="system-ostree-version-link"></a></td>
-                </tr>
-                <tr>
-                    <td translatable="yes">Host Name</td>
-                    <td><span id="hostname-tooltip"><a class="hostname-privileged"
-                            id="system_information_hostname_button"></a></span></td>
-                </tr>
-                <tr id="system-info-domain" hidden>
-                    <td translatable="yes">Domain</td>
-                    <td class="button-location">
-                    </td>
-                </tr>
-                <tr>
-                    <td translatable="yes">System Time</td>
-                    <td><span id="systime-tooltip">
-                        <a class="systime-privileged"
-                           id="system_information_systime_button"></a></span>
+            <form class="ct-form-layout">
+                <label class="control-label" for="system_information_hardware_text" translatable="yes">Hardware</label>
+                <span> <!-- wrap the <a> so that it doesn't stretch to the whole page width; otherwise tooltip looks bad -->
+                    <a id="system_information_hardware_text"></a>
+                </span>
+
+                <label class="control-label" for="system_information_asset_tag_text" translatable="yes">Asset Tag</label>
+                <span id="system_information_asset_tag_text"></span>
+
+                <label class="control-label" for="system_machine_id" translatable="yes">Machine ID</label>
+                <span class="system_information_machine_id_tooltip">
+                    <span id="system_machine_id"></span>
+                </span>
+
+                <label class="control-label" for="system_information_os_text" translatable="yes">Operating System</label>
+                <span id="system_information_os_text"></span>
+
+                <div role="group">
+                    <span id="system_information_updates_icon" hidden></span>
+                    <span id="system_information_updates_text"></span>
+                </div>
+
+                <label class="control-label" for="system-ssh-keys-link" translatable="yes">Secure Shell Keys</label>
+                <a id="system-ssh-keys-link" translatable="yes" data-toggle="modal"
+                   data-target="#system_information_ssh_keys">Show fingerprints</a>
+
+                <label class="control-label hidden" for="system-ostree-version-link" translatable="yes">Version</label>
+                <a id="system-ostree-version-link" class="hidden"></a>
+
+                <label class="control-label" for="system_information_hostname_button" translatable="yes">Host Name</label>
+                <span id="hostname-tooltip">
+                    <a class="hostname-privileged" id="system_information_hostname_button"></a>
+                </span>
+
+                <label class="control-label" for="system-info-domain" translatable="yes" hidden>Domain</label>
+                <span id="system-info-domain" hidden></span>
+
+                <label class="control-label" for="system_information_systime_button" translatable="yes">System Time</label>
+                <div role="group">
+                    <span id="systime-tooltip">
+                        <a class="systime-privileged" id="system_information_systime_button"></a>
+                    </span>
                       <a hidden id="system_information_systime_ntp_status"
                          tabindex="0" role="button" data-toggle="tooltip"
                          data-placement="bottom" data-html="true" >
                       </a>
-                    </td>
-                </tr>
-                <tr>
-                    <td translatable="yes" id="system_information_power_options_label">Power Options</td>
-                    <td id="shutdown-group">
-                        <div class="btn-group">
-                            <button class="btn btn-default btn-danger shutdown-privileged" data-action="restart"
-                                data-container="body" translatable="yes">Restart</button>
-                            <button data-toggle="dropdown" class="btn
-                                btn-default dropdown-toggle
-                                shutdown-privileged"
-                                aria-labelledby="system_information_power_options_label">
-                                <span class="caret"></span>
-                            </button>
-                            <ul role="menu" class="dropdown-menu">
-                                <li class="presentation">
-                                    <a role="menuitem" data-action="restart" translatable="yes">Restart</a>
-                                </li>
-                                <li class="presentation">
-                                    <a role="menuitem" data-action="shutdown" translatable="yes">Shut Down</a>
-                                </li>
-                            </ul>
-                        </div>
-                    </td>
-                </tr>
-                <tr id="system-info-performance" hidden>
-                    <td translatable="yes">Performance Profile</td>
-                    <td class="button-location">
-                    </td>
-                </tr>
-                <tr id="server-pmlogger-onoff-row" hidden>
-                    <td translatable="yes">Store metrics</td>
-                    <td>
-                        <div class="btn-group btn-onoff-ct" id="server-pmlogger-switch" data-toggle="buttons">
-                            <label class="btn">
-                                <input type="radio" name="pmlogger-switch" autocomplete="off">
-                                <span translatable="yes">On</span>
-                            </label>
-                            <label class="btn active">
-                                <input type="radio" name="pmlogger-switch" autocomplete="off" checked>
-                                <span translatable="yes">Off</span>
-                            </label>
-                        </div>
-                    </td>
-                </tr>
-                <tr id="system-information-enable-pcp" hidden>
-                    <td></td>
-                    <td>
-                        <a id="system-information-enable-pcp-link">
-                            <span class="pficon pficon-info"></span>
-                            <span translate>Enable stored metrics…</span>
-                        </a>
-                    </td>
-                </tr>
-            </table>
+                </div>
+
+                <label class="control-label" translatable="yes">Power Options</label>
+                <div id="shutdown-group" class="btn-group">
+                    <button class="btn btn-default btn-danger shutdown-privileged" data-action="restart"
+                        data-container="body" translatable="yes">Restart</button>
+                    <button data-toggle="dropdown" class="btn
+                        btn-default dropdown-toggle
+                        shutdown-privileged"
+                        aria-labelledby="system_information_power_options_label">
+                        <span class="caret"></span>
+                    </button>
+                    <ul role="menu" class="dropdown-menu">
+                        <li class="presentation">
+                            <a role="menuitem" data-action="restart" translatable="yes">Restart</a>
+                        </li>
+                        <li class="presentation">
+                            <a role="menuitem" data-action="shutdown" translatable="yes">Shut Down</a>
+                        </li>
+                    </ul>
+                </div>
+
+                <label class="control-label" translatable="yes">Performance Profile</label>
+                <span id="system-info-performance" hidden></span>
+
+                <label class="control-label" for="server-pmlogger-switch" translatable="yes" hidden>Store Metrics</label>
+                <div class="btn-group btn-onoff-ct" id="server-pmlogger-switch" data-toggle="buttons" hidden>
+                    <label class="btn">
+                        <input type="radio" name="pmlogger-switch" autocomplete="off">
+                        <span translatable="yes">On</span>
+                    </label>
+                    <label class="btn active">
+                        <input type="radio" name="pmlogger-switch" autocomplete="off" checked>
+                        <span translatable="yes">Off</span>
+                    </label>
+                </div>
+
+                <a id="system-information-enable-pcp-link" hidden>
+                    <span class="pficon pficon-info"></span>
+                    <span translate>Enable stored metrics…</span>
+                </a>
+            </form>
         </div>
+
         <div id="server-graph-columns" class="col-md-8 col-lg-9" role="presentation">
             <div id="server-graph-toolbar" class="zoom-controls standard-zoom-controls">
                 <div class="dropdown">

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -93,9 +93,7 @@
                 <span id="system_information_asset_tag_text"></span>
 
                 <label class="control-label" for="system_machine_id" translatable="yes">Machine ID</label>
-                <span class="system_information_machine_id_tooltip">
-                    <span id="system_machine_id"></span>
-                </span>
+                <span id="system_machine_id"></span>
 
                 <label class="control-label" for="system_information_os_text" translatable="yes">Operating System</label>
                 <span id="system_information_os_text"></span>

--- a/pkg/tuned/dialog.js
+++ b/pkg/tuned/dialog.js
@@ -289,7 +289,7 @@ function setup() {
 }
 
 $(permission).on('changed', function () {
-    $('#system-info-performance').removeAttr('hidden');
-    $('#system-info-performance').find('.button-location')
-            .append(setup());
+    var element = $('#system-info-performance');
+    element.append(setup());
+    element.removeAttr('hidden');
 });

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -566,10 +566,10 @@ class TestPackageInstall(packagelib.PackageCase):
         b.wait_present("#system-info-domain a.disabled")
         # check tooltip
         b.wait_present("#system-info-domain [data-original-title]")
-        b.mouse("#system-info-domain .button-location span", "mouseover")
+        b.mouse("#system-info-domain span", "mouseover")
         b.wait_present(".tooltip-inner")
         b.wait_in_text(".tooltip-inner", "realmd is not available on this system")
-        b.mouse("#system-info-domain .button-location span", "mouseout")
+        b.mouse("#system-info-domain span", "mouseout")
         b.logout()
 
         # case 2: enable PackageKit, but no realmd package available
@@ -579,10 +579,10 @@ class TestPackageInstall(packagelib.PackageCase):
         b.wait_text("#system-info-domain a", "Join Domain")
         # check tooltip
         b.wait_present("#system-info-domain [data-original-title]")
-        b.mouse("#system-info-domain .button-location span", "mouseover")
+        b.mouse("#system-info-domain span", "mouseover")
         b.wait_present(".tooltip-inner")
         b.wait_in_text(".tooltip-inner", "requires installation of realmd")
-        b.mouse("#system-info-domain .button-location span", "mouseout")
+        b.mouse("#system-info-domain span", "mouseout")
 
         b.click("#system-info-domain a")
         b.wait_present("#cockpit_modal_dialog .dialog-error")
@@ -603,10 +603,10 @@ class TestPackageInstall(packagelib.PackageCase):
         b.wait_text("#system-info-domain a", "Join Domain")
         # check tooltip
         b.wait_present("#system-info-domain [data-original-title]")
-        b.mouse("#system-info-domain .button-location span", "mouseover")
+        b.mouse("#system-info-domain span", "mouseover")
         b.wait_present(".tooltip-inner")
         b.wait_in_text(".tooltip-inner", "requires installation of realmd")
-        b.mouse("#system-info-domain .button-location span", "mouseout")
+        b.mouse("#system-info-domain span", "mouseout")
 
         b.click("#system-info-domain a")
         b.wait_present("#cockpit_modal_dialog .modal-footer button.btn-primary:not([disabled])")
@@ -632,10 +632,10 @@ class TestPackageInstall(packagelib.PackageCase):
         b.wait_text("#system-info-domain a", "Join Domain")
         # check tooltip
         b.wait_present("#system-info-domain [data-original-title]")
-        b.mouse("#system-info-domain .button-location span", "mouseover")
+        b.mouse("#system-info-domain span", "mouseover")
         b.wait_present(".tooltip-inner")
         b.wait_in_text(".tooltip-inner", "requires installation of realmd")
-        b.mouse("#system-info-domain .button-location span", "mouseout")
+        b.mouse("#system-info-domain span", "mouseout")
 
         b.click("#system-info-domain a")
         b.wait_present("#cockpit_modal_dialog .modal-footer button.btn-primary:not([disabled])")
@@ -653,7 +653,7 @@ class TestPackageInstall(packagelib.PackageCase):
         b.wait_popdown("realms-op")
 
         # should not have a tooltip any more
-        b.mouse("#system-info-domain .button-location span", "mouseover")
+        b.mouse("#system-info-domain span", "mouseover")
         time.sleep(2)
         self.assertFalse(b.is_present(".tooltip-inner"))
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -162,11 +162,11 @@ class TestSystemInfo(MachineCase):
         b.wait_popdown("system_information_change_hostname")
 
         if m.atomic_image:
-            b.wait_present('#system-ostree-version')
-            b.wait_visible('#system-ostree-version')
+            b.wait_present('#system-ostree-version-link')
+            b.wait_visible('#system-ostree-version-link')
             b.wait_text('#system-ostree-version-link', "cockpit-base.1")
         else:
-            b.wait_not_visible("#system-ostree-version")
+            b.wait_not_visible("#system-ostree-version-link")
 
         b.wait_text('#system_information_hostname_button', "Adventure Box (host1.cockpit.lan)")
         # HACK /usr/bin/hostname output is delayed in systemd v208, so that DBus gets notified early
@@ -405,9 +405,9 @@ class TestPcp(packagelib.PackageCase):
         # the atomics don't have pcp and can't install additional software
         if m.atomic_image:
             self.login_and_go("/system")
-            b.wait_present("#server-pmlogger-onoff-row")
-            b.wait_not_visible("#server-pmlogger-onoff-row")
-            b.wait_not_visible("#system-information-enable-pcp")
+            b.wait_present("#server-pmlogger-switch")
+            b.wait_not_visible("#server-pmlogger-switch")
+            b.wait_not_visible("#system-information-enable-pcp-link")
             return
 
         m.execute("pkcon remove -y pcp")
@@ -424,20 +424,20 @@ class TestPcp(packagelib.PackageCase):
 
         # the offer to install it should be visible
         self.login_and_go("/system")
-        b.wait_present("#server-pmlogger-onoff-row")
-        b.wait_not_visible("#server-pmlogger-onoff-row")
-        b.wait_visible("#system-information-enable-pcp")
+        b.wait_present("#server-pmlogger-switch")
+        b.wait_not_visible("#server-pmlogger-switch")
+        b.wait_visible("#system-information-enable-pcp-link")
         if m.image in ["rhel-7-6-distropkg"]:
-            b.wait_in_text("#system-information-enable-pcp", "Enable persistent metrics…")
+            b.wait_in_text("#system-information-enable-pcp-link", "Enable persistent metrics…")
         else:
-            b.wait_in_text("#system-information-enable-pcp", "Enable stored metrics…")
+            b.wait_in_text("#system-information-enable-pcp-link", "Enable stored metrics…")
         b.click("#system-information-enable-pcp-link")
         b.wait_present("#cockpit_modal_dialog .modal-footer button.btn-primary:not([disabled])")
         b.click("#cockpit_modal_dialog .modal-footer button.btn-primary")
         b.wait_not_present("#cockpit_modal_dialog")
 
-        b.wait_visible("#server-pmlogger-onoff-row")
-        b.wait_not_visible("#system-information-enable-pcp")
+        b.wait_visible("#server-pmlogger-switch")
+        b.wait_not_visible("#system-information-enable-pcp-link")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As we don't have IDs for containing table rows any more, adjust the code
to directly interact with the action element, and possibly its label
(`.prev()`).

Similarly to commit 1570bf3624d, prevent the shutdown/restart button
click event from falling through to the parent form handler, to avoid
immediately closing the dialog that is about to open.

Adjust CSS selectors check-realms for the dropped intermediate
`button-location` span. This also still works for the old HTML on
rhel-7-6-distropkg, as there is no other span than the tooltip inside
`#system-info-domain`.

Fixes #9773

 - [x] Fix misplaced tooltip for hardware info
 - [x] Some form-layout fixes: PR #10974