### PR TITLE
bots: Add second naughty for the podman crash on PullImage with non-existing tag

### DIFF
--- a/bots/naughty/fedora-29/11579-podman-pull-non-existing-tag-crash-no-coredump-available
+++ b/bots/naughty/fedora-29/11579-podman-pull-non-existing-tag-crash-no-coredump-available
@@ -1,0 +1,7 @@
+# testDownloadImage (__main__.TestApplication)
+*
+Traceback (most recent call last):
+  File *, line *, in testDownloadImage
+    dialog.openDialog() \
+  File *, line *, in selectImageAndDownload
+*


### PR DESCRIPTION
testDownloadImage sometimes fails, because the podman crash causes the
UI to get reloaded, causing the expected elements to not be present.

However we only check the journal messages for coredumps only for
sucessfull tests, so we don't catch the podman crash in this case.

Add this second naughty for #11579 which will cover the above mentioned
scenario.

Known issue #11579