### PR TITLE
Revert "package.json: Pin down terser 3.14.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "stdio": "~0.2.7",
     "strict-loader": "~1.1.0",
     "style-loader": "~0.13.1",
-    "terser": "3.14.1",
     "uglify-js": "^3.4.9",
     "webpack": "^4.17.1",
     "webpack-cli": "^3.1.0"


### PR DESCRIPTION
This reverts commit 0a60d0f44c2e82f3e1fea6f60e0896c93cb7741f.

terser 3.16.1 got released which fixes the regression.