### PR TITLE
cockpit-desktop: support simple arguments

### DIFF
--- a/doc/man/cockpit-desktop.xml
+++ b/doc/man/cockpit-desktop.xml
@@ -78,10 +78,9 @@
     <para>
       The <literal>BROWSER </literal> environment variable specifies
       the browser command (and possibly options) that will be used to open the
-      requested Cockpit page. If not set, <command>cockpit-desktop</command> uses
-      <citerefentry>
-        <refentrytitle>xdg-open</refentrytitle><manvolnum>1</manvolnum>
-      </citerefentry>.
+      requested Cockpit page. If not set, <command>cockpit-desktop</command> attempts to use
+      an internal minimalistic WebKit browser, and failing that, will attempt to detect some
+      reasonable alternatives.
     </para>
   </refsect1>
 

--- a/doc/man/cockpit-desktop.xml
+++ b/doc/man/cockpit-desktop.xml
@@ -68,7 +68,8 @@
       <ulink url="https://cockpit-project.org/guide/latest/embedding.html">particular page frame</ulink>,
       not the entire Cockpit navigation and menu. For example, the path
       <literal>/cockpit/@localhost/storage/index.html</literal> will open the Storage
-      page.
+      page.  It is also possible to give abbreviated forms of urls, such as "<literal>storage</literal>"
+      or "<literal>network/firewall</literal>".
     </para>
   </refsect1>
 

--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -22,7 +22,10 @@
 # have cockpit.socket enabled. The web server and browser run in an unshared
 # network namespace, and thus are totally isolated from everything else.
 #
-# Example: cockpit-desktop /cockpit/@localhost/system/index.html
+# Examples:
+#   cockpit-desktop /cockpit/@localhost/system/index.html
+#   cockpit-desktop network/firewall
+#   cockpit-desktop users
 set -eu
 
 # minimalistic WebKit browser
@@ -131,7 +134,21 @@ if [ -z "${1:-}" ]; then
     exit 1
 fi
 
-URL_PATH="$1"
+# Expand the commandline argument into a url
+case "$1" in
+    /*)
+        URL_PATH="$1"
+        ;;
+    */)
+        URL_PATH="/cockpit/@localhost/$1index.html"
+        ;;
+    */*)
+        URL_PATH="/cockpit/@localhost/$1.html"
+        ;;
+    *)
+        URL_PATH="/cockpit/@localhost/$1/index.html"
+        ;;
+esac
 
 detect_browser
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -405,8 +405,19 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
 
     @skipImage("Atomic doesn't have cockpit-ws installed", "fedora-atomic", "rhel-atomic", "continuous-atomic")
     @skipImage("Kernel does not allow user namespaces", "centos-7", "rhel-7-6", "rhel-7-7", "debian-stable", "debian-testing")
-    @skipImage("Added in 184", "rhel-7-6-distropkg")
+    @skipImage("Simple paths added in PR #11701", "rhel-7-6-distropkg")
     def testCockpitDesktop(self):
+        cases = [(['/cockpit/@localhost/system/index.html', 'system', 'system/index', 'system/'],
+                  ['id="system_machine_id"', 'data-action="shutdown"']
+                 ),
+                 (['/cockpit/@localhost/network/firewall.html', 'network/firewall'],
+                  ['div id="firewall"', 'script src="firewall.js"']
+                 ),
+                 (['/cockpit/@localhost/playground/react-patterns.html', 'playground/react-patterns'],
+                  ['script src="react-patterns.js"']
+                 ),
+                ]
+
         m = self.machine
 
         if "debian" in m.image or "ubuntu" in m.image:
@@ -414,12 +425,17 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
         else:
             cockpit_desktop = "/usr/libexec/cockpit-desktop"
 
-        m.execute('''su - -c 'BROWSER="curl --compressed -o /tmp/out.html" %s /cockpit/@localhost/system/index.html' admin''' % cockpit_desktop)
-        out = m.execute("cat /tmp/out.html")
-        self.assertIn('id="system_machine_id"', out)
-        self.assertIn('data-action="shutdown"', out)
-        # should clean up processes
-        self.assertEqual(m.execute("! pgrep -a cockpit-ws && ! pgrep -a cockpit-bridge"), "")
+        for (pages, asserts) in cases:
+            for page in pages:
+                m.execute('''su - -c 'BROWSER="curl --silent --compressed -o /tmp/out.html" %s %s' admin''' %
+                          (cockpit_desktop, page))
+
+                out = m.execute("cat /tmp/out.html")
+                for a in asserts:
+                    self.assertIn(a, out)
+
+                # should clean up processes
+                self.assertEqual(m.execute("! pgrep -a cockpit-ws && ! pgrep -a cockpit-bridge"), "")
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 


### PR DESCRIPTION
Add support for short page names like 'users' or 'network/firewall'
directly on the commandline.

Closes #10809