### PR TITLE
ws: Mark deleted cookie as "Secure" with https

### DIFF
--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -268,7 +268,7 @@ cockpit_web_response_new (GIOStream *io,
       host = g_hash_table_lookup (in_headers, "Host");
     }
 
-  protocol = cockpit_web_response_get_protocol (io, in_headers);
+  protocol = cockpit_web_response_get_protocol (self, in_headers);
   if (protocol && host)
     self->origin = g_strdup_printf ("%s://%s", protocol, host);
 
@@ -1929,8 +1929,21 @@ cockpit_web_response_get_origin (CockpitWebResponse *self)
 }
 
 const gchar *
-cockpit_web_response_get_protocol (GIOStream *connection,
+cockpit_web_response_get_protocol (CockpitWebResponse *self,
                                    GHashTable *headers)
+{
+  return cockpit_connection_get_protocol (self->io, headers);
+}
+
+static void
+cockpit_web_response_flow_iface_init (CockpitFlowIface *iface)
+{
+  /* No implementation */
+}
+
+const gchar *
+cockpit_connection_get_protocol (GIOStream *connection,
+                                 GHashTable *headers)
 {
   const gchar *protocol = NULL;
   const gchar *protocol_header;
@@ -1947,10 +1960,4 @@ cockpit_web_response_get_protocol (GIOStream *connection,
     }
 
   return protocol ? protocol : "http";
-}
-
-static void
-cockpit_web_response_flow_iface_init (CockpitFlowIface *iface)
-{
-  /* No implementation */
 }

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -145,7 +145,7 @@ const gchar *  cockpit_web_response_get_url_root         (CockpitWebResponse *re
 
 const gchar *  cockpit_web_response_get_origin           (CockpitWebResponse *response);
 
-const gchar *  cockpit_web_response_get_protocol         (GIOStream *connection,
+const gchar *  cockpit_web_response_get_protocol         (CockpitWebResponse *response,
                                                           GHashTable *headers);
 
 void           cockpit_web_response_template             (CockpitWebResponse *response,
@@ -155,6 +155,10 @@ void           cockpit_web_response_template             (CockpitWebResponse *re
 
 gchar *      cockpit_web_response_security_policy        (const gchar *content_security_policy,
                                                           const gchar *self_origin);
+
+
+const gchar *  cockpit_connection_get_protocol           (GIOStream *connection,
+                                                          GHashTable *headers);
 
 G_END_DECLS
 

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1649,12 +1649,16 @@ cockpit_auth_parse_application (const gchar *path,
 }
 
 gchar *
-cockpit_auth_empty_cookie_value (const gchar *path)
+cockpit_auth_empty_cookie_value (const gchar *path, gboolean secure)
 {
   gchar *application = cockpit_auth_parse_application (path, NULL);
   gchar *cookie = application_cookie_name (application);
 
-  gchar *cookie_line = g_strdup_printf ("%s=deleted; PATH=/; HttpOnly", cookie);
+  /* this is completely security irrelevant, but security scanners complain
+   * about the lack of Secure (rhbz#1677767) */
+  gchar *cookie_line = g_strdup_printf ("%s=deleted; PATH=/;%s HttpOnly",
+                                        cookie,
+                                        secure ? " Secure;" : "");
 
   g_free (application);
   g_free (cookie);

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -106,7 +106,8 @@ gchar *         cockpit_auth_steal_authorization      (GHashTable *headers,
                                                        gchar **ret_type,
                                                        gchar **ret_conversation);
 
-gchar *         cockpit_auth_empty_cookie_value       (const gchar *path);
+gchar *         cockpit_auth_empty_cookie_value       (const gchar *path,
+                                                       gboolean secure);
 
 G_END_DECLS
 

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -579,7 +579,6 @@ cockpit_channel_response_serve (CockpitWebService *service,
   GHashTableIter iter;
   JsonObject *object = NULL;
   JsonObject *heads;
-  GIOStream *connection;
   const gchar *protocol;
   const gchar *http_host = "localhost";
   gchar *channel = NULL;
@@ -680,8 +679,7 @@ cockpit_channel_response_serve (CockpitWebService *service,
     }
 
   /* Send along the HTTP scheme the package should assume is accessing things */
-  connection = cockpit_web_response_get_stream (response);
-  protocol = cockpit_web_response_get_protocol (connection, in_headers);
+  protocol = cockpit_web_response_get_protocol (response, in_headers);
 
   json_object_set_string_member (heads, "Host", host);
   json_object_set_string_member (heads, "X-Forwarded-Proto", protocol);

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -418,7 +418,8 @@ send_login_html (CockpitWebResponse *response,
   else
     {
       /* The login Content-Security-Policy allows the page to have inline <script> and <style> tags. */
-      cookie_line = cockpit_auth_empty_cookie_value (path);
+      gboolean secure = g_strcmp0 (cockpit_web_response_get_protocol (response, headers), "https") == 0;
+      cookie_line = cockpit_auth_empty_cookie_value (path, secure);
       content_security_policy = cockpit_web_response_security_policy ("default-src 'self' 'unsafe-inline'",
                                                                       cockpit_web_response_get_origin (response));
 

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1325,7 +1325,7 @@ cockpit_web_service_create_socket (const gchar **protocols,
     }
   else
     {
-      protocol = cockpit_web_response_get_protocol (io_stream, headers);
+      protocol = cockpit_connection_get_protocol (io_stream, headers);
     }
 
   secure = g_strcmp0 (protocol, "https") == 0;

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -523,7 +523,7 @@ static const DefaultFixture fixture_shell_path_login = {
   .org_path = "/path/system/host",
   .auth = NULL,
   .expect = "HTTP/1.1 200*"
-      "Set-Cookie: cockpit=deleted*"
+      "Set-Cookie: cockpit=deleted; PATH=/; HttpOnly\r*"
       "<html>*"
       "<base href=\"/path/\">*"
       "login-button*"

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -195,7 +195,7 @@ class Browser:
         cookies = self.cdp.invoke("Network.getCookies")
         for c in cookies["cookies"]:
             if c["name"] == name:
-                return c["value"]
+                return c
         return None
 
     def go(self, hash, host="localhost"):

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -50,6 +50,11 @@ class TestConnection(MachineCase):
         b.expect_load()
         b.enter_page("/system")
 
+        # cookie should not be marked as secure, it's not https
+        cookie = b.cookie("cockpit")
+        self.assertTrue(cookie["httpOnly"])
+        self.assertFalse(cookie["secure"])
+
         # take cockpit-ws down on the server page
         m.stop_cockpit()
         b.switch_to_top()
@@ -90,6 +95,14 @@ class TestConnection(MachineCase):
         b.expect_load()
         b.enter_page("/system")
         b.logout()
+
+        # deleted cookie after logout should not be marked as secure, it's not https
+        cookie = b.cookie("cockpit")
+        self.assertEqual(cookie["value"], "deleted")
+        if m.image != "rhel-7-6-distropkg":
+            # fixed in PR #10766
+            self.assertTrue(cookie["httpOnly"])
+        self.assertFalse(cookie["secure"])
 
         if not m.atomic_image:  # cannot write to /usr on Atomics, and cockpit-session is in a container
             # damage cockpit-session permissions (Fedora-ish and Debian-ish path), expect generic error message
@@ -134,6 +147,7 @@ class TestConnection(MachineCase):
 
     def testTls(self):
         m = self.machine
+        b = self.browser
 
         # Start Cockpit with TLS
         m.start_cockpit(tls=True)
@@ -192,6 +206,22 @@ class TestConnection(MachineCase):
         # check the Debian smoke test
         m.upload(["../tools/debian/tests/smoke"], "/tmp")
         m.execute("/tmp/smoke")
+
+        b.ignore_ssl_certificate_errors(True)
+        self.login_and_go("/system")
+        cookie = b.cookie("cockpit")
+        # cookie should be marked as secure
+        self.assertTrue(cookie["httpOnly"])
+        self.assertTrue(cookie["secure"])
+        # same after logout
+        b.logout()
+        cookie = b.cookie("cockpit")
+        self.assertEqual(cookie["value"], "deleted")
+        if m.image != "rhel-7-6-distropkg":
+            # fixed in PR #10766
+            self.assertTrue(cookie["httpOnly"])
+            # fixed in PR #11279
+            self.assertTrue(cookie["secure"])
 
     def testConfigOrigins(self):
         m = self.machine


### PR DESCRIPTION
This is completely irrelevant for security, but scanners such as Qualys
complain about it. This makes the deleted cookie have the same
attributes as the real one. See commit 8ec9c8cda for a similar issue.

Adjust test-handlers to verify the non-secure path. The TLS path is
unwieldy to handle in unit tests, so cover that in check-connection.

Fixes half of https://bugzilla.redhat.com/show_bug.cgi?id=1677767