### PR TITLE
tools: Fix home directory of the cockpit-ws user

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -540,7 +540,7 @@ The Cockpit Web Service listens on the network, and authenticates users.
 
 %pre ws
 getent group cockpit-ws >/dev/null || groupadd -r cockpit-ws
-getent passwd cockpit-ws >/dev/null || useradd -r -g cockpit-ws -d / -s /sbin/nologin -c "User for cockpit-ws" cockpit-ws
+getent passwd cockpit-ws >/dev/null || useradd -r -g cockpit-ws -d /nonexisting -s /sbin/nologin -c "User for cockpit-ws" cockpit-ws
 
 %post ws
 %systemd_post cockpit.socket

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-adduser --system --group --home / --no-create-home cockpit-ws
+adduser --system --group --home /nonexisting --no-create-home cockpit-ws
 
 if ! dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
     dpkg-statoverride --update --add root cockpit-ws 4750 /usr/lib/cockpit/cockpit-session


### PR DESCRIPTION
Don't make that `/`, otherwise removing the system user with deleting
the home dir will wreak havoc. Use `/nonexisting` instead, which
complies to the Debian Policy §9.2.3.

Fixes #11049