### PR TITLE
terminal: Implement own context handler for copy&paste

### DIFF
--- a/pkg/lib/cockpit-components-context-menu.jsx
+++ b/pkg/lib/cockpit-components-context-menu.jsx
@@ -1,0 +1,114 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import PropTypes from "prop-types";
+
+import "context-menu.css";
+
+const _ = cockpit.gettext;
+
+/*
+ * A context menu component that contains copy and paste fields.
+ *
+ * It requires two properties:
+ *  - getText, method which is called when copy is clicked
+ *  - setText, method which is called when paste is clicked
+ */
+export class ContextMenu extends React.Component {
+    constructor() {
+        super();
+        this.state = { visible: false };
+        this._handleContextMenu = this._handleContextMenu.bind(this);
+        this._handleClick = this._handleClick.bind(this);
+    }
+
+    componentDidMount() {
+        document.addEventListener('contextmenu', this._handleContextMenu);
+        document.addEventListener('click', this._handleClick);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('contextmenu', this._handleContextMenu);
+        document.removeEventListener('click', this._handleClick);
+    }
+
+    _handleContextMenu(event) {
+        event.preventDefault();
+
+        this.setState({ visible: true });
+
+        const clickX = event.clientX;
+        const clickY = event.clientY;
+        const screenW = window.innerWidth;
+        const screenH = window.innerHeight;
+        const rootW = this.root.offsetWidth;
+        const rootH = this.root.offsetHeight;
+
+        const right = (screenW - clickX) > rootW;
+        const left = !right;
+        const top = (screenH - clickY) > rootH;
+        const bottom = !top;
+
+        if (right) {
+            this.root.style.left = `${clickX + 5}px`;
+        }
+
+        if (left) {
+            this.root.style.left = `${clickX - rootW - 5}px`;
+        }
+
+        if (top) {
+            this.root.style.top = `${clickY + 5}px`;
+        }
+
+        if (bottom) {
+            this.root.style.top = `${clickY - rootH - 5}px`;
+        }
+    }
+
+    _handleClick(event) {
+        if (event && event.button === 0) {
+            const wasOutside = !(event.target.contains === this.root);
+
+            if (wasOutside && this.state.visible)
+                this.setState({ visible: false });
+        }
+    }
+
+    render() {
+        return this.state.visible &&
+            <div ref={ ref => { this.root = ref } } className="contextMenu">
+                <div className="contextMenuOption" onClick={this.props.getText}>
+                    <div className="contextMenuName"> { _("Copy") } </div>
+                    <div className="contextMenuShortcut">{ _("Ctrl+Insert") }</div>
+                </div>
+                <div className="contextMenuOption" onClick={this.props.setText} >
+                    <div className="contextMenuName"> { _("Paste") } </div>
+                    <div className="contextMenuShortcut">{ _("Shift+Insert") }</div>
+                </div>
+            </div>;
+    }
+}
+
+ContextMenu.propTypes = {
+    getText: PropTypes.func.isRequired,
+    setText: PropTypes.func.isRequired
+};

