### PR TITLE
terminal: Introduce themes

### DIFF
--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -24,6 +24,58 @@ import { Terminal as Term } from "xterm";
 import { ContextMenu } from "cockpit-components-context-menu.jsx";
 import "console.css";
 
+const theme_core = {
+    yellow: "#b58900",
+    brightRed: "#cb4b16",
+    red: "#dc322f",
+    magenta: "#d33682",
+    brightMagenta: "#6c71c4",
+    blue: "#268bd2",
+    cyan: "#2aa198",
+    green: "#859900"
+};
+
+const themes = {
+    "black-theme": {
+        background: "#000000",
+        foreground: "#ffffff"
+    },
+    "dark-theme": Object.assign({}, theme_core, {
+        background: "#002b36",
+        foreground: "#fdf6e3",
+        cursor: "#eee8d5",
+        selection: "#ffffff77",
+        brightBlack: "#002b36",
+        black: "#073642",
+        brightGreen: "#586e75",
+        brightYellow: "#657b83",
+        brightBlue: "#839496",
+        brightCyan: "#93a1a1",
+        white: "#eee8d5",
+        brightWhite: "#fdf6e3"
+    }),
+    "light-theme": Object.assign({}, theme_core, {
+        background: "#fdf6e3",
+        foreground: "#002b36",
+        cursor: "#073642",
+        selection: "#00000044",
+        brightWhite: "#002b36",
+        white: "#073642",
+        brightCyan: "#586e75",
+        brightBlue: "#657b83",
+        brightYellow: "#839496",
+        brightGreen: "#93a1a1",
+        black: "#eee8d5",
+        brightBlack: "#fdf6e3"
+    }),
+    "white-theme": {
+        background: "#ffffff",
+        foreground: "#000000",
+        selection: "#00000044",
+        cursor: "#000000",
+    },
+};
+
 /*
  * A terminal component that communicates over a cockpit channel.
  *
@@ -38,6 +90,8 @@ import "console.css";
  * the title of the terminal changes.
  *
  * Call focus() to set the input focus on the terminal.
+ *
+ * Also it is possible to set up theme by property 'theme'.
  */
 export class Terminal extends React.Component {
     constructor(props) {
@@ -53,6 +107,7 @@ export class Terminal extends React.Component {
         this.onFocusOut = this.onFocusOut.bind(this);
         this.setText = this.setText.bind(this);
         this.getText = this.getText.bind(this);
+        this.setTerminalTheme = this.setTerminalTheme.bind(this);
     }
 
     componentWillMount() {
@@ -85,6 +140,7 @@ export class Terminal extends React.Component {
             window.addEventListener('resize', this.onWindowResize);
             this.onWindowResize();
         }
+        this.setTerminalTheme(this.props.theme || 'black-theme');
         this.state.terminal.focus();
     }
 
@@ -103,6 +159,9 @@ export class Terminal extends React.Component {
             this.state.terminal.reset();
             this.disconnectChannel();
         }
+
+        if (nextProps.theme !== this.props.theme)
+            this.setTerminalTheme(nextProps.theme);
     }
 
     componentDidUpdate(prevProps) {
@@ -202,6 +261,10 @@ export class Terminal extends React.Component {
         });
     }
 
+    setTerminalTheme(theme) {
+        this.state.terminal.setOption("theme", themes[theme]);
+    }
+
     onBeforeUnload(event) {
         // Firefox requires this when the page is in an iframe
         event.preventDefault();
@@ -225,5 +288,6 @@ Terminal.propTypes = {
     cols: PropTypes.number,
     rows: PropTypes.number,
     channel: PropTypes.object.isRequired,
-    onTitleChanged: PropTypes.func
+    onTitleChanged: PropTypes.func,
+    theme: PropTypes.string
 };

--- a/pkg/lib/console.css
+++ b/pkg/lib/console.css
@@ -34,8 +34,11 @@
     text-align: left;
     outline: medium none;
     background-color: black;
-    border: 1px solid black;
     padding: 10px;
+    border-top: 1px solid black;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
 }
 
 .terminal .terminal-cursor {

--- a/pkg/systemd/terminal.css
+++ b/pkg/systemd/terminal.css
@@ -13,9 +13,36 @@ html, body {
     bottom: 0px;
     left: 0px;
     right: 0px;
-    background-color: black;
+}
+
+.black-theme {
+    background-color: #000000;
+}
+
+.dark-theme {
+    background-color: #002b36;
+}
+
+.light-theme {
+    background-color: #fdf6e3;
+}
+
+.white-theme {
+    background-color: #ffffff;
 }
 
 #terminal {
     height: 100%;
+}
+
+.terminal-group {
+    display: flex;
+    justify-content: space-between;
+}
+
+#theme-select {
+    margin-left: 5px;
+    margin-right: 5px;
+    width: auto;
+    min-width: 10rem;
 }

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { Terminal } from "cockpit-components-terminal.jsx";
+import { Select, SelectEntry } from "cockpit-components-select.jsx";
 
 const _ = cockpit.gettext;
 
