### PR TITLE
bots, test: Introduce rhel-8-0-distropkg mode

### DIFF
--- a/bots/images/scripts/rhel-8-0-distropkg.install
+++ b/bots/images/scripts/rhel-8-0-distropkg.install
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+set -e
+
+/var/lib/testvm/fedora.install --rhel "$@"

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -24,7 +24,7 @@ import parent
 from testlib import *
 
 
-@skipImage("Don't run upstream tests against distro packages", "rhel-7-6-distropkg")
+@skipImage("Don't run upstream tests against distro packages", "rhel-7-6-distropkg", "rhel-8-0-distropkg")
 class TestAccounts(MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-active-pages
+++ b/test/verify/check-active-pages
@@ -63,7 +63,7 @@ class TestActivePages(MachineCase):
         b.focus(".terminal")
 
         def line_sel(i):
-            if m.image == "rhel-7-6-distropkg":
+            if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
                 return '.terminal div:nth-child(%d)' % i
             else:
                 return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -217,7 +217,7 @@ class TestConnection(MachineCase):
         b.logout()
         cookie = b.cookie("cockpit")
         self.assertEqual(cookie["value"], "deleted")
-        if m.image != "rhel-7-6-distropkg":
+        if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             # fixed in PR #10766
             self.assertTrue(cookie["httpOnly"])
             # fixed in PR #11279

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -216,7 +216,7 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
 
         b.enter_page("/system", "10.111.113.3")
         b.wait_text_not("#system_information_systime_button", "")
-        if m.image == "rhel-7-6-distropkg":
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             sel = "#link-network"
         else:
             sel = "#link-network a"

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -26,7 +26,7 @@ from testlib import *
 
 
 @skipPackage("cockpit-docker")
-@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-1")
+@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
 class TestDocker(MachineCase):
 
     def setUp(self):
@@ -576,7 +576,7 @@ CMD ["/bin/sh"]
     @skipImage("Newer version of ABRT required", "centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7")
     @skipImage("No cockpit-docker on i386", "fedora-i386")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-1804", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-8-0", "rhel-8-1")
+               "ubuntu-1804", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
     def testContainerProblems(self):
         b = self.browser
         m = self.machine
@@ -621,7 +621,7 @@ CMD ["/bin/sh"]
 
 @skipImage("Skip on systems without atomic and ones with missing deps", "centos-7", "debian-stable",
            "debian-testing", "ubuntu-1804", "ubuntu-stable", "rhel-atomic", "fedora-atomic", "fedora-i386")
-@skipImage("No docker packaged", "rhel-8-0", "rhel-8-1")
+@skipImage("No docker packaged", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
 @skipPackage("cockpit-docker")
 class TestAtomicScan(MachineCase):
 

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -42,7 +42,7 @@ def can_manage(machine):
 
 
 @skipImage("No cockpit-docker on i386", "fedora-i386")
-@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-1")
+@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
 @skipPackage("cockpit-docker")
 class TestDockerStorageDirect(MachineCase):
 
@@ -61,7 +61,7 @@ class TestDockerStorageDirect(MachineCase):
 
 
 @skipImage("No cockpit-docker on i386", "fedora-i386")
-@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-1")
+@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
 @skipPackage("cockpit-docker")
 class TestDockerStorage(MachineCase):
     provision = {"machine1": {"address": "10.111.113.1/20"}}

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -283,7 +283,7 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         n = ""
         # In older version there was bug which showed messages two times
         # Fixed in #11672
-        if m.image == "rhel-7-6-distropkg":
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             n = "2"
         b.click('#journal-load-earlier')
         wait_log_lines([expected_date,
@@ -293,7 +293,7 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                         ])
 
         # Check selecting of services
-        if m.image == "rhel-7-6-distropkg": # Introduced in #8347 and #11675
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]: # Introduced in #8347 and #11675
             return
 
         b.go("#/?start=previous-boot&tag=check-journal")
