### PR TITLE
firewall: Make it possible to add custom ports

### DIFF
--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -82,7 +82,7 @@
   }
 
   // Auto-stretch elements to the grid (except when relaxed)
-  > :not(.ct-form-layout-relax) {
+  > :not(.ct-form-layout-relax):not(.spinner) {
     width: auto;
   }
 
@@ -145,7 +145,7 @@
 
   // Some elements need special width considerations
   // as PatternFly normally fixes the width
-  > :not(.ct-form-layout-relax) {
+  > :not(.ct-form-layout-relax):not(.spinner) {
     width: auto !important;
   }
 

--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -31,6 +31,9 @@
 // elsewhere, you can force it to stretch. This is mainly useful when
 // using <div role="group"> to group elements.
 //
+// `ct-form-layout-full`: Force a widget to be the full width of the form,
+// invading the label space.
+//
 // role="group": When there are two related elements, such as a text
 // input and a dropdown, you can group them together using this HTML
 // attribute. It's similar in purpose to a <fieldset>, but works for
@@ -74,7 +77,7 @@
 
   // Put all control elements to the right of the labels,
   // stretching to the rightmost column
-  > :not(.control-label):not(hr):not(.ct-form-layout-split) {
+  > :not(.control-label):not(hr):not(.ct-form-layout-split):not(.ct-form-layout-full) {
     grid-column: ~"2 / -1";
   }
 
@@ -240,6 +243,11 @@
   // Relax split elements to only take up one column
   > .ct-form-layout-split {
     grid-column: ~"auto / auto";
+  }
+
+  // Stretch to full width
+  > .ct-form-layout-full {
+    grid-column: ~"1 / -1";
   }
 }
 

--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -253,6 +253,26 @@
   > .ct-form-layout-full {
     grid-column: ~"1 / -1";
   }
+
+  // Move warnings, errors, info, etc. up a bit to associate with previous field
+  .bump-up() {
+    position: relative;
+    top: -0.5rem;
+  }
+
+  > .has-success,
+  > .has-warning,
+  > .has-error {
+    &:not(.form-group) {
+      .bump-up();
+    }
+
+
+  }
+
+  > .help-block {
+    .bump-up();
+  }
 }
 
 // Apply left-padding to control-labels when in a modal dialog

--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -129,6 +129,8 @@
     > [data-field],
     > .form-group,
     > .btn-group,
+    > label.checkbox,
+    > label.radio,
     > .checkbox-inline,
     > .radio-inline {
       // Vertically align elements with text
@@ -201,6 +203,8 @@
   }
 
   // Vertically align checkboxes and radios properly using flex
+  label.checkbox,
+  label.radio,
   .checkbox > label,
   .radio > label,
   .checkbox-inline,

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -134,10 +134,10 @@ const renderPorts = ports => {
             udpPorts.push(port.port);
     }
     return (
-        <small>
-            { tcpPorts.length > 0 && <span><strong>TCP: </strong>{ tcpPorts.join(', ') }&nbsp;</span> }
-            { udpPorts.length > 0 && <span><strong>UDP: </strong>{ udpPorts.join(', ') }</span> }
-        </small>
+        <React.Fragment>
+            { tcpPorts.length > 0 && <span className="service-ports tcp"><strong>TCP: </strong>{ tcpPorts.join(', ') }</span> }
+            { udpPorts.length > 0 && <span className="service-ports udp"><strong>UDP: </strong>{ udpPorts.join(', ') }</span> }
+        </React.Fragment>
     );
 };
 
@@ -419,10 +419,13 @@ class AddServicesModal extends React.Component {
                                                         <ListView.Item key={s.id}
                                                                        className="list-group-item"
                                                                        checkboxInput={ <input data-id={s.id}
+                                                                                              id={"firewall-service-" + s.id}
                                                                                               type="checkbox"
                                                                                               checked={this.state.selected.has(s.id)}
                                                                                               onChange={this.onToggleService} /> }
-                                                                       heading={ <React.Fragment><span>{s.name}</span>{ renderPorts(s.ports) }</React.Fragment> }>
+                                                                       stacked
+                                                                       heading={ <label htmlFor={"firewall-service-" + s.id}>{s.name}</label> }
+                                                                       description={ renderPorts(s.ports) }>
                                                         </ListView.Item>
                                                     ))
                                                 }
