### PR TITLE
Update OAuthClient for OpenShift 4.x

### DIFF
--- a/containers/openshift-cockpit.template
+++ b/containers/openshift-cockpit.template
@@ -158,13 +158,13 @@
       },
       {
         "kind": "OAuthClient",
-        "apiVersion": "v1",
+        "apiVersion": "oauth.openshift.io/v1",
         "metadata": {
           "name": "${OPENSHIFT_OAUTH_CLIENT_ID}"
         },
         "respondWithChallenges": false,
         "secret": "${OPENSHIFT_OAUTH_CLIENT_SECRET}",
-        "allowAnyScope": true,
+        "grantMethod": "auto",
         "redirectURIs": [
             "${COCKPIT_KUBE_URL}"
         ]


### PR DESCRIPTION
This change updates the OAuthClient to:

1. Use the groupified apiVersion
2. Drop the allowAnyScope field (it was removed long ago)
3. Set grantMethod to auto as that is required in OpenShift 4.x