### PR TITLE
containers: Make rpm installation robust for same name prefixes

### DIFF
--- a/containers/bastion/scripts/install-rpms.sh
+++ b/containers/bastion/scripts/install-rpms.sh
@@ -37,7 +37,7 @@ OSVER=$(. /etc/os-release && echo "$VERSION_ID")
 
 for package in $@
 do
-    rpm=$(ls /container/rpms/$package-*$OSVER.*$arch.rpm || true)
+    rpm=$(ls /container/rpms/$package-[0-9]*$OSVER.*$arch.rpm || true)
     if [ -z "$rpm" ]; then
         if [ -n "$VERSION" ]; then
             package="$package-$VERSION"

--- a/containers/kubernetes/scripts/install-rpms.sh
+++ b/containers/kubernetes/scripts/install-rpms.sh
@@ -37,7 +37,7 @@ OSVER=$(. /etc/os-release && echo "$VERSION_ID")
 
 for package in $@
 do
-    rpm=$(ls /container/rpms/$package-*$OSVER.*$arch.rpm || true)
+    rpm=$(ls /container/rpms/$package-[0-9]*$OSVER.*$arch.rpm || true)
     if [ -z "$rpm" ]; then
         if [ -n "$VERSION" ]; then
             package="$package-$VERSION"


### PR DESCRIPTION
Tighten the glob to expect the version number (starting with a digit)
right after the package name. This makes sure that calling
install-rpms.sh only installs the expected package (e. g. "cockpit-ws")
and not other packages which start with the same prefix (e. g.
"cockpit-ws-someextension").