### PR TITLE
docker: Add .listing-ct-body to image details

### DIFF
--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -404,7 +404,7 @@ class ImageDetails extends React.Component {
 
         return (
             <React.Fragment>
-                <dl>
+                <dl className='listing-ct-body'>
                     <dt>{_("Id")}</dt>         <dd title={image.Id}>{ docker.truncate_id(image.Id) }</dd>
                     <dt>{_("Tags")}</dt>       <dd>{ repotags.join(" ") }</dd>
                     <dt>{_("Entrypoint")}</dt> <dd>{ util.quote_cmdline(entrypoint) }</dd>


### PR DESCRIPTION
Seems that aacd03f5ac dropped this class, but it ended up  breaking table in image details (see attached images).
The mentioned commit by @garrett  drops this class on two places as he says that it nests `.listing-ct-body` class. It is true in the first case, but as far as I can see it is not true with the later case. 
@garrett I know it has been a while, but maybe you remember reason behind dropping it in the second place as well?

Current upstream:
![original](https://user-images.githubusercontent.com/12330670/51472559-1eb67380-1d7a-11e9-913f-7ece453b1452.png)

After this commit:
![afterrevert](https://user-images.githubusercontent.com/12330670/51472557-1eb67380-1d7a-11e9-8019-9c78f9dc2db0.png)


