### PR TITLE
naughty: Close 10586:  SELinux is preventing systemd-timesyncd from using the 'nnp_transition'

### DIFF
--- a/bots/naughty/fedora-29/10586-selinux-timesyncd-nnp_transition
+++ b/bots/naughty/fedora-29/10586-selinux-timesyncd-nnp_transition
@@ -1,2 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { nnp_transition } for * comm="(imesyncd)"
-


### PR DESCRIPTION
Known issue which has not occurred in 25 days

 SELinux is preventing systemd-timesyncd from using the 'nnp_transition'

Fixes #10586