### PR TITLE
[no-test] bots: Use no-test in PR from issues

### DIFF
--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -138,7 +138,7 @@ def begin(publish, name, context, issue):
         number = issue["number"]
         identifier = "{0}-{1}-{2}".format(name, number, current)
         title = issue["title"]
-        wip = "WIP: {0}: {1}".format(hostname, title)
+        wip = "WIP: {0}: [no-test] {1}".format(hostname, title)
         requests = [ {
             "method": "POST",
             "resource": api.qualify("issues/{0}".format(number)),


### PR DESCRIPTION
PR that is created from issue misses "no-test" in the title. The issue
title needs to be updated before PR is created. That means putting it
into the title when the task begins or right before PR is gonna be
created.
I picked the first one as in the second one we would need to place this
[no-test] text after "WIP" text as there are check that control if the
title starts with WIP.

This label is gonna be removed with the `pull()` method itself after
force push is done.

Such problem can be seen with #11536 
