### PR TITLE
storage: Ignore traditional LVM2 snapshots

### DIFF
--- a/bots/naughty/debian-testing/11032-udisks2-fails-with-thin-snapshots-2
+++ b/bots/naughty/debian-testing/11032-udisks2-fails-with-thin-snapshots-2
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-lvm2", line *, in testSnapshots
+    self.content_row_wait_in_col(3, 2, "mysnapshot")

--- a/bots/naughty/fedora-29/11032-udisks2-fails-with-thin-snapshots-2
+++ b/bots/naughty/fedora-29/11032-udisks2-fails-with-thin-snapshots-2
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-lvm2", line *, in testSnapshots
+    self.content_row_wait_in_col(3, 2, "mysnapshot")

--- a/bots/naughty/rhel-7/11032-udisks2-fails-with-thin-snapshots-2
+++ b/bots/naughty/rhel-7/11032-udisks2-fails-with-thin-snapshots-2
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-lvm2", line *, in testSnapshots
+    self.content_row_wait_in_col(3, 2, "mysnapshot")

--- a/bots/naughty/rhel-8/11032-udisks2-fails-with-thin-snapshots-2
+++ b/bots/naughty/rhel-8/11032-udisks2-fails-with-thin-snapshots-2
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-lvm2", line *, in testSnapshots
+    self.content_row_wait_in_col(3, 2, "mysnapshot")

--- a/bots/naughty/ubuntu-1804/11032-udisks2-fails-with-thin-snapshots
+++ b/bots/naughty/ubuntu-1804/11032-udisks2-fails-with-thin-snapshots
@@ -1,0 +1,1 @@
+Error creating snapshot: Process reported exit code 3:   --size may not be zero.

--- a/bots/naughty/ubuntu-1804/11032-udisks2-fails-with-thin-snapshots-2
+++ b/bots/naughty/ubuntu-1804/11032-udisks2-fails-with-thin-snapshots-2
@@ -1,0 +1,3 @@
+Traceback (most recent call last):
+  File "check-storage-lvm2", line *, in testSnapshots
+    self.content_row_wait_in_col(3, 2, "mysnapshot")

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -621,7 +621,7 @@ function append_logical_volume(client, rows, level, lvol) {
 function vgroup_rows(client, vgroup) {
     var rows = [ ];
     (client.vgroups_lvols[vgroup.path] || [ ]).forEach(function (lvol) {
-        if (lvol.ThinPool == "/")
+        if (lvol.ThinPool == "/" && lvol.Origin == "/")
             append_logical_volume(client, rows, 0, lvol);
     });
     return rows;

--- a/pkg/storaged/lvol-tabs.jsx
+++ b/pkg/storaged/lvol-tabs.jsx
@@ -347,14 +347,6 @@ export class BlockVolTab extends React.Component {
                           Fields: [
                               TextInput("name", _("Name"),
                                         { validate: utils.validate_lvm2_name }),
-                              SizeSlider("size", _("Size"),
-                                         { value: lvol.Size * 0.2,
-                                           max: lvol.Size,
-                                           round: vgroup.ExtentSize,
-                                           visible: function () {
-                                               return lvol.ThinPool == "/";
-                                           }
-                                         })
                           ],
                           Action: {
                               Title: _("Create"),
@@ -392,7 +384,7 @@ export class BlockVolTab extends React.Component {
         return (
             <div>
                 <div className="tab-actions">
-                    <StorageButton onClick={create_snapshot}>{_("Create Snapshot")}</StorageButton>
+                    { pool && <StorageButton onClick={create_snapshot}>{_("Create Snapshot")}</StorageButton> }
                 </div>
                 <div className="ct-form-layout">
                     <label className="control-label">{_("Name")}</label>

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -273,13 +273,31 @@ class TestStorage(StorageCase):
         b.click('tr:contains("TEST")')
         b.wait_visible("#storage-detail")
 
+        # Create a thinpool and a thin volume in it
+
         m.execute("lvcreate TEST --thinpool pool -L 20m")
         m.execute("lvcreate -T TEST/pool -n thin -V 100m")
         self.content_row_wait_in_col(2, 2, "/dev/TEST/thin")
 
-        self.content_tab_action(2, 1, "Create Snapshot")
-        self.dialog({"name": "mysnapshot"})
+        # Create a logical volume and take a snapshot of it.  We will
+        # later check that the snapshot isn't shown.
 
+        m.execute("lvcreate TEST -n lvol0 -L 20m")
+        m.execute("lvcreate -s -n snap0 -L 20m TEST/lvol0")
+
+        # Take a snapshot of the thin volume and check that it appears
+
+        self.content_tab_action(3, 1, "Create Snapshot")
+        self.dialog({"name": "mysnapshot"})
+        self.content_row_wait_in_col(3, 2, "mysnapshot")
+
+        # Now check that the traditional snapshot is not shown.  We do
+        # this here to be sure that Cockpit is fully caught up and has
+        # actually ignored it instead of just not having gotten around
+        # to showing it.
+
+        self.content_row_wait_in_col(1, 2, "/dev/TEST/lvol0")
+        b.wait_not_in_text("#storage-detail", "snap0")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Cockpit does not really account for the idiosyncrasies of traditional
snapshots, including:

 - Deleting the origin will delete all snapshots.

 - Activating/deactivating the origin will do the same to all
   snapshots, and vice versa.

 - The size of a snaphot does not correspond to the size of its block
   device, and resizing a snapshot does not resize the block device.

 - Writing to the origin might cause the snapshot to run out of space,
   but Cockpit doesn't allow to monitor this.

Snapshots of thin volumes are different as they are truly independent
of their origin after creation and function just like any other thin
volume.  To emphasize this, we call the action of creating them
"cloning".