### PR TITLE
branding: Include branding for Scientific Linux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -403,6 +403,7 @@ include src/branding/fedora/Makefile.am
 include src/branding/kubernetes/Makefile.am
 include src/branding/registry/Makefile.am
 include src/branding/rhel/Makefile.am
+include src/branding/scientific/Makefile.am
 include src/branding/ubuntu/Makefile.am
 include src/bridge/Makefile.am
 include src/common/Makefile-common.am

--- a/src/branding/scientific/Makefile.am
+++ b/src/branding/scientific/Makefile.am
@@ -1,0 +1,14 @@
+scientificbrandingdir = $(datadir)/cockpit/branding/scientific
+
+scientificbranding_DATA = \
+	src/branding/scientific/branding.css \
+	$(NULL)
+
+EXTRA_DIST += $(scientificbranding_DATA)
+
+# Opportunistically use Scientific Linux logos. 
+install-data-hook::
+	$(LN_S) -f /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(scientificbrandingdir)/logo.png
+	$(LN_S) -f /usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(scientificbrandingdir)/apple-touch-icon.png
+	$(LN_S) -f /etc/favicon.png $(DESTDIR)$(scientificbrandingdir)/favicon.ico
+

--- a/src/branding/scientific/branding.css
+++ b/src/branding/scientific/branding.css
@@ -1,0 +1,25 @@
+body.login-pf {
+    background-size: auto;
+    background-color: #777777;
+}
+
+#badge {
+    width: 225px;
+    height: 80px;
+    background-image: url("logo.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
+#brand {
+    font-size: 18pt;
+    text-transform: uppercase;
+}
+
+#brand:before {
+    content: "${NAME}";
+}
+
+#index-brand:before {
+    content: "${NAME}";
+}


### PR DESCRIPTION
Add `scientific` directory at `src/branding/scientific`, as `scientific`
is the ID value in /etc/os-release for Scientific Linux
Update Cockpit's Makefile.am file to include the new branding directory
Include SL-specific branding CSS and favicon files