### PR TITLE
ws: Replace pam_shells with running bridge through user's shell

### DIFF
--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -117,6 +117,8 @@ on_pipe_close (CockpitPipe *pipe,
             problem = "terminated";
           else if (is_cockpit && WIFEXITED (status) && WEXITSTATUS (status) == 127)
             problem = "no-cockpit";      // cockpit-bridge not installed
+          else if (is_cockpit && WIFEXITED (status) && WEXITSTATUS (status) == 1)
+            problem = "access-denied";   // disabled user shells like /bin/false or /sbin/nologin exit 1
           else if (WIFEXITED (status) && WEXITSTATUS (status) == 255)
             problem = "terminated";      // failed or got a signal, etc.
           else if (!g_spawn_check_exit_status (status, &error))

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -844,7 +844,10 @@ on_transport_closed (CockpitTransport *transport,
       if (cockpit_pipe_get_pid (pipe, NULL))
         status = cockpit_pipe_exit_status (pipe);
       g_debug ("%s: authentication process exited: %d; problem %s", session->name, status, problem);
-      if (problem)
+
+      /* we get "access-denied" both if cockpit-session cannot execute cockpit-bridge (common case)
+       * and if cockpit-session itself is not executable (corner case, messed up install) */
+      if (problem && (!session->authorize || g_strcmp0 (problem, "access-denied") != 0))
         {
           g_set_error (&error, COCKPIT_ERROR, COCKPIT_ERROR_FAILED,
                        g_strcmp0 (problem, "no-cockpit") == 0

--- a/tools/cockpit.debian.pam
+++ b/tools/cockpit.debian.pam
@@ -3,7 +3,6 @@ auth	   required	pam_sepermit.so
 auth       substack     common-auth
 auth       optional     pam_ssh_add.so
 account    required     pam_nologin.so
-account    required     pam_shells.so
 account    include      common-account
 password   include      common-password
 # pam_selinux.so close should be the first session rule

--- a/tools/cockpit.pam
+++ b/tools/cockpit.pam
@@ -4,7 +4,6 @@ auth       substack     password-auth
 auth       include      postlogin
 auth       optional     pam_ssh_add.so
 account    required     pam_nologin.so
-account    required     pam_shells.so
 account    include      password-auth
 password   include      password-auth
 # pam_selinux.so close should be the first session rule


### PR DESCRIPTION
There are some shells like session-recording's tlog or rsh which the
user shouldn't be able to enable or disable, and thus they aren't in
/etc/shells. But they are nevertheless a legit login shell.

So using pam_shells in commit a96ec9b8343 was too strong. Drop it, and
instead simulate what /sbin/login or ssh do by running our session
leader cockpit-bridge through the user's configured shell. This will
fail (with exit code 1) for e. g. /sbin/nologin or /bin/false; handle
that in on_pipe_close() for a nicer error feedback than
"internal-error".

However, this makes the cases of cockpit-session failing to run
cockpit-bridge, and cockpit-ws failing to  run cockpit-session itself
(broken install) indistinguishable by just looking at the exit code and
problem (1 and "access-denied") in both cases). To decide which case we
have, check if the authorization protocol already started or not.

https://bugzilla.redhat.com/show_bug.cgi?id=1631905

Closes #11575