### PR TITLE
build: Fix clean/distclean make target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,8 +27,10 @@ CLEANFILES = \
 
 DISTCLEANFILES = \
 	$(srcdir)/Makefile \
-	node_modules \
 	cockpit-cache-*.tar.xz \
+	$(NULL)
+
+MAINTAINERCLEANFILES = \
 	$(NULL)
 
 EXTRA_DIST = \
@@ -188,7 +190,7 @@ WEBPACK_STAMPS = $(WEBPACK_PACKAGES:%=dist/%/stamp)
 WEBPACK_MANIFEST_IN = $(WEBPACK_PACKAGES:%=pkg/%/manifest.json.in)
 
 noinst_SCRIPTS += $(WEBPACK_STAMPS) $(WEBPACK_INSTALL)
-CLEANFILES += $(WEBPACK_STAMPS) $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS)
+MAINTAINERCLEANFILES += $(WEBPACK_STAMPS) $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS)
 EXTRA_DIST += $(WEBPACK_STAMPS) $(WEBPACK_DEPS) $(WEBPACK_MANIFEST_IN) webpack.config.js
 
 PRINT_COPY_MSG_0 = echo "  COPY    " $@ &&
@@ -216,8 +218,13 @@ dist/%/manifest.json: pkg/%/manifest.json
 
 -include $(WEBPACK_DEPS)
 
-distclean-local::
-	rm -rf dist/
+# the rules above copy a lot of stuff into builddir; clean it up so that distcleancheck works
+clean-local::
+	$(AM_V_at)test "$(srcdir)" == "$(builddir)" || rm -rf dist/
+
+maintainer-clean-local::
+	rm -rf dist/ node_modules/
+
 install-data-local:: $(WEBPACK_INSTALL)
 	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
 	tar -cf - $^ | tar -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
@@ -325,7 +332,7 @@ dist/fonts/%.woff:
 
 EXTRA_DIST += $(OPENSANS_FONTS)
 
-CLEANFILES += $(OPENSANS_FONTS)
+MAINTAINERCLEANFILES += $(OPENSANS_FONTS)
 
 if ENABLE_DOC
 

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -54,10 +54,18 @@ make V=1 all
 # not yet been able to figure out what is putting it non-blocknig.
 python3 -c "import fcntl, os; map(lambda fd: fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) &~ os.O_NONBLOCK), [0, 1, 2])"
 
-# only run distcheck on main arch
 if [ "$ARCH" = amd64 ]; then
+    # run distcheck on main arch
     make distcheck 2>&1
 else
+    # on i386, validate that "distclean" does not remove too much
+    make dist-gzip
+    mkdir _distcleancheck
+    tar -C _distcleancheck -xf cockpit-[0-9]*.tar.gz
+    cd _distcleancheck/cockpit-*
+    ./configure
+    make distclean
+    ./configure
     make check 2>&1
 fi
 

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -85,7 +85,7 @@ noinst_DATA += \
 	dist/guide/html/index.html \
 	dist/guide/index.html
 
-CLEANFILES += \
+MAINTAINERCLEANFILES += \
 	dist/guide/html/* \
 	dist/guide/links.html \
 	dist/guide/index.html \

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -220,7 +220,7 @@ EXTRA_DIST += \
 	$(base_TESTS_JAVASCRIPT) \
 	$(NULL)
 
-CLEANFILES += \
+MAINTAINERCLEANFILES += \
 	dist/base1/cockpit.js \
 	dist/base1/cockpit.min.css \
 	dist/base1/cockpit.min.css.gz \

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -37,7 +37,7 @@ dist/static/login.po.%.html: src/ws/%.po src/ws/po.empty.html
 staticfontsdir = $(staticdir)/fonts
 staticfonts_DATA = $(OPENSANS_FONTS)
 
-CLEANFILES += \
+MAINTAINERCLEANFILES += \
 	dist/static/login.html \
 	dist/static/login.min.html \
 	dist/static/login.js \

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -218,9 +218,9 @@ function generateDeps(makefile, stats) {
     lines.push("");
 
     lines.push(prefix + ": " + stampfile);
-    lines.push("clean-" + prefix + ": ");
+    lines.push("maintainer-clean-" + prefix + ": ");
     lines.push("\trm -rf $(" + prefix + "_OUTPUTS) $(" + prefix + "_INSTALL) " + stampfile);
-    lines.push("clean-local:: clean-" + prefix);
+    lines.push("maintainer-clean-local:: clean-" + prefix);
 
     data = lines.join("\n") + "\n";
     fs.writeFileSync(makefile, data);


### PR DESCRIPTION
dist/ and (a subset of) node_modules/ are part of our release tarballs,
and thus `make clean` or `distclean` should not remove them. Otherwise
the source becomes unbuildable, as the devDependencies npm modules are
(deliberately) not shipped.

This fixes `make distclean` failing on
```
find: './dist': No such file or directory
make[1]: *** [Makefile:9446: clean-local] Error 1
```

It also fixes
```
rm: cannot remove 'node_modules': Is a directory
```

Remove these files only on `make maintainer-clean`. Note that this is
still not completely correct according to the automake rules
(See https://www.gnu.org/software/automake/manual/html_node/Clean.html)
but at least stops breaking standard distribution rules.

To validate this, run a configure/distclean/configure/make sequence on
our i386 semaphore check.

https://bugs.debian.org/924744