### PR TITLE
systemd: Drop -i shell option in Terminal

### DIFF
--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -23,7 +23,7 @@ const _ = cockpit.gettext;
         createChannel(user) {
             return cockpit.channel({
                 "payload": "stream",
-                "spawn": [user.shell || "/bin/bash", "-i"],
+                "spawn": [user.shell || "/bin/bash"],
                 "environ": [
                     "TERM=xterm-256color",
                 ],


### PR DESCRIPTION
Some shells like tlog-rec-session don't have an `-i` option, which
breaks the Terminal page. Shells should be interactive if their stdio is
a PTY and there are no further options, which is the case for the
terminal.

See https://bugzilla.redhat.com/show_bug.cgi?id=1631905