### PR TITLE
Fix testNetworkingPage flake

### DIFF
--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -76,6 +76,8 @@ class TestFirewall(MachineCase):
         b.click(".breadcrumb li:first a")
         b.enter_page("/network")
 
+        self.allow_journal_messages(".*The name org.fedoraproject.FirewallD1 was not provided by any .service files.*")
+
     def testFirewallPage(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -76,7 +76,8 @@ class TestFirewall(MachineCase):
         b.click(".breadcrumb li:first a")
         b.enter_page("/network")
 
-        self.allow_journal_messages(".*The name org.fedoraproject.FirewallD1 was not provided by any .service files.*")
+        self.allow_journal_messages(".*The name org.fedoraproject.FirewallD1 was not provided by any .service files.*",
+                                    ".*org.fedoraproject.FirewallD1: couldn't introspect /org/fedoraproject/FirewallD1/config: GDBus.Error:org.freedesktop.DBus.Error.NoReply: Message recipient disconnected from message bus without replying.*")
 
     def testFirewallPage(self):
         b = self.browser


### PR DESCRIPTION
testNetworkingPage was sometimes failing because of journal messages containing
the following line:

The name org.fedoraproject.FirewallD1 was not provided by any .service files

This is suprisingly an error coming from libvirtd, which is complaining
that firewalld was stopped while libvirtd was running. For more info
see, https://bugzilla.redhat.com/show_bug.cgi?id=1348434

Since this is harmless for us, and as mentioned in the BZ is an WONTFIX
issue, let's ignore it in the test's teardown checks.