### PR TITLE
Show firewalld services with empty name

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -48,9 +48,6 @@ function EmptyState(props) {
 }
 
 function ServiceRow(props) {
-    if (!props.service.name)
-        return <ListingRow key={props.service.id} columns={["", "", ""]} />;
-
     var tcp = props.service.ports.filter(p => p.protocol.toUpperCase() == 'TCP');
     var udp = props.service.ports.filter(p => p.protocol.toUpperCase() == 'UDP');
 
@@ -143,7 +140,12 @@ class AddServicesBody extends React.Component {
 
     componentDidMount() {
         firewall.getAvailableServices()
-                .then(services => this.setState({ services: services }));
+                .then(services => this.setState({
+                    services: services.map(s => {
+                        s.name = s.name || s.id;
+                        return s;
+                    })
+                }));
     }
 
     onFilterChanged(value) {
@@ -333,7 +335,11 @@ export class Firewall extends React.Component {
             );
         }
 
-        var services = [...this.state.firewall.enabledServices].map(id => this.state.firewall.services[id]);
+        var services = [...this.state.firewall.enabledServices].map(id => {
+            const service = this.state.firewall.services[id];
+            service.name = service.name || id;
+            return service;
+        });
         services.sort((a, b) => a.name.localeCompare(b.name));
 
         var enabled = this.state.pendingTarget !== null ? this.state.pendingTarget : this.state.firewall.enabled;

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -324,13 +324,13 @@ export class Firewall extends React.Component {
             addServiceAction = (
                 <OverlayTrigger className="pull-right" placement="top"
                                 overlay={ <Tooltip id="tip-auth">{ _("You are not authorized to modify the firewall.") }</Tooltip> } >
-                    <Button bsStyle="primary" className="pull-right" disabled> {_("Add Services…")} </Button>
+                    <Button bsStyle="primary" className="pull-right" disabled> {_("Add Services")} </Button>
                 </OverlayTrigger>
             );
         } else {
             addServiceAction = (
                 <Button bsStyle="primary" onClick={this.open} className="pull-right">
-                    {_("Add Services…")}
+                    {_("Add Services")}
                 </Button>
             );
         }

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -115,6 +115,11 @@ class TestFirewall(MachineCase):
         b.wait_not_present("tr[data-row-id='pop3']")
         self.assertNotIn('pop3', m.execute("firewall-cmd --list-services").split())
 
+        # Test that service without name is shown properly
+        if m.image != "rhel-7-6-distropkg": # Fixed in #11318
+            m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload && firewall-cmd --add-service=empty")
+            b.wait_present("tr[data-row-id='empty']")
+
         # switch service off again
         b.click(".btn-onoff-ct label.active span")
         b.wait_present(".btn-onoff-ct label.active:not(.disabled)")
@@ -126,6 +131,7 @@ class TestFirewall(MachineCase):
     @skipImage("Filtering got fixed, and IDs changed to data-id in 184", "rhel-7-6-distropkg")
     def testAddServices(self):
         b = self.browser
+        m = self.machine
 
         self.login_and_go("/network/firewall")
 
@@ -164,6 +170,12 @@ class TestFirewall(MachineCase):
         b.wait_not_present("#cockpit_modal_dialog li input[data-id='pop3']")
         b.click("#add-services-dialog .modal-footer .btn-cancel")
         b.wait_not_present("#cockpit_modal_dialog")
+
+        # Service without name should appear in the dialog
+        if m.image != "rhel-7-6-distropkg": # Fixed in #11318
+            m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload")
+            b.click("caption button.btn-primary")
+            b.wait_present("#cockpit_modal_dialog li input[data-id='empty']")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -82,7 +82,7 @@ class TestFirewall(MachineCase):
         m.execute("systemctl stop firewalld")
         self.login_and_go("/network/firewall")
 
-        # "Add Services…" button should not be present
+        # "Add Services" button should not be present
         b.wait_not_present("caption button.btn-primary")
 
         # to toggle the switch, click on the non-active label, where the slider is
@@ -93,7 +93,7 @@ class TestFirewall(MachineCase):
         b.wait_in_text(".btn-onoff-ct label.active", "On")
         wait_unit_state(m, "firewalld", "active")
 
-        # "Add Services…" button should be enabled
+        # "Add Services" button should be enabled
         b.wait_present("caption button.btn-primary:enabled")
 
         # ensure that pop3 is not enabled (shouldn't be on any of our images),
@@ -125,7 +125,7 @@ class TestFirewall(MachineCase):
         b.wait_present(".btn-onoff-ct label.active:not(.disabled)")
         b.wait_in_text(".btn-onoff-ct label.active", "Off")
         wait_unit_state(m, "firewalld", "inactive")
-        # "Add Services…" button should be hidden again
+        # "Add Services" button should be hidden again
         b.wait_not_present("caption button.btn-primary")
 
     @skipImage("Filtering got fixed, and IDs changed to data-id in 184", "rhel-7-6-distropkg")
@@ -135,7 +135,7 @@ class TestFirewall(MachineCase):
 
         self.login_and_go("/network/firewall")
 
-        # click on the "Add Services…" button
+        # click on the "Add Services" button
         b.wait_present("caption button.btn-primary:enabled")
         b.click("caption button.btn-primary")
         b.wait_present("#cockpit_modal_dialog li input[data-id='pop3']")


### PR DESCRIPTION
Try without this patch:
1. `firewall-cmd --add-service=gre`
2. Go to `Networking` check number of active rules (N)
3. Go to `Firewall` page, count active services. There is N-1. Also first row is empty, but hover works on it.

Also removed dots from button, I think it is better like this :)