### PR TITLE
lib: Redesign On/Off switch

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -492,8 +492,8 @@ export class KdumpPage extends React.Component {
                 <form className="ct-form-layout">
                     <label className="control-label">{_("kdump status")}</label>
                     <div role="group">
-                        <OnOffSwitch state={serviceRunning} onChange={this.props.onSetServiceState}
-                            enabled={(!this.props.stateChanging).toString()} />
+                        <OnOffSwitch state={!!serviceRunning} onChange={this.props.onSetServiceState}
+                            disabled={this.props.stateChanging} />
                         {serviceWaiting}
                         {kdumpServiceDetails}
                     </div>

--- a/pkg/lib/cockpit-components-onoff.css
+++ b/pkg/lib/cockpit-components-onoff.css
@@ -1,6 +1,0 @@
-/* on-off button styling depends on data-toggle in bootstrap */
-.btn-onoff-ct input {
-    position: absolute;
-    clip: rect(0, 0, 0, 0);
-    pointer-events: none;
-}

--- a/pkg/lib/cockpit-components-onoff.jsx
+++ b/pkg/lib/cockpit-components-onoff.jsx
@@ -17,61 +17,23 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import cockpit from "cockpit";
 import React from "react";
 
-import "./cockpit-components-onoff.css";
-
-const _ = cockpit.gettext;
+import "./cockpit-components-onoff.less";
 
 /* Component to show an on/off switch
  * state      boolean value (off or on)
- * captionOff optional string, default 'Off'
- * captionOn  optional string, default 'On'
  * onChange   triggered when the switch is flipped, parameter: new state
  * enabled    whether the component is enabled or not, defaults to true
  * id         optional string, ID of the top-level HTML tag (only necessary
  *            when embedding this into a non-React page)
+ * text       optional string that appears to the right of the button
  */
-export class OnOffSwitch extends React.Component {
-    handleOnOffClick(newState, e) {
-        // only consider primary mouse button
-        if (!e || e.button !== 0)
-            return;
-        // only notify if the component is enabled
-        if (this.props.onChange && this.props.enabled)
-            this.props.onChange(newState);
-        e.stopPropagation();
-    }
-
-    render() {
-        var onClasses = ["btn"];
-        var offClasses = ["btn"];
-        if (this.props.state)
-            onClasses.push("active");
-        else
-            offClasses.push("active");
-        if (!this.props.enabled) {
-            onClasses.push("disabled");
-            offClasses.push("disabled");
-        }
-        var clickHandler = this.handleOnOffClick.bind(this, !this.props.state);
-        return (
-            <div id={this.props.id} className="btn-group btn-onoff-ct">
-                <label className={ onClasses.join(" ") }>
-                    <input type="radio" />
-                    <span onClick={clickHandler}>{this.props.captionOn}</span>
-                </label>
-                <label className={ offClasses.join(" ") }>
-                    <input type="radio" />
-                    <span onClick={clickHandler}>{this.props.captionOff}</span>
-                </label>
-            </div>
-        );
-    }
-}
-OnOffSwitch.defaultProps = {
-    captionOff: _("Off"),
-    captionOn: _("On"),
-    enabled: true,
-};
+export const OnOffSwitch = ({ state, onChange, text, disabled, id }) => (
+    <label id={id} className="onoff-ct">
+        <input type="checkbox" disabled={disabled} checked={state}
+            onChange={ ev => onChange ? onChange(ev.target.checked) : null } />
+        <span className="switch-toggle" />
+        { text ? <span className={ state ? "switch-on" : "switch-off" }>{text}</span> : null }
+    </label>
+);

--- a/pkg/lib/cockpit-components-onoff.less
+++ b/pkg/lib/cockpit-components-onoff.less
@@ -1,0 +1,139 @@
+label.onoff-ct {
+  --switch-width: 40px;
+  --switch-height: 24px;
+  --switch-background: #d1d1d1; /* pf-black-300 */
+  --switch-border-color: transparent;
+  --switch-border-style: solid;
+  --switch-border-width: 1px;
+  --switch-text: inherit;
+  --switch-dot-size: 14px;
+  --switch-dot: #fff;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 0;
+  padding: 1px 0; /* Height is 24px; bump to 26px like other widgets */
+  vertical-align: middle;
+
+  > .switch-on,
+  > .switch-off,
+  > input ~ .switch-toggle,
+  > input ~ .switch-toggle::after {
+    transition: all 300ms ease-in-out;
+  }
+
+  > .switch-on,
+  > .switch-off {
+    color: var(--switch-text);
+    margin-left: 0.5em;
+  }
+
+  > input {
+    opacity: 0;
+    position: absolute;
+
+    /* Base toggle graphic */
+    ~ .switch-toggle {
+      --switch-dot-offset-x: calc(var(--switch-dot-size)/3 - var(--switch-border-width));
+      --switch-dot-offset-y: calc(50% - 14px / 2);
+      /* Don't let the border draw over the background */
+      background-clip: content-box;
+      background: var(--switch-background);
+      border-radius: var(--switch-height);
+      border: var(--switch-border-width) var(--switch-border-style) var(--switch-border-color);
+      box-shadow: inset 0 0 0 1px transparent;
+      width: var(--switch-width);
+      height: var(--switch-height);
+      display: inline-block;
+      position: relative;
+      margin: 0;
+      cursor: pointer;
+
+      /* Dot graphic */
+      &::after {
+        background: var(--switch-dot);
+        box-shadow: 0 0 var(--switch-dot-offset-x) rgba(0, 0, 0, 0.2);
+        display: inline-block;
+        content: "";
+        height: var(--switch-dot-size);
+        width: var(--switch-dot-size);
+        border-radius: 50%;
+        top: var(--switch-dot-offset-y);
+        left: var(--switch-dot-offset-x);
+        position: absolute;
+        pointer-events: none;
+      }
+    }
+
+    ~ .switch-off {
+      --switch-text: #72767b; /* pf-black-600 */
+    }
+
+    &:checked {
+      ~ .switch-toggle {
+        --switch-background: #0088ce; /* pf-blue-400 */
+        --switch-dot-offset-x: calc(100% - var(--switch-dot-size) * 1.333333 + var(--switch-border-width));
+
+        &:last-child {
+          // Show a check if there's no label
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10.583 6.35'%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-width='.529' d='M2.252 3.365l.756.758L4.48 2.65' opacity='.75'/%3E%3C/svg%3E");
+        }
+      }
+    }
+
+    &:disabled ~ .switch-toggle {
+      --switch-background: #72767b; /* pf-black-600 */
+      --switch-dot: #d1d1d1; /* pf-black-300 */
+    }
+
+    &:disabled ~ * {
+      cursor: not-allowed;
+    }
+
+    /* Hide unused switch label */
+    &:checked ~ .switch-off,
+    &:not(:checked) ~ .switch-on {
+      display: none;
+    }
+  }
+
+  :disabled {
+    ~ .switch-on,
+    ~ .switch-off {
+      --switch-text: #72767b; /* pf-black-600 */
+    }
+  }
+
+  /* Focus ring */
+  :focus ~ .switch-toggle::before {
+    border: 1px dotted rgba(0, 0, 0, 0.75);
+    border-radius: calc(var(--switch-width) - 10px);
+    position: absolute;
+    content: '';
+    top: -4px;
+    bottom: -4px;
+    left: -4px;
+    width: calc(var(--switch-width) + 6px);
+    transition: all 300ms ease-in-out;
+    /* HACK: Keyboard has nothing to transition from, but hover does */
+    /* (as it changes the ring to transparent and back). */
+    /* So we delay the hover to not have the focus ring on hover out. */
+    /* This makes the focus ring show up for keyboard users, but not on a mouse click. */
+    transition-delay: 600s;
+    z-index: 1;
+  }
+
+  /* Don't show the focus ring for mouse clicks (when hovering) */
+  :focus:hover ~ .switch-toggle::before {
+    border-color: transparent;
+  }
+
+  /* Subtly darken the inner part of the switch on hover */
+  &:hover :not(:disabled) ~ .switch-toggle {
+    box-shadow: inset 0 1px 5px 1px rgba(0, 0, 0, 0.15);
+  }
+}
+
+h1 label.onoff-ct {
+  vertical-align: bottom;
+}

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -723,7 +723,7 @@ export class Firewall extends React.Component {
                 <h1>
                     {_("Firewall")}
                     <OnOffSwitch state={enabled}
-                                 enabled={this.state.pendingTarget === null}
+                                 disabled={!!this.state.pendingTarget}
                                  onChange={this.onSwitchChanged} />
                 </h1>
                 <div id="zones-listing">

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2302,7 +2302,7 @@ PageNetworkInterface.prototype = {
                 React.createElement(OnOffSwitch, {
                     id: 'networking-firewall-switch',
                     state: firewall.enabled,
-                    enabled: !pending,
+                    disabled: pending,
                     onChange: onFirewallSwitchChange }),
                 document.querySelector('#networking-firewall .panel-actions')
             );
@@ -2573,7 +2573,7 @@ PageNetworkInterface.prototype = {
         if (managed) {
             onoff = React.createElement(OnOffSwitch, {
                 state: !!(dev && dev.ActiveConnection),
-                enabled: !(!iface || (dev && dev.State == 20)),
+                disabled: !iface || (dev && dev.State == 20),
                 onChange: enable => enable ? self.connect() : self.disconnect() });
         }
         ReactDOM.render(onoff, document.getElementById('network-interface-delete-switch'));

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -164,7 +164,7 @@ span.inverted-switchbox {
     margin-right: 20px;
 }
 
-h1 .btn-onoff-ct {
+h1 .onoff-ct {
     margin-left: 1.5em;
     vertical-align: text-bottom;
 }

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -345,7 +345,7 @@ export default class AutoUpdates extends React.Component {
             <div className="header-buttons pk-updates--header pk-updates--header--auto" id="automatic">
                 <h2 className="pk-updates--header--heading">{_("Automatic Updates")}</h2>
                 <div className="pk-updates--header--actions">
-                    <OnOffSwitch state={onOffState} enabled={!this.state.pending}
+                    <OnOffSwitch state={onOffState} disabled={this.state.pending}
                                  onChange={e => {
                                      if (!this.state.backend.installed) {
                                          install_dialog(this.state.backend.packageName)

--- a/pkg/playground/react-demo-onoff.jsx
+++ b/pkg/playground/react-demo-onoff.jsx
@@ -50,16 +50,17 @@ class OnOffDemo extends React.Component {
                         <td><OnOffSwitch state={this.state.onOffA} onChange={this.onChangeA} /></td>
                     </tr>
                     <tr>
-                        <td><span>Regular</span></td>
-                        <td><OnOffSwitch state={this.state.onOffB} onChange={this.onChangeB} /></td>
+                        <td><span>Regular with text</span></td>
+                        <td><OnOffSwitch state={this.state.onOffB} onChange={this.onChangeB}
+                                         text={ this.state.onOffB ? "Description for On" : "Description for Off" } /></td>
                     </tr>
                     <tr>
                         <td><span>Disabled On</span></td>
-                        <td><OnOffSwitch state enabled={false} /></td>
+                        <td><OnOffSwitch state disabled /></td>
                     </tr>
                     <tr>
                         <td><span>Disabled Off</span></td>
-                        <td><OnOffSwitch state={false} enabled={false} /></td>
+                        <td><OnOffSwitch state={false} disabled /></td>
                     </tr>
                 </tbody>
             </table>

--- a/pkg/selinux/setroubleshoot.css
+++ b/pkg/selinux/setroubleshoot.css
@@ -80,16 +80,9 @@ div.alert-ct-top {
     font-size: 13px;
 }
 
-.selinux-policy-ct .btn-onoff-ct {
+.selinux-policy-ct .onoff-ct {
     padding-left: 10px;
     padding-right: 10px;
-}
-
-/* on-off button styling depends on data-toggle in bootstrap */
-.btn-onoff-ct input {
-    position: absolute;
-    clip: rect(0, 0, 0, 0);
-    pointer-events: none;
 }
 
 .listing-ct-body .list-group {

--- a/pkg/shell/credentials.js
+++ b/pkg/shell/credentials.js
@@ -65,11 +65,11 @@ export function setup() {
                 });
     }
 
-    function renderKeyOnOff(id, state, enabled, tbody) {
+    function renderKeyOnOff(id, state, disabled, tbody) {
         ReactDOM.render(
             React.createElement(OnOffSwitch, {
                 state: state,
-                enabled: enabled,
+                disabled: disabled,
                 onChange: enable => onToggleKey(id, enable, tbody) }),
             document.querySelector('table.credential-listing tbody[data-id="' + id + '"] .listing-ct-actions'));
     }
@@ -101,7 +101,7 @@ export function setup() {
                     });
         }
 
-        renderKeyOnOff(id, enable, true, tbody);
+        renderKeyOnOff(id, enable, false, tbody);
     }
 
     $("#credentials-dialog")
@@ -320,7 +320,7 @@ export function setup() {
                             row.attr("data-name", key.name)
                                     .attr("data-loaded", key.loaded ? "1" : "0");
 
-                            renderKeyOnOff(id, key.loaded || row.hasClass("unlock"), !!key.name, row);
+                            renderKeyOnOff(id, key.loaded || row.hasClass("unlock"), !key.name, row);
                         } else if (id !== "adding") {
                             row.remove();
                         }

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -204,7 +204,7 @@ export class StorageOnOff extends React.Component {
                                 <OnOffSwitch state={this.state.promise
                                     ? this.state.promise_goal_state
                                     : this.props.state}
-                                                 enabled={!excuse && !this.state.promise}
+                                                 disabled={!!(excuse || this.state.promise)}
                                                  onChange={onChange} />
                             )} />
         );

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -395,7 +395,7 @@ PageServer.prototype = {
             ReactDOM.render(
                 React.createElement(OnOffSwitch, {
                     state: pmlogger_service.state === "running",
-                    enabled: pmlogger_service.state !== "starting" && !force_disable,
+                    disabled: pmlogger_service.state == "starting" || force_disable,
                     onChange: onPmLoggerSwitchChange }),
                 document.getElementById('server-pmlogger-switch')
             );

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -76,12 +76,17 @@ class TestKdump(MachineCase):
 
         b.wait_visible("#app")
 
-        onOffSelectorActive = "div.btn-onoff-ct label.active"
+        def assertActive(active):
+            # changed in PR #11769
+            if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
+                b.wait_in_text("div.btn-onoff-ct label.active", active and "On" or "Off")
+            else:
+                b.wait_present(".onoff-ct input" + (active and ":checked" or ":not(:checked)"))
 
         if m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             # some OSes have kdump enabled by default (crashkernel=auto)
             b.wait_in_text("#app", "Service is running")
-            b.wait_in_text(onOffSelectorActive, "On")
+            assertActive(True)
         else:
             # right now we have no memory reserved
             if m.image in ["rhel-7-5-distropkg", "rhel-7-6-distropkg"]:
@@ -93,7 +98,7 @@ class TestKdump(MachineCase):
                 b.mouse("#app span.popover-ct-kdump", "mouseout")
             # service should indicate an error and the button should be off
             b.wait_in_text("#app", "Service has an error")
-            b.wait_in_text(onOffSelectorActive, "Off")
+            assertActive(False)
 
         # there shouldn't be any crash reports in the target directory
         self.assertEqual(m.execute("""find "/var/crash" -maxdepth 1 -mindepth 1 -type d -exec echo {} \;"""), "")
@@ -140,7 +145,7 @@ class TestKdump(MachineCase):
         b.wait_in_text("#app", "256 MiB")
         # service should start up properly and the button should be on
         b.wait_in_text("#app", "Service is running")
-        b.wait_in_text(onOffSelectorActive, "On")
+        assertActive(True)
         b.wait_in_text("#app", "Service is running")
 
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1536327
@@ -168,7 +173,7 @@ class TestKdump(MachineCase):
         # service has to restart after changing the config, wait for it to be running
         # otherwise the button to test will be disabled
         b.wait_in_text("#app", "Service is running")
-        b.wait_in_text(onOffSelectorActive, "On")
+        assertActive(True)
 
         # crash the kernel and make sure it wrote a report into the right directory
         b.click("button.btn-default")

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -158,6 +158,21 @@ class TestKeys(MachineCase):
         def list_keys():
             return b.eval_js("cockpit.spawn([ '/bin/sh', '-c', 'ssh-add -l || true' ])")
 
+        def assertKeyState(selector, enabled):
+            # changed in PR #11769
+            if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
+                b.wait_present("%s .btn.active:contains('%s')" % (selector, enabled and "On" or "Off"))
+            else:
+                b.wait_present("%s input%s" % (selector, enabled and ":checked" or ":not(:checked)"))
+
+        def toggleKeyState(selector, on_area=False):
+            # changed in PR #11769
+            if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
+                # old On/Off button only accepts half of the widget area
+                b.click(selector + " .btn:contains('%s') span" % (on_area and "On" or "Off"))
+            else:
+                b.click(selector + " .onoff-ct input")
+
         # Operating systems where auto loading doesn't work
         auto_load = "atomic" not in m.image
 
@@ -203,7 +218,7 @@ class TestKeys(MachineCase):
 
         # Automatically loaded
         if auto_load:
-            assert b.is_present("tbody[data-name=id_rsa] .btn.active:contains('On')")
+            assertKeyState("tbody[data-name=id_rsa]", True)
         b.click("tbody[data-name=id_rsa] tr.listing-ct-item")
         assert b.is_visible("tbody[data-name=id_rsa] .listing-ct-body")
         assert b.is_visible("tbody[data-name=id_rsa] ul")
@@ -229,14 +244,13 @@ class TestKeys(MachineCase):
         assert not b.is_visible("tbody[data-name=id_rsa] .listing-ct-body")
 
         # Load the id_dsa key
-        b.wait_present("tbody[data-name=id_dsa]")
-        assert b.is_visible("tbody[data-name=id_dsa] .btn.active:contains('Off')")
-        b.click("tbody[data-name=id_dsa] .btn:contains('On') span")
+        assertKeyState("tbody[data-name=id_dsa]", False)
+        toggleKeyState("tbody[data-name=id_dsa]", True)
         assert b.is_present("tbody[data-name=id_dsa] .credential-unlock")
         b.set_val("tbody[data-name=id_dsa] .credential-password", "badbad")
         b.click("tbody[data-name=id_dsa] .credential-unlock .btn")
         b.wait_present("tbody[data-name=id_dsa][data-loaded=1]")
-        assert b.is_present("tbody[data-name=id_dsa] .btn.active:contains('On')")
+        assertKeyState("tbody[data-name=id_dsa]", True)
 
         # Both keys are now loaded
         keys = list_keys()
@@ -250,7 +264,7 @@ class TestKeys(MachineCase):
             self.assertIn(old_dsa, keys)
 
         # Unload the RSA key
-        b.click("tbody[data-name=id_rsa] .btn:contains('Off') span")
+        toggleKeyState("tbody[data-name=id_rsa]")
         b.wait_present("tbody[data-name=id_rsa][data-loaded=0]")
 
         # Only DSA keys now loaded
@@ -332,7 +346,7 @@ class TestKeys(MachineCase):
         # keys are marked as "agent_only", thereby limiting functionality
         if openssh_version >= [7, 8]:
             # "agent_only" keys cannot be turned off, or have their passwords changed
-            assert b.is_visible(new_key_tbody + " .btn.active.disabled:contains('On')")
+            assertKeyState(new_key_tbody, True)
         else:
             # Change password of key
             b.click(new_key_tbody + " li:contains('Password') a")
@@ -343,7 +357,7 @@ class TestKeys(MachineCase):
             b.wait_present(new_key_tbody + " li.active:contains('Details')")
 
             # Turn key off, it goes away
-            b.click(new_key_tbody + " .btn:contains('Off') span")
+            toggleKeyState(new_key_tbody)
             b.wait_not_present(new_key_tbody)
 
             # Key now has password that needs to be entered to add

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -70,8 +70,12 @@ class TestNetworking(NetworkCase):
         self.wait_onoff(".panel-heading:contains('tbond')", True)
         self.toggle_onoff(".panel-heading:contains('tbond')")
         b.wait_in_text("tr:contains('Status')", "Inactive")
-        self.assertNotIn("disabled",
-                         b.attr(".panel-heading:contains('tbond') .btn:contains('On')", "class"))
+        # changed in PR #11769
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
+            self.assertNotIn("disabled",
+                             b.attr(".panel-heading:contains('tbond') .btn:contains('On')", "class"))
+        else:
+            b.wait_not_present(".panel-heading:contains('tbond') .onoff-ct input:disabled")
 
         b.reload()
         b.enter_page("/network")

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -21,6 +21,7 @@
 import parent
 import time
 from testlib import *
+from netlib import NetworkCase
 
 
 def wait_unit_state(machine, unit, state):
@@ -36,7 +37,7 @@ def wait_unit_state(machine, unit, state):
 
 
 @skipImage("enabling firewall got fixed in PR #10511", "rhel-7-6-distropkg")
-class TestFirewall(MachineCase):
+class TestFirewall(NetworkCase):
 
     def testNetworkingPage(self):
         b = self.browser
@@ -48,30 +49,25 @@ class TestFirewall(MachineCase):
             m.execute("firewall-cmd --permanent --zone=public --add-interface=eth1")
         m.execute("systemctl stop firewalld")
 
-        switch_sel = "#networking-firewall-switch label:not(.active) span"
-
         self.login_and_go("/network")
-        b.wait_in_text("#networking-firewall-switch label.active", "Off")
-
-        b.click(switch_sel)
-        b.wait_present("#networking-firewall-switch label.active:not(.disabled)")
-        b.wait_in_text("#networking-firewall-switch label.active", "On")
+        self.wait_onoff("#networking-firewall-switch", False)
+        self.toggle_onoff("#networking-firewall-switch")
+        self.wait_onoff("#networking-firewall-switch", True)
         wait_unit_state(m, "firewalld", "active")
         active_rules = m.execute("firewall-cmd --list-services").split()
         b.wait_in_text("#networking-firewall-summary", "{} Active Rule".format(len(active_rules)))
 
-        b.click(switch_sel)
-        b.wait_present("#networking-firewall-switch label.active:not(.disabled)")
-        b.wait_in_text("#networking-firewall-switch label.active", "Off")
+        self.toggle_onoff("#networking-firewall-switch")
+        self.wait_onoff("#networking-firewall-switch", False)
         wait_unit_state(m, "firewalld", "inactive")
         b.wait_in_text("#networking-firewall-summary", "0 Active Rules")
 
         # toggle the service from CLI, page should react
         m.execute("systemctl start firewalld")
-        b.wait_in_text("#networking-firewall-switch label.active", "On")
+        self.wait_onoff("#networking-firewall-switch", True)
         b.wait_in_text("#networking-firewall-summary", "{} Active Rule".format(len(active_rules)))
         m.execute("systemctl stop firewalld")
-        b.wait_in_text("#networking-firewall-switch label.active", "Off")
+        self.wait_onoff("#networking-firewall-switch", False)
         b.wait_in_text("#networking-firewall-summary", "0 Active Rules")
 
         b.click("#networking-firewall-link")
@@ -99,11 +95,9 @@ class TestFirewall(MachineCase):
         # "Add Services" button should not be present
         b.wait_not_present("caption button.btn-primary")
 
-        # to toggle the switch, click on the non-active label, where the slider is
-        b.wait_in_text(".btn-onoff-ct label.active", "Off")
-        b.click(".btn-onoff-ct label.active span")
-        b.wait_present(".btn-onoff-ct label.active:not(.disabled)")
-        b.wait_in_text(".btn-onoff-ct label.active", "On")
+        self.wait_onoff("h1", False)
+        self.toggle_onoff("h1")
+        self.wait_onoff("h1", True)
         wait_unit_state(m, "firewalld", "active")
 
         # Wait until the default zone is listed
@@ -140,9 +134,8 @@ class TestFirewall(MachineCase):
         b.wait_present("tr[data-row-id='empty']")
 
         # switch service off again
-        b.click(".btn-onoff-ct label.active span")
-        b.wait_present(".btn-onoff-ct label.active:not(.disabled)")
-        b.wait_in_text(".btn-onoff-ct label.active", "Off")
+        self.toggle_onoff("h1")
+        self.wait_onoff("h1", False)
         wait_unit_state(m, "firewalld", "inactive")
         # "Add Services" button should be hidden again
         b.wait_not_present("caption button.btn-primary")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -803,7 +803,8 @@ class TestAutoUpdates(PackageCase):
 
         def wait_pending():
             # the controls get disabled while applying the config changes is in progress; wait for both transitions
-            b.wait_present("#automatic .disabled")
+            b.wait_present("#automatic input:disabled")
+            b.wait_not_present("#automatic input:disabled")
             b.wait_not_present("#automatic .disabled")
 
         def assertTimerDnf(hour, dow):
@@ -853,14 +854,14 @@ class TestAutoUpdates(PackageCase):
 
         # automatic updates are supported, but off
         b.wait_present("#automatic h2")
-        b.wait_in_text("#automatic div.btn-onoff-ct label.active", "Off")
+        b.wait_present("#automatic .onoff-ct input:not(:checked)")
         self.assertFalse(b.is_present("#auto-update-type"))
         assertTimer(None)
 
         # enable
-        b.click("#automatic div.btn-onoff-ct label.active span")
+        b.click("#automatic .onoff-ct input")
         wait_pending()
-        b.wait_in_text("#automatic div.btn-onoff-ct label.active", "On")
+        b.wait_present("#automatic .onoff-ct input:checked")
         assertTimer("06")
         assertType("all")
         b.wait_in_text("#auto-update-type", "Apply all updates")
@@ -903,9 +904,9 @@ class TestAutoUpdates(PackageCase):
         assertTimer("21")
 
         # disable
-        b.click("#automatic div.btn-onoff-ct label.active span")
+        b.click("#automatic .onoff-ct input")
         wait_pending()
-        b.wait_in_text("#automatic div.btn-onoff-ct label.active", "Off")
+        b.wait_present("#automatic .onoff-ct input:not(:checked)")
         self.assertFalse(b.is_present("#auto-update-type"))
         assertTimer(None)
 
@@ -926,12 +927,12 @@ class TestAutoUpdates(PackageCase):
             self.assertFalse(b.is_present("#auto-update-type"))
             return
 
-        b.wait_in_text("#automatic div.btn-onoff-ct label.active", "Off")
+        b.wait_present("#automatic .onoff-ct input:not(:checked)")
         self.assertFalse(b.is_present("#auto-update-type"))
 
         # enable
-        b.click("#automatic div.btn-onoff-ct label.active span")
-        b.wait_in_text("#automatic div.btn-onoff-ct label.active", "On")
+        b.click("#automatic .onoff-ct input")
+        b.wait_present("#automatic .onoff-ct input:checked")
         b.wait_present("#auto-update-type")
 
         if self.backend == 'dnf':
@@ -980,7 +981,7 @@ class TestAutoUpdates(PackageCase):
         b.login_and_go("/updates")
         b.wait_present("#available")
         if self.backend == 'dnf':
-            b.wait_in_text('#automatic div.btn-onoff-ct > .btn.active > span', 'Off')
+            b.wait_present("#automatic .onoff-ct input:not(:checked)")
         else:
             # on-demand installation isn't supported, switch to enable it isn't visible
             self.assertFalse(b.is_present("#automatic"))
@@ -1031,7 +1032,7 @@ WantedBy=basic.target
         b.login_and_go('/updates')
 
         # click through install dialog
-        b.click('#automatic div.btn-onoff-ct > .btn.active > span')
+        b.click("#automatic .onoff-ct input")
         b.wait_popup('dialog')
         b.wait_visible('#dialog button.apply')
         b.wait_not_attr('#dialog button.apply', 'disabled', '')
@@ -1039,7 +1040,7 @@ WantedBy=basic.target
 
         # as dnf-automatic isn't actually installed DnfImpl.setConfig will fail,
         # but we can check that the backend is now enabled
-        b.wait_in_text('#automatic div.btn-onoff-ct > .btn.active > span', 'On')
+        b.wait_present("#automatic .onoff-ct input:checked")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -160,14 +160,24 @@ class TestSelinux(MachineCase):
         # wait for the page to be present
         b.wait_in_text("body", "SELinux Policy")
 
+        def assertEnforce(active):
+            # changed in PR #11769
+            if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
+                b.wait_in_text("div.btn-onoff-ct label.active", active and "On" or "Off")
+            else:
+                b.wait_present(".onoff-ct input" + (active and ":checked" or ":not(:checked)"))
+
         # SELinux should be enabled and enforcing at the beginning
-        on_off_selector_active = "div.btn-onoff-ct label.active"
-        b.wait_in_text(on_off_selector_active, "On")
+        assertEnforce(True)
         m.execute("getenforce | grep -q 'Enforcing'")
 
         # now set to permissive using the ui button
-        b.click("div.btn-onoff-ct label.active span")
-        b.wait_in_text(on_off_selector_active, "Off")
+        # changed in PR #11769
+        if m.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
+            b.click("div.btn-onoff-ct label.active span")
+        else:
+            b.click(".onoff-ct input")
+        assertEnforce(False)
         m.execute("getenforce | grep -q 'Permissive'")
 
         # when in permissive mode, expect a warning
@@ -175,7 +185,7 @@ class TestSelinux(MachineCase):
 
         # switch back using cli, ui should react
         m.execute("setenforce 1")
-        b.wait_in_text(on_off_selector_active, "On")
+        assertEnforce(True)
 
         # warning should disappear
         b.wait_not_in_text("div.selinux-policy-ct", "Setting deviates")
@@ -192,7 +202,7 @@ class TestSelinux(MachineCase):
         b.switch_to_top()
         b.go("/selinux/setroubleshoot")
         b.enter_page("/selinux/setroubleshoot")
-        b.wait_in_text(on_off_selector_active, "Off")
+        assertEnforce(False)
         b.wait_in_text("div.selinux-policy-ct", "Setting deviates")
 
 

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -68,8 +68,8 @@ class TestStorage(StorageCase):
         b.wait_in_text(detail(3), "used of 5 GiB")
         b.wait_in_text(detail(4), "used of 5 GiB")
         b.wait_text(detail(5), "256 MiB")
-        b.wait_present(detail(6) + " .active:contains(On)")
-        b.wait_present(detail(7) + " .active:contains(On)")
+        b.wait_present(detail(6) + " input:checked")
+        b.wait_present(detail(7) + " input:checked")
 
         # Make a filesystem on it
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -438,9 +438,10 @@ class TestSystemInfo(MachineCase):
             else:
                 b.click('#hwinfo a:contains(Mitigations)')
 
-            if expect_smt_state:
+            if expect_smt_state is not None:
                 b.wait_present('#cpu-mitigations-dialog span:contains(nosmt)')
-                b.wait_in_text('#cpu-mitigations-dialog #nosmt-switch .btn.active', expect_smt_state)
+                b.wait_present('#cpu-mitigations-dialog #nosmt-switch input' +
+                               (expect_smt_state and ":checked" or ":not(:checked)"))
 
             if cmdline:
                 m.execute('while ! umount /proc/cmdline; do sleep 1; done')
@@ -448,17 +449,17 @@ class TestSystemInfo(MachineCase):
 
         # We expect our test VMs to not set nosmt
         spoof_threads(1, False)
-        spoof_threads(2, True, 'On', 'param1 param2 nosmt param3=value3')
-        spoof_threads(2, True, 'On', 'param1 param2 nosmt=force param3=value3')
+        spoof_threads(2, True, True, 'param1 param2 nosmt param3=value3')
+        spoof_threads(2, True, True, 'param1 param2 nosmt=force param3=value3')
         spoof_threads(2, False, cmdline='param1 nosmt=someunknown param3=value3')
-        spoof_threads(2, True, 'Off', None)
+        spoof_threads(2, True, False, None)
 
         # Enable nosmt option
         b.reload()
         b.enter_page('/system/hwinfo')
         b.click('#hwinfo a:contains(Mitigations)')
-        b.click('#cpu-mitigations-dialog #nosmt-switch .btn-onoff-ct label.active span')
-        b.wait_in_text('#cpu-mitigations-dialog #nosmt-switch .btn.active', 'On')
+        b.click('#cpu-mitigations-dialog #nosmt-switch input')
+        b.wait_present('#cpu-mitigations-dialog #nosmt-switch input:checked')
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
         m.wait_reboot()
         self.assertIn('nosmt', m.execute('cat /proc/cmdline'))
@@ -506,9 +507,9 @@ fi
         self.login_and_go('/system/hwinfo')
         b.click('#hwinfo a:contains(Mitigations)')
         b.wait_present('#cpu-mitigations-dialog span:contains(nosmt)')
-        b.wait_in_text('#cpu-mitigations-dialog #nosmt-switch .btn.active', 'On')
-        b.click('#cpu-mitigations-dialog #nosmt-switch .btn-onoff-ct label.active span')
-        b.wait_in_text('#cpu-mitigations-dialog #nosmt-switch .btn.active', 'Off')
+        b.wait_present('#cpu-mitigations-dialog #nosmt-switch input:checked')
+        b.click('#cpu-mitigations-dialog #nosmt-switch input')
+        b.wait_present('#cpu-mitigations-dialog #nosmt-switch input:not(:checked)')
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
         m.wait_reboot()
         self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
@@ -526,8 +527,8 @@ fi
         m.execute('[ ! -f /usr/sbin/grubby ] || mount --bind /tmp/grubby /usr/sbin/grubby')
         self.login_and_go('/system/hwinfo')
         b.click('#hwinfo a:contains(Mitigations)')
-        b.click('#cpu-mitigations-dialog #nosmt-switch .btn-onoff-ct label.active span')
-        b.wait_in_text('#cpu-mitigations-dialog #nosmt-switch .btn.active', 'On')
+        b.click('#cpu-mitigations-dialog #nosmt-switch input')
+        b.wait_present('#cpu-mitigations-dialog #nosmt-switch input:checked')
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
         b.wait_present('#cpu-mitigations-dialog .alert:contains(No supported grub update mechanism found)')
 
@@ -586,12 +587,12 @@ class TestPcp(packagelib.PackageCase):
             return
 
         # Turn stored metrics on
-        b.wait_in_text("#server-pmlogger-switch label.active", "Off")
-        b.click("#server-pmlogger-switch label.active span")
-        b.wait_attr_contains("#server-pmlogger-switch label.active", "class", "disabled")
+        b.wait_present("#server-pmlogger-switch input:not(:checked)")
+        b.click("#server-pmlogger-switch input")
+        b.wait_present("#server-pmlogger-switch input:disabled")
         m.execute("touch /tmp/pmlogger.start")
-        b.wait_attr_not_contains("#server-pmlogger-switch label.active", "class", "disabled")
-        b.wait_in_text("#server-pmlogger-switch label.active", "On")
+        b.wait_present("#server-pmlogger-switch input:not(:disabled)")
+        b.wait_present("#server-pmlogger-switch input:checked")
 
 
 if __name__ == '__main__':

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -118,11 +118,15 @@ class NetworkCase(MachineCase):
         m.execute("chmod a+x /usr/sbin/dhclient")
 
     def wait_onoff(self, sel, val):
-        self.browser.wait_present(sel + " label.active:contains('%s')" % ("On" if val else "Off"))
+        # PR #11769 changes On/Off implementation
+        if self.machine.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
+            self.browser.wait_present(sel + " label.active:contains('%s')" % ("On" if val else "Off"))
+        else:
+            self.browser.wait_present(sel + " input" + (":checked" if val else ":not(:checked)"))
 
     def toggle_onoff(self, sel):
-        # Since PR #11773 the click target of a OnOff button has changed
+        # PR #11769 changes On/Off implementation
         if self.machine.image in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             self.browser.click(sel + " label:not(.active)")
         else:
-            self.browser.click(sel + " label:not(.active) span")
+            self.browser.click(sel + " input")


### PR DESCRIPTION
Update the On/Off switch redesign to how PatternFly 4's Switch looks
like [1]. This makes the button more accessible, easier to click (as the
full button area can be clicked, not just half of it), and drops all
translatable text, thereby avoiding the overflow in translations.

While at it, invert the "enabled" property into the standard "disabled"
one. As the PF4 design differs between switches with and without extra
text, add a new "text" property. This isn't being used anywhere except
the "React Patterns" page right now, but may be in the future.

CSS (the hard part) is all credit to Garrett LeSage.

[1] https://pf4.patternfly.org/components/Switch/

Fixes #9408
Fixes #11225
Fixes #11226
Fixes #11814
https://bugzilla.redhat.com/show_bug.cgi?id=1650942

TODO:
 - [x] Port non-React instances over, drop on/off switches on the jquery patterns page: PR #11773
 - [x] Convert last remaining jQuery On/Off button on Networking page: PR #11784
 - [x] Fix spacing on Firewall page
 - [x] Port remaining `enabled` -> `disabled` properties from recently Reactified pages
 - [x] Fix bad alignment at network interface actions (delete button and on/off)
 - [x] Fix font size in buttons on `<h1>` at Firewall page
 - [x] Adjust tests
 - [ ] ~Add aria annotations (?)~
 - [x] Keyboard focus
 - [x] Focus style
 - [x] Hover style
 - [x] test on firefox desktop
 - [x] test on firefox mobile
 - [x] test on chromium desktop
 - [x] test on chromium mobile
 - [x] test on edge
 - [x] test on Safari