@@ -433,7 +436,6 @@ class AddServicesModal extends React.Component {
                                     )}
                                 </React.Fragment>
                             }
-                            <div />
                             <label className="radio ct-form-layout-full">
                                 <input type="radio" name="type" value="ports" onChange={this.onToggleType} disabled={this.state.avail_services == null} />
                                 {_("Custom Ports")}

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -34,6 +34,7 @@ import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 
 import "page.css";
 import "table.css";
+import "form-layout.less";
 import "./networking.css";
 
 const _ = cockpit.gettext;
@@ -140,38 +141,53 @@ const renderPorts = ports => {
     );
 };
 
-class AddServicesBody extends React.Component {
+class AddServicesModal extends React.Component {
     constructor() {
         super();
 
         this.state = {
             services: null,
             selected: new Set(),
-            filter: ""
+            filter: "",
+            custom: false,
+            generate_name: true,
+            tcp_error: "",
+            udp_error: "",
+            avail_services: null,
+            custom_id: "",
+            custom_name: "",
+            custom_tcp_ports: [],
+            custom_udp_ports: [],
+            custom_tcp_value: "",
+            custom_udp_value: "",
         };
-
         this.save = this.save.bind(this);
         this.onFilterChanged = this.onFilterChanged.bind(this);
         this.onToggleService = this.onToggleService.bind(this);
+        this.setName = this.setName.bind(this);
+        this.getName = this.getName.bind(this);
+        this.validate = this.validate.bind(this);
+        this.createPorts = this.createPorts.bind(this);
+        this.parseServices = this.parseServices.bind(this);
+        this.generateName = this.generateName.bind(this);
+        this.onToggleType = this.onToggleType.bind(this);
+    }
+
+    createPorts() {
+        var ret = [];
+        this.state.custom_tcp_ports.forEach(port => ret.push([port, 'tcp']));
+        this.state.custom_udp_ports.forEach(port => ret.push([port, 'udp']));
+        return ret;
     }
 
     save() {
-        firewall.addServices([...this.state.selected]);
+        if (this.state.custom) {
+            firewall.createService(this.state.custom_id, this.state.custom_name, this.createPorts())
+                    .then(firewall.enableService(this.state.custom_id));
+        } else {
+            firewall.addServices([...this.state.selected]);
+        }
         this.props.close();
-    }
-
-    componentDidMount() {
-        firewall.getAvailableServices()
-                .then(services => this.setState({
-                    services: services.map(s => {
-                        s.name = s.name || s.id;
-                        return s;
-                    })
-                }));
-    }
-
-    onFilterChanged(value) {
-        this.setState({ filter: value.toLowerCase() });
     }
 
     onToggleService(event) {
@@ -192,6 +208,169 @@ class AddServicesBody extends React.Component {
         });
     }
 
+    /* Create list of services from /etc/services type file
+     *
+     * Return dictionary of services:
+     *  - key => port number or port alias (80/http)
+     *  - item => dictionary with 3 compulsory items:
+     *      - name => port alias (http)
+     *      - port => port number (80)
+     *      - type => list of types (tcp/udp...)
+     *      - description => _may be not present_ (Web Server)
+     */
+    parseServices(content) {
+        if (!content) {
+            console.warn("Couldn't read /etc/services");
+            return [ ];
+        }
+
+        var ret = {};
+        content.split('\n').forEach(line => {
+            if (!line || line.startsWith("#"))
+                return;
+            let m = line.match(/^(\S+)\s+(\d+)\/(\S+).*?(#(.*))?$/);
+            let new_port = { name: m[1], port: m[2], type: [m[3]] };
+            if (m.length > 5 && m[5])
+                new_port['description'] = m[5].trim();
+            if (ret[m[1]])
+                ret[m[1]]['type'].push(new_port['type'][0]);
+            else
+                ret[m[1]] = new_port;
+            if (ret[m[2]])
+                ret[m[2]]['type'].push(new_port['type'][0]);
+            else
+                ret[m[2]] = new_port;
+        });
+        return ret;
+    }
+
+    setName(event) {
+        this.setState({
+            custom_name: event.target.value,
+            generate_name: false,
+        });
+    }
+
+    getName(port) {
+        let known = this.state.avail_services[port];
+        if (known)
+            return known['name'];
+        else
+            return port;
+    }
+
+    generateName(all_ports) {
+        var name = "";
+        if (all_ports.length === 1) {
+            let known = this.state.avail_services[all_ports[0]];
+            if (known)
+                name = known['description'] || known['name'];
+            else
+                name = all_ports[0];
+        } else if (all_ports.length > 1) {
+            name = all_ports.slice(0, 3).map(this.getName)
+                    .join(", ");
+            if (all_ports.length > 3)
+                name += "...";
+        }
+        return name;
+    }
+
+    getPortNumber(port, type, avail) {
+        if (!avail) {
+            let num_p = Number(port);
+            if (isNaN(num_p))
+                return [0, _("Unknown service name")];
+            else if (num_p <= 0 || num_p > 65535)
+                return [0, _("Invalid port number")];
+            else
+                return [port, ""];
+        } else if (avail['type'].indexOf(type) < 0)
+            return [0, _("Port number and type do not match")];
+        else {
+            return [avail.port, ""];
+        }
+    }
+
+    validate(event) {
+        let ports = event.target.value.split(',');
+        let error = "";
+        let targets = ['tcp', 'custom_tcp_ports', 'tcp_error', 'custom_tcp_value'];
+        if (event.target.id === "udp-ports")
+            targets = ['udp', 'custom_udp_ports', 'udp_error', 'custom_udp_value'];
+
+        let new_ports = [];
+        let self = this;
+        ports.forEach(function(port) {
+            port = port.trim();
+            if (!port)
+                return;
+            let ports;
+            if (port.indexOf("-") > -1) {
+                ports = port.split("-");
+                if (ports.length != 2) {
+                    error = _("Invalid range");
+                    return;
+                }
+                [ports[0], error] = self.getPortNumber(ports[0], targets[0], self.state.avail_services[ports[0]]);
+                if (!error) {
+                    [ports[1], error] = self.getPortNumber(ports[1], targets[0], self.state.avail_services[ports[1]]);
+                    if (!error) {
+                        if (Number(ports[0]) >= Number(ports[1]))
+                            error = _("Range must be strictly ordered");
+                        else
+                            new_ports.push(ports[0] + "-" + ports[1]);
+                    }
+                }
+            } else {
+                [ports, error] = self.getPortNumber(port, targets[0], self.state.avail_services[port]);
+                if (!error)
+                    new_ports.push(ports);
+            }
+        });
+        let newState = { [targets[1]]: new_ports,
+                         [targets[2]]: error,
+                         [targets[3]]: event.target.value };
+
+        let name = this.state.custom_name;
+        let all_ports = new_ports.concat(this.state.custom_udp_ports);
+        if (event.target.id === "udp-ports")
+            all_ports = this.state.custom_tcp_ports.concat(new_ports);
+
+        if (this.state.generate_name)
+            name = this.generateName(all_ports);
+
+        let new_id = "custom--" + all_ports.map(this.getName).join('-');
+
+        newState['custom_name'] = name;
+        newState['custom_id'] = new_id;
+        this.setState(newState);
+    }
+
+    onToggleType(event) {
+        this.setState({
+            custom: event.target.value === "ports"
+        });
+    }
+
+    componentDidMount() {
+        firewall.getAvailableServices()
+                .then(services => this.setState({
+                    services: services.map(s => {
+                        s.name = s.name || s.id;
+                        return s;
+                    })
+                }));
+        cockpit.file('/etc/services').read()
+                .done(content => this.setState({
+                    avail_services: this.parseServices(content)
+                }));
+    }
+
+    onFilterChanged(value) {
+        this.setState({ filter: value.toLowerCase() });
+    }
+
     render() {
         let services;
         if (this.state.filter && this.state.services && !isNaN(this.state.filter))
@@ -210,63 +389,96 @@ class AddServicesBody extends React.Component {
         if (services)
             services = services.filter(s => !firewall.enabledServices.has(s.id));
 
-        let body;
-        if (this.state.services) {
-            body = (
-                <Modal.Body id="add-services-dialog">
-                    <table className="form-table-ct">
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <label htmlFor="filter-services-input" className="control-label">
-                                        {_("Filter Services")}
-                                    </label>
-                                </td>
-                                <td>
-                                    <SearchInput id="filter-services-input"
-                                                 className="form-control"
-                                                 onChange={this.onFilterChanged} />
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <ListView className="dialog-list-ct">
-                        {
-                            services.map(s => (
-                                <ListView.Item key={s.id}
-                                               checkboxInput={ <input data-id={s.id}
-                                                                      type="checkbox"
-                                                                      checked={this.state.selected.has(s.id)}
-                                                                      onChange={this.onToggleService} /> }
-                                               heading={ <React.Fragment><span>{s.name}</span>{ renderPorts(s.ports) }</React.Fragment> }>
-                                </ListView.Item>
-                            ))
-                        }
-                    </ListView>
-                </Modal.Body>
-            );
-        } else {
-            body = (
-                <Modal.Body id="add-services-dialog">
-                    <div className="spinner spinner-lg" />
-                </Modal.Body>
-            );
-        }
-
+        var addText = this.state.custom ? _("Add Ports") : _("Add Services");
         return (
             <Modal id="add-services-dialog" show onHide={this.props.close}>
                 <Modal.Header>
-                    <Modal.Title> {`Add Services`} </Modal.Title>
+                    <Modal.Title> {addText} </Modal.Title>
                 </Modal.Header>
                 <div id="cockpit_modal_dialog">
-                    {body}
+                    <Modal.Body id="add-services-dialog">
+                        <form action="" className="toggle-body">
+                            <input type="radio" name="type" value="services" onChange={this.onToggleType} defaultChecked />
+                            {_("Services")}
+                            { this.state.custom ||
+                                <React.Fragment>
+                                    { services ? (
+                                        <React.Fragment>
+                                            <table className="form-table-ct">
+                                                <tbody>
+                                                    <tr>
+                                                        <td>
+                                                            <label htmlFor="filter-services-input" className="control-label">
+                                                                {_("Filter Services")}
+                                                            </label>
+                                                        </td>
+                                                        <td>
+                                                            <SearchInput id="filter-services-input"
+                                                                         value={this.state.filter}
+                                                                         className="form-control"
+                                                                         onChange={this.onFilterChanged} />
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                            <ListView className="dialog-list-ct">
+                                                {
+                                                    services.map(s => (
+                                                        <ListView.Item key={s.id}
+                                                                       checkboxInput={ <input data-id={s.id}
+                                                                                              type="checkbox"
+                                                                                              checked={this.state.selected.has(s.id)}
+                                                                                              onChange={this.onToggleService} /> }
+                                                                       heading={ <React.Fragment><span>{s.name}</span>{ renderPorts(s.ports) }</React.Fragment> }>
+                                                        </ListView.Item>
+                                                    ))
+                                                }
+                                            </ListView>
+                                        </React.Fragment>
+                                    ) : (
+                                        <div className="spinner spinner-lg" />
+                                    )}
+                                </React.Fragment>
+                            }
+                            <div />
+                            <input type="radio" name="type" value="ports" onChange={this.onToggleType} disabled={this.state.avail_services == null} />
+                            {_("Custom Ports")}
+                            { !this.state.custom ||
+                                <fieldset className="ct-form-layout">
+                                    <label className="control-label" htmlFor="hint" hidden>Hint</label>
+                                    <p id="hint">
+                                        {_("Comma-separated ports, ranges, and aliases are accepted")}
+                                    </p>
+
+                                    <label className="control-label" htmlFor="tcp-ports">TCP</label>
+                                    <input id="tcp-ports" type="text" onChange={this.validate}
+                                           className={"form-control " + (this.state.tcp_error ? "error" : "") }
+                                           value={this.state.custom_tcp_value}
+                                           placeholder={_("Example: 22,ssh,8080,5900-5910")}
+                                           autoFocus />
+                                    <output className="has-error" htmlFor="tcp-ports">{this.state.tcp_error}</output>
+
+                                    <label className="control-label" htmlFor="udp-ports">UDP</label>
+                                    <input id="udp-ports" type="text" onChange={this.validate}
+                                           className={"form-control " + (this.state.udp_error ? "error" : "") }
+                                           value={this.state.custom_udp_value}
+                                           placeholder={_("Example: 88,2019,nfs,rsync")} />
+                                    <output className="has-error" htmlFor="udp-ports">{this.state.udp_error}</output>
+
+                                    <label className="control-label" htmlFor="service-name">Name</label>
+                                    <input id="service-name" className="form-control" type="text" onChange={this.setName}
+                                           placeholder={_("(Optional)")} value={this.state.custom_name} />
+                                </fieldset>
+                            }
+                        </form>
+                    </Modal.Body>
                 </div>
                 <Modal.Footer>
                     <Button bsStyle='default' className='btn-cancel' onClick={this.props.close}>
                         {_("Cancel")}
                     </Button>
                     <Button bsStyle='primary' onClick={this.save}>
-                        {_("Add Services")}
+                        {addText}
                     </Button>
                 </Modal.Footer>
             </Modal>
@@ -393,7 +605,7 @@ export class Firewall extends React.Component {
                                                       onRemoveService={this.onRemoveService} />)
                     }
                 </Listing> }
-                { this.state.showModal && <AddServicesBody close={this.close} /> }
+                { this.state.showModal && <AddServicesModal close={this.close} /> }
             </div>
         );
     }

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -397,34 +397,27 @@ class AddServicesModal extends React.Component {
                 </Modal.Header>
                 <div id="cockpit_modal_dialog">
                     <Modal.Body id="add-services-dialog">
-                        <form action="" className="toggle-body">
-                            <input type="radio" name="type" value="services" onChange={this.onToggleType} defaultChecked />
-                            {_("Services")}
+                        <form action="" className="toggle-body ct-form-layout">
+                            <label className="radio ct-form-layout-full">
+                                <input type="radio" name="type" value="services" onChange={this.onToggleType} defaultChecked />
+                                {_("Services")}
+                            </label>
                             { this.state.custom ||
                                 <React.Fragment>
                                     { services ? (
-                                        <React.Fragment>
-                                            <table className="form-table-ct">
-                                                <tbody>
-                                                    <tr>
-                                                        <td>
-                                                            <label htmlFor="filter-services-input" className="control-label">
-                                                                {_("Filter Services")}
-                                                            </label>
-                                                        </td>
-                                                        <td>
-                                                            <SearchInput id="filter-services-input"
-                                                                         value={this.state.filter}
-                                                                         className="form-control"
-                                                                         onChange={this.onFilterChanged} />
-                                                        </td>
-                                                    </tr>
-                                                </tbody>
-                                            </table>
-                                            <ListView className="dialog-list-ct">
+                                        <fieldset className="ct-form-layout">
+                                            <label htmlFor="filter-services-input" className="control-label">
+                                                {_("Filter Services")}
+                                            </label>
+                                            <SearchInput id="filter-services-input"
+                                                value={this.state.filter}
+                                                className="form-control"
+                                                onChange={this.onFilterChanged} />
+                                            <ListView className="list-group dialog-list-ct ct-form-layout-full">
                                                 {
                                                     services.map(s => (
                                                         <ListView.Item key={s.id}
+                                                                       className="list-group-item"
                                                                        checkboxInput={ <input data-id={s.id}
                                                                                               type="checkbox"
                                                                                               checked={this.state.selected.has(s.id)}
@@ -434,15 +427,17 @@ class AddServicesModal extends React.Component {
                                                     ))
                                                 }
                                             </ListView>
-                                        </React.Fragment>
+                                        </fieldset>
                                     ) : (
                                         <div className="spinner spinner-lg" />
                                     )}
                                 </React.Fragment>
                             }
                             <div />
-                            <input type="radio" name="type" value="ports" onChange={this.onToggleType} disabled={this.state.avail_services == null} />
-                            {_("Custom Ports")}
+                            <label className="radio ct-form-layout-full">
+                                <input type="radio" name="type" value="ports" onChange={this.onToggleType} disabled={this.state.avail_services == null} />
+                                {_("Custom Ports")}
+                            </label>
                             { !this.state.custom ||
                                 <fieldset className="ct-form-layout">
                                     <label className="control-label" htmlFor="hint" hidden>Hint</label>

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -94,14 +94,16 @@ function ServiceRow(props) {
 }
 
 class SearchInput extends React.Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
 
         this.onValueChanged = this.onValueChanged.bind(this);
+        this.state = { value: props.value || "" };
     }
 
     onValueChanged(event) {
         let value = event.target.value;
+        this.setState({ value:value });
 
         if (this.timer)
             window.clearTimeout(this.timer);
@@ -115,6 +117,7 @@ class SearchInput extends React.Component {
     render() {
         return <input autoFocus
                       id={this.props.id}
+                      value={this.state.value}
                       className={this.props.className}
                       onChange={this.onValueChanged} />;
     }

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -201,3 +201,49 @@ h1 .btn-onoff-ct {
 #add-services-dialog small {
     font-size: 90%;
 }
+
+.toggle-body > input {
+    margin-right: 2px;
+}
+
+.toggle-body > :not(input) {
+    margin-left: 14px;
+}
+
+.form-control.error {
+    border-color: #cc0000;
+}
+
+.form-control.error:hover {
+    border-color: #990000;
+}
+
+.form-control.error:focus {
+    border-color: #990000;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ff3333;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ff3333;
+}
+
+#add-services-dialog .has-error {
+    animation: 300ms error-slide-down ease-in-out;
+    color: #c00;
+    padding: 0;
+}
+
+#add-services-dialog .has-error:empty {
+    display: none;
+}
+
+@keyframes error-slide-down {
+    0% {
+        line-height: 0;
+        height: 0;
+        opacity: 0;
+        overflow: hidden;
+    }
+    100% {
+        line-height: inherit;
+        height: auto;
+        opacity: 1;
+    }
+}

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -195,18 +195,37 @@ h1 .btn-onoff-ct {
 }
 
 #add-services-dialog .list-view-pf-main-info {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 1rem 0;
 }
 
-#add-services-dialog .list-view-pf-checkbox,
+#add-services-dialog .list-view-pf-checkbox {
+    margin: 1rem 1rem 1rem 0;
+}
+
 #add-services-dialog .list-view-pf-view {
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin: 0;
 }
 
-#add-services-dialog small {
-    font-size: 90%;
+#add-services-dialog .list-view-pf-description {
+    flex: auto;
+}
+
+#add-services-dialog .list-group-item-heading {
+    font-size: 1.2em;
+    margin: 0;
+}
+
+#add-services-dialog .list-group-item-text {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+#add-services-dialog .service-ports {
+    opacity: 0.75;
+}
+
+#add-services-dialog .service-ports:first-of-type {
+    margin-right: 1em;
 }
 
 #add-services-dialog .spinner-lg {
