### PR TITLE
PCP improvements

### DIFF
--- a/bots/images/scripts/fedora-29.install
+++ b/bots/images/scripts/fedora-29.install
@@ -2,8 +2,3 @@
 
 set -e
 /var/lib/testvm/fedora.install "$@"
-
-# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1557913
-# this fails every test due to the SELinux violations (so naughty override
-# causes too much spamming) and causes long boot times due to holding up default.target
-systemctl disable pmcd.service

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -355,6 +355,14 @@ PageServer.prototype = {
         var pmlogger_exists = false;
         var packagekit_exists = false;
 
+        function disable_logger_switch() {
+            $("#server-pmlogger-switch label").addClass("disabled");
+        }
+
+        function enable_logger_switch() {
+            $("#server-pmlogger-switch label").removeClass("disabled");
+        }
+
         function update_pmlogger_row() {
             var logger_switch = $("#server-pmlogger-switch");
             var enable_pcp = $('#system-information-enable-pcp-link');
@@ -364,10 +372,14 @@ PageServer.prototype = {
                 logger_switch.prev().hide();
             } else if (!pmlogger_promise) {
                 enable_pcp.hide();
-                logger_switch.onoff('value', pmlogger_service.enabled);
+                logger_switch.onoff('value', pmlogger_service.state === "running");
                 logger_switch.show();
                 logger_switch.prev().show();
             }
+            if (pmlogger_service.state === "starting")
+                disable_logger_switch();
+            else
+                enable_logger_switch();
         }
 
         function pmlogger_service_changed() {
@@ -400,6 +412,7 @@ PageServer.prototype = {
             if (!pmlogger_exists)
                 return;
 
+            disable_logger_switch();
             if ($(this).onoff('value')) {
                 pmlogger_promise = Promise.all([
                     pmcd_service.enable(),

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -93,6 +93,11 @@ function ph_has_attr (sel, attr, val)
     return ph_attr(sel, attr) == val;
 }
 
+function ph_attr_contains (sel, attr, val)
+{
+    return ph_attr(sel, attr).indexOf(val) > -1;
+}
+
 function ph_mouse(sel, type, x, y, btn, force) {
     let el = ph_find(sel);
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -349,6 +349,12 @@ class Browser:
     def wait_attr(self, selector, attr, val):
         return self.wait_js_func('ph_has_attr', selector, attr, val)
 
+    def wait_attr_contains(self, selector, attr, val):
+        return self.wait_js_func('ph_attr_contains', selector, attr, val)
+
+    def wait_attr_not_contains(self, selector, attr, val):
+        return self.wait_js_func('!ph_attr_contains', selector, attr, val)
+
     def wait_not_attr(self, selector, attr, val):
         return self.wait_js_func('!ph_has_attr', selector, attr, val)
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -442,7 +442,7 @@ class TestPcp(packagelib.PackageCase):
 
         pmlogger = {
             "/usr/bin/pmlogger": "",
-            "/etc/systemd/system/pmlogger.service": "[Service]\nExecStart=/bin/true"
+            "/etc/systemd/system/pmlogger.service": "[Service]\nExecStart=/bin/sh -c \"while [ ! -f /tmp/pmlogger.start ]; do sleep 1; done\"\nType=oneshot\nRemainAfterExit=true"
         }
 
         self.createPackage("cockpit-pcp", "999", "1", content=pmlogger,
@@ -466,6 +466,16 @@ class TestPcp(packagelib.PackageCase):
 
         b.wait_visible("#server-pmlogger-switch")
         b.wait_not_visible("#system-information-enable-pcp-link")
+
+        # Turn stored metrics on
+        self.assertIn("active", b.attr("#server-pmlogger-switch label:nth-child(2)", "class"))
+        b.click("#server-pmlogger-switch label:first-child")
+        if m.image == "rhel-7-6-distropkg": # PR #11224
+            return
+        b.wait_attr_contains("#server-pmlogger-switch label:first-child", "class", "disabled")
+        m.execute("touch /tmp/pmlogger.start")
+        b.wait_attr_not_contains("#server-pmlogger-switch label:first-child", "class", "disabled")
+        b.wait_attr_contains("#server-pmlogger-switch label:first-child", "class", "active")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR brings two changes:
1) Dropping hack from install script which is not needed and brings pmlogger into stuck state
2) Disable switch while pmlogger is starting

This is just result of investigation why when switch for storing metrics is on no metrics are stored. Problem is that pmlogger can be in state `starting`/`activating`. Often this takes a few seconds to start but it can be indefinite (reproducible by stop pmcd, start pmlogger). We should somehow indicate that logger is trying to start - @garrett suggested disabling the switch.

Note:

- No tests yet, will write some when design is sattled


