### PR TITLE
[no-test]bots: Teach bots to make more commits per PR

### DIFF
--- a/bots/task/test-task
+++ b/bots/task/test-task
@@ -28,6 +28,7 @@ import signal
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 
 BASE = os.path.dirname(__file__)
 os.environ["GITHUB_API"] = "http://127.0.0.9:9898"
@@ -38,7 +39,8 @@ task = imp.load_source("task", os.path.join(BASE, "__init__.py"))
 DATA = {
     "/repos/project/repo/issues/3333": {
         "title": "The issue title"
-    }
+    },
+    "/users/user/repos": [{"full_name": "project/repo"}]
 }
 
 def mockServer():
@@ -70,7 +72,14 @@ def mockServer():
             if self.path == "/repos/project/repo/pulls":
                 content_len = int(self.headers.get('content-length'))
                 data = json.loads(self.rfile.read(content_len).decode('utf-8'))
+                assert(data['title'] == "[no-test] Task title")
                 data["number"] = 1234
+                self.replyJson(data)
+            elif self.path == "/repos/project/repo/pulls/1234":
+                content_len = int(self.headers.get('content-length'))
+                data = json.loads(self.rfile.read(content_len).decode('utf-8'))
+                data["number"] = 1234
+                data["body"] = "This is the body"
                 self.replyJson(data)
             elif self.path == "/repos/project/repo/issues/1234/comments":
                 content_len = int(self.headers.get('content-length'))
@@ -99,6 +108,18 @@ def mockServer():
 
     httpd.serve_forever()
     os._exit(1)
+
+def mock_execute(*args):
+    assert(args[0] == 'git')
+    if args[1] == "show":
+        return "Task title\n"
+    elif args[1] == "commit" and args[2] == "--amend":
+        if args[4] !=  "Task title\nCloses #1234":
+            raise Exception("Incorrect commit message")
+    elif args[1] == "push":
+        assert(args[2] == "-f")
+    else:
+        raise Exception("Mocking unsupported git command")
 
 def mockKill(child):
     os.kill(child, signal.SIGTERM)
@@ -133,6 +154,7 @@ class TestTask(unittest.TestCase):
         label = task.label(1234, ['xxx'])
         self.assertEqual(label, ['xxx'])
 
+    @patch('task.execute', mock_execute)
     def testPullBody(self):
         args = { "title": "Task title" }
         pull = task.pull("user:branch", body="This is the body", **args)


### PR DESCRIPTION
Also as a side effect each PR will contain "Closes #" line. This is done
with firstly opening PR with [no-test], removing [no-test] once PR is
opened, adding Closes # line to the last commit and force pushing.

With this code I created https://github.com/marusak/cockpit/pull/8 by running `./bots/po-refresh`

How to test:
Depends where you want to push - be careful not to push to the cockpit-project/cockpit :) I changed this in a ugly way, surely (hopefully?) this can be done in a nicer way. I have done it with [this](https://github.com/marusak/cockpit/commit/52d921c0490b0f43f4c873d62be4b6e9c3afa2fc#diff-24f387660994cdcce18bc439271626b1R352), [this](https://github.com/marusak/cockpit/commit/52d921c0490b0f43f4c873d62be4b6e9c3afa2fc#diff-24f387660994cdcce18bc439271626b1R365), and [this](https://github.com/marusak/cockpit/commit/52d921c0490b0f43f4c873d62be4b6e9c3afa2fc#diff-db6809c87cc6a0705d99460bedb2d8ab).
And then some code that makes more then one commit, for example [this](https://github.com/marusak/cockpit/pull/8/commits/52d921c0490b0f43f4c873d62be4b6e9c3afa2fc#diff-cc7b030dfa9b0fbfb3db8eeec53f5fb1).