### PR TITLE
machines: fix oops in main machines page when using Edge browser

### DIFF
--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -174,7 +174,7 @@ export function parseDumpxml(dispatch, connectionName, domXml, id_overwrite) {
         return;
     }
 
-    const osElem = domainElem.getElementsByTagName("os")[0];
+    const osElem = domainElem.getElementsByTagNameNS("", "os")[0];
     const currentMemoryElem = domainElem.getElementsByTagName("currentMemory")[0];
     const vcpuElem = domainElem.getElementsByTagName("vcpu")[0];
     const cpuElem = domainElem.getElementsByTagName("cpu")[0];


### PR DESCRIPTION
getElementsByTagName method from DOMParser has slightly different
behaviour on Edge compared to other browsers that cockpit supports.

Specifically, when there are elements from different namespaces with
the same tag, getElementsByTagName will include them in the result array
when called inside Edge, but when called in other browsers it won't.

In our case, the <os> element actually exists in another namespace apart
from the empty one. It's the <libosinfo:os> which is containing the
installation media of a VM.

Adjust the calling of getElementsByTagName to getElementsByTagNameNS to
fix this issue.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1692707