### PR TITLE
test: Explicitly unmount filesystem before shrinking it

### DIFF
--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -151,6 +151,17 @@ class TestStorage(StorageCase):
             time.sleep(2)
         raise Error('element did not disappear')
 
+    def shrink_extfs(self, fs_dev, size):
+        # fsadm can automatically unmount and check the fs when doing
+        # a resize, but in that case it will try to remount it
+        # afterwards.  This remounting will mostly fail because
+        # UDisks2 has removed the mount point directory in the mean
+        # time.  But sometimes it will succeed.  So we take control
+        # and unmount the fs explicitly.  But then we also need to
+        # check it explicitly.
+        #
+        self.machine.execute("umount '%s' && fsadm -y check '%s' && fsadm -y resize '%s' '%s'" % (fs_dev, fs_dev, fs_dev, size))
+
     def testGrowShrinkHelp(self):
         m = self.machine
         b = self.browser
@@ -195,7 +206,8 @@ class TestStorage(StorageCase):
         # Shrink the filesystem and let Cockpit shrink the logical volume
 
         fs_dev = m.execute("lsblk -pnl /dev/TEST/vol -o NAME | tail -1").strip()
-        m.execute("fsadm -y resize '%s' 200M" % fs_dev)
+        self.shrink_extfs(fs_dev, "200M")
+
         self.content_tab_action(1, 2, "Mount")
         self.content_tab_wait_in_info(1, 2, "Mounted At", mountpoint)
         warning_tab = self.content_tab_expand(1, 3)
@@ -260,7 +272,7 @@ class TestStorage(StorageCase):
         # Shrink the filesystem and let Cockpit shrink the LUKS container and logical volume
 
         fs_dev = m.execute("lsblk -pnl /dev/TEST/vol -o NAME | tail -1").strip()
-        m.execute("fsadm -y resize '%s' 200M" % fs_dev)
+        self.shrink_extfs(fs_dev, "200M")
         self.content_tab_action(2, 1, "Mount")
         self.content_tab_wait_in_info(2, 1, "Mounted At", mountpoint)
         warning_tab = self.content_tab_expand(2, 2)
@@ -287,7 +299,7 @@ class TestStorage(StorageCase):
 
         # Shrink the filesystem and the LUKS container and let Cockpit shrink the logical volume
 
-        m.execute("fsadm -y resize '%s' 198M" % fs_dev)
+        self.shrink_extfs(fs_dev, "198M")
         m.execute("echo vainu-reku-toma-rolle-kaja | cryptsetup resize '%s' 200M" % fs_dev)
         self.content_tab_action(2, 1, "Mount")
         self.content_tab_wait_in_info(2, 1, "Mounted At", mountpoint)


### PR DESCRIPTION
The resize2fs tool will unmount the filesystem itself, but when it
does so, it will try to remount it after the resize is complete.

However, as soon UDisks2 notices that the filesystem has been
unmounted, it will remove the mount point directory.  Thus, normally
resize2fs is not able to remount the filesystem, and we have been
expecting this behavior.

But sometimes UDisks2 is not fast enough and the mount point directory
still exists when resize2fs finishes and it succeeds in remounting the
filesystem.  This breaks the rest of the test script.

Now we explicitly unmount the filesystem and don't rely on resize2fs
doing it implicitly.  This means that resize2fs will never try to
remount it.