### PR TITLE
storage: Use headline case for "Create Partition" dialogs and buttons

### DIFF
--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -553,7 +553,7 @@ const BlockContent = ({ client, block, allow_partitions }) => {
         format_disk_btn = (
             <div className="pull-right">
                 <StorageButton onClick={format_disk} excuse={block.ReadOnly ? _("Device is read-only") : null}>
-                    {_("Create partition table")}
+                    {_("Create Partition Table")}
                 </StorageButton>
             </div>);
 

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -180,7 +180,7 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
 
     var title;
     if (create_partition)
-        title = cockpit.format(_("Create partition on $0"), utils.block_name(block));
+        title = cockpit.format(_("Create Partition on $0"), utils.block_name(block));
     else
         title = cockpit.format(_("Format $0"), utils.block_name(block));
 
@@ -329,7 +329,7 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                           dlg.set_nested_values("crypto_options", { ro: false });
                   },
                   Action: {
-                      Title: create_partition ? _("Create partition") : _("Format"),
+                      Title: create_partition ? _("Create Partition") : _("Format"),
                       Danger: (create_partition
                           ? null : _("Formatting a storage device will erase all data on it.")),
                       action: function (vals) {

--- a/po/ca.po
+++ b/po/ca.po
@@ -2168,16 +2168,12 @@ msgstr "Crea-ho"
 msgid "Create new Logical Volume"
 msgstr "Crea un volum lògic nou"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "Crea una partició"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Crea una partició a $0"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Crea la taula de particions"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/cs.po
+++ b/po/cs.po
@@ -2247,16 +2247,12 @@ msgstr "Vytvořit to"
 msgid "Create new Logical Volume"
 msgstr "Vytvořit nový logický svazek"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "Vytvořit oddíl"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Vytvořit oddíl na $0"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Vytvořit tabulku rozdělení úložiště"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/da.po
+++ b/po/da.po
@@ -2155,16 +2155,12 @@ msgstr ""
 msgid "Create new Logical Volume"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr ""
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr ""
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr ""
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/de.po
+++ b/po/de.po
@@ -2217,16 +2217,12 @@ msgstr "Erstellen"
 msgid "Create new Logical Volume"
 msgstr "Logischen Datenträger erstellen"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "Partition erzeugen"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Partition auf $0 erzeugen"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Partitionstabelle erzeugen"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/es.po
+++ b/po/es.po
@@ -2225,16 +2225,12 @@ msgstr "Crearlo"
 msgid "Create new Logical Volume"
 msgstr "Crear un nuevo Volumen Lógico"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "Crear partición"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Crear partición en $0"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Crear tabla de particiones"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/eu.po
+++ b/po/eu.po
@@ -2112,16 +2112,12 @@ msgstr "Sortu"
 msgid "Create new Logical Volume"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:331
-msgid "Create partition"
-msgstr "Sortu partizioa"
-
 #: pkg/storaged/format-dialog.jsx:187
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr ""
 
 #: pkg/storaged/content-views.jsx:534
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr ""
 
 #: pkg/kubernetes/views/route-body.html:7 pkg/kubernetes/views/node-body.html:3

--- a/po/fi.po
+++ b/po/fi.po
@@ -2193,16 +2193,12 @@ msgstr "Luo se"
 msgid "Create new Logical Volume"
 msgstr "Luo uusi looginen taltio"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "Luo osio"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Luo osio kohteessa $0"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Luo osiotaulu"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/fr.po
+++ b/po/fr.po
@@ -2212,16 +2212,12 @@ msgstr "Créez-le"
 msgid "Create new Logical Volume"
 msgstr "Créer un nouveau volume logique"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "Créer une partition"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Créer une partition sur $0"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Créer une table de partition"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/hr.po
+++ b/po/hr.po
@@ -2105,10 +2105,6 @@ msgstr ""
 msgid "Create New VM"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:438
-msgid "Create Partition"
-msgstr ""
-
 #: pkg/storaged/mdraids-panel.jsx:38
 msgid "Create RAID Device"
 msgstr "Stvori RAID uređaj"
@@ -2172,15 +2168,15 @@ msgid "Create new Logical Volume"
 msgstr ""
 
 #: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
+msgid "Create Partition"
 msgstr "Načini particiju"
 
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr ""
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr ""
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/hu.po
+++ b/po/hu.po
@@ -2153,16 +2153,12 @@ msgstr ""
 msgid "Create new Logical Volume"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr ""
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr ""
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr ""
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/it.po
+++ b/po/it.po
@@ -2186,16 +2186,12 @@ msgstr "Crea"
 msgid "Create new Logical Volume"
 msgstr "Creare un nuovo volume logico"
 
-#: pkg/storaged/format-dialog.jsx:331
-msgid "Create partition"
-msgstr "Creare una partizione"
-
 #: pkg/storaged/format-dialog.jsx:187
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Creare una partizione su $0"
 
 #: pkg/storaged/content-views.jsx:534
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Creare una tabella delle partizioni"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys, author fvalen

--- a/po/ja.po
+++ b/po/ja.po
@@ -2122,16 +2122,12 @@ msgstr "作成"
 msgid "Create new Logical Volume"
 msgstr "新規論理ボリュームの作成"
 
-#: pkg/storaged/format-dialog.jsx:331
-msgid "Create partition"
-msgstr "パーティションの作成"
-
 #: pkg/storaged/format-dialog.jsx:187
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "$0 上でのパーティションの作成"
 
 #: pkg/storaged/content-views.jsx:534
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "パーティションテーブルの作成"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/ko.po
+++ b/po/ko.po
@@ -2083,10 +2083,6 @@ msgstr ""
 msgid "Create New VM"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:438
-msgid "Create Partition"
-msgstr ""
-
 #: pkg/storaged/mdraids-panel.jsx:38
 msgid "Create RAID Device"
 msgstr ""
@@ -2150,15 +2146,15 @@ msgid "Create new Logical Volume"
 msgstr "새 볼륨 그룹 만들기 "
 
 #: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
+msgid "Create Partition"
 msgstr "파티션 생성"
 
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "$0에 파티션 만들기"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "파티션 테이블 만들기 "
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys

--- a/po/my.po
+++ b/po/my.po
@@ -2131,16 +2131,12 @@ msgstr ""
 msgid "Create new Logical Volume"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr ""
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr ""
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr ""
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/nl.po
+++ b/po/nl.po
@@ -2117,16 +2117,12 @@ msgstr ""
 msgid "Create new Logical Volume"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:331
-msgid "Create partition"
-msgstr ""
-
 #: pkg/storaged/format-dialog.jsx:187
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr ""
 
 #: pkg/storaged/content-views.jsx:534
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr ""
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/pa.po
+++ b/po/pa.po
@@ -2111,16 +2111,12 @@ msgstr ""
 msgid "Create new Logical Volume"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:331
-msgid "Create partition"
-msgstr ""
-
 #: pkg/storaged/format-dialog.jsx:187
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr ""
 
 #: pkg/storaged/content-views.jsx:534
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr ""
 
 #: pkg/kubernetes/views/route-body.html:7 pkg/kubernetes/views/node-body.html:3

--- a/po/pl.po
+++ b/po/pl.po
@@ -2221,16 +2221,12 @@ msgstr "Utwórz"
 msgid "Create new Logical Volume"
 msgstr "Utworzono:"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "Utwórz partycję"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Utwórz partycję w $0"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Utwórz tablicę partycji"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/pt.po
+++ b/po/pt.po
@@ -2108,16 +2108,12 @@ msgstr ""
 msgid "Create new Logical Volume"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:331
-msgid "Create partition"
-msgstr ""
-
 #: pkg/storaged/format-dialog.jsx:187
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr ""
 
 #: pkg/storaged/content-views.jsx:534
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr ""
 
 #: pkg/kubernetes/views/route-body.html:7 pkg/kubernetes/views/node-body.html:3

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2208,16 +2208,12 @@ msgstr "Criá-lo"
 msgid "Create new Logical Volume"
 msgstr "Criar novo Volume Lógico"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "Criar partição"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Criar partição em $0"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Criar tabela de partições"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/ru.po
+++ b/po/ru.po
@@ -2184,16 +2184,12 @@ msgstr "Создать это"
 msgid "Create new Logical Volume"
 msgstr "Создать новый логический том"
 
-#: pkg/storaged/format-dialog.jsx:331
-msgid "Create partition"
-msgstr "Создать раздел"
-
 #: pkg/storaged/format-dialog.jsx:187
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Создать раздел на $0"
 
 #: pkg/storaged/content-views.jsx:534
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Создать таблицу разделов"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys

--- a/po/sv.po
+++ b/po/sv.po
@@ -2155,16 +2155,12 @@ msgstr "Skapa den"
 msgid "Create new Logical Volume"
 msgstr "Skapa en ny logisk volym"
 
-#: pkg/storaged/format-dialog.jsx:331
-msgid "Create partition"
-msgstr "Skapa en partition"
-
 #: pkg/storaged/format-dialog.jsx:187
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Skapa en partition på $0"
 
 #: pkg/storaged/content-views.jsx:534
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Skapa en partitionstabell"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/tr.po
+++ b/po/tr.po
@@ -2164,16 +2164,12 @@ msgstr ""
 msgid "Create new Logical Volume"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr ""
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr ""
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr ""
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/uk.po
+++ b/po/uk.po
@@ -2224,16 +2224,12 @@ msgstr "Створити"
 msgid "Create new Logical Volume"
 msgstr "Створити логічний том"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "Створити розділ"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "Створити розділ на $0"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "Створити таблицю розділів"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2152,16 +2152,12 @@ msgstr "创建它"
 msgid "Create new Logical Volume"
 msgstr "创建新逻辑卷"
 
-#: pkg/storaged/format-dialog.jsx:332
-msgid "Create partition"
-msgstr "创建分区"
-
 #: pkg/storaged/format-dialog.jsx:183
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "为 $0 创建分区"
 
 #: pkg/storaged/content-views.jsx:556
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "创建分区表"
 
 #: pkg/kubernetes/views/deploymentconfig-body.html:7

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2116,16 +2116,12 @@ msgstr "創造它"
 msgid "Create new Logical Volume"
 msgstr "創建新的邏輯卷"
 
-#: pkg/storaged/format-dialog.jsx:331
-msgid "Create partition"
-msgstr "創建分區"
-
 #: pkg/storaged/format-dialog.jsx:187
-msgid "Create partition on $0"
+msgid "Create Partition on $0"
 msgstr "創建分區 $0"
 
 #: pkg/storaged/content-views.jsx:534
-msgid "Create partition table"
+msgid "Create Partition Table"
 msgstr "創建分區表"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -39,7 +39,7 @@ class TestStorage(StorageCase):
         b.wait_in_text("#drives", "MYDISK")
         b.click('tr:contains("MYDISK")')
         b.wait_visible("#storage-detail")
-        b.click('button:contains(Create partition table)')
+        b.click('button:contains(Create Partition Table)')
         self.dialog({"type": "gpt"})
         self.content_row_wait_in_col(1, 1, "Free Space")
 

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -189,8 +189,8 @@ class TestStorage(StorageCase):
             # (https://github.com/storaged-project/storaged/issues/98)
             part_prefix = dev + "p"
 
-        # Create partition table
-        b.click('button:contains(Create partition table)')
+        # Create Partition Table
+        b.click('button:contains(Create Partition Table)')
         self.dialog({"type": "gpt"})
         self.content_row_wait_in_col(1, 1, "Free Space")
 

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -38,7 +38,7 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
 
         # Format it with a DOS partition table
-        b.click('button:contains(Create partition table)')
+        b.click('button:contains(Create Partition Table)')
         self.dialog({"type": "dos"})
         self.content_row_wait_in_col(1, 1, "Free Space")
 

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -48,8 +48,8 @@ class TestStorage(StorageCase):
         b.click('tr:contains("%s")' % dev)
         b.wait_present('#storage-detail')
 
-        b.wait_visible('button:contains(Create partition table)')
-        b.click('button:contains(Create partition table)')
+        b.wait_visible('button:contains(Create Partition Table)')
+        b.click('button:contains(Create Partition Table)')
         self.dialog({"type": "gpt"})
         self.content_row_wait_in_col(1, 1, "Free Space")
 
@@ -73,8 +73,8 @@ class TestStorage(StorageCase):
         b.click('#drives tr:contains("DISK1")')
         b.wait_present('#storage-detail')
 
-        b.wait_visible('button:contains(Create partition table)')
-        b.click('button:contains(Create partition table)')
+        b.wait_visible('button:contains(Create Partition Table)')
+        b.click('button:contains(Create Partition Table)')
         self.dialog({"type": "gpt"})
         self.content_row_wait_in_col(1, 1, "Free Space")
 

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -67,7 +67,7 @@ class TestStorage(StorageCase):
 
         # No go ahead and let the automatic teardown take care of the mount
 
-        b.click('button:contains(Create partition table)')
+        b.click('button:contains(Create Partition Table)')
         self.dialog_wait_open()
         b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")
         self.dialog_apply()


### PR DESCRIPTION
Be consistent with other buttons and dialogs.

Also adjust translations to avoid breaking them all.

Fixes #8146