### PR TITLE
[no-test] Allow triggering more tests - but only ours

### DIFF
--- a/bots/tests-trigger
+++ b/bots/tests-trigger
@@ -24,7 +24,7 @@ def trigger_pull(api, opts):
     revision = pull['head']['sha']
     statuses = api.statuses(revision)
     if opts.context:
-        contexts = [ opts.context ]
+        contexts = opts.context
         all = False
     else:
         contexts = set(statuses.keys())
@@ -64,7 +64,7 @@ def main():
                         help="Allow triggering for users that aren't whitelisted")
     parser.add_argument('--repo', help="The repository to trigger the robots in", default=None)
     parser.add_argument('pull', help='The pull request to trigger')
-    parser.add_argument('context', nargs='?', help='The github task context to trigger')
+    parser.add_argument('context', nargs='*', help='The github task context(s) to trigger')
     opts = parser.parse_args()
 
     api = github.GitHub(repo=opts.repo)

--- a/bots/tests-trigger
+++ b/bots/tests-trigger
@@ -24,7 +24,7 @@ def trigger_pull(api, opts):
     revision = pull['head']['sha']
     statuses = api.statuses(revision)
     if opts.context:
-        contexts = opts.context
+        contexts = [cntx for cntx in opts.context if github.known_context(cntx)]
         all = False
     else:
         contexts = set(statuses.keys())


### PR DESCRIPTION
Yesterday I successfully triggered semaphoreci with `./bots/tests-trigger 123 semaphoreci` which was not what I should have done. I counted on bots not to allow me to do something I should not do.
Also adding possibility to trigger more than one test like this:
`./bots/tests-trigger 123 verify/fedora-29 verify/debian-stable`

EDIT:
I think this should be [no-test] but so easy to forget to add it there while opening PR