### PR TITLE
Image refresh for fedora-testing [no-test]

### DIFF
--- a/bots/images/fedora-testing
+++ b/bots/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-959464c1b29fd3fd996b893469b887c4a7beae1a1df6d5f67ead17f46e0be2df.qcow2
+fedora-testing-8b0d9745ea8e912c27ce29e31ade8ee1fb541d37950e88dc86924811d47d7498.qcow2

--- a/bots/images/scripts/lib/docker-images.setup
+++ b/bots/images/scripts/lib/docker-images.setup
@@ -24,6 +24,9 @@ if [ $(uname -m) = x86_64 ]; then
     docker pull busybox:buildroot-2014.02
     docker pull gcr.io/google_containers/pause:0.8.0
     docker pull k8s.gcr.io/pause-amd64:3.1
+    # some aliases for different k8s variants
+    docker tag k8s.gcr.io/pause-amd64:3.1 gcr.io/google_containers/pause-amd64:3.0
+    docker tag k8s.gcr.io/pause-amd64:3.1 k8s.gcr.io/pause:3.1
 fi
 
 # Download the i386 image and rename it

--- a/bots/machine/machine_core/ssh_connection.py
+++ b/bots/machine/machine_core/ssh_connection.py
@@ -118,7 +118,7 @@ class SSHConnection(object):
             raise exceptions.Failure("Unable to reach machine {0} via ssh: {1}:{2}".format(self.label, self.ssh_address, self.ssh_port))
         self.boot_id = boot_id
 
-    def wait_reboot(self, timeout_sec=120):
+    def wait_reboot(self, timeout_sec=180):
         self.disconnect()
         assert self.boot_id, "Before using wait_reboot() use wait_boot() successfully"
         boot_id = self.boot_id

--- a/test/verify/check-kubernetes
+++ b/test/verify/check-kubernetes
@@ -84,7 +84,7 @@ class TestConnection(kubelib.KubernetesCase):
 
         # Check that this failed as a double check
         output = m.execute("curl -k -sS https://10.111.113.1:6443/api 2>&1 || true")
-        self.assertRegex(output, "Unauthorized|No policy matched")
+        self.assertRegex(output, "Unauthorized|No policy matched|Forbidden")
 
         m.execute("rm -r /home/admin/.kube")
         self.login_and_go("/kubernetes")

--- a/test/verify/check-kubernetes
+++ b/test/verify/check-kubernetes
@@ -40,8 +40,8 @@ class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
 
         m.upload(["verify/files/mock-k8s-tiny-app.json"], "/tmp")
         self.wait_api_server()
-        # HACK: https://github.com/cockpit-project/cockpit/issues/9179 ; fix this
-        # in docker-images.setup instead and rebuild images
+        # HACK: https://github.com/cockpit-project/cockpit/issues/9179 ; fixed
+        # in docker-images.setup, drop this after all images got rebuilt
         m.execute("docker tag gcr.io/google_containers/pause-amd64:3.0 k8s.gcr.io/pause-amd64:3.1 || true")
 
 


### PR DESCRIPTION
Image refresh for fedora-testing
 * [x] image-refresh fedora-testing
 * [x] investigate kubernetes pod startup regression
 * [x] fix `testConnect` failure
 * [x] fix `testNodes` failure: PR #11385 
 * [x] fix `testCreateTimer` flake