### PR TITLE
test: Remove more redundant wait_present() calls

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -259,7 +259,6 @@ class Browser:
     def select_from_dropdown(self, selector, value, substring=False):
         # This is a backwards compat helper method; new code should use .set_val()
 
-        self.wait_present(selector)
         self.wait_visible(selector)
 
         # translate text value into <option value=".."> ID
@@ -286,7 +285,6 @@ class Browser:
         spinner_selector = "{0} .spinner".format(selector)
         file_item_selector_template = "{0} ul li a:contains({1})"
 
-        self.wait_present(selector)
         self.wait_visible(selector)
 
         for path_part in filter(None, location.split('/')):

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -115,7 +115,6 @@ class VolumeTests(object):
             m = self.openshift
 
         self.login_and_go("/kubernetes")
-        b.wait_present(".dashboard-status:nth-child(2)")
         b.wait_in_text(".dashboard-status:nth-child(2)", "No volumes in use")
         b.wait_not_present(".pvc-notice a")
 
@@ -125,19 +124,15 @@ class VolumeTests(object):
         # By adding another volume claim more issues are found
         m.execute("kubectl create namespace another && kubectl create --namespace=another -f /tmp/mock-volume-tiny-app.json")
 
-        b.wait_present(".pvc-notice a")
         b.wait_in_text(".pvc-notice a", "2")
         b.wait_in_text(".pvc-notice a", "pending volume claims")
         b.click(".pvc-notice a")
         b.wait_present(".pvc-listing")
 
         b.wait_present("tbody[data-id='default/mock-volume-claim']")
-        b.wait_present("tbody[data-id='default/mock-volume-claim'] td:last-child button.btn-danger")
         b.click("tbody[data-id='default/mock-volume-claim'] td:last-child button.btn-danger", force=True)
 
-        b.wait_present("modal-dialog")
         b.wait_in_text("modal-dialog .modal-body", "mock-volume-claim")
-        b.wait_present("modal-dialog .modal-body ul")
         b.wait_in_text("modal-dialog .modal-body ul", "mock-volume-")
         b.wait_not_in_text("modal-dialog .modal-body ul", "mock-volume-claim")
         b.click("modal-dialog button.btn-danger")
@@ -148,7 +143,6 @@ class VolumeTests(object):
         m.upload(["verify/files/mock-volume-tiny-app.json"], "/tmp")
         m.execute("kubectl create -f /tmp/mock-volume-tiny-app.json")
 
-        b.wait_present("tbody[data-id='default/mock-volume-claim']")
         b.wait_in_text("tbody[data-id='default/mock-volume-claim']", "5Gi")
         b.click("tbody[data-id='default/mock-volume-claim'] tr")
 
@@ -185,13 +179,10 @@ class VolumeTests(object):
             m = self.openshift
 
         self.login_and_go("/kubernetes")
-        b.wait_present("#kubernetes-volumes")
         b.click("#kubernetes-volumes")
         b.wait_present(".pv-listing")
 
-        b.wait_present("#register-volume")
         b.click("#register-volume")
-        b.wait_present("modal-dialog")
         b.click("modal-dialog #volume-type button ")
         b.click("#volume-type #volume-type-nfs")
         b.wait_in_text("modal-dialog #volume-type button", "NFS")
@@ -222,7 +213,6 @@ class VolumeTests(object):
         b.wait_present(".pv-listing tbody[data-id='pv1']")
 
         b.click("#register-volume")
-        b.wait_present("modal-dialog")
         b.click("modal-dialog #volume-type button ")
         b.click("#volume-type #volume-type-hostPath")
         b.wait_in_text("modal-dialog #volume-type button", "Host Path")
@@ -246,7 +236,6 @@ class VolumeTests(object):
         b.wait_present(".content-filter")
         b.wait_in_text(".listing-ct-inline", "/tmp")
         b.wait_in_text(".listing-ct-inline", "This volume has not been claimed")
-        b.wait_present(".content-filter button.pficon-edit")
         b.click(".content-filter button.pficon-edit")
         b.wait_present("modal-dialog")
 
@@ -261,14 +250,12 @@ class VolumeTests(object):
         b.wait_not_present("modal-dialog")
 
         b.click("a.hidden-xs")
-        b.wait_present(".pv-listing tbody[data-id='fc-volume']")
         b.click(".pv-listing tbody[data-id='fc-volume'] th")
         b.wait_present(".content-filter")
         b.wait_present(".content-filter button.btn-delete")
         b.wait_not_present(".content-filter button.pficon-edit")
         b.click(".content-filter button.btn-delete")
         b.wait_present("modal-dialog")
-        b.wait_present("modal-dialog .modal-footer button.btn-danger")
         b.click("modal-dialog .modal-footer button.btn-danger")
         b.wait_present(".pv-listing")
         b.wait_not_present(".pv-listing tbody[data-id='fc-volume']")
@@ -308,7 +295,6 @@ class VolumeTests(object):
         b.wait_in_text(".listing-ct-body div[data-id='{}']".format(secret), "mock-volume-container")
         b.wait_in_text(".listing-ct-body div[data-id='{}']".format(secret),
                        "/var/run/secrets/kubernetes.io/serviceaccount")
-        b.wait_present(".listing-ct-body div[data-id='host-tmp']")
         b.wait_in_text(".listing-ct-body div[data-id='host-tmp']", "Persistent Volume")
         b.wait_in_text(".listing-ct-body div[data-id='host-tmp']", "mock-volume-claim")
         b.wait_in_text(".listing-ct-body div[data-id='host-tmp']", "mock-volume-container")
@@ -330,16 +316,12 @@ class KubernetesCommonTests(VolumeTests):
         # Check that container log output shows up
         b.click("#content .containers-listing tbody:first-of-type tr.listing-ct-item td.listing-ct-toggle")
         b.wait_in_text("#content .containers-listing tbody.open tr.listing-ct-item td:last-child", "running")
-        b.wait_present("tbody.open .listing-ct-panel")
         b.click("tbody.open .listing-ct-panel .listing-ct-head li a.logs")
-        b.wait_present("tbody.open .listing-ct-panel pre")
         b.wait_visible("tbody.open .listing-ct-panel pre")
         b.wait_in_text("tbody.open .listing-ct-panel pre", "HelloMessage.")
 
     def check_shell(self, b):
-        b.wait_present("tbody.open .listing-ct-panel .listing-ct-head li a.shell")
         b.click("tbody.open .listing-ct-panel .listing-ct-head li a.shell")
-        b.wait_present("tbody.open .listing-ct-panel div.terminal")
         b.wait_visible("tbody.open .listing-ct-panel div.terminal")
         b.wait_in_text("tbody.open .listing-ct-panel div.terminal", "#")
         b.focus('tbody.open .listing-ct-panel .terminal')
@@ -352,7 +334,6 @@ class KubernetesCommonTests(VolumeTests):
         b.wait_timeout(120)
 
         self.login_and_go("/kubernetes")
-        b.wait_present("#node-list")
         b.wait_in_text("#node-list", "127.0.0.1")
 
         m.execute("kubectl create -f /tmp/mock-k8s-tiny-app.json")
@@ -373,7 +354,6 @@ class KubernetesCommonTests(VolumeTests):
         b.click(".details-listing tbody[data-id='services/default/mock'] td.listing-ct-toggle")
         b.wait_visible(".details-listing tbody[data-id='services/default/mock'] .delete-entity")
         b.click(".details-listing tbody[data-id='services/default/mock'] .delete-entity")
-        b.wait_present("modal-dialog")
         b.click("modal-dialog .btn-danger")
         b.wait_not_present("modal-dialog")
         b.wait_not_present(".details-listing tbody[data-id='services/default/mock']")
@@ -381,7 +361,6 @@ class KubernetesCommonTests(VolumeTests):
         b.click(".details-listing tbody[data-id='replicationcontrollers/default/mock'] td.listing-ct-toggle")
         b.wait_visible(".details-listing tbody[data-id='replicationcontrollers/default/mock'] .delete-entity")
         b.click(".details-listing tbody[data-id='replicationcontrollers/default/mock'] .delete-entity")
-        b.wait_present("modal-dialog")
         b.click("modal-dialog .btn-danger")
         b.wait_not_present("modal-dialog")
         b.wait_not_present(".details-listing tbody[data-id='replicationcontrollers/default/mock']")
@@ -389,7 +368,6 @@ class KubernetesCommonTests(VolumeTests):
         b.click(".details-listing tbody[data-id='pods/default/" + podl[0] + "'] td.listing-ct-toggle")
         b.wait_visible(".details-listing tbody[data-id='pods/default/" + podl[0] + "'] .delete-pod")
         b.click(".details-listing tbody[data-id='pods/default/" + podl[0] + "'] .delete-pod")
