### PR TITLE
package.json: Pin down terser 3.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "stdio": "~0.2.7",
     "strict-loader": "~1.1.0",
     "style-loader": "~0.13.1",
+    "terser": "3.14.1",
     "uglify-js": "^3.4.9",
     "webpack": "^4.17.1",
     "webpack-cli": "^3.1.0"


### PR DESCRIPTION
The recent terser 3.16.0 release causes the build to break with

    TypeError: Cannot read property 'minify' of undefined

(https://github.com/terser-js/terser/issues/251)

Until this is fixed, pin down the version of terser to the previous
known version 3.14.1.