### PR TITLE
accounts: change position of tooltips because they were hiding help text

### DIFF
--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -420,7 +420,7 @@
   <script id="role-entry-tmpl" type="x-template/mustache">
     {{#roles}}
     <div class="checkbox accounts-privileged">
-      <label data-container="body" data-toggle="tooltip" data-original-title="Unix group: {{name}}" data-placement="bottom">
+      <label data-container="body" data-toggle="tooltip" data-original-title="Unix group: {{name}}" data-placement="right">
         <input type="checkbox" name="account-role-checkbox-{{id}}"
                data-gid="{{id}}" data-name="{{name}}"
                id="account-role-checkbox-{{id}}" {{#member}}checked{{/member}}/>


### PR DESCRIPTION
Fixes #11729