### PR TITLE
bots: Fix naughty for podman crash on PullImage API

### DIFF
--- a/bots/naughty/fedora-29/11579-podman-pull-non-existing-tag-crash-no-coredump-available
+++ b/bots/naughty/fedora-29/11579-podman-pull-non-existing-tag-crash-no-coredump-available
@@ -3,5 +3,5 @@
 Traceback (most recent call last):
   File *, line *, in testDownloadImage
     dialog.openDialog() \
-  File *, line *, in selectImageAndDownload
+  File *, line *, in expectDownloadErrorForNonExistingTag
 *


### PR DESCRIPTION
The correct function that this naughty should catch is the
expectDownloadErrorForNonExistingTag.