@@ -368,7 +368,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
 
         b.wait_text("#journal-entry-message", "[no data]")
 
-    @skipImage("https://bugzilla.redhat.com/show_bug.cgi?id=1665421", "rhel-7-6-distropkg")
+    @skipImage("https://bugzilla.redhat.com/show_bug.cgi?id=1665421", "rhel-7-6-distropkg", "rhel-8-0-distropkg")
     def testLogLevel(self):
 
         b = self.browser
@@ -400,7 +400,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
     @skipImage("Newer version of ABRT required", "centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7")
     @skipImage("ABRT does not work on i386", "fedora-i386")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-1804", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-8-0", "rhel-8-1")
+               "ubuntu-1804", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
     def testAbrtSegv(self):
         self.allow_core_dumps = True
         b = self.browser
@@ -448,7 +448,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
     @skipImage("Newer version of ABRT required", "centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7")
     @skipImage("ABRT does not work on i386", "fedora-i386")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-1804", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-8-0", "rhel-8-1")
+               "ubuntu-1804", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
     def testAbrtDelete(self):
         self.allow_core_dumps = True
         b = self.browser
@@ -482,7 +482,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
     @skipImage("Newer version of ABRT required", "centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7")
     @skipImage("ABRT does not work on i386", "fedora-i386")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-1804", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-8-0", "rhel-8-1")
+               "ubuntu-1804", "rhel-atomic", "fedora-atomic", "continuous-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
     def testAbrtReport(self):
         self.allow_core_dumps = True
         # The testing server is located at verify/files/mock-faf-server.py

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -37,7 +37,7 @@ class TestKdump(MachineCase):
             contents = self.machine.execute(command="cat /boot/grub2/grub.cfg", quiet=True)
             self.assertIn("crashkernel=auto", contents)
             self.machine.write("/boot/grub2/grub.cfg", contents.replace("crashkernel=auto", "crashkernel=256M"))
-        elif self.machine.image in ["rhel-8-0", "rhel-8-1"]:
+        elif self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             # these images use BootLoaderSpec and grubenv
             self.machine.execute(
                 "sed -i '/^kernelopts=/ { s/crashkernel=[^ ]*//; s/$/ crashkernel=256M/; }' /boot/grub2/grubenv")
@@ -78,7 +78,7 @@ class TestKdump(MachineCase):
 
         onOffSelectorActive = "div.btn-onoff-ct label.active"
 
-        if m.image in ["rhel-8-0", "rhel-8-1"]:
+        if m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             # some OSes have kdump enabled by default (crashkernel=auto)
             b.wait_in_text("#app", "Service is running")
             b.wait_in_text(onOffSelectorActive, "On")
@@ -103,7 +103,7 @@ class TestKdump(MachineCase):
         b.wait_visible("#app")
         self.enableLocalSsh()
 
-        if m.image not in ["rhel-7-6-distropkg"]:
+        if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             # minimal nfs validation
             settingsLink = "a:contains('locally in /var/crash')"
             b.click(settingsLink, True)
@@ -144,7 +144,7 @@ class TestKdump(MachineCase):
         b.wait_in_text("#app", "Service is running")
 
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1536327
-        if m.image in ["rhel-7-6-distropkg"]:
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             return
 
         # try to change the path to a directory that doesn't exist

--- a/test/verify/check-kubernetes
+++ b/test/verify/check-kubernetes
@@ -27,7 +27,7 @@ from testlib import *
 
 
 @skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1804",
-           "ubuntu-stable", "fedora-i386", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-1", "centos-7")
+           "ubuntu-stable", "fedora-i386", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "centos-7")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "fedora-30")
 @skipPackage("cockpit-kubernetes")
 class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
@@ -46,7 +46,7 @@ class TestKubernetes(kubelib.KubernetesCase, kubelib.KubernetesCommonTests):
 
 
 @skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1804",
