### PR TITLE
machines: Use libosinfo APIs instead of calling its tools

### DIFF
--- a/pkg/machines/components/create-vm-dialog/autoDetectOS.py
+++ b/pkg/machines/components/create-vm-dialog/autoDetectOS.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+import gi
+gi.require_version('Libosinfo', '1.0')
+from gi.repository import Libosinfo
+import sys
+
+
+loader = Libosinfo.Loader()
+loader.process_default_path()
+db = loader.get_db()
+
+url_type_media = sys.argv[1].endswith(".iso")
+
+os = None
+if url_type_media:
+    media = Libosinfo.Media().create_from_location(sys.argv[1])
+    db.identify_media(media)
+    os = media.get_os()
+else:
+    tree = Libosinfo.Tree().create_from_location(sys.argv[1])
+    os, _ = db.guess_os_from_tree(tree)
+
+if os:
+    print(os.get_id())

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -134,12 +134,7 @@ class CreateVM extends React.Component {
                     autodetectOS(os)
                             .fail(ex => console.log("osinfo-detect command failed: ", ex.message))
                             .then(res => {
-                                let osName = res.match(/OS ['"](.*)['"]/)[1];
-                                // osinfo-query is nto yet aware of variants, https://gitlab.com/libosinfo/libosinfo/issues/24
-                                // but osinfo-detect is. Remove the variant suffix to eliminate this issue
-                                osName = osName.replace(/ Server$/, "");
-                                osName = osName.replace(/ Workstation$/, "");
-                                const osEntry = this.props.osInfoList.filter(osEntry => osEntry.name == osName);
+                                const osEntry = this.props.osInfoList.filter(osEntry => osEntry.id == res);
 
                                 if (osEntry && osEntry[0]) {
                                     this.setState({

--- a/pkg/machines/getOSList.py
+++ b/pkg/machines/getOSList.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+
+import gi
+gi.require_version('Libosinfo', '1.0')
+from gi.repository import Libosinfo
+import sys
+
+
+loader = Libosinfo.Loader()
+loader.process_default_path()
+db = loader.get_db()
+
+oses = db.get_os_list()
+for i in range(oses.get_length()):
+    os = oses.get_nth(i)
+
+    osId = os.get_id() or ""
+    osShortId = os.get_short_id() or ""
+    osName = os.get_name() or ""
+    osVersion = os.get_version() or ""
+    osFamily = os.get_family() or ""
+    osVendor = os.get_vendor() or ""
+    osReleaseDate = os.get_release_date_string() or ""
+    osEOLDate = os.get_eol_date_string() or ""
+    osCodename = os.get_codename() or ""
+
+    print("%s|%s|%s|%s|%s|%s|%s|%s|%s" %
+          (osId, osShortId, osName, osVersion, osFamily, osVendor,
+           osReleaseDate, osEOLDate, osCodename))

--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -2,8 +2,10 @@ import cockpit from 'cockpit';
 import * as service from '../lib/service.js';
 import createVmScript from 'raw-loader!./scripts/create_machine.sh';
 import installVmScript from 'raw-loader!./scripts/install_machine.sh';
-import getOSListScript from 'raw-loader!./scripts/get_os_list.sh';
 import getLibvirtServiceNameScript from 'raw-loader!./scripts/get_libvirt_service_name.sh';
+
+import * as python from "python.js";
+import getOSListScript from 'raw-loader!./getOSList.py';
 
 import {
     setLoggedInUser,
@@ -760,7 +762,7 @@ export function parseNodeDeviceDumpxml(nodeDevice) {
 }
 
 export function parseOsInfoList(dispatch, osList) {
-    const osColumnsNames = ['shortId', 'name', 'version', 'family', 'vendor', 'releaseDate', 'eolDate', 'codename'];
+    const osColumnsNames = ['id', 'shortId', 'name', 'version', 'family', 'vendor', 'releaseDate', 'eolDate', 'codename'];
     let parsedList = [];
 
     osList.split('\n').forEach(line => {
@@ -1232,7 +1234,7 @@ export function GET_LOGGED_IN_USER() {
 
 export function GET_OS_INFO_LIST () {
     logDebug(`${this.name}.GET_OS_INFO_LIST():`);
-    return dispatch => cockpit.script(getOSListScript, null, { err: "message", environ: ['LC_ALL=en_US.UTF-8'] })
+    return dispatch => python.spawn(getOSListScript, null, { err: "message", environ: ['LC_ALL=en_US.UTF-8'] })
             .then(osList => {
                 parseOsInfoList(dispatch, osList);
             })

--- a/pkg/machines/scripts/get_os_list.sh
+++ b/pkg/machines/scripts/get_os_list.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# sed strips spaces at the end, the beginning and spaces around '|'
-osinfo-query os --fields=short-id,name,version,family,vendor,release-date,eol-date,codename | tail -n +3 | sed -e 's/\s*|\s*/|/g; s/^\s*//g; s/\s*$//g'

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -709,6 +709,8 @@ Requires: libvirt-client
 Requires: libvirt-dbus >= 1.2.0
 # Optional components
 Recommends: virt-install
+Recommends: libosinfo
+Recommends: python3-gobject-base
 %endif
 
 %description -n cockpit-machines

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -104,9 +104,8 @@ Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
          libvirt-daemon-system,
-         libvirt-clients | libvirt-bin,
-         libosinfo-bin
-Recommends: virtinst, libvirt-dbus
+         libvirt-clients | libvirt-bin
+Recommends: virtinst, libvirt-dbus, python3-gi, gir1.2-libosinfo-1.0
 Description: Cockpit user interface for virtual machines
  The Cockpit components for managing virtual machines.
  .


### PR DESCRIPTION
Instead of calling libosinfo tools, let's rely on libosinfo APIs in
order to avoid doing a lot of parsing to match the detected OS from a
media or a tree.

In order to do so, the code in libvirt-common.js has been expanded to
also store the (unique) OS ID and, when detecting some media or tree,
then just use this ID when filtering the OS list in autodetectOS().

With the changes, two new python scripts have been added:
- autoDetectOS.py, which does the media/tree detection and returns the
  OS ID;
- getOSList.py, which gets exactly the same information (and in the same
  format) returned by osinfo-query, plus the OS ID.

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>