### PR TITLE
bots: Drop VirtMachine.add_netiface() vlan option

### DIFF
--- a/bots/machine/machine_core/machine_virtual.py
+++ b/bots/machine/machine_core/machine_virtual.py
@@ -677,16 +677,12 @@ class VirtMachine(Machine):
         self.message(output.strip())
         return output
 
-    def add_netiface(self, networking=None, vlan=0):
+    def add_netiface(self, networking=None):
         if not networking:
             networking = VirtNetwork().interface()
-        cmd = "device_add virtio-net-pci,mac={0}".format(networking["mac"])
-        if vlan == 0:
-            self._qemu_monitor("netdev_add socket,mcast=230.0.0.1:{mcast},id={id}".format(mcast=networking["mcast"], id=networking["hostnet"]))
-            cmd += ",netdev={id}".format(id=networking["hostnet"])
-        else:
-            cmd += ",vlan={vlan}".format(vlan=vlan)
-        self._qemu_monitor(cmd)
+        self._qemu_monitor("netdev_add socket,mcast=230.0.0.1:{mcast},id={id}".format(mcast=networking["mcast"], id=networking["hostnet"]))
+        cmd = "device_add virtio-net-pci,mac={0},netdev={1}".format(networking["mac"], networking["hostnet"])
+        self._qemu_monitor("device_add virtio-net-pci,mac={0},netdev={1}".format(networking["mac"], networking["hostnet"]))
         return networking["mac"]
 
     def needs_writable_usr(self):

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -35,12 +35,10 @@ class TestNetworking(NetworkCase):
 
         self.login_and_go("/network")
 
-        # The second interface is connected to a different outside network than
-        # the first to avoid a cycle between the bridge that all VMs are
-        # connected to, and the bridge we are creating here.
-
+        # These are two independent networks. Thus there is no loop between the
+        # bridge that all VMs are connected to, and the bridge we are creating here.
         iface1 = self.add_iface()
-        iface2 = self.add_iface(vlan=1, activate=False)
+        iface2 = self.add_iface(activate=False)
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2, active=False)
 

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -66,9 +66,9 @@ class NetworkCase(MachineCase):
         print("%s -> %s" % (mac, iface))
         return iface
 
-    def add_iface(self, mac=None, vlan=0, activate=True):
+    def add_iface(self, activate=True):
         m = self.machine
-        mac = m.add_netiface(networking=self.network.interface(), vlan=vlan)
+        mac = m.add_netiface(networking=self.network.interface())
         # Wait for the interface to show up
         self.get_iface(m, mac)
         # Trigger udev to make sure that it has been renamed to its final name


### PR DESCRIPTION
This isn't supported by newer QEMU versions any more (as in Fedora 29).

`check-networking-bridge TestNetworking.testBridge` was the only user of
that. But as the second `add_iface()` call does not specify an existing
VirtNetwork, this creates a new network anyway, and thus it's already
an independent network.