### PR TITLE
machines: remove useless notifications from disk tab

### DIFF
--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -21,7 +21,6 @@ import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 
 import { Listing, ListingRow } from 'cockpit-components-listing.jsx';
-import { Info } from './notification/inlineNotification.jsx';
 import { convertToUnit, toReadableNumber, units } from "../helpers.js";
 import RemoveDiskAction from './diskRemove.jsx';
 import VmLastMessage from './vmLastMessage.jsx';
@@ -56,8 +55,7 @@ const VmDiskCell = ({ value, id }) => {
     );
 };
 
-const VmDisksTab = ({ idPrefix, vm, disks, actions, renderCapacity, notificationText, dispatch, provider }) => {
-    let notification = null;
+const VmDisksTab = ({ idPrefix, vm, disks, actions, renderCapacity, dispatch, provider }) => {
     const columnTitles = [_("Device")];
     let renderCapacityUsed, renderReadOnly;
     const currentTab = 'disk';
@@ -80,16 +78,10 @@ const VmDisksTab = ({ idPrefix, vm, disks, actions, renderCapacity, notification
         columnTitles.push(_("Source"));
         // An empty string header is needed for detach actions
         columnTitles.push("");
-
-        if (notificationText) {
-            notification = (<Info text={notificationText}
-                                  textId={`${idPrefix}-notification`} />);
-        }
     }
 
     return (
         <div className="machines-disks">
-            {notification}
             {message}
             <Listing compact columnTitles={columnTitles} actions={actions} emptyCaption={_("No disks defined for this VM")}>
                 {disks.map(disk => {
@@ -135,7 +127,6 @@ VmDisksTab.propTypes = {
     actions: PropTypes.arrayOf(PropTypes.node),
     disks: PropTypes.array.isRequired,
     renderCapacity: PropTypes.bool,
-    notificationText: PropTypes.string,
     provider: PropTypes.string,
 };
 

--- a/pkg/machines/components/vmDisksTabLibvirt.jsx
+++ b/pkg/machines/components/vmDisksTabLibvirt.jsx
@@ -61,15 +61,9 @@ class VmDisksTabLibvirt extends React.Component {
     }
 
     getNotification(vm, areDiskStatsSupported) {
-        if (areDiskStatsSupported) {
-            return null;
-        }
-
-        if (vm.state === 'running') {
+        if (!areDiskStatsSupported && vm.state === 'running') {
             return _("Upgrade to a more recent version of libvirt to view disk statistics");
         }
-
-        return _("Start the VM to see disk statistics.");
     }
 
     prepareDiskData(disk, diskStats, idPrefix, storagePools) {

--- a/pkg/machines/components/vmDisksTabLibvirt.jsx
+++ b/pkg/machines/components/vmDisksTabLibvirt.jsx
@@ -18,14 +18,11 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import cockpit from 'cockpit';
 
 import { vmId } from '../helpers.js';
 import { AddDiskAction } from './diskAdd.jsx';
 import VmDisksTab from './vmDisksTab.jsx';
 import DiskSourceCell from './vmDiskSourceCell.jsx';
-
-const _ = cockpit.gettext;
 
 class VmDisksTabLibvirt extends React.Component {
     componentWillMount() {
@@ -43,7 +40,6 @@ class VmDisksTabLibvirt extends React.Component {
         /* Possible states for disk stats:
             available ~ already read
             supported, but not available yet ~ will be read soon
-            unsupported ~ failed attempt to read (old libvirt)
          */
         let areDiskStatsSupported = false;
         if (vm.disksStats) {
@@ -58,12 +54,6 @@ class VmDisksTabLibvirt extends React.Component {
         }
 
         return areDiskStatsSupported;
-    }
-
-    getNotification(vm, areDiskStatsSupported) {
-        if (!areDiskStatsSupported && vm.state === 'running') {
-            return _("Upgrade to a more recent version of libvirt to view disk statistics");
-        }
     }
 
     prepareDiskData(disk, diskStats, idPrefix, storagePools) {
@@ -130,7 +120,6 @@ class VmDisksTabLibvirt extends React.Component {
                 vm={vm}
                 disks={disks}
                 renderCapacity={areDiskStatsSupported}
-                notificationText={this.getNotification(vm, areDiskStatsSupported)}
                 dispatch={dispatch}
                 provider={config.provider.name} />
         );

--- a/pkg/machines/libvirt-virsh.js
+++ b/pkg/machines/libvirt-virsh.js
@@ -536,8 +536,6 @@ function parseDomstatsForDisks(domstatsLines) {
         return;
     }
 
-    // Libvirt reports disk capacity since version 1.2.18 (year 2015)
-    // TODO: If disk stats is required for old systems, find a way how to get it when 'block.X.capacity' is not present, consider various options for 'sources'
     const disksStats = {};
     for (let i = 0; i < count; i++) {
         const target = getValueFromLine(domstatsLines, `block.${i}.name=`);


### PR DESCRIPTION
First commit removes the notifacation about starting VM to see disks statistics. Disk stats are available for disks of offline VMs, not sure since which libvirt version or if that's is somehow connected. I can't seem to be able to make domstats API not return disk statistics any more. I would leave it there, but it's blinking before the stats are fetched, and I prefered to remove it than to have it there for some corner cases I don't seem able to find.

Second commit removes the warning about old libvirt, since all version with libvirt version old enough to not support these APIs are not supported any more. Same here, it fixes the blinking notification issue.