### PR TITLE
bots: Fix candlepin image refresh

### DIFF
--- a/bots/images/candlepin
+++ b/bots/images/candlepin
@@ -1,1 +1,1 @@
-candlepin-44efad7b05562a81cfdc417dfd2b5d8b80d7beda84c9c9ecb1b7a46d6463ce7d.qcow2
+candlepin-d1f11196ab444e5522f13b22474e0f771f6fbd11a1bcefea0f1c667992c91c5b.qcow2

--- a/bots/images/scripts/candlepin.setup
+++ b/bots/images/scripts/candlepin.setup
@@ -16,8 +16,12 @@ yum -y install $CANDLEPIN_DEPS
 
 # Check out candlepin; HACK: newer releases split out Ansible roles to
 # https://github.com/candlepin/ansible-role-candlepin, but these playbooks are
-# completely broken with Ansible 2.6.
+# impossible to work with: https://bugzilla.redhat.com/show_bug.cgi?id=1688153
 git clone --depth=1 -b candlepin-2.5.1-1 https://github.com/candlepin/candlepin.git /root/candlepin
+
+# HACK: Apply https://github.com/candlepin/ansible-role-candlepin/commit/82ae5bf521 to old checkout
+sed -i '/rubygem-qpid_proton/ s/$/\n    - rubygem-json_pure/' /root/candlepin/vagrant/roles/candlepin-root/tasks/main.yml
+perl -i -00ne 'print unless /(Gem refreshing|Install gem dependencies)/' /root/candlepin/vagrant/roles/candlepin-root/tasks/main.yml
 
 # Insert our variables and change parameters
 cp /var/lib/testvm/candlepin-defaults.yml /root/candlepin/vagrant/roles/candlepin-user/defaults/main.yml


### PR DESCRIPTION
Even with Ansible 2.7 the ansible-role-candlepin playbooks don't work.
Reported as <https://bugzilla.redhat.com/show_bug.cgi?id=1688153>.

Cowboy-apply a fix to the playbooks to avoid a rubygem update. This
doesn't work any more with current gems, as these need ruby >= 2.3.

Fixes #11325

 * [x] image-refresh candlepin