### PR TITLE
storage: Update file system descriptions [no-test]

### DIFF
--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -244,12 +244,12 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
     }
 
     var filesystem_options = [ ];
-    add_fsys("xfs", { value: "xfs", title: _("XFS - Red Hat Enterprise Linux 7 default") });
-    add_fsys("ext4", { value: "ext4", title: _("ext4 - Red Hat Enterprise Linux 6 default") });
+    add_fsys("xfs", { value: "xfs", title: "XFS - " + _("Recommended default") });
+    add_fsys("ext4", { value: "ext4", title: "EXT4" });
     add_fsys("xfs", { value: "luks+xfs", title: _("Encrypted XFS (LUKS)") });
     add_fsys("ext4", { value: "luks+ext4", title: _("Encrypted EXT4 (LUKS)") });
-    add_fsys("vfat", { value: "vfat", title: _("VFAT - Compatible with all systems and devices") });
-    add_fsys("ntfs", { value: "ntfs", title: _("NTFS - Compatible with most systems") });
+    add_fsys("vfat", { value: "vfat", title: "VFAT" });
+    add_fsys("ntfs", { value: "ntfs", title: "NTFS" });
     add_fsys(true, { value: "dos-extended",
                      title: _("Extended Partition"),
                      disabled: !(create_partition && enable_dos_extended) });


### PR DESCRIPTION
"RHEL 7" is confusing on RHEL 8 or Fedora. According to
https://access.redhat.com/articles/3129891 the main reason to chose ext4
over XFS these days is that it may perform better on low-end hardware
wit limited I/O or CPU performance.

But in general, any 5-word file system description is misleading; e. g., 
users might be tricked into choosing VFAT as it's "compatible with all 
systems", but it's a really poor choice for /var or /home. So remove all 
file system descriptions.

Stop i18n'ing the file system names; they are proper nouns. As we
changed the strings, this avoids showing up as untranslated again.

Fixes #11481