### PR TITLE
[no-test] Accessible navtabs in services

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -334,9 +334,11 @@ $(function() {
             }
         }
 
-        function clear_filters() {
+        function clear_filters(event) {
             $("#services-text-filter").val("");
             $('#services-dropdown').val(0);
+            $("#services-text-filter").focus();
+            event.preventDefault();
             render();
         }
 
@@ -496,6 +498,7 @@ $(function() {
             $(this)
                     .addClass('active')
                     .attr('aria-current', true);
+            $("#services-text-filter").focus();
             render();
         });
 
@@ -896,6 +899,7 @@ $(function() {
             cockpit.location = '';
         }
         $("body").show();
+        $("#services-filter li:first-child").focus();
         ensure_units();
     }
 

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -268,7 +268,7 @@ $(function() {
 
         function render_now() {
             $("#loading-fallback").hide();
-            var pattern = $('#services-filter li.active').attr('data-pattern');
+            var pattern = $('#services-filter [aria-current=true]').attr('data-pattern');
             var current_text_filter = $('#services-text-filter').val()
                     .toLowerCase();
             var current_type_filter = parseInt($('#services-dropdown').val());
@@ -491,15 +491,44 @@ $(function() {
             update_all();
         });
 
-        $('#services-filter li').on('click', function() {
-            $('#services-filter li')
-                    .removeClass('active')
+        function service_type_change(obj, keep_focus) {
+            $('#services-filter a')
+                    .attr('aria-selected', false)
                     .removeAttr('aria-current');
-            $(this)
-                    .addClass('active')
+            $('#services-filter li')
+                    .removeClass('active');
+            $(obj)
+                    .attr('aria-selected', true)
                     .attr('aria-current', true);
-            $("#services-text-filter").focus();
+            $(obj).parent()
+                    .addClass('active');
+            if (keep_focus)
+                $(obj).focus();
+            else
+                $("#services-text-filter").focus();
             render();
+        }
+
+        $('#services-filter').on('focus', function() { $('#services-filter li.active a').focus() });
+        $('#services-filter a').on('click keydown', function(event) {
+            if (event.type === 'click' || event.keyCode === 13) {
+                service_type_change(this, false);
+                event.preventDefault();
+            }
+
+            var li = $(this).parent();
+
+            if (event.keyCode === 37) { // left
+                var prev = $(li).prev()
+                        .children()[0];
+                if (prev)
+                    service_type_change(prev, true);
+            } else if (event.keyCode === 39) { // right
+                var next = $(li).next()
+                        .children()[0];
+                if (next)
+                    service_type_change(next, true);
+            }
         });
 
         $('#services-dropdown').on('change', render);
@@ -899,7 +928,7 @@ $(function() {
             cockpit.location = '';
         }
         $("body").show();
-        $("#services-filter li:first-child").focus();
+        $("#services-filter li:first-child a").focus();
         ensure_units();
     }
 

--- a/pkg/systemd/services.css
+++ b/pkg/systemd/services.css
@@ -130,3 +130,9 @@ table.systemd-unit-relationship-table td:first-child {
     border-bottom: none;
     flex: auto;
 }
+
+.nav-tabs li:focus {
+  box-shadow: 1px 1px 2px -2px #72767b inset;
+  outline: none;
+}
+

--- a/pkg/systemd/services.css
+++ b/pkg/systemd/services.css
@@ -131,7 +131,7 @@ table.systemd-unit-relationship-table td:first-child {
     flex: auto;
 }
 
-.nav-tabs li:focus {
+.nav-tabs a:focus {
   box-shadow: 1px 1px 2px -2px #72767b inset;
   outline: none;
 }

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -53,11 +53,21 @@
   <div id="services">
     <div class="content-header-extra with-navtabs">
       <ul class="nav nav-tabs" id="services-filter">
-        <li tabindex="0" data-pattern="\.target$"><a tabindex="0" translatable="yes">Targets</a></li>
-        <li class="active" aria-current=true tabindex="0" data-pattern="\.service$"><a tabindex="0" translatable="yes">System Services</a></li>
-        <li tabindex="0" data-pattern="\.socket$"><a tabindex="0" translatable="yes">Sockets</a></li>
-        <li tabindex="0" data-pattern="\.timer$"><a tabindex="0" translatable="yes">Timers</a><li>
-        <li tabindex="0" data-pattern="\.path$"><a tabindex="0" translatable="yes">Paths</a><li>
+        <li>
+        <a href="#" role="tab" aria-controls="services-list" data-pattern="\.target$" id="target-tab" translatable="yes">Targets</a>
+        </li>
+        <li class="active">
+          <a href="#" aria-current=true aria-selected="true" role="tab" aria-controls="services-list" data-pattern="\.service$" id="service-tab" translatable="yes">System Services</a>
+        </li>
+        <li>
+          <a href="#" role="tab" aria-controls="services-list" data-pattern="\.socket$" id="socket-tab" translatable="yes">Sockets</a>
+        </li>
+        <li>
+          <a href="#" role="tab" aria-controls="services-list" data-pattern="\.timer$" id="timer-tab" translatable="yes">Timers</a>
+        </li>
+        <li>
+          <a href="#" role="tab" aria-controls="services-list" data-pattern="\.path$" id="path-tab" translatable="yes">Paths</a>
+        </li>
       </ul>
       <div class="filter-group">
         <button id="create-timer" data-toggle="#timer-dialog" data-target="#timer-dialog" class="btn btn-primary" translate>Create Timer</button>

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -53,11 +53,11 @@
   <div id="services">
     <div class="content-header-extra with-navtabs">
       <ul class="nav nav-tabs" id="services-filter">
-        <li>
-        <a href="#" role="tab" aria-controls="services-list" data-pattern="\.target$" id="target-tab" translatable="yes">Targets</a>
-        </li>
         <li class="active">
           <a href="#" aria-current=true aria-selected="true" role="tab" aria-controls="services-list" data-pattern="\.service$" id="service-tab" translatable="yes">System Services</a>
+        </li>
+        <li>
+        <a href="#" role="tab" aria-controls="services-list" data-pattern="\.target$" id="target-tab" translatable="yes">Targets</a>
         </li>
         <li>
           <a href="#" role="tab" aria-controls="services-list" data-pattern="\.socket$" id="socket-tab" translatable="yes">Sockets</a>


### PR DESCRIPTION
This PR tries to make navtabs in services page accessible.
The accessibility is implemented two ways - (in both cases enter and space select current tab)

1. As bunch on toggle buttons, which is simpler but does not make much sense as it may seem that more of them can be selected at once
2. As navtabs. It is possible to move with left and right arrow. And makes more sense.

Then there is implementation of focus. It is implemented that firstly is focused selection of type of unit and when selected search field is focused. This makes sense for users with screenreaders (because when search field is focused first, then it would be very hard to discover that there is something before that) but for other users it may seem as there is nothing focused (but if it would be discoverable that hitting space or enter would jump to search box...)

Also last commit moves default selected tab as first. This is the same logic about discovering elements on left while using screen readers.

@garrett definitely will have options about this and will explain to me if this is the right direction or not :) 