@@ -216,6 +235,10 @@ h1 .btn-onoff-ct {
 
 #add-services-dialog .toggle-body > .ct-form-layout {
     margin-left: 1rem;
+}
+
+#add-services-dialog .toggle-body > .ct-form-layout + label {
+    margin-top: 1rem;
 }
 
 #add-services-dialog .toggle-body > .ct-form-layout > .control-label {

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -177,11 +177,17 @@ h1 .btn-onoff-ct {
 /* set min-height to the same as max-height, so that the list doesn't shrink
  * when filtering */
 #add-services-dialog .dialog-list-ct {
-    min-height: 230px;
+    height: 100vh;
+    /* Constrain the list to a maximum size of the viewport height - UI chrome */
+    max-height: calc(100vh - 30rem);
+    min-height: 13em;
 }
 
-#add-services-dialog .form-table-ct {
-    margin-bottom: 0.5em;
+@media screen and (min-width: 640px) {
+    /* Add a bit more padding in desktop mode */
+    #add-services-dialog .dialog-list-ct {
+        max-height: calc(100vh - 40rem);
+    }
 }
 
 #add-services-dialog .list-group-item {
@@ -193,7 +199,8 @@ h1 .btn-onoff-ct {
     padding-bottom: 0;
 }
 
-#add-services-dialog .list-view-pf-checkbox {
+#add-services-dialog .list-view-pf-checkbox,
+#add-services-dialog .list-view-pf-view {
     margin-top: 10px;
     margin-bottom: 10px;
 }
