### PR TITLE
[no-test] WIP: Move our OnOffSwitches to Switch component from @patternfly/react-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "dependencies": {
     "@babel/polyfill": "7.4.4",
+    "@patternfly/patternfly": "^2.6.6",
     "@patternfly/react-console": "1.10.40",
+    "@patternfly/react-core": "^3.16.10",
     "angular": "1.3.20",
     "angular-bootstrap-npm": "0.13.4",
     "angular-gettext": "2.3.11",
@@ -13,6 +15,7 @@
     "bootstrap-datepicker": "1.8.0",
     "c3": "0.4.23",
     "d3": "3.5.17",
+    "file-loader": "^3.0.1",
     "jquery": "3.3.1",
     "jquery-flot": "0.8.3",
     "js-sha1": "0.6.0",
@@ -82,6 +85,7 @@
     "strict-loader": "~1.1.0",
     "style-loader": "~0.13.1",
     "uglify-js": "^3.4.9",
+    "url-loader": "^1.1.2",
     "webpack": "^4.17.1",
     "webpack-cli": "^3.1.0"
   },

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -30,7 +30,10 @@ import {
 
 import firewall from "./firewall-client.js";
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
-import { OnOffSwitch } from "cockpit-components-onoff.jsx";
+import { Switch } from "@patternfly/react-core";
+
+import "../../node_modules/@patternfly/patternfly/patternfly-variables.css";
+import "../../node_modules/@patternfly/patternfly/components/Switch/switch.css";
 
 import "page.css";
 import "table.css";
@@ -696,12 +699,13 @@ export class Firewall extends React.Component {
                     <li><a tabIndex="0" onClick={go_up}>{_("Networking")}</a></li>
                     <li className="active">{_("Firewall")}</li>
                 </ol>
-                <h1>
-                    {_("Firewall")}
-                    <OnOffSwitch state={enabled}
-                                 enabled={this.state.pendingTarget === null}
-                                 onChange={this.onSwitchChanged} />
-                </h1>
+                <label htmlFor='firewall-onoff-switch'>
+                    <h1> {_("Firewall")} </h1>
+                </label>
+                <Switch id='firewall-onoff-switch' isChecked={enabled}
+                       isDisabled={this.state.pendingTarget}
+                       onChange={this.onSwitchChanged} />
+
                 <div id="zones-listing">
                     { enabled && <Listing title={_("Active zones")}
                              columnTitles={[ _("Zone"), "", _("Interfaces"), _("IP Range") ]}

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -174,6 +174,10 @@ h1 .btn-onoff-ct {
     background-color: #def3ff;
 }
 
+label[for=firewall-onoff-switch] {
+    margin-left: 10px;
+}
+
 /* set min-height to the same as max-height, so that the list doesn't shrink
  * when filtering */
 #add-services-dialog .dialog-list-ct {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -454,6 +454,14 @@ module.exports = {
                         angular: true
                     }
                 }]
+            },
+            {
+                test: /\.(eot|woff|woff2|svg|ttf)([\?]?.*)$/,
+                loader: 'file-loader',
+            },
+            {
+                test: /\.(jpg)$/i,
+                loader: 'url-loader',
             }
         ],
     }


### PR DESCRIPTION
This is just a demonstration that we can move one component at a time to PF-4.
In this demo patch I ported the firewall Switch to use PF-4.

However it's still not showing up correctly (I think), looks too small, I guess I am missing some css file to import. Though, from the documentation I am not able to find out what is actually needed.

@jgiardino maybe you can help find out what css are we missing to import here?

Currently it looks like this.
Switch on state:
![firewall-on](https://user-images.githubusercontent.com/14921356/57438772-f711eb00-7244-11e9-9ec2-857a888fb3d2.png)

Switch off state:
![firewall-off](https://user-images.githubusercontent.com/14921356/57438773-f711eb00-7244-11e9-8f1f-a267ed190100.png)

Leaving this PR here as a base for discussion for our PF-4 migration. 
