### PR TITLE
bots: include fedora-30 tests for podman in the tests-scan matrix

### DIFF
--- a/bots/naughty/fedora-30/11579-podman-pull-non-existing-tag-crash-no-coredump-available
+++ b/bots/naughty/fedora-30/11579-podman-pull-non-existing-tag-crash-no-coredump-available
@@ -1,0 +1,7 @@
+# testDownloadImage (__main__.TestApplication)
+*
+Traceback (most recent call last):
+  File *, line *, in testDownloadImage
+    dialog.openDialog() \
+  File *, line *, in selectImageAndDownload
+*

--- a/bots/naughty/fedora-30/11579-podman-pull-nonexisting-tag-crash
+++ b/bots/naughty/fedora-30/11579-podman-pull-nonexisting-tag-crash
@@ -1,0 +1,3 @@
+# testDownloadImage (__main__.TestApplication)*
+*
+*process * (podman) of user 0 dumped core.

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -65,6 +65,7 @@ EXTERNAL_PROJECTS = {
     ],
     'cockpit-project/cockpit-podman': [
         'cockpit/fedora-29',
+        'cockpit/fedora-30',
     ],
     'weldr/welder-web': [
         'cockpit/fedora-29/chrome',


### PR DESCRIPTION
Copy the podman related naughties from fedora-29 to fedora-30, since
podman version is the same for these two.