### PR TITLE
systemd: Only link from graphs to available pages

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -510,6 +510,10 @@ PageServer.prototype = {
             self.unregistered = !subscribed;
             refresh_os_updates_state();
         });
+
+        // Only link from graphs to available pages
+        set_page_link("#link-disk", "storage", _("Disk I/O"));
+        set_page_link("#link-network", "network", _("Network Traffic"));
     },
 
     enter: function() {
@@ -1686,16 +1690,6 @@ $("#link-cpu").on("click", function() {
 
 $("#link-memory, #link-memory-and-swap").on("click", function() {
     cockpit.location.go([ "memory" ]);
-    return false;
-});
-
-$("#link-network").on("click", function() {
-    cockpit.jump("/network", cockpit.transport.host);
-    return false;
-});
-
-$("#link-disk").on("click", function() {
-    cockpit.jump("/storage", cockpit.transport.host);
     return false;
 });
 

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -215,12 +215,12 @@
             <div id="server_memory_graph" class="server-graph zoomable-plot"></div>
             <br/>
             <div>
-              <span class="plot-unit" id="server_disk_io_unit"></span><a id="link-disk" translate>Disk I/O</a>
+              <span class="plot-unit" id="server_disk_io_unit"></span><span id="link-disk"></span>
             </div>
             <div id="server_disk_io_graph" class="server-graph zoomable-plot"></div>
             <br/>
             <div>
-              <span class="plot-unit" id="server_network_traffic_unit"></span><a id="link-network" translate>Network Traffic</a>
+              <span class="plot-unit" id="server_network_traffic_unit"></span><span id="link-network"></span>
             </div>
             <div id="server_network_traffic_graph" class="server-graph zoomable-plot"></div>
         </div>

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -221,8 +221,12 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
 
         b.enter_page("/system", "10.111.113.3")
         b.wait_text_not("#system_information_systime_button", "")
-        b.wait_present("#link-network")
-        b.click("#link-network")
+        if m.image == "rhel-7-6-distropkg":
+            sel = "#link-network"
+        else:
+            sel = "#link-network a"
+        b.wait_present(sel)
+        b.click(sel)
         b.enter_page("/network", "10.111.113.3")
 
         self.allow_hostkey_messages()


### PR DESCRIPTION
Fixes #10663

Following picture shows how it looks like if both network and storage plugins are not available:
![cockpit-neither](https://user-images.githubusercontent.com/12330670/51611504-ae495700-1f1f-11e9-9c11-114faf808d69.png)
