### PR TITLE
machines: fix misalligned labels in boot order modal dialog

### DIFF
--- a/pkg/machines/components/vm/bootOrderModal.jsx
+++ b/pkg/machines/components/vm/bootOrderModal.jsx
@@ -65,9 +65,7 @@ const DeviceInfo = ({ descr, value }) => {
     return (
         <div className='ct-form-layout'>
             <label className='control-label' htmlFor={value}>
-                <output>
-                    {descr}
-                </output>
+                {descr}
             </label>
             <span id={value}>
                 {value}


### PR DESCRIPTION
Previously the label names where wrapped with <output> html element.
output elements is supposed to be containing results of calculations, I
don't see the purpose of wrapping label strings.

This change also fixed the misallignment of the above labels.

Fixes #11751