### PR TITLE
bots: Drop fedora-i386 from master PRs [no-test]

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -33,7 +33,7 @@ DEFAULT_VERIFY = {
     'verify/continuous-atomic': [ ],
     'verify/debian-stable': [ 'master' ],
     'verify/debian-testing': [ 'master' ],
-    'verify/fedora-i386': [ 'master' ],
+    'verify/fedora-i386': [ ],
     'verify/fedora-29': [ 'master' ],
     'verify/fedora-30': [ ],
     'verify/fedora-atomic': [ 'master' ],


### PR DESCRIPTION
This image doesn't really do that much for us. We cover our own C code
in semaphore and unit tests already, and in integration tests the
browser and JS run on the x86_64 container host anyway. So at most this
detects 32 bit specific bugs in the OS.

For that purpose it's enough to run this once a week during image
refreshes, it's not necessary to run it for every PR.