### PR TITLE
bots: Consume test tasks from amqp

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -13,8 +13,8 @@
 
 set -ex
 
-# Scan for all tests
-bots/tests-scan
+# Process exactly one item from the queue
+echo bots/run-queue --amqp amqp.cockpit.svc.cluster.local --queue tasks
 
 # When run automated, randomize to minimize stampeding herd
 if [ -t 0 ]; then

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -131,10 +131,10 @@ def run(image, verbose=False, **kwargs):
         api = github.GitHub()
         for trigger in triggers:
             api.post("statuses/{0}".format(head), { "state": "pending", "context": trigger,
-                "description": github.NOT_TESTED })
+                "description": github.NOT_TESTED_DIRECT })
         # pre-creating statuses circumvents tests-scan's detection of whether bots/ changed
         # we want to validate all image refreshes with external projects
         task.label(pull, ["test-external"])
 
 if __name__ == '__main__':
-    task.main(function=run, title="Refresh image")
+    task.main(function=run, title="Refresh image [no-test]")

--- a/bots/inspect-queue
+++ b/bots/inspect-queue
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+MAX_PRIORITY = 9
+
+import argparse
+import sys
+import time
+
+import amqp
+
+def main():
+    parser = argparse.ArgumentParser(description='Read and print messages from the queue without acknowleding them')
+    parser.add_argument('--amqp', default='localhost',
+                        help='The URL of the AMQP server to consume from')
+    parser.add_argument('--queue', default='tasks',
+                        help='The name of the queue to consume from')
+    parser.add_argument('-n', '--number', default=0,
+                        help='Number of queue items to show, starting from the front (0=all)')
+    parser.add_argument('-t', '--timeout', default=0.5,
+                        help='Time to wait for messages')
+    opts = parser.parse_args()
+
+    connection = amqp.Connection(host=opts.amqp)
+    connection.connect()
+    channel = connection.channel()
+    try:
+        channel.queue_declare(queue=opts.queue, passive=True, auto_delete=False)
+    except amqp.exceptions.NotFound:
+        sys.stdout.write('queue is empty\n')
+        return 0
+    channel.basic_qos(0, opts.number, True)
+
+    def callback(msg):
+        sys.stdout.write("{0}\n".format(msg.body))
+        msg.channel.basic_reject(msg.delivery_tag, requeue=True)
+
+    channel.basic_consume(callback=callback, queue=opts.queue)
+    time.sleep(opts.timeout)
+    sys.stdout.flush()
+    connection.close()
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bots/make-checkout
+++ b/bots/make-checkout
@@ -67,8 +67,24 @@ def main():
             execute("git", "remote", "remove", "test")
         execute("git", "remote", "add", "test", "https://github.com/" + opts.repo)
 
-    execute("git", "fetch", "test" if opts.repo else "origin", opts.ref)
-    execute("git", "checkout", "--detach", opts.revision)
+    # if the pr was updated while the command was in the queue, the revision
+    # won't be tied to the ref anymore, and it won't exist locally, so exit
+    # silently
+    output = None
+    try:
+        args = ["git", "fetch", "test" if opts.repo else "origin", opts.ref]
+        if opts.verbose:
+            sys.stderr.write("+ {0}\n".format(" ".join(args)))
+        output = subprocess.check_output(args, cwd=BASE, universal_newlines=True)
+        args = ["git", "checkout", "--detach", opts.revision]
+        if opts.verbose:
+            sys.stderr.write("+ {0}\n".format(" ".join(args)))
+        output = subprocess.check_output(args, cwd=BASE, universal_newlines=True)
+    except subprocess.CalledProcessError:
+        return 0
+    finally:
+        if opts.verbose and output:
+            sys.stderr.write("> " + output + "\n")
 
     # If the bots directory doesn't exist in this branch or repo, check it out from master
     if opts.repo or (opts.base and opts.base != "master"):