-        b.wait_present("modal-dialog")
         b.wait_in_text("modal-dialog .modal-body", "Deleting a Pod will")
         b.click("modal-dialog .btn-danger")
         b.wait_not_present("modal-dialog")
@@ -400,7 +378,6 @@ class KubernetesCommonTests(VolumeTests):
         b = self.browser
 
         self.login_and_go("/kubernetes")
-        b.wait_present("#node-list")
         b.wait_in_text("#node-list", "127.0.0.1")
 
         m.execute("kubectl create -f /tmp/mock-k8s-tiny-app.json")
@@ -452,7 +429,6 @@ class KubernetesCommonTests(VolumeTests):
         # Adjust the service
         b.click("#services-enable-change")
         b.click("#service-list tr[data-name='mock']:first-of-type button")
-        b.wait_present("modal-dialog")
         b.set_val("modal-dialog input.adjust-replica", 2)
         b.click("modal-dialog .btn-primary")
         b.wait_not_present("modal-dialog .dialog-wait-ct")
@@ -481,7 +457,6 @@ class KubernetesCommonTests(VolumeTests):
 
         # Click on the service to expand into a panel
         b.click(".details-listing tbody[data-id='services/default/mock'] td.listing-ct-toggle")
-        b.wait_present(".details-listing tbody[data-id='services/default/mock'] tr.listing-ct-panel")
         b.wait_visible(".details-listing tbody[data-id='services/default/mock'] tr.listing-ct-panel")
         b.wait_in_text(".details-listing tbody[data-id='services/default/mock'] tr.listing-ct-panel", "mock")
 
@@ -492,7 +467,6 @@ class KubernetesCommonTests(VolumeTests):
         b.click(".details-listing tbody[data-id='services/mynamespace1/mock'] tr.listing-ct-item")
         b.wait_in_text(".listing-ct-inline", "Service")
         b.wait_in_text(".listing-ct-inline", "Endpoints")
-        b.wait_present(".content-filter h3")
         b.wait_text(".content-filter h3", "mock")
         b.click("a.hidden-xs")
         b.wait_present("#content .details-listing")
@@ -538,7 +512,6 @@ class KubernetesCommonTests(VolumeTests):
         b = self.browser
 
         self.login_and_go("/kubernetes")
-        b.wait_present("#node-list")
         b.wait_in_text("#node-list", "127.0.0.1")
 
         # localhost node should be up and healthy
@@ -548,11 +521,9 @@ class KubernetesCommonTests(VolumeTests):
 
         b.click("#node-list tbody tr:first-child")
 
-        b.wait_present(".listing-ct-inline")
         b.wait_in_text(".listing-ct-inline", "Node")
         b.wait_in_text(".listing-ct-inline", "Capacity")
         b.wait_in_text(".listing-ct-inline", "KubeletReady")
-        b.wait_present(".content-filter h3")
         b.wait_text(".content-filter h3", "127.0.0.1")
         b.click("a.hidden-xs")
 
@@ -566,19 +537,14 @@ class KubernetesCommonTests(VolumeTests):
             b.wait_present(".nodes-listing tbody[data-id='{}-mynode']".format(l))
 
         # Check inner page
-        b.wait_present(".nodes-listing tbody[data-id='a-mynode'] tr.listing-ct-item")
         b.click(".nodes-listing tbody[data-id='a-mynode'] tr.listing-ct-item")
-        b.wait_present(".content-filter h3")
         b.wait_text(".content-filter h3", "a-mynode")
         b.click("a.hidden-xs")
 
         # Delete from inner page
         b.wait_present(".nodes-listing")
-        b.wait_present(".nodes-listing tbody[data-id='a-mynode'] tr.listing-ct-item")
         b.click(".nodes-listing tbody[data-id='a-mynode'] tr.listing-ct-item")
-        b.wait_present(".content-filter button.btn-danger")
         b.click(".content-filter button.btn-danger")
-        b.wait_present("modal-dialog")
         b.wait_in_text("modal-dialog", "a-mynode")
         b.click("modal-dialog .btn-danger")
         b.wait_not_present("modal-dialog .dialog-wait-ct")
@@ -592,30 +558,26 @@ class KubernetesCommonTests(VolumeTests):
         b.wait_present(".nodes-listing tbody[data-id='127.0.0.1'] tr.listing-ct-panel")
         self.assertTrue(b.is_visible(".nodes-listing tbody[data-id='127.0.0.1'] tr.listing-ct-panel"))
         b.wait_in_text("tbody[data-id='127.0.0.1'] tr.listing-ct-panel", "Ready")
-        b.wait_present(".nodes-listing tbody[data-id='127.0.0.1'] tr.listing-ct-panel a.machine-jump")
         b.click(".nodes-listing tbody[data-id='127.0.0.1'] tr.listing-ct-panel a.machine-jump")
 
         is_docker = m.execute("docker ps | grep 'cockpit/kubernetes' || true")
-        # When running as a container, localhost only has kubernetes
         if is_docker:
+            # When running as a container, localhost only has kubernetes
             b.wait_present(".dashboard-cards")
-            b.wait_present("a[href='#/nodes']")
             b.click("a[href='#/nodes']")
-        # Normally it goes to system
         else:
+            # Normally it goes to system
             b.enter_page("/system")
             b.switch_to_top()
             b.click("li.dashboard-link a[href='/kubernetes']")
             b.enter_page("/kubernetes")
 
         # Delete from panel
-        b.wait_present(".nodes-listing tbody[data-id='b-mynode']")
         b.click(".nodes-listing tbody[data-id='b-mynode'] tr.listing-ct-item td.listing-ct-toggle")
         b.wait_present(".nodes-listing tbody[data-id='b-mynode'] tr.listing-ct-panel")
         self.assertTrue(b.is_visible(".nodes-listing tbody[data-id='b-mynode'] tr.listing-ct-panel"))
         b.wait_in_text("tbody[data-id='b-mynode'] tr.listing-ct-panel", "Unknown")
         b.click("tbody[data-id='b-mynode'] .listing-ct-actions button.btn-delete")
-        b.wait_present("modal-dialog")
         b.wait_in_text("modal-dialog", "b-mynode")
         b.click("modal-dialog .btn-danger")
         b.wait_not_present("modal-dialog .dialog-wait-ct")
@@ -624,21 +586,17 @@ class KubernetesCommonTests(VolumeTests):
 
         # Delete multiple
         b.wait_present(".nodes-listing")
-        b.wait_present(".content-filter button.fa-check")
         b.click(".content-filter button.fa-check")
         b.wait_present(".content-filter button.fa-check.active")
         b.wait_present(".content-filter button.btn-danger.disabled")
-        b.wait_present("tbody[data-id='c-mynode'] td.listing-ct-toggle input[type=checkbox]")
         b.click("tbody[data-id='c-mynode'] td.listing-ct-toggle input[type=checkbox]")
         b.wait_not_present(".content-filter button.btn-danger.disabled")
         b.wait_present(".content-filter button.btn-danger")
         b.click("tbody[data-id='c-mynode'] td.listing-ct-toggle input[type=checkbox]")
         b.wait_present(".content-filter button.btn-danger.disabled")
         b.click("tbody[data-id='c-mynode'] td.listing-ct-toggle input[type=checkbox]")
-        b.wait_present("tbody[data-id='d-mynode'] td.listing-ct-toggle input[type=checkbox]")
         b.click("tbody[data-id='d-mynode'] td.listing-ct-toggle input[type=checkbox]")
         b.click(".content-filter button.btn-danger")
-        b.wait_present("modal-dialog")
         b.wait_in_text("modal-dialog", "c-mynode")
         b.wait_in_text("modal-dialog", "d-mynode")
         b.wait_not_in_text("modal-dialog", "127.0.0.1")
@@ -646,7 +604,6 @@ class KubernetesCommonTests(VolumeTests):
         b.wait_not_present("modal-dialog")
 
         b.click(".content-filter button.btn-danger")
-        b.wait_present("modal-dialog")
         b.wait_in_text("modal-dialog", "c-mynode")
         b.wait_in_text("modal-dialog", "d-mynode")
         b.click("modal-dialog .btn-danger")
@@ -663,7 +620,6 @@ class KubernetesCommonTests(VolumeTests):
         # The service has loaded and containers instantiated
         self.login_and_go("/kubernetes")
         m.execute("kubectl create -f /tmp/mock-k8s-tiny-app.json")
