### PR TITLE
Fix and validate AppStream metadata

### DIFF
--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -13,7 +13,7 @@ ARG _crossdeps="libglib2.0-dev libgudev-1.0-dev libjson-glib-dev libkeyutils-dev
 RUN dpkg --add-architecture ${arch} && echo ${arch} > /arch && apt-get update && \
     apt-get install -y --no-install-recommends build-essential gcc-multilib clang python3 \
       autoconf automake gdb gtk-doc-tools intltool libjavascript-minifier-xs-perl libjson-perl valgrind \
-      xmlto xsltproc npm nodejs-legacy git libfontconfig1 dbus ssh curl chromium-browser \
+      xmlto xsltproc npm nodejs-legacy git libfontconfig1 dbus ssh curl chromium-browser appstream-util \
       $(for p in ${_crossdeps}; do echo $p:${arch}; done) && \
     apt-get install -y --allow-downgrades libssh-dev:${arch}=0.6.3-4.3 libssh-4:${arch}=0.6.3-4.3 && \
     echo 'deb http://archive.ubuntu.com/ubuntu bionic universe' > /etc/apt/sources.list.d/stable.list && \

--- a/pkg/kdump/org.cockpit-project.cockpit-kdump.metainfo.xml
+++ b/pkg/kdump/org.cockpit-project.cockpit-kdump.metainfo.xml
@@ -1,10 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.cockpit-project.cockpit-kdump</id>
+  <id>org.cockpit_project.cockpit_kdump</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Kernel Dump</name>
-  <summary>
-    Collect kernel crash dumps
-  </summary>
+  <summary>Collect kernel crash dumps</summary>
   <description>
     <p>
       This tool configures the system to write kernel crash dumps to
@@ -13,4 +12,6 @@
   </description>
   <extends>cockpit.desktop</extends>
   <launchable type="cockpit-manifest">kdump</launchable>
+  <url type="homepage">https://cockpit-project.org/</url>
+  <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
 </component>

--- a/pkg/machines/org.cockpit-project.cockpit-machines.metainfo.xml
+++ b/pkg/machines/org.cockpit-project.cockpit-machines.metainfo.xml
@@ -1,10 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.cockpit-project.cockpit-machines</id>
+  <id>org.cockpit_project.cockpit_machines</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Machines</name>
-  <summary>
-    Manage your virtual machines
-  </summary>
+  <summary>Manage your virtual machines</summary>
   <description>
     <p>
       This tool manages virtual machines.  With it, you can create,
@@ -14,4 +13,6 @@
   </description>
   <extends>cockpit.desktop</extends>
   <launchable type="cockpit-manifest">machines</launchable>
+  <url type="homepage">https://cockpit-project.org/</url>
+  <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
 </component>

--- a/pkg/selinux/org.cockpit-project.cockpit-selinux.metainfo.xml
+++ b/pkg/selinux/org.cockpit-project.cockpit-selinux.metainfo.xml
@@ -1,10 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.cockpit-project.cockpit-selinux</id>
+  <id>org.cockpit_project.cockpit_selinux</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>SELinux</name>
-  <summary>
-    Security Enhanced Linux configuration and troubleshooting
-  </summary>
+  <summary>Security Enhanced Linux configuration and troubleshooting</summary>
   <description>
     <p>
       This tool configures the SELinux policy and can help with
@@ -13,4 +12,6 @@
   </description>
   <extends>cockpit.desktop</extends>
   <launchable type="cockpit-manifest">setroubleshoot</launchable>
+  <url type="homepage">https://cockpit-project.org/</url>
+  <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
 </component>

--- a/pkg/sosreport/org.cockpit-project.cockpit-sosreport.metainfo.xml
+++ b/pkg/sosreport/org.cockpit-project.cockpit-sosreport.metainfo.xml
@@ -1,11 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.cockpit-project.cockpit-sosreport</id>
+  <id>org.cockpit_project.cockpit_sosreport</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Diagnostic Reports</name>
   <icon type="local" height="64" width="64">/usr/share/pixmaps/cockpit-sosreport.png</icon>
-  <summary>
-    Collect and package diagnostic and support data
-  </summary>
+  <summary>Collect and package diagnostic and support data</summary>
   <description>
     <p>
       This tool generates an archive of configuration and diagnostic
@@ -18,4 +17,6 @@
   </description>
   <extends>cockpit.desktop</extends>
   <launchable type="cockpit-manifest">sosreport</launchable>
+  <url type="homepage">https://cockpit-project.org/</url>
+  <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
 </component>

--- a/src/ws/cockpit.appdata.xml.in
+++ b/src/ws/cockpit.appdata.xml.in
@@ -27,6 +27,9 @@
       Once Cockpit is installed, enable it with "systemctl enable --now cockpit.socket".
     </_p>
   </description>
+  <categories>
+    <category>System</category>
+  </categories>
   <translation type="gettext">cockpit</translation>
   <icon type="local" width="128" height="128">/usr/share/pixmaps/cockpit.png</icon>
   <launchable type="url">https://localhost:9090</launchable>
@@ -46,5 +49,5 @@
   </screenshots>
   <url type="homepage">https://cockpit-project.org/</url>
   <url type="help">https://cockpit-project.org/running.html</url>
-  <update_contact>anilsson_at_redhat.com</update_contact>
+  <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
 </component>

--- a/tools/check-dist
+++ b/tools/check-dist
@@ -15,3 +15,6 @@ find $1/po -name '*.po' -print | while read file; do
         exit 1
     fi
 done
+
+# Validate our AppStream metadata
+find $1 -name '*.metainfo.xml' -o -name '*.appdata.xml' | xargs appstream-util validate


### PR DESCRIPTION
- Add missing `<?xml>` headers.
- Add missing `<url>` and `<update_contact>` tags.
- Add missing category to cockpit.appdata.xml
- Update extension IDs to not contain hyphens (§2.1.3)
- Remove line breaks from summaries
- Update `<update_contact>` for cockpit to the mailing list.
- Validate all shipped metadata during distcheck. (Don't yet do it in
  cockpit.spec as our VM images lack libappstream-utils in their mocks)