@@ -202,12 +209,17 @@ h1 .btn-onoff-ct {
     font-size: 90%;
 }
 
-.toggle-body > input {
-    margin-right: 2px;
+#add-services-dialog .spinner-lg {
+    /* (Max-height of dialog-list-ct (above) - spinner size + grid gap) / 2 */
+    margin: calc(((100vh - 40rem) - 30px + 0.5rem) / 2) auto;
 }
 
-.toggle-body > :not(input) {
-    margin-left: 14px;
+#add-services-dialog .toggle-body > .ct-form-layout {
+    margin-left: 1rem;
+}
+
+#add-services-dialog .toggle-body > .ct-form-layout > .control-label {
+    padding-left: 0;
 }
 
 .form-control.error {

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -146,8 +146,8 @@ class TestFirewall(MachineCase):
         b.set_input_text("#filter-services-input", "pop")
         b.wait_not_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
         b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='pop3']")
-        self.assertIn("TCP: 110", b.text("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child small"))
-        self.assertNotIn("UDP", b.text("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child small"))
+        self.assertIn("TCP: 110", b.text("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child .service-ports.tcp"))
+        b.wait_not_present("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child .service-ports.udp")
         # clear filter
         b.set_input_text("#filter-services-input", "")
         b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
@@ -158,8 +158,8 @@ class TestFirewall(MachineCase):
         b.set_input_text("#filter-services-input", "110")
         b.wait_not_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
         b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='pop3']")
