### PR TITLE
bots: Do not run tests automatically for image refresh

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -133,7 +133,7 @@ def run(image, verbose=False, **kwargs):
 
     branch = task.branch(image, "images: Update {0} image".format(image), pathspec="bots/images", **kwargs)
     if branch:
-        pull = task.pull(branch, **kwargs)
+        pull = task.pull(branch, run_tests=False, **kwargs)
 
         # Trigger this pull request
         head = pull["head"]["sha"]


### PR DESCRIPTION
Some tasks need to firstly drop [no-test] from title and then push force
so all tests are triggered. However some (such as image-refresh) need to
do this in a reverse order, since tests are triggered by setting up a status.