-           "ubuntu-stable", "fedora-i386", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-1", "centos-7")
+           "ubuntu-stable", "fedora-i386", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "centos-7")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "fedora-30")
 @skipPackage("cockpit-kubernetes")
 class TestConnection(kubelib.KubernetesCase):
@@ -225,7 +225,7 @@ class TestConnection(kubelib.KubernetesCase):
 
 
 @skipImage("No kubernetes packaged", "debian-stable", "debian-testing", "ubuntu-1804",
-           "ubuntu-stable", "fedora-i386", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-1", "centos-7")
+           "ubuntu-stable", "fedora-i386", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "centos-7")
 @unittest.skipIf(True, "Nulecule deploys temporarily removed.")
 @skipPackage("cockpit-kubernetes")
 class TestNulecule(kubelib.KubernetesCase):

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -831,7 +831,7 @@ class TestMachinesDBus(machineslib.TestMachines):
             ).execute()
 
             # iscsi-direct pool type is available since libvirt 4.7
-            if m.image not in ["rhel-8-0", "rhel-8-1"]:
+            if m.image not in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
                 StoragePoolCreateDialog(
                     self,
                     name="my_iscsi_direct_pool",

--- a/test/verify/check-machines-virsh
+++ b/test/verify/check-machines-virsh
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @skipImage("LibvirtDBus is the only available provider",
-           "fedora-29", "fedora-30", "fedora-i386", "fedora-testing", "rhel-8-0", "rhel-8-1")
+           "fedora-29", "fedora-30", "fedora-i386", "fedora-testing", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
 class TestMachinesVirsh(machineslib.TestMachines):
 
     def removeLibvirtDBus(self):

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -203,7 +203,7 @@ class TestMultiMachineAdd(MachineCase):
 
     @skipImage("Newer version (>= 0.8.5) of libssh required", "debian-stable", "debian-testing",
                "ubuntu-1804", "ubuntu-stable", "fedora-atomic", "rhel-atomic", "continuous-atomic",
-               "rhel-8-0", "centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7")
+               "rhel-8-0", "rhel-8-0-distropkg", "centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7")
     def testGlobalSSHConfig(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -79,6 +79,7 @@ class TestFirewall(MachineCase):
         self.allow_journal_messages(".*The name org.fedoraproject.FirewallD1 was not provided by any .service files.*",
                                     ".*org.fedoraproject.FirewallD1: couldn't introspect /org/fedoraproject/FirewallD1/config: GDBus.Error:org.freedesktop.DBus.Error.NoReply: Message recipient disconnected from message bus without replying.*")
 
+    @skipImage("Button got fixed in PR #10975", "rhel-7-6-distropkg", "rhel-8-0-distropkg")
     def testFirewallPage(self):
         b = self.browser
         m = self.machine
@@ -119,9 +120,8 @@ class TestFirewall(MachineCase):
         self.assertNotIn('pop3', m.execute("firewall-cmd --list-services").split())
 
         # Test that service without name is shown properly
-        if m.image != "rhel-7-6-distropkg": # Fixed in #11318
-            m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload && firewall-cmd --add-service=empty")
-            b.wait_present("tr[data-row-id='empty']")
+        m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload && firewall-cmd --add-service=empty")
+        b.wait_present("tr[data-row-id='empty']")
 
         # switch service off again
         b.click(".btn-onoff-ct label.active span")
@@ -131,7 +131,8 @@ class TestFirewall(MachineCase):
         # "Add Services" button should be hidden again
         b.wait_not_present("caption button.btn-primary")
 
-    @skipImage("Filtering got fixed, and IDs changed to data-id in 184", "rhel-7-6-distropkg")
+    @skipImage("Filtering got fixed, IDs changed to data-id, and conversion to ListView in 191",
+               "rhel-7-6-distropkg", "rhel-8-0-distropkg")
     def testAddServices(self):
         b = self.browser
         m = self.machine
@@ -192,7 +193,7 @@ class TestFirewall(MachineCase):
             b.click("caption button.btn-primary")
             b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='empty']")
 
