### PR TITLE
naughty: Close 10718: Debian: qemu crashes in tcg mode when under heavy load

### DIFF
--- a/bots/naughty/debian-stable/10718-qemu-crash-in-tcg-mode
+++ b/bots/naughty/debian-stable/10718-qemu-crash-in-tcg-mode
@@ -1,3 +1,0 @@
-# testCreate (check_machines*
-*
-Process * (qemu-system-x86) of user * dumped core.


### PR DESCRIPTION
Known issue which has not occurred in 26 days

Debian: qemu crashes in tcg mode when under heavy load

Fixes #10718