### PR TITLE
bots: Randomize "since" time in issue() check [no-test]

### DIFF
--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -308,6 +308,10 @@ def issue(title, body, item, context=None, items=[], state="open", since=None):
     if context:
         item = "{0} {1}".format(item, context).strip()
 
+    if since:
+        # don't let all bots pass the deadline in the same second, to avoid many duplicates
+        since += random.randint(-3600, 3600)
+
     for issue in api.issues(state=state, since=since):
         checklist = github.Checklist(issue["body"])
         if item in checklist.items:


### PR DESCRIPTION
Avoid letting all bots cross the deadline in issue() at the exact same
time. Apparently there is some more aggressive GitHub caching now that
causes one bot not to see a new issue that was created a few seconds
ago. Spread out the deadline over two hours, to avoid creating lots of
duplicate NPM and image refreshes.

This is similar to how stale() randomizes the time.