### PR TITLE
logs: 'Critical and above' does not filter ABRT reports

### DIFF
--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -293,11 +293,6 @@ $(function() {
                 match.push('PRIORITY=' + i.toString());
         }
 
-        // If item 'Only Problems' was selected, match only ABRT's problems
-        if (prio_level === 2) {
-            match.push('SYSLOG_IDENTIFIER=abrt-notification');
-        }
-
         var options = cockpit.location.options;
         if (options['service'])
             match.push('_SYSTEMD_UNIT=' + options['service']);


### PR DESCRIPTION
It is reminder from previous representation, where priority '2' meant
'Only problems'. Now priority '2' is 'Critical and above'.