### PR TITLE
selinux: Show local modifications

### DIFF
--- a/pkg/lib/cockpit-components-modifications.css
+++ b/pkg/lib/cockpit-components-modifications.css
@@ -1,0 +1,32 @@
+.modifications-table {
+    border: solid 1px var(--color-light-gray);
+}
+
+.modifications-table .listing-ct-empty {
+    border-top: inherit;
+}
+
+.modification-row:not(:last-child){
+    border-bottom: 1px solid var(--color-gray-1);
+}
+
+.modification-row:last-child{
+    border-bottom: 1px solid var(--color-light-gray);
+}
+
+.modification-row td {
+    padding: 5px 10px;
+}
+
+.modifications-caption {
+    display: flex;
+    justify-content: space-between;
+}
+
+.modifications-caption a.modifications-export {
+    margin-top: 10px;
+}
+
+.automation-script-modal pre {
+    max-height: 20em;
+}

--- a/pkg/lib/cockpit-components-modifications.css
+++ b/pkg/lib/cockpit-components-modifications.css
@@ -30,3 +30,15 @@
 .automation-script-modal pre {
     max-height: 20em;
 }
+
+.automation-script-modal .fa {
+    padding-right: 5px;
+}
+
+.automation-script-modal .modal-footer button:first-child {
+    float: left;
+}
+
+.green-icon {
+    color: var(--pf-global--success-color--100);
+}

