### PR TITLE
containers: More reasonable make parallelization in unit tests [no-test]

### DIFF
--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -4,6 +4,7 @@ set -o pipefail
 set -eux
 
 export LANG=C.UTF-8
+export MAKEFLAGS="-j $(nproc)"
 
 # HACK: Something invoked by our build system is setting stdio to non-blocking.
 # Validate that this isn't the surrounding context. See more below.
@@ -55,12 +56,12 @@ python3 -c "import fcntl, os; map(lambda fd: fcntl.fcntl(fd, fcntl.F_SETFL, fcnt
 
 # only run distcheck on main arch
 if [ "$ARCH" = amd64 ]; then
-    make -j8 distcheck 2>&1
+    make distcheck 2>&1
 else
-    make -j8 check 2>&1
+    make check 2>&1
 fi
 
-make -j8 check-memory 2>&1 || {
+make check-memory 2>&1 || {
     cat test-suite.log
     exit 1
 }


### PR DESCRIPTION
Running 8 tests in parallel causes too many stalls and thus many random
timeouts on Semaphore VMs (they have 2 VCPUs), especially with the very
expensive valgrind test.

Default to the number of available CPUs, and set `-j` in one place only.
This also will parallelize the build.