### PR TITLE
lib: support 'pmcd' source in plot

### DIFF
--- a/pkg/lib/plot.js
+++ b/pkg/lib/plot.js
@@ -197,6 +197,15 @@ class Metrics_sum_series extends Metrics_series {
                 host: this.desc.host
             });
         }
+        if (this.desc.pmcd) {
+            this.chanopts_list.push({
+                source: 'pmcd',
+                metrics: this.desc.pmcd.map(this.build_metric, this),
+                instances: this.desc.instances,
+                'omit-instances': this.desc['omit-instances'],
+                host: this.desc.host
+            });
+        }
         if (this.desc.internal) {
             this.chanopts_list.push({
                 source: 'internal',
@@ -255,6 +264,15 @@ class Metrics_difference_series extends Metrics_series {
                 source: 'direct',
                 archive_source: 'pcp-archive',
                 metrics: this.desc.direct.map(this.build_metric, this),
+                instances: this.desc.instances,
+                'omit-instances': this.desc['omit-instances'],
+                host: this.desc.host
+            });
+        }
+        if (this.desc.pmcd) {
+            this.chanopts_list.push({
+                source: 'pmcd',
+                metrics: this.desc.pmcd.map(this.build_metric, this),
                 instances: this.desc.instances,
                 'omit-instances': this.desc['omit-instances'],
                 host: this.desc.host
@@ -320,6 +338,16 @@ class Metrics_stacked_instances_series extends Metrics_series {
                 source: 'direct',
                 archive_source: 'pcp-archive',
                 metrics: [ this.build_metric(this.desc.direct) ],
+                metrics_path_names: [ 'a' ],
+                instances: this.desc.instances,
+                'omit-instances': this.desc['omit-instances'],
+                host: this.desc.host
+            });
+        }
+        if (this.desc.pmcd) {
+            this.chanopts_list.push({
+                source: 'pmcd',
+                metrics: this.desc.pmcd.map(this.build_metric, this),
                 metrics_path_names: [ 'a' ],
                 instances: this.desc.instances,
                 'omit-instances': this.desc['omit-instances'],

--- a/pkg/playground/plot.html
+++ b/pkg/playground/plot.html
@@ -39,8 +39,11 @@
       </div>
     </div>
 
-    <span class="plot-unit" id="plot_unit"></span>
-    <div id="plot" class="zoomable-plot"></div>
+    <span class="plot-unit" id="plot_direct_unit"></span>
+    <div id="plot_direct" class="zoomable-plot"></div>
+
+    <span class="plot-unit" id="plot_pmcd_unit"></span>
+    <div id="plot_pmcd" class="zoomable-plot"></div>
   </div>
 </body>
 </html>

--- a/pkg/playground/plot.js
+++ b/pkg/playground/plot.js
@@ -4,27 +4,44 @@ import * as plot from "plot.js";
 import "plot.css";
 
 $(function () {
-    var pl = new plot.Plot($('#plot'), 300);
-    var options = plot.plot_simple_template();
-    $.extend(options.yaxis, {
+    var plot_direct = new plot.Plot($('#plot_direct'), 300);
+    var options_direct = plot.plot_simple_template();
+    $.extend(options_direct.yaxis, {
         ticks: plot.memory_ticks,
         tickFormatter: plot.format_bytes_tick_no_unit
     });
-    options.post_hook = function memory_post_hook(p) {
+    options_direct.post_hook = function memory_post_hook(p) {
         var axes = p.getAxes();
-        $('#plot_unit').text(plot.bytes_tick_unit(axes.yaxis));
+        $('#plot_direct_unit').text(plot.bytes_tick_unit(axes.yaxis));
     };
-
-    pl.set_options(options);
-    pl.add_metrics_difference_series({
+    plot_direct.set_options(options_direct);
+    plot_direct.add_metrics_difference_series({
         direct: [ "mem.physmem", "mem.util.available" ],
         units: "bytes"
     }, { });
 
+    var plot_pmcd = new plot.Plot($('#plot_pmcd'), 300);
+    var options_pmcd = plot.plot_simple_template();
+    $.extend(options_pmcd.yaxis, {
+        ticks: plot.memory_ticks,
+        tickFormatter: plot.format_bytes_tick_no_unit
+    });
+    options_pmcd.post_hook = function memory_post_hook(p) {
+        var axes = p.getAxes();
+        $('#plot_pmcd_unit').text(plot.bytes_tick_unit(axes.yaxis));
+    };
+    plot_pmcd.set_options(options_pmcd);
+    plot_pmcd.add_metrics_difference_series({
+        pmcd: [ "mem.physmem", "mem.util.available" ],
+        units: "bytes"
+    }, { });
+
     $("body").show();
-    $("#plot").css({ height: "200px" });
-    pl.resize();
+    $("#plot_direct").css({ height: "200px" });
+    $("#plot_pmcd").css({ height: "200px" });
+    plot_direct.resize();
+    plot_pmcd.resize();
 
     var plot_controls = plot.setup_plot_controls($('body'), $('#toolbar'));
-    plot_controls.reset([ pl ]);
+    plot_controls.reset([ plot_direct, plot_pmcd ]);
 });

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -418,8 +418,11 @@ OnCalendar=daily
         b = self.browser
         m = self.machine
 
+        m.execute("systemctl start pmcd")
+
         self.login_and_go("/playground/plot")
-        b.wait_present("#plot")
+        b.wait_present("#plot_direct")
+        b.wait_present("#plot_pmcd")
 
         def read_mem_info(machine):
             info = {}
@@ -483,7 +486,11 @@ OnCalendar=daily
 
         meminfo = read_mem_info(m)
         mem_used = meminfo['MemTotal'] - meminfo['MemAvailable']
-        b.wait_js_func("ph_flot_data_plateau", "#plot", mem_used * 0.95, mem_used * 1.05, 15, "mem")
+        b.wait_js_func("ph_flot_data_plateau", "#plot_direct", mem_used * 0.95, mem_used * 1.05, 15, "mem")
+
+        meminfo = read_mem_info(m)
+        mem_used = meminfo['MemTotal'] - meminfo['MemAvailable']
+        b.wait_js_func("ph_flot_data_plateau", "#plot_pmcd", mem_used * 0.95, mem_used * 1.05, 15, "mem")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Plot helper class is only supporting "internal" and "direct" source for metrics1 channel. A third source called "pcmd" exists and allows to query the pmcd daemon directly for metrics.

This patch adds "pmcd" as source in the Plot helper class.

- [x] Fix playground and add test: PR #11427