### PR TITLE
logs: Correctly show older entries

### DIFF
--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -290,7 +290,8 @@ $(function() {
 
         var last = null;
         var count = 0;
-        var stopped = null;
+        var oldest = null;
+        var stopped = false;
 
         procs.push(journal.journalctl(match, options)
                 .fail(query_error)
@@ -302,9 +303,10 @@ $(function() {
                     }
                     count += entries.length;
                     append_entries(entries);
+                    oldest = entries[entries.length - 1]["__CURSOR"];
                     if (count >= query_count) {
-                        stopped = entries[entries.length - 1]["__CURSOR"];
-                        didnt_reach_start(stopped);
+                        stopped = true;
+                        didnt_reach_start(oldest);
                         this.stop();
                     }
                 })
@@ -323,7 +325,7 @@ $(function() {
                                 }));
                     }
                     if (!all || stopped)
-                        didnt_reach_start();
+                        didnt_reach_start(oldest);
                 }));
 
         outer.stop = function stop() {

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -276,9 +276,14 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                         "Load earlier entries",
                         ])
 
+        n = ""
+        # In older version there was bug which showed messages two times
+        # Fixed in #11672
+        if m.image == "rhel-7-6-distropkg":
+            n = "2"
         b.click('#journal-load-earlier')
         wait_log_lines([expected_date,
-                        ["check-journal", "AFTER BOOT", "2"],
+                        ["check-journal", "AFTER BOOT", n],
                         ["", "Reboot", ""],
                         ["check-journal", "BEFORE BOOT", ""]
                         ])


### PR DESCRIPTION
Calling `didnt_reach_start` without any arguments results in calling
`journalctl -r`, which fetches all logs from newest instead of
continuing from the last log that is displayed.

This is reproducible with selecting some time filter (like 'Current
boot`, scrolling down and clicking `Load earlier entries` which will
log the same entries that we already have (starting from the newest one).
There is even test for this but it was testing this problem (expecting
that "After boot" is gonna be twice, which is incorrect behaviour.