### PR TITLE
WIP: Show older logs

### DIFF
--- a/pkg/lib/cockpit-components-logs-panel.jsx
+++ b/pkg/lib/cockpit-components-logs-panel.jsx
@@ -102,7 +102,7 @@ class JournalOutput {
 
     limit(max) {
         if (this.logs.length > max)
-            this.logs = this.logs.slice(-max);
+            this.logs = this.logs.slice(0, max);
     }
 }
 

--- a/pkg/playground/react-demo-logs.jsx
+++ b/pkg/playground/react-demo-logs.jsx
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { LogsPanel } from "cockpit-components-logs-panel.jsx";
+
+const _ = cockpit.gettext;
+
+export class DemoLogsPanel extends React.Component {
+    render() {
+        var match = [
+            "_SYSTEMD_UNIT=slow10.service", "+",
+            "_SYSTEMD_UNIT=log123.service"
+        ];
+
+        return <LogsPanel title={_("Demo Logs")} match={match} max={10} />;
+    }
+}
+
+export function showLogsDemo(rootElement) {
+    ReactDOM.render(<DemoLogsPanel />, document.getElementById('demo-logs'));
+}

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -36,6 +36,11 @@
         <textarea id="edit-file"></textarea>
         <br/>
         Visibility: <label id="hidden"></label>
+
+        <div class="container-fluid">
+            <h3>Demo Logs</h3>
+            <div id="demo-logs"></div>
+        </div>
     </div>
 </body>
 </html>

--- a/pkg/playground/test.js
+++ b/pkg/playground/test.js
@@ -1,5 +1,7 @@
 import $ from "jquery";
 import cockpit from "cockpit";
+import "journal.css";
+import { showLogsDemo } from "./react-demo-logs.jsx";
 
 $(function() {
     $("#hammer").on("click", function () { $(this).hide() });
@@ -117,4 +119,7 @@ $(function() {
 
     $(cockpit).on("visibilitychange", show_hidden);
     show_hidden();
+
+    // Logs
+    showLogsDemo(document.getElementById('demo-logs'));
 });

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -271,6 +271,19 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                         ["check-journal", "BEFORE BOOT", ""]
                         ])
 
+        # Check embedded log panel
+        b.logout()
+        self.login_and_go("/playground/test")
+
+        def wait_logline(msg):
+            sel = "#demo-logs .cockpit-logline .cockpit-log-message:contains('{0}')".format(msg)
+            b.wait_present(sel)
+            b.wait_visible(sel)
+
+        wait_logline("SLOW")
+        for i in range(116, 124):
+            wait_logline(str(i))
+
     def testBinary(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Fixes #771
I am opening this PR so someone can look at it and say if this approach makes sense.

Before:
![before771](https://user-images.githubusercontent.com/12330670/52343177-a73e4080-2a17-11e9-9c7c-adcda05744cc.png)
After:
![after771](https://user-images.githubusercontent.com/12330670/52343182-ab6a5e00-2a17-11e9-8256-6b007f02a550.png)

Known issues:
1) If the last line to be added happened in different day, we add two lines (line with day and the line itself). However then we cut to N lines and last line stays the day line. pics or it didn't happen - 
![10day771](https://user-images.githubusercontent.com/12330670/52343375-2b90c380-2a18-11e9-9241-58b59d9a393c.png)

2) When new lines are added (as they later happen) those appended are not removed. (Trying to figure this out, but thought that I will open this to see if I am walking in a right direction)