### PR TITLE
containers: Bump unit-tests to Ubuntu 19.04 [no-test]

### DIFF
--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:19.04
 
 ARG arch=amd64
 
@@ -6,29 +6,30 @@ ARG arch=amd64
 # we must do cross-builds on i386 as phantomjs is not available for i386
 ARG _crossdeps="libglib2.0-dev libgudev-1.0-dev libjson-glib-dev libkeyutils-dev liblvm2-dev libnm-glib-dev \
     libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev \
-    libssh-dev libsystemd-dev libkrb5-dev \
-    glib-networking glib-networking-dbg libc6-dbg libglib2.0-0-dbg pkg-config"
+    libssh-dev libsystemd-dev libkrb5-dev glib-networking pkg-config \
+    libc6-dbg libglib2.0-0-dbgsym glib-networking-dbgsym"
 
-# HACK: Avoid libssh security update, it breaks keyboard-interactive (https://bugs.debian.org/913870)
-RUN dpkg --add-architecture ${arch} && echo ${arch} > /arch && apt-get update && \
-    apt-get install -y --no-install-recommends build-essential gcc-multilib clang python3 \
-      autoconf automake gdb gtk-doc-tools intltool libjavascript-minifier-xs-perl libjson-perl valgrind \
-      xmlto xsltproc npm nodejs-legacy git libfontconfig1 dbus ssh curl chromium-browser appstream-util \
-      $(for p in ${_crossdeps}; do echo $p:${arch}; done) && \
-    apt-get install -y --allow-downgrades libssh-dev:${arch}=0.6.3-4.3 libssh-4:${arch}=0.6.3-4.3 && \
-    echo 'deb http://archive.ubuntu.com/ubuntu bionic universe' > /etc/apt/sources.list.d/stable.list && \
+# enable debug symbol archive (https://wiki.ubuntu.com/DebuggingProgramCrash)
+RUN dpkg --add-architecture ${arch} && \
+    echo ${arch} > /arch && \
     apt-get update && \
-    apt-get install -y pyflakes pyflakes3 python3-pep8 && \
+    apt-get install -y --no-install-recommends gnupg2 eatmydata && \
+    echo "deb http://ddebs.ubuntu.com disco main universe" > /etc/apt/sources.list.d/ddebs.list && \
+    echo "deb http://ddebs.ubuntu.com disco-updates main universe" >> /etc/apt/sources.list.d/ddebs.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F2EDC64DC5AEE1F6B9C621F0C8CAB6595FDFF622 && \
+    apt-get update && \
+    eatmydata apt-get install -y --no-install-recommends build-essential gcc-multilib clang python3 \
+      autoconf automake gdb gtk-doc-tools intltool libjavascript-minifier-xs-perl libjson-perl valgrind \
+      xmlto xsltproc npm nodejs git libfontconfig1 dbus ssh curl chromium-browser appstream-util \
+      pyflakes3 python3-pep8 \
+      $(for p in ${_crossdeps}; do echo $p:${arch}; done) && \
     apt-get clean
 
-# use latest npm/node
 # add system user to avoid same UIDs as host's source volume
-RUN npm install -g n && n stable && \
-    adduser --system --gecos "Builder" builder
+RUN adduser --system --gecos "Builder" builder
 
 # HACK: Working around Node.js screwing around with stdio
-ENV NODE_PATH /usr/local/bin/nodejs
-RUN mv /usr/local/bin/node /usr/local/bin/nodejs
+ENV NODE_PATH /usr/bin/node
 ADD turd-polish /usr/local/bin/node
 
 USER builder


### PR DESCRIPTION
This tests on a less ancient toolchain, more recent libssh, and gives us
a more recent pyflakes which is able to spot a lot more errors.

The main repo -dbg packages are mostly gone now, so enable the dbgsym
repository (as per https://wiki.ubuntu.com/DebuggingProgramCrash) and
install the corresponding -dbgsym packages instead.

Stop installing and using the "g" npm module, the distro's nodejs is now
recent enough.

Use eatmydata to install the bulk of packages for faster container
creation.

 - [x] Fix false-positive memleaks with glib 2.60: PR #11776 
 - [x] Ignore GSocketClient leak in glib 2.60: PR #11781