### PR TITLE
bots: Remove trailing slash from origin

### DIFF
--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -116,7 +116,7 @@ def get_origin_repo():
     url = res.decode('utf-8').strip()
     m = re.fullmatch("(git@github.com:|https://github.com/)(.*?)(\\.git)?", url)
     if m:
-        return m.group(2)
+        return m.group(2).rstrip("/")
     raise RuntimeError("Not a GitHub repo: %s" % url)
 
 class GitHub(object):


### PR DESCRIPTION
There has been origin repo set up to
`https://github.com/cockpit-project/cockpit/` which from is_origin_repo
returned `cockpit-project/cockpit/` that was not matching conditions `if
repo == "cockpit-project/cockpit"`.

Related: https://github.com/cockpit-project/cockpituous/pull/260