### PR TITLE
machines: Change URL when navigating between different resource types

### DIFF
--- a/pkg/machines/components/aggregateStatusCards.jsx
+++ b/pkg/machines/components/aggregateStatusCards.jsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import cockpit from 'cockpit';
 
 import {
     Card,
@@ -36,8 +37,8 @@ export class AggregateStatusCards extends React.Component {
         return (
             <div className='cards-pf grid-cards-ct cards-ct-hybrid'>
                 <Card accented aggregated id='card-pf-storage-pools'>
-                    <CardTitle onClick={ () => this.props.changeActiveList(2) }>
-                        <a href='#'>
+                    <CardTitle onClick={ () => cockpit.location.go(['storages']) }>
+                        <a>
                             <Icon type='pf' name='server' />
                             <AggregateStatusCount>
                                 { this.props.storagePools.length }
@@ -61,8 +62,8 @@ export class AggregateStatusCards extends React.Component {
                     </CardBody>
                 </Card>
                 <Card accented aggregated id='card-pf-networks'>
-                    <CardTitle onClick={ () => this.props.changeActiveList(3) }>
-                        <a href='#'>
+                    <CardTitle onClick={ () => cockpit.location.go(['networks']) }>
+                        <a>
                             <Icon type='pf' name='network' />
                             <AggregateStatusCount>
                                 { this.props.networks.length }
@@ -92,5 +93,4 @@ export class AggregateStatusCards extends React.Component {
 AggregateStatusCards.propTypes = {
     networks: PropTypes.array.isRequired,
     storagePools: PropTypes.array.isRequired,
-    changeActiveList: PropTypes.func.isRequired,
 };

--- a/pkg/machines/components/networks/networkList.jsx
+++ b/pkg/machines/components/networks/networkList.jsx
@@ -35,7 +35,7 @@ export class NetworkList extends React.Component {
         return (
             <React.Fragment>
                 <Breadcrumb className='machines-listing-breadcrumb' title>
-                    <Breadcrumb.Item onClick={() => this.props.changeActiveList(1)}>
+                    <Breadcrumb.Item onClick={() => cockpit.location.go(['vms']) }>
                         {_("Virtual Machines")}
                     </Breadcrumb.Item>
                     <Breadcrumb.Item active>
@@ -66,7 +66,6 @@ export class NetworkList extends React.Component {
 NetworkList.propTypes = {
     dispatch: PropTypes.func.isRequired,
     networks: PropTypes.array.isRequired,
-    changeActiveList: PropTypes.func.isRequired,
     onAddErrorNotification: PropTypes.func.isRequired,
     resourceHasError: PropTypes.object.isRequired,
 };

--- a/pkg/machines/components/storagePools/storagePoolList.jsx
+++ b/pkg/machines/components/storagePools/storagePoolList.jsx
@@ -37,7 +37,7 @@ export class StoragePoolList extends React.Component {
         return (
             <React.Fragment>
                 <Breadcrumb className='machines-listing-breadcrumb' title>
-                    <Breadcrumb.Item onClick={() => this.props.changeActiveList(1)}>
+                    <Breadcrumb.Item onClick={() => cockpit.location.go(['vms']) }>
                         {_("Virtual Machines")}
                     </Breadcrumb.Item>
                     <Breadcrumb.Item active>
@@ -72,7 +72,6 @@ export class StoragePoolList extends React.Component {
 StoragePoolList.propTypes = {
     storagePools: PropTypes.array.isRequired,
     vms: PropTypes.array.isRequired,
-    changeActiveList: PropTypes.func.isRequired,
     onAddErrorNotification: PropTypes.func.isRequired,
     resourceHasError: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
Previously navigating between the VMs, Storage Pools and Virtual Networks
page didn't not have any effect on the URL.
With this commit we started listening to URL changes, and the above
components will have prefixes in the URL, /vms, /storages and /networks
accordingly.