### PR TITLE
packagekit: Add LVM update snapshots and rollbacks

### DIFF
--- a/doc/guide/feature-packagekit.xml
+++ b/doc/guide/feature-packagekit.xml
@@ -41,4 +41,24 @@ Proceed with changes? [N/y] y
   <command>dnf updateinfo info</command> on Fedora or
   <command>sudo apt upgrade</command> on Debian.</para>
 
+<para>If the root partition is on LVM, this page also allows you to
+  <ulink url="https://linux.die.net/man/8/lvcreate">create</ulink>,
+  <ulink url="https://linux.die.net/man/8/lvconvert">restore</ulink>,
+  <ulink url="https://linux.die.net/man/8/lvremove">delete</ulink>, and
+  <ulink url="https://linux.die.net/man/8/lvdisplay">list</ulink>
+  snapshots. These operations can be performed on the command
+  line with the standard LVM tools:</para>
+
+<programlisting>
+$ <command>lvdisplay --all</command>
+
+$ <command>lvcreate --snapshot -n update-package-foo --size 5G fedora/root</command>
+
+# update was successful, delete the snapshot
+$ <command>lvremove fedora/update-package-foo</command>
+
+# update failed, roll back to the snapshot
+$ <command>lvconvert --merge fedora/update-package-foo</command>
+$ <command>reboot</command>
+</programlisting>
 </chapter>

--- a/pkg/packagekit/history.jsx
+++ b/pkg/packagekit/history.jsx
@@ -21,11 +21,29 @@ import moment from 'moment';
 import React from "react";
 import PropTypes from "prop-types";
 
-import { OverlayTrigger, Tooltip } from "patternfly-react";
+import { Button, Label, DropdownKebab, MenuItem, Modal,
+    OverlayTrigger, Tooltip } from "patternfly-react";
 
 import cockpit from "cockpit";
 
+import { snapshots } from "./snapshots.jsx";
+
 const _ = cockpit.gettext;