--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -37,14 +37,31 @@ class ModificationsExportDialog extends React.Component {
         super(props);
 
         this.state = {
-            active_tab: "shell"
+            active_tab: "shell",
+            copied: false
         };
 
         this.handleSelect = this.handleSelect.bind(this);
+        this.copyToClipboard = this.copyToClipboard.bind(this);
     }
 
     handleSelect(active_tab) {
         this.setState({ active_tab });
+    }
+
+    copyToClipboard() {
+        try {
+            navigator.clipboard.writeText(this.props[this.state.active_tab])
+                    .then(() => {
+                        this.setState({ copied: true });
+                        setTimeout(() => {
+                            this.setState({ copied: false });
+                        }, 3000);
+                    })
+                    .catch(e => console.error('Text could not be copied: ', e ? e.toString() : ""));
+        } catch (error) {
+            console.error('Text could not be copied: ', error.toString());
+        }
     }
 
     render() {
@@ -84,6 +101,10 @@ class ModificationsExportDialog extends React.Component {
                     </TabContainer>
                 </Modal.Body>
                 <Modal.Footer>
+                    <Button bsStyle='default' className='btn' onClick={this.copyToClipboard}>
+                        { this.state.copied ? <span className="fa fa-check fa-xs green-icon" /> : <span className="fa fa-clipboard fa-xs" /> }
+                        <span>{ _("Copy to clipboard") }</span>
+                    </Button>
                     <Button bsStyle='default' className='btn-cancel' onClick={this.props.onClose}>
                         { _("Close") }
                     </Button>

--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -1,0 +1,172 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Button, Modal, Nav, NavItem, TabContent, TabPane, TabContainer } from 'patternfly-react';
+
+import cockpit from "cockpit";
+import './listing.less';
+import 'cockpit-components-modifications.css';
+
+const _ = cockpit.gettext;
+
+/* Dialog for showing scripts to modify system
+ *
+ * Enables showing shell and ansible script. Shell one is mandatory and ansible one can be omitted.
+ *
+ */
+class ModificationsExportDialog extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            active_tab: "shell"
+        };
+
+        this.handleSelect = this.handleSelect.bind(this);
+    }
+
+    handleSelect(active_tab) {
+        this.setState({ active_tab });
+    }
+
+    render() {
+        return (
+            <Modal show={this.props.show} className="automation-script-modal">
+                <Modal.Header>
+                    <Modal.Title>{ _("Automation Script") }</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <TabContainer id="basic-tabs-pf" defaultActiveKey={"shell"}>
+                        <React.Fragment>
+                            <Nav bsClass="nav nav-tabs nav-tabs-pf" onSelect={this.handleSelect}>
+                                <NavItem eventKey={"shell"}>
+                                    {_("Shell Script")}
+                                </NavItem>
+                                {this.props.ansible &&
+                                    <NavItem eventKey={"ansible"}>
+                                        {_("Ansible Playbook")}
+                                    </NavItem>
+                                }
+                            </Nav>
+                            <TabContent animation>
+                                <TabPane eventKey={"shell"}>
+                                    <pre>
+                                        {this.props.shell}
+                                    </pre>
+                                </TabPane>
+                                {this.props.ansible &&
+                                    <TabPane eventKey={"ansible"}>
+                                        <pre>
+                                            {this.props.ansible}
+                                        </pre>
+                                    </TabPane>
+                                }
+                            </TabContent>
+                        </React.Fragment>
+                    </TabContainer>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button bsStyle='default' className='btn-cancel' onClick={this.props.onClose}>
+                        { _("Close") }
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+ModificationsExportDialog.propTypes = {
+    shell: PropTypes.string.isRequired,
+    ansible: PropTypes.string,
+    show: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+};
+
+/* Display list of modifications in human readable format
+ *
+ * Also show `View automation script` button which opens dialog in which different
+ * scripts are available. With these scripts it is possible to apply the same
+ * configurations to  other machines.
+ *
+ * Pass array `entries` to show human readable messages.
+ * Pass string `shell` and `ansible` with scripts.
+ *
+ */
+export class Modifications extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showDialog: false,
+        };
+    }
+
+    render() {
+        let emptyRow = null;
+        if (this.props.entries === null) {
+            emptyRow = <thead className={"listing-ct-empty"}>
+                <tr className="modification-row">
+                    <td>
+                        <div className="spinner spinner-sm" />
+                        <span>{_("Loading system modifications...")}</span>
+                    </td>
+                </tr>
+            </thead>;
+        }
+        if (this.props.entries !== null && this.props.entries.length === 0) {
+            emptyRow = <thead className={"listing-ct-empty"}>
+                <tr className="modification-row">
+                    <td>
+                        { this.props.permitted ? _("No System Modifications") : _("The logged in user is not permitted to view system modifications") }
+                    </td>
+                </tr>
+            </thead>;
+        }
+
+        return (
+            <React.Fragment>
+                <ModificationsExportDialog show={this.state.showDialog} shell={this.props.shell} ansible={this.props.ansible} onClose={ () => this.setState({ showDialog: false }) } />
+                <table className={"listing-ct listing-ct-wide modifications-table"}>
+                    <caption className="cockpit-caption">
+                        <div className="modifications-caption">
+                            {this.props.title}
+                            { !emptyRow &&
+                                <a className="modifications-export" onClick={ () => this.setState({ showDialog: true }) } >{_("View automation script")}</a>
+                            }
+                        </div>
+                    </caption>
+                    { emptyRow ||
+                        <tbody>
+                            {this.props.entries.map(entry => <tr className="modification-row" key={entry.split(' ').join('')}><td>{entry}</td></tr>)}
+                        </tbody>
+                    }
+                </table>
+            </React.Fragment>
+        );
+    }
+}
+
+Modifications.propTypes = {
+    title: PropTypes.string.isRequired,
+    permitted: PropTypes.bool.isRequired,
+    entries: PropTypes.arrayOf(PropTypes.string),
+    shell: PropTypes.string.isRequired,
+    ansible: PropTypes.string,
+};

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -23,6 +23,7 @@ import React from "react";
 
 import * as cockpitListing from "cockpit-components-listing.jsx";
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
+import { Modifications } from "cockpit-components-modifications.jsx";
 
 const _ = cockpit.gettext;
 
