### PR TITLE
test: Wait for Cockpit to catch up after resize

### DIFF
--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -81,6 +81,7 @@ class TestStorage(StorageCase):
             self.dialog_wait_close()
             # HACK - https://github.com/storaged-project/udisks/pull/631
             m.execute("udevadm trigger")
+            self.content_tab_wait_in_info(1, 1, "Size", "400 MiB")
             if grow_needs_unmount:
                 self.content_tab_action(fsys_row, fsys_tab, "Mount")
                 self.content_tab_wait_in_info(fsys_row, fsys_tab, "Mounted At", mountpoint)
@@ -102,6 +103,7 @@ class TestStorage(StorageCase):
             self.dialog_wait_close()
             # HACK - https://github.com/storaged-project/udisks/pull/631
             m.execute("udevadm trigger")
+            self.content_tab_wait_in_info(1, 1, "Size", "200 MiB")
             if shrink_needs_unmount:
                 self.content_tab_action(fsys_row, fsys_tab, "Mount")
                 self.content_tab_wait_in_info(fsys_row, fsys_tab, "Mounted At", mountpoint)


### PR DESCRIPTION
While the resize happens and isn't complete, Cockpit will briefly show
a warning about mismatching sizes.  We now wait for that warning to be
gone and the regular buttons to reappear.

Without this, the test might hit the "Shrink Volume" button when it
aims for the "Shrink" button.  This happens because it clicks on any
button that _contains_ the string "Shrink" somewhere, instead of
hitting one that has _exactly_ "Shrink" as the text, which is a bug by
itself.