### PR TITLE
doc: Fix arguments for cockpit.dbus().proxy() [no-test]

### DIFF
--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -385,7 +385,7 @@ proxy.wait(function() {
   <refsection id="cockpit-dbus-proxy-onchanged">
     <title>proxy.onchanged</title>
 <programlisting>
-proxy.addEventListener("changed", function(data) {
+proxy.addEventListener("changed", function(event, data) {
     ...
 });
 </programlisting>


### PR DESCRIPTION
This gets an `event` argument first. (We don't use that anywhere in the
code.)