### PR TITLE
services: Show loading state

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -267,6 +267,7 @@ $(function() {
         mustache.parse(units_template);
 
         function render_now() {
+            $("#loading-fallback").hide();
             var pattern = $('#services-filter li.active').attr('data-pattern');
             var current_text_filter = $('#services-text-filter').val()
                     .toLowerCase();
@@ -890,8 +891,6 @@ $(function() {
     function update() {
         var path = cockpit.location.path;
 
-        ensure_units();
-
         if (path.length === 0) {
             show_unit(null);
             $("#services").show();
@@ -903,6 +902,7 @@ $(function() {
             cockpit.location = '';
         }
         $("body").show();
+        ensure_units();
     }
 
     $(cockpit).on("locationchanged", update);

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -11,8 +11,8 @@
     <script src="../base1/cockpit.js"></script>
     <script src="../*/po.js"></script>
 </head>
-<body id="services-page" hidden>
 
+<body id="services-page" hidden>
   <script id="services-units-tmpl" type="x-template/mustache">
     <div class="panel panel-default">
       <table class="table table-hover">
@@ -50,7 +50,7 @@
     </div>
   </script>
 
-  <div id="services" hidden>
+  <div id="services">
     <div class="content-header-extra with-navtabs">
       <ul class="nav nav-tabs" id="services-filter">
         <li tabindex="0" data-pattern="\.target$"><a translatable="yes">Targets</a></li>
@@ -80,6 +80,10 @@
 
     <div class="container-fluid" role="tabpanel">
       <div id="services-list"></div>
+    </div>
+    <div id="loading-fallback" class="blank-slate-pf blank-screen">
+      <div class="spinner spinner-lg"></div>
+      <h1 translate>Loading...</h1>
     </div>
   </div>
 

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -328,6 +328,8 @@ WantedBy=default.target
             "busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP"))
         m.execute("timedatectl set-time '2020-01-01 15:30:00'")
         self.login_and_go("/system/services")
+        if m.image != "rhel-7-6-distropkg": # Introduced in #11280
+            b.wait_not_visible("#loading-fallback")
         b.click('#services-filter :nth-child(4)')
         b.wait_visible("#create-timer")
         b.click('#create-timer')


### PR DESCRIPTION
By default show top panel with spinner and when ready to render
services itself hide spinner.

Also show body and top panel as soon as possible so there is as little as possible of elements showing and hiding while things are loaded and rendered.

![screenshot from 2019-03-03 12-34-33](https://user-images.githubusercontent.com/12330670/53694601-6b499180-3db1-11e9-9d6c-8edd44173daa.png)
