### PR TITLE
bots: Fix data type

### DIFF
--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -169,7 +169,7 @@ def guessFlake(output, context, verbose=False):
             data = urllib.request.urlopen(url, data=jsonl.encode('utf-8')).read()
         except (ConnectionResetError, urllib.error.URLError, socket.gaierror) as ex:
             sys.stderr.write("{0}: {1}\n".format(url, ex))
-            data = "{ }"
+            data = b"{ }"
         try:
             response = json.loads(data.decode('utf-8'))
         except ValueError as ex:


### PR DESCRIPTION
WHen opening the flake data fails, provide a byte array instead of a
string as fallback, so that the subsequent `.decode()` call doesn't fail
on an `AttributeError`.