### PR TITLE
machines: Use cockpit.all() instead of Promise.all()

### DIFF
--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -360,7 +360,10 @@ LIBVIRT_DBUS_PROVIDER = {
                 }
             }
 
-            return dispatch => Promise.all(storageVolPromises)
+            // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
+            // https://github.com/cockpit-project/cockpit/issues/10956
+            // eslint-disable-next-line cockpit/no-cockpit-all
+            return dispatch => cockpit.all(storageVolPromises)
                     .then(() => {
                         return call(connectionName, objPath, 'org.libvirt.Domain', 'Undefine', [flags], TIMEOUT);
                     });
@@ -435,7 +438,10 @@ LIBVIRT_DBUS_PROVIDER = {
     }) {
         return dispatch => {
             call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListNodeDevices', [0], TIMEOUT)
-                    .then(objPaths => Promise.all(objPaths[0].map(path => dispatch(getNodeDevice({ connectionName, id:path })))))
+                    // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
+                    // https://github.com/cockpit-project/cockpit/issues/10956
+                    // eslint-disable-next-line cockpit/no-cockpit-all
+                    .then(objPaths => cockpit.all(objPaths[0].map(path => dispatch(getNodeDevice({ connectionName, id:path })))))
                     .fail(ex => console.warn('GET_ALL_NODE_DEVICES action failed:', JSON.stringify(ex)));
         };
     },

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -830,8 +830,8 @@ class TestMachinesDBus(machineslib.TestMachines):
                 source={"host": "127.0.0.1", "source_path": target_iqn}
             ).execute()
 
-            # iscsi-direct pool type is available since libvirt 4.7 which is not available yet in RHEL
-            if m.image not in ["rhel-8.0", "rhel-8.1"]:
+            # iscsi-direct pool type is available since libvirt 4.7
+            if m.image not in ["rhel-8-0", "rhel-8-1"]:
                 StoragePoolCreateDialog(
                     self,
                     name="my_iscsi_direct_pool",


### PR DESCRIPTION
Otherwise the Machines page crashes with

    TypeError: Method Promise.prototype.then called on incompatible receiver #<Object>

when running against cockpit-system 185 (in RHEL 8.0). As we don't
enforce this through versioned dependencies, and don't want to, go back
to `cockpit.all()` for `ListNodeDevices()`, as some other parts of the code already do.