### PR TITLE
machines: Fix Oops due to new OS autodetection code in VM creation dialog

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -138,9 +138,10 @@ class CreateVM extends React.Component {
                                 // osinfo-query is nto yet aware of variants, https://gitlab.com/libosinfo/libosinfo/issues/24
                                 // but osinfo-detect is. Remove the variant suffix to eliminate this issue
                                 osName = osName.replace(/ Server$/, "");
+                                osName = osName.replace(/ Workstation$/, "");
                                 const osEntry = this.props.osInfoList.filter(osEntry => osEntry.name == osName);
 
-                                if (osEntry) {
+                                if (osEntry && osEntry[0]) {
                                     this.setState({
                                         vendor: osEntry[0].vendor,
                                         os: osEntry[0].shortId


### PR DESCRIPTION
Depending on libosinfo version, osinfo-detect prints sometimes the os name
together with a variant (Server/Workstation). However osinfo-query which
gives us the available OS list is not aware of the variants.

Note: There is already an open issue to make these two tools have
consistent outputs. https://gitlab.com/libosinfo/libosinfo/issues/24

Fixes #11628