### PR TITLE
users: Turn č and ç to c when suggesting a username

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -570,7 +570,7 @@ PageAccountsCreate.prototype = {
             var translate_table = {
                 'a' :  '[àáâãäå]',
                 'ae':  'æ',
-                'c' :  'čç',
+                'c' :  '[čç]',
                 'd' :  'ď',
                 'e' :  '[èéêë]',
                 'i' :  '[íìïî]',


### PR DESCRIPTION
These letters were already in the translation table, but the character
set parens were missing from the regular expression.