### PR TITLE
naughty: Close 10898: kvdo broken on current rhel-8: kernel version mismatch

### DIFF
--- a/bots/naughty/rhel-8-0/10898-kvdo-missing
+++ b/bots/naughty/rhel-8-0/10898-kvdo-missing
@@ -1,4 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-vdo", line *, in testVdo
-*
-warning: vdo: ERROR - Kernel module kvdo not installed


### PR DESCRIPTION
Known issue which has not occurred in 27 days

kvdo broken on current rhel-8: kernel version mismatch

Fixes #10898