+
+const RollbackDialog = ({ time, close, onRollback }) => (
+    <Modal show onHide={close}>
+        <Modal.Header>
+            <Modal.Title>{ _("Roll Back to Snapshot") }</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+            { cockpit.format(_("Are you sure you want to roll back to the system state snapshot of $0 and reboot the system?"), time) }
+        </Modal.Body>
+        <Modal.Footer>
+            <Button bsStyle="default" className="btn-cancel" onClick={close}>{ _("Cancel")}</Button>
+            <Button bsStyle="danger" onClick={ () => { close(); onRollback() } }>{ _("Roll Back and Reboot")}</Button>
+        </Modal.Footer>
+    </Modal>
+);
 
 function formatPkgs(pkgs) {
     let names = Object.keys(pkgs).filter(i => i != "_time");
@@ -42,7 +60,22 @@ export const PackageList = ({ packages }) => packages ? <ul className='flow-list
 export class History extends React.Component {
     constructor() {
         super();
-        this.state = { expanded: new Set([0]) };
+        this.state = { expanded: new Set([0]), rollbackName: null, rollbackTime: null };
+        this.onSnapshotsChanged = this.onSnapshotsChanged.bind(this);
+    }
+
+    onSnapshotsChanged() {
+        this.setState({});
+    }
+
+    componentDidMount() {
+        snapshots.addEventListener("changed", this.onSnapshotsChanged);
+        if (snapshots.rootLV) // in case it initialized before mounting
+            this.onSnapshotsChanged();
+    }
+
+    componentWillUnmount() {
+        snapshots.removeEventListener("changed", this.onSnapshotsChanged);
     }
 
     onExpand(index) {
@@ -54,17 +87,37 @@ export class History extends React.Component {
         this.setState({ expanded: e });
     }
 
-    /* Some PackageKit transactions come in pairs with identical package list,
-     * but different versions. This is an internal technicality, merge them
-     * together for presentation.
+    /* Merge snapshot and PackageKit history into a shared one. PackageKit
+     * updates that can be matched to a snapshot get merged into a single
+     * entry.
+     *
+    /* Also, some PackageKit transactions come in pairs with identical package
+     * list, but different versions. This is an internal technicality, merge
+     * them together for presentation.
      *
      * Returns a time sorted (descending) list of objects like
-     * { time: moment_object, num_packages: 2, packages: {names...}}
+     *
+     * { time: moment_object, lv_name: "update-20190211-1232", lv_size: 2147483648, lv_merging: "",
+     *   num_packages: 2, packages: {names...}}
+     *
+     * where "lv_*" only exists for snapshots, and "packages" only exists if
+     * there is a matching PackageKit update.
      */
     mergeHistory() {
+        // create copy and normalize "time"
         let history = [];
-        let prevTime, prevPackages;
+        snapshots.history.map(s => history.push(Object.assign({}, s, { time: s.lv_time })));
 
+        // limit PackageKit history to time of oldest snapshot, if snapshots are used; otherwise show 3
+        let pkmax = 3;
+        if (snapshots.history.length > 0) {
+            let oldest = snapshots.history.reduce((oldest, s) => (oldest < s.lv_time.unix()) ? oldest : s.lv_time.unix(), undefined);
+            let too_old_idx = this.props.packagekit.findIndex(pkgs => pkgs["_time"] / 1000 < oldest);
+            pkmax = (too_old_idx >= 0) ? Math.min(too_old_idx, pkmax) : null;
+        }
+
+        // copy, normalize, and clean out PackageKit history
+        let prevTime, prevPackages;
         for (let i = 0; i < this.props.packagekit.length; ++i) {
             let packages = Object.keys(this.props.packagekit[i]).filter(i => i != "_time");
             let time = moment(this.props.packagekit[i]["_time"]);
@@ -76,11 +129,20 @@ export class History extends React.Component {
 
             history.push({ time, packages: this.props.packagekit[i], num_packages: packages.length });
 
-            if (history.length === 3)
+            if (history.length === pkmax)
                 break;
 
             prevPackages = packages;
             prevTime = time;
+        }
+
+        // sort by descending time
+        history.sort((u1, u2) => u2.time - u1.time);
+
+        // merge each PackageKit update that is followed by a snapshot
+        for (let i = 0; i < history.length - 1; ++i) {
+            if (history[i].packages && history[i + 1].lv_name)
+                Object.assign(history[i], history.splice(i + 1, 1)[0]);
         }
 
         return history;
@@ -91,31 +153,74 @@ export class History extends React.Component {
         if (history.length === 0)
             return null;
 
+        const pending_rollback = snapshots.history.find(s => !!s.lv_merging);
+
         let rows = history.map((update, index) => {
             const time = update.time.format("YYYY-MM-DD HH:mm");
-            let pkgcount, details;
+            let pkgcount, snapsize, rollback_action, kebab_action, details;
 
-            pkgcount = (
-                <div className="list-view-pf-additional-info-item">
-                    <span className="pficon pficon-bundle" />
-                    { cockpit.format(cockpit.ngettext("$0 Package", "$0 Packages", update.num_packages), update.num_packages) }
-                </div>);
+            if (update.lv_merging) {
+                rollback_action = <Label bsStyle="info">{ _("Restoring...") }</Label>;
+            } else if (update.lv_name) {
+                // if there is a pending rollback, one cannot apply more rollbacks
+                if (!pending_rollback)
+                    rollback_action = (
+                        <Button onClick={ event => {
+                            this.setState({ rollbackName: update.lv_name, rollbackTime: time });
+                            event.stopPropagation();
+                        } } >
+                            { _("Roll Back") }
+                        </Button>);
 
-            details = (
-                <tr className="listing-ct-panel">
-                    <td colSpan="3">
-                        <div className="listing-ct-body">
-                            <PackageList packages={update.packages} />
-                        </div>
-                    </td>
-                </tr>);
+                kebab_action = (
+                    // HACK: DropdownKebab uses react-bootstrap's Dropdown, whose handleClick() forgets to stop
+                    // event propagation in version <= 0.32.4. So stop it in here the parent element instead. This
+                    // code change in react-bootstrap 1.0.0, but that version doesn't yet work with PF-React.
+                    <span className="history-kebab" onClick={ ev => ev.stopPropagation() }>
+                        <DropdownKebab key="actions" id={ "actions-" + update.lv_name } pullRight>
+                            <MenuItem onClick={ () => snapshots.delete(update.lv_name) }>{ _("Delete Snapshot") }</MenuItem>
+                        </DropdownKebab>
+                    </span>);
+            }
+
+            if (update.lv_size) {
+                snapsize = (
+                    <div className="list-view-pf-additional-info-item">
+                        <span className="pficon pficon-restart" />
+                        { cockpit.format(_("$0 Snapshot"), cockpit.format_bytes(update.lv_size, 1024)) }
+                    </div>);
+            }
+
+            if (update.packages) {
+                pkgcount = (
+                    <div className="list-view-pf-additional-info-item">
+                        <span className="pficon pficon-bundle" />
+                        { cockpit.format(cockpit.ngettext("$0 Package", "$0 Packages", update.num_packages), update.num_packages) }
+                    </div>);
+
+                details = (
+                    <tr className="listing-ct-panel">
+                        <td colSpan="6">
+                            <div className="listing-ct-body">
+                                <PackageList packages={update.packages} />
+                            </div>
+                        </td>
+                    </tr>);
+            }
 
             return (
                 <tbody key={index} className={ details && this.state.expanded.has(index) ? "open" : null } >
                     <tr className="listing-ct-item" onClick={ () => this.onExpand(index) } >
                         { details ? <td className="listing-ct-toggle"><i className="fa fa-fw" /></td> : <td /> }
                         <th>{time}</th>
-                        <td className="history-pkgcount">{pkgcount}</td>
+                        <td className="listing-ct-meta">
+                            <div className="history-pkgcount listing-ct-info">{pkgcount}</div>
+                            <div className="history-snapsize listing-ct-info">{snapsize}</div>
+                            <div className="history-rollback listing-ct-action">
+                                {rollback_action}
+                                {kebab_action}
+                            </div>
+                        </td>
                     </tr>
                     {details}
                 </tbody>);
@@ -127,6 +232,11 @@ export class History extends React.Component {
                 <table className="listing-ct updates-history">
                     {rows}
                 </table>
+
+                { this.state.rollbackName &&
+                    <RollbackDialog time={this.state.rollbackTime}
+                                    close={ () => this.setState({ rollbackName: null }) }
+                                    onRollback={ () => snapshots.rollback(this.state.rollbackName) } /> }
             </React.Fragment>
         );
     }

--- a/pkg/packagekit/mock-updates.js
+++ b/pkg/packagekit/mock-updates.js
@@ -11,6 +11,8 @@
  *          let pkg_ids = Object.keys(updates);
  */
 
+import moment from "moment";
+
 export function injectMockUpdates(updates) {
     // some security updates
     updates["security-crit;2.3-4"] = {
@@ -109,3 +111,20 @@ export function injectMockUpdates(updates) {
         description: "This is FUBAR",
     };
 }
+
+/*
+ * Mock history.jsx History.mergeHistory() results. To use it,
+ * assign it to "history" right before returning:
+ *
+ * -        return history;
+ * +        return require("./mock-updates.js").fakeHistory;
+ */
+export const fakeHistory = [
+    // empty snapshot
+    { time: moment("2019-02-22T10:30:38.000Z"), lv_name: "update-20190222-1130", lv_size: "2147483648", lv_merging: "" },
+    // snapshot with packages
+    { time: moment("2019-02-22T10:21:26.000Z"), lv_name: "update-20190222-1121", lv_size: "5368709120", lv_merging: "",
+      packages: { "_time":1550831315335, lemon: "1.0-1", chocolate: "1.0-1" }, num_packages: 2 },
+    // plain update without snapshot
+    { time: moment("2019-02-22T10:20:35.485Z"), packages: { "_time": 1550830835485, vanilla: "1.0-1" }, num_packages: 1 }
+];

--- a/pkg/packagekit/snapshots.jsx
+++ b/pkg/packagekit/snapshots.jsx
@@ -1,0 +1,266 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import moment from "moment";
+import React from "react";
+
+import { Button, Modal, Alert, OverlayTrigger, Tooltip } from "patternfly-react";
+
+import cockpit from "cockpit";
+import 'form-layout.less';
+
+const _ = cockpit.gettext;
+const LVM_TIME_FORMAT = "YYYY-MM-DD HH:mm:ss Z";
+const GiB = 1024 * 1024 * 1024;
+
+function debug() {
+    if (window.debugging == "all" || window.debugging == "packagekit")
+        console.log.apply(console, arguments);
+}
+
+/*
+ *
+ * Snapshots management object
+ *
+ */
+
+export var snapshots = {
+    rootLV: null,
+    VG: null,
+    availableSpace: 0,
+    usedSpace: null,
+    sizeGiB: null,
+    history: [], // objects with lv_name, lv_time (moment object), lv_size, lv_merging (see lvmreport(7))
+};
+
+snapshots.init = () => {
+    // check if root device is on LVM
+    cockpit.spawn(["findmnt", "--noheadings", "--output", "SOURCE", "/"], { err: "message" })
+            .then(rootdev => {
+                rootdev = rootdev.trim();
+                debug("findmnt /:", rootdev);
+                if (rootdev.startsWith("/dev/mapper/")) {
+                    // check available and used space
+                    Promise.all([
+                        cockpit.spawn(["lvdisplay", "--noheadings", "--columns", "--units=b", "--nosuffix", "-ovg_free,vg_name,lv_name", rootdev],
+                                      { err: "message", superuser: "require" }),
+                        cockpit.spawn(["df", "--block-size=1", "--output=used", "/"], { err: "message" })
+                    ])
+                            .then(outputs => {
+                                let fields = outputs[0].trim().split(' ');
+                                let avail = parseInt(fields[0]);
+                                snapshots.VG = fields[1];
+                                let lv_name = fields[2];
+
+                                // df output looks like "   Used\n12345\n"
+                                let used = parseInt(outputs[1].trim().split('\n')[1]);
+                                debug("free space on root VG", snapshots.VG, ":", avail, "used space on root fs:", used);
+                                snapshots.rootLV = rootdev;
+                                snapshots.availableSpace = avail;
+                                snapshots.usedSpace = used;
+                                // default size to used space on root fs
+                                snapshots.sizeGiB = Math.round(used / GiB);
+
+                                snapshots.dispatchEvent("changed");
+
+                                // get existing snapshots
+                                cockpit.spawn(["lvs", "--reportformat=json", "--all", "--units=b", "--nosuffix",
+                                    "--options=lv_name,lv_time,lv_size,lv_attr,lv_merging",
+                                    "--select", "lv_attr=~^[sS] && origin=" + lv_name, snapshots.VG],
+                                              { err: "message", superuser: "require" })
+                                        .then(output => {
+                                            let info = JSON.parse(output);
+                                            // parse lv_time
+                                            snapshots.history = info.report[0].lv.map(s => {
+                                                s.lv_time = moment(s.lv_time, LVM_TIME_FORMAT, true);
+                                                return s;
+                                            });
+                                            debug("snapshot history:", JSON.stringify(snapshots.history));
+                                            snapshots.dispatchEvent("changed");
+                                        })
+                                        .catch(error => {
+                                            console.warn("failed to list existing snapshots:", JSON.stringify(error));
+                                        });
+                            })
+                            .catch(error => {
+                                console.warn("failed to determine available and free space:", JSON.stringify(error));
+                            });
+                }
+            })
+            .catch(error => {
+                debug("findmnt / failed: ", error);
+            });
+};
+
+snapshots.create = () => {
+    if (!snapshots.rootLV)
+        return Promise.reject(new Error("There is no LVM root LV, snapshots not available"));
+
+    const name = "update-" + moment().format("YYYYMMDD-HHmm");
+
+    debug("creating snapshot", name, "with size", snapshots.sizeGiB, "GiB on", snapshots.rootLV);
+
+    let pr = cockpit.spawn(["lvcreate", "--snapshot", "-n", name, "--size", snapshots.sizeGiB + "G", snapshots.rootLV],
+                           { err: "message", superuser: "require" });
+    pr.then(() => snapshots.init());
+    return pr;
+};
+
+snapshots.delete = (name) => {
+    debug("deleting snapshot", name);
+    let pr = cockpit.spawn(["lvremove", "--force", snapshots.VG + "/" + name],
+                           { err: "message", superuser: "require" });
+    pr.then(() => snapshots.init());
+    return pr;
+};
+
+snapshots.rollback = (name) => {
+    debug("rolling back to snapshot", name);
+    return cockpit.spawn(["lvconvert", "--merge", snapshots.VG + "/" + name],
+                         { err: "message", superuser: "require" })
+            .then(() => {
+                // quick UI update, until it disconnects due to rebooting
+                snapshots.init();
+                debug("rebooting to apply snapshot", name);
+                cockpit.spawn(["shutdown", "--reboot", "now"], { superuser: "require", err: "message" })
+                        .fail(error => console.error("Failed to reboot:", error.toString()));
+            });
+};
+
+cockpit.event_target(snapshots);
+snapshots.init();
+
+/*
+ *
+ * Snapshot creation dialog
+ *
+ */
+
+class SnapshotCreateDialog extends React.Component {
+    constructor() {
+        super();
+        this.state = { sizeGiB: snapshots.sizeGiB, error: null };
+        this.onSizeChange = this.onSizeChange.bind(this);
+        this.onUpdate = this.onUpdate.bind(this);
+    }
+
+    onSizeChange(event) {
+        let n = parseInt(event.target.value);
+        if (!isNaN(n))
+            this.setState({ sizeGiB: n });
+    }
+
+    onUpdate() {
+        snapshots.sizeGiB = this.state.sizeGiB;
+        snapshots.create()
+                .then(() => {
+                    this.setState({ error: null });
+                    this.props.close();
+                })
+                .catch(err => this.setState({ error: err.toString() }));
+    }
+
+    render() {
+        return (
+            <Modal id="create-snapshot-dialog" show onHide={this.props.close}>
+                <Modal.Header>
+                    <Modal.Title>{ _("Create Snapshot") }</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <p>{ _("The snapshot must be big enough to contain all future updates and changes to the root volume.") }</p>
+
+                    <form className="ct-form-layout">
+                        <label className="control-label" htmlFor="create-snapshot-size">{ _("Snapshot Size") }</label>
+                        <div role="group">
+                            <input id="create-snapshot-size" type="number" value={this.state.sizeGiB} onChange={this.onSizeChange}
+                                   min={1} max={ Math.floor(snapshots.availableSpace / 1000000000) } />
+                            <label>GiB</label>
+                        </div>
+                    </form>
+                </Modal.Body>
+                <Modal.Footer>
+                    { this.state.error && <Alert><span>{this.state.error}</span></Alert> }
+                    <Button bsStyle="default" className="btn-cancel" onClick={this.props.close}>{ _("Cancel")}</Button>
+                    <Button bsStyle="primary" onClick={this.onUpdate}>{ _("Create")}</Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+/*
+ *
+ * Snapshots creation button
+ *
+ */
+
+export class SnapshotCreateButton extends React.Component {
+    constructor() {
+        super();
+        this.state = { showDialog: false };
+        this.onSnapshotsChanged = this.onSnapshotsChanged.bind(this);
+    }
+
+    onSnapshotsChanged() {
+        this.setState({ });
+        debug("SnapshotCreateButton.onSnapshotsChanged", JSON.stringify(snapshots));
+    }
+
+    componentDidMount() {
+        snapshots.addEventListener("changed", this.onSnapshotsChanged);
+        if (snapshots.rootLV) // in case it initialized before mounting
+            this.onSnapshotsChanged();
+    }
+
+    componentWillUnmount() {
+        snapshots.removeEventListener("changed", this.onSnapshotsChanged);
+    }
+
+    render() {
+        if (!snapshots.rootLV)
+            return null;
+
+        let button;
+        const button_label = _("Create Snapshot");
+        if (snapshots.availableSpace < snapshots.usedSpace) {
+            const tooltip = cockpit.format(_("The $0 volume group does not have enough free space to create snapshots."), snapshots.VG);
+
+            button = (
+                <OverlayTrigger overlay={ <Tooltip id="tip-snapshots-nospc">{tooltip}</Tooltip> } placement="bottom">
+                    <button className="pk-update--snapshot btn btn-default" disabled>
+                        {button_label}
+                    </button>
+                </OverlayTrigger>);
+        } else {
+            button = (
+                <button className="pk-update--snapshot btn btn-default" onClick={ () => this.setState({ showDialog: true }) }>
+                    {button_label}
+                </button>);
+        }
+
+        return (
+            <React.Fragment>
+                {button}
+                { this.state.showDialog &&
+                    <SnapshotCreateDialog close={ () => this.setState({ showDialog: false }) } />
+                }
+            </React.Fragment>
+        );
+    }
+}

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -26,6 +26,7 @@ import moment from "moment";
 import { OverlayTrigger, Tooltip } from "patternfly-react";
 import Markdown from "react-remarkable";
 import AutoUpdates from "./autoupdates.jsx";
+import { snapshots, SnapshotCreateButton } from "./snapshots.jsx";
 import { History, PackageList } from "./history.jsx";
 
 import * as PK from "packagekit.js";
@@ -718,6 +719,9 @@ class OsUpdates extends React.Component {
                                                    this.state.errorMessages.push(cockpit.format(_("PackageKit reported error code $0"), exit));
                                                this.setState({ state: "updateError" });
                                            }
+
+                                           // refresh available/used space and snapshot history
+                                           snapshots.init();
                                        },
 
                                        // not working/being used in at least Fedora
@@ -821,6 +825,7 @@ class OsUpdates extends React.Component {
                     <div id="available" className="pk-updates--header">
                         <h2 className="pk-updates--header--heading">{_("Available Updates")}</h2>
                         <div className="pk-updates--header--actions">
+                            <SnapshotCreateButton />
                             {applySecurity}
                             {applyAll}
                         </div>

--- a/pkg/packagekit/updates.less
+++ b/pkg/packagekit/updates.less
@@ -127,6 +127,101 @@ tr.listing-ct-item {
     color: #72767b;
 }
 
+.listing-ct.updates-history {
+    .listing-ct-item > th,
+    .listing-ct-item > td, {
+        vertical-align: baseline;
+    }
+
+    .listing-ct-item > th {
+        // Table cell widths are a "best effort". Setting it to 0 for a table cell
+        // means "make this as small as possible".
+        white-space: nowrap;
+        width: 0;
+
+        // Alignment of the items has changed; so must the separator
+        &:before {
+            top: auto !important;
+        }
+    }
+
+    .listing-ct-meta {
+        display: flex;
+        grid-gap: 1rem; // WebKit doesn't support generic "gap" yet
+        gap: 1rem;
+        align-items: first baseline;
+        flex-wrap: wrap;
+    }
+
+    .listing-ct-info {
+        flex-basis: content;
+    }
+
+    .history-pkgcount {
+        flex: auto;
+    }
+
+    .listing-ct-action {
+        justify-items: baseline;
+    }
+
+    // Make the extended menu icon more clickable
+    .history-kebab {
+        button {
+            padding: 0;
+        }
+        .fa {
+            padding-left: 0.5rem;
+            padding-right: 0.5rem;
+            // Compensate for padding
+            margin-right: -0.5rem;
+        }
+    }
+
+    .list-view-pf-additional-info-item {
+        // Align this widget to the first baseline by default (for the text)
+        align-items: first baseline;
+
+        > .pficon {
+            // ...and align the icon to the center of the widget,
+            // assuming there's only 1 line (as the text shouldn't wrap here)
+            align-self: center;
+        }
+    }
+
+    @media (max-width: 540px) {
+        // Put rollback on its own line
+        .history-rollback {
+            flex-basis: 100%;
+        }
+    }
+
+    @media (max-width: 420px) {
+        // Constrain meta by making title take up maximum space
+        .listing-ct-item > th {
+            white-space: normal;
+            width: 100%;
+        }
+
+        // Info should take up maximum space within their containing cell
+        .listing-ct-info {
+            flex: auto;
+
+        }
+
+        // Don't wrap information or buttons
+        .listing-ct-info,
+        .listing-ct-action {
+            white-space: nowrap;
+
+            // Don't display empty elements
+            &:empty {
+                display: none;
+            }
+        }
+    }
+}
+
 // backport "pficon-*" for usage on RHEL/CentOS 7
 @font-face {
     font-family: "pf-symbols";

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -178,6 +178,12 @@ class TestUpdates(PackageCase):
         # no update history yet
         self.assertFalse(b.is_present("table.updates-history"))
 
+        # all our test images either have a full VG or don't use LVM at all
+        if "/dev/mapper" in m.execute("findmnt --noheadings --output SOURCE /"):
+            b.wait_present("button.pk-update--snapshot:disabled")
+        else:
+            b.wait_not_present("button.pk-update--snapshot")
+
         # should only have one button (no security updates)
         b.wait_not_present("button.pk-update--security")
         self.assertEqual(b.text("button.pk-update--all"), "Install All Updates")
@@ -228,8 +234,8 @@ class TestUpdates(PackageCase):
         m.execute("test -f /stamp-vanilla-1.0-2 && test -f /stamp-chocolate-2.0-2")
 
         # history shows the two packages, expanded by default
-        b.wait_present("table.updates-history tbody.open td.history-pkgcount")
-        b.wait_text("table.updates-history tbody.open td.history-pkgcount", "2 Packages")
+        b.wait_present("table.updates-history tbody.open .history-pkgcount")
+        b.wait_text("table.updates-history tbody.open .history-pkgcount", "2 Packages")
         b.wait_present("table.updates-history tbody.open .listing-ct-panel")
         b.wait_in_text("table.updates-history tbody.open .listing-ct-panel", "chocolate")
         b.wait_in_text("table.updates-history tbody.open .listing-ct-panel", "vanilla")
@@ -696,6 +702,192 @@ class TestUpdates(PackageCase):
         b.wait_present("#system_information_updates_text")
         b.wait_not_visible("#system_information_updates_text")
         self.assertEqual(b.attr("#system_information_updates_icon", "class"), "")
+
+    @skipImage("Image does not have root on LVM", "debian-stable", "debian-testing", "ubuntu-1804", "ubuntu-stable",
+               "centos-7", "fedora-i386")
+    def testSnapshot(self):
+        b = self.browser
+        m = self.machine
+
+        def create_updates(*packages):
+            for p in packages:
+                self.createPackage(p, "1.0", "1", install=True)
+                self.createPackage(p, "1.0", "2")
+            self.enableRepo()
+            m.execute("pkcon refresh force")
+
+        def apply_updates():
+            b.click("button.pk-update--all")
+            b.wait_present("#app .container-fluid h1")
+            b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
+            b.wait_present("#app .container-fluid button.btn-default")
+            b.click("#app .container-fluid button.btn-default")
+
+        def create_snapshot(size_gb, expect_error=None):
+            b.wait_present("button.pk-update--snapshot")
+            b.click("button.pk-update--snapshot")
+            b.wait_present("#create-snapshot-size")
+            b.set_input_text("#create-snapshot-size", str(size_gb))
+            b.click("#create-snapshot-dialog .btn-primary")
+            if expect_error:
+                b.wait_present("#create-snapshot-dialog .alert")
+                b.wait_in_text("#create-snapshot-dialog .alert", expect_error)
+                b.click("#create-snapshot-dialog .btn-default")  # cancel
+            else:
+                self.assertFalse(b.is_present("#create-snapshot-dialog .alert"))
+
+            b.wait_not_present("#create-snapshot-dialog")
+
+        def assert_history(updates):
+            # updates is a list of (pkgcount, snapsize) expected values
+            for i, (pkgcount, snapsize) in enumerate(updates):
+                tbody = "table.updates-history tbody:nth-child(%i) " % (i + 1)
+                b.wait_present(tbody + ".history-snapsize")
+                b.wait_text(tbody + ".history-pkgcount", pkgcount)
+                b.wait_text(tbody + ".history-snapsize", snapsize)
+            b.wait_not_present("table.updates-history tbody:nth-child(%i)" % (len(updates) + 1))
+
+        def assert_details(tbody_sel, package_list):
+            sel = "table.updates-history %s .listing-ct-panel" % tbody_sel
+            b.wait_present(sel)
+            for p in package_list:
+                b.wait_in_text(sel, p)
+
+        def wait_next_minute():
+            '''wait until the next minute, to have different times in table headers'''
+            m.execute("M=$(date +%M); while [ $(date +%M) = $M ]; do sleep 5; done")
+
+        # make some room on our root VG
+        m.add_disk("10G", serial="DISK1")
+        m.execute("while [ ! -e /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 ]; do sleep 1; done")
+        m.execute("pvcreate /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
+        m.execute("vgextend $(vgs | tail -n1 | awk '{print $1}') /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
+
+        #
+        # 1. update without snapshot (CLI for simplicity)
+        #
+        create_updates("vanilla")
+        m.execute("pkcon update -y")
+        if m.image == "rhel-8-0":
+            # HACK: avoid PackageKit crash: https://bugzilla.redhat.com/show_bug.cgi?id=1679916
+            m.execute("pkcon quit")
+        wait_next_minute()
+
+        #
+        # 2. update with snapshot
+        #
+        create_updates("chocolate", "lemon")
+
+        m.start_cockpit()
+        b.login_and_go("/updates")
+        # shows update from 1., open by default
+        assert_history([("1 Package", "")])
+        assert_details("tbody.open", ["vanilla"])
+        b.wait_not_present("table.updates-history tbody:not(.open)")
+
+        b.wait_present("button.pk-update--snapshot")
+        b.click("button.pk-update--snapshot")
+        # default size should be something reasonable; it defaults to the rounded up used space
+        b.wait_present("#create-snapshot-dialog")
+        b.wait_visible("#create-snapshot-dialog")
+        size = int(b.attr("#create-snapshot-size", "value"))
+        self.assertGreaterEqual(size, 3)
+        self.assertLessEqual(size, 8)
+        # cancel: no snapshot gets created
+        b.wait_visible("#create-snapshot-dialog .btn-cancel")
+        b.click("#create-snapshot-dialog .btn-cancel")
+        b.wait_not_present("#create-snapshot-dialog")
+        self.assertNotIn("update", m.execute("lvs --no-heading"))
+        # invalid size (this needs some creativity by human users, but set_input_text() can do it)
+        create_snapshot(0, "size may not be zero")
+        # create 5 GB snapshot
+        create_snapshot(5)
+        # topmost history is now an empty snapshot, second entry is the update from 1.
+        assert_history([("", "5 GiB Snapshot"), ("1 Package", "")])
+        # .. so nothing is expanded
+        b.wait_not_present("table.updates-history tbody.open")
+        apply_updates()
+        # shows a merged open update+snapshot
+        assert_history([("2 Packages", "5 GiB Snapshot"), ("1 Package", "")])
+        assert_details("tbody.open", ["chocolate", "lemon"])
+        if m.image == "rhel-8-0":
+            # HACK: avoid PackageKit crash: https://bugzilla.redhat.com/show_bug.cgi?id=1679916
+            m.execute("pkcon quit")
+
+        #
+        # 3. another update with snapshot
+        #
+        create_updates("strawberry", "kiwi", "nougat")
+        # wait until the next minute, to have different times in table headers
+        wait_next_minute()
+        # click "Check for Updates"
+        b.click(".content-header-extra button")
+        create_snapshot(3)
+        apply_updates()
+        assert_history([("3 Packages", "3 GiB Snapshot"), ("2 Packages", "5 GiB Snapshot"), ("1 Package", "")])
+        assert_details("tbody.open", ["strawberry", "kiwi", "nougat"])
+        self.assertEqual(m.execute("lvs | grep --count update-").strip(), "2")
+
+        # system is now up to date, no snapshot button
+        b.wait_not_present("button.pk-update--snapshot")
+        # so let's add another available update
+        create_updates("stracciatella")
+        b.click(".content-header-extra button")
+        b.wait_in_text("#state", "1 update")
+        # Snapshot button should now be disabled, as there's not enough space left
+        b.wait_present("button.pk-update--snapshot:disabled")
+
+        #
+        # 4. delete the old snapshot from 2.
+        #
+        kebab = "table.updates-history tbody:nth-child(2) .history-kebab button"
+        b.wait_present(kebab)
+        b.click(kebab)
+        delete = "table.updates-history tbody:nth-child(2) .history-kebab a[role='menuitem']"
+        b.wait_present(delete)
+        # this should not expand the table (we have a workaround for a react-bootstrap bug)
+        b.wait_not_present("table.updates-history tbody.open:nth-of-type(2)")
+        b.click(delete)
+        # PK history is still shown, snapshot is gone
+        assert_history([("3 Packages", "3 GiB Snapshot"), ("2 Packages", ""), ("1 Package", "")])
+        # now we should have enough space again
+        b.wait_present("button.pk-update--snapshot:not([disabled])")
+        self.assertEqual(m.execute("lvs | grep --count update-").strip(), "1")
+
+        #
+        # 5. roll back the recent snapshot
+        #
+        b.click("table.updates-history tbody:first-child .history-rollback button.btn-default")
+        b.wait_present(".modal-dialog button.btn-danger")
+        b.click(".modal-dialog button.btn-danger")
+        b.switch_to_top()
+        b.wait_visible(".curtains-ct")
+        b.wait_in_text(".curtains-ct h1", "Disconnected")
+        m.wait_reboot()
+        m.start_cockpit()
+        b.login_and_go("/updates")
+
+        # should show snapshot that is being restored; this is a race, we can't always catch it
+        if 'update-' in m.execute("lvs --all"):
+            assert_history([("", "3 GiB Snapshot"), ("2 Packages", ""), ("1 Package", "")])
+            b.wait_present("table.updates-history tbody:first-child .history-rollback span.label")
+            b.wait_in_text("table.updates-history tbody:first-child .history-rollback span.label", "Restoring")
+            # should not have any actions
+            self.assertFalse(b.is_present("table.updates-history button"))
+            # wait until internal snapshot rollback is done; this can take a while
+            wait(lambda: "update-" not in m.execute("lvs --all"), delay=10)
+            # this does not send any event, so reload
+            b.reload()
+            b.enter_page("/updates")
+
+        # all snapshots are gone now
+        assert_history([("2 Packages", ""), ("1 Package", "")])
+        assert_details("tbody.open", ["chocolate", "lemon"])
+        # and updates from 3. are available again
+        b.wait_in_text("#state", "3 updates")
+        b.wait_in_text("table.available", "kiwi")
+        b.wait_in_text("table.available", "nougat")
+        b.wait_in_text("table.available", "strawberry")
 
 
 @skipImage("Image uses OSTree", "continuous-atomic", "fedora-atomic", "rhel-atomic")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -179,8 +179,9 @@ class TestUpdates(PackageCase):
         self.assertFalse(b.is_present("table.updates-history"))
 
         # should only have one button (no security updates)
-        self.assertEqual(b.text("#app .container-fluid button"), "Install All Updates")
-        b.click("#app .container-fluid button")
+        b.wait_not_present("button.pk-update--security")
+        self.assertEqual(b.text("button.pk-update--all"), "Install All Updates")
+        b.click("button.pk-update--all")
 
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
@@ -355,8 +356,8 @@ class TestUpdates(PackageCase):
         b.enter_page("/updates")
 
         # install only security updates
-        self.assertEqual(b.text("#app .container-fluid button.btn-default"), "Install Security Updates")
-        b.click("#app .container-fluid button.btn-default")
+        self.assertEqual(b.text("button.pk-update--security"), "Install Security Updates")
+        b.click("button.pk-update--security")
 
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
@@ -406,8 +407,9 @@ class TestUpdates(PackageCase):
         m.execute("test -f /stamp-buggy-2-1 && test -f /stamp-norefs-bin-1-1 && test -f /stamp-norefs-doc-1-1")
 
         # should now only have one button (no security updates left)
-        self.assertEqual(b.text("#app .container-fluid button"), "Install All Updates")
-        b.click("#app .container-fluid button")
+        b.wait_not_present("button.pk-update--security")
+        self.assertEqual(b.text("button.pk-update--all"), "Install All Updates")
+        b.click("button.pk-update--all")
 
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
@@ -470,7 +472,8 @@ class TestUpdates(PackageCase):
         self.assertEqual(b.text("#state"), "1 security fix")
 
         # should only have one button (only security updates)
-        self.assertEqual(b.text("#app .container-fluid button"), "Install Security Updates")
+        b.wait_not_present("button.pk-update--security")
+        self.assertEqual(b.text("button.pk-update--all"), "Install Security Updates")
 
         # security fix without CVE URLs
         # PackageKit's dnf backend does not recognize this (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
@@ -565,8 +568,8 @@ class TestUpdates(PackageCase):
         b.wait_in_text(".container-fluid h2", "Available Updates")
         self.assertEqual(b.text("#state"), "1 update")
 
-        b.wait_present("#app .container-fluid button")
-        b.click("#app .container-fluid button")
+        b.wait_present("button.pk-update--all")
+        b.click("button.pk-update--all")
 
         b.wait_in_text("#state", "Applying updates failed")
 
@@ -598,8 +601,8 @@ class TestUpdates(PackageCase):
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.wait_present("#app .container-fluid button")
-        b.click("#app .container-fluid button")
+        b.wait_present("button.pk-update--all")
+        b.click("button.pk-update--all")
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-description")
         b.wait_in_text("#app div.progress-description", "slow")
@@ -653,8 +656,8 @@ class TestUpdates(PackageCase):
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.wait_present("#app .container-fluid button")
-        b.click("#app .container-fluid button")
+        b.wait_present("button.pk-update--all")
+        b.click("button.pk-update--all")
 
         # let updates start and zap PackageKit
         b.wait_present("#app div.progress-bar")
@@ -824,8 +827,8 @@ class TestUpdatesSubscriptions(PackageCase):
 
         # has action buttons
         b.wait_present(".content-header-extra button")
-        b.wait_present("#app .container-fluid button")
-        self.assertEqual(b.text("#app .container-fluid button"), "Install All Updates")
+        b.wait_not_present("button.pk-update--security")
+        self.assertEqual(b.text("button.pk-update--all"), "Install All Updates")
 
         # show available updates on system page too
         b.go("/system")


### PR DESCRIPTION
Provide a UI for the LVM command line tools to create, remove, apply,
and report LVM snapshots. Nothing changes on systems which don't have
their root partition on LVM. On systems which do use LVM, but don't have
enough space, show a disabled "Create Snapshot" button with a tooltip,
to make this feature more discoverable.

Integrate existing snapshots into the "Update History" table. A
PackageKit update following a snapshot will be shown as one merged table
line, so that the user sees which packages get rolled back when applying
a snapshot.

This is a minimal implementation of the most common workflow. We cannot
save any preferences (like whether to do snapshots automatically, or how 
many to keep, etc.) anywhere as there is no underlying subsystem,
configuration files, or integration into package managers for this yet.

TODO:
 - [x] this builds on top of history redesign (PR #11196)
 - [x] fix history table row widths
 - [x] clicking on kebab should not expand the table
 - [x] update feature page
 - [x] handle failure in onUpdate()
 - [x] fix wrong `vgextend` invocation on [centos-7](https://fedorapeople.org/groups/cockpit/logs/pull-11201-20190219-113131-bbe86937-verify-centos-7/log.html#205) and [fedora-i386](https://fedorapeople.org/groups/cockpit/logs/pull-11201-20190219-113131-bbe86937-verify-fedora-i386/log.html#260)
 - [x] investigate/report/work around PackageKit crash on [rhel 8.0](https://fedorapeople.org/groups/cockpit/logs/pull-11201-20190219-113131-bbe86937-verify-rhel-8-0/log.html#260): [bz#1679916](https://bugzilla.redhat.com/show_bug.cgi?id=1679916)
 - [x] fix [race condition on updating repo](https://fedorapeople.org/groups/cockpit/logs/pull-11201-20190219-113131-bbe86937-verify-fedora-29/log.html#260)
 - [x] fix [failure on RHEL 7.6](https://fedorapeople.org/groups/cockpit/logs/pull-11201-20190219-113131-bbe86937-verify-rhel-7-6-distropkg/log.html#260)
- [x] make video once design is finalized: https://youtu.be/9fCzDo_RfaA
- [ ] use snapshot-manager API, which should provide this missing functionality:
  *  backup/restore grubenv with snapshots
  * include `/var` in the snapshot, i. e. possibly snapshot multiple LVs simultaneously.