### PR TITLE
ws: Set proper $HOME for session leader shell

### DIFF
--- a/src/ws/session-utils.c
+++ b/src/ws/session-utils.c
@@ -227,6 +227,7 @@ open_session (pam_handle_t *pamh)
   int res;
   static struct passwd pwd_buf;
   static char pwd_string_buf[8192];
+  static char home_env_buf[8192];
   int i;
 
   name = NULL;
@@ -298,8 +299,13 @@ open_session (pam_handle_t *pamh)
 
       debug ("opening pam session for %s", name);
 
+      res = snprintf (home_env_buf, sizeof (home_env_buf), "HOME=%s", pwd->pw_dir);
+      /* this really can't fail, as the buffer for the entire pwd is not larger, but make double sure */
+      assert (res < sizeof (home_env_buf));
+
       pam_putenv (pamh, "XDG_SESSION_CLASS=user");
       pam_putenv (pamh, "XDG_SESSION_TYPE=web");
+      pam_putenv (pamh, home_env_buf);
 
       res = pam_setcred (pamh, PAM_ESTABLISH_CRED);
       if (res != PAM_SUCCESS)

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -158,6 +158,17 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         # Wait for text to show up
         wait_line(n + 2, "foo")
 
+        # check that we get a sensible $PATH; this varies across OSes, so don't be too strict about it
+        b.key_press('\rclear\recho $PATH > /tmp/path\r')
+        # don't use wait_line() for the full match here, as line breaks get in the way; just wait until command has run
+        wait_line(n + 1, "$")
+        path = m.execute("cat /tmp/path").strip()
+        if m.atomic_image:
+            self.assertIn("/usr/local/bin:/usr/bin", path)
+        else:
+            self.assertIn("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", path)
+        self.assertNotIn(":/.local", path)  # would happen with empty $HOME
+
         def check_theme_select(name, style):
             b.select_from_dropdown("#theme-select", name)
             b.wait_attr(".xterm-viewport", "style", style)


### PR DESCRIPTION
Commit a9375441df7777b introduced a regression: The session's initial
shell did not have `$HOME`, which lead to ~/.bashrc constructing a
`$PATH` with bogus elements like `/.local/bin`.

As we can't rely on every shell providing a `--norc` option, imitate
what cockpit-bridge does and set `$HOME` to the user's home directory in
passwd.

This got caught by accident by check-system-info; add a more direct
test case to ensure that the session has a sensible `$PATH`.