### PR TITLE
services: Rename column from Id to Name

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -277,7 +277,7 @@ $(function() {
             var units = [ ];
             var header = {
                 Description: _("Description"),
-                Id: _("Id"),
+                Id: _("Name"),
                 is_timer: (~pattern.indexOf("timer")),
                 Next_Run_Time: _("Next Run"),
                 Last_Trigger_Time: _("Last Trigger"),

--- a/pkg/systemd/services.css
+++ b/pkg/systemd/services.css
@@ -31,7 +31,7 @@ table.systemd-unit-relationship-table td:first-child {
 }
 
 #services-text-filter {
-  width: auto;
+  width: 21rem;
   display: inline;
   vertical-align: middle;
   padding-right: 35px;

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -61,7 +61,7 @@
       </ul>
       <div class="filter-group">
         <button id="create-timer" data-toggle="#timer-dialog" data-target="#timer-dialog" class="btn btn-primary" translate>Create Timer</button>
-        <input type="search" id="services-text-filter" class="form-control" aria-label="Filter" placeholder="Filter by Id or description..." translate="placeholder"/>
+        <input type="search" id="services-text-filter" class="form-control" aria-label="Filter" placeholder="Filter by name or description..." translate="placeholder"/>
         <div class="dropdown" id="services-dropdown">
           <button class="btn btn-default dropdown-toggle" type="button" id="service-type" data-toggle="dropdown">
             <span id="current-service-type" class="pull-left" data-num=0 translatable="yes">All</span>


### PR DESCRIPTION
It was pointed out that what we call Id is called unit name.
Purposefully I changed only label and not the code itself (as variable
        names) as `id` is used absolutely everywhere in the code.

@andreasn wrote:
> I also noticed you changed the name for _id_ to _name_ and I'm trying to figure out what the best name would be for this column. I can't find any mention of _Id_ anywhere. It seems it's either called _Name_ or _Unit_. It would be good to be able to transition from the UI to the CLI and maintain the same wording, so I wonder if Unit is more correct here, see the systemctl --help command for example. It's full of the word _unit_.
[RHEL systemd documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/chap-managing_services_with_systemd)
[systemd upstream documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html)
So that's another thing I'm a little bit on the fence about.

If you grep [systemd upstream documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) for `unit name` you will notice it is used there a lot.
The column shows `Unit name` or you can be more specific and call it `service name`, `target name`...
Agree that if you look into `systemctl --help` you can see there for example `start UNIT...                       Start (activate) one or more units` where `UNIT` really refers to this column.

Surely it can be also `Unit`. I lean more to `name` but if more people agree with `unit` I will change it to that. (Then just what should be placeholder in search field?)