### PR TITLE
bots: robustify podman testDownloadImage naughty skip

### DIFF
--- a/bots/naughty/fedora-29/11579-podman-pull-nonexisting-tag-crash
+++ b/bots/naughty/fedora-29/11579-podman-pull-nonexisting-tag-crash
@@ -1,3 +1,6 @@
 # testDownloadImage (__main__.TestApplication)*
 *
-*process * (podman) of user 0 dumped core.
+Traceback (most recent call last):
+  File "test/check-application", line *, in testDownloadImage
+    dialog.openDialog() \
+  File "test/check-application", line *, in expectDownloadErrorForNonExistingTag


### PR DESCRIPTION
Previously we were searching the test logs for coredump messages, since
we were expecting the podman to crash.
That was quite flaky, with the coredumps sometimes not appearing on the test
log but only in the journal, probably because of the processing time of the
coredump being quite long.

This commit changes the matching string of the naughty to be the Traceback of
the test instead of the coredump messages.