### PR TITLE
Pretty package output

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -1394,7 +1394,7 @@ cockpit_packages_dump (void)
   for (l = names; l != NULL; l = g_list_next (l))
     {
       package = g_hash_table_lookup (by_name, l->data);
-      g_print ("%s: %s\n", package->name, package->directory);
+      g_print ("%-20.20s %s\n", package->name, package->directory);
     }
 
   if (packages->checksum)

--- a/tools/debian/tests/smoke
+++ b/tools/debian/tests/smoke
@@ -11,9 +11,9 @@ check_out() {
 echo " * bridge works and has expected packages"
 OUT=$(cockpit-bridge --packages)
 echo "$OUT"
-check_out "^base1: /usr/share/cockpit/base1"
-check_out "^system:"
-check_out "^users:"
+check_out "^base1.* /usr/share/cockpit/base1"
+check_out "^system"
+check_out "^users"
 
 # on an RPM based system we expect cockpit.socket not to be enabled by default;
 # on a Debian-based system we do


### PR DESCRIPTION
This has annoyed me for a while.

Old:
```
$ cockpit-bridge --packages
apps: /usr/share/cockpit/apps
base1: /usr/share/cockpit/base1
cockpit-composer: /home/lars/.local/share/cockpit/cockpit-composer
dashboard: /usr/share/cockpit/dashboard
docker: /usr/share/cockpit/docker
domain: /usr/share/cockpit/realmd
machines: /usr/share/cockpit/machines
network: /usr/share/cockpit/networkmanager
performance: /usr/share/cockpit/tuned
podman: /home/lars/.local/share/cockpit/podman
shell: /usr/share/cockpit/shell
ssh: /usr/share/cockpit/ssh
storage: /usr/share/cockpit/storaged
system: /usr/share/cockpit/systemd
updates: /usr/share/cockpit/packagekit
users: /usr/share/cockpit/users
```

New:
```
$ cockpit-bridge --packages
NAME                 PROVIDES                                 PATH
apps                 Applications                             /usr/share/cockpit/apps
base1                                                         /usr/share/cockpit/base1
cockpit-composer                                              /home/lars/.local/share/cockpit/cockpit-composer
dashboard                                                     /usr/share/cockpit/dashboard
docker               Containers                               /usr/share/cockpit/docker
domain                                                        /usr/share/cockpit/realmd
machines             Virtual Machines                         /usr/share/cockpit/machines
network              Networking                               /usr/share/cockpit/networkmanager
performance                                                   /usr/share/cockpit/tuned
podman               Podman Containers                        /home/lars/.local/share/cockpit/podman
shell                                                         /usr/share/cockpit/shell
ssh                                                           /usr/share/cockpit/ssh
storage              Storage                                  /usr/share/cockpit/storaged
system               Services, System, Logs, Terminal         /usr/share/cockpit/systemd
updates              Software Updates                         /usr/share/cockpit/packagekit
users                Accounts                                 /usr/share/cockpit/users
```

See individual commits.