-        self.assertIn("TCP: 110", b.text("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child small"))
-        self.assertNotIn("UDP", b.text("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child small"))
+        self.assertIn("TCP: 110", b.text("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child .service-ports.tcp"))
+        b.wait_not_present("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child .service-ports.udp")
         # clear filter
         b.set_input_text("#filter-services-input", "")
         b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -19,6 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent
+import time
 from testlib import *
 
 
@@ -190,6 +191,82 @@ class TestFirewall(MachineCase):
             m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload")
             b.click("caption button.btn-primary")
             b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='empty']")
+
+    @skipImage("Custom ports were introduced in #11420", "rhel-7-6-distropkg")
+    def testAddCustomServices(self):
+        b = self.browser
+
+        self.login_and_go("/network/firewall")
+
+
+        def open_dialog():
+            b.wait_present("caption button.btn-primary:enabled")
+            b.click("caption button.btn-primary")
+            b.wait_present("#add-services-dialog input[value='ports']:enabled")
+            b.click("#add-services-dialog input[value='ports']")
+            b.wait_present("#tcp-ports")
+            b.wait_visible("#tcp-ports")
+
+        def set_field(sel, val, expected):
+            b.set_input_text(sel, val)
+            b.wait_val("#service-name", expected)
+
+        def check_error(text):
+            b.wait_present(".has-error:contains({0})".format(text))
+            b.wait_visible(".has-error:contains({0})".format(text))
+
+        def save(identifier, name, tcp, udp):
+            b.click("button:contains(Add Ports)")
+            b.wait_not_present("#add-services-dialog")
+            line_sel = "tr[data-row-id='{0}']".format(identifier)
+            b.wait_present(line_sel)
+            b.wait_in_text(line_sel, "".join([name, tcp, udp]))
+
+        open_dialog()
+        set_field("#tcp-ports", "80", "WorldWideWeb HTTP")
+        set_field("#tcp-ports", "", "")
+        set_field("#tcp-ports", "80,7", "http, echo")
+        set_field("#udp-ports", "194", "http, echo, irc")
+        set_field("#udp-ports", "194,   50000", "http, echo, irc...")
+        set_field("#tcp-ports", "", "irc, 50000")
+        set_field("#tcp-ports", "https", "https, irc, 50000")
+        save("custom--https-irc-50000", "https, irc, 50000", "443", "194, 50000")
+
+        open_dialog()
+        set_field("#tcp-ports", "80-82", "80-82")
+        set_field("#tcp-ports", "80-82, echo", "80-82, echo")
+        set_field("#udp-ports", "ntp-irc", "80-82, echo, 123-194")
+        set_field("#udp-ports", "83-ntp", "80-82, echo, 83-123")
+        set_field("#udp-ports", "83-ntp, irc", "80-82, echo, 83-123...")
+        save("custom--80-82-echo-83-123-irc", "80-82, echo, 83-123...", "80-82, 7", "83-123, 194")
+
+        open_dialog()
+        set_field("#tcp-ports", "80", "WorldWideWeb HTTP")
+        b.set_input_text("#service-name", "I am persistent")
+        b.set_input_text("#tcp-ports", "7")
+        time.sleep(5) # We need to validate that the service name did not change
+        b.wait_val("#service-name", "I am persistent")
+        save("custom--echo", "I am persistent", "7", "")
+
+        open_dialog()
+        set_field("#tcp-ports", "500000", "")
+        check_error("Invalid port number")
+        set_field("#tcp-ports", "-1", "")
+        check_error("Invalid port number")
+        set_field("#tcp-ports", "8a", "")
+        check_error("Unknown service name")
+        set_field("#tcp-ports", "foobar", "")
+        check_error("Unknown service name")
+        set_field("#tcp-ports", "80-80", "")
+        check_error("Range must be strictly ordered")
+        set_field("#tcp-ports", "80-79", "")
+        check_error("Range must be strictly ordered")
+        set_field("#tcp-ports", "https-http", "")
+        check_error("Range must be strictly ordered")
+        set_field("#tcp-ports", "80-90-", "")
+        check_error("Invalid range")
+        set_field("#tcp-ports", "80-90-100", "")
+        check_error("Invalid range")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This implements https://raw.githubusercontent.com/cockpit-project/cockpit-design/master/firewall/firewall-dialog-add-service.png (except bottom row in middle, but it provides all needed info, so easy to add as follow up)

It is bigger that I expected it to be, but with all the automatically generated names, id, checking if values make sense etc. it grew a bit :) 
Please no code review yet, I did not check the code after myself, I am opening as I want to discuss the design and usability first.

So @garrett and @andreasn if you have some time could you please check this? Mainly if it works as expected, if there are some things which behave weirdly etc.
And also @garrett I have one favor to ask you (I will happily work in meantime on some of your isses if you need some tests or whatever :) )- if you would have time could you please help me a bit with css in here? Mainly to make it look all nice. I did as much as possible, but the biggest problem I see is that when you open the dialog, search bar is way to wide. Not sure how to make this work in any sensible way.

And as usual some screenshots:
Only one port suggests you description:
![onewithlongname](https://user-images.githubusercontent.com/12330670/54534181-1cdceb00-498c-11e9-942a-a821627a6183.png)
More ports use names or port number if no name available:
![more](https://user-images.githubusercontent.com/12330670/54534180-1cdceb00-498c-11e9-8888-a6801aabde2d.png)
Invalid values make the input red:
![witherrors](https://user-images.githubusercontent.com/12330670/54534178-1cdceb00-498c-11e9-9932-bd010cb406a1.png)


