### PR TITLE
correct misleading translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -4593,7 +4593,7 @@ msgstr "Einhängestelle"
 
 #: pkg/storaged/nfs-details.jsx:172 pkg/storaged/format-dialog.jsx:85
 msgid "Mount at boot"
-msgstr "Am Kofferraum montieren"
+msgstr "Beim System-Start einhängen"
 
 #: pkg/docker/index.html:519
 msgid "Mount container volumes"


### PR DESCRIPTION
"Am Kofferraum montieren" means "mount on the trunk"
when i read this in the UI i could not even imagine what this translation originated from