### PR TITLE
Revert "machines: Disallow http URLs in favour of https"

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -330,10 +330,10 @@ function validateParams(vmParams) {
             break;
         case URL_SOURCE:
         default:
-            if (!vmParams.source.startsWith("https") &&
+            if (!vmParams.source.startsWith("http") &&
                     !vmParams.source.startsWith("ftp") &&
                     !vmParams.source.startsWith("nfs")) {
-                return _("Source should start with https, ftp or nfs protocol");
+                return _("Source should start with http, ftp or nfs protocol");
             }
             break;
         }

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1113,7 +1113,7 @@ class TestMachines(MachineCase):
         runner.destroy()
 
     class TestCreateConfig:
-        VALID_URL = 'https://mirror.i3d.net/pub/centos/7/os/x86_64/'
+        VALID_URL = 'http://mirror.i3d.net/pub/centos/7/os/x86_64/'
         NOVELL_MOCKUP_ISO_PATH = '/var/lib/libvirt/novell.iso'  # libvirt in ubuntu-1604 does not accept /tmp
         NOT_EXISTENT_PATH = '/tmp/not-existent.iso'
 


### PR DESCRIPTION
This reverts commit 23b8ff366ee97dcea6a2c9e8946a81a0f571adaf.

After further discussion on https://bugzilla.redhat.com/show_bug.cgi?id=1644267
it was decided that this restriction was not necessary.

On the BZ it was suggested to also handle the virt-install error in case http driver is not supported and provide some more user friendly error.

TBH I don't feel very happy to change the errors of the tools we use. This might cover issues and the user will not be able to search with the actual error messages.