### PR TITLE
services: Break top bar nicely on small screen

### DIFF
--- a/pkg/systemd/services.css
+++ b/pkg/systemd/services.css
@@ -30,6 +30,25 @@ table.systemd-unit-relationship-table td:first-child {
   justify-content: space-between;
 }
 
+@media screen and (max-width: 960px) {
+    #services .content-header-extra {
+        flex-direction: column-reverse;
+    }
+
+    #services-filter {
+        padding-top: 10px;
+    }
+
+    .filter-group {
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    .filter-group .dropdown {
+         margin-left: 4px;
+    }
+}
+
 #services-text-filter {
   width: 21rem;
   display: inline;


### PR DESCRIPTION
On small screen break into two rows, where top row contains
filters and bottom row contains navtab selection

before:
![beforebreaking](https://user-images.githubusercontent.com/12330670/53695080-861f0480-3db7-11e9-80ad-f99cefc09732.png)

after:
![afterpatch](https://user-images.githubusercontent.com/12330670/53695081-86b79b00-3db7-11e9-86a3-573fa1bd78f5.png)
