### PR TITLE
storage: Make sure enable_vdo_features never rejects

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -396,14 +396,14 @@ function init_model(callback) {
     }
 
     function enable_vdo_features() {
-        return client.vdo_overlay.start()
-                .then(function (success) {
-                    client.features.vdo = success;
-                    return cockpit.resolve();
-                })
-                .fail(function () {
-                    return cockpit.resolve();
-                });
+        return client.vdo_overlay.start().then(
+            function (success) {
+                client.features.vdo = success;
+                return cockpit.resolve();
+            },
+            function () {
+                return cockpit.resolve();
+            });
     }
 
     function enable_clevis_features() {


### PR DESCRIPTION
Using ".fail" will return the rejected promise while we want to always
return a resolved one.