### PR TITLE
rhel-8-appstream backports for downstream testing

### DIFF
--- a/test/avocado/selenium-base.py
+++ b/test/avocado/selenium-base.py
@@ -52,7 +52,7 @@ class BasicTestSuite(SeleniumTest):
         self.wait_text("reboot.target")
         self.click(self.wait_text("System Services", cond=clickable))
         self.wait_id("services-list-enabled")
-        self.wait_text("dbus.service")
+        self.wait_text("sshd.service")
         self.mainframe()
 
     def test50ChangeTabLogs(self):

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -842,6 +842,11 @@ class MachineCase(unittest.TestCase):
                                     '.*: GDBus.Error:org.freedesktop.PolicyKit1.Error.Failed: .*',
                                     '.*g_dbus_connection_call_finish_internal.*G_IS_DBUS_CONNECTION.*',
                                     '.*Message recipient disconnected from message bus without replying.*',
+
+                                    # If restarts or reloads happen really fast, the code in python.js
+                                    # that figures out which python to use crashes with SIGPIPE,
+                                    # and this is the resulting message
+                                    'which: no python in .*'
                                     )
 
     def allow_authorize_journal_messages(self):

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -884,6 +884,8 @@ class MachineCase(unittest.TestCase):
         if self.image in ['rhel-8-0']:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1653872
             self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { setsched } for .* comm="rngd".*')
+            # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1679468
+            self.allowed_messages.append('audit: type=1400 audit(.*): avc:  denied  { signull } for .* comm="systemd-journal".*')
 
         # these images don't have tuned; keep in sync with bots/images/scripts/debian.setup
         if self.image in ["debian-stable"]:

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -114,6 +114,9 @@ class TestApps(PackageCase):
         self.allow_journal_messages("invalid or unusable locale.*",
                                     "Error .* data: Connection reset by peer")
 
+        # Because of the reloading done by set_lang
+        self.allow_restart_journal_messages()
+
         # Reset everything
         m.execute("rm -rf /usr/share/metainfo /usr/share/app-info /var/cache/app-info")
 

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -243,6 +243,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     'sudo: a password is required',
                                     'sudo: sorry, you must have a tty to run sudo')
         self.allow_restart_journal_messages()
+        self.allow_authorize_journal_messages()
 
     def testConversation(self):
         m = self.machine

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -919,6 +919,7 @@ class TestMultiMachine(MachineCase):
         b.wait_visible("#login-available .empty")
 
         self.allow_hostkey_messages()
+        self.allow_authorize_journal_messages()
         self.allow_journal_messages('.* couldn\'t connect: .*',
                                     '.*: Connection reset by peer',
                                     '.* failed to retrieve resource: invalid-hostkey',

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1088,6 +1088,7 @@ ConditionPathExists=!/run/ostree-booted
 [Timer]
 OnBootSec=1h
 OnUnitInactiveSec=1d
+Unit=-.mount
 
 [Install]
 WantedBy=basic.target

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -98,7 +98,8 @@ class TestStorage(StorageCase):
 
         # With old Udisks2 versions, the partition will end up being
         # 25.1M while newer versions give us 26M.
-        wait(lambda: m.execute("lsblk -no SIZE /dev/sda1").strip() in [ "25.1M", "26M" ])
+        wait(lambda: m.execute("lsblk -no SIZE /dev/sda1").strip() in ["25.1M", "26M"])
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
See individual commits for details. This backports a bunch of fixes from master to fix tests. The primar goal is to run check-packagekit to run against an existing machine, which we need for downstream testing.