### PR TITLE
networking: Reduce checkpoint rollback time to 7 seconds

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2090,11 +2090,16 @@ function choice_title(choices, choice, def) {
  * rollback_time too long:  The user has to wait a long time before
  *                          his/her mistake is corrected and might
  *                          consider Cockpit to be dead already.
+ *                          Also, the network connection machinery in
+ *                          the kernels and browsers must recover
+ *                          after no packages have been flowing for
+ *                          this much time.  Windows seems to have
+ *                          less patience than Linux in this regard.
  */
 
 var curtain_time = 1.5;
 var settle_time = 1.0;
-var rollback_time = 15.0;
+var rollback_time = 7.0;
 
 function with_checkpoint(model, modify, options) {
     var manager = model.get_manager();

--- a/test/verify/check-networking-checkpoints
+++ b/test/verify/check-networking-checkpoints
@@ -75,9 +75,9 @@ class TestNetworking(NetworkCase):
         # We test slow rollbacks by slowing down DHCP requests.
         #
         # We need at least 60 seconds of network disconnection to let
-        # the health check fail reliably.  A rollback is started 15
+        # the health check fail reliably.  A rollback is started 7
         # seconds after disconnection, so we need to delay the DHCP
-        # request by at least 45 seconds.  However, NetworkManager has
+        # request by at least 53 seconds.  However, NetworkManager has
         # a default DHCP timeout of 45 seconds, so we need to increase
         # that.
         #


### PR DESCRIPTION
This helps when the browser is on Windows.

Fixes #7859