@@ -361,6 +362,7 @@ export class SETroubleshootPage extends React.Component {
         var self = this;
         var entries;
         var troubleshooting;
+        var modifications;
         var title = _("SELinux Access Control Errors");
         var emptyCaption = _("No SELinux alerts.");
         if (!this.props.connected) {
@@ -452,6 +454,15 @@ export class SETroubleshootPage extends React.Component {
             </cockpitListing.Listing>
         );
 
+        modifications = (
+            <Modifications
+                title={ _("System Modifications") }
+                permitted={ this.props.selinuxStatus.permitted }
+                shell={ this.props.selinuxStatus.shell }
+                entries={ this.props.selinuxStatus.modifications }
+            />
+        );
+
         var errorMessage;
         if (this.props.error) {
             errorMessage = (
@@ -475,6 +486,7 @@ export class SETroubleshootPage extends React.Component {
                 />
                 {errorMessage}
                 {troubleshooting}
+                {modifications}
             </div>
         );
     }

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -152,6 +152,8 @@ class TestSelinux(MachineCase):
         if m.image in ["rhel-8-0-distropkg"]: # Introduced in #11789
             return
 
+        b.grant_permissions("clipboardRead", "clipboardWrite")
+
         b.wait_visible("tr.modification-row > td:contains(Allow zebra to write config)")
         b.wait_visible("tr.modification-row > td:contains(fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/')")
         b.click(".modifications-export")
@@ -159,7 +161,23 @@ class TestSelinux(MachineCase):
         b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "fcontext -D")
         b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "boolean -m -1 zebra_write_config")
         b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/'")
+        b.click(".automation-script-modal .fa-clipboard")
+
+        # Check the content of clipboard by pasting the clipboard to the terminal
+        b.go("/system/terminal")
+        b.enter_page("/system/terminal")
+        b.focus('.terminal')
+        b.key_press("\"\r")
+        # Right click and paste
+        b.mouse(".terminal", "contextmenu", btn=2)
+        b.click('.contextMenu .contextMenuOption:nth-child(2)')
+        b.wait_in_text(".xterm-accessibility-tree", "boolean -D")
+        b.wait_in_text(".xterm-accessibility-tree", "boolean -m -1 zebra_write_config")
+        b.wait_in_text(".xterm-accessibility-tree", "fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/'")
+
         m.execute("semanage boolean -D && semanage fcontext -D")
+        b.go("/selinux/setroubleshoot")
+        b.enter_page("/selinux/setroubleshoot")
         b.reload()
         b.enter_page("/selinux/setroubleshoot")
         b.wait_text("table.listing-ct.modifications-table > thead > tr > td", "No System Modifications")

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -59,6 +59,14 @@ class TestSelinux(MachineCase):
     @skipImage("No setroubleshoot", "debian-stable", "debian-testing", "fedora-atomic", "ubuntu-1804", "ubuntu-stable")
     def testTroubleshootAlerts(self):
         b = self.browser
+        m = self.machine
+
+        # Do some local modifications
+        m.execute("semanage fcontext --add -t samba_share_t /var/tmp/")
+        m.execute("semanage boolean --modify --on zebra_write_config")
+        self.allow_journal_messages("audit: type=1405 .* bool=zebra_write_config val=1 old_val=0.*")
+        self.allow_journal_messages(".*couldn't introspect /org/fedoraproject/Setroubleshootd: GDBus.Error:org.freedesktop.DBus.Error.NoReply: Remote peer disconnected.*")
+        self.allow_authorize_journal_messages()
 
         self.login_and_go("/selinux/setroubleshoot")
 
@@ -140,6 +148,24 @@ class TestSelinux(MachineCase):
 
         b.click(row_selector + " button.pficon-delete")
         b.wait_not_present(row_selector)
+
+        if m.image in ["rhel-8-0-distropkg"]: # Introduced in #11789
+            return
+
+        b.wait_visible("tr.modification-row > td:contains(Allow zebra to write config)")
+        b.wait_visible("tr.modification-row > td:contains(fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/')")
+        b.click(".modifications-export")
+        b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "boolean -D")
+        b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "fcontext -D")
+        b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "boolean -m -1 zebra_write_config")
+        b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/'")
+        m.execute("semanage boolean -D && semanage fcontext -D")
+        b.reload()
+        b.enter_page("/selinux/setroubleshoot")
+        b.wait_text("table.listing-ct.modifications-table > thead > tr > td", "No System Modifications")
+        b.relogin("/selinux/setroubleshoot", "admin", authorized=False)
+        b.wait_text("table.listing-ct.modifications-table > thead > tr > td", "The logged in user is not permitted to view system modifications")
+
 
     @skipImage("No cockpit-selinux", "debian-stable", "debian-testing", "fedora-atomic", "ubuntu-1804", "ubuntu-stable")
     def testEnforcingToggle(self):


### PR DESCRIPTION
![zebra](https://user-images.githubusercontent.com/12330670/57528401-8d700a80-7332-11e9-88aa-ce234fdec3a4.png)
![sranda_vyskakovacia](https://user-images.githubusercontent.com/12330670/57519592-f13b0900-731b-11e9-8ea1-d9264aa7bfe5.png)

Mostly Fixes #8657

There is no ansible script, this is gonna be follow up for sure.
This PR for now only shows booleans in normal readable form, others are just dumped from `semange export`. Each type needs to have its own parsing function and then just add this function into the map of functions. Some of these types could be introduced in this PR, but I also expect most of them as follow up.

@andreasn could you take a look and let me know if design is right or you would change something?
Thank you!