### PR TITLE
machines: some code enhancements as a follow-up of #11206

### DIFF
--- a/pkg/machines/scripts/create_machine.sh
+++ b/pkg/machines/scripts/create_machine.sh
@@ -66,12 +66,9 @@ fi
 XMLS_FILE="`mktemp`"
 
 if [ "$START_VM" = "true" ]; then
-    STARTUP_PARAMS="--wait -1 --noautoconsole"
-    # `noreboot` parameter should not be used for installation options that
-    # don't have install phase, because it blocks the domain from starting.
-    if [ "$SOURCE_TYPE" != "disk_image" ]; then
-        STARTUP_PARAMS="$STARTUP_PARAMS --noreboot"
-    fi
+    # Use --wait 0 to not wait till guest console closes.
+    # Simply kick off the install and exit
+    STARTUP_PARAMS="--noautoconsole --wait 0"
     HAS_INSTALL_PHASE="false"
 else
     # 2 = last phase only

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -910,6 +910,11 @@ class MachineCase(unittest.TestCase):
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { mount } for .* comm="find" .*pcp_pmlogger_t.*')
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1662866
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { execute } for .* comm="which" .*pcp_pmlogger_t.*')
+            # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1406979
+            # The bug is closed and for old release but should be here as reference for the solutions
+            # It suggests configure auditd to dontaudit these messages since selinux can't offer whitelisting this directory for qemu process
+            self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { search } for  .* comm="qemu-system-x86" .* dev="proc" .*')
+            self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { read } for  .* comm="qemu-system-x86" .* dev="proc" .*')
 
         if self.image in ['rhel-8-0']:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1653872

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1048,7 +1048,7 @@ class TestMachines(MachineCase):
         # try to CREATE WITH DIALOG ERROR
 
         # name
-        checkDialogFormValidationTest(TestMachines.VmDialog(self, ""), {"Name": "Name should not be empty"})
+        checkDialogFormValidationTest(TestMachines.VmDialog(self, "", storage_size='1'), {"Name": "Name should not be empty"})
 
         # location
         checkDialogFormValidationTest(TestMachines.VmDialog(self, "subVmTestCreate7", sourceType='url',
@@ -1133,8 +1133,8 @@ class TestMachines(MachineCase):
         # to start properly.
         # This is applicable only for the following test so let's keep it last,
         # in order to allow the rest of the tests to run faster with QEMU KVM
-        # Run modprobe -r in retry loop because it fails sometimes with 'Module kvm is in use'
-        self.machine.execute("for i in 1 2 3 4 5; do modprobe -r kvm_intel && modprobe -r kvm && break || sleep 1; done")
+        # Stop pmcd service if available which is invoking pmdakvm and is keeping KVM module used
+        self.machine.execute("(systemctl stop pmcd || true) && modprobe -r kvm_intel && modprobe -r kvm_amd && modprobe -r kvm")
 
         createTest(TestMachines.VmDialog(self, "subVmTestCreate17", sourceType='disk_image',
                                          location=config.VALID_DISK_IMAGE_PATH,
@@ -1334,7 +1334,9 @@ class TestMachines(MachineCase):
             b.set_input_text("#memory-size", str(self.memory_size))
             b.select_from_dropdown("#memory-size-unit-select", self.memory_size_unit)
 
-            if self.storage_size is not None:
+            if self.storage_size is None:
+                b.wait_not_present("#storage-size")
+            else:
                 b.set_input_text("#storage-size", str(self.storage_size))
                 b.select_from_dropdown("#storage-size-unit-select", self.storage_size_unit)
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -996,12 +996,12 @@ class TestMachines(MachineCase):
         def createTest(dialog):
             runner.tryCreate(dialog) \
 
-            # When start_vm is set the virt-install is used with --print-xml
-            # and thus the virt-install script should be running at this point
-            if not dialog.start_vm:
-                runner.assertScriptFinished()
-
-            runner.deleteVm(dialog) \
+            # When creating VMs we should always wait for the virt-install script
+            # to finish the and VM to get defined
+            # Then we are ready to delete it.
+            runner.assertScriptFinished() \
+                .assertDomainDefined(dialog.name, dialog.connection) \
+                .deleteVm(dialog) \
                 .checkEnvIsEmpty()
 
         def installWithErrorTest(dialog):
@@ -1573,6 +1573,19 @@ class TestMachines(MachineCase):
         def assertScriptFinished(self):
             with self.browser.wait_timeout(20):
                 self.browser.wait(functools.partial(self._commandNotRunning, "virt-install"))
+
+            return self
+
+        def assertDomainDefined(self, name, connection):
+            listCmd = ""
+            if connection == "session":
+                listCmd = "runuser -l admin -c 'virsh -c qemu:///session list --persistent --all'"
+            else:
+                # When creating VMs from the UI default connection is the system
+                # In this case don't use runuser -l admin because we get errors 'authentication unavailable'
+                listCmd = "virsh -c qemu:///system list --persistent --all"
+
+            wait(lambda: name in self.machine.execute(listCmd))
 
             return self
 


### PR DESCRIPTION
* <del> create_machines.sh script fixed to do int comparisons in a clean way </del>
* testCreate test was adjusted to check that storage_size dialog entry
is not present when importing existing disk
* utilize testlib.wait instead of using for loop in shell