### PR TITLE
systemd: Don't clobber the system $PATH in the terminal

### DIFF
--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -25,7 +25,6 @@ const _ = cockpit.gettext;
                 "spawn": [user.shell || "/bin/bash", "-i"],
                 "environ": [
                     "TERM=xterm-256color",
-                    "PATH=/sbin:/bin:/usr/sbin:/usr/bin"
                 ],
                 "directory": user.home || "/",
                 "pty": true


### PR DESCRIPTION
These days, the default `$PATH` is set via pam_env(8), not any more in
/etc/profile, and usually not in ~/.bashrc either. So let's not clobber
it by overwriting it to a static fixed value (which was also missing
at least /usr/local).

Fixes #8814