### PR TITLE
packagekit: Show three most recent updates

### DIFF
--- a/pkg/packagekit/history.jsx
+++ b/pkg/packagekit/history.jsx
@@ -1,0 +1,137 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import moment from 'moment';
+import React from "react";
+import PropTypes from "prop-types";
+
+import { OverlayTrigger, Tooltip } from "patternfly-react";
+
+import cockpit from "cockpit";
+
+const _ = cockpit.gettext;
+
+function formatPkgs(pkgs) {
+    let names = Object.keys(pkgs).filter(i => i != "_time");
+    names.sort();
+    return names.map(n => (
+        <OverlayTrigger key={n} overlay={ <Tooltip id="tip-history">{ n + " " + pkgs[n] }</Tooltip> } placement="top">
+            <li>{n}</li>
+        </OverlayTrigger>)
+    );
+}
+
+export const PackageList = ({ packages }) => packages ? <ul className='flow-list'>{formatPkgs(packages)}</ul> : null;
+
+export class History extends React.Component {
+    constructor() {
+        super();
+        this.state = { expanded: new Set([0]) };
+    }
+
+    onExpand(index) {
+        let e = new Set(this.state.expanded);
+        if (e.has(index))
+            e.delete(index);
+        else
+            e.add(index);
+        this.setState({ expanded: e });
+    }
+
+    /* Some PackageKit transactions come in pairs with identical package list,
+     * but different versions. This is an internal technicality, merge them
+     * together for presentation.
+     *
+     * Returns a time sorted (descending) list of objects like
+     * { time: moment_object, num_packages: 2, packages: {names...}}
+     */
+    mergeHistory() {
+        let history = [];
+        let prevTime, prevPackages;
+
+        for (let i = 0; i < this.props.packagekit.length; ++i) {
+            let packages = Object.keys(this.props.packagekit[i]).filter(i => i != "_time");
+            let time = moment(this.props.packagekit[i]["_time"]);
+            packages.sort();
+
+            if (prevTime && (time - prevTime) <= 600000 /* 10 mins */ &&
+                prevPackages.toString() == packages.toString())
+                history.pop();
+
+            history.push({ time, packages: this.props.packagekit[i], num_packages: packages.length });
+
+            if (history.length === 3)
+                break;
+
+            prevPackages = packages;
+            prevTime = time;
+        }
+
+        return history;
+    }
+
+    render() {
+        const history = this.mergeHistory();
+        if (history.length === 0)
+            return null;
+
+        let rows = history.map((update, index) => {
+            const time = update.time.format("YYYY-MM-DD HH:mm");
+            let pkgcount, details;
+
+            pkgcount = (
+                <div className="list-view-pf-additional-info-item">
+                    <span className="pficon pficon-bundle" />
+                    { cockpit.format(cockpit.ngettext("$0 Package", "$0 Packages", update.num_packages), update.num_packages) }
+                </div>);
+
+            details = (
+                <tr className="listing-ct-panel">
+                    <td colSpan="3">
+                        <div className="listing-ct-body">
+                            <PackageList packages={update.packages} />
+                        </div>
+                    </td>
+                </tr>);
+
+            return (
+                <tbody key={index} className={ details && this.state.expanded.has(index) ? "open" : null } >
+                    <tr className="listing-ct-item" onClick={ () => this.onExpand(index) } >
+                        { details ? <td className="listing-ct-toggle"><i className="fa fa-fw" /></td> : <td /> }
+                        <th>{time}</th>
+                        <td className="history-pkgcount">{pkgcount}</td>
+                    </tr>
+                    {details}
+                </tbody>);
+        });
+
+        return (
+            <React.Fragment>
+                <h2>{ _("Update History") }</h2>
+                <table className="listing-ct updates-history">
+                    {rows}
+                </table>
+            </React.Fragment>
+        );
+    }
+}
+
+History.propTypes = {
+    packagekit: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -153,8 +153,8 @@ class TestUpdates(PackageCase):
         b.wait_in_text("#available h2", "Available Updates")
         self.assertEqual(b.text("#state"), "2 updates")
 
-        b.wait_present("table.listing-ct")
-        b.wait_in_text("table.listing-ct", "vanilla")
+        b.wait_present("table.available")
+        b.wait_in_text("table.available", "vanilla")
         self.check_nth_update(1, "chocolate", "2.0-2")
         self.check_nth_update(2, "vanilla", "1.0-2")
 
@@ -176,7 +176,7 @@ class TestUpdates(PackageCase):
         m.execute("test -f /stamp-vanilla-1.0-1 && test -f /stamp-chocolate-2.0-1")
 
         # no update history yet
-        self.assertFalse(b.is_present("#history"))
+        self.assertFalse(b.is_present("table.updates-history"))
 
         # should only have one button (no security updates)
         self.assertEqual(b.text("#app .container-fluid button"), "Install All Updates")
@@ -226,6 +226,13 @@ class TestUpdates(PackageCase):
         # new versions are now installed
         m.execute("test -f /stamp-vanilla-1.0-2 && test -f /stamp-chocolate-2.0-2")
 
+        # history shows the two packages, expanded by default
+        b.wait_present("table.updates-history tbody.open td.history-pkgcount")
+        b.wait_text("table.updates-history tbody.open td.history-pkgcount", "2 Packages")
+        b.wait_present("table.updates-history tbody.open .listing-ct-panel")
+        b.wait_in_text("table.updates-history tbody.open .listing-ct-panel", "chocolate")
+        b.wait_in_text("table.updates-history tbody.open .listing-ct-panel", "vanilla")
+
         # system page has current state as well
         b.go("/system")
         b.enter_page("/system")
@@ -270,8 +277,8 @@ class TestUpdates(PackageCase):
         b.wait_in_text("#available h2", "Available Updates")
         self.assertEqual(b.text("#state"), "6 updates, including 3 security fixes")
 
-        b.wait_present("table.listing-ct")
-        b.wait_in_text("table.listing-ct", "sevcritical")
+        b.wait_present("table.available")
+        b.wait_in_text("table.available", "sevcritical")
 
         # security updates should get sorted on top and then alphabetically, so start with "secdeclare"
         sel = self.check_nth_update(1, "secdeclare", "3-4.b1", "security", 1,
@@ -382,14 +389,14 @@ class TestUpdates(PackageCase):
         b.wait_in_text("#state", "3 updates")
         b.wait_present(".container-fluid #available h2")
         b.wait_in_text(".container-fluid #available h2", "Available Updates")
-        b.wait_in_text("table.listing-ct", "norefs-doc")
-        self.assertIn("buggy", b.text("table.listing-ct"))
-        self.assertNotIn("secdeclare", b.text("table.listing-ct"))
-        self.assertNotIn("secparse", b.text("table.listing-ct"))
+        b.wait_in_text("table.available", "norefs-doc")
+        self.assertIn("buggy", b.text("table.available"))
+        self.assertNotIn("secdeclare", b.text("table.available"))
+        self.assertNotIn("secparse", b.text("table.available"))
 
         # history should show the security updates
-        b.wait_present(".container-fluid #history h2")
-        assertHistory("#history ul", ["secdeclare", "secparse", "sevcritical"])
+        b.wait_present("table.updates-history")
+        assertHistory("table.updates-history ul", ["secdeclare", "secparse", "sevcritical"])
 
         # stop PackageKit (e. g. idle timeout) to make sure the page survives that
         m.execute("systemctl kill --signal=KILL packagekit.service")
@@ -438,8 +445,10 @@ class TestUpdates(PackageCase):
         # empty state visible in main area
         b.wait_present(".container-fluid div.blank-slate-pf")
 
-        # history on "up to date" page should show the recent update
-        assertHistory("ul", ["buggy", "norefs-bin", "norefs-doc"])
+        # history on "up to date" page should show the recent update (expanded by default)
+        assertHistory("table.updates-history tbody.open ul", ["buggy", "norefs-bin", "norefs-doc"])
+        # and the previous one, not expaned
+        assertHistory("table.updates-history tbody:not(.open) ul", ["secdeclare", "secparse", "sevcritical"])
 
         self.allow_restart_journal_messages()
 
@@ -479,8 +488,8 @@ class TestUpdates(PackageCase):
             b.wait_in_text("#available h2", "Available Updates")
             b.wait_in_text("#state", "2")
 
-            b.wait_present("table.listing-ct")
-            b.wait_in_text("table.listing-ct", "secnocve")
+            b.wait_present("table.available")
+            b.wait_in_text("table.available", "secnocve")
 
             # secnocve should be displayed properly
             self.check_nth_update(2, "secnocve", "1-2", "security", desc_matches=["Fix leak"])
@@ -512,8 +521,8 @@ class TestUpdates(PackageCase):
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.wait_present("table.listing-ct")
-        b.wait_in_text("table.listing-ct", "Things change")
+        b.wait_present("table.available")
+        b.wait_in_text("table.available", "Things change")
 
         # "coarse" package list should be complete
         t = b.text("#app .listing-ct tbody:nth-of-type(1) th")
@@ -627,8 +636,8 @@ class TestUpdates(PackageCase):
         b.wait_in_text(".container-fluid #available h2", "Available Updates")
         self.assertEqual(b.text("#state"), "2 updates")
 
-        b.wait_present("table.listing-ct")
-        b.wait_in_text("table.listing-ct", "cockpit-ws")
+        b.wait_present("table.available")
+        b.wait_in_text("table.available", "cockpit-ws")
 
         b.wait_present("#app div.alert-warning")
         b.wait_in_text("#app div.alert-warning", "This web console will be updated.")
@@ -814,7 +823,7 @@ class TestUpdatesSubscriptions(PackageCase):
         b.wait_present("#available h2")
         b.wait_in_text("#available h2", "Available Updates")
         # no update history yet
-        self.assertFalse(b.is_present("#history"))
+        self.assertFalse(b.is_present("table.updates-history"))
 
         # has action buttons
         b.wait_present(".content-header-extra button")


### PR DESCRIPTION
Show the Update History in a proper table, with (at most) the three most
recent updates. Also show how many packages got updated. The most recent
update table row is expanded by default, to mimic the previous
behaviour.

This requires some surgery on the PackageKit history: Often one update
is represented as two transactions, one of which has the old package
versions, the following one the new ones. Only show the latter
transaction in this case to avoid confusion.

Add an `available` class to our existing "available updates" table, so
that we can tell the two tables apart in tests and CSS.

This design extends easily to integrating snapshots in the future.