### PR TITLE
test: Wait longer for sosreport to finish [no-test]

### DIFF
--- a/test/avocado/selenium-sosreport.py
+++ b/test/avocado/selenium-sosreport.py
@@ -34,7 +34,7 @@ class SosReportingTab(SeleniumTest):
         # duration of report generation depends on the target system - as along as sosreport is active, we don't want to timeout
         # it is also important to call some selenium method there to ensure that connection to HUB will not be lost
 
-        @Retry(attempts=30, timeout=10, exceptions=(subprocess.CalledProcessError,),
+        @Retry(attempts=150, timeout=10, exceptions=(subprocess.CalledProcessError,),
                error=Exception('Timeout: sosreport did not finish'), inverse=True)
         def waitforsosreport():
             self.machine.execute("pgrep sosreport")


### PR DESCRIPTION
`waitforsosreport()` finishes fairly quickly, so 30 attempts only result
in a ~ 1 minute wait. sosreport needs much longer than that, so increase
the timeout.