### PR TITLE
AUTHORS: Refer to git information [no-test]

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,5 @@
-Andreas Nilsson
-Dominik Perpeet
-Lars Karlitski
-Marius Vollmer
-Peter Volpe
-Stef Walter
-Colin Walters
-David Zeuthen
+Cockpit is being developed by many contributors. Please see
+https://github.com/cockpit-project/cockpit/graphs/contributors
+for a list of authors.
+
+In a git checkout of the project you can also use `git shortlog -sn`.


### PR DESCRIPTION
The AUTHORS file is very outdated, and hard to keep up to date. It's
2019, let git answer such questions.