### PR TITLE
lib/file-autocomplete: Fix caret placement & enlarge click target

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.css
+++ b/pkg/lib/cockpit-components-file-autocomplete.css
@@ -1,5 +1,5 @@
 .file-autocomplete-ct input {
-    padding-right: 24px;
+    padding-right: 38px;
 }
 
 .file-autocomplete-ct ul {
@@ -25,16 +25,21 @@
     padding: 0;
 }
 
-.file-autocomplete-ct span.spinner,
-.file-autocomplete-ct span.caret {
+.file-autocomplete-ct .spinner,
+.file-autocomplete-ct .caret {
     position: absolute;
     top: 7px;
     z-index: 9;
 }
 
-.file-autocomplete-ct span.caret {
-    width: 1.5em;
-    height: 1.5em;
+.file-autocomplete-ct .caret {
+    top: 0;
+    height: 26px;
     cursor: pointer;
     pointer-events: all;
+    padding: 0 23px 0 12px;
+}
+
+.file-autocomplete-ct .caret:before {
+    position: static;
 }


### PR DESCRIPTION
## Before

![screenshot_2019-03-05 virtual machines - sunny 3](https://user-images.githubusercontent.com/10246/53823395-fa9da300-3f71-11e9-9954-df09bc01483e.png)


## After (enlarged)

![caret-compare](https://user-images.githubusercontent.com/10246/53822958-0d63a800-3f71-11e9-90cd-fdc10c9caf59.png)

(BTW: You can really see how the SVG is pixel-perfect and the icon font is smeary here.)