### PR TITLE
WIP: machines: fix testAddDisk by unnesting the modal from the listing actions

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -391,7 +391,7 @@ class AddDiskModalBody extends React.Component {
         const vmStoragePools = storagePools;
 
         const defaultBody = (
-            <form className='ct-form-layout'>
+            <div className='ct-form-layout'>
                 <label className='control-label' htmlFor={`${idPrefix}-source`}>
                     {_("Source")}
                 </label>
@@ -433,7 +433,7 @@ class AddDiskModalBody extends React.Component {
                                      provider={provider}
                                      vm={vm} />
                 )}
-            </form>
+            </div>
         );
 
         return (


### PR DESCRIPTION
Sometimes when testAddDisk dialog is opened, it immediately closes again,
apparently the button click event somehow "falls through" the dialog that opens.

This commit moves the code for the modal dialog out from listing
actions to avoid unnecessary nesting.