--- a/pkg/lib/context-menu.css
+++ b/pkg/lib/context-menu.css
@@ -1,0 +1,25 @@
+.contextMenu {
+    position: fixed;
+    /* xterm accessibility tree has z-index 100 and we need to be in front of it
+     * to be able to handle mouse events.
+     */
+    z-index: 101;
+    background: white;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    box-shadow: 0px 2px 10px #999999;
+}
+
+.contextMenuOption {
+    padding: 5px 15px 5px 15px;
+    min-width: 220px;
+    font-size: 13px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.contextMenuOption:hover,
+.contextMenuOption:active {
+    background-color: #4683db;
+    color: white;
+}

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -119,11 +119,17 @@ function ph_mouse(sel, type, x, y, btn, force) {
         top += elp.offsetTop;
     }
 
+    var detail = 0;
+    if (["click", "mousedown", "mouseup"].indexOf(type) > -1)
+        detail = 1;
+    else if (type === "dblclick")
+        detail = 2;
+
     var ev = document.createEvent("MouseEvent");
     ev.initMouseEvent(
         type,
         true /* bubble */, true /* cancelable */,
-        window, null,
+        window, detail,
         left + x, top + y, left + x, top + y, /* coordinates */
         false, false, false, false, /* modifier keys */
         btn, null);

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -508,6 +508,13 @@ class Browser:
             print("-> Setting SSL certificate error policy to %s" % action)
         self.cdp.command("new Promise((resolve, _) => { ssl_bad_certificate_action = '%s'; resolve() })" % action)
 
+    def grant_permissions(self, *args):
+        """Grant permissions to the browser"""
+        # https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-grantPermissions
+        self.cdp.invoke("Browser.grantPermissions",
+                        origin="http://%s:%s" % (self.address, self.port),
+                        permissions=args)
+
     def snapshot(self, title, label=None):
         """Take a snapshot of the current screen and save it as a PNG and HTML.
 

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -98,6 +98,69 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         wait_line(n + 1, blank_state)
         self.assertNotIn('admin', b.text(line_sel(n + 1)))
 
+        # Fixed in PR #11148
+        if m.image == "rhel-7-6-distropkg":
+            return
+
+        def select_line(sel, width):
+            # Select line by dragging mouse
+            # 10px padding on all sides
+            # Height on a line is around 14px, so start approx. in the middle of line
+            b.mouse(sel, "mousedown", 10, 17)
+            b.mouse(sel, "mousemove", 10 + width, 17)
+            b.mouse(sel, "mouseup", 10 + width, 17)
+
+        b.grant_permissions("clipboardRead", "clipboardWrite")
+
+        # Execute command
+        wait_line(n, prompt)
+        b.key_press('echo "XYZ"\r')
+        wait_line(n + 1, "XYZ")
+
+        sel = line_sel(n + 1)
+
+        # Highlight 40px (3 letters, never wider that ~14px)
+        select_line(sel, 40)
+
+        # Right click and pick copy
+        b.mouse(sel, "contextmenu", btn=2)
+        b.wait_present('.contextMenu')
+        b.wait_visible('.contextMenu')
+        b.click('.contextMenu .contextMenuOption:first-child')
+
+        # Right click and pick paste
+        b.mouse(sel, "contextmenu", btn=2)
+        b.wait_present('.contextMenu')
+        b.wait_visible('.contextMenu')
+        b.click('.contextMenu .contextMenuOption:nth-child(2)')
+
+        # Wait for text to show up
+        wait_line(n + 2, "XYZ")
+
+        # now reset terminal
+        b.click('.btn:contains("Reset")')
+
+        # assert that the output from earlier is gone
+        wait_line(n + 1, blank_state)
+
+        # Execute another command
+        wait_line(n, prompt)
+        b.key_press('echo "foo"\r')
+        wait_line(n + 1, "foo")
+
+        # Highlight 40px (3 letters, never wider that ~14px)
+        select_line(sel, 40)
+
+        # Use keyboard shortcuts to copy text
+        # HACK - '-' is interpreted as insert key because when modifiers are
+        #   used, windowsVirtualKeyCode is used and insert key has code 45.
+        #   At the same time '-' has ascii code 45.
+        b.key_press("-", 2) # Ctrl + Insert
+        b.key_press("-", 8) # Shift + Insert
+
+        # Wait for text to show up
+        wait_line(n + 2, "foo")
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Implementing own context menu when right click on terminal. Support copy
and paste even when screenReaderMode (accessibility mode) is used.

To see demo watch https://youtu.be/OHdrFrMSgEg

Context menu changed a bit from the demo, current screenshot:
![currectscreen](https://user-images.githubusercontent.com/12330670/52548648-2c867400-2dcf-11e9-8d3a-367937d8b361.png)



## Browsers support
### Chrome
Full support since version 66. On first paste will ask for permission.

### Firefox
Copy support since version 63. Paste does not work :( Firefox did not implement clipboard permissions for web applications (only for extensions).

### Opera
Full support since version 53. On first paste will ask for permission.

### Edge
Not tested, but seems there is no support at all.

## Using sync vs async
This PR implements newer async clipboard API. There is also sync approach by using method ` execCommand` which is deprecated but is supported from much older version in all browsers. However pasting in firefox is still not supported even with this older method.

## Pros

- Copy&paste
- Discoverable keyboard shortcuts

## Cons

- Paste does not work in all browsers
- Edge is (most likely) not supported at all
- Works only in newer versions of browsers (possibility to use old deprecated approach?) 

Note: There are no tests and that't for two reasons:

1. I want to be sure this will get accepted before I fight with tests ( as there are some issues with some browsers)
2. I am not sure where and how to write tests for this, will need some guidance.

TODO:
 - [x] fix text selection in test
 - [x] cover keyboard shortcuts (Ctrl+Insert and Shift+Insert) in test