### PR TITLE
bots: Install freeipa-client on debian-testing, enable check-realms

### DIFF
--- a/bots/images/debian-testing
+++ b/bots/images/debian-testing
@@ -1,1 +1,1 @@
-debian-testing-6b3b0942cd064b988cd42db1fbf7130cc7cae6a48ef61c713347f6c75483ee21.qcow2
+debian-testing-c06f17496452da0aa28fed05f468f57b9f0f35762bb8fddf4e5ccf55f5616d2f.qcow2

--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -42,6 +42,7 @@ udisks2-lvm2 \
 # We also install the packages necessary to join a FreeIPA domain so
 # that we don't have to go to the network during a test run.
 IPA_CLIENT_PACKAGES="\
+freeipa-client \
 sssd-tools \
 sssd-dbus \
 packagekit \
@@ -71,6 +72,7 @@ case "$RELEASE" in
         COCKPIT_DEPS="${COCKPIT_DEPS/libblockdev-mdraid2 /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/udisks2-lvm2 /}"
         COCKPIT_DEPS="${COCKPIT_DEPS/libvirt-dbus /}"
+        IPA_CLIENT_PACKAGES="${IPA_CLIENT_PACKAGES/freeipa-client /}"
         # keep in sync with allowed messages in test/common/testlib.py
         COCKPIT_DEPS="${COCKPIT_DEPS/tuned /}"
 
@@ -88,7 +90,6 @@ case "$RELEASE" in
 esac
 
 if grep -q 'ID=ubuntu' /etc/os-release; then
-    IPA_CLIENT_PACKAGES="$IPA_CLIENT_PACKAGES freeipa-client"
     PBUILDER_OPTS='COMPONENTS="main universe"'
 
     # We want to use/test NetworkManager instead of netplan/networkd for ethernets

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -57,7 +57,7 @@ done
 
 
 @skipImage("No realmd available", "continuous-atomic", "fedora-atomic", "rhel-atomic")
-@skipImage("No freeipa available", "debian-stable", "debian-testing")
+@skipImage("No freeipa available", "debian-stable")
 class TestRealms(MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},
@@ -440,7 +440,7 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 
 
 @skipImage("No realmd available", "continuous-atomic", "fedora-atomic", "rhel-atomic")
-@skipImage("No freeipa available", "debian-stable", "debian-testing")
+@skipImage("No freeipa available", "debian-stable")
 class TestKerberos(MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},


### PR DESCRIPTION
FreeIPA finally made it into Debian testing a month ago:
https://tracker.debian.org/pkg/freeipa

After that we can enable check-realms there.

 * [x] image-refresh debian-testing