### PR TITLE
naughty: Close 9994: timesyncd fails to start on fedora-29

### DIFF
--- a/bots/naughty/fedora-29/9994-timesyncd-crash-on-start
+++ b/bots/naughty/fedora-29/9994-timesyncd-crash-on-start
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-system-info", line *, in testTimeServers
-    b.wait_visible("#systime-ntp-servers")


### PR DESCRIPTION
Known issue which has not occurred in 26 days

timesyncd fails to start on fedora-29

Fixes #9994