### PR TITLE
kubernetes: Remove deprecated spec.externalID

### DIFF
--- a/examples/kubernetes/node.json
+++ b/examples/kubernetes/node.json
@@ -4,9 +4,6 @@
   "metadata": {
     "name": "192.168.124.4"
   },
-  "spec": {
-    "externalID": "192.168.124.4"
-  },
   "status": {
     "capacity": {
       "cpu": "3",

--- a/pkg/kubernetes/scripts/nodes.js
+++ b/pkg/kubernetes/scripts/nodes.js
@@ -164,10 +164,10 @@
 
                     $scope.jump = function (node) {
                         var host, ip;
-                        if (!node || !node.spec)
+                        if (!node || !node.metadata)
                             return;
 
-                        host = node.spec.externalID;
+                        host = node.metadata.name;
                         ip = nodeData.nodeIPAddress(node);
 
                         if (ip == "127.0.0.1" || ip == "::1") {
@@ -421,9 +421,6 @@
                                 "apiVersion": "v1",
                                 "metadata": {
                                     "name": name || address,
-                                },
-                                "spec": {
-                                    "externalID": address
                                 }
                             };
                             defer.resolve(item);

--- a/pkg/kubernetes/scripts/test-kube-client.js
+++ b/pkg/kubernetes/scripts/test-kube-client.js
@@ -434,8 +434,13 @@ require("./kube-client-mock");
                 "uid": "6e51438e-d161-11e4-acbc-10c37bdb8410",
                 "resourceVersion": "634539",
             },
-            "spec": {
-                "externalID": "172.2.3.1"
+            "status": {
+                "addresses": [
+                    {
+                        "address": "172.2.3.1",
+                        "type": "ExternalIP"
+                    }
+                ]
             }
         }
     ];

--- a/pkg/kubernetes/views/node-body.html
+++ b/pkg/kubernetes/views/node-body.html
@@ -4,8 +4,8 @@
         <dd title="{{ item.metadata.creationTimestamp }}">{{ item.metadata.creationTimestamp | dateRelative }}</dd>
         <dt translate>Address</dt>
         <dd>
-            <a tabindex="0" class="machine-jump" ng-if="item.status.addresses" ng-click="jump(item)">{{item.spec.externalID}}</a>
-            <span ng-if="!item.status.addresses">{{item.spec.externalID}}</span>
+            <a tabindex="0" class="machine-jump" ng-if="item.status.addresses" ng-click="jump(item)">{{item.metadata.name}}</a>
+            <span ng-if="!item.status.addresses">{{item.metadata.name}}</span>
         </dd>
         <dt translate>IP</dt>
         <dd ng-if="item.status.addresses">{{ nodeIPAddress(item) }}</dd>

--- a/pkg/kubernetes/views/nodes-page.html
+++ b/pkg/kubernetes/views/nodes-page.html
@@ -60,7 +60,7 @@
             <td>
                 <div ng-if="item.status.nodeInfo.osImage">{{item.status.nodeInfo.osImage}}</div>
             </td>
-            <td>{{item.spec.externalID}}</td>
+            <td>{{ nodeIPAddress(item) }}</td>
             <td>
                 <span class="spinner-inline node-status" kubernetes-status-icon status="nodeStatusIcon(item)"></span>
                 {{ nodeStatus(item) }}


### PR DESCRIPTION
This got marked as deprecated four years ago [1], and finally removed
last year [2]. This is not present at all any more in Kubernetes 1.12.

This has been identical to `metadata.name` since [1], so just use the
latter directly.

In the nodes overview list, don't show the name/ID again in the Address
column, as that's just redundant: The first column already shows that.
So show the actual address instead.

[1] https://github.com/kubernetes/kubernetes/pull/7775/files#diff-e58c0c0709cf6f8a3b00aef6069b66b7
[2] https://github.com/kubernetes/kubernetes/pull/60692