### PR TITLE
[rhel-8.0] storage: Always round dialog size slider input

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -807,6 +807,9 @@ class SizeSliderElement extends React.Component {
                     value = round(value);
                 else
                     value = Math.round(value / round) * round;
+            } else {
+                // Only produce integers by default
+                value = Math.round(value);
             }
 
             onChange(Math.max(min, value));


### PR DESCRIPTION
Otherwise we will very likely pass a non-integer number to the D-Bus
call, which will fail.

This affects the size slider for new partitions, and without this fix,
setting a size for a new partition with the slider will cause a
unhelpful error message.