### PR TITLE
bots: Move composer tests to current Fedora/RHEL versions

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -78,9 +78,9 @@ REDHAT_EXTERNAL_PROJECTS = {
         'cockpit/rhel-atomic',
     ],
     'weldr/welder-web': [
-        'cockpit/rhel-7-6/firefox',
-        'cockpit/rhel-8-0/chrome',
-        'cockpit/fedora-29/edge',
+        'cockpit/rhel-7-7/firefox',
+        'cockpit/rhel-8-1/chrome',
+        'cockpit/fedora-30/edge',
     ],
 }
 


### PR DESCRIPTION
cockpit-composer is included in Fedora 30, so test it (only) there.

RHEL 7.6 and 8.0 are done from our side, so move testing to 7.7 and 8.1
(our current development targets).

 - [x] fix composer for RHEL 7.7 testing: https://github.com/weldr/welder-web/pull/621