### PR TITLE
Build internal libraries with -fPIC

### DIFF
--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -98,6 +98,7 @@ libcockpit_common_a_SOURCES = \
 	$(NULL)
 
 libcockpit_common_a_CFLAGS = \
+	-fPIC \
 	-DG_LOG_DOMAIN=\"cockpit-protocol\" \
 	$(COCKPIT_CFLAGS) \
 	$(NULL)

--- a/src/ssh/Makefile-ssh.am
+++ b/src/ssh/Makefile-ssh.am
@@ -20,6 +20,7 @@ libcockpit_ssh_a_SOURCES += \
 endif
 
 libcockpit_ssh_a_CFLAGS = \
+	-fPIC \
 	-I$(top_srcdir)/src/ssh \
 	-DCOCKPIT_BUILD_INFO=\"$(COCKPIT_BUILD_INFO)\"	\
 	-DG_LOG_DOMAIN=\"cockpit-ssh\" \


### PR DESCRIPTION
libtool would do that automatically, but we don't use it, so set it by
ourselves. This fixes build errors on some platforms.

Fixes #11327