### PR TITLE
naughty: Close 10816: Leaving IPA domain fails: Unable to activate profile [sssd] [22]: Invalid argument

### DIFF
--- a/bots/naughty/rhel-8-0/10816-authselect-activate-sssd
+++ b/bots/naughty/rhel-8-0/10816-authselect-activate-sssd
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-realms", line *, in testIpa
-    wait_number_domains(0)
-  File "test/verify/check-realms", line *, in wait_number_domains
-    b.wait_text("#system-info-domain a", "Join Domain")
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 25 days

Leaving IPA domain fails: Unable to activate profile [sssd] [22]: Invalid argument

Fixes #10816