### PR TITLE
Replace depreceted document.createEvent

### DIFF
--- a/pkg/kubernetes/scripts/graphs.js
+++ b/pkg/kubernetes/scripts/graphs.js
@@ -541,8 +541,11 @@
                                 }
                             }
 
-                            var event = document.createEvent("CustomEvent");
-                            event.initCustomEvent("changed", false, false, null);
+                            var event = new CustomEvent("changed", {
+                                bubbles: false,
+                                cancelable: false,
+                                detail: null
+                            });
                             self.dispatchEvent(event, null);
                         };
 

--- a/pkg/kubernetes/scripts/kube-client-cockpit.js
+++ b/pkg/kubernetes/scripts/kube-client-cockpit.js
@@ -475,12 +475,10 @@
                             });
 
                             channel.addEventListener("close", function(ev, options) {
-                                var problem = options.problem || "";
                                 channel = null;
 
                                 state = 3;
-                                var cev = document.createEvent('Event');
-                                cev.initEvent('close', false, false, !!problem, 1000, problem);
+                                var cev = new Event("close", { bubbles: false, cancelable: false });
                                 ws.dispatchEvent(cev);
                             });
 
@@ -498,14 +496,12 @@
                             });
 
                             state = 1;
-                            var oev = document.createEvent('Event');
-                            oev.initEvent('open', false, false);
+                            var oev = new Event("open", { bubbles: false, cancelable: false });
                             ws.dispatchEvent(oev);
                         }
 
                         function fail() {
-                            var ev = document.createEvent('Event');
-                            ev.initEvent('close', false, false, false, 1002, "protocol-error");
+                            var ev = new Event("close", { bubbles: false, cancelable: false });
                             ws.dispatchEvent(ev);
                         }
 
@@ -632,12 +628,10 @@
                             }));
 
                             channel.addEventListener("close", function(ev, options) {
-                                var problem = options.problem || "";
                                 channel = null;
 
                                 state = 3;
-                                var cev = document.createEvent('Event');
-                                cev.initEvent('close', false, false, !!problem, 1000, problem);
+                                var cev = new Event("close", { bubbles: false, cancelable: false });
                                 ws.dispatchEvent(cev);
                             });
 
@@ -653,8 +647,7 @@
                             });
 
                             state = 1;
-                            var oev = document.createEvent('Event');
-                            oev.initEvent('open', false, false);
+                            var oev = new Event("open", { bubbles: false, cancelable: false });
                             ws.dispatchEvent(oev);
                         });
 

--- a/pkg/kubernetes/scripts/kube-client-cockpit.js
+++ b/pkg/kubernetes/scripts/kube-client-cockpit.js
@@ -485,13 +485,7 @@
                             channel.addEventListener("message", function(ev, data) {
                                 if (base64)
                                     data = "1" + window.btoa(data);
-                                var mev;
-                                if (window.MessageEvent) {
-                                    mev = new window.MessageEvent('message', { 'data': data });
-                                } else {
-                                    mev = document.createEvent('MessageEvent');
-                                    mev.initMessageEvent('message', false, false, data, null, null, window, null);
-                                }
+                                var mev = new window.MessageEvent('message', { data: data });
                                 ws.dispatchEvent(mev);
                             });
 
@@ -636,13 +630,7 @@
                             });
 
                             channel.addEventListener("message", function(ev, data) {
-                                var mev;
-                                if (window.MessageEvent) {
-                                    mev = new window.MessageEvent('message', { 'data': data });
-                                } else {
-                                    mev = document.createEvent('MessageEvent');
-                                    mev.initMessageEvent('message', false, false, data, null, null, window, null);
-                                }
+                                var mev = new window.MessageEvent('message', { data: data });
                                 ws.dispatchEvent(mev);
                             });
 