--- a/bots/run-queue
+++ b/bots/run-queue
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+MAX_PRIORITY = 9
+
+import argparse
+import json
+import subprocess
+import sys
+
+import amqp
+
+def main():
+    parser = argparse.ArgumentParser(description='Bot: read a single test command from the queue and execute it')
+    parser.add_argument('--amqp', default='localhost',
+                        help='The URL of the AMQP server to consume from')
+    parser.add_argument('--queue', default='tasks',
+                        help='The name of the queue to consume from')
+    opts = parser.parse_args()
+
+    connection = amqp.Connection(host=opts.amqp)
+    connection.connect()
+    channel = connection.channel()
+    try:
+        channel.queue_declare(queue=opts.queue, passive=True, auto_delete=False)
+    except amqp.exceptions.NotFound:
+        sys.stdout.write('queue is empty\n')
+        return 0
+
+    channel.basic_qos(0, 1, True)
+
+    # Get one item from the queue if present
+    msg = channel.basic_get(queue=opts.queue)
+    if msg:
+        body = json.loads(msg.body)
+        sys.stderr.write("Consuming {0} task:\n{1}\n".format(body['type'],json.dumps(body, indent=2, sort_keys=True)))
+        sys.stderr.flush()
+        subprocess.check_call(body['command'], shell=True)
+        channel.basic_ack(msg.delivery_tag)
+
+    channel.close()
+    connection.close()
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -42,8 +42,17 @@ __all__ = (
 )
 
 TESTING = "Testing in progress"
-NOT_TESTED = "Not yet tested"
 NO_TESTING = "Manual testing required"
+
+# if the webhook receives a pull request event, it will create a status for each
+# context with NOT_TESTED as description
+# the subsequent status events caused by the webhook creating the statuses, will
+# be ignored by the webhook as it only handles NOT_TESTED_DIRECT as described
+# below
+NOT_TESTED = "Not yet tested"
+# if the webhook receives a status event with NOT_TESTED_DIRECT as description,
+# it will publish a test task to the queue (used to trigger specific contexts)
+NOT_TESTED_DIRECT = "Not yet tested (direct trigger)"
 
 OUR_CONTEXTS = [
     "verify/",

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -48,6 +48,7 @@ def main():
     parser.add_argument('--publish', dest='publish', default=os.environ.get("TEST_PUBLISH", ""),
             action='store', help='Publish results centrally to a sink')
     parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
+    parser.add_argument('--pull-number', help="The number of the pull request to test")
     parser.add_argument('context', help="The context or type of integration tests to run")
     parser.add_argument('ref', nargs='?', help="The Git remote ref to pull")
     opts = parser.parse_args()
@@ -83,10 +84,29 @@ class PullTask(object):
         self.sink = None
         self.github_status_data = None
 
-    def start_publishing(self, host):
+    def detect_collisions(self, opts):
         api = github.GitHub()
         if not self.github_revision:
             self.github_revision = self.revision
+
+        if opts.pull_number:
+            pull = api.get("pulls/{0}".format(opts.pull_number))
+            if pull and pull["head"]["sha"] != self.revision:
+                return "Newer revision available on GitHub for this pull request"
+
+        if not self.github_revision:
+            return None
+
+        statuses = api.get("commits/{0}/statuses".format(self.github_revision))
+        for status in statuses:
+            if status.get("context") == self.context:
+                if status.get("state") == "pending" and status.get("description") not in [github.NOT_TESTED, github.NOT_TESTED_DIRECT]:
+                    return "Status of context isn't pending or description is not in [{0}, {1}]".format(github.NOT_TESTED, github.NOT_TESTED_DIRECT)
+                else: # only check the newest status of the supplied context
+                    return None
+
+    def start_publishing(self, host):
+        api = github.GitHub()
 
         # build a unique file name for this test run
         id_context = self.context
@@ -250,6 +270,7 @@ class PullTask(object):
         if isinstance(ret, str):
             message = ret
             mark_failed()
+            ret = 0
         elif ret == 0:
             message = "Tests passed"
             mark_passed()
@@ -269,6 +290,12 @@ class PullTask(object):
         return ret
 
     def run(self, opts):
+        # Collision detection
+        ret = self.detect_collisions(opts)
+        if ret:
+            sys.stderr.write('Collision detected: {0}\n'.format(ret))
+            return None
+
         if opts.publish:
             self.start_publishing(opts.publish)
             os.environ["TEST_ATTACHMENTS"] = self.sink.attachments

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -124,7 +124,9 @@ def main():
     parser.add_argument('-c', '--context', action="append", default=[ ],
                         help='Test contexts to use.')
     parser.add_argument('-p', '--pull-number', default=None,
-                        help='Pull request to scan for tasks')
+                        help='Single pull request to scan for tasks')
+    parser.add_argument('-s', '--sha', default=None,
+                        help='SHA beloging to pull request to scan for tasks')
     parser.add_argument('--amqp', default=None,
                         help='The URL of the AMQP server to publish to')
     parser.add_argument('--queue', default='tasks',
@@ -139,6 +141,14 @@ def main():
     try:
         if opts.context:
             policy = { c: [ "master" ] for c in opts.context }
+        elif opts.repo:
+            policy = {}
+            if opts.repo in EXTERNAL_PROJECTS:
+                policy.update({ c: [ "master" ] for c in EXTERNAL_PROJECTS[opts.repo] })
+            if opts.repo in REDHAT_EXTERNAL_PROJECTS:
+                policy.update({ c: [ "master" ] for c in REDHAT_EXTERNAL_PROJECTS[opts.repo] })
+            if not policy:
+                policy = default_policy()
         else:
             policy = default_policy()
         results = scan_for_pull_tasks(api, policy, opts, None)
@@ -169,12 +179,12 @@ def distributed_queue(host, queue):
     arguments = {
         "x-max-priority": MAX_PRIORITY
     }
-    channel.queue_declare(queue=queue, arguments=arguments)
+    channel.queue_declare(queue=queue, arguments=arguments, auto_delete=False)
     yield channel
     connection.close()
 
 # Prepare a human readable output
-def tests_human(priority, name, revision, ref, context, base, repo, bots_ref):
+def tests_human(priority, name, number, revision, ref, context, base, repo, bots_ref):
     if not priority:
         return
     try:
@@ -190,8 +200,8 @@ def tests_human(priority, name, revision, ref, context, base, repo, bots_ref):
         bots_ref=bots_ref and (" [bots@%s]" % bots_ref) or "",
     )
 