-    @skipImage("Custom ports were introduced in #11420", "rhel-7-6-distropkg")
+    @skipImage("Custom ports were introduced in #11420", "rhel-7-6-distropkg", "rhel-8-0-distropkg")
     def testAddCustomServices(self):
         b = self.browser
 

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -40,7 +40,7 @@ def wait_healthz(openshift):
 
 
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1804", "ubuntu-stable", "fedora-i386")
-@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "rhel-8-0", "rhel-8-1", "fedora-30")
+@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "fedora-30")
 class TestOpenshift(MachineCase, OpenshiftCommonTests):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},
@@ -369,7 +369,7 @@ class TestOpenshiftPrerelease(TestOpenshift):
 
 
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1804", "ubuntu-stable", "fedora-i386")
-@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "rhel-8-0", "rhel-8-1", "fedora-30")
+@skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "fedora-30")
 class TestRegistry(MachineCase, RegistryTests):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},

--- a/test/verify/check-ovirt
+++ b/test/verify/check-ovirt
@@ -70,7 +70,7 @@ TEST_VDSM_CONF_CONTENT = "Dummy content of the vdsm.conf file"
 
 
 @skipImage("No oVirt release", "continuous-atomic", "debian-stable", "debian-testing", "fedora-i386",
-           "fedora-atomic", "rhel-atomic", "rhel-8-0", "rhel-8-1", "fedora-testing", "ubuntu-1804", "ubuntu-stable",
+           "fedora-atomic", "rhel-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "fedora-testing", "ubuntu-1804", "ubuntu-stable",
            "fedora-30")
 class TestOVirtMachines(MachineCase):
     provision = {

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -98,7 +98,7 @@ OnCalendar=daily
         b.switch_to_top()
         b.click("a[href='/system/services']")
         b.enter_page("/system/services")
-        if m.image == "rhel-7-6-distropkg":
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             b.wait_present("#services-list-enabled")
         else:
             b.wait_present("#services-list")
@@ -156,7 +156,7 @@ OnCalendar=daily
         # Systemd timer localization
         b.go("/system/services")
         b.enter_page("/system/services")
-        if m.image == "rhel-7-6-distropkg":
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             b.click('#services-filter button[data-pattern=\'\\\.timer\$\']')
         else:
             b.click('#services-filter li[data-pattern=\'\\\.timer\$\']')
@@ -308,7 +308,7 @@ OnCalendar=daily
         # Systemd timer localization
         b.go('/system/services')
         b.enter_page('/system/services')
-        if m.image == "rhel-7-6-distropkg":
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             b.click('#services-filter button[data-pattern=\'\\\.timer\$\']')
         else:
             b.click('#services-filter li[data-pattern=\'\\\.timer\$\']')

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -67,7 +67,7 @@ class TestRealms(MachineCase):
     def setUp(self):
         super().setUp()
         # classes converted to IDs in PR #11022
-        if self.machine.image == "rhel-7-6-distropkg":
+        if self.machine.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             self.op_address = ".realms-op-address"
             self.op_admin = ".realms-op-admin"
             self.op_admin_password = ".realms-op-admin-password"
@@ -105,7 +105,7 @@ class TestRealms(MachineCase):
         b.wait_popup("realms-op")
         with b.wait_timeout(180):
             b.set_val(self.op_address, "cockpit.lan")
-            if m.image != "rhel-7-6-distropkg":
+            if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
                 # changed in PR #11022
                 b.wait_text(".realms-op-address-error", "Contacted domain")
             b.wait_attr(self.op_admin, "placeholder", 'e.g. "admin"')
@@ -119,7 +119,7 @@ class TestRealms(MachineCase):
             wait_number_domains(1)
 
         # when joined to a domain, changing the hostname is fatal, so should be disabled
-        if m.image != "rhel-7-6-distropkg":
+        if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             # fixed in Cockpit 186
             b.wait_present("#system_information_hostname_button[disabled]")
             b.mouse("#system_information_hostname_button", "mouseover")
@@ -206,7 +206,7 @@ class TestRealms(MachineCase):
         b.wait_in_text("#system-info-domain a", "cockpit.lan")
         b.click("#system-info-domain a")
         b.wait_popup("realms-op")
-        if m.image != "rhel-7-6-distropkg":
+        if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             b.wait_visible("#realms-op-info-domain")
             b.wait_text("#realms-op-info-domain", "cockpit.lan")
             b.wait_text("#realms-op-info-login-format", "username@cockpit.lan")
@@ -253,7 +253,7 @@ class TestRealms(MachineCase):
         b.click("#system-info-domain a")
         b.wait_popup("realms-op")
         b.set_val(self.op_address, "NOPE")
-        if m.image != "rhel-7-6-distropkg":
+        if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             # changed in PR #11022
             b.wait_text(".realms-op-address-error", "Domain NOPE could not be contacted")
             b.wait_not_visible(".realms-op-address-spinner")
@@ -306,7 +306,7 @@ class TestRealms(MachineCase):
         b.wait_in_text("#system-info-domain a", "cockpit.lan")
 
         # Show domain information (PR #11096)
-        if m.image != "rhel-7-6-distropkg":
+        if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             b.click("#system-info-domain a")
             b.wait_popup("realms-op")
             b.wait_visible("#realms-op-info-domain")
@@ -369,7 +369,7 @@ class TestRealms(MachineCase):
         b.click("#system-info-domain a")
         b.wait_popup("realms-op")
         b.set_val(self.op_address, "cockpit.lan")
-        if m.image != "rhel-7-6-distropkg":
+        if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             # changed in PR #11022
             b.wait_in_text(".realms-op-address-error", "Domain cockpit.lan is not supported")
         else:
@@ -494,13 +494,13 @@ class TestKerberos(MachineCase):
         b.focus(".terminal")
 
         def line_sel(i):
-            if m.image == "rhel-7-6-distropkg":
+            if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
                 return '.terminal div:nth-child(%d)' % i
             else:
                 return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i
 
         def wait_prompt(b, line):
-            if m.image == "rhel-7-6-distropkg":
+            if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
                 b.wait_js_func("(function (sel) { return ph_text(sel).trim() != ''})", line_sel(line))
             else:
                 b.wait_js_func("(function (sel) { return ph_text(sel).trim() != 'Blank line'})", line_sel(line))

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -108,7 +108,7 @@ Unit=test.service
             b.wait_in_text(svc_sel(service), state)
 
         def wait_service_in_panel(service, title):
-            if m.image == "rhel-7-6-distropkg": # Changed in #11241
+            if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]: # Changed in #11241
                 b.wait_in_text(".panel:contains('%s') .panel-heading" % service, title)
             else:
                 wait_service_state(service, title)
