### PR TITLE
test: Fix --sit with avocado/selenium tests

### DIFF
--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -254,12 +254,8 @@ def run_avocado(avocado_tests, verbose, browser, download_logs, sit):
             copy_avocado_logs(machine, "PASSED")
 
         if not success and sit:
-            sys.stderr.write(machine.diagnose() + "\n")
-            try:
-                input = raw_input
-            except NameError:
-                pass
-            input("Press RET to continue... ")
+            sys.stderr.write(machine.diagnose() + "\nPress RET to continue...\n")
+            sys.stdin.readline()
 
         return success
     finally:


### PR DESCRIPTION
Avoid input(), as that doesn't work well with bilingual code.
Similar to what was done to the verify tests in commit 44e0fd48caa5c8.

Fixes this error:
```
  File "test/avocado/run-tests", line 262, in run_avocado
    input("Press RET to continue... ")
UnboundLocalError: local variable 'input' referenced before assignment
```