### PR TITLE
storage: Don't allow resizing of volumes with unused space

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -27,7 +27,7 @@ import inotify_py from "raw-loader!inotify.py";
 import nfs_mounts_py from "raw-loader!./nfs-mounts.py";
 import vdo_monitor_py from "raw-loader!./vdo-monitor.py";
 
-import { find_warnings } from "./warning-tab.jsx";
+import { find_warnings } from "./warnings.jsx";
 
 /* STORAGED CLIENT
  */

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -79,6 +79,8 @@ class TestStorage(StorageCase):
                 self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
             self.dialog_apply()
             self.dialog_wait_close()
+            # HACK - https://github.com/storaged-project/udisks/pull/631
+            m.execute("udevadm trigger")
             if grow_needs_unmount:
                 self.content_tab_action(fsys_row, fsys_tab, "Mount")
                 self.content_tab_wait_in_info(fsys_row, fsys_tab, "Mounted At", mountpoint)
@@ -98,6 +100,8 @@ class TestStorage(StorageCase):
                 self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
             self.dialog_apply()
             self.dialog_wait_close()
+            # HACK - https://github.com/storaged-project/udisks/pull/631
+            m.execute("udevadm trigger")
             if shrink_needs_unmount:
                 self.content_tab_action(fsys_row, fsys_tab, "Mount")
                 self.content_tab_wait_in_info(fsys_row, fsys_tab, "Mounted At", mountpoint)
@@ -182,13 +186,14 @@ class TestStorage(StorageCase):
         self.content_tab_action(1, 2, "Mount")
         self.content_tab_wait_in_info(1, 2, "Mounted At", mountpoint)
 
+        vol_tab = self.content_tab_expand(1, 1)
+
         # Grow the logical volume and let Cockpit grow the filesystem
 
         m.execute("lvresize TEST/vol -L+100M")
-        warning_tab = self.content_tab_expand(1, 3)
-
-        self.content_tab_action(1, 3, "Grow Content")
-        self.wait_not_present_with_udev_trigger(warning_tab)
+        b.wait_present(vol_tab + " button:contains(Grow Content)")
+        self.content_tab_action(1, 1, "Grow Content")
+        self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Grow Content)")
         size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
         self.assertGreater(size, 250000)
 
@@ -198,10 +203,9 @@ class TestStorage(StorageCase):
         m.execute("fsadm -y resize '%s' 200M" % fs_dev)
         self.content_tab_action(1, 2, "Mount")
         self.content_tab_wait_in_info(1, 2, "Mounted At", mountpoint)
-        warning_tab = self.content_tab_expand(1, 3)
-
-        self.content_tab_action(1, 3, "Shrink Volume")
-        self.wait_not_present_with_udev_trigger(warning_tab)
+        b.wait_present(vol_tab + " button:contains(Shrink Volume)")
+        self.content_tab_action(1, 1, "Shrink Volume")
+        self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Shrink Volume)")
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))
         self.assertLess(size, 250000000)
 
@@ -238,10 +242,11 @@ class TestStorage(StorageCase):
         self.content_tab_action(2, 1, "Mount")
         self.content_tab_wait_in_info(2, 1, "Mounted At", mountpoint)
 
+        vol_tab = self.content_tab_expand(1, 1)
+
         # Grow the logical volume and let Cockpit grow the LUKS container and the filesystem
 
         m.execute("lvresize TEST/vol -L+100M")
-        warning_tab = self.content_tab_expand(2, 2)
 
         def confirm_with_passphrase():
             self.dialog_wait_open()
@@ -250,10 +255,11 @@ class TestStorage(StorageCase):
             self.dialog_apply()
             self.dialog_wait_close()
 
-        self.content_tab_action(2, 2, "Grow Content")
+        b.wait_present(vol_tab + " button:contains(Grow Content)")
+        self.content_tab_action(1, 1, "Grow Content")
         if self.machine.image in ["rhel-8-0", "rhel-8-1"]:
             confirm_with_passphrase()
-        self.wait_not_present_with_udev_trigger(warning_tab)
+        self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Grow Content)")
         size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
         self.assertGreater(size, 250000)
 
@@ -263,12 +269,12 @@ class TestStorage(StorageCase):
         m.execute("fsadm -y resize '%s' 200M" % fs_dev)
         self.content_tab_action(2, 1, "Mount")
         self.content_tab_wait_in_info(2, 1, "Mounted At", mountpoint)
-        warning_tab = self.content_tab_expand(2, 2)
 
-        self.content_tab_action(2, 2, "Shrink Volume")
+        b.wait_present(vol_tab + " button:contains(Shrink Volume)")
+        self.content_tab_action(1, 1, "Shrink Volume")
         if self.machine.image in ["rhel-8-0", "rhel-8-1"]:
             confirm_with_passphrase()
-        self.wait_not_present_with_udev_trigger(warning_tab)
+        self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Shrink Volume)")
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))
         self.assertLess(size, 250000000)
 
@@ -276,12 +282,12 @@ class TestStorage(StorageCase):
 
         m.execute("lvresize TEST/vol -L+100M")
         m.execute("echo vainu-reku-toma-rolle-kaja | cryptsetup resize %s" % fs_dev)
-        warning_tab = self.content_tab_expand(2, 2)
 
-        self.content_tab_action(2, 2, "Grow Content")
+        b.wait_present(vol_tab + " button:contains(Grow Content)")
+        self.content_tab_action(1, 1, "Grow Content")
         if self.machine.image in ["rhel-8-0", "rhel-8-1"]:
             confirm_with_passphrase()
-        self.wait_not_present_with_udev_trigger(warning_tab)
+        self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Grow Content)")
         size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
         self.assertGreater(size, 250000)
 
@@ -291,12 +297,12 @@ class TestStorage(StorageCase):
         m.execute("echo vainu-reku-toma-rolle-kaja | cryptsetup resize '%s' 200M" % fs_dev)
         self.content_tab_action(2, 1, "Mount")
         self.content_tab_wait_in_info(2, 1, "Mounted At", mountpoint)
-        warning_tab = self.content_tab_expand(2, 2)
 
-        self.content_tab_action(2, 2, "Shrink Volume")
+        b.wait_present(vol_tab + " button:contains(Shrink Volume)")
+        self.content_tab_action(1, 1, "Shrink Volume")
         if self.machine.image in ["rhel-8-0", "rhel-8-1"]:
             confirm_with_passphrase()
-        self.wait_not_present_with_udev_trigger(warning_tab)
+        self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Shrink Volume)")
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))
         self.assertLess(size, 250000000)
 


### PR DESCRIPTION
When resizing a logical volume, Cockpit resizes the content
accordingly.  But if the content doesn't initially fills the whole
volume, it's not clear what the expected behavior is.  Thus, we want
to force people to first bring the content and volume sizes into
agreement.

This is achieved by moving the "unused-space" warning to the "Volume"
tab and making it a strict alternative to the Shrink/Grow buttons.
Either you can shrink/grow the volume, or you have to deal with the
unused space.