### PR TITLE
storage: Move "Format" button to row header

### DIFF
--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -314,6 +314,10 @@ function create_tabs(client, target, is_partition) {
         add_action(_("Delete"), delete_, excuse);
     }
 
+    if (block) {
+        add_action(_("Format"), () => format_dialog(client, block.path));
+    }
+
     return {
         renderers: tabs,
         actions: <React.Fragment>{tab_actions}</React.Fragment>,

--- a/pkg/storaged/crypto-tab.jsx
+++ b/pkg/storaged/crypto-tab.jsx
@@ -23,7 +23,7 @@ import { array_find, encode_filename, decode_filename } from "./utils.js";
 
 import React from "react";
 import { StorageButton, StorageLink } from "./storage-controls.jsx";
-import { FormatButton, crypto_options_dialog_fields, crypto_options_dialog_options } from "./format-dialog.jsx";
+import { crypto_options_dialog_fields, crypto_options_dialog_options } from "./format-dialog.jsx";
 
 import { CryptoKeyslots } from "./crypto-keyslots.jsx";
 
@@ -120,9 +120,6 @@ export class CryptoTab extends React.Component {
 
         return (
             <div>
-                <div className="tab-actions">
-                    <FormatButton client={this.props.client} block={this.props.block} />
-                </div>
                 <div className="ct-form-layout">
                     { !self.props.client.is_old_udisks2
                         ? <React.Fragment>

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -17,8 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
-
 import cockpit from "cockpit";
 import * as utils from "./utils.js";
 
@@ -27,8 +25,6 @@ import {
     TextInput, PassInput, CheckBoxes, SelectOne, SizeSlider,
     BlockingMessage, TeardownMessage
 } from "./dialog.jsx";
-
-import { StorageButton } from "./storage-controls.jsx";
 
 const _ = cockpit.gettext;
 
@@ -404,24 +400,4 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                       }
                   }
     });