--- a/pkg/subscriptions/subscriptions-client.js
+++ b/pkg/subscriptions/subscriptions-client.js
@@ -37,8 +37,7 @@ client.subscriptionStatus = {
 var service;
 
 function needRender() {
-    var ev = document.createEvent("Event");
-    ev.initEvent("dataChanged", false, false);
+    var ev = new Event("dataChanged", { bubbles: false, cancelable: false });
     client.dispatchEvent(ev);
 }
 

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -240,13 +240,19 @@ function event_mixin(obj, handlers) {
                 if (typeof event === "string") {
                     type = event;
                     args = Array.prototype.slice.call(arguments, 1);
-                    event = document.createEvent("CustomEvent");
+
+                    var detail = null;
                     if (arguments.length == 2)
-                        event.initCustomEvent(type, false, false, arguments[1]);
+                        detail = arguments[1];
                     else if (arguments.length > 2)
-                        event.initCustomEvent(type, false, false, args);
-                    else
-                        event.initCustomEvent(type, false, false, null);
+                        detail = args;
+
+                    event = new CustomEvent(type, {
+                        bubbles: false,
+                        cancelable: false,
+                        detail: detail
+                    });
+
                     args.unshift(event);
                 } else {
                     type = event.type;

--- a/src/base1/test-events.js
+++ b/src/base1/test-events.js
@@ -14,8 +14,7 @@ QUnit.test("event dispatch", function (assert) {
         count += 1;
     }
 
-    var ev = document.createEvent("Event");
-    ev.initEvent("action", false, false);
+    var ev = new Event("action", { bubbles: false, cancelable: false });
     ev.data = "Data";
 
     obj.dispatchEvent(ev);

--- a/test/avocado/testlib_avocado/seleniumlib.py
+++ b/test/avocado/testlib_avocado/seleniumlib.py
@@ -225,8 +225,8 @@ This function is only for internal purposes:
             self.take_screenshot(fatal=False)
             raise SeleniumElementFailure('Unable to SEND_KEYS to element ({})'.format(e))
         if javascript_operations:
-            self._driver_excecute('var ev = document.createEvent("Event"); ev.initEvent("change", true, false); arguments[0].dispatchEvent(ev);', element)
-            self._driver_excecute('var ev = document.createEvent("Event"); ev.initEvent("keydown", true, false); arguments[0].dispatchEvent(ev);', element)
+            self._driver_excecute('var ev = new Event("change", { bubbles: true, cancelable: false }); arguments[0].dispatchEvent(ev);', element)
+            self._driver_excecute('var ev = new Event("change", { bubbles: true, cancelable: false }); arguments[0].dispatchEvent(ev);', element)
 
     def check_box(self, element, checked=True):
         try:

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -52,8 +52,7 @@ function ph_set_val (sel, val)
     if (el.value === undefined)
         throw sel + " does not have a value";
     el.value = val;
-    var ev = document.createEvent("Event");
-    ev.initEvent("change", true, false);
+    var ev = new Event("change", { bubbles: true, cancelable: false });
     el.dispatchEvent(ev);
 }
 
@@ -85,8 +84,7 @@ function ph_set_attr (sel, attr, val)
     else
         el.setAttribute(attr, val);
 
-    var ev = document.createEvent("Event");
-    ev.initEvent("change", true, false);
+    var ev = new Event("change", { bubbles: true, cancelable: false });
     el.dispatchEvent(ev);
 }
 

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -125,14 +125,17 @@ function ph_mouse(sel, type, x, y, btn, force) {
     else if (type === "dblclick")
         detail = 2;
 
-    var ev = document.createEvent("MouseEvent");
-    ev.initMouseEvent(
-        type,
-        true /* bubble */, true /* cancelable */,
-        window, detail,
-        left + x, top + y, left + x, top + y, /* coordinates */
-        false, false, false, false, /* modifier keys */
-        btn, null);
+    var ev = new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        detail: detail,
+        screenX: left + x,
+        screenY: top + y,
+        clientX: left + x,
+        clientY: top + y,
+        button: btn
+    });
 
     el.dispatchEvent(ev);
 

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -682,14 +682,12 @@ class KubernetesCommonTests(VolumeTests):
                     var x = el[i].getAttribute("cx");
                     var y = el[i].getAttribute("cy");
                     if (x && y) {
-                        var ev = document.createEvent("MouseEvent");
-                        ev.initMouseEvent(
-                            "mousedown",
-                            true /* bubble */, true /* cancelable */,
-                            window, null,
-                            0, 0, 0, 0, /* coordinates */
-                            false, false, false, false, /* modifier keys */
-                            0 /*left*/, null);
+                        var ev = new MouseEvent("mousedown", {
+                            bubbles: true,
+                            cancelable: true,
+                            view: window,
+                            button: 0
+                        });
 
                         /* Now dispatch the event */
                         el[i].dispatchEvent(ev);


### PR DESCRIPTION
I kept only `StorageEvent` in `src/base1/cockpit.js` as I did not find proper documentation and I don't want to just guess. 