### PR TITLE
login: Take url_root into account when selecting page style

### DIFF
--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -69,11 +69,6 @@
     if (!console)
         console = function() { };
 
-    /* Determine if we are nested or not, and switch styles */
-    if (window.location.pathname.indexOf("/cockpit/") === 0 ||
-        window.location.pathname.indexOf("/cockpit+") === 0)
-        document.documentElement.setAttribute("class", "inline");
-
     function id(name) {
         return document.getElementById(name);
     }
@@ -252,6 +247,11 @@
         translate();
 
         setup_path_globals(window.location.pathname);
+
+        /* Determine if we are nested or not, and switch styles */
+        if (window.location.pathname.indexOf("/" + url_root + "/cockpit/") === 0 ||
+            window.location.pathname.indexOf("/" + url_root + "/cockpit+") === 0)
+            document.documentElement.setAttribute("class", "inline");
 
         // Setup title
         var title = environment.page.title;


### PR DESCRIPTION
We want to select the "inline" style for the login page when the URL
directly points at a page instead of the shell, like /cockpit/system.
This is done by looking for the special /cockpit prefix.

However, with a UrlRoot, the path looks like /urlroot/cockpit/system
and we would show the fully branded style for a individual page.

Similarily, if the UrlRoot is actuall "/cockpit", the normal shell
path looks like "/cockpit/system" and we would show the inline style
for the regular login.

Both issues are fixed by expecting the UrlRoot to be part of the
prefix.

Fixes #10073