### PR TITLE
login: Correctly decode statusText also for OAuth responses

### DIFF
--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -375,7 +375,7 @@
                         if (prompt_data)
                             show_converse(prompt_data);
                         else
-                            fatal(xhr.statusText);
+                            fatal(decodeURIComponent(xhr.statusText));
                     }
                 }
             };


### PR DESCRIPTION
Cockpit-ws encodes the status text in its responses, and login.js
needs to decode it.  It does this already in all places except this
one.