### PR TITLE
test: Don't use actual multipath disks to test multipath

### DIFF
--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -67,7 +67,7 @@ class TestStorage(StorageCase):
           }""")
 
         # Add a disk
-        disk = m.add_disk("10M", serial="MYSERIAL")
+        m.add_disk("10M", serial="MYSERIAL")
 
         b.wait_in_text("#drives", "MYSERIAL")
         b.click('tr:contains("MYSERIAL")')
@@ -75,9 +75,13 @@ class TestStorage(StorageCase):
         wait_detail_row(5, "Device File")
         b.wait_in_text(detail_row_value(5), "/dev/sda")
 
-        # Add another path to the same disk.  The primary device file
-        # should disappear and multipathed devices should be listed.
-        m.add_disk(path=disk["path"], serial=disk["serial"])
+        # Add another disk with the same serial, which fools
+        # multipathd into treating it as another path to the first
+        # disk.  Since we never actually write to it, this is fine.
+
+        # The primary device file should disappear and multipathed
+        # devices should be listed.
+        m.add_disk("10M", serial="MYSERIAL")
         b.wait_text_not(detail_row_value(5), "/dev/sda")
         wait_detail_row(6, "Multipathed Devices")
         b.wait_in_text(detail_row_value(6), "/dev/sda")


### PR DESCRIPTION
Calling "m.add_disk" with a path doesn't seem to be doing what we
expect, and the disk shows up inside the virtual machine with a very
wrong size.

This causes newer versions of multipathd to discard the second block
device.

Instead, we now use two regular disks that have the same serial.
Multipathd will still think they are the same disk, and as long as we
don't actually write to them, everything should be fine.