### PR TITLE
test-server: Exit when bridge was already closed

### DIFF
--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -1392,6 +1392,20 @@ cockpit_pipe_get_pid (CockpitPipe *self,
 }
 
 /**
+ * cockpit_pipe_is_closed:
+ * @self: a pipe
+ *
+ * Returns: TRUE if the pipe is closed
+ */
+gboolean
+cockpit_pipe_is_closed (CockpitPipe *self)
+{
+  g_return_val_if_fail (COCKPIT_IS_PIPE (self), FALSE);
+
+  return self->priv->closed;
+}
+
+/**
  * cockpit_pipe_get_name:
  * @self: a pipe
  *

--- a/src/common/cockpitpipe.h
+++ b/src/common/cockpitpipe.h
@@ -104,6 +104,8 @@ GByteArray *       cockpit_pipe_get_stderr   (CockpitPipe *self);
 gboolean           cockpit_pipe_get_pid      (CockpitPipe *self,
                                               GPid *pid);
 
+gboolean           cockpit_pipe_is_closed    (CockpitPipe *self);
+
 void               cockpit_pipe_skip         (GByteArray *buffer,
                                               gsize skip);
 


### PR DESCRIPTION
Some of the qunit tests can trigger protocol errors (especially the new
protocol tests). The bridge closes immediately when encountering those
errors. The test-server doesn't handle this case: it only connects to
the bridge's "close" signal in its own SIGTERM handler. The signal might
have already been emitted at this point. This causes the test-server
(and thus `make check`) to hang forever.

Add a cockpit_pipe_is_closed(), which test-server can use to check for
this case directly.