### PR TITLE
test: Fix race condition in TestSystemInfo.testTimeServers

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -306,6 +306,10 @@ PageServer.prototype = {
         var $ntp_status = $('#system_information_systime_ntp_status');
 
         function update_ntp_status() {
+            // flag for tests that timedated proxy got activated
+            if (self.server_time.timedate.CanNTP !== undefined)
+                $('#system_information_systime_button').attr("data-timedated-initialized", true);
+
             if (!self.server_time.timedate.NTP) {
                 $ntp_status.hide();
                 $ntp_status.attr("data-original-title", null);

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -280,10 +280,6 @@ class TestSystemInfo(MachineCase):
         m = self.machine
         b = self.browser
 
-        def can_ntp():
-            return 'true' in m.execute(
-                'busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 CanNTP')
-
         conf = "/etc/systemd/timesyncd.conf.d/50-cockpit.conf"
 
         # Use systemd-timedated as the provider of
@@ -292,16 +288,8 @@ class TestSystemInfo(MachineCase):
 
         self.login_and_go("/system")
 
-        # HACK: This check needs to stay here, since it solves the following race condition;
-        # Previously the test was opening the dialog before the proxy was initialized, resulting in showing only
-        # the manual select entry in the dialog.
-        # Keeping the can_ntp call here, will make sure that the dialog will get updated, since
-        # can_ntp call will start the timedated service, and the dialog will
-        # receive the changed signal to update the enabled select entries.
-        wait(can_ntp)
-
         # Wait until everything is ready to go...
-        b.wait_text_not("#system_information_systime_button", "")
+        b.wait_attr("#system_information_systime_button", "data-timedated-initialized", "true")
 
         # Add two NTP servers.  We can't expect the servers to be used, so
         # we only test that they get added.


### PR DESCRIPTION
Waiting for timedated to become ready in the test is not enough: We need
to wait until Cockpit's host.js initializes the proxy and updates the
properties, which takes a little longer. Thus the dialog was still often
opened too early, before `CanNTP` was initialized.

Now set a `data-timedated-initialized` attribute to the page's time
information once the proxy is ready, and let the test wait for it.