### PR TITLE
naughty: Close 9330: leaving IPA domain fails with: Failed to remove krb5/LDAP configuration: expected str, bytes or os.PathLike object, not NoneType

### DIFF
--- a/bots/naughty/fedora-29/9330-ipa-leave-domain-None
+++ b/bots/naughty/fedora-29/9330-ipa-leave-domain-None
@@ -1,7 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-realms", line *, in testIpa
-    wait_number_domains(0)
-  File "test/verify/check-realms", line *, in wait_number_domains
-    b.wait_text("#system-info-domain a", "Join Domain")
-*
-Error: timeout


### PR DESCRIPTION
Known issue which has not occurred in 22 days

leaving IPA domain fails with: Failed to remove krb5/LDAP configuration: expected str, bytes or os.PathLike object, not NoneType

Fixes #9330