### PR TITLE
lib/form-layout: Add support for widgets nested in splits

### DIFF
--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -220,10 +220,14 @@
     > input[type="checkbox"],
     > input[type="radio"] {
       // Typical browser widget height for radios & checks; standardized here
-      height: 16px;
-      margin: @padding-small-vertical 0;
-      margin-right: 0.5rem;
-      position: static;
+      @checkradio-height: 16px;
+      // Baseline alignment needs an offset to compensate for size difference
+      @baseline-offset: (@widget-height - @checkradio-height) / 2;
+      align-self: baseline;
+      height: @checkradio-height;
+      margin: 0 0.5rem 0 0;
+      position: relative;
+      top: @baseline-offset;
     }
   }
 

--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -182,6 +182,7 @@
         grid-column: ~"1 / -1";
       }
     }
+  }
 
   > [role=group],
   > .ct-validation-wrapper > [role=group],

--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -251,6 +251,23 @@
     margin-bottom: @padding-small-vertical;
   }
 
+  // Fix up list group items too (alignment and clickable areas)
+  .list-group-item {
+    // Move padding into the label
+    padding: 0;
+
+    label {
+      display: flex;
+      padding: 0.5rem 1rem;
+      align-items: first baseline;
+
+      > input[type=checkbox],
+      > input[type=radio] {
+        top: 3px;
+      }
+    }
+  }
+
   // Relax split elements to only take up one column
   > .ct-form-layout-split {
     grid-column: ~"auto / auto";

--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -114,9 +114,10 @@
     -webkit-appearance: textarea;
   }
 
-  // Special considerations for widgets (and widget-like elements)
+  // Special considerations for widgets (and widget-like elements),
+  // supporting direct children and also validation wrapper & split nesting.
   // This is a LESS mixin that will not be in the compiled CSS.
-  .widget-rules() {
+  .ct-form-widget-rules() {
     > input,
     > textarea,
     > select,
@@ -141,8 +142,8 @@
     }
   }
 
-  &, > .ct-validation-wrapper {
-    .widget-rules();
+  &, > .ct-validation-wrapper, > .ct-form-layout-split {
+    .ct-form-widget-rules();
   }
 
   // Some elements need special width considerations
@@ -179,13 +180,6 @@
       }
     }
 
-    > .checkbox,
-    > .radio {
-        // Spacing is handled by grid, not margin
-        margin: 0;
-    }
-  }
-
   > [role=group],
   > .ct-validation-wrapper > [role=group],
   > .ct-validation-wrapper > [data-field] {
@@ -199,6 +193,12 @@
       > .ct-select {
         width: 100%;
       }
+    }
+
+    > .checkbox,
+    > .radio {
+        // Spacing is handled by grid, not margin
+        margin: 0;
     }
   }
 

--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -127,11 +127,14 @@
     > .combobox-container,
     > fieldset,
     > [role=group],
-    > [data-field],
+    > [data-field]:not(ul),
     > .form-group,
     > .btn-group,
     > label.checkbox,
     > label.radio,
+    > .input-group,
+    > .ct-form-layout-split > .checkbox-inline,
+    > .ct-form-layout-split > .radio-inline,
     > .checkbox-inline,
     > .radio-inline {
       // Vertically align elements with text


### PR DESCRIPTION
Fix alignment as mentioned in https://github.com/cockpit-project/cockpit/pull/11083/#issuecomment-460710561 by applying special widget offseting & min-height to widgets also directly enclosed within `ct-form-layout-split`, which should behave now similarly to top-level children.