@@ -208,7 +208,7 @@ Unit=test.service
         self.allow_journal_messages("Failed to get realtime timestamp: Cannot assign requested address")
 
         # Test searching and filtering
-        if m.image == "rhel-7-6-distropkg": # Introduced in #11241
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]: # Introduced in #11241
             return
 
         def wait_service_present(service):
@@ -321,7 +321,7 @@ WantedBy=default.target
             "busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP"))
         m.execute("timedatectl set-time '2020-01-01 15:30:00'")
         self.login_and_go("/system/services")
-        if m.image != "rhel-7-6-distropkg": # Introduced in #11280
+        if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]: # Introduced in #11280
             b.wait_not_visible("#loading-fallback")
         b.click('#services-filter :nth-child(4)')
         b.wait_visible("#create-timer")

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -51,7 +51,7 @@ class TestSession(MachineCase):
         wait_session(True)
 
         # Check session type (fixed in PR #10963)
-        if not m.atomic_image and m.image != "rhel-7-6-distropkg":
+        if not m.atomic_image and m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             id = m.execute("loginctl list-sessions | awk '/admin/ {print $1}'").strip()
             self.assertEqual(m.execute("loginctl show-session -p Type %s" % id).strip(), "Type=web")
 

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -48,7 +48,7 @@ threads=2
         b.wait_visible("#sos")
 
         with b.wait_timeout(360):
