### PR TITLE
Fix displaying of docker containers with long names

### DIFF
--- a/pkg/docker/details.js
+++ b/pkg/docker/details.js
@@ -208,6 +208,7 @@ PageContainerDetails.prototype = {
 
         $('#container-details-id').text(info.Id);
         $('#container-details-names').text(util.render_container_name(info.Name));
+        $('#container-details-names').prop('title', util.render_container_name(info.Name));
         $('#container-details-created').text(moment(info.Created).isValid()
             ? moment(info.Created).calendar() : info.Created);
 

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -317,6 +317,18 @@ table > tbody > tr > .cell-buttons {
     height: 25px;
 }
 
+.container-details-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: calc(100% - 350px);;
+}
+
+.container-details-text {
+    display: inline-block;
+    vertical-align: middle;
+}
+
 .resource-value {
     min-width: 8em;
     text-align: right;

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -58,7 +58,7 @@ div.spinner {
  * HACK: Because CSS has no parant selector.
  */
 .cell-buttons,
-.table > tbody > tr > .cell-buttons {
+table > tbody > tr > .cell-buttons {
     padding-top: 4px;
     padding-bottom: 4px;
     width: 30px;
@@ -110,9 +110,9 @@ div.spinner {
 }
 
 #image-details-containers .cell-buttons button,
-#image-details-containers .table > tbody > tr > .cell-buttons button,
+#image-details-containers table > tbody > tr > .cell-buttons button,
 #containers .cell-buttons button,
-#containers .table > tbody > tr > .cell-buttons button {
+#containers table > tbody > tr > .cell-buttons button {
     position: absolute;
     right: 36px;
     width: 28px;
@@ -174,18 +174,18 @@ div.spinner {
     float: left;
 }
 
-#containers #containers-containers .table,
-#containers #containers-images .table,
-#image-details-containers .table {
+#containers #containers-containers table,
+#containers #containers-images table,
+#image-details-containers table {
     table-layout: fixed;
 }
 
-#containers #containers-containers .table th,
-#containers #containers-containers .table td,
-#containers #containers-images .table th,
-#containers #containers-images .table td,
-#image-details #image-details-containers .table th,
-#image-details #image-details-containers .table td {
+#containers #containers-containers table th,
+#containers #containers-containers table td,
+#containers #containers-images table th,
+#containers #containers-images table td,
+#image-details #image-details-containers table th,
+#image-details #image-details-containers table td {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -633,6 +633,6 @@ table.drive-list td:nth-child(2) img {
     border: none;
 }
 
-#delete-image-confirmation-dialog-containers .table {
+#delete-image-confirmation-dialog-containers table {
     margin-bottom: 0px;
 }

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -313,20 +313,26 @@ table > tbody > tr > .cell-buttons {
     height: 120px;
 }
 
-#container-details .panel-heading .pull-right {
-    height: 25px;
+#container-details .panel-heading {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: first baseline;
 }
 
 .container-details-name {
+    margin: 0 0.5rem;
+}
+
+.panel-heading .container-details-name {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: calc(100% - 350px);;
+    flex: auto;
+    flex-basis: 10em;
 }
 
