### PR TITLE
bots: Use python3 in bootstrap script

### DIFF
--- a/bots/images/rhel-atomic
+++ b/bots/images/rhel-atomic
@@ -1,1 +1,1 @@
-rhel-atomic-e92c9e7ed73cd3a2dd028285d4c495ed1642cc8efe47ce136345dc21dd591744.qcow2
+rhel-atomic-639dde3ad1606d5932907cea6701eb02e4badf0f722b48c6b80efd9a2ec676a9.qcow2

--- a/bots/images/scripts/atomic.bootstrap
+++ b/bots/images/scripts/atomic.bootstrap
@@ -65,7 +65,7 @@ fi
 # will grow the partitions etc as appropriate, and atomic.setup will
 # explicitly grow the docker pool.
 
-vsize=$(qemu-img info "$out" --output=json | python -c 'import json, sys; print json.load(sys.stdin)["virtual-size"]')
+vsize=$(qemu-img info "$out" --output=json | python3 -c 'import json, sys; print(json.load(sys.stdin)["virtual-size"])')
 
 if [ "$vsize" -lt 12884901888 ]; then
     qemu-img resize "$out" 12884901888


### PR DESCRIPTION
Now (since https://github.com/cockpit-project/cockpituous/commit/0fd4962c78a006dd22b628c84ce8bc95a51cf10e) tasks are run on F30, which does not support `python` binary anymore. To see if it works, lets refresh `rhel-atomic` - based on https://github.com/cockpit-project/cockpit/issues/11731

 * [x] image-refresh rhel-atomic