### PR TITLE
bots: Don't run container/kubernetes test on RHEL 8 [no-test]

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -25,7 +25,7 @@ BRANCHES = [ 'master', 'rhel-7.6', 'rhel-7.7', 'rhel-8.0', 'rhel-8-appstream' ]
 
 DEFAULT_VERIFY = {
     'avocado/fedora': BRANCHES,
-    'container/kubernetes': BRANCHES,
+    'container/kubernetes': [ 'master', 'rhel-7.6', 'rhel-7.7' ],
     'container/bastion': BRANCHES,
     'selenium/firefox': BRANCHES,
     'selenium/chrome': BRANCHES,


### PR DESCRIPTION
We don't ship it there, so it's pointless to run and maintain the test
in the rhel-8* branches.