### PR TITLE
firewall: Do not expand if no details present

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -85,9 +85,9 @@ function ServiceRow(props) {
         deleteButton
     ];
 
-    var tabs = [
-        { name: _("Details"), renderer: () => <p>{props.service.description}</p> }
-    ];
+    var tabs = [];
+    if (props.service.description)
+        tabs.push({ name: _("Details"), renderer: () => <p>{props.service.description}</p> });
 
     return <ListingRow key={props.service.id}
                        rowId={props.service.id}


### PR DESCRIPTION
I am not sure if I like new version either. Lets hear others option :) If this should be somehow handled or is it fine as it is now?

Before this PR - it can happen there are no details and when you open the item you are presented with:
![before_allow_expand](https://user-images.githubusercontent.com/12330670/53884599-43119b00-401c-11e9-890b-ac5f588d1769.png)

After this PR - it is not possible to expand such item. However I don't really like how it stands out in the list.
![after_allow_expand](https://user-images.githubusercontent.com/12330670/53884632-5a508880-401c-11e9-89d7-df5e9ce5d601.png)
