### PR TITLE
build: Bump webpack timeout [no-test]

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -176,7 +176,7 @@ V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
 V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/stamp=%)";
 
 WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) BUILDDIR=$(abs_builddir) \
-	       timeout 5m $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
+	       timeout 15m $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
 
 WEBPACK_CONFIG = $(srcdir)/webpack.config.js
 WEBPACK_INPUTS =


### PR DESCRIPTION
Semaphore tests currently often fail with

    make[1]: *** [dist/kubernetes/stamp] Error 124

This means it took more than 5 minutes, apparenlty the semaphore VMs are
quite loaded at times. Bump it to 15 minutes.