-            if m.image != "rhel-7-6-distropkg": # Fixed in #11484
+            if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]: # Fixed in #11484
                 b.wait(lambda: b.eval_js('ph_find(".progress-bar").offsetWidth') > 0)
             b.wait_visible("#sos-download")
 

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -94,7 +94,7 @@ class TestStorage(StorageCase):
         else:
             check_type("vfat", 11)
 
-        if self.storaged_is_old_udisks or m.image in ["rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "centos-7", "rhel-8-0", "rhel-8-1"]:
+        if self.storaged_is_old_udisks or m.image in ["rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "centos-7", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             check_unsupported_type("ntfs")
         else:
             check_type("ntfs", 128)

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -233,7 +233,7 @@ class TestStorage(StorageCase):
         m = self.machine
         b = self.browser
 
-        luks_2 = m.image in ["rhel-8-0", "rhel-8-1"]
+        luks_2 = m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]
         error_base = "Error unlocking /dev/sda: Failed to activate device: "
         error_messages = [error_base + "Operation not permitted",
                           error_base + "Incorrect passphrase."]

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -122,7 +122,7 @@ class TestStorage(StorageCase):
                          can_shrink=False,
                          can_grow=True, grow_needs_unmount=False)
 
-    @skipImage("No NTFS support installed", "centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-1")
+    @skipImage("No NTFS support installed", "centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
     def testResizeNtfs(self):
         self.checkResize("ntfs",
                          can_shrink=True, shrink_needs_unmount=True,
@@ -130,12 +130,12 @@ class TestStorage(StorageCase):
 
     def testResizeLuks(self):
         # Only newer versions of UDisks support resizing encrypted block devices
-        if self.machine.image in ["rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-1", "fedora-29",
+        if self.machine.image in ["rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "fedora-29",
                                   "fedora-30", "fedora-testing", "fedora-i386", "debian-testing", "ubuntu-stable", "centos-7"]:
             self.checkResize("luks+ext4",
                              can_shrink=True, shrink_needs_unmount=True,
                              can_grow=True, grow_needs_unmount=False,
-                             need_passphrase=(self.machine.image in ["rhel-8-0", "rhel-8-1"]))
+                             need_passphrase=(self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]))
         else:
             self.checkResize("luks+ext4",
                              can_shrink=False,
@@ -271,7 +271,7 @@ class TestStorage(StorageCase):
 
         b.wait_present(vol_tab + " button:contains(Grow Content)")
         self.content_tab_action(1, 1, "Grow Content")
-        if self.machine.image in ["rhel-8-0", "rhel-8-1"]:
+        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             confirm_with_passphrase()
         self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Grow Content)")
         size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
@@ -286,7 +286,7 @@ class TestStorage(StorageCase):
 
         b.wait_present(vol_tab + " button:contains(Shrink Volume)")
         self.content_tab_action(1, 1, "Shrink Volume")
-        if self.machine.image in ["rhel-8-0", "rhel-8-1"]:
+        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             confirm_with_passphrase()
         self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Shrink Volume)")
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))
@@ -299,7 +299,7 @@ class TestStorage(StorageCase):
 
         b.wait_present(vol_tab + " button:contains(Grow Content)")
         self.content_tab_action(1, 1, "Grow Content")
-        if self.machine.image in ["rhel-8-0", "rhel-8-1"]:
+        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             confirm_with_passphrase()
         self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Grow Content)")
         size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
@@ -314,7 +314,7 @@ class TestStorage(StorageCase):
 
         b.wait_present(vol_tab + " button:contains(Shrink Volume)")
         self.content_tab_action(1, 1, "Shrink Volume")
