### PR TITLE
bridge: Fix race condition in test-pipe-channel

### DIFF
--- a/src/bridge/test-pipe-channel.c
+++ b/src/bridge/test-pipe-channel.c
@@ -48,7 +48,7 @@ typedef struct {
   MockTransport *transport;
   CockpitChannel *channel;
   gchar *channel_problem;
-  const gchar *unix_path;
+  gchar *unix_path;
   gchar *temp_file;
 } TestCase;
 
@@ -105,12 +105,12 @@ setup (TestCase *tc,
   GSocketAddress *address;
   GError *error = NULL;
 
-  tc->unix_path = data;
+  tc->unix_path = g_strdup (data);
   if (tc->unix_path == NULL)
     {
-      tc->unix_path = tc->temp_file = g_strdup ("/tmp/cockpit-test-XXXXXX.sock");
+      tc->temp_file = g_strdup ("/tmp/cockpit-test-XXXXXX");
       g_assert (close (g_mkstemp (tc->temp_file)) == 0);
-      g_assert (g_unlink (tc->temp_file) == 0);
+      tc->unix_path = g_strconcat (tc->temp_file, ".sock", NULL);
     }
 
   address = g_unix_socket_address_new (tc->unix_path);
@@ -171,6 +171,8 @@ teardown (TestCase *tc,
   g_clear_object (&tc->conn_sock);
 
   g_unlink (tc->unix_path);
+  g_free (tc->unix_path);
+  g_unlink (tc->temp_file);
   g_free (tc->temp_file);
 
   g_object_unref (tc->transport);


### PR DESCRIPTION
This test often failed with

    cockpit-bridge:ERROR:src/bridge/test-pipe-channel.c:123:setup: assertion failed (error == NULL):
    Error binding to address: Address already in use (g-io-error-quark, 33)

when being run multiple times in parallel. Apparently `g_mkstemp()`
doesn't involve too much randomness and file names are very similar to
each other. This causes temp file name collisions as the temporary file
is deleted before binding a socket to it. To avoid that, leave the file
throughout the test case and use that for locking the name, and use a
different name (with a `.sock`) prefix for the actual socket.