### PR TITLE
networking: Explicitly order actions when removing a bond etc

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2400,11 +2400,7 @@ PageNetworkInterface.prototype = {
             // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
             // https://github.com/cockpit-project/cockpit/issues/10956
             // eslint-disable-next-line cockpit/no-cockpit-all
-            return cockpit.all(con.delete_(),
-                               // eslint-disable-next-line cockpit/no-cockpit-all
-                               cockpit.all(con.Slaves.map(function (s) {
-                                   return free_slave_connection(s);
-                               })));
+            return cockpit.all(con.Slaves.map(s => free_slave_connection(s))).then(() => con.delete_());
         }
 
         function delete_connections(cons) {


### PR DESCRIPTION
Similarily as with creating a bond, it matters what is done first:
deleting the bond connection settings object or updating the former
slave connection settings objects.

If the bond connection is deleted first, the slaves are inactive
afterwards.  If the slaves are updated first, they keep the activation
state.

We want the former slaves to keep their activation state, we
explicitly update them first.

Also see https://bugzilla.redhat.com/show_bug.cgi?id=1684200