-        b.wait_present("#service-list tr[data-name='mock'] td.containers")
         b.wait_text("#service-list tr[data-name='mock'] td.containers", "1")
 
         # Switch to topology view
@@ -698,7 +654,6 @@ class KubernetesCommonTests(VolumeTests):
             })""", "true")
 
         b.wait_present("div.sidebar-pf-right")
-        b.wait_present("div.sidebar-pf-right kubernetes-object-describer")
         b.wait_in_text("div.sidebar-pf-right kubernetes-object-describer", "127.0.0.1")
         b.wait_in_text("div.sidebar-pf-right kubernetes-object-describer h3:first", "Node")
 
@@ -712,7 +667,6 @@ class OpenshiftCommonTests(VolumeTests):
         self.openshift.execute("oc expose service docker-registry --hostname=test.example.com")
 
         self.login_and_go("/kubernetes")
-        b.wait_present("#service-list")
         b.wait_in_text("#service-list", "registry")
 
         # Switch to detail view
@@ -731,7 +685,6 @@ class OpenshiftCommonTests(VolumeTests):
 
         # Switch to images view
         b.click("a[href='#/images']")
-        b.wait_present("tbody[data-id='marmalade/busybee']")
         b.wait_in_text("tbody[data-id='marmalade/busybee'] tr", "0.x")
 
         # Switch to topology view
@@ -761,7 +714,6 @@ class OpenshiftCommonTests(VolumeTests):
         b.click(".details-listing tbody[data-id='routes/default/mock'] td.listing-ct-toggle")
         b.wait_visible(".details-listing tbody[data-id='routes/default/mock'] .route-delete")
         b.click(".details-listing tbody[data-id='routes/default/mock'] .route-delete")
-        b.wait_present("modal-dialog")
         b.wait_in_text("modal-dialog .modal-header", "Delete Route")
         b.wait_in_text("modal-dialog .modal-body", "Route 'mock'")
         b.click(".modal-footer button.btn-danger")
@@ -787,17 +739,14 @@ class OpenshiftCommonTests(VolumeTests):
         m.execute("echo '10.111.112.101  f1.cockpit.lan' >> /etc/hosts")
 
         self.login_and_go("/kubernetes")
-        b.wait_present("a[href='#/nodes']")
         b.click("a[href='#/nodes']")
 
-        b.wait_present(".nodes-listing tbody[data-id='f1.cockpit.lan']")
         b.wait_in_text(".nodes-listing tbody[data-id='f1.cockpit.lan'] tr.listing-ct-item", "Ready")
 
         b.click(".nodes-listing tbody[data-id='f1.cockpit.lan'] tr.listing-ct-item td.listing-ct-toggle")
         b.wait_present(".nodes-listing tbody[data-id='f1.cockpit.lan'] tr.listing-ct-panel")
         self.assertTrue(b.is_visible(".nodes-listing tbody[data-id='f1.cockpit.lan'] tr.listing-ct-panel"))
         b.wait_in_text(".nodes-listing tbody[data-id='f1.cockpit.lan'] tr.listing-ct-panel", "10.111.112.101")
-        b.wait_present(".nodes-listing tbody[data-id='f1.cockpit.lan'] tr.listing-ct-panel a.machine-jump")
         b.click(".nodes-listing tbody[data-id='f1.cockpit.lan'] tr.listing-ct-panel a.machine-jump")
 
         b.switch_to_top()
@@ -811,7 +760,6 @@ class OpenshiftCommonTests(VolumeTests):
         # We can accept the key
         b.click("#troubleshoot-dialog .btn-primary")
         b.wait_in_text("#troubleshoot-dialog", 'Log in to')
-        b.wait_present("#troubleshoot-dialog .modal-footer .btn-default")
         b.click("#troubleshoot-dialog .modal-footer .btn-default")
         b.wait_in_text(".curtains-ct", "Login failed")
 
@@ -823,7 +771,6 @@ class OpenshiftCommonTests(VolumeTests):
         b.click('#machine-troubleshoot')
         b.wait_popup('troubleshoot-dialog')
         b.wait_in_text("#troubleshoot-dialog", 'Log in to')
-        b.wait_present("#login-type button")
         b.click("#login-type button")
         b.click("#login-type li[value=password] a")
         b.wait_in_text("#login-type button span", "Type a password")
@@ -838,7 +785,6 @@ class OpenshiftCommonTests(VolumeTests):
 
         b.wait_not_visible(".curtains-ct")
         b.enter_page('/system', "root@10.111.112.101")
-        b.wait_present('#system_information_os_text')
         b.wait_visible('#system_information_os_text')
         b.wait_text_not("#system_information_os_text", "")
         b.logout()
@@ -894,7 +840,6 @@ class RegistryTests(object):
         # Filter the dashboard to marmalide project
         b.click(".dashboard-images .namespace-filter button")
         b.wait_visible(".dashboard-images .namespace-filter .dropdown-menu")
-        b.wait_present(".dashboard-images .namespace-filter a[value='marmalade']")
         b.click(".dashboard-images .namespace-filter a[value='marmalade']")
         b.wait_not_in_text(".card-pf-wide.dashboard-images", "pizzazz/")
         b.wait_in_text(".card-pf-wide.dashboard-images", "marmalade/busybee")
@@ -903,13 +848,11 @@ class RegistryTests(object):
         b.click("a[href='#/images/marmalade/busybee']")
         b.wait_in_text(".content-filter h3", "marmalade/busybee")
         b.click("tbody[data-id='marmalade/busybee:0.x'] tr td.listing-ct-toggle")
-        b.wait_present("tbody[data-id='marmalade/busybee:0.x'] .listing-ct-panel dl.registry-image-tags")
         b.wait_in_text(
             "tbody[data-id='marmalade/busybee:0.x'] .listing-ct-panel dl.registry-image-tags", "marmalade/busybee:0.x")
 
         # Look at the image layers
         b.click(".listing-ct-head li:last-child a")
-        b.wait_present(".listing-ct-body .registry-image-layers")
         b.wait_visible(".listing-ct-body .registry-image-layers")
         b.wait_in_text(".listing-ct-body .registry-image-layers", "KiB")
 
@@ -945,7 +888,6 @@ class RegistryTests(object):
 
         # Go to the images view and create a new imagestream
         b.click("#content a[href='#/images/marmalade']")
-        b.wait_present("a i.pficon-add-circle-o")
         b.click("a i.pficon-add-circle-o")
         b.wait_present("modal-dialog")
         b.wait_visible("#imagestream-modify-name")
@@ -969,9 +911,7 @@ class RegistryTests(object):
         b.wait_visible("tbody[data-id='default/zero']")
 
         # Go to the images view and check annotations
-        b.wait_present("tbody[data-id='default/busybox']")
         b.click("tbody[data-id='default/busybox'] th")
-        b.wait_present(".content-filter h3")
         b.wait_in_text(".content-filter h3", "default/busybox")
         b.wait_in_text("#content", "Annotations")
         b.wait_in_text("registry-imagestream-meta", "openshift.io/image.dockerRepositoryCheck")
@@ -980,7 +920,6 @@ class RegistryTests(object):
         b.go("#/images/marmalade/busybee:0.x")
         b.wait_in_text(".content-filter h3", "marmalade/busybee:0.x")
         b.click(".pficon-delete")
-        b.wait_present("modal-dialog")
         b.click("modal-dialog .btn-danger")
         b.wait_not_present("modal-dialog")
 
@@ -989,13 +928,10 @@ class RegistryTests(object):
         b.wait_not_in_text("#content", "0.x")
 
         # Delete via the main UI
-        b.wait_present("tbody[data-id='marmalade/busybee:latest']")
         b.click("tbody[data-id='marmalade/busybee:latest'] tr.listing-ct-item td.listing-ct-toggle")
-        b.wait_present("tbody[data-id='marmalade/busybee:latest'] .listing-ct-panel dl.registry-image-tags")
         b.wait_in_text(
             "tbody[data-id='marmalade/busybee:latest'] .listing-ct-panel dl.registry-image-tags", "marmalade/busybee:latest")
         b.click("tbody[data-id='marmalade/busybee:latest'] .listing-ct-head .pficon-delete")
-        b.wait_present("modal-dialog")
         b.click("modal-dialog .btn-danger")
         b.wait_not_present("modal-dialog")
 
@@ -1005,7 +941,6 @@ class RegistryTests(object):
         # Show the image on the right screen
         b.go("#/images/marmalade/juggs")
         b.wait_in_text(".content-filter h3", "marmalade/juggs")
-        b.wait_present("tbody[data-id='marmalade/juggs:2.9']")
         b.click("tbody[data-id='marmalade/juggs:2.9'] tr.listing-ct-item td.listing-ct-toggle")
 
         # Various labels should show up in this image
@@ -1016,21 +951,16 @@ class RegistryTests(object):
 
         # And some key labels shouldn't show up on the metadata
         b.click("tbody[data-id='marmalade/juggs:2.9'] .listing-ct-head li:last-child a")
-        b.wait_present("tbody[data-id='marmalade/juggs:2.9'] registry-image-meta")
         b.wait_in_text("tbody[data-id='marmalade/juggs:2.9'] registry-image-meta", "build-date=2016-03-04")
 
         # Check panel navigations
         b.go("#/images")
-        b.wait_present("tbody[data-id='marmalade/juggs']")
         b.wait_in_text("tbody[data-id='marmalade/juggs'] tr", "and 1 other")
         b.wait_present("tbody[data-id='marmalade/juggs'] tr td a.registry-image-tag:contains('2.11')")
         b.click("tbody[data-id='marmalade/juggs'] tr td.listing-ct-toggle")
         b.wait_visible("tbody[data-id='marmalade/juggs'] tr.listing-ct-panel")
-        b.wait_present("tbody[data-id='marmalade/juggs'] tr.listing-ct-panel ul li:contains('Tags')")
         b.click("tbody[data-id='marmalade/juggs'] tr.listing-ct-panel ul li:contains('Tags') a")
         b.wait_present("tbody[data-id='marmalade/juggs'] tr.listing-ct-panel td table.listing-ct")
-        b.wait_present(
-            "tbody[data-id='marmalade/juggs'] tr.listing-ct-panel td table.listing-ct tbody[data-id='marmalade/juggs:latest']")
         b.wait_in_text(
             "tbody[data-id='marmalade/juggs'] tr.listing-ct-panel td table.listing-ct tbody[data-id='marmalade/juggs:latest'] tr th", "latest")
         b.click(
@@ -1040,16 +970,13 @@ class RegistryTests(object):
         b.wait_text(".content-filter h3 span", "marmalade/juggs:latest")
 
         b.go("#/images")
-        b.wait_present("tbody[data-id='marmalade/juggs']")
         b.wait_in_text("tbody[data-id='marmalade/juggs'] tr", "and 1 other")
-        b.wait_present("tbody[data-id='marmalade/juggs'] tr td a.registry-image-tag:contains('2.11')")
         b.click("tbody[data-id='marmalade/juggs'] tr td a.registry-image-tag:contains('2.11')")
         b.wait_js_cond('window.location.hash == "#/images/marmalade/juggs:2.11"')
         b.wait_present("#content div.listing-ct-inline")
         b.wait_in_text(".content-filter h3", "marmalade/juggs:2.11")
 
         b.go("#/images")
-        b.wait_present("tbody[data-id='marmalade/juggs'] tr")
         b.wait_in_text("tbody[data-id='marmalade/juggs'] tr", "and 1 other")
         b.click("tbody[data-id='marmalade/juggs'] tr")
         b.wait_js_cond('window.location.hash == "#/images/marmalade/juggs"')
@@ -1061,7 +988,6 @@ class RegistryTests(object):
 
         self.login_and_go(self.registry_root)
         b.wait_present(".dashboard-images")
-        b.wait_present("#content a[href='#/images/marmalade']")
         b.click("#content a[href='#/images/marmalade']")
         b.wait_visible("a:contains('New image stream')")
 
@@ -1120,7 +1046,6 @@ class RegistryTests(object):
         b.wait_visible("#add_user_to_group")
         b.click("#add_user_to_group button")
         b.wait_visible("#add_user_to_group .dropdown-menu")
-        b.wait_present(".dropdown-menu a[value='scruffy']")
         b.wait_visible(".dropdown-menu a[value='scruffy']")
         b.click(".dropdown-menu a[value='scruffy']")
         b.click(".btn-primary")
@@ -1138,7 +1063,6 @@ class RegistryTests(object):
         b.wait_visible("#add_user_to_group")
         b.click("#add_user_to_group button")
         b.wait_visible("#add_user_to_group .dropdown-menu")
-        b.wait_present(".dropdown-menu a[value='scruffy']")
         b.wait_visible(".dropdown-menu a[value='scruffy']")
         b.click(".dropdown-menu a[value='scruffy']")
         b.click(".btn-primary")
@@ -1186,7 +1110,6 @@ class RegistryTests(object):
         b.wait_not_present("modal-dialog")
 
         #wait for it
-        b.wait_present("tbody[data-id='testprojectuser']")
 
         #goto user page
         b.click("tbody[data-id='testprojectuser'] tr:first-child td:nth-of-type(2)")
@@ -1216,7 +1139,6 @@ class RegistryTests(object):
         b.wait_not_present("modal-dialog")
 
         #delete project member X
-        b.wait_present("tbody[data-id='testprojectuserproj'] tr td:last-child a i.pficon-close")
         b.click("tbody[data-id='testprojectuserproj'] tr td:last-child a i.pficon-close")
         b.wait_present("modal-dialog")
         b.wait_visible(".modal-body")
@@ -1239,7 +1161,6 @@ class RegistryTests(object):
 
         #add another role to project member
         b.wait_present("tbody[data-id='testprojectuserproj']")
-        b.wait_present("tbody[data-id='testprojectuserproj'] tr .btn-group")
         b.wait_visible("tbody[data-id='testprojectuserproj'] tr .btn-group")
         b.click("tbody[data-id='testprojectuserproj'] tr .btn-group button")
         b.wait_visible("tbody[data-id='testprojectuserproj'] tr .btn-group .dropdown-menu")
@@ -1294,7 +1215,6 @@ class RegistryTests(object):
 
         # try to add user with invalid name from testprojectuserproj page
         b.go("#/projects/testprojectuserproj")
-        b.wait_present("a i.pficon-add-circle-o")
         b.click("a i.pficon-add-circle-o")
         b.wait_present("modal-dialog")
         b.wait_visible("#add_member_name")
@@ -1315,7 +1235,6 @@ class RegistryTests(object):
         self.assertNotIn('foo ^ bar', o.execute("oc get rolebinding -n testprojectuserproj"))
 
         # service accounts should be accepted
-        b.wait_present("a i.pficon-add-circle-o")
         b.click("a i.pficon-add-circle-o")
         b.wait_present("modal-dialog")
         b.wait_visible("#add_member_name")
@@ -1380,7 +1299,6 @@ class RegistryTests(object):
         b.wait_in_text(".content-filter h3", "testprojectpolicyproj")
 
         #add user with role
-        b.wait_present("a i.pficon-add-circle-o")
         b.click("a i.pficon-add-circle-o")
         b.wait_present("modal-dialog")
         b.wait_visible("#add_member_group")
@@ -1394,7 +1312,6 @@ class RegistryTests(object):
         b.wait_not_present("modal-dialog")
 
         b.wait_present(".inner-project-listing")
-        b.wait_present("a i.pficon-add-circle-o")
         b.click("a i.pficon-add-circle-o")
         b.wait_present("modal-dialog")
         b.wait_visible("#add_member_group")
@@ -1405,7 +1322,6 @@ class RegistryTests(object):
         b.wait_not_present("modal-dialog")
 
         b.wait_present(".inner-project-listing")
-        b.wait_present("a i.pficon-add-circle-o")
         b.click("a i.pficon-add-circle-o")
         b.wait_present("modal-dialog")
         b.wait_visible("#add_member_group")
@@ -1420,7 +1336,6 @@ class RegistryTests(object):
 
         # Add a non-existent user
         b.wait_present(".inner-project-listing")
-        b.wait_present("a i.pficon-add-circle-o")
         b.click("a i.pficon-add-circle-o")
         b.wait_present("modal-dialog")
         b.wait_visible("#add_member_group")
@@ -1433,7 +1348,6 @@ class RegistryTests(object):
 
         # Add a non-existent user, negative case
         b.wait_present(".inner-project-listing")
-        b.wait_present("a i.pficon-add-circle-o")
         b.click("a i.pficon-add-circle-o")
         b.wait_present("modal-dialog")
         b.wait_visible("#add_member_group")
@@ -1456,7 +1370,6 @@ class RegistryTests(object):
         self.login_and_go(self.registry_root)
 
         # Make sure the default view is not visible to non cluster admins
-        b.wait_present(".dashboard-images")
         b.wait_visible(".dashboard-images:nth-child(1)")
         b.wait_not_in_text(".card-pf-wide.dashboard-images", "default/busybox")
 
@@ -1536,7 +1449,6 @@ class RegistryTests(object):
         # Go and modify the project
         b.go("#/projects")
         b.wait_present("tbody[data-id='llama']")
-        b.wait_present("tbody[data-id='llama'] tr.listing-ct-item")
         b.click("tbody[data-id='llama'] tr.listing-ct-item td:nth-of-type(2)")
         b.wait_in_text(".content-filter h3", "Display llama (llama)")
         b.wait_in_text("#content", "Description goes here")
@@ -1594,7 +1506,6 @@ class RegistryTests(object):
         b.wait_visible(".dashboard-images .namespace-filter")
         b.click(".dashboard-images .namespace-filter button")
         b.wait_visible(".dashboard-images .namespace-filter .dropdown-menu")
-        b.wait_present(".dashboard-images .namespace-filter a[value='pizzazz']")
         b.click(".dashboard-images .namespace-filter a[value='pizzazz']")
         b.wait_visible('#docker-pull-commands')
         b.wait_not_visible('#docker-push-commands')
@@ -1602,7 +1513,6 @@ class RegistryTests(object):
         # push user should see docker push and pull commands on marmalade overview page
         b.click(".dashboard-images .namespace-filter button")
         b.wait_visible(".dashboard-images .namespace-filter .dropdown-menu")
-        b.wait_present(".dashboard-images .namespace-filter a[value='marmalade']")
         b.click(".dashboard-images .namespace-filter a[value='marmalade']")
         b.wait_visible('#docker-push-commands')
 
@@ -1627,7 +1537,6 @@ class RegistryTests(object):
         b.wait_visible(".dashboard-images .namespace-filter")
         b.click(".dashboard-images .namespace-filter button")
         b.wait_visible(".dashboard-images .namespace-filter .dropdown-menu")
-        b.wait_present(".dashboard-images .namespace-filter a[value='marmalade']")
         b.click(".dashboard-images .namespace-filter a[value='marmalade']")
         b.wait_visible('#docker-pull-commands')
         b.wait_not_visible('#docker-push-commands')
@@ -1648,11 +1557,9 @@ class RegistryTests(object):
         b.wait_present("modal-dialog")
         b.wait_val("#imagestream-modify-project-text", "marmalade")
         b.set_val("#imagestream-modify-name", "alltags")
-        b.wait_present("#imagestream-modify-populate")
         b.click("#imagestream-modify-populate button")
         b.wait_visible("#imagestream-modify-populate .dropdown-menu")
         b.click("#imagestream-modify-populate .dropdown-menu a[value='pull']")
-        b.wait_present("#imagestream-modify-pull")
         b.wait_visible("#imagestream-modify-pull")
         b.set_val("#imagestream-modify-pull", "localhost:5555/juggs")
         b.click("modal-dialog div.modal-footer button.btn-primary")
@@ -1660,7 +1567,6 @@ class RegistryTests(object):
 
         # new stream with both "latest" and "2.11" tags should now appear
         b.wait_present("tr.imagestream-item th:contains('marmalade/alltags')")
-        b.wait_present('tbody[data-id="marmalade/alltags"]')
         b.wait_in_text('tbody[data-id="marmalade/alltags"] tr', "latest")
         b.wait_in_text('tbody[data-id="marmalade/alltags"] tr', "2.11")
 
@@ -1676,11 +1582,9 @@ class RegistryTests(object):
         b.wait_val("#imagestream-modify-project-text", "marmalade")
         b.wait_js_cond("document.activeElement == document.getElementById('imagestream-modify-name')")
         b.set_val("#imagestream-modify-name", "sometags")
-        b.wait_present("#imagestream-modify-populate")
         b.click("#imagestream-modify-populate button")
         b.wait_visible("#imagestream-modify-populate .dropdown-menu")
         b.click("#imagestream-modify-populate .dropdown-menu a[value='tags']")
-        b.wait_present("#imagestream-modify-tags")
         b.wait_visible("#imagestream-modify-tags")
         b.set_val("#imagestream-modify-pull", "localhost:5555/juggs")
         # fields.tags is not an <input> element, type manually

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -257,11 +257,9 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
-        b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "running")
 
         m.execute('[ "$(virsh domstate {0})" = running ] || '
@@ -277,13 +275,10 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
-        b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "running")
-        b.wait_present("#vm-subVmTest1-vcpus")
         b.wait_in_text("#vm-subVmTest1-vcpus", "1")
 
         b.wait_in_text("#vm-subVmTest1-bootorder", "disk,network")
@@ -291,13 +286,10 @@ class TestMachines(NetworkCase):
         self.assertTrue(len(emulated_machine) > 0) # emulated machine varies across test machines
 
         # switch to and check Usage
-        b.wait_present("#vm-subVmTest1-usage")
         b.click("#vm-subVmTest1-usage")
-        b.wait_present("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption")
         b.wait_in_text("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption", "256 MiB")
         b.wait_present("#chart-donut-0 .donut-title-big-pf")
         b.wait(lambda: float(b.text("#chart-donut-0 .donut-title-big-pf")) > 0.0)
-        b.wait_present("tbody.open .listing-ct-body td:nth-child(2) .usage-donut-caption")
         b.wait_in_text("tbody.open .listing-ct-body td:nth-child(2) .usage-donut-caption", "1 vCPU")
         # CPU usage cannot be nonzero with blank image, so just ensure it's a percentage
         b.wait_present("#chart-donut-1 .donut-title-big-pf")
@@ -338,18 +330,14 @@ class TestMachines(NetworkCase):
 
         # start another one, should appear automatically
         self.startVm("subVmTest2")
-        b.wait_present("#virtual-machines-listing .listing-ct tbody:nth-of-type(2) th")
         b.wait_in_text("#virtual-machines-listing .listing-ct tbody:nth-of-type(2) th", "subVmTest2")
         b.click("#virtual-machines-listing .listing-ct tbody:nth-of-type(2) th") # click on the row header
-        b.wait_present("#vm-subVmTest2-state")
         b.wait_in_text("#vm-subVmTest2-state", "running")
-        b.wait_present("#vm-subVmTest2-vcpus")
         b.wait_in_text("#vm-subVmTest2-vcpus", "1")
         b.wait_in_text("#vm-subVmTest2-bootorder", "disk,network")
 
         # restart libvirtd
         m.execute("systemctl stop libvirtd.service")
-        b.wait_present("#slate-header")
         b.wait_in_text("#slate-header", "Virtualization Service (libvirt) is Not Active")
         m.execute("systemctl start libvirtd.service")
         # HACK: https://launchpad.net/bugs/1802005
@@ -357,17 +345,12 @@ class TestMachines(NetworkCase):
             m.execute("chmod o+rwx /run/libvirt/libvirt-sock")
         b.wait_in_text("body", "Virtual Machines")
         b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
-        b.wait_present("#virtual-machines-listing .listing-ct tbody:nth-of-type(1) th")
         b.wait_in_text("#virtual-machines-listing .listing-ct tbody:nth-of-type(1) th", "subVmTest1")
-        b.wait_present("#virtual-machines-listing .listing-ct tbody:nth-of-type(2) th")
         b.wait_in_text("#virtual-machines-listing .listing-ct tbody:nth-of-type(2) th", "subVmTest2")
-        b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "shut off")
-        b.wait_present("#vm-subVmTest2-state")
         b.wait_in_text("#vm-subVmTest2-state", "running")
 
         # stop second VM, event handling should still work
-        b.wait_present("#virtual-machines-listing .listing-ct tbody:nth-of-type(2) th")
         b.wait_in_text("#virtual-machines-listing .listing-ct tbody:nth-of-type(2) th", "subVmTest2")
         b.click("#virtual-machines-listing .listing-ct tbody:nth-of-type(2) th") # click on the row header
         b.click("#vm-subVmTest2-off-caret")
@@ -382,11 +365,9 @@ class TestMachines(NetworkCase):
         # triangle by status
         b.wait_present("tr.listing-ct-item.listing-ct-nonavigate span span.pficon-warning-triangle-o.machines-status-alert")
         # inline notification with error
-        b.wait_present("div.alert.alert-danger strong")
         b.wait_in_text("div.alert.alert-danger strong", "VM subVmTest2 failed to start")
 
-        b.wait_present("a.alert-link.machines-more-button") # more/less button
-        b.wait_in_text("a.alert-link.machines-more-button", "show more")
+        b.wait_in_text("a.alert-link.machines-more-button", "show more") # more/less button
         b.click("a.alert-link.machines-more-button")
         b.wait_present("a.alert-link + p")
 
@@ -412,7 +393,6 @@ class TestMachines(NetworkCase):
         m.execute("virsh destroy subVmTest2 && virsh destroy subVmTest3 && virsh net-destroy default")
 
         def tryRunDomain(index, name):
-            b.wait_present("#virtual-machines-listing .listing-ct tbody:nth-of-type({0}) th".format(index))
             b.wait_in_text("#virtual-machines-listing .listing-ct tbody:nth-of-type({0}) th".format(index), name)
 
             row_classes = b.attr("#virtual-machines-listing .listing-ct tbody:nth-of-type({0})".format(index), "class")
@@ -420,36 +400,29 @@ class TestMachines(NetworkCase):
             if not expanded:
                 b.click("#virtual-machines-listing .listing-ct tbody:nth-of-type({0}) th".format(index)) # click on the row header
 
-            b.wait_present("#vm-{0}-run".format(name))
             b.click("#vm-{0}-run".format(name))
 
         # Try to run subVmTest1 - it will fail because of inactive default network
         tryRunDomain(1, 'subVmTest1')
-        b.wait_present(".toast-notifications-list-pf div:nth-child(1) strong")
         b.wait_in_text(".toast-notifications-list-pf div:nth-child(1) strong", "VM subVmTest1 failed to start")
 
         # Try to run subVmTest2
         tryRunDomain(2, 'subVmTest2')
-        b.wait_present(".toast-notifications-list-pf div:nth-child(2) strong")
         b.wait_in_text(".toast-notifications-list-pf div:nth-child(2) strong", "VM subVmTest2 failed to start")
 
         # Delete the first notification and check notifications list again
         b.focus(".toast-notifications-list-pf")
-        b.wait_present(".toast-notifications-list-pf div:nth-child(1)")
         b.click(".toast-notifications-list-pf div:nth-child(1) button.close")
         b.wait_not_present(".toast-notifications-list-pf div:nth-child(2) strong")
         b.wait_in_text(".toast-notifications-list-pf div:nth-child(1) strong", "VM subVmTest2 failed to start")
 
         # Add one more notification
         tryRunDomain(3, 'subVmTest3')
-        b.wait_present(".toast-notifications-list-pf div:nth-child(1) strong")
         b.wait_in_text(".toast-notifications-list-pf div:nth-child(1) strong", "VM subVmTest2 failed to start")
-        b.wait_present(".toast-notifications-list-pf div:nth-child(2) strong")
         b.wait_in_text(".toast-notifications-list-pf div:nth-child(2) strong", "VM subVmTest3 failed to start")
 
         # Delete the last notification
         b.focus(".toast-notifications-list-pf")
-        b.wait_present(".toast-notifications-list-pf div:nth-child(2) button.close")
         b.click(".toast-notifications-list-pf div:nth-child(2) button.close")
         b.wait_not_present(".toast-notifications-list-pf div:nth-child(2) strong")
         b.wait_in_text(".toast-notifications-list-pf div:nth-child(1) strong", "VM subVmTest2 failed to start")
@@ -483,13 +456,11 @@ class TestMachines(NetworkCase):
         self.login_and_go("/machines")
 
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         m.execute("systemctl disable {0}".format(libvirtServiceName))
         m.execute("systemctl stop {0}".format(libvirtServiceName))
 
-        b.wait_present("#slate-header")
         b.wait_in_text("#slate-header", "Virtualization Service (libvirt) is Not Active")
         b.wait_present("#enable-libvirt:checked")
         b.click("#start-libvirt")
@@ -499,11 +470,9 @@ class TestMachines(NetworkCase):
         if self.provider == "libvirt-dbus" and m.image == "ubuntu-stable":
             m.execute("chmod o+rwx /run/libvirt/libvirt-sock")
         b.wait(lambda: checkLibvirtEnabled())
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         m.execute("systemctl stop {0}".format(libvirtServiceName))
-        b.wait_present("#slate-header")
         b.wait_in_text("#slate-header", "Virtualization Service (libvirt) is Not Active")
         b.wait_present("#enable-libvirt:checked")
         b.click("#enable-libvirt") # uncheck it ; ; TODO: fix this, do not assume initial state of the checkbox
@@ -513,13 +482,11 @@ class TestMachines(NetworkCase):
         if self.provider == "libvirt-dbus" and m.image == "ubuntu-stable":
             m.execute("chmod o+rwx /run/libvirt/libvirt-sock")
         b.wait(lambda: not checkLibvirtEnabled())
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         m.execute("systemctl enable {0}".format(libvirtServiceName))
         m.execute("systemctl stop {0}".format(libvirtServiceName))
 
-        b.wait_present("#slate-header")
         b.wait_in_text("#slate-header", "Virtualization Service (libvirt) is Not Active")
         b.wait_present("#enable-libvirt:checked")
 
@@ -536,14 +503,11 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
-        b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "running")
 
-        b.wait_present("#vm-subVmTest1-disks") # wait for the tab
         b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
 
         # Test basic disk properties
@@ -559,7 +523,6 @@ class TestMachines(NetworkCase):
         self.wait_for_disk_stats("subVmTest1", "hda")
         if b.is_present("#vm-subVmTest1-disks-hda-used"):
             b.wait_in_text("#vm-subVmTest1-disks-hda-used", "0.0")
-            b.wait_present("#vm-subVmTest1-disks-hdb-used")
             b.wait_in_text("#vm-subVmTest1-disks-hdb-used", "0.0")
 
             b.wait_in_text("#vm-subVmTest1-disks-hdb-capacity", "1")
@@ -573,7 +536,6 @@ class TestMachines(NetworkCase):
 
         b.wait_in_text("#vm-subVmTest1-disks-hda-bus", "ide")
 
-        b.wait_present("#vm-subVmTest1-disks-vdc-device") # verify after modal dialog close
         b.wait_in_text("#vm-subVmTest1-disks-vdc-bus", "virtio")
         b.wait_in_text("#vm-subVmTest1-disks-vdc-device", "disk")
         b.wait_in_text("#vm-subVmTest1-disks-vdc-source", "/var/lib/libvirt/images/image3.img")
@@ -612,20 +574,15 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
-        b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "running")
 
-        b.wait_present("#vm-subVmTest1-disks") # wait for the tab
         b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
 
-        b.wait_present("#vm-subVmTest1-disks-adddisk") # button
-        b.click("#vm-subVmTest1-disks-adddisk")
+        b.click("#vm-subVmTest1-disks-adddisk") # button
         b.wait_present("label:contains(Create New)") # radio button label in the modal dialog
-        b.wait_present("#vm-subVmTest1-disks-adddisk-new-select-pool")
 
         b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", "myPoolOne")
         b.set_input_text("#vm-subVmTest1-disks-adddisk-new-name", "mydiskofpoolone_temporary")
@@ -639,31 +596,25 @@ class TestMachines(NetworkCase):
         b.wait_in_text("#vm-subVmTest1-state", "running") # re-check
         b.click("#vm-subVmTest1-disks-adddisk-dialog-add")
         b.wait_not_present("#vm-subVmTest1-test-disks-adddisk-dialog-modal-window")
-        b.wait_present("#vm-subVmTest1-disks-vda-device") # verify after modal dialog close
         b.wait_in_text("#vm-subVmTest1-disks-vda-bus", "virtio")
         b.wait_in_text("#vm-subVmTest1-disks-vda-device", "disk")
         # should be gone after shut down
         b.wait_in_text("#vm-subVmTest1-disks-vda-source", "mydiskofpoolone_temporary")
 
         b.click("#vm-subVmTest1-disks-adddisk")
-        b.wait_present("#vm-subVmTest1-disks-adddisk-new-permanent")
-        b.wait_present("#vm-subVmTest1-disks-adddisk-new-name")
         b.click("#vm-subVmTest1-disks-adddisk-new-permanent")
         b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", "myPoolOne")
         b.set_input_text("#vm-subVmTest1-disks-adddisk-new-name", "mydiskofpoolone_permanent")
         b.set_input_text("#vm-subVmTest1-disks-adddisk-new-size", "2") # keep GiB and qcow2 format
         b.click("#vm-subVmTest1-disks-adddisk-dialog-add")
         b.wait_not_present("#vm-subVmTest1-test-disks-adddisk-dialog-modal-window")
-        b.wait_present("#vm-subVmTest1-disks-vdb-device") # verify after modal dialog close
         b.wait_in_text("#vm-subVmTest1-disks-vdb-bus", "virtio")
         b.wait_in_text("#vm-subVmTest1-disks-vdb-device", "disk")
         b.wait_in_text("#vm-subVmTest1-disks-vdb-source",
                        "mydiskofpoolone_permanent") # should survive the shut down
 
-        b.click("#vm-subVmTest1-disks-adddisk")
-        b.wait_present("label:contains(Use Existing)") # radio button label in the modal dialog
+        b.click("#vm-subVmTest1-disks-adddisk") # radio button label in the modal dialog
         b.click("label:contains(Use Existing)") # radio button label in the modal dialog
-        b.wait_present("#vm-subVmTest1-disks-adddisk-existing-select-pool")
         b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "myPoolOne")
         # since both disks are already attached
         b.wait_attr("#vm-subVmTest1-disks-adddisk-existing-select-volume", "disabled", "")
@@ -671,18 +622,14 @@ class TestMachines(NetworkCase):
         b.click("#vm-subVmTest1-disks-adddisk-dialog-cancel")
         b.wait_not_present("#vm-subVmTest1-test-disks-adddisk-dialog-modal-window")
 
-        b.click("#vm-subVmTest1-disks-adddisk")
-        b.wait_present("label:contains(Use Existing)") # radio button label in the modal dialog
+        b.click("#vm-subVmTest1-disks-adddisk") # radio button label in the modal dialog
         b.click("label:contains(Use Existing)") # radio button label in the modal dialog
-        b.wait_present("#vm-subVmTest1-disks-adddisk-existing-select-volume")
-        b.wait_present("#vm-subVmTest1-disks-adddisk-existing-permanent")
         b.click("#vm-subVmTest1-disks-adddisk-existing-permanent")
         b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "myPoolTwo")
         b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-volume", "mydiskofpooltwo_permanent")
         b.click("#vm-subVmTest1-disks-adddisk-dialog-add")
 
         b.wait_not_present("#vm-subVmTest1-test-disks-adddisk-dialog-modal-window")
-        b.wait_present("#vm-subVmTest1-disks-vdc-device") # verify after modal dialog close
         b.wait_in_text("#vm-subVmTest1-disks-vdc-bus", "virtio")
         b.wait_in_text("#vm-subVmTest1-disks-vdc-device", "disk")
         b.wait_in_text("#vm-subVmTest1-disks-vdc-source", "mydiskofpooltwo_permanent")
@@ -697,28 +644,24 @@ class TestMachines(NetworkCase):
         # or adding the _temporary volume results in showing that the _permanent one actually gets added
         # See https://github.com/cockpit-project/cockpit/issues/9945
         # b.click("#vm-subVmTest1-disks-adddisk")
-        # b.wait_present(".add-disk-dialog label:contains(Use Existing)") # radio button label in the modal dialog
         # b.click(".add-disk-dialog label:contains(Use Existing)") # radio button label in the modal dialog
         # b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-pool", "myPoolTwo")
         # b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-select-volume", "mydiskofpooltwo_temporary")
         # b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-existing-target", "vdb")
         # b.click(".modal-footer button:contains(Add)")
         # b.wait_not_present("#cockpit_modal_dialog")
-        # b.wait_present("#vm-subVmTest1-disks-vdb-target") # verify after modal dialog close
         # b.wait_in_text("#vm-subVmTest1-disks-vdb-target", "vdb")
         # b.wait_in_text("#vm-subVmTest1-disks-vdb-bus", "virtio")
         # b.wait_in_text("#vm-subVmTest1-disks-vdb-device", "disk")
         # b.wait_in_text("#vm-subVmTest1-disks-vdb-source", "/mnt/vm_two/mydiskofpooltwo_temporary")
 
         # check the autoselected options
-        b.click("#vm-subVmTest1-disks-adddisk")
-        b.wait_present("label:contains(Use Existing)") # radio button label in modal dialog
+        b.click("#vm-subVmTest1-disks-adddisk") # radio button label in modal dialog
         b.click("label:contains(Use Existing)")
         # default_tmp pool should be autoselected since it's the first in alphabetical order
         # defaultVol volume should be autoselected since it's the only volume in default_tmp pool
         b.click("#vm-subVmTest1-disks-adddisk-dialog-add")
         b.wait_not_present("#vm-subVmTest1-test-disks-adddisk-dialog-modal-window")
-        b.wait_present("#vm-subVmTest1-disks-vdd-device") # verify after modal dialog close
         b.wait_in_text("#vm-subVmTest1-disks-vdd-bus", "virtio")
         b.wait_in_text("#vm-subVmTest1-disks-vdd-device", "disk")
         b.wait_in_text("#vm-subVmTest1-disks-vdd-source", "defaultVol")
@@ -743,17 +686,13 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
-        b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "running")
 
-        b.wait_present("#vm-subVmTest1-networks") # wait for the tab
         b.click("#vm-subVmTest1-networks") # open the "Networks" subtab
 
-        b.wait_present("#vm-subVmTest1-network-1-type")
         b.wait_in_text("#vm-subVmTest1-network-1-type", "network")
         b.wait_in_text("#vm-subVmTest1-network-1-source", "default")
 
@@ -762,7 +701,6 @@ class TestMachines(NetworkCase):
         # Test add network
         m.execute("virsh attach-interface --domain subVmTest1 --type network --source default --model virtio --mac 52:54:00:4b:73:5f --config --live")
 
-        b.wait_present("#vm-subVmTest1-network-2-type")
         b.wait_in_text("#vm-subVmTest1-network-2-type", "network")
         b.wait_in_text("#vm-subVmTest1-network-2-source", "default")
         b.wait_in_text("#vm-subVmTest1-network-2-model", "virtio")
@@ -778,14 +716,11 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
         b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
 
-        b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "running")
 
-        b.wait_present("#vm-subVmTest1-vcpus-count") # wait for the tab
         b.click("#vm-subVmTest1-vcpus-count") # open VCPU modal detail window
 
         b.wait_present(".vcpu-detail-modal-table")
@@ -851,7 +786,6 @@ class TestMachines(NetworkCase):
         b.wait_in_text("#vm-subVmTest1-state", "shut off")
 
         # Open dialog
-        b.wait_present("#vm-subVmTest1-vcpus-count")
         b.click("#vm-subVmTest1-vcpus-count")
 
         b.wait_present(".vcpu-detail-modal-table")
@@ -877,7 +811,6 @@ class TestMachines(NetworkCase):
         b.wait_in_text("#vm-subVmTest1-state", "running")
 
         # Open dialog
-        b.wait_present("#vm-subVmTest1-vcpus-count")
         b.click("#vm-subVmTest1-vcpus-count")
 
         b.wait_present(".vcpu-detail-modal-table")
@@ -902,23 +835,18 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
-        b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "running") # running or paused
 
-        b.wait_present("#vm-subVmTest1-consoles") # wait for the tab
         b.click("#vm-subVmTest1-consoles") # open the "Console" subtab
 
         # since VNC is not defined for this VM, the view for "Desktop Viewer" is rendered by default
-        b.wait_present("#vm-subVmTest1-consoles-manual-address") # wait for the tab
         b.wait_in_text("#vm-subVmTest1-consoles-manual-address", "127.0.0.1")
         b.wait_in_text("#vm-subVmTest1-consoles-manual-port-spice", "5900")
 
-        b.wait_present("#vm-subVmTest1-consoles-launch") # "Launch Remote Viewer" button
-        b.click("#vm-subVmTest1-consoles-launch")
+        b.click("#vm-subVmTest1-consoles-launch") # "Launch Remote Viewer" button
         b.wait_present("#dynamically-generated-file") # is .vv file generated for download?
         self.assertEqual(b.attr("#dynamically-generated-file", "href"),
                          u"data:application/x-virt-viewer,%5Bvirt-viewer%5D%0Atype%3Dspice%0Ahost%3D127.0.0.1%0Aport%3D5900%0Adelete-this-file%3D1%0Afullscreen%3D0%0A")
@@ -930,14 +858,11 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
-        b.wait_present("#vm-subVmTest1-state")
         b.wait_in_text("#vm-subVmTest1-state", "running") # running or paused
 
-        b.wait_present("#vm-subVmTest1-consoles") # wait for the tab
         b.click("#vm-subVmTest1-consoles") # open the "Console" subtab
 
         # since VNC is defined for this VM, the view for "In-Browser Viewer" is rendered by default
@@ -954,7 +879,6 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest1] th")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", name)
 
         m.execute("test -f {0}".format(img2))
@@ -964,13 +888,10 @@ class TestMachines(NetworkCase):
         def addDisk(volName, poolName):
             # Virsh does not offer some option to create disks of type volume
             # We have to do this from cockpit UI
-            b.wait_present("#vm-subVmTest1-disks") # wait for the tab
             b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
 
-            b.wait_present("#vm-subVmTest1-disks-adddisk") # button
-            b.click("#vm-subVmTest1-disks-adddisk")
+            b.click("#vm-subVmTest1-disks-adddisk") # button
             b.wait_present("label:contains(Create New)") # radio button label in the modal dialog
-            b.wait_present("#vm-subVmTest1-disks-adddisk-new-select-pool")
 
             b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", poolName)
             b.set_input_text("#vm-subVmTest1-disks-adddisk-new-name", volName)
@@ -988,10 +909,8 @@ class TestMachines(NetworkCase):
         secondDiskPoolPath = "/var/lib/libvirt/images/"
         addDisk(secondDiskVolName, poolName)
 
-        b.wait_present("#vm-{0}-delete".format(name))
         b.click("#vm-{0}-delete".format(name))
 
-        b.wait_present("#vm-{0}-delete-modal-dialog".format(name))
         b.wait_present("#vm-{0}-delete-modal-dialog div:contains(The VM is running)".format(name))
         b.wait_present("#vm-{1}-delete-modal-dialog ul li:first-child #disk-source-file:contains({0})".format(img2, name))
         # virsh attach-disk does not create disks of type volume
@@ -1018,25 +937,19 @@ class TestMachines(NetworkCase):
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
-        b.wait_present("tbody tr[data-row-id=vm-{0}] th".format(name))
         b.wait_in_text("tbody tr[data-row-id=vm-{0}] th".format(name), name)
 
         b.click("tbody tr[data-row-id=vm-{0}] th".format(name)) # click on the row header
-        b.wait_present("#vm-{0}-state".format(name))
         b.wait_in_text("#vm-{0}-state".format(name), "running") # running or paused
 
-        b.wait_present("#vm-{0}-consoles".format(name)) # wait for the tab
         b.click("#vm-{0}-consoles".format(name)) # open the "Console" subtab
 
-        b.wait_present("#console-type-select")
         b.set_val("#console-type-select", "serial-browser")
         b.wait_present("div.terminal canvas.xterm-text-layer") # if connected the xterm canvas is rendered
 
-        b.wait_present("#{0}-serialconsole-reconnect".format(name))
         b.click("#{0}-serialconsole-reconnect".format(name))
         b.wait_present("div.terminal canvas.xterm-text-layer")
 
-        b.wait_present("#{0}-serialconsole-disconnect".format(name))
         b.click("#{0}-serialconsole-disconnect".format(name))
         b.wait_not_present("div.terminal canvas.xterm-text-layer")
         b.wait_present("div.blank-slate-pf")
@@ -1445,7 +1358,6 @@ class TestMachines(NetworkCase):
         def open(self):
             b = self.browser
 
-            b.wait_present("#create-new-vm")
             b.click("#create-new-vm")
             b.wait_present("#create-vm-dialog")
             b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create New Virtual Machine")
@@ -1484,7 +1396,6 @@ class TestMachines(NetworkCase):
             b.wait_visible(system_selector)
             try:
                 with b.wait_timeout(1):
-                    b.wait_present(system_item_selector)
                     b.wait_visible(system_item_selector)
                 # os found which is not ok
                 raise AssertionError("{0} was not filtered".format(self.os_name))
@@ -1684,7 +1595,6 @@ class TestMachines(NetworkCase):
                 .create()
 
             # successfully created
-            b.wait_present("#vm-{0}-row".format(name))
             b.wait_in_text("#vm-{0}-row".format(name), name)
 
             if dialog.start_vm:
@@ -1696,14 +1606,11 @@ class TestMachines(NetworkCase):
                 b.wait_present("#vm-{0}-vcpus".format(name))
 
             # check memory
-            b.wait_present("#vm-{0}-usage".format(name))
             b.click("#vm-{0}-usage".format(name))
-            b.wait_present("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption")
             b.wait_in_text("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption", dialog.getMemoryText())
 
             # check disks
-            b.wait_present("#vm-{0}-disks".format(name))  # wait for the tab
-            b.click("#vm-{0}-disks".format(name))  # open the "Disks" subtab
+            b.click("#vm-{0}-disks".format(name)) # open the "Disks" subtab
 
             # Test disk got imported/created
             if dialog.sourceType == 'disk_image':
@@ -1728,20 +1635,16 @@ class TestMachines(NetworkCase):
                 .fill() \
                 .create()
 
-            b.wait_present("#vm-{0}-install".format(name))
             # should fail because of memory error
             b.click("#vm-{0}-install".format(name))
             b.wait_in_text("#vm-{0}-state".format(name), "shut off")
-            b.wait_present("#app .listing-ct tbody:nth-of-type(1) th")
             b.wait_in_text("#app .listing-ct tbody:nth-of-type(1) th", name)
             b.wait_present("#app .listing-ct tbody:nth-of-type(1) tr td span span.pficon-warning-triangle-o")
 
             b.wait_present("#vm-{0}-install".format(name))
             # Overview should be opened
-            b.wait_present("#vm-{0}-overview".format(name)) # wait for the tab
             b.click("#vm-{0}-overview".format(name)) # open the "overView" subtab
 
-            b.wait_present("div.alert.alert-danger strong")
             b.wait_in_text("div.alert.alert-danger strong", "VM {0} failed to get installed".format(name))
             b.wait_in_text("a.alert-link.machines-more-button", "show more")
 
@@ -1751,7 +1654,6 @@ class TestMachines(NetworkCase):
             b = self.browser
             vm_delete_button = "#vm-{0}-delete".format(dialog.name)
 
-            b.wait_present(vm_delete_button)
             b.click(vm_delete_button)
             b.wait_present("#vm-{0}-delete-modal-dialog".format(dialog.name))
             b.click("#vm-{0}-delete-modal-dialog button:contains(Delete)".format(dialog.name))
@@ -1793,7 +1695,6 @@ class TestMachines(NetworkCase):
 
         def checkEnvIsEmpty(self):
             b = self.browser
-            b.wait_present("#virtual-machines-listing thead tr td")
             b.wait_in_text("#virtual-machines-listing thead tr td", "No VM is running")
             # wait for the vm and disks to be deleted
             b.wait(lambda: self.machine.execute("virsh list --all | wc -l") == '3\n')

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -91,7 +91,6 @@ class NetworkCase(MachineCase):
             text = "Inactive"
 
         try:
-            self.browser.wait_present(sel)
             self.browser.wait_visible(sel)
             self.browser.wait_in_text(sel, text)
         except Error as e:

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -84,7 +84,6 @@ class StorageCase(MachineCase):
 
     def content_row_action(self, index, title):
         btn = self.content_row_tbody(index) + " .listing-ct-item .listing-ct-actions button:contains(%s)" % title
-        self.browser.wait_present(btn)
         self.browser.click(btn)
 
     # The row might come and go a couple of times until it has the
@@ -98,14 +97,12 @@ class StorageCase(MachineCase):
     def content_head_action(self, index, title):
         self.content_row_expand(index)
         btn = self.content_row_tbody(index) + " .listing-ct-head .listing-ct-actions button:contains(%s)" % title
-        self.browser.wait_present(btn)
         self.browser.click(btn)
 
     def content_tab_expand(self, row_index, tab_index):
         tab_btn = self.content_row_tbody(row_index) + " .listing-ct-head li:nth-child(%d) a" % tab_index
         tab = self.content_row_tbody(row_index) + " .listing-ct-body:nth-child(%d)" % (tab_index + 1)
         self.content_row_expand(row_index)
-        self.browser.wait_present(tab_btn)
         self.browser.click(tab_btn)
         self.browser.wait_present(tab)
         return tab
@@ -113,7 +110,6 @@ class StorageCase(MachineCase):
     def content_tab_action(self, row_index, tab_index, title):
         tab = self.content_tab_expand(row_index, tab_index)
         btn = tab + " button:contains(%s)" % title
-        self.browser.wait_present(btn)
         self.browser.wait_attr(btn, "disabled", None)
         self.browser.click(btn)
 
@@ -180,13 +176,11 @@ class StorageCase(MachineCase):
             link = label + " + div a"
         else:
             link = label + " + a"
-        self.browser.wait_present(link)
         self.browser.click(link)
 
     # Dialogs
 
     def dialog_wait_open(self):
-        self.browser.wait_present('#dialog')
         self.browser.wait_visible('#dialog')
 
     def dialog_wait_alert(self, text):
@@ -261,7 +255,6 @@ class StorageCase(MachineCase):
 
     def dialog_wait_error(self, field, val):
         # XXX - allow for more than one error
-        self.browser.wait_present('#dialog .dialog-error')
         self.browser.wait_in_text('#dialog .dialog-error', val)
 
     def dialog_wait_not_visible(self, field):


### PR DESCRIPTION
Extend the RedBaron script to also recognize `self.browser.wait_*()`,
and also run  it against test/verify/*lib.py.