### PR TITLE
naughty: Close 10908: PackageKit often dumps core on current rhel-8

### DIFF
--- a/bots/naughty/rhel-8/10908-packagekit-dumps-core
+++ b/bots/naughty/rhel-8/10908-packagekit-dumps-core
@@ -1,3 +1,0 @@
-# testBasic (check_apps.TestApps)
-*
-* warning: PackageKit went away during transaction *


### PR DESCRIPTION
Known issue which has not occurred in 21 days

PackageKit often dumps core on current rhel-8

Fixes #10908