### PR TITLE
machines: always shut off the VMs before deletion

### DIFF
--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -125,7 +125,7 @@ export class DeleteDialog extends React.Component {
                     if ((d.type == 'file' && d.source.file) || d.type == 'volume')
                         disks.push(Object.assign(d, { checked: !d.readonly }));
                 });
-        this.setState({ showModal: true, disks: disks, destroy: vm.state === 'running' });
+        this.setState({ showModal: true, disks: disks, destroy: vm.state != 'shut off' });
     }
 
     delete() {

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -947,6 +947,18 @@ class TestMachines(NetworkCase):
 
         self.assertNotIn(name, m.execute("virsh list --all"))
 
+        # Try to delete a paused VM
+        name = "paused-test-vm"
+        img = "/var/lib/libvirt/images/{0}.img".format(name)
+        self.startVm(name)
+
+        b.click("tbody tr[data-row-id=vm-{0}] th".format(name)) # click on the row header
+        self.machine.execute("virsh -c qemu:///system suspend {0}".format(name))
+        b.wait_in_text("#vm-{0}-state".format(name), "paused")
+        b.click("#vm-{0}-delete".format(name))
+        self.browser.reload()
+        b.wait_not_present("tbody tr[data-row-id=vm-{0}] th".format(name)) # click on the row header
+
     def testSerialConsole(self):
         b = self.browser
         name = "vmWithSerialConsole"


### PR DESCRIPTION
Previously we were executing the virDomainDestroy API only against
running VMs. This resulted in paused VMs to keep appearing in the list
after deletion.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1706678