### PR TITLE
machines: add support for existing disk as installation mode for new VMs

### DIFF
--- a/bots/naughty/debian-stable/11265-virt-install-fails-vnc
+++ b/bots/naughty/debian-stable/11265-virt-install-fails-vnc
@@ -1,0 +1,3 @@
+# testCreate (check_machines*
+*
+*ERROR*Failed to start VNC server: Failed to bind socket: Address already in use*

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -52,6 +52,7 @@ const _ = cockpit.gettext;
 
 const URL_SOURCE = 'url';
 const LOCAL_INSTALL_MEDIA_SOURCE = 'file';
+const EXISTING_DISK_IMAGE_SOURCE = 'disk_image';
 
 /* Create a virtual machine
  * props:
@@ -193,6 +194,15 @@ class CreateVM extends React.Component {
                     superUser="try" />
             );
             break;
+        case EXISTING_DISK_IMAGE_SOURCE:
+            installationSourceId = "source-disk";
+            installationSource = (
+                <FileAutoComplete id={installationSourceId}
+                    placeholder={_("Existing disk image on host's file system")}
+                    onChange={this.onChangedValue.bind(this, 'source')}
+                    superuser="try" />
+            );
+            break;
         case URL_SOURCE:
         default:
             installationSourceId = "source-url";
@@ -260,6 +270,7 @@ class CreateVM extends React.Component {
                     <Select.SelectEntry data={LOCAL_INSTALL_MEDIA_SOURCE}
                                         key={LOCAL_INSTALL_MEDIA_SOURCE}>{_("Local Install Media")}</Select.SelectEntry>
                     <Select.SelectEntry data={URL_SOURCE} key={URL_SOURCE}>{_("URL")}</Select.SelectEntry>
+                    <Select.SelectEntry data={EXISTING_DISK_IMAGE_SOURCE} key={EXISTING_DISK_IMAGE_SOURCE}>{_("Existing Disk Image")}</Select.SelectEntry>
                 </Select.Select>
 
                 <label className="control-label" htmlFor={installationSourceId}>
@@ -295,12 +306,13 @@ class CreateVM extends React.Component {
                                  onValueChange={this.onChangedEventValue.bind(this, 'memorySize')}
                                  onUnitChange={this.onChangedValue.bind(this, 'memorySizeUnit')} />
 
+                {this.state.sourceType != EXISTING_DISK_IMAGE_SOURCE &&
                 <MemorySelectRow label={_("Storage Size")}
                                  id={"storage-size"}
                                  value={this.state.storageSize}
                                  initialUnit={this.state.storageSizeUnit}
                                  onValueChange={this.onChangedEventValue.bind(this, 'storageSize')}
-                                 onUnitChange={this.onChangedValue.bind(this, 'storageSizeUnit')} />
+                                 onUnitChange={this.onChangedValue.bind(this, 'storageSizeUnit')} />}
 
                 <hr />
 
@@ -336,6 +348,7 @@ function validateParams(vmParams) {
     if (!isEmpty(source)) {
         switch (vmParams.sourceType) {
         case LOCAL_INSTALL_MEDIA_SOURCE:
+        case EXISTING_DISK_IMAGE_SOURCE:
             if (!vmParams.source.startsWith("/")) {
                 validationFailed['source'] = _("Invalid filename");
             }

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -51,7 +51,7 @@ import VMS_CONFIG from '../../config.js';
 const _ = cockpit.gettext;
 
 const URL_SOURCE = 'url';
-const COCKPIT_FILESYSTEM_SOURCE = 'file';
+const LOCAL_INSTALL_MEDIA_SOURCE = 'file';
 
 /* Create a virtual machine
  * props:
@@ -184,7 +184,7 @@ class CreateVM extends React.Component {
         let installationSource;
         let installationSourceId;
         switch (this.state.sourceType) {
-        case COCKPIT_FILESYSTEM_SOURCE:
+        case LOCAL_INSTALL_MEDIA_SOURCE:
             installationSourceId = "source-file";
             installationSource = (
                 <FileAutoComplete id={installationSourceId}
@@ -256,8 +256,8 @@ class CreateVM extends React.Component {
                 <Select.Select id="source-type"
                                initial={this.state.sourceType}
                                onChange={this.onChangedValue.bind(this, 'sourceType')}>
-                    <Select.SelectEntry data={COCKPIT_FILESYSTEM_SOURCE}
-                                        key={COCKPIT_FILESYSTEM_SOURCE}>{_("Filesystem")}</Select.SelectEntry>
+                    <Select.SelectEntry data={LOCAL_INSTALL_MEDIA_SOURCE}
+                                        key={LOCAL_INSTALL_MEDIA_SOURCE}>{_("Local Install Media")}</Select.SelectEntry>
                     <Select.SelectEntry data={URL_SOURCE} key={URL_SOURCE}>{_("URL")}</Select.SelectEntry>
                 </Select.Select>
 
@@ -334,7 +334,7 @@ function validateParams(vmParams) {
 
     if (!isEmpty(source)) {
         switch (vmParams.sourceType) {
-        case COCKPIT_FILESYSTEM_SOURCE:
+        case LOCAL_INSTALL_MEDIA_SOURCE:
             if (!vmParams.source.startsWith("/")) {
                 validationFailed['source'] = _("Invalid filename");
             }
@@ -363,7 +363,7 @@ class CreateVmModal extends React.Component {
             'validate': false,
             'vmName': '',
             'connectionName': LIBVIRT_SYSTEM_CONNECTION,
-            "sourceType": COCKPIT_FILESYSTEM_SOURCE,
+            "sourceType": LOCAL_INSTALL_MEDIA_SOURCE,
             'source': '',
             'vendor': NOT_SPECIFIED,
             "os": OTHER_OS_SHORT_ID,

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -189,7 +189,8 @@ class CreateVM extends React.Component {
             installationSource = (
                 <FileAutoComplete id={installationSourceId}
                     placeholder={_("Path to ISO file on host's file system")}
-                    onChange={this.onChangedValue.bind(this, 'source')} />
+                    onChange={this.onChangedValue.bind(this, 'source')}
+                    superUser="try" />
             );
             break;
         case URL_SOURCE:

--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -701,7 +701,7 @@ export function CONSOLE_VM({
     };
 }
 
-export function CREATE_VM({ connectionName, vmName, source, os, memorySize, storageSize, startVm }) {
+export function CREATE_VM({ connectionName, vmName, source, sourceType, os, memorySize, storageSize, startVm }) {
     logDebug(`${this.name}.CREATE_VM(${vmName}):`);
     return dispatch => {
         // shows dummy vm  until we get vm from virsh (cleans up inProgress)
@@ -715,6 +715,7 @@ export function CREATE_VM({ connectionName, vmName, source, os, memorySize, stor
             connectionName,
             vmName,
             source,
+            sourceType,
             os,
             memorySize,
             storageSize,

--- a/pkg/machines/scripts/install_machine.sh
+++ b/pkg/machines/scripts/install_machine.sh
@@ -48,9 +48,9 @@ else
 fi
 
 if [ "${SOURCE#/}" != "$SOURCE" ] && [ -f "${SOURCE}" ]; then
-    LOCATION_PARAM="--cdrom $SOURCE"
+    INSTALL_METHOD="--cdrom $SOURCE"
 else
-    LOCATION_PARAM="--location $SOURCE"
+    INSTALL_METHOD="--location $SOURCE"
 fi
 
 # backup
@@ -71,7 +71,7 @@ virt-install \
     --noautoconsole \
     --noreboot \
     $DISKS_PARAM \
-    $LOCATION_PARAM \
+    $INSTALL_METHOD \
     $GRAPHICS_PARAM
 EXIT_STATUS=$?
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1279,7 +1279,7 @@ class TestMachines(MachineCase):
             b.set_input_text("#vm-name", self.name)
 
             if self.sourceType == 'file':
-                expected_source_type = 'Filesystem'
+                expected_source_type = 'Local Install Media'
             else:
                 expected_source_type = 'URL'
             b.select_from_dropdown("#source-type", expected_source_type)

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1015,14 +1015,14 @@ class TestMachines(MachineCase):
 
         # test just the DIALOG CREATION and cancel
         print("    *\n    * validation errors and ui info/warn messages expected:\n    * ")
-        cancelDialogTest(TestMachines.VmDialog(self, "subVmTestCreate1", is_filesystem_location=True,
+        cancelDialogTest(TestMachines.VmDialog(self, "subVmTestCreate1", sourceType='file',
                                                location=config.NOVELL_MOCKUP_ISO_PATH,
                                                memory_size=1, memory_size_unit='MiB',
                                                storage_size=12500, storage_size_unit='GiB',
                                                os_vendor=config.UNSPECIFIED_VENDOR,
                                                os_name=config.OTHER_OS,
                                                start_vm=True))
-        cancelDialogTest(TestMachines.VmDialog(self, "subVmTestCreate2", is_filesystem_location=False,
+        cancelDialogTest(TestMachines.VmDialog(self, "subVmTestCreate2", sourceType='url',
                                                location=config.VALID_URL,
                                                memory_size=12654, memory_size_unit='GiB',
                                                storage_size=0, storage_size_unit='MiB',
@@ -1046,7 +1046,7 @@ class TestMachines(MachineCase):
         checkDialogFormValidationTest(TestMachines.VmDialog(self, ""), {"Name": "Name should not be empty"})
 
         # location
-        checkDialogFormValidationTest(TestMachines.VmDialog(self, "subVmTestCreate7", is_filesystem_location=False,
+        checkDialogFormValidationTest(TestMachines.VmDialog(self, "subVmTestCreate7", sourceType='url',
                                                             location="invalid/url",
                                                             os_vendor=config.NOVELL_VENDOR,
                                                             os_name=config.NOVELL_NETWARE_4), {"Source": "Source should start with"})
@@ -1073,13 +1073,13 @@ class TestMachines(MachineCase):
                                       {"Source": "Installation Source should not be empty"})
 
         # try to CREATE few machines
-        createTest(TestMachines.VmDialog(self, "subVmTestCreate11", is_filesystem_location=False,
+        createTest(TestMachines.VmDialog(self, "subVmTestCreate11", sourceType='url',
                                          location=config.VALID_URL,
                                          storage_size=1,
                                          os_vendor=config.MICROSOFT_VENDOR,
                                          os_name=config.MICROSOFT_VISTA))
 
-        createTest(TestMachines.VmDialog(self, "subVmTestCreate12", is_filesystem_location=False,
+        createTest(TestMachines.VmDialog(self, "subVmTestCreate12", sourceType='url',
                                          location=config.VALID_URL,
                                          memory_size=256, memory_size_unit='MiB',
                                          storage_size=100, storage_size_unit='MiB',
@@ -1087,7 +1087,7 @@ class TestMachines(MachineCase):
                                          os_name=config.MICROSOFT_XP_OS,
                                          start_vm=False))
 
-        createTest(TestMachines.VmDialog(self, "subVmTestCreate13", is_filesystem_location=False,
+        createTest(TestMachines.VmDialog(self, "subVmTestCreate13", sourceType='url',
                                          location=config.VALID_URL,
                                          memory_size=900, memory_size_unit='GiB',
                                          storage_size=100, storage_size_unit='MiB',
@@ -1095,7 +1095,7 @@ class TestMachines(MachineCase):
                                          os_name=config.MACOS_X_TIGER,
                                          start_vm=False))
 
-        createTest(TestMachines.VmDialog(self, "subVmTestCreate14", is_filesystem_location=True,
+        createTest(TestMachines.VmDialog(self, "subVmTestCreate14", sourceType='file',
                                          location=config.NOVELL_MOCKUP_ISO_PATH,
                                          memory_size=256, memory_size_unit='MiB',
                                          storage_size=0, storage_size_unit='MiB',
@@ -1104,7 +1104,7 @@ class TestMachines(MachineCase):
                                          start_vm=False,
                                          connection='session'))
         # try to INSTALL WITH ERROR
-        installWithErrorTest(TestMachines.VmDialog(self, "subVmTestCreate15", is_filesystem_location=True,
+        installWithErrorTest(TestMachines.VmDialog(self, "subVmTestCreate15", sourceType='file',
                                                    location=config.NOVELL_MOCKUP_ISO_PATH,
                                                    memory_size=900, memory_size_unit='GiB',
                                                    storage_size=10, storage_size_unit='MiB',
@@ -1166,7 +1166,7 @@ class TestMachines(MachineCase):
 
     class VmDialog:
 
-        def __init__(self, test_obj, name, is_filesystem_location=True, location='',
+        def __init__(self, test_obj, name, sourceType='file', location='',
                      memory_size=1, memory_size_unit='GiB',
                      storage_size=1, storage_size_unit='GiB',
                      os_vendor=None,
@@ -1174,7 +1174,7 @@ class TestMachines(MachineCase):
                      start_vm=False,
                      connection=None):
 
-            if not is_filesystem_location and start_vm:
+            if sourceType == 'url' and start_vm:
                 raise Exception("cannot start vm because url specified (no connection available in this test)")
 
             self.browser = test_obj.browser
@@ -1182,7 +1182,7 @@ class TestMachines(MachineCase):
             self.assertTrue = test_obj.assertTrue
 
             self.name = name
-            self.is_filesystem_location = is_filesystem_location
+            self.sourceType = sourceType
             self.location = location
             self.memory_size = memory_size
             self.memory_size_unit = memory_size_unit
@@ -1278,9 +1278,12 @@ class TestMachines(MachineCase):
             b = self.browser
             b.set_input_text("#vm-name", self.name)
 
-            expected_source_type = 'Filesystem' if self.is_filesystem_location else 'URL'
+            if self.sourceType == 'file':
+                expected_source_type = 'Filesystem'
+            else:
+                expected_source_type = 'URL'
             b.select_from_dropdown("#source-type", expected_source_type)
-            if self.is_filesystem_location:
+            if self.sourceType == 'file':
                 b.set_file_autocomplete_val("#source-file", self.location)
             else:
                 b.set_input_text("#source-url", self.location)

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1032,13 +1032,13 @@ class TestMachines(MachineCase):
 
         # check if older os are filtered
         checkFilteredOsTest(TestMachines.VmDialog(self, "subVmTestCreate3", os_vendor=config.REDHAT_VENDOR,
-                                                  os_name=config.REDHAT_RHEL_4_7_FILTERED_OS))
+                                                  storage_size=1, os_name=config.REDHAT_RHEL_4_7_FILTERED_OS))
 
         checkFilteredOsTest(TestMachines.VmDialog(self, "subVmTestCreate4", os_vendor=config.MANDRIVA_FILTERED_VENDOR,
-                                                  os_name=config.MANDRIVA_2011_FILTERED_OS))
+                                                  storage_size=1, os_name=config.MANDRIVA_2011_FILTERED_OS))
 
         checkFilteredOsTest(TestMachines.VmDialog(self, "subVmTestCreate5", os_vendor=config.MAGEIA_VENDOR,
-                                                  os_name=config.MAGEIA_3_FILTERED_OS))
+                                                  storage_size=1, os_name=config.MAGEIA_3_FILTERED_OS))
 
         # try to CREATE WITH DIALOG ERROR
 
@@ -1047,7 +1047,7 @@ class TestMachines(MachineCase):
 
         # location
         checkDialogFormValidationTest(TestMachines.VmDialog(self, "subVmTestCreate7", sourceType='url',
-                                                            location="invalid/url",
+                                                            location="invalid/url", storage_size='1',
                                                             os_vendor=config.NOVELL_VENDOR,
                                                             os_name=config.NOVELL_NETWARE_4), {"Source": "Source should start with"})
 
@@ -1068,6 +1068,7 @@ class TestMachines(MachineCase):
 
         # start vm
         checkDialogFormValidationTest(TestMachines.VmDialog(self, "subVmTestCreate10",
+                                                            storage_size='1',
                                                             os_vendor=config.NOVELL_VENDOR,
                                                             os_name=config.NOVELL_NETWARE_6, start_vm=True),
                                       {"Source": "Installation Source should not be empty"})
@@ -1168,7 +1169,7 @@ class TestMachines(MachineCase):
 
         def __init__(self, test_obj, name, sourceType='file', location='',
                      memory_size=1, memory_size_unit='GiB',
-                     storage_size=1, storage_size_unit='GiB',
+                     storage_size=None, storage_size_unit='GiB',
                      os_vendor=None,
                      os_name=None,
                      start_vm=False,
@@ -1294,8 +1295,9 @@ class TestMachines(MachineCase):
             b.set_input_text("#memory-size", str(self.memory_size))
             b.select_from_dropdown("#memory-size-unit-select", self.memory_size_unit)
 
-            b.set_input_text("#storage-size", str(self.storage_size))
-            b.select_from_dropdown("#storage-size-unit-select", self.storage_size_unit)
+            if self.storage_size is not None:
+                b.set_input_text("#storage-size", str(self.storage_size))
+                b.select_from_dropdown("#storage-size-unit-select", self.storage_size_unit)
 
             b.wait_visible("#start-vm")
             if self.start_vm:

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1154,6 +1154,9 @@ class TestMachines(MachineCase):
         self.allow_journal_messages('.*Connection.*')
         self.allow_journal_messages('.*session closed.*')
 
+        # Deleting a running guest will disconnect the serial console
+        self.allow_browser_errors("Disconnection timed out.")
+
         runner.destroy()
 
     class TestCreateConfig:


### PR DESCRIPTION
![existing-disk-image](https://user-images.githubusercontent.com/14921356/53039780-39b2fb00-3480-11e9-8053-8491d2280cce.png)

and the existing `Filesystem` select Entry was renamed to `Local Install media` to avoid confusion.
![local-install-media](https://user-images.githubusercontent.com/14921356/53039903-767ef200-3480-11e9-8824-196fcd1dbde4.png)
