### PR TITLE
machines: when changing installation source type in the create VM dialog don't reset source

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -151,14 +151,17 @@ class CreateVM extends React.Component {
             break;
         case 'sourceType':
             this.setState({ [key]: value });
-            if (value != PXE_SOURCE) {
-                notifyValuesChanged('source', null);
-            } else {
+            if (value == PXE_SOURCE) {
                 let initialPXESource = getPXEInitialNetworkSource(this.props.nodeDevices,
                                                                   this.props.networks,
                                                                   this.props.vmParams.connectionName);
 
                 notifyValuesChanged('source', initialPXESource);
+            } else if (this.state.sourceType == PXE_SOURCE && value != PXE_SOURCE) {
+                // Reset the source when the previous selection was PXE;
+                // all the other choices are string set by the user
+                notifyValuesChanged('source', '');
+                this.setState({ 'source': '' });
             }
             break;
         case 'memorySize':


### PR DESCRIPTION
For PXE installations the installation source is a dropdown of
available resources and needs to be initialized when this mode is
selected. However, for the rest of the installation modes, the source is a
plain input string and we should not reset it each time the user changes
mode.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1707655