### PR TITLE
containers: Adjust cockpit kubernetes container deployment instructions [no-test]

### DIFF
--- a/containers/kubernetes/README.md
+++ b/containers/kubernetes/README.md
@@ -28,7 +28,7 @@ Cockpit will use the OpenShift OAuth server to authenticate users. You need to p
 
 ```
 oc process -f containers/openshift-cockpit.template
-    -v COCKPIT_KUBE_URL=https://ip-or-domain -v OPENSHIFT_OAUTH_PROVIDER_URL=https://ip-or-domain:port | oc create -f -
+    -p COCKPIT_KUBE_URL=https://ip-or-domain -p OPENSHIFT_OAUTH_PROVIDER_URL=https://ip-or-domain:port | oc create -f -
 ```
 
 This will create an OAuth Client and a openshift-cockpit service replication controller and pod.

--- a/doc/guide/feature-kubernetes.xml
+++ b/doc/guide/feature-kubernetes.xml
@@ -81,7 +81,7 @@ $ <command>kubectl get service kubernetes-cockpit</command>
 
 <programlisting>
 $ <command>wget https://raw.githubusercontent.com/cockpit-project/cockpit/master/containers/openshift-cockpit.template</command>
-$ <command>oc process -f openshift-cockpit.template -v COCKPIT_KUBE_URL=https://XXX -v OPENSHIFT_OAUTH_PROVIDER_URL=https://YYY:8443 | oc create -f -</command>
+$ <command>oc process -f openshift-cockpit.template -p COCKPIT_KUBE_URL=https://XXX -p OPENSHIFT_OAUTH_PROVIDER_URL=https://YYY:8443 | oc create -f -</command>
 </programlisting>
 
     <para>You can retrieve the address where you can access the dashboard via:</para>


### PR DESCRIPTION
`oc process`' `-v` option was renamed to `-p` a while ago, see commit
0b1966b7a3. Update the documentation accordingly.