### PR TITLE
Machines: Change term "Networks" to "Network interfaces" in the UI

### DIFF
--- a/pkg/machines/components/nicEdit.jsx
+++ b/pkg/machines/components/nicEdit.jsx
@@ -122,7 +122,7 @@ const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues, netwo
     return (
         <React.Fragment>
             <label className='control-label' htmlFor={`${idPrefix}-select-type`}>
-                {_("Network Type")}
+                {_("Interface Type")}
             </label>
             <Select.Select id={`${idPrefix}-select-type`}
                            onChange={value => onNetworkTypeChanged(value)}
@@ -213,7 +213,7 @@ export class EditNICAction extends React.Component {
             networkSource: this.state.networkSource
         }))
                 .fail((exc) => {
-                    this.dialogErrorSet(_("Network settings could not be saved"), exc.message);
+                    this.dialogErrorSet(_("Network interface settings could not be saved"), exc.message);
                 })
                 .then(() => {
                     dispatch(getVm({ connectionName: vm.connectionName, id: vm.id }));

--- a/pkg/machines/components/vm/vm.jsx
+++ b/pkg/machines/components/vm/vm.jsx
@@ -53,7 +53,7 @@ const Vm = ({ vm, config, hostDevices, storagePools, onStart, onInstall, onShutd
     const overviewTabName = (<div id={`${vmId(vm.name)}-overview`}>{_("Overview")}</div>);
     const usageTabName = (<div id={`${vmId(vm.name)}-usage`}>{_("Usage")}</div>);
     const disksTabName = (<div id={`${vmId(vm.name)}-disks`}>{_("Disks")}</div>);
-    const networkTabName = (<div id={`${vmId(vm.name)}-networks`}>{_("Networks")}</div>);
+    const networkTabName = (<div id={`${vmId(vm.name)}-networks`}>{_("Network Interfaces")}</div>);
     const consolesTabName = (<div id={`${vmId(vm.name)}-consoles`}>{_("Consoles")}</div>);
 
     let tabRenderers = [


### PR DESCRIPTION
Current usage of "Networks" term in guests networks tab is inaccurate, since the tab itself refers to guest's network interfaces. This can lead to confusion with virtual networks, which is a different thing.