@@ -34,11 +35,14 @@ const _ = cockpit.gettext;
 
         constructor(props) {
             super(props);
+            var theme = document.cookie.replace(/(?:(?:^|.*;\s*)theme_cookie\s*=\s*([^;]*).*$)|^.*$/, "$1");
             this.state = {
-                title: 'Terminal'
+                title: 'Terminal',
+                theme: theme || "black-theme"
             };
             this.onTitleChanged = this.onTitleChanged.bind(this);
             this.onResetClick = this.onResetClick.bind(this);
+            this.onThemeChanged = this.onThemeChanged.bind(this);
         }
 
         componentWillMount() {
@@ -49,6 +53,13 @@ const _ = cockpit.gettext;
 
         onTitleChanged(title) {
             this.setState({ title: title });
+        }
+
+        onThemeChanged(value) {
+            this.setState({ theme: value });
+            var cookie = "theme_cookie=" + encodeURIComponent(value) +
+                         "; path=/; expires=Sun, 16 Jul 3567 06:23:41 GMT";
+            document.cookie = cookie;
         }
 
         onResetClick(event) {
@@ -71,19 +82,31 @@ const _ = cockpit.gettext;
             if (this.state.channel)
                 terminal = (<Terminal ref="terminal"
                      channel={this.state.channel}
+                     theme={this.state.theme}
                      onTitleChanged={this.onTitleChanged} />);
             else
                 terminal = <span>Loading...</span>;
 
             return (
                 <div className="console-ct-container">
-                    <div className="panel-heading">
+                    <div className="panel-heading terminal-group">
                         <tt className="terminal-title">{this.state.title}</tt>
-                        <button ref="resetButton"
-                             className="btn btn-default pull-right"
-                             onClick={this.onResetClick}>{_("Reset")}</button>
+                        <div>
+                            <label className="control-label" htmlFor="theme-select">{ _("Appearance:") }</label>
+                            <Select onChange={ this.onThemeChanged }
+                                    id="theme-select"
+                                    initial={ this.state.theme }>
+                                <SelectEntry data='black-theme'>{ _("Black") }</SelectEntry>
+                                <SelectEntry data='dark-theme'>{ _("Dark") }</SelectEntry>
+                                <SelectEntry data='light-theme'>{ _("Light") }</SelectEntry>
+                                <SelectEntry data='white-theme'>{ _("White") }</SelectEntry>
+                            </Select>
+                            <button ref="resetButton"
+                                 className="btn btn-default"
+                                 onClick={ this.onResetClick }>{ _("Reset") }</button>
+                        </div>
                     </div>
-                    <div className="panel-body">
+                    <div className={ "panel-body " + this.state.theme }>
                         {terminal}
                     </div>
                 </div>

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -161,6 +161,27 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         # Wait for text to show up
         wait_line(n + 2, "foo")
 
+        def check_theme_select(name, style):
+            b.select_from_dropdown("#theme-select", name)
+            b.wait_attr(".xterm-viewport", "style", style)
+
+        # Check that color theme changes
+        white_style = "background-color: rgb(255, 255, 255);"
+
+        check_theme_select("Black", "background-color: rgb(0, 0, 0);")
+        check_theme_select("Dark", "background-color: rgb(0, 43, 54);")
+        check_theme_select("Light", "background-color: rgb(253, 246, 227);")
+        check_theme_select("White", white_style)
+
+        # Relogin and white-style should be remembered
+        # Relogin on different page, as reloging on terminal prompts asking if you want to leave the site
+        b.go("/system")
+        b.relogin("/system")
+        b.go("/system/terminal")
+        b.enter_page("/system/terminal")
+        b.wait_present('.terminal')
+        b.wait_attr(".xterm-viewport", "style", white_style)
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This is the first version of themes in terminal.
There are a few questions which needs to be answered, such as:

1.  What is default theme?
2. How should the selection look like? *
3. What themes we want and are these suitable?

* This is discussed in #11177 @garrett has some awesome ideas for simple dialog-thing  which would contain nice theme selection as well as setting of the font size. Question is if this should be in this PR or as follow-up.

Any comments are welcome. Now default theme is dark.
Screenshots:
![darkmodedone](https://user-images.githubusercontent.com/12330670/52840084-7be2e200-30f8-11e9-8bbc-0869de1543ca.png)
![lightmodedone](https://user-images.githubusercontent.com/12330670/52840085-7c7b7880-30f8-11e9-8ea3-cab527703dfa.png)

Fixes #11177

Marking as no-test for now, if this will be close to landing I will enable tests (I dont want to test it pointlessly if big changes will be required)