-# Prepare an test invocation command
-def tests_invoke(priority, name, revision, ref, context, base, repo, bots_ref, options):
+# Prepare a test invocation command
+def tests_invoke(priority, name, number, revision, ref, context, base, repo, bots_ref, options):
     if not run_redhat_tasks and (context in REDHAT_VERIFY or
                                  context in REDHAT_EXTERNAL_PROJECTS.get(repo, [])):
         return ''
@@ -205,12 +215,14 @@ def tests_invoke(priority, name, revision, ref, context, base, repo, bots_ref, o
     current = time.strftime('%Y%m%d-%H%M%M')
 
     checkout = "PRIORITY={priority:04d} bots/make-checkout --verbose"
-    cmd = "TEST_NAME={name}-{current} TEST_REVISION={revision} bots/tests-invoke"
+    cmd = "TEST_NAME={name}-{current} TEST_REVISION={revision} bots/tests-invoke --pull-number={pull_number} "
     if base:
         cmd += " --rebase={base}"
         checkout += " --base={base}"
 
-    if repo:
+    if repo or (options.amqp and options.repo):
+        if not repo:
+            repo = options.repo
         checkout += " --repo={repo}"
         cmd += " --remote=test"
         if bots_ref:
@@ -241,11 +253,12 @@ def tests_invoke(priority, name, revision, ref, context, base, repo, bots_ref, o
         bots_ref=pipes.quote(bots_ref),
         context=pipes.quote(context),
         current=current,
+        pull_number=number,
         repo=pipes.quote(repo),
     )
 
-def queue_test(priority, name, revision, ref, context, base, repo, bots_ref, queue, options):
-    command = tests_invoke(priority, name, revision, ref, context, base, repo, bots_ref, options)
+def queue_test(priority, name, number, revision, ref, context, base, repo, bots_ref, queue, options):
+    command = tests_invoke(priority, name, number, revision, ref, context, base, repo, bots_ref, options)
     if command:
         if priority > MAX_PRIORITY:
             priority = MAX_PRIORITY
@@ -321,7 +334,7 @@ def update_status(api, revision, context, last, changes):
         return False
     return True
 
-def cockpit_tasks(api, update, contexts, repo, pull_number, amqp):
+def cockpit_tasks(api, update, contexts, repo, pull_number, sha, amqp):
     results = []
     branch_contexts = { }
     for (context, branches) in contexts.items():
@@ -353,6 +366,10 @@ def cockpit_tasks(api, update, contexts, repo, pull_number, amqp):
         statuses = api.statuses(revision)
         login = pull["head"]["user"]["login"]
         base = pull["base"]["ref"]  # The branch this pull request targets
+
+        # If sha is present only scan PR with selected sha
+        if sha and revision != sha and not revision.startswith(sha):
+            continue
 
         def labels():
             if "labels" not in pull:
@@ -387,7 +404,7 @@ def cockpit_tasks(api, update, contexts, repo, pull_number, amqp):
             else:
                 (priority, changes) = prioritize(status, title, labels, baseline, context)
             if not update or update_status(api, revision, context, status, changes):
-                results.append((priority, "pull-%d" % number, revision, "pull/%d/head" % number, context, base, repo, None))
+                results.append((priority, "pull-%d" % number, number, revision, "pull/%d/head" % number, context, base, repo, None))
 
         # if a cockpit (default repo) PR changes bots/, also trigger all external tests against this cockpit PR
 
@@ -425,7 +442,7 @@ def cockpit_tasks(api, update, contexts, repo, pull_number, amqp):
                         (priority, changes) = prioritize(status, title, labels, baseline, repo_context)
                     if not update or update_status(api, revision, repo_context, status, changes):
                         # don't specify a ref to check out; make-source already checks out project master
-                        results.append((priority, "pull-%d" % number, revision, "", context, base, proj_repo, "pull/%s/head" % number))
+                        results.append((priority, "pull-%d" % number, number, revision, "", context, base, proj_repo, "pull/%s/head" % number))
 
     return results
 
@@ -435,7 +452,7 @@ def scan_for_pull_tasks(api, policy, opts, repo):
         sys.stderr.write("tests-scan: No /dev/kvm access, not running tests here\n")
         return []
 
-    results = cockpit_tasks(api, not opts.dry, policy, repo, opts.pull_number, opts.amqp)
+    results = cockpit_tasks(api, not opts.dry, policy, repo, opts.pull_number, opts.sha, opts.amqp)
 
     if opts.human_readable:
         func = lambda x: tests_human(*x)

--- a/bots/tests-trigger
+++ b/bots/tests-trigger
@@ -45,7 +45,7 @@ def trigger_pull(api, opts):
                     ret = 1
                 continue
         sys.stderr.write("{0}: triggering on pull request {1}\n".format(context, opts.pull))
-        changes = { "state": "pending", "description": github.NOT_TESTED, "context": context }
+        changes = { "state": "pending", "description": github.NOT_TESTED_DIRECT, "context": context }
 
         # Keep the old link for reference, until testing starts again
         link = status.get("target_url", None)


### PR DESCRIPTION
check list for testing after merging:
 - [X] push PR, check for queued tests and statuses
 - [X] update PR, queueing items
 - [ ] FAIL: manual trigger (status gets created, but nothing queued)
 - [X] external project manual
 - [ ] FAIL: external project webhook: triggers cockpit tasks
 - [ ] update external PR
 - [ ] collision detection: ignore obsolete queued item on force-push
 - [ ] collision detection: same queue on both clouds don't get into each other's way

things to fix:
  - [x] run-queue debug output to stderr
  - [ ] bring back request body logging in webhook (but only interesting parts of it)
  - [x] add queue inspection tool

todo after merging:
 - [x] deploy webhook and amqp pod on bos
 - [ ] enable pull_request and status events on welder-web (and other) webhooks
 - [ ] add webhook for podman


