### PR TITLE
[no-test] bots: Update CentOS Atomic cloud image download

### DIFF
--- a/bots/images/continuous-atomic
+++ b/bots/images/continuous-atomic
@@ -1,1 +1,1 @@
-continuous-atomic-c08b0a2bc7f295d6eadd9bf77d0a48f16ada0a4063e7f0195fc69e65461efe02.qcow2
+continuous-atomic-91df6d231e76ff74f5557d62e56cc31aeaa7e5d3c2d606ae505531edf9381db6.qcow2

--- a/bots/images/scripts/continuous-atomic.bootstrap
+++ b/bots/images/scripts/continuous-atomic.bootstrap
@@ -3,8 +3,8 @@
 
 set -e
 
-url="http://cloud.centos.org/centos/7/atomic/images"
-prefix="CentOS-Atomic-Host-7-GenericCloud.qcow2"
+url="https://cloud.centos.org/centos/7/atomic/images"
+prefix="CentOS-Atomic-Host-GenericCloud.qcow2"
 
 BASE=$(dirname $0)
 $BASE/atomic.bootstrap "$1" "$url" "$prefix"

--- a/bots/naughty/continuous-atomic/8831-selinux-rhsmd-subscription_manager
+++ b/bots/naughty/continuous-atomic/8831-selinux-rhsmd-subscription_manager
@@ -1,0 +1,1 @@
+Error: type=1400 audit(*): avc:  denied  { write } for  pid=* comm="rhsmd" name="subscription_manager"

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -845,7 +845,7 @@ class TestMultiMachine(MachineCase):
         b.set_val("#edit-machine-port", "2222")
         b.click('#troubleshoot-dialog .btn-primary')
         # Using libssh's knownhosts api port is taken into account when verifying a host
-        if m1.image not in ['rhel-7-6', 'rhel-7-6-distropkg', "rhel-7-7",
+        if m1.image not in ['rhel-7-6', 'rhel-7-6-distropkg', "rhel-7-7", 'continuous-atomic',
                             'rhel-atomic', 'debian-stable', 'centos-7', 'ubuntu-1804']:
             b.wait_in_text('#troubleshoot-dialog h4', "Unknown Host Key")
             b.wait_present("#troubleshoot-dialog .btn-primary:not([disabled])")


### PR DESCRIPTION
The file name dropped the "-7". Also move to https:// URL.

Fixes #9971
Closes #11765

 * [x] image-refresh continuous-atomic