### PR TITLE
naughty: Close 10565: SELinux denial: Unable to open config database [/var/lib/sss/db/config.ldb] on fedora-testing

### DIFF
--- a/bots/naughty/fedora-29/10565-selinux-chpasswd-sss-cache
+++ b/bots/naughty/fedora-29/10565-selinux-chpasswd-sss-cache
@@ -1,1 +1,0 @@
-[sss_cache] [confdb_init] (0x0010): Unable to open config database [/var/lib/sss/db/config.ldb]

--- a/bots/naughty/rhel-8-0/10565-selinux-chpasswd-sss-cache
+++ b/bots/naughty/rhel-8-0/10565-selinux-chpasswd-sss-cache
@@ -1,1 +1,0 @@
-[sss_cache] [confdb_init] (0x0010): Unable to open config database [/var/lib/sss/db/config.ldb]


### PR DESCRIPTION
Known issue which has not occurred in 25 days

SELinux denial: Unable to open config database [/var/lib/sss/db/config.ldb] on fedora-testing

Fixes #10565