### PR TITLE
ws: Apply file system and IPC restrictions to cockpit.service

### DIFF
--- a/src/ws/cockpit.service.in
+++ b/src/ws/cockpit.service.in
@@ -6,6 +6,12 @@ Requires=cockpit.socket
 [Service]
 ExecStartPre=@sbindir@/remotectl certificate --ensure --user=root --group=@group@ --selinux-type=@selinux_config_type@
 ExecStart=@libexecdir@/cockpit-ws
+# deprecated, replace with + prefix once we stop supporting systemd 219
 PermissionsStartOnly=true
 User=@user@
 Group=@group@
+ProtectSystem=full
+# cockpit-ssh needs to read ~/.ssh/
+ProtectHome=read-only
+PrivateTmp=true
+RemoveIPC=true


### PR DESCRIPTION
Running as unprivileged system user already isolates the untrusted web
server rather thoroughly; but take it a step further and deny writing
anything into most of the file system. However, use `ProtectSystem=full`
instead of `strict` to retain the ability to write into `/var` (even
though we don't current use that).

Also add a comment about the deprecation of `PermissionsStartOnly` to
make this easier to find in the future.