### PR TITLE
tests: Workaround valgrind limitations with ghash [no-test]

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -295,6 +295,10 @@ VALGRIND_SUPPRESSIONS = \
 	tools/json-glib.supp \
 	$(NULL)
 
+if VALGRIND_MINADDR_HACK
+VALGRIND_ARGS += --aspace-minaddr=0x100000000
+endif
+
 valgrind-suppressions: $(VALGRIND_SUPPRESSIONS)
 	$(AM_V_GEN) cat $^ > $@
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,10 @@ AC_ISC_POSIX
 AC_HEADER_STDC
 AC_PROG_LN_S
 
+# HACK - Prevent valgrind false-positives due to GHashTable trickery
+AC_CHECK_SIZEOF([void *])
+AM_CONDITIONAL([VALGRIND_MINADDR_HACK], [test "$ac_cv_sizeof_void_p" -eq 8])
+
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_MSG_CHECKING([whether to install to prefix only])


### PR DESCRIPTION
Valgrind can't deal with the space-saving optimisations in GLib 2.60.
Add a workaround.

Fixes #11766