### PR TITLE
[no-test] bots: Declare fedora-30 image

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -35,6 +35,7 @@ DEFAULT_VERIFY = {
     'verify/debian-testing': [ 'master' ],
     'verify/fedora-i386': [ 'master' ],
     'verify/fedora-29': [ 'master' ],
+    'verify/fedora-30': [ ],
     'verify/fedora-atomic': [ 'master' ],
     'verify/fedora-testing': [ ],
     'verify/ubuntu-1804': [ 'master' ],


### PR DESCRIPTION
Fedora 30 has forked from Rawhide [1], so we'll need an image for this.

[1] https://fedoraproject.org/wiki/Releases/30/Schedule