### PR TITLE
bots: Give OS some extra time to write/flush pending log messages, fix flaky tests

### DIFF
--- a/bots/machine/machine_core/machine.py
+++ b/bots/machine/machine_core/machine.py
@@ -146,6 +146,11 @@ class Machine(ssh_connection.SSHConnection):
     def journal_messages(self, syslog_ids, log_level, cursor=None):
         """Return interesting journal messages"""
 
+        # give the OS some time to write pending log messages, to make
+        # unexpected message detection more reliable; RHEL/CentOS 7 does not
+        # yet know about --sync, so ignore failures
+        self.execute("journalctl --sync 2>/dev/null || true; sleep 3; journalctl --sync 2>/dev/null || true")
+
         # Journald does not always set trusted fields like
         # _SYSTEMD_UNIT or _EXE correctly for the last few messages of
         # a dying process, so we filter by the untrusted but reliable

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -243,6 +243,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     'sudo: a password is required',
                                     'sudo: sorry, you must have a tty to run sudo')
         self.allow_restart_journal_messages()
+        self.allow_authorize_journal_messages()
 
     def testConversation(self):
         m = self.machine

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -919,6 +919,7 @@ class TestMultiMachine(MachineCase):
         b.wait_visible("#login-available .empty")
 
         self.allow_hostkey_messages()
+        self.allow_authorize_journal_messages()
         self.allow_journal_messages('.* couldn\'t connect: .*',
                                     '.*: Connection reset by peer',
                                     '.* failed to retrieve resource: invalid-hostkey',

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1088,6 +1088,7 @@ ConditionPathExists=!/run/ostree-booted
 [Timer]
 OnBootSec=1h
 OnUnitInactiveSec=1d
+Unit=-.mount
 
 [Install]
 WantedBy=basic.target

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -192,7 +192,6 @@ class TestSystemInfo(MachineCase):
         b.wait_text('#system_machine_id', mid)
 
         self.allow_journal_messages("error loading contents of os-release: .*")
-        self.check_journal_messages()
 
     def testTime(self):
         m = self.machine

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -944,6 +944,7 @@ class TestMachines(MachineCase):
 
         # disconnecting the serial console closes the pty channel
         self.allow_journal_messages("connection unexpectedly closed by peer")
+        self.allow_browser_errors("Disconnection timed out.")
 
     def testCreate(self):
         """


### PR DESCRIPTION
Our unexpected message detection is rather unreliable for messages that
only get triggered close to when a test ends. Give the OS some extra 3
seconds to settle down, and force journald to write everything pending
to disk.

This should make tests that cause unexpected log messages to fail more
reliably.

## Tests to fix

 - [x] [testSerialConsole](https://fedorapeople.org/groups/cockpit/logs/pull-11137-20190208-112727-486fab54-verify-debian-testing/log.html#50) happens on other OSes now (already fixed in PR #11136)
- [x] [testSerialConsole in d-bus mode](https://fedorapeople.org/groups/cockpit/logs/pull-11137-20190208-112727-486fab54-verify-debian-testing/log.html#36) fails on an unexpected browser message. These are indirectly affected as they now also get delayed by 3 seconds.
- `polkit-agent-helper-1: pam_authenticate failed: Authentication failure` happens in several tests:
    * [x]  [check-login TestLogin.testExpired](https://fedorapeople.org/groups/cockpit/logs/pull-11137-20190208-112424-486fab54-verify-debian-stable/log.html#21)
    * [x] [check-multi-machine TestMultiMachine.testTroubleshooting](https://fedorapeople.org/groups/cockpit/logs/pull-11137-20190208-112424-486fab54-verify-debian-stable/log.html#61)
 - [x] `Job for dnf-automatic-install.timer failed.` happens in [check-packagekit TestAutoUpdates.testInstall](https://fedorapeople.org/groups/cockpit/logs/pull-11137-20190208-111212-486fab54-verify-fedora-29/log.html#131)