### PR TITLE
bridge: Allow data: image and font sources in C-S-P by default

### DIFF
--- a/src/bridge/mock-resource/csp/cockpit/strip/manifest.json
+++ b/src/bridge/mock-resource/csp/cockpit/strip/manifest.json
@@ -1,3 +1,3 @@
 {
-    "content-security-policy": "img-src: 'self' data:; default-src 'self'"
+    "content-security-policy": "img-src 'self'; default-src 'self'"
 }

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -43,7 +43,7 @@
 #define CHECKSUM_RELOAD_OLD     "53264dd51401b6f6de0ba63180397919697155653855848dee0f6f71c6e93f40"
 #define CHECKSUM_RELOAD_NEW     "eae62ca12c4a92b4ae7f6b0d2f41cb20be0005a6fc62466fccda1ebe0532cc23"
 #define CHECKSUM_RELOAD_UPDATED "0d1c0b7c6133cc7c3956197fd8a76bef68b158bd78beac75cfa80b75c36aa827"
-#define CHECKSUM_CSP            "25cab69451c3667cb9ed33f006fc7003c248f1029dae4a763bbadb0c4cafaf8d"
+#define CHECKSUM_CSP            "80921dc3cde9ff9f2acd2a5851f9b2a3b25ea7b4577128461d9e32fbdd671e16"
 
 extern const gchar **cockpit_bridge_data_dirs;
 extern const gchar *cockpit_bridge_local_address;
