### PR TITLE
Fix AppStream ID

### DIFF
--- a/pkg/kdump/org.cockpit-project.cockpit-kdump.metainfo.xml
+++ b/pkg/kdump/org.cockpit-project.cockpit-kdump.metainfo.xml
@@ -10,7 +10,7 @@
       disk.
     </p>
   </description>
-  <extends>cockpit.desktop</extends>
+  <extends>org.cockpit_project.cockpit</extends>
   <launchable type="cockpit-manifest">kdump</launchable>
   <url type="homepage">https://cockpit-project.org/</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>

--- a/pkg/machines/org.cockpit-project.cockpit-machines.metainfo.xml
+++ b/pkg/machines/org.cockpit-project.cockpit-machines.metainfo.xml
@@ -11,7 +11,7 @@
       subsystem.
     </p>
   </description>
-  <extends>cockpit.desktop</extends>
+  <extends>org.cockpit_project.cockpit</extends>
   <launchable type="cockpit-manifest">machines</launchable>
   <url type="homepage">https://cockpit-project.org/</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>

--- a/pkg/selinux/org.cockpit-project.cockpit-selinux.metainfo.xml
+++ b/pkg/selinux/org.cockpit-project.cockpit-selinux.metainfo.xml
@@ -10,7 +10,7 @@
       understanding and resolving policy violations.
     </p>
   </description>
-  <extends>cockpit.desktop</extends>
+  <extends>org.cockpit_project.cockpit</extends>
   <launchable type="cockpit-manifest">setroubleshoot</launchable>
   <url type="homepage">https://cockpit-project.org/</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>

--- a/pkg/sosreport/org.cockpit-project.cockpit-sosreport.metainfo.xml
+++ b/pkg/sosreport/org.cockpit-project.cockpit-sosreport.metainfo.xml
@@ -15,7 +15,7 @@
       debugging.
     </p>
   </description>
-  <extends>cockpit.desktop</extends>
+  <extends>org.cockpit_project.cockpit</extends>
   <launchable type="cockpit-manifest">sosreport</launchable>
   <url type="homepage">https://cockpit-project.org/</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>

--- a/src/ws/cockpit.appdata.xml.in
+++ b/src/ws/cockpit.appdata.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
 <component type="web-application">
-  <id>cockpit.desktop</id>
+  <id>org.cockpit_project.cockpit</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LGPL-2.0+</project_license>
   <name>Cockpit</name>

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -35,7 +35,7 @@ class TestApps(PackageCase):
         self.createPackage(name, version, revision, content={
             "/usr/share/metainfo/org.cockpit-project.{0}.metainfo.xml".format(name): """
 <component type="addon">
-  <extends>cockpit.desktop</extends>
+  <extends>org.cockpit_project.cockpit</extends>
   <id>org.cockpit-project.{0}</id>
   <name>{0}</name>
   <summary>An application for testing</summary>
@@ -49,7 +49,7 @@ class TestApps(PackageCase):
         for p in self.appstream_collection:
             body += """
   <component type="addon">
-    <extends>cockpit.desktop</extends>
+  <extends>org.cockpit_project.cockpit</extends>
     <id>org.cockpit-project.{0}</id>
     <name>{0}</name>
     <summary>An application for testing</summary>
@@ -127,7 +127,7 @@ class TestApps(PackageCase):
         m.write("/usr/share/app-info/xmls/test.xml", """
 <components origin="test">
   <component type="addon">
-    <extends>cockpit.desktop</extends>
+    <extends>org.cockpit_project.cockpit</extends>
     <id>org.cockpit-project.foo</id>
     <name>NAME:none</name>
     <name xml:lang="de">NAME:de</name>
@@ -188,7 +188,7 @@ class TestApps(PackageCase):
             m.write("/usr/share/app-info/xmls/test.xml", """
 <components origin="test">
   <component type="addon">
-    <extends>cockpit.desktop</extends>
+    <extends>org.cockpit_project.cockpit</extends>
     <id>org.cockpit-project.test</id>
     <name>Name</name>
     <summary>Summary</summary>
@@ -223,7 +223,7 @@ This <is <not XML.
         m.write("/usr/share/app-info/xmls/test.xml", """
 <components>
   <component type="addon">
-    <extends>cockpit.desktop</extends>
+    <extends>org.cockpit_project.cockpit</extends>
     <id>org.cockpit-project.test</id>
     <name>Name</name>
     <summary>Summary</summary>
@@ -241,7 +241,7 @@ This <is <not XML.
         m.write("/usr/share/app-info/xmls/test.xml", """
 <components origin="test">
   <component type="addon">
-    <extends>cockpit.desktop</extends>
+    <extends>org.cockpit_project.cockpit</extends>
     <id>org.cockpit-project.test</id>
     <name>Name</name>
     <summary>Summary</summary>
@@ -258,7 +258,7 @@ This <is <not XML.
         m.write("/usr/share/app-info/xmls/test.xml", """
 <components origin="test">
   <component type="addon">
-    <extends>cockpit.desktop</extends>
+    <extends>org.cockpit_project.cockpit</extends>
     <name>Name</name>
     <summary>No description</summary>
     <launchable type="cockpit-manifest">foo</launchable>
@@ -272,7 +272,7 @@ This <is <not XML.
         m.write("/usr/share/app-info/xmls/test.xml", """
 <components origin="test">
   <component type="addon">
-    <extends>cockpit.desktop</extends>
+    <extends>org.cockpit_project.cockpit</extends>
     <id>org.cockpit-project.test2</id>
     <name>Name</name>
     <summary>Summary</summary>
@@ -283,7 +283,7 @@ This <is <not XML.
     <pkgname>foo</pkgname>
   </component>
   <component type="addon">
-    <extends>cockpit.desktop</extends>
+    <extends>org.cockpit_project.cockpit</extends>
     <id>org.cockpit-project.test</id>
     <name>Name</name>
     <summary>Summary 2</summary>


### PR DESCRIPTION
Rename the "cockpit.desktop" AppStream ID to
"org.cockpit_project.cockpit" to conform to the AppStream spec [1].

With the current name, the scanner seems to ignore all Cockpit
extensions; as it shows them as "Extends: cockpit", it apparently strips
off the ".desktop" suffix. As it's currently broken anyway, now is the
time to rename the ID.

[1] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent
[2] https://dl.fedoraproject.org/pub/alt/screenshots/f30/failed.html