### PR TITLE
machines: rewrite VM delete dialog to use unsorted list html elements

### DIFF
--- a/pkg/machines/components/deleteDialog.css
+++ b/pkg/machines/components/deleteDialog.css
@@ -1,13 +1,31 @@
-.table tbody tr:last-child td {
-    border-bottom: 1px solid #d1d1d1;
+.modal[id$=delete-modal-dialog] .list-group-item {
+    /* Remove padding here and move into the label */
+    padding: 0;
 }
 
-table.delete-dialog-disks.table tbody tr td:nth-child(1) {
-    padding-left: 5px;
-    padding-right: 5px;
-    width: 20px;
+.modal .list-group-item > .disk-row > label {
+    align-items: center;
+    display: grid;
+    grid: auto-flow / auto 1fr;
+    grid-gap: 0 1rem;
+    padding: 1rem 1.5em;
 }
 
-table.delete-dialog-disks.table tbody tr td:nth-child(3) {
-    text-align: right;
+.modal .disk-row {
+    margin: 0;
+}
+
+/* override PatternFly checkmark placement */
+.modal .disk-row input[type=checkbox] {
+    position: static;
+    margin: 0;
+}
+
+.modal .disk-row > label + label {
+    border-top: 1px solid #d1d1d1; /* pf-black-300 */
+}
+
+.modal .disk-file {
+    grid-column-start: 2;
+    opacity: 0.85; /* approx pf-black-700; AAA contrast; works with hover */
 }

--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -31,16 +31,18 @@ const _ = cockpit.gettext;
 const DeleteDialogBody = ({ disks, destroy, onChange }) => {
     function disk_row(disk, index) {
         return (
-            <tr key={disk.target}>
-                <td>
-                    <input type="checkbox" checked={disk.checked}
-                           onChange={(event) => {
-                               onChange(index, event.target.checked);
-                           }} />
-                </td>
-                <td>{disk.file}</td>
-                <td>{disk.target}</td>
-            </tr>
+            <li className='list-group-item' key={disk.target}>
+                <div className='checkbox disk-row'>
+                    <label>
+                        <input type="checkbox" checked={disk.checked}
+                            onChange={(event) => {
+                                onChange(index, event.target.checked);
+                            }} />
+                        <strong>{disk.target}</strong>
+                        <div className='disk-file'>{disk.file}</div>
+                    </label>
+                </div>
+            </li>
         );
     }
 
@@ -51,14 +53,14 @@ const DeleteDialogBody = ({ disks, destroy, onChange }) => {
     let disksBody = null;
     if (disks.length > 0)
         disksBody = (
-            <div>
+            <React.Fragment>
                 <p>{_("Delete associated storage files:")}</p>
-                <table className="table delete-dialog-disks">
-                    <tbody>
+                <form>
+                    <ul className="list-group dialog-list-ct">
                         { disks.map(disk_row) }
-                    </tbody>
-                </table>
-            </div>
+                    </ul>
+                </form>
+            </React.Fragment>
         );
 
     return (

--- a/test/avocado/selenium-machines-basic.py
+++ b/test/avocado/selenium-machines-basic.py
@@ -99,7 +99,7 @@ class MachinesBasicTestSuite(MachinesLib):
         self.wait_css('#vm-{}-disks-vda-bus'.format(name))
 
         self.click(self.wait_css("#vm-{}-delete".format(name), cond=clickable))
-        self.click(self.wait_css("#vm-{}-delete-modal-dialog tbody tr:nth-of-type(1) input".format(name), cond=clickable))
+        self.click(self.wait_css("#vm-{}-delete-modal-dialog li:nth-of-type(1) input".format(name), cond=clickable))
         self.click(self.wait_css("#vm-{}-delete-modal-dialog button.btn-danger".format(name), cond=clickable))
         self.wait_css("#vm-{}-row".format(name), cond=invisible)
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -916,7 +916,7 @@ class TestMachines(MachineCase):
 
         b.wait_present("#vm-{0}-delete-modal-dialog".format(name))
         b.wait_present("#vm-{0}-delete-modal-dialog div:contains(The VM is running)".format(name))
-        b.wait_present("#vm-{1}-delete-modal-dialog tr:contains({0})".format(img2, name))
+        b.wait_present("#vm-{1}-delete-modal-dialog .disk-file:contains({0})".format(img2, name))
         b.click("#vm-{0}-delete-modal-dialog button:contains(Delete)".format(name))
         b.wait_not_present("#vm-{0}-delete-modal-dialog".format(name))
 


### PR DESCRIPTION
Previously it was using tables, which are behaving bad in small screens.

Fixes #11374