### PR TITLE
storage: Minimally test snapshots of thin volumes

### DIFF
--- a/bots/naughty/debian-testing/11032-udisks2-fails-with-thin-snapshots
+++ b/bots/naughty/debian-testing/11032-udisks2-fails-with-thin-snapshots
@@ -1,0 +1,1 @@
+Error creating snapshot: Process reported exit code 3:   --size may not be zero.

--- a/bots/naughty/fedora-29/11032-udisks2-fails-with-thin-snapshots
+++ b/bots/naughty/fedora-29/11032-udisks2-fails-with-thin-snapshots
@@ -1,0 +1,1 @@
+Error creating snapshot: Process reported exit code 3:   --size may not be zero.

--- a/bots/naughty/rhel-7/11032-udisks2-fails-with-thin-snapshots
+++ b/bots/naughty/rhel-7/11032-udisks2-fails-with-thin-snapshots
@@ -1,0 +1,1 @@
+Error creating snapshot: Process reported exit code 3:   --size may not be zero.

--- a/bots/naughty/rhel-8-0/11032-udisks2-fails-with-thin-snapshots
+++ b/bots/naughty/rhel-8-0/11032-udisks2-fails-with-thin-snapshots
@@ -1,0 +1,1 @@
+Error creating snapshot: Process reported exit code 3:   --size may not be zero.

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -260,6 +260,28 @@ class TestStorage(StorageCase):
                                values={"disks": {"DISK2": True}})
         b.wait_in_text("#detail-sidebar", "Partition of QEMU QEMU HARDDISK (DISK2)")
 
+    def testSnapshots(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+        b.wait_in_text("#drives", "VirtIO")
+
+        m.add_disk("200M", serial="DISK1")
+        b.wait_in_text("#drives", "DISK1")
+
+        m.execute("vgcreate TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
+        b.wait_present("#vgroups")
+        b.wait_in_text("#vgroups", "TEST")
+        b.click('tr:contains("TEST")')
+        b.wait_visible("#storage-detail")
+
+        m.execute("lvcreate TEST --thinpool pool -L 20m")
+        m.execute("lvcreate -T TEST/pool -n thin -V 100m")
+        self.content_row_wait_in_col(2, 2, "/dev/TEST/thin")
+
+        self.content_tab_action(2, 1, "Create Snapshot")
+        self.dialog({ "name": "mysnapshot" })
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This is expected to fail on all images that use the modern UDisks2.  debian-stable should pass.