-}
-
-export class FormatButton extends React.Component {
-    constructor(props) {
-        super(props);
-        this.onClick = this.onClick.bind(this);
-    }
-
-    onClick() {
-        format_dialog(this.props.client, this.props.block.path);
-    }
-
-    render() {
-        return (
-            <StorageButton onClick={this.onClick}
-                           excuse={this.props.block.ReadOnly ? _("Device is read-only") : null}>
-                {_("Format")}
-            </StorageButton>
-        );
-    }
 }

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -146,9 +146,6 @@ export class FilesystemTab extends React.Component {
 
         return (
             <div>
-                <div className="tab-actions">
-                    <FormatDialog.FormatButton client={this.props.client} block={this.props.block} />
-                </div>
                 <div className="ct-form-layout">
                     <label className="control-label">{_("Name")}</label>
                     <StorageLink onClick={rename_dialog}>

--- a/pkg/storaged/pvol-tabs.jsx
+++ b/pkg/storaged/pvol-tabs.jsx
@@ -22,8 +22,6 @@ import React from "react";
 import cockpit from "cockpit";
 import * as utils from "./utils.js";
 
-import { FormatButton } from "./format-dialog.jsx";
-
 const _ = cockpit.gettext;
 
 export class PVolTab extends React.Component {
@@ -33,9 +31,6 @@ export class PVolTab extends React.Component {
 
         return (
             <div>
-                <div className="tab-actions">
-                    <FormatButton client={this.props.client} block={this.props.block} />
-                </div>
                 <div className="ct-form-layout">
                     <label className="control-label">{_("Volume Group")}</label>
                     <div>{vgroup
@@ -60,9 +55,6 @@ export class MDRaidMemberTab extends React.Component {
 
         return (
             <div>
-                <div className="tab-actions">
-                    <FormatButton client={this.props.client} block={this.props.block} />
-                </div>
                 <div className="ct-form-layout">
                     <label className="control-label">{_("RAID Device")}</label>
                     <div>{mdraid
@@ -84,9 +76,6 @@ export class VDOBackingTab extends React.Component {
 
         return (
             <div>
-                <div className="tab-actions">
-                    <FormatButton client={this.props.client} block={this.props.block} />
-                </div>
                 <div className="ct-form-layout">
                     <label className="control-label">{_("VDO Device")}</label>
                     <div>{vdo

--- a/pkg/storaged/swap-tab.jsx
+++ b/pkg/storaged/swap-tab.jsx
@@ -22,7 +22,6 @@ import cockpit from "cockpit";
 import * as utils from "./utils.js";
 
 import { StorageButton } from "./storage-controls.jsx";
-import { FormatButton } from "./format-dialog.jsx";
 
 const _ = cockpit.gettext;
 
@@ -77,7 +76,6 @@ export class SwapTab extends React.Component {
                         ? <StorageButton onClick={stop}>{_("Stop")}</StorageButton>
                         : <StorageButton onClick={start}>{_("Start")}</StorageButton>
                     }
-                    <FormatButton client={this.props.client} block={this.props.block} />
                 </div>
                 <div className="ct-form-layout">
                     <label className="control-label">{_("Used")}</label>

--- a/pkg/storaged/unrecognized-tab.jsx
+++ b/pkg/storaged/unrecognized-tab.jsx
@@ -20,17 +20,12 @@
 import React from "react";
 import cockpit from "cockpit";
 
-import { FormatButton } from "./format-dialog.jsx";
-
 const _ = cockpit.gettext;
 
 export class UnrecognizedTab extends React.Component {
     render() {
         return (
             <div>
-                <div className="tab-actions">
-                    <FormatButton client={this.props.client} block={this.props.block} />
-                </div>
                 <div className="ct-form-layout">
                     <label className="control-label">{_("Usage")}</label>
                     <div>{this.props.block.IdUsage || "-"}</div>

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -45,7 +45,7 @@ class TestStorage(StorageCase):
         b.click('#drives tr:contains("DISK1")')
         b.wait_present('#storage-detail')
 
-        self.content_tab_action(1, 1, "Format")
+        self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("type", "xfs")
         self.dialog_apply()
@@ -68,7 +68,7 @@ class TestStorage(StorageCase):
         b.wait_present('#storage-detail')
 
         def check_type(type, label_limit):
-            self.content_tab_action(1, 1, "Format")
+            self.content_head_action(1, "Format")
             self.dialog_wait_open()
             self.dialog_set_val("type", type)
             self.dialog_set_val("name", "X" * (label_limit + 1))
@@ -80,7 +80,7 @@ class TestStorage(StorageCase):
             self.content_row_wait_in_col(1, 1, type + " File System")
 
         def check_unsupported_type(type):
-            self.content_tab_action(1, 1, "Format")
+            self.content_head_action(1, "Format")
             self.dialog_wait_open()
             b.wait_not_present('#dialog li[value=%s]' % type)
             self.dialog_cancel()

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -59,7 +59,7 @@ class TestStorage(StorageCase):
                      'size': 48})
         self.content_row_wait_in_col(1, 2, "/dev/TEST/lvol")
 
-        self.content_tab_action(1, 2, "Format")
+        self.content_head_action(1, "Format")
         self.dialog({"type": "luks+ext4",
                      "name": "FS",
                      "passphrase": "einszweidrei",
@@ -122,7 +122,7 @@ class TestStorage(StorageCase):
 
         b.click('#mdraids tr:contains("ARR")')
         b.wait_present('#storage-detail')
-        self.content_tab_action(1, 1, "Format")
+        self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
                      "name": "FS2",
                      "mounting": "custom",

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -111,7 +111,7 @@ class TestStorage(StorageCase):
         b.click('#drives tr:contains("LIO-ORG test")')
         b.wait_present('#storage-detail')
         self.content_row_wait_in_col(1, 1, "Unrecognized Data")
-        self.content_tab_action(1, 1, "Format")
+        self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
                      "name": "FILESYSTEM",
                      "mounting": "custom",

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -167,7 +167,7 @@ class TestStorage(StorageCase):
         b.click('tr:contains("MYDISK")')
         b.wait_visible("#storage-detail")
 
-        self.content_tab_action(1, 1, "Format")
+        self.content_head_action(1, "Format")
         self.dialog({"type": "luks+ext4",
                      "name": "ENCRYPTED",
                      "passphrase": "vainu-reku-toma-rolle-kaja",
@@ -245,7 +245,7 @@ class TestStorage(StorageCase):
         b.click('tr:contains("MYDISK")')
         b.wait_visible("#storage-detail")
         # create volume and passphrase
-        self.content_tab_action(1, 1, "Format")
+        self.content_head_action(1, "Format")
         self.dialog({"type": "luks+ext4",
                      "name": "ENCRYPTED",
                      "passphrase": "vainu-reku-toma-rolle-kaja",

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -147,7 +147,7 @@ class TestStorage(StorageCase):
         self.dialog({"size": 30})
 
         # format and mount it
-        self.content_tab_action(1, 2, "Format")
+        self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
                      "mounting": "custom",
                      "mount_point": mount_point_one})
@@ -207,7 +207,7 @@ class TestStorage(StorageCase):
         b.wait_present('#detail-sidebar tr:nth-child(2) button.disabled')
 
         # use almost all of the pool by erasing the thin volume
-        self.content_tab_action(2, 2, "Format")
+        self.content_head_action(2, "Format")
         self.dialog({"erase": "zero",
                      "type": "ext4",
                      "mounting": "custom",

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -60,7 +60,7 @@ class TestStorage(StorageCase):
 
         # Format it
 
-        self.content_tab_action(1, 1, "Format")
+        self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("type", "ext4")
         self.dialog_set_val("name", "FILESYSTEM")
@@ -142,7 +142,7 @@ class TestStorage(StorageCase):
             self.content_tab_action(1, 1, "Unmount")
             b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
 
-        self.content_tab_action(1, 1, "Format")
+        self.content_head_action(1, "Format")
         self.dialog({"type": "empty"})
         self.content_row_wait_in_col(1, 1, "Unrecognized Data")
 
@@ -163,7 +163,7 @@ class TestStorage(StorageCase):
 
         # Open format dialog and play with the checkboxes
 
-        self.content_tab_action(1, 1, "Format")
+        self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("type", "luks+ext4")
         self.dialog_set_val("mounting", "custom")

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -51,7 +51,7 @@ class TestStorage(StorageCase):
         self.content_tab_wait_in_info(1, 2, "Name", "FIRST")
 
         # Open dialog for formatting the primary partition and check that "dos-extended" is not offered.
-        self.content_tab_action(1, 2, "Format")
+        self.content_head_action(1, "Format")
         self.dialog_wait_open()
         b.wait_attr("select option[value='dos-extended']", "disabled", "")
         self.dialog_cancel()

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -52,7 +52,7 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
         self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
 
-        self.content_tab_action(1, 2, "Format")
+        self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_wait_apply_enabled()
         self.dialog_set_val("name", "FSYS")
@@ -187,7 +187,7 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
         self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
 
-        self.content_tab_action(1, 2, "Format")
+        self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("name", "FSYS")
         self.dialog_set_val("type", "ext4")
@@ -242,7 +242,7 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
         self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
 
-        self.content_tab_action(1, 2, "Format")
+        self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("name", "FSYS")
         self.dialog_set_val("type", "luks+ext4")

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -49,7 +49,7 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
         self.content_tab_wait_in_info(2, 1, "Mounted At", "/mnt")
 
-        self.content_tab_action(2, 1, "Format")
+        self.content_head_action(2, "Format")
         self.dialog_wait_open()
         b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")
         self.dialog_cancel()

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -74,7 +74,7 @@ class TestStorage(StorageCase):
         # Make a filesystem on it
 
         self.content_row_wait_in_col(1, 1, "Unrecognized Data")
-        self.content_tab_action(1, 1, "Format")
+        self.content_head_action(1, "Format")
         self.dialog({"type": "xfs",
                      "name": "FILESYSTEM",
                      "mounting": "custom",


### PR DESCRIPTION
Fixes #10014

Release Notes
---------------

### Storage: The "Format" button is no longer hidden

The button to format a block device used to be in the tab that describes the current content of the device, such as in the "Filesytem" or "Physical Volume" tab.  Now it is in the header row where it should be easier to find.

![format-in-header](https://user-images.githubusercontent.com/3228183/56958315-a28ab380-6b52-11e9-81ae-e7277e48b25e.png)
