### PR TITLE
ws: Fix update-motd on systems that use hostname binary from coreutils

### DIFF
--- a/src/ws/update-motd
+++ b/src/ws/update-motd
@@ -10,7 +10,7 @@ port=${1:-$(systemctl show --property Listen cockpit.socket |
 port=${port:-9090}
 
 # hostname from cmdline, then `hostname -f`
-hostname=${2:-$(hostname -f)}
+hostname=${2:-$(hostname -f || hostname)}
 
 # ip addr from cmdline, then default route source addr
 ip=${3:-$(ip -o route get 255.0 2>/dev/null | sed -e 's/.*src \([^ ]*\) .*/\1/')}


### PR DESCRIPTION
The coreutils hostname binary does not provide the -f flag. Fallback on
hostname if hostname -f failed.

```# hostname --help
Usage: hostname [NAME]
  or:  hostname OPTION
Print or set the hostname of the current system.

      --help     display this help and exit
      --version  output version information and exit

GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
Report hostname translation bugs to <https://translationproject.org/team/>
Full documentation at: <https://www.gnu.org/software/coreutils/hostname>
or available locally via: info '(coreutils) hostname invocation'
```
