### PR TITLE
tools: Enable bodhi for Fedora 30 [no-test]

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -39,7 +39,7 @@ job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 
 # Push out a Bodhi update
 job release-bodhi F29
-#job release-bodhi F30
+job release-bodhi F30
 
 # Upload documentation
 job bots/release-guide dist/guide cockpit-project/cockpit-project.github.io


### PR DESCRIPTION
It's active now.
See https://fedoraproject.org/wiki/Releases/30/Schedule