### PR TITLE
realmd: Fix translatable string

### DIFF
--- a/pkg/realmd/operation.html
+++ b/pkg/realmd/operation.html
@@ -24,9 +24,7 @@
             <a href="#" id="realms-op-leave-toggle" translatable="yes">Leave Domain</a>
             <span id="realms-op-leave-caret" class="fa fa-caret-right"></span>
             <div id="realms-op-alert" class="alert alert-warning" hidden>
-              <div translatable="yes">After leaving the domain, only users with local credentials will be able
-                to log into this machine. This may also affect other services as DNS resolution settings and
-                the list of trusted CAs may change.</div>
+              <div translatable="yes">After leaving the domain, only users with local credentials will be able to log into this machine. This may also affect other services as DNS resolution settings and the list of trusted CAs may change.</div>
               <button class="btn btn-danger realms-op-leave" type="submit" translatable="yes">Leave Domain</button>
             </div>
           </div>


### PR DESCRIPTION
Avoid so much empty space in the "After leaving.." string. It goes into
the translation templates and confuses translators.