### PR TITLE
lib: Flake fixes in FileAutoComplete component

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -32,7 +32,7 @@ export class FileAutoComplete extends React.Component {
         this.updateFiles(value);
         this.state = {
             value: value,
-            directory: '/',
+            directory: '',
             directoryFiles: null,
             displayFiles: [],
             open: false,
@@ -50,12 +50,13 @@ export class FileAutoComplete extends React.Component {
         this.showAllOptions = this.showAllOptions.bind(this);
         this.selectItem = this.selectItem.bind(this);
         this.debouncedChange = debounce(300, (value) => {
-            this.pendingCallback = false;
-            if (!this.updateIfDirectoryChanged(value)) {
+            let cb = () => {
+                this.pendingCallback = false;
                 let stateUpdate = this.filterFiles(value);
-                this.setState(stateUpdate);
-                this.onChangeCallback(value, { error: stateUpdate.error });
-            }
+                this.setState(stateUpdate, () => this.onChangeCallback(value, { error: stateUpdate.error }));
+            };
+            if (!this.updateIfDirectoryChanged(value, cb))
+                cb();
         });
     }
 
@@ -150,16 +151,18 @@ export class FileAutoComplete extends React.Component {
         });
     }
 
-    updateIfDirectoryChanged(value) {
+    updateIfDirectoryChanged(value, cb) {
         const directory = this.getDirectoryForValue(value);
         const changed = directory !== this.state.directory;
         if (changed && this.state.directoryFiles !== null) {
-            this.setState({
-                displayFiles: [],
-                directoryFiles: null,
-                directory: directory,
-                open: false,
-            });
+            this.setState(() => {
+                return {
+                    displayFiles: [],
+                    directoryFiles: null,
+                    directory: directory,
+                    open: false,
+                };
+            }, cb);
             this.updateFiles(directory);
         }
         return changed;


### PR DESCRIPTION
This fixes a race between entering a new value and marking the component
as having passed the new value to it's parent component.