@@ -230,7 +230,7 @@ test_forwarded (TestCase *tc,
   data = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (data, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' https://blah:9090; connect-src 'self' https://blah:9090 wss://blah:9090; form-action 'self' https://blah:9090; base-uri 'self' https://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\",\"Access-Control-Allow-Origin\":\"https://blah:9090\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' https://blah:9090; connect-src 'self' https://blah:9090 wss://blah:9090; form-action 'self' https://blah:9090; base-uri 'self' https://blah:9090; object-src 'none'; font-src 'self' https://blah:9090 data:; img-src 'self' https://blah:9090 data:; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\",\"Access-Control-Allow-Origin\":\"https://blah:9090\"}}");
   json_object_unref (object);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
@@ -263,7 +263,7 @@ test_localized_translated (TestCase *tc,
   data = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (data, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; font-src 'self' http://blah:9090 data:; img-src 'self' http://blah:9090 data:; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}");
   json_object_unref (object);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
@@ -296,7 +296,7 @@ test_localized_unknown (TestCase *tc,
   data = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (data, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; font-src 'self' http://blah:9090 data:; img-src 'self' http://blah:9090 data:; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}");
   json_object_unref (object);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
@@ -330,7 +330,7 @@ test_localized_prefer_region (TestCase *tc,
   data = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (data, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; font-src 'self' http://blah:9090 data:; img-src 'self' http://blah:9090 data:; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}");
   json_object_unref (object);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
@@ -364,7 +364,7 @@ test_localized_fallback (TestCase *tc,
   data = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (data, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"default-src 'self' http://blah:9090; connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; font-src 'self' http://blah:9090 data:; img-src 'self' http://blah:9090 data:; block-all-mixed-content\",\"Content-Type\":\"text/html\",\"Cache-Control\":\"no-cache, no-store\"}}");
   json_object_unref (object);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);
@@ -1115,7 +1115,7 @@ test_csp_strip (TestCase *tc,
   data = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (data, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; block-all-mixed-content; img-src: 'self' http://blah:9090 data:; default-src 'self' http://blah:9090\",\"Content-Type\":\"text/html\",\"X-Cockpit-Pkg-Checksum\":\"" CHECKSUM_CSP "\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{\"Referrer-Policy\":\"no-referrer\",\"X-DNS-Prefetch-Control\":\"off\",\"Content-Security-Policy\":\"connect-src 'self' http://blah:9090 ws://blah:9090; form-action 'self' http://blah:9090; base-uri 'self' http://blah:9090; object-src 'none'; font-src 'self' http://blah:9090 data:; block-all-mixed-content; img-src 'self' http://blah:9090; default-src 'self' http://blah:9090\",\"Content-Type\":\"text/html\",\"X-Cockpit-Pkg-Checksum\":\"" CHECKSUM_CSP "\"}}");
   json_object_unref (object);
 
   data = mock_transport_combine_output (tc->transport, "444", &count);

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1860,6 +1860,8 @@ cockpit_web_response_security_policy (const gchar *content_security_policy,
   const gchar *form_action = "form-action 'self'";
   const gchar *base_uri = "base-uri 'self'";
   const gchar *object_src = "object-src 'none'";
+  const gchar *font_src = "font-src 'self' data:";
+  const gchar *img_src = "img-src 'self' data:";
   const gchar *block_all_mixed_content = "block-all-mixed-content";
   gchar **parts = NULL;
   GString *result;
@@ -1897,6 +1899,10 @@ cockpit_web_response_security_policy (const gchar *content_security_policy,
     g_string_append_printf (result, "%s; ", base_uri);
   if (!strv_have_prefix (parts, "object-src "))
     g_string_append_printf (result, "%s; ", object_src);
+  if (!strv_have_prefix (parts, "font-src "))
+    g_string_append_printf (result, "%s; ", font_src);
+  if (!strv_have_prefix (parts, "img-src "))
+    g_string_append_printf (result, "%s; ", img_src);
   if (!strv_have_prefix (parts, "block-all-mixed-content"))
     g_string_append_printf (result, "%s; ", block_all_mixed_content);
 

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -198,7 +198,7 @@ test_resource_simple (TestResourceCase *tc,
     "HTTP/1.1 200 OK\r\n"
     "X-DNS-Prefetch-Control: off\r\n"
     "Referrer-Policy: no-referrer\r\n"
-    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
+    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; font-src 'self' http://localhost data:; img-src 'self' http://localhost data:; block-all-mixed-content\r\n"
     "Content-Type: text/html\r\n"
     "Cache-Control: no-cache, no-store\r\n"
     "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -257,7 +257,7 @@ test_resource_simple_host (TestResourceCase *tc,
   const gchar *expected =
     "HTTP/1.1 200 OK\r\n"
     "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
-    "Content-Security-Policy: default-src 'self' http://my.host; connect-src 'self' http://my.host ws://my.host; form-action 'self' http://my.host; base-uri 'self' http://my.host; object-src 'none'; block-all-mixed-content\r\n"
+    "Content-Security-Policy: default-src 'self' http://my.host; connect-src 'self' http://my.host ws://my.host; form-action 'self' http://my.host; base-uri 'self' http://my.host; object-src 'none'; font-src 'self' http://my.host data:; img-src 'self' http://my.host data:; block-all-mixed-content\r\n"
     "Content-Type: text/html\r\n"
     "Cache-Control: no-cache, no-store\r\n"
     "Access-Control-Allow-Origin: http://my.host\r\n"
@@ -315,7 +315,7 @@ test_resource_language (TestResourceCase *tc,
   gchar *url = "/@localhost/another/test.html";
   const gchar *expected =  "HTTP/1.1 200 OK\r\n"
     "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
-    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
+    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; font-src 'self' http://localhost data:; img-src 'self' http://localhost data:; block-all-mixed-content\r\n"
     "Content-Type: text/html\r\n"
     "Cache-Control: no-cache, no-store\r\n"
     "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -372,7 +372,7 @@ test_resource_cookie (TestResourceCase *tc,
   const gchar *url = "/@localhost/another/test.html";
   const gchar *expected = "HTTP/1.1 200 OK\r\n"
     "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
-    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
+    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; font-src 'self' http://localhost data:; img-src 'self' http://localhost data:; block-all-mixed-content\r\n"
     "Content-Type: text/html\r\n"
     "Cache-Control: no-cache, no-store\r\n"
     "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -881,7 +881,7 @@ test_resource_language_suffix (TestResourceCase *tc,
   gconstpointer str;
   const gchar *expected = "HTTP/1.1 200 OK\r\n"
     "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
-    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
+    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; font-src 'self' http://localhost data:; img-src 'self' http://localhost data:; block-all-mixed-content\r\n"
     "Content-Type: text/html\r\n"
     "Cache-Control: no-cache, no-store\r\n"
     "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -937,7 +937,7 @@ test_resource_language_fallback (TestResourceCase *tc,
   gconstpointer str;
   const gchar *expected = "HTTP/1.1 200 OK\r\n"
     "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
-    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
+    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; font-src 'self' http://localhost data:; img-src 'self' http://localhost data:; block-all-mixed-content\r\n"
     "Content-Type: text/html\r\n"
     "Cache-Control: no-cache, no-store\r\n"
     "Access-Control-Allow-Origin: http://localhost\r\n"
@@ -1041,7 +1041,7 @@ test_resource_head (TestResourceCase *tc,
   const gchar *url = "/@localhost/another/test.html";
   const gchar *expected = "HTTP/1.1 200 OK\r\n"
     "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
-    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; block-all-mixed-content\r\n"
+    "Content-Security-Policy: default-src 'self' http://localhost; connect-src 'self' http://localhost ws://localhost; form-action 'self' http://localhost; base-uri 'self' http://localhost; object-src 'none'; font-src 'self' http://localhost data:; img-src 'self' http://localhost data:; block-all-mixed-content\r\n"
     "Content-Type: text/html\r\n"
     "Cache-Control: no-cache, no-store\r\n"
     "Access-Control-Allow-Origin: http://localhost\r\n"


### PR DESCRIPTION
This will allow us to embed SVGs or glyphs for global styling, as
relying on externally shipped graphics in a central place is really
difficult given the API compatibility with older -ws versions.

We already do this in machines, ovirt, and packagekit, and will need it
for moving to `<select>` (PR #11155) and eventually when moving to
PatternFly 4 (which uses background images). This does not weaken our
security as we only load CSS from trusted places, so let's generalize
this.

Note that packages cannot immediately rely on this, as they might be
served from an older cockpit-bridge package. Until then, packages need
to explicitly add this C-S-P to their manifest.

In `test_csp_strip()`, change the manifest override to drop data:, as
that's now the default. Instead, verify that not specifying data: in the
manifest is respected.