### PR TITLE
naughty: Close 10011: "E0906 Failed to create cgroup" when creating pod on fedora-29

### DIFF
--- a/bots/naughty/fedora-29/10011-kubernetes-e0906-on-pod-create
+++ b/bots/naughty/fedora-29/10011-kubernetes-e0906-on-pod-create
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "/home/sanne/workstuff/cockpit-3/test/verify/kubelib.py", line *, in testDashboard
-    b.wait_text("#service-list tr[data-name='mock']:first-of-type td.containers", "1")

--- a/bots/naughty/fedora-29/10011-kubernetes-e0906-on-pod-create-2
+++ b/bots/naughty/fedora-29/10011-kubernetes-e0906-on-pod-create-2
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "/home/sanne/workstuff/cockpit-3/test/verify/kubelib.py", line *, in testTopology
-    b.wait_text("#service-list tr[data-name='mock'] td.containers", "1")


### PR DESCRIPTION
Known issue which has not occurred in 27 days

"E0906 Failed to create cgroup" when creating pod on fedora-29

Fixes #10011