### PR TITLE
ws: Allow https Origin for http connections

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -56,6 +56,9 @@
                 <para>By default cockpit will not accept crossdomain websocket connections. Use this
                   setting to allow access from alternate domains. Origins should include scheme, host
                   and port, if necessary.</para>
+                <para>By default, https origins are always accepted, http origins only for http
+                  (unencrypted) connections. However, if you set <option>Origins</option> explicitly,
+                  you also must specify all allowed protocols.</para>
 
           <informalexample>
 <programlisting language="js">

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -858,19 +858,24 @@ static const TestFixture fixture_allowed_origin_rfc6455 = {
 };
 
 static const TestFixture fixture_allowed_origin_proto_header = {
-  .origin = "https://127.0.0.1",
-  .forward = "https",
+  .origin = "foo://127.0.0.1",
+  .forward = "foo",
   .config = SRCDIR "/src/ws/mock-config/cockpit/cockpit-alt.conf"
 };
 
-static const TestFixture fixture_bad_origin_proto_no_header = {
+static const TestFixture fixture_allowed_origin_https_to_http = {
   .origin = "https://127.0.0.1",
+  .config = NULL
+};
+
+static const TestFixture fixture_bad_origin_proto_no_header = {
+  .origin = "foo://127.0.0.1",
   .config = SRCDIR "/src/ws/mock-config/cockpit/cockpit-alt.conf"
 };
 
 static const TestFixture fixture_bad_origin_proto_no_config = {
-  .origin = "https://127.0.0.1",
-  .forward = "https",
+  .origin = "foo://127.0.0.1",
+  .forward = "foo",
   .config = NULL
 };
 
@@ -1514,6 +1519,9 @@ main (int argc,
               test_bad_origin, teardown_for_socket);
   g_test_add ("/web-service/allowed-origin/protocol-header", TestCase,
               &fixture_allowed_origin_proto_header, setup_for_socket,
+              test_handshake_and_auth, teardown_for_socket);
+  g_test_add ("/web-service/allowed-origin/https-to-http", TestCase,
+              &fixture_allowed_origin_https_to_http, setup_for_socket,
               test_handshake_and_auth, teardown_for_socket);
 
   g_test_add ("/web-service/close-error", TestCase,


### PR DESCRIPTION
Previously, cockpit-ws rejected non-GnuTLS connections with a https://
origin with

    received request from bad Origin: https://localhost:9090

The most common case for that is to run cockpit-ws behind a reverse
proxy that does the TLS termination.

Accept https:// origins for non-TLS connections by default, which
eliminates the need to configure Origins for this use case.