### PR TITLE
logs: Do not use pointer on panel heading

### DIFF
--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -397,7 +397,7 @@ body {
     font-size: 13px;
 }
 
-.panel-heading {
+.panel-heading.problem-panel{
     cursor: pointer;
 }
 


### PR DESCRIPTION
Introduced in 32bf3db (ha, I did it almost 2 years ago :smiley: )
Purpose of this css style was so ABRT problem can have details created
from panels. However this style matches too widely.