-.container-details-text {
-    display: inline-block;
-    vertical-align: middle;
+.container-details-text:not(.container-details-name) {
+    flex: none;
 }
 
 .resource-value {
@@ -335,19 +341,49 @@ table > tbody > tr > .cell-buttons {
 }
 
 .content-filter {
+    align-items: first baseline;
     background: #f5f5f5;
     border-bottom: 1px solid #ddd;
-    padding: 10px 16px 10px 20px;
-    position: fixed;
-    width: 100%;
-    top: 0px;
-    right: 0px;
+    display: flex;
+    max-width: 100vw;
+    padding: 1rem 2rem;
+    position: sticky;
+    top: 0;
     z-index: 1;
-    height: 50px;
 }
 
-.content-filter + div {
-    margin-top: 70px;
+#container-details .content-filter {
+    margin: 0 -2rem 2rem;
+}
+
+.content-filter .listing-ct-actions {
+    align-self: center;
+}
+
+.content-filter h3 {
+    align-items: first baseline;
+    display: flex;
+    font-size: 18px;
+    line-height: 28px;
+    margin: 0;
+}
+
+.content-filter .container-details-name {
+    flex: auto;
+    word-wrap: anywhere;
+    word-break: break-all;
+    /* Make sure long names don't get too tall on small screens */
+    max-height: 25vh;
+    overflow-y: auto;
+}
+
+.content-filter a {
+    white-space: nowrap;
+}
+
+#image-details .content-filter a {
+    flex: auto;
+    padding: 0 2rem;
 }
 
 .content-filter input[type="text"] {
@@ -362,34 +398,22 @@ table > tbody > tr > .cell-buttons {
     margin-top: 2px;
 }
 
-.content-filter h3 {
-    display: inline;
-    font-size: 18px;
-    line-height: 28px;
-}
-
 .content-filter i {
     font-size: 24px;
     position: relative;
-    padding-right: 3px;
+    padding-right: 1rem;
 }
 
 .content-filter i.pficon-image {
-    top: 3px;
 }
 
 .content-filter i.fa {
-    margin-top: 2px;
     font-size: 18px;
     line-height: 28px;
 }
 
 .content-filter i.fa-cube {
     font-size: 22px;
-}
-
-.content-filter a {
-    padding-left: 30px;
 }
 
 /*

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -123,7 +123,7 @@
     <div class="content-filter">
       <h3>
         <i class="fa fa-cube fa-fw"></i>
-        <span></span>
+        <span class="container-details-text container-details-name">
       </h3>
       <a translatable="yes">Show all containers</a>
     </div>
@@ -138,8 +138,8 @@
                   data-toggle="modal" data-target="#container-commit-dialog" translate>Commit</button>
           <div class="spinner" hidden></div>
         </div>
-        <span translate>Container:</span>
-        <span id="container-details-names"></span>
+        <span class="container-details-text" translate>Container:</span>
+        <span id="container-details-names" class="container-details-text container-details-name"></span>
       </div>
       <div class="panel-body">
         <table class="info-table-ct">

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -129,7 +129,9 @@
     </div>
     <div class="panel-default panel">
       <div class="panel-heading">
-        <div class="pull-right">
+        <span class="container-details-text" translate>Container:</span>
+        <span id="container-details-names" class="container-details-text container-details-name"></span>
+        <div class="container-details-actions">
           <button class="btn btn-default" id="container-details-start" translate>Start</button>
           <button class="btn btn-default" id="container-details-stop" translate>Stop</button>
           <button class="btn btn-default" id="container-details-restart" translate>Restart</button>
@@ -138,8 +140,6 @@
                   data-toggle="modal" data-target="#container-commit-dialog" translate>Commit</button>
           <div class="spinner" hidden></div>
         </div>
-        <span class="container-details-text" translate>Container:</span>
-        <span id="container-details-names" class="container-details-text container-details-name"></span>
       </div>
       <div class="panel-body">
         <table class="info-table-ct">
@@ -240,6 +240,11 @@
 
   <div id="image-details" hidden>
     <div class="content-filter">
+      <h3>
+        <i class="pficon pficon-image"></i>
+        <span></span>
+      </h3>
+      <a translatable="yes">Show all images</a>
       <div class="listing-ct-actions" id="image-details-buttons">
         <button class="btn btn-default" id="image-details-run"
             data-toggle="modal" data-target="#containers_run_image_dialog" translate>Run</button>
@@ -247,11 +252,6 @@
             class="btn btn-danger btn-delete pficon pficon-delete"></button>
         <div class="spinner" hidden></div>
       </div>
-      <h3>
-        <i class="pficon pficon-image"></i>
-        <span></span>
-      </h3>
-      <a translatable="yes">Show all images</a>
     </div>
 
     <div class="content">

--- a/pkg/lib/table.css
+++ b/pkg/lib/table.css
@@ -10,7 +10,7 @@
 
 .panel-heading {
     background: #F5F5F5;
-    height: 44px;
+    min-height: 44px;
 }
 
 /* Vertically center dropdown buttons in panel headers */


### PR DESCRIPTION
Fixes  #1072 and other issue (see pictures).

Most of the table is out of view due to long name:
![docker1](https://user-images.githubusercontent.com/12330670/51445440-212ab600-1d05-11e9-83c7-9b504be9d985.png)
After this PR:
![docker1f](https://user-images.githubusercontent.com/12330670/51445439-20921f80-1d05-11e9-856c-0dad6590e762.png)

Broken layout:
![docker2](https://user-images.githubusercontent.com/12330670/51445447-3c95c100-1d05-11e9-8878-db566e4b3d42.png)
After this commit: (two resolutions)
![docker2f2](https://user-images.githubusercontent.com/12330670/51445450-4d463700-1d05-11e9-803b-72d23df3cbee.png)
![docker2f](https://user-images.githubusercontent.com/12330670/51445451-4ddecd80-1d05-11e9-967d-4789150d39dc.png)


