### PR TITLE
tools: Release into Fedora 30 [no-test]

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -25,6 +25,7 @@ job release-srpm
 # Do fedora builds for the tag, using tarball
 job release-koji -k master
 job release-koji f29
+job release-koji f30
 
 # Upload release to github, using tarball
 job release-github
@@ -38,6 +39,7 @@ job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 
 # Push out a Bodhi update
 job release-bodhi F29
+#job release-bodhi F30
 
 # Upload documentation
 job bots/release-guide dist/guide cockpit-project/cockpit-project.github.io


### PR DESCRIPTION
Fedora 30 has forked from Rawhide now.

See https://fedoraproject.org/wiki/Releases/30/Schedule