### PR TITLE
test: Eliminate cockpit_test_skip()

### DIFF
--- a/src/bridge/test-connect.c
+++ b/src/bridge/test-connect.c
@@ -265,7 +265,7 @@ test_connect_loopback (TestConnect *tc,
 
   if (tc->skip_ipv6_loopback)
     {
-      cockpit_test_skip ("no loopback for ipv6 found");
+      g_test_skip ("no loopback for ipv6 found");
       return;
     }
 
@@ -322,7 +322,7 @@ test_fail_access_denied (void)
 
   if (geteuid () == 0)
     {
-      cockpit_test_skip ("running as root");
+      g_test_skip ("running as root");
       return;
     }
 

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -323,7 +323,7 @@ test_read_denied (TestCase *tc,
 
   if (geteuid () == 0)
     {
-      cockpit_test_skip ("running as root");
+      g_test_skip ("running as root");
       return;
     }
 
@@ -446,7 +446,7 @@ test_read_non_mmappable (TestCase *tc,
 
   if (g_strcmp0 (tag, "-") == 0)
     {
-      cockpit_test_skip ("No /sys/power/state");
+      g_test_skip ("No /sys/power/state");
       return;
     }
 
@@ -605,7 +605,7 @@ test_write_denied (TestCase *tc,
 
   if (geteuid () == 0)
     {
-      cockpit_test_skip ("running as root");
+      g_test_skip ("running as root");
       return;
     }
 

--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -125,7 +125,7 @@ test_host_header (TestGeneral *tt,
 
   if (tt->host == NULL)
     {
-      cockpit_test_skip ("Couldn't determine non local ip");
+      g_test_skip ("Couldn't determine non local ip");
       return;
     }
 

--- a/src/bridge/test-pcp.c
+++ b/src/bridge/test-pcp.c
@@ -47,7 +47,7 @@ init_mock_pmda (void)
 {
   if (pmLoadNameSpace (SRCDIR "/src/bridge/mock-pmns") < 0)
     {
-      cockpit_test_skip ("No PCP\n");
+      g_test_skip ("No PCP\n");
       exit (0);
     }
 

--- a/src/bridge/test-pipe-channel.c
+++ b/src/bridge/test-pipe-channel.c
@@ -816,7 +816,7 @@ test_fail_access_denied (void)
 
   if (geteuid () == 0)
     {
-      cockpit_test_skip ("running as root");
+      g_test_skip ("running as root");
       return;
     }
 

--- a/src/bridge/test-stream.c
+++ b/src/bridge/test-stream.c
@@ -838,7 +838,7 @@ test_connect_loopback (TestConnect *tc,
 
   if (tc->skip_ipv6_loopback)
     {
-      cockpit_test_skip ("no loopback for ipv6 found");
+      g_test_skip ("no loopback for ipv6 found");
       return;
     }
 
@@ -950,7 +950,7 @@ test_fail_access_denied (void)
 
   if (geteuid () == 0)
     {
-      cockpit_test_skip ("running as root");
+      g_test_skip ("running as root");
       return;
     }
 

--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -370,24 +370,6 @@ _cockpit_assert_strmatch_msg (const char *domain,
     }
 }
 
-/**
- * cockpit_test_skip()
- *
- * Can't call g_test_skip(). It's not available in
- * the GLib's we target. Call this instead.
- *
- * Same caveat applies. Must return from test, this
- * doesn't somehow jump out for you.
- */
-void
-cockpit_test_skip (const gchar *reason)
-{
-  if (g_test_verbose ())
-    g_print ("GTest: skipping: %s\n", reason);
-  else
-    g_print ("SKIP: %s ", reason);
-}
-
 void
 _cockpit_assert_json_eq_msg (const char *domain,
                              const char *file,

--- a/src/common/cockpittest.h
+++ b/src/common/cockpittest.h
@@ -107,7 +107,7 @@ void     _cockpit_assert_bytes_eq_msg       (const char *domain,
   (_cockpit_assert_bytes_eq_msg (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, (data), (exp), (len)))
 
 
-void            cockpit_test_skip                      (const gchar *reason);
+void            g_test_skip                      (const gchar *reason);
 
 void            cockpit_test_signal_backtrace          (int sig);
 

--- a/src/common/test-locale.c
+++ b/src/common/test-locale.c
@@ -111,7 +111,7 @@ test_set_language (const gconstpointer data)
   /* Check if the locale is available on the test system */
   if (fixture->lang && !locale_available (fixture->lang))
     {
-      cockpit_test_skip ("locale not available");
+      g_test_skip ("locale not available");
       return;
     }
 

--- a/src/common/test-pipe.c
+++ b/src/common/test-pipe.c
@@ -1165,7 +1165,7 @@ test_fail_access_denied (void)
 
   if (geteuid () == 0)
     {
-      cockpit_test_skip ("running as root");
+      g_test_skip ("running as root");
       return;
     }
 

--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -41,7 +41,7 @@ typedef struct {
     gboolean inet_only;
 } TestFixture;
 
-#define SKIP_NO_HOSTPORT if (!tc->hostport) { cockpit_test_skip ("No non-loopback network interface available"); return; }
+#define SKIP_NO_HOSTPORT if (!tc->hostport) { g_test_skip ("No non-loopback network interface available"); return; }
 
 static void
 setup (TestCase *tc,

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -282,7 +282,7 @@ test_authenticate (TestCase *test,
 
   if (!mock_kdc_available)
     {
-      cockpit_test_skip ("mock kdc not available to test against");
+      g_test_skip ("mock kdc not available to test against");
       return;
     }
 


### PR DESCRIPTION
We now can rely on g_test_skip(), it was introduced in glib 2.38 and
configure.ac enforces ≥ 2.44.