### PR TITLE
storage: Factor encryption out of filesystem type when formatting

### DIFF
--- a/pkg/lib/form-layout.less
+++ b/pkg/lib/form-layout.less
@@ -48,6 +48,10 @@
 // Most of the time, you can ignore all the optional classes (and
 // attribute and hr element) and simply wrap your labels & controls in
 // a <form class="ct-form-layout"> and layout magic happens.
+//
+// `ct-form-box`:
+// Box for encapsulating a block of sub-options. Creates a gray box
+// around elements
 
 .ct-form-layout {
   // Locally redefine padding to Bootstrap values for this LESS block
@@ -272,6 +276,16 @@
 
   > .help-block {
     .bump-up();
+  }
+
+  .ct-form-box {
+    background: #f5f5f5; /* pf-black-150 */
+    border-width: 1px;
+    border-style: solid;
+    border-color: #bbbbbb; /* pf-black-400 */
+    padding: 0.5rem;
+    padding-top: 1rem;
+    width: 100%;
   }
 }
 

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -277,10 +277,6 @@ const Body = ({ body, fields, values, errors, onChange }) => {
     function make_row(field, index) {
         function change(val) {
             values[field.tag] = val;
-            fields.forEach(f => {
-                if (f.tag && f.options && f.options.update)
-                    values[f.tag] = f.options.update(values, field.tag);
-            });
             onChange(field.tag);
         }
 

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -275,6 +275,9 @@ function is_visible(field, values) {
 
 const Body = ({ body, fields, values, errors, onChange }) => {
     function make_row(field, index) {
+        if (field.length !== undefined)
+            return make_rows(field, index);
+
         function change(val) {
             values[field.tag] = val;
             onChange(field.tag);
@@ -288,20 +291,31 @@ const Body = ({ body, fields, values, errors, onChange }) => {
             );
     }
 
+    function make_rows(fields, index) {
+        let rows = fields.map(make_row).filter(r => r);
+        if (rows.length === 0)
+            return null;
+        else if (index === undefined) // top-level
+            return <form className="ct-form-layout">{ rows }</form>;
+        else // nested
+            return <div key={index} className="ct-form-layout ct-form-box">{ rows }</div>;
+    }
+
     return (
         <div className="modal-body">
             { body || null }
-            { fields.length > 0
-                ? <form className="ct-form-layout">
-                    { fields.map(make_row) }
-                </form> : null
-            }
+            { make_rows(fields) }
         </div>
     );
 };
 
+function flatten(arr1) {
+    return arr1.reduce((acc, val) => Array.isArray(val) ? acc.concat(flatten(val)) : acc.concat(val), []);
+}
+
 export const dialog_open = (def) => {
-    let fields = def.Fields || [ ];
+    let nested_fields = def.Fields || [ ];
+    let fields = flatten(nested_fields);
     let values = { };
 
     fields.forEach(f => { values[f.tag] = f.initial_value });
@@ -322,7 +336,7 @@ export const dialog_open = (def) => {
             id: "dialog",
             title: def.Title,
             body: <Body body={def.Body}
-                        fields={fields}
+                        fields={nested_fields}
                         values={values}
                         errors={errors}
                         onChange={trigger => update(null, trigger)} />

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -246,10 +246,9 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
     add_fsys("ext4", { value: "luks+ext4", title: _("Encrypted EXT4 (LUKS)") });
     add_fsys("vfat", { value: "vfat", title: "VFAT" });
     add_fsys("ntfs", { value: "ntfs", title: "NTFS" });
-    add_fsys(true, { value: "dos-extended",
-                     title: _("Extended Partition"),
-                     disabled: !(create_partition && enable_dos_extended) });
     add_fsys(true, { value: "empty", title: _("No Filesystem") });
+    if (create_partition && enable_dos_extended)
+        add_fsys(true, { value: "dos-extended", title: _("Extended Partition") });
 
     var usage = utils.get_active_usage(client, create_partition ? null : path);
 

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -250,7 +250,6 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                      title: _("Extended Partition"),
                      disabled: !(create_partition && enable_dos_extended) });
     add_fsys(true, { value: "empty", title: _("No Filesystem") });
-    add_fsys(true, { value: "custom", title: _("Custom (Enter filesystem type)") });
 
     var usage = utils.get_active_usage(client, create_partition ? null : path);
 
@@ -285,11 +284,6 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                       TextInput("name", _("Name"),
                                 { validate: (name, vals) => utils.validate_fsys_label(name, vals.type),
                                   visible: is_filesystem
-                                }),
-                      TextInput("custom", _("Filesystem type"),
-                                { visible: function (vals) {
-                                    return vals.type == "custom";
-                                }
                                 }),
                       PassInput("passphrase", _("Passphrase"),
                                 { validate: function (phrase) {
@@ -329,9 +323,6 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                       Danger: (create_partition
                           ? null : _("Formatting a storage device will erase all data on it.")),
                       action: function (vals) {
-                          if (vals.type == "custom")
-                              vals.type = vals.custom;
-
                           var options = { 'no-block': { t: 'b', v: true },
                                           'dry-run-first': { t: 'b', v: true },
                                           'tear-down': { t: 'b', v: true }

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -720,3 +720,7 @@ td.storage-action {
     flex-grow: 1;
     margin-left: 10px;
 }
+
+.ct-form-box {
+    margin-bottom: 1em;
+}

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -59,7 +59,8 @@ class TestStorage(StorageCase):
         self.content_row_wait_in_col(1, 2, "/dev/TEST/lvol")
 
         self.content_head_action(1, "Format")
-        self.dialog({"type": "luks+ext4",
+        self.dialog({"type": "ext4",
+                     "crypto.on": True,
                      "name": "FS",
                      "passphrase": "einszweidrei",
                      "passphrase2": "einszweidrei",

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -49,15 +49,16 @@ class TestStorage(StorageCase):
         self.content_row_action(1, "Create Partition")
         self.dialog_wait_open()
         self.dialog_set_val("size", 17)
-        self.dialog_set_val("type", "luks+ext4")
+        self.dialog_set_val("type", "ext4")
+        self.dialog_set_val("crypto.on", True)
         self.dialog_set_val("name", "ENCRYPTED")
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
         if not self.storaged_is_old_udisks:
-            self.dialog_set_val("store_passphrase.val", True)
+            self.dialog_set_val("crypto_options.store_passphrase", True)
+            self.dialog_set_val("crypto_options.extra", "crypto,options")
             self.dialog_set_val("mounting", "custom")
             self.dialog_set_val("mount_point", mount_point_secret)
-            self.dialog_set_val("crypto_options.extra", "crypto,options")
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 1, "Encrypted data")
@@ -168,7 +169,8 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
 
         self.content_head_action(1, "Format")
-        self.dialog({"type": "luks+ext4",
+        self.dialog({"type": "ext4",
+                     "crypto.on": True,
                      "name": "ENCRYPTED",
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
@@ -246,7 +248,8 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
         # create volume and passphrase
         self.content_head_action(1, "Format")
-        self.dialog({"type": "luks+ext4",
+        self.dialog({"type": "ext4",
+                     "crypto.on": True,
                      "name": "ENCRYPTED",
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
@@ -352,6 +355,26 @@ class TestStorage(StorageCase):
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-8"})
         self.content_row_wait_in_col(2, 1, "ext4 File System")
 
+
+    def testNoFsys(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        # Add a disk and format it with luks, but without filesystem
+        m.add_disk("50M", serial="MYDISK")
+        b.wait_in_text("#drives", "MYDISK")
+        b.click('tr:contains("MYDISK")')
+        b.wait_visible("#storage-detail")
+
+        self.content_head_action(1, "Format")
+        self.dialog({"type": "empty",
+                     "crypto.on": True,
+                     "passphrase": "vainu-reku-toma-rolle-kaja",
+                     "passphrase2": "vainu-reku-toma-rolle-kaja"})
+        self.content_row_wait_in_col(1, 1, "Encrypted data")
+        self.content_row_wait_in_col(2, 1, "Unrecognized Data")
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -165,7 +165,8 @@ class TestStorage(StorageCase):
 
         self.content_head_action(1, "Format")
         self.dialog_wait_open()
-        self.dialog_set_val("type", "luks+ext4")
+        self.dialog_set_val("type", "ext4")
+        self.dialog_set_val("crypto.on", True)
         self.dialog_set_val("mounting", "custom")
 
         def wait_checked(field):

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -53,14 +53,14 @@ class TestStorage(StorageCase):
         # Open dialog for formatting the primary partition and check that "dos-extended" is not offered.
         self.content_head_action(1, "Format")
         self.dialog_wait_open()
-        b.wait_attr("select option[value='dos-extended']", "disabled", "")
+        b.wait_not_present("select option[value='dos-extended']")
         self.dialog_cancel()
         self.dialog_wait_close()
 
         # Create a extended partition to fill the rest of the disk
         self.content_row_action(2, "Create Partition")
         self.dialog_wait_open()
-        b.wait_attr("option[value='dos-extended']", "disabled", None)
+        b.wait_present("option[value='dos-extended']")
         self.dialog_set_val("type", "dos-extended")
         self.dialog_wait_not_present("name")
         self.dialog_wait_not_present("mounting")
@@ -75,7 +75,7 @@ class TestStorage(StorageCase):
         # not offered.
         self.content_row_action(3, "Create Partition")
         self.dialog_wait_open()
-        b.wait_attr("select option[value='dos-extended']", "disabled", "")
+        b.wait_not_present("select option[value='dos-extended']")
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_row_wait_in_col(3, 1, "xfs File System")

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -29,12 +29,12 @@ from testlib import *
 @skipImage("UDisks doesn't have support for LVM", "debian-stable")
 class TestStorage(StorageCase):
 
-    def checkResize(self, fsys, can_shrink, can_grow, shrink_needs_unmount=None, grow_needs_unmount=None,
+    def checkResize(self, fsys, crypto, can_shrink, can_grow, shrink_needs_unmount=None, grow_needs_unmount=None,
                     need_passphrase=False):
         m = self.machine
         b = self.browser
 
-        if fsys.startswith("luks+"):
+        if crypto:
             fsys_row = 2
             fsys_tab = 1
         else:
@@ -57,7 +57,8 @@ class TestStorage(StorageCase):
         self.dialog_wait_apply_enabled()
         self.dialog_set_val("name", "FSYS")
         self.dialog_set_val("type", fsys)
-        if fsys.startswith("luks+"):
+        if crypto:
+            self.dialog_set_val("crypto.on", crypto)
             self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
             self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
@@ -113,18 +114,18 @@ class TestStorage(StorageCase):
             self.wait_content_tab_action_disabled(1, 1, "Shrink")
 
     def testResizeExt4(self):
-        self.checkResize("ext4",
+        self.checkResize("ext4", False,
                          can_shrink=True, shrink_needs_unmount=True,
                          can_grow=True, grow_needs_unmount=False)
 
     def testResizeXfs(self):
-        self.checkResize("xfs",
+        self.checkResize("xfs", False,
                          can_shrink=False,
                          can_grow=True, grow_needs_unmount=False)
 
     @skipImage("No NTFS support installed", "centos-7", "rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
     def testResizeNtfs(self):
-        self.checkResize("ntfs",
+        self.checkResize("ntfs", None,
                          can_shrink=True, shrink_needs_unmount=True,
                          can_grow=True, grow_needs_unmount=True)
 
@@ -132,12 +133,12 @@ class TestStorage(StorageCase):
         # Only newer versions of UDisks support resizing encrypted block devices
         if self.machine.image in ["rhel-7-6", "rhel-7-6-distropkg", "rhel-7-7", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "fedora-29",
                                   "fedora-30", "fedora-testing", "fedora-i386", "debian-testing", "ubuntu-stable", "centos-7"]:
-            self.checkResize("luks+ext4",
+            self.checkResize("ext4", True,
                              can_shrink=True, shrink_needs_unmount=True,
                              can_grow=True, grow_needs_unmount=False,
                              need_passphrase=(self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]))
         else:
-            self.checkResize("luks+ext4",
+            self.checkResize("ext4", True,
                              can_shrink=False,
                              can_grow=False)
 
@@ -245,7 +246,8 @@ class TestStorage(StorageCase):
         self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("name", "FSYS")
-        self.dialog_set_val("type", "luks+ext4")
+        self.dialog_set_val("type", "ext4")
+        self.dialog_set_val("crypto.on", True)
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()


### PR DESCRIPTION
This way, people can easily make encrypted block devices without
filesystems in them.

This also opens the avenue to adding more encryption technologies,
like "LUKSv2".

Fixes #11482

Release notes:
-------------
### Storage: When formatting, encryption can be selected independently

Previously, Cockpit has offered encryption for only two types of filesystems, xfs and ext4.  Now you can select the filesystem type and the encrpytion technology separately.
![image](https://user-images.githubusercontent.com/3228183/57758953-84e84d00-7701-11e9-8fc6-2bccf46f4718.png)
