### PR TITLE
tests: Don't resolve ``localhost`` for mocked systems

### DIFF
--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -81,7 +81,7 @@ setup (TestCase *tc,
 
   /* Automatically chosen by the web server */
   g_object_get (tc->web_server, "port", &port, NULL);
-  tc->localport = g_strdup_printf ("localhost:%d", port);
+  tc->localport = g_strdup_printf ("127.0.0.1:%d", port);
   if (str)
     tc->hostport = g_strdup_printf ("%s:%d", str, port);
   if (inet)


### PR DESCRIPTION
An actual host resolving happens in
`gio/gthreadedresolver.c:do_lookup_by_name` by calling the `getaddrinfo`
function with ai_flags=AI_ADDRCONFIG.

According to getaddrinfo(3):
```
If hints.ai_flags includes the AI_ADDRCONFIG flag, then IPv4
addresses are returned in the list pointed to by res only if the
local system has at least one IPv4 address configured, and IPv6
addresses are returned only if the local system has at least one IPv6
address configured.  The loopback address is not considered for this
case as valid as a configured address.
```

Our build tool (https://en.altlinux.org/Hasher) has only loopback interfaces.
Thus, `localhost` resolving results in
EAI_NONAME /* NAME or SERVICE is unknown. */

A simple workaround is to use the IPv4 address instead.

Fixes: https://github.com/cockpit-project/cockpit/issues/11616