### PR TITLE
sosreport: Adjust progress bar to new s-r output

### DIFF
--- a/bots/naughty/rhel-atomic/7462-atomic-sosreport-hangs-forever
+++ b/bots/naughty/rhel-atomic/7462-atomic-sosreport-hangs-forever
@@ -1,5 +1,5 @@
 Traceback (most recent call last):
   File "test/verify/check-sosreport", line *, in testBasic
-    b.wait_visible("#sos-download")
+    b.wait(lambda: b.eval_js('ph_find(".progress-bar").offsetWidth') > 0)
 *
-Error: timeout
+Error: timed out waiting for predicate to become true

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -38,7 +38,8 @@ class TestSOS(MachineCase):
         m.write("/etc/sos.conf",
                 """
 [general]
-only-plugins=release
+only-plugins=release,date,host
+threads=2
 """)
 
         self.login_and_go("/sosreport")
@@ -47,6 +48,8 @@ only-plugins=release
         b.wait_visible("#sos")
 
         with b.wait_timeout(360):
+            if m.image != "rhel-7-6-distropkg": # Fixed in #11484
+                b.wait(lambda: b.eval_js('ph_find(".progress-bar").offsetWidth') > 0)
             b.wait_visible("#sos-download")
 
         download_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Yesterday on @mvollmer presentation progress bar was not working, so let's fix it.

Sos report now runs plugins concurrently [1]. With this the output of
the utility changed.

When new plugin is started it is presented by line:
`Starting 81/114 pcp             [Running: logs origin pci pcp]`
therefore we need to show (81 - (running.length)) / 114

However few last ones are presented as:
`Finishing plugins              [Running: origin systemd systemtap yum]`
Therefore we need to remember the count of all plugins and then show
(all_plugins - (running.length)) / all_plugins

Also to not check each and every line with regex, lets just go from last
line until we find one that can be parsed.

[1] https://github.com/sosreport/sos/commit/04df94418071b48a15aa80636dd34243ed374d2c