### PR TITLE
system: Only attach click handler to active time options

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -1071,7 +1071,7 @@ PageSystemInformationChangeSystime.prototype = {
         $("#systime-apply-button").on("click", $.proxy(this._on_apply_button, this));
 
         self.ntp_type = "manual_time";
-        $('#change_systime li').on('click', function() {
+        $('#change_systime ul').on('click', "li:not('.disabled')", function() {
             self.ntp_type = $(this).attr("value");
             self.update();
         });


### PR DESCRIPTION
I _believe_ this fixes what was being reported in #8621 namely, that the "Automatically from specific NTP Servers" option in the dropdown is disabled on RedHat 7/CentOS 7 (due to lack of systemd-timedated or something like that) but that if you ignore the disabled styling and mouse cursor and choose to click the menu entry anyway the form to add NTP servers is displayed anyway and then if you fill *that* form out it will not save your changes ... which cockpit knew was going to happen and tried to prevent but accidentally allowed anyway.

This change keeps the click handler from firing on the disabled element.

The only thing I wish I could have managed to do here but couldn't figure out how to make happen would be to have the dropdown stay open when the click occurs. (As is the menu still disappears when you click the disabled entry even though nothing happens. You don't get any indication that something wrong happened the menu just unceremoniously closes on you leaving the currently selected option selected.)

I started thinking about trying to write a test for this but I wasn't sure how I would, meaningfully, go about asserting that something *didn't* happen (without it being race-y).