### PR TITLE
logs: Show previous boot

### DIFF
--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -40,6 +40,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
         <ul class="dropdown-menu" role="menu">
           <li><a tabindex="0" data-op="recent" translatable="yes">Recent</a></li>
           <li><a tabindex="0" data-op="boot" translatable="yes">Current boot</a></li>
+          <li><a tabindex="0" data-op="previous-boot" translatable="yes">Previous boot</a></li>
           <li><a tabindex="0" data-op="last-24h" translatable="yes">Last 24 hours</a></li>
           <li><a tabindex="0" data-op="last-week" translatable="yes">Last 7 days</a></li>
         </ul>

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -266,9 +266,17 @@ $(function() {
             reverse: true
         };
 
+        var last = null;
+        var count = 0;
+        var oldest = null;
+        var stopped = false;
+
         var all = false;
         if (start == 'boot') {
             options["boot"] = null;
+        } else if (start == 'previous-boot') {
+            options["boot"] = "-1";
+            last = 1; // Do not try to get newer logs
         } else if (start == 'last-24h') {
             options["since"] = "-1days";
         } else if (start == 'last-week') {
@@ -287,11 +295,6 @@ $(function() {
             clear_service_list();
             load_service_filters(tags_match, options);
         }
-
-        var last = null;
-        var count = 0;
-        var oldest = null;
-        var stopped = false;
 
         procs.push(journal.journalctl(match, options)
                 .fail(query_error)

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -293,8 +293,14 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                         ])
 
         # Check selecting of services
-        if m.image == "rhel-7-6-distropkg": # Introduced in #8347
+        if m.image == "rhel-7-6-distropkg": # Introduced in #8347 and #11675
             return
+
+        b.go("#/?start=previous-boot&tag=check-journal")
+        wait_log_lines([expected_date,
+                        ["check-journal", "BEFORE BOOT", ""],
+                        "Load earlier entries"
+                        ])
 
         b.go("#/?start=boot&prio=6")
 


### PR DESCRIPTION
Add option to show logs from previous boot which makes it easier to
debug why a system crashed.

Fixes #11662