### PR TITLE
realmd: Show domain information and less scary leave dialog

### DIFF
--- a/pkg/realmd/operation.html
+++ b/pkg/realmd/operation.html
@@ -6,7 +6,30 @@
       </div>
       <div class="modal-body">
         <div class="realms-op-fields">
-          <p class="realms-op-leave-only-row"></p>
+          <div class="realms-op-leave-only-row">
+            <form class="ct-form-layout">
+              <label class="control-label" for="realms-op-info-domain" translatable="yes">Domain</label>
+              <span id="realms-op-info-domain"></span>
+
+              <label class="control-label" for="realms-op-info-login-format" translatable="yes">Login Format</label>
+              <span id="realms-op-info-login-format"></span>
+
+              <label class="control-label" for="realms-op-info-server-sw" translatable="yes">Server Software</label>
+              <span id="realms-op-info-server-sw"></span>
+
+              <label class="control-label" for="realms-op-info-client-sw" translatable="yes">Client Software</label>
+              <span id="realms-op-info-client-sw"></span>
+            </form>
+
+            <a href="#" id="realms-op-leave-toggle" translatable="yes">Leave Domain</a>
+            <span id="realms-op-leave-caret" class="fa fa-caret-right"></span>
+            <div id="realms-op-alert" class="alert alert-warning" hidden>
+              <div translatable="yes">Only users with local credentials will be able to log into this machine. This may
+                also effect other services as DNS resolution settings and the list of trusted CAs may change.</div>
+
+              <button class="btn btn-danger realms-op-leave" type="submit" translatable="yes">Leave Domain</button>
+            </div>
+          </div>
 
           <form class="ct-form-layout realms-op-join-only">
             <label class="control-label" translatable="yes">Domain Address</label>

--- a/pkg/realmd/operation.js
+++ b/pkg/realmd/operation.js
@@ -45,6 +45,7 @@ function instance(realmd, mode, realm, button) {
     });
 
     $(".realms-op-apply").on("click", perform);
+    $(".realms-op-leave").on("click", perform);
     $(".realms-op-field")
             .on("keydown", function(ev) {
                 if (ev.which == 13)
@@ -110,30 +111,44 @@ function instance(realmd, mode, realm, button) {
         auth_changed($(this));
     });
 
-    var title, label, text;
+    var title, label;
     if (mode == 'join') {
         title = _("page-title", _("Join a Domain"));
         label = _("Join");
         $(".realms-op-join-only").show();
         $(".realms-op-leave-only-row").hide();
+        $(".realms-op-apply").text(label);
         check("");
     } else {
-        title = _("page-title", _("Leave Domain"));
-        label = _("Leave");
-        text = _("Are you sure you want to leave this domain?");
-        if (realm && realm.Name) {
-            text = cockpit.format(_("Are you sure you want to leave the '$0' domain?"), realm.Name);
-        }
+        title = _("page-title", _("Domain"));
+        $("#realms-op-info-domain").text(realm && realm.Name);
+        if (realm && realm.LoginFormats && realm && realm.LoginFormats.length > 0)
+            $("#realms-op-info-login-format").text(realm.LoginFormats[0].replace("%U", "username"));
+        $("#realms-op-info-server-sw").text(find_detail(realm, "server-software"));
+        $("#realms-op-info-client-sw").text(find_detail(realm, "client-software"));
 
-        text = cockpit.format(_("$0 Only users with local credentials will be able to log into this machine. This may also effect other services as DNS resolution settings and the list of trusted CAs may change."), text);
+        $("#realms-op-leave-toggle").on("click", ev => {
+            if ($("#realms-op-alert").is(":visible")) {
+                $("#realms-op-alert").hide();
+                $("#realms-op-leave-caret")
+                        .removeClass("fa-caret-down")
+                        .addClass("fa-caret-right");
+            } else {
+                $("#realms-op-alert").show();
+                $("#realms-op-leave-caret")
+                        .removeClass("fa-caret-right")
+                        .addClass("fa-caret-down");
+            }
 
-        $(".realms-op-leave-only-row").text(text);
-        $(".realms-op-join-only").hide();
+            ev.preventDefault();
+        });
+
         $(".realms-op-leave-only-row").show();
+        $(".realms-op-join-only").hide();
+        $(".realms-op-apply").hide();
     }
 
     $(".realms-op-title").text(title);
-    $(".realms-op-apply").text(label);
     $(".realms-op-field").val("");
 
     function check(name) {

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -112,10 +112,25 @@ body {
 /* leave some space towards the help block */
 #realms-op-address {
     margin-bottom: 10px;
-};
+}
 
 .realms-op-error .realms-op-more-diagnostics {
   font-weight: normal;
+}
+
+/* leave some space between form and leave toggle */
+#realms-op-leave-toggle {
+    font-weight: bold;
+    line-height: 5rem;
+}
+
+/* standard PF alerts have a wide margin */
+.realms-op-leave-only-row .alert {
+    padding-left: 2ex;
+}
+
+.realms-op-leave-only-row .alert button {
+    margin: 1ex 0;
 }
 
 /* Other styles */

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -204,15 +204,30 @@ class TestRealms(MachineCase):
         b.wait_present("#dashboard-hosts a[data-address='x0.cockpit.lan']")
         b.logout()
 
