### PR TITLE
storage: Fix StorageButton event propagation

### DIFF
--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -93,6 +93,8 @@ function checked(callback) {
         // only consider primary mouse button
         if (!event || event.button !== 0)
             return;
+        // don't let the click "fall through" to the dialog's form
+        event.preventDefault();
         var promise = callback();
         if (promise)
             promise.fail(function (error) {
@@ -100,7 +102,6 @@ function checked(callback) {
                               Body: error.toString()
                 });
             });
-        event.stopPropagation();
     };
 }
 


### PR DESCRIPTION
Similar to commit 1570bf3624d or 61adf70c1b, stop the StorageButton
clicks from bubbling into the dialog that's about to open. They
sometimes trigger the dialog form's submit handler, leading to immediate
dialog close again.

Fixes #11697