### PR TITLE
WIP: machines: fix testAddDisk by preventing click event to fall through

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -391,7 +391,7 @@ class AddDiskModalBody extends React.Component {
         const vmStoragePools = storagePools;
 
         const defaultBody = (
-            <form className='ct-form-layout'>
+            <form onSubmit={event => event.preventDefault()} className='ct-form-layout'>
                 <label className='control-label' htmlFor={`${idPrefix}-source`}>
                     {_("Source")}
                 </label>


### PR DESCRIPTION
Sometimes when testAddDisk dialog is opened, it immediately closes again,
apparently the button click event somehow "falls through" the dialog that opens.
Fix that by stopping event processing in the handler.