-        if self.machine.image in ["rhel-8-0", "rhel-8-1"]:
+        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             confirm_with_passphrase()
         self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Shrink Volume)")
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -82,7 +82,7 @@ print [ e['id'] for e in data if e['owner']['key'] == 'admin' and e['contractNum
 
 @skipImage("No subscriptions", "centos-7", "continuous-atomic", "debian-stable", "debian-testing", "fedora-29",
            "fedora-30", "fedora-i386", "fedora-atomic", "fedora-testing", "ubuntu-1804", "ubuntu-stable")
-@skipImage("cockpit-subscriptions obsoleted by external subscription-manager-cockpit", "rhel-8-0", "rhel-8-1")
+@skipImage("cockpit-subscriptions obsoleted by external subscription-manager-cockpit", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
 class TestSubscriptions(MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20"},

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -275,7 +275,7 @@ class TestSystemInfo(MachineCase):
         b.wait_not_present('#systime-tooltip ~ div.tooltip')
 
     @skipImage("No NTP servers config", "centos-7", "continuous-atomic",
-               "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-1", "rhel-atomic")
+               "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-atomic")
     def testTimeServers(self):
         m = self.machine
         b = self.browser
@@ -393,7 +393,7 @@ class TestSystemInfo(MachineCase):
         b.enter_page("/system")
 
         # now pretend this is a system without DMI; fixed in PR #11005
-        if self.machine.image == 'rhel-7-6-distropkg':
+        if self.machine.image in ['rhel-7-6-distropkg', 'rhel-8-0-distropkg']:
             return
 
         b.logout()
@@ -419,7 +419,7 @@ class TestSystemInfo(MachineCase):
 
         self.machine.execute("umount /sys/class/dmi")
 
-    @skipImage("Added in pull 11368", "rhel-7-6-distropkg")
+    @skipImage("Added in pull 11368", "rhel-7-6-distropkg", "rhel-8-0-distropkg")
     def testCPUSecurityMitigations(self):
         b = self.browser
         m = self.machine
@@ -591,7 +591,7 @@ class TestPcp(packagelib.PackageCase):
         # Turn stored metrics on
         self.assertIn("active", b.attr("#server-pmlogger-switch label:nth-child(2)", "class"))
         b.click("#server-pmlogger-switch label:first-child")
-        if m.image == "rhel-7-6-distropkg": # PR #11224
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]: # PR #11224
             return
         b.wait_attr_contains("#server-pmlogger-switch label:first-child", "class", "disabled")
         m.execute("touch /tmp/pmlogger.start")

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -40,11 +40,11 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         self.login_and_go("/system/terminal")
 
         blank_state = ''
-        if m.image != "rhel-7-6-distropkg":
+        if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             blank_state = 'Blank line'
 
         def line_sel(i):
-            if m.image == "rhel-7-6-distropkg":
+            if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
                 return '.terminal div:nth-child(%d)' % i
             else:
                 return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i
@@ -98,7 +98,7 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         self.assertNotIn('admin', b.text(line_sel(n + 1)))
 
         # Fixed in PR #11148
-        if m.image == "rhel-7-6-distropkg":
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             return
 
         def select_line(sel, width):

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -36,7 +36,7 @@ class PackageCase(MachineCase):
         # expected backend; hardcode this on image names to check the auto-detection
         if self.machine.image.startswith("debian") or self.machine.image.startswith("ubuntu"):
             self.backend = "apt"
-        elif self.machine.image.startswith("fedora") or self.machine.image in ["rhel-8-0", "rhel-8-1"]:
+        elif self.machine.image.startswith("fedora") or self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             self.backend = "dnf"
         elif self.machine.image in ["centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7"]:
             self.backend = "yum"


### PR DESCRIPTION
We will use this to test the rhel-8-appstream branch as well as z-stream
updates.

 - [x] Fix Machines page for running against cockpit-system 185: PR #11704 
 - [x] Declare rhel-8-0-distropkg test: PR #11705