-        # Leave the domain
+        # Test domain info (PR #11096), leave the domain
         b.login_and_go("/system")
         b.wait_present("#system-info-domain a")
         b.wait_in_text("#system-info-domain a", "cockpit.lan")
         b.click("#system-info-domain a")
         b.wait_popup("realms-op")
-        b.wait_visible(".realms-op-leave-only-row")
-        b.wait_in_text(".realms-op-leave-only-row", "cockpit.lan")
-        b.click(".realms-op-apply")
+        if m.image != "rhel-7-6-distropkg":
+            b.wait_visible("#realms-op-info-domain")
+            b.wait_text("#realms-op-info-domain", "cockpit.lan")
+            b.wait_text("#realms-op-info-login-format", "username@cockpit.lan")
+            b.wait_text("#realms-op-info-server-sw", "ipa")
+            b.wait_text("#realms-op-info-client-sw", "sssd")
+            # leave button should be hidden behind expander by default
+            b.wait_not_visible("button.realms-op-leave")
+            b.wait_not_visible("#realms-op-alert")
+            b.click("#realms-op-leave-toggle")
+            b.wait_visible("#realms-op-alert")
+            b.wait_visible("button.realms-op-leave")
+            b.click(".realms-op-leave")
+        else:
+            b.wait_visible(".realms-op-leave-only-row")
+            b.wait_in_text(".realms-op-leave-only-row", "cockpit.lan")
+            b.click(".realms-op-apply")
+
         b.wait_popdown("realms-op")
         wait_number_domains(0)
         # re-enables hostname changing
@@ -294,6 +309,18 @@ class TestRealms(MachineCase):
         self.login_and_go("/system")
         b.wait_present("#system-info-domain a")
         b.wait_in_text("#system-info-domain a", "cockpit.lan")
+
+        # Show domain information (PR #11096)
+        if m.image != "rhel-7-6-distropkg":
+            b.click("#system-info-domain a")
+            b.wait_popup("realms-op")
+            b.wait_visible("#realms-op-info-domain")
+            b.wait_text("#realms-op-info-domain", "cockpit.lan")
+            b.wait_text("#realms-op-info-login-format", "username")  # no @domain
+            b.wait_text("#realms-op-info-server-sw", "ipa")
+            b.wait_text("#realms-op-info-client-sw", "sssd")
+            b.click(".realms-op-cancel")
+            b.wait_popdown("realms-op")
 
         # should be able to run admin operations
         b.go('/system/services#/systemd-tmpfiles-clean.timer')


### PR DESCRIPTION
Participants in our usability studies expected to get further details
about an IdM domain when clicking on the domain name on the System page,
intead of directly asking to leave it. 

So change the dialog to show the domain name, login format (slightly
more human friendly to replace `%u%` with `username`), server and client
software. Hide the "Leave Domain" behind an expander, and show the 
warning in there.

Fixes #10063 

 - [x] PR #11022 
 - [x] Fix spacing between form and "Leave Domain" link