### PR TITLE
bridge: Fix polkit policy file

### DIFF
--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -279,8 +279,9 @@ polkitdir        = $(datadir)/polkit-1/actions
 polkit_in_files  = src/bridge/org.cockpit-project.cockpit-bridge.policy.in
 polkit_DATA = $(polkit_in_files:.policy.in=.policy)
 
+# gettext-domain= must only occur on C strings, not translated ones
 %.policy: %.policy.in $(PO_FILES)
-	$(AM_V_GEN) $(INTLTOOL_MERGE) -q -x $(top_srcdir)/po $< $@
+	$(AM_V_GEN) $(INTLTOOL_MERGE) -q -x $(top_srcdir)/po $< - | sed '/xml:lang=/ s/\ gettext-domain=".*"//' > $@
 
 EXTRA_DIST += $(polkit_in_files)
 CLEANFILES += $(polkit_DATA)


### PR DESCRIPTION
Apparently polkit .policy files can have the `gettext-domain=` attribute
only in the C messages, not on the translated ones. In the latter case,
polkit just grabs the last string in the file for display (currently
Ukrainian), ignoring xml:lang.

So remove the domain attribute from all translated strings to fix that.

https://bugzilla.redhat.com/show_bug.cgi?id=1671773