### PR TITLE
bots/image-customize: Add --resize

### DIFF
--- a/bots/image-customize
+++ b/bots/image-customize
@@ -45,6 +45,7 @@ parser.add_argument('-s', '--script', action='append', dest="scriptlist",
 parser.add_argument('-u', '--upload', action='append', dest="uploadlist",
                     default=[], help='Upload file/dir to destination file/dir separated by ":" example: -u file.txt:/var/lib')
 parser.add_argument('--base-image', help='Base image name, if "image" does not match a standard Cockpit VM image name')
+parser.add_argument('--resize', help="Resize the image. Size in bytes with using K, M, or G suffix.")
 parser.add_argument('image', help='The image to use (destination name when using --base-image)')
 args = parser.parse_args()
 
@@ -72,6 +73,9 @@ def prepare_install_image(base_image, install_image):
         if os.path.lexists(install_image):
             os.unlink(install_image)
         os.symlink(os.path.basename(qcow2_image), install_image)
+
+    if args.resize:
+        subprocess.check_call(["qemu-img", "resize", install_image, args.resize])
 
     return install_image
 
@@ -124,7 +128,7 @@ def install_packages(machine_instance, packagelist, install_command):
     if allpackages:
         machine_instance.execute(install_command + " " + ' '.join(allpackages), timeout=1800)
 
-if args.commandlist or args.packagelist or args.scriptlist or args.uploadlist:
+if args.commandlist or args.packagelist or args.scriptlist or args.uploadlist or args.resize:
     if '/' not in args.base_image:
         subprocess.check_call(["image-download", args.base_image])
     machine = testvm.VirtMachine(maintain=True,

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import os
 import shutil
 import subprocess
@@ -111,6 +112,19 @@ class TestImageCustomize(unittest.TestCase):
             with self.assertRaises(subprocess.CalledProcessError):
                 subprocess.check_call(["bots/image-customize", "--verbose",
                                        "--run-command", "false", img])
+
+    def testResize(self):
+        dest = tempfile.mkdtemp(dir=".")
+        self.addCleanup(shutil.rmtree, dest)
+        img = os.path.join(dest, os.environ["TEST_OS"])
+
+        with testvm.Timeout(seconds=300, error_message="Timed out waiting for image-customize"):
+            subprocess.check_call(["bots/image-customize", "--verbose",
+                                   "--resize", "20G", img])
+
+        output = subprocess.check_output(["qemu-img", "info", "--output=json", img], encoding="utf-8")
+        info = json.loads(output)
+        self.assertEqual(int(info['virtual-size']) // 1024 // 1024 // 1024, 20)
 
 
 @unittest.skipUnless("TEST_OS" in os.environ, "TEST_OS not set")


### PR DESCRIPTION
Allow resizing an image from image-customize. This is tricky to do from
the outside, because the image might not yet be downloaded.