### PR TITLE
bots: Robustify TLS configuration in Machine

### DIFF
--- a/bots/machine/machine_core/machine.py
+++ b/bots/machine/machine_core/machine.py
@@ -222,15 +222,16 @@ class Machine(ssh_connection.SSHConnection):
             self.execute(script="""#!/bin/sh
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
             systemctl daemon-reload &&
+            systemctl stop cockpit.service &&
             systemctl start cockpit.socket
             """)
         else:
             self.execute(script="""#!/bin/sh
             mkdir -p /etc/systemd/system/cockpit.service.d/ &&
             rm -f /etc/systemd/system/cockpit.service.d/notls.conf &&
-            systemctl daemon-reload &&
             printf \"[Service]\nExecStartPre=-/bin/sh -c 'echo 0 > /proc/sys/kernel/yama/ptrace_scope'\nExecStart=\n%s --no-tls\n\" `systemctl cat cockpit.service | grep ExecStart=` > /etc/systemd/system/cockpit.service.d/notls.conf &&
             systemctl daemon-reload &&
+            systemctl stop cockpit.service &&
             systemctl start cockpit.socket
             """)
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -758,8 +758,8 @@ class MachineCase(unittest.TestCase):
             self.check_browser_errors()
         shutil.rmtree(self.tmpdir)
 
-    def login_and_go(self, path=None, user=None, host=None, authorized=True):
-        self.machine.start_cockpit(host)
+    def login_and_go(self, path=None, user=None, host=None, authorized=True, tls=False):
+        self.machine.start_cockpit(host, tls=tls)
         self.browser.login_and_go(path, user=user, host=host, authorized=authorized)
 
     allow_core_dumps = False

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -77,9 +77,11 @@ class OCMachine(VirtMachine):
                 i = i + 1
                 time.sleep(1)
 
-    def start_cockpit(self, host=None):
+    def start_cockpit(self, host=None, tls=False):
         if self.started:
             return
+        if tls:
+            raise NotImplementedError("TLS support not implemented here")
 
         path = os.path.join(base_dir, "files", "cockpit-openshift-template.json")
         self.upload([path], "/tmp")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -208,7 +208,7 @@ class TestConnection(MachineCase):
         m.execute("/tmp/smoke")
 
         b.ignore_ssl_certificate_errors(True)
-        self.login_and_go("/system")
+        self.login_and_go("/system", tls=True)
         cookie = b.cookie("cockpit")
         # cookie should be marked as secure
         self.assertTrue(cookie["httpOnly"])


### PR DESCRIPTION
After enabling or disabling TLS, stop cockpit.service to make sure that
the change will actually get picked up at the next connection to
cockpit.

Also drop a duplicate `daemon-reload`.