### PR TITLE
[no-test] bots: Firstly rename issue and then push force

### DIFF
--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -450,8 +450,7 @@ def pull(branch, body=None, issue=None, base="master", labels=['bot'], **kwargs)
 
     if pull["number"]:
         # Drop [no-test] from the title
-        if not issue:
-            pull = api.post("pulls/" + str(pull["number"]), {"title": kwargs["title"]}, accept=[ 422 ])
+        pull = api.post("pulls/" + str(pull["number"]), {"title": kwargs["title"]}, accept=[ 422 ])
         last_commit_m = execute("git", "show", "--no-patch", "--format=%B")
         last_commit_m += "Closes #" + str(pull["number"])
         execute("git", "commit", "--amend", "-m", last_commit_m)


### PR DESCRIPTION
Third time lucky? Hopefully :crossed_fingers: 
Now I need to live with the shame, buuut yeah, it still does not work properly (damn those issues converted into PRs)

First push for PR created from issue is not tested, but neither is the
second one. The problem is that the title is changed after the force
push for issues. Let's enforce the title change before the second (force) push.

This is inspired by https://github.com/cockpit-project/starter-kit/pull/160
There is also problem that it tried to open two PR for the same issue. This seems like deduplication problem for bots - is this something new, or was this happening even before?