### PR TITLE
machines: fix wrong filtering of net nodedevs in filterVirtualBridgesFromNetNodeDevices

### DIFF
--- a/pkg/machines/components/create-vm-dialog/pxe-helpers.js
+++ b/pkg/machines/components/create-vm-dialog/pxe-helpers.js
@@ -36,7 +36,7 @@ function filterVirtualBridgesFromNetNodeDevices(netNodeDevices, virtualNetworks)
 
     return netNodeDevices.filter(netNodeDevice => {
         if (!netNodeDevice.capability.interface.endsWith('-nic'))
-            return false;
+            return true;
 
         for (let i in libvirtVirBridges) {
             if (netNodeDevice.capability.interface == (libvirtVirBridges[i] + '-nic'))


### PR DESCRIPTION
This function is supposed to filter out net nodedevices which have the
format net_virbr*_nic. Anything not having nic suffix should be included in the
result.