### PR TITLE
[no-test] bots: Make po-refresh bot more universal

### DIFF
--- a/bots/po-refresh
+++ b/bots/po-refresh
@@ -67,46 +67,61 @@ def run(context, verbose=False, **kwargs):
     current_manifest = None
     current_linguas = []
     language_map = {}
+    # LINGUAS file in use and therefore needs updating
+    linguas_exists = os.path.isfile("po/LINGUAS")
+    # Manifest file is use - and for its updating we also need language map
+    manifest_exists = os.path.isfile("pkg/shell/manifest.json.in") and os.path.isfile("po/language_map.txt")
 
     # Get locale from language-map file. Fail with keyError when not found
     def get_locale(file_name):
         language = os.path.splitext(os.path.basename(file_name))[0]
-        return language_map[language]
+        if manifest_exists:
+            return language_map[language]
+        return [language]
 
     def add_and_commit_lang(name, language, action):
-        with open("po/LINGUAS", "w", encoding='utf-8') as lngs:
-            print("\n".join(current_linguas), file=lngs)
-        with open("pkg/shell/manifest.json.in", "w", encoding='utf-8') as mnfst:
-            text = json.dumps(current_manifest, ensure_ascii=False, indent=4)
-            print(text, file=mnfst)
-        execute("git", "add", "--", "po/LINGUAS", "pkg/shell/manifest.json.in", name)
+        git_cmd = ["git", "add", "--"]
+        if linguas_exists:
+            with open("po/LINGUAS", "w", encoding='utf-8') as lngs:
+                print("\n".join(current_linguas), file=lngs)
+            git_cmd.append("po/LINGUAS")
+        if manifest_exists:
+            with open("pkg/shell/manifest.json.in", "w", encoding='utf-8') as mnfst:
+                text = json.dumps(current_manifest, ensure_ascii=False, indent=4)
+                print(text, file=mnfst)
+            git_cmd.append("pkg/shell/manifest.json.in")
+        execute(*git_cmd, name)
         return task.branch(context, "po: {0} '{1}' language".format(action, language),
                            pathspec=None, branch=local_branch, push=False, **kwargs)
 
-    # Build language map
-    with open("po/language_map.txt", "r") as lm:
-        for line in lm:
-            line = line.strip()
-            if not line:
-                continue
-            items = line.split(":")
-            language_map[items[0]] = items
+    # Build language map a read manifest
+    if manifest_exists:
+        with open("po/language_map.txt", "r") as lm:
+            for line in lm:
+                line = line.strip()
+                if not line:
+                    continue
+                items = line.split(":")
+                language_map[items[0]] = items
 
-    # Read manifest
-    with open("pkg/shell/manifest.json.in", "r", encoding='utf-8') as mnfst:
-        current_manifest = json.load(mnfst)
+        # Read manifest
+        with open("pkg/shell/manifest.json.in", "r", encoding='utf-8') as mnfst:
+            current_manifest = json.load(mnfst)
 
     # Read linguas
-    with open("po/LINGUAS", "r", encoding='utf-8') as lngs:
-        current_linguas = lngs.read().strip().split()
+    if linguas_exists:
+        with open("po/LINGUAS", "r", encoding='utf-8') as lngs:
+            current_linguas = lngs.read().strip().split()
 
     # Remove languages that fall under 50% translated
     files = output("git", "ls-files", "--deleted", "po/")
     for name in files.splitlines():
         if name.endswith(".po"):
             locale = get_locale(name)
-            current_manifest["locales"].pop(locale[2])
-            current_linguas.remove(locale[0])
+            if current_manifest:
+                current_manifest["locales"].pop(locale[2])
+            if current_linguas:
+                current_linguas.remove(locale[0])
             (user, local_branch) = add_and_commit_lang(name, locale[0], "Drop").split(":")
 
     # Add languages that got over 50% translated
@@ -114,10 +129,12 @@ def run(context, verbose=False, **kwargs):
     for name in files.splitlines():
         if name.endswith(".po"):
             locale = get_locale(name)
-            current_manifest["locales"][locale[2]] = locale[1]
-            current_manifest["locales"] = dict(sorted(current_manifest["locales"].items()))
-            current_linguas.append(locale[0])
-            current_linguas.sort()
+            if current_manifest:
+                current_manifest["locales"][locale[2]] = locale[1]
+                current_manifest["locales"] = dict(sorted(current_manifest["locales"].items()))
+            if current_linguas:
+                current_linguas.append(locale[0])
+                current_linguas.sort()
             (user, local_branch) = add_and_commit_lang(name, locale[0], "Add").split(":")
 
     # Here we have logic to only include files that actually


### PR DESCRIPTION
In 0cda3d2a bots learned how to add and drop languages with updating
manifest and LINGUAS. However these are very specific just for
c-p/cockpit but not used for other projects.
This commit teaches Mr. po-refresh not to try to update files that are
not present.

 * [x] po-refresh