### PR TITLE
bots: Drop openshift-prerelease image [no-test]

### DIFF
--- a/bots/image-create
+++ b/bots/image-create
@@ -49,7 +49,7 @@ parser.add_argument('image', help='The image to create')
 args = parser.parse_args()
 
 # default to --no-build for some images
-if args.image in ["candlepin", "continuous-atomic", "fedora-atomic", "ipa", "rhel-atomic", "selenium", "openshift", "openshift-prerelease", "openshift-node", "ovirt"]:
+if args.image in ["candlepin", "continuous-atomic", "fedora-atomic", "ipa", "rhel-atomic", "selenium", "openshift", "ovirt"]:
     if not args.no_build:
         if args.verbose:
             print("Creating machine without build capabilities based on the image type")

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -35,7 +35,6 @@ REFRESH = {
     "ubuntu-1804": { },
     "ubuntu-stable": { },
     "openshift": { "refresh-days": 30 },
-    "openshift-prerelease": { "refresh-days": 30 },
     "ovirt": { "refresh-days": 120 },
     'rhel-7-6': { },
     'rhel-7-7': { },

--- a/bots/images/openshift-prerelease
+++ b/bots/images/openshift-prerelease
@@ -1,1 +1,0 @@
-openshift-prerelease-cddcaff41b5cf1957b1e2597f260d21f88ba77bb1024d95fef81c2421203ea69.qcow2

--- a/bots/images/scripts/openshift-prerelease.bootstrap
+++ b/bots/images/scripts/openshift-prerelease.bootstrap
@@ -1,1 +1,0 @@
-openshift.bootstrap

--- a/bots/images/scripts/openshift-prerelease.install
+++ b/bots/images/scripts/openshift-prerelease.install
@@ -1,1 +1,0 @@
-openshift.install

--- a/bots/images/scripts/openshift-prerelease.setup
+++ b/bots/images/scripts/openshift-prerelease.setup
@@ -1,1 +1,0 @@
-openshift.setup

--- a/bots/images/scripts/openshift.setup
+++ b/bots/images/scripts/openshift.setup
@@ -1,10 +1,6 @@
 #! /bin/bash
 
 set -eux
-PRERELEASE=
-if [ "${1%prerelease*}" != "$1" ]; then
-    PRERELEASE=1
-fi
 
 # Wait for x for many minutes
 function wait() {
@@ -67,21 +63,16 @@ systemctl enable docker
 # HACK: docker falls over regularly, print its log if it does
 systemctl start docker || journalctl -u docker
 
-if [ -n "$PRERELEASE" ]; then
-    VERSION=latest
-else
-    # Can't use latest because release on older versions are done out of order
-    RELEASES_JSON=$(curl -s https://api.github.com/repos/openshift/origin/releases)
-    set +x
-    VERSION=$(echo "$RELEASES_JSON" | LC_ALL=C.UTF-8 python3 -c "import json, sys, distutils.version; obj=json.load(sys.stdin); releases = [x.get('tag_name', '') for x in obj if not x.get('prerelease')]; print(sorted (releases, reverse=True, key=distutils.version.LooseVersion)[0])") || {
-        echo "Failed to parse latest release:" >&2
-        echo "$RELEASES_JSON" >&2
-        echo "------------------------------------" >&2
-        exit 1
-    }
-    set -x
-fi
-
+# Can't use latest because release on older versions are done out of order
+RELEASES_JSON=$(curl -s https://api.github.com/repos/openshift/origin/releases)
+set +x
+VERSION=$(echo "$RELEASES_JSON" | LC_ALL=C.UTF-8 python3 -c "import json, sys, distutils.version; obj=json.load(sys.stdin); releases = [x.get('tag_name', '') for x in obj if not x.get('prerelease')]; print(sorted (releases, reverse=True, key=distutils.version.LooseVersion)[0])") || {
+    echo "Failed to parse latest release:" >&2
+    echo "$RELEASES_JSON" >&2
+    echo "------------------------------------" >&2
+    exit 1
+}
+set -x
 
 # origin is too rotund to build in a normal sized VM. The linker
 # step runs out of memory. In addition origin has no Fedora packages

--- a/test/verify/check-openshift
+++ b/test/verify/check-openshift
@@ -360,13 +360,6 @@ LABEL io.projectatomic.nulecule.atomicappversion="0.1.11" \
         b.wait_present("#service-list")
 
 
-class TestOpenshiftPrerelease(TestOpenshift):
-    provision = {
-        "machine1": {"address": "10.111.113.1/20"},
-        "openshift": {"image": "openshift-prerelease", "forward": {30000: 30000, 8443: 8443}}
-    }
-
-
 @skipImage("Kubernetes not packaged", "debian-stable", "debian-testing", "ubuntu-1804", "ubuntu-stable", "fedora-i386")
 @skipImage("No cockpit-kubernetes packaged", "continuous-atomic", "fedora-atomic", "rhel-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "fedora-30", "fedora-testing")
 class TestRegistry(MachineCase, RegistryTests):
@@ -402,13 +395,6 @@ class TestRegistry(MachineCase, RegistryTests):
         # This happens with docker restarts and during startup polling
         self.allow_journal_messages('.*received truncated HTTP response.*')
         self.allow_journal_messages(".*/api.*couldn't connect.*")
-
-
-class TestRegistryPrerelease(TestRegistry):
-    provision = {
-        "machine1": {"address": "10.111.113.1/20"},
-        "openshift": {"image": "openshift-prerelease", "forward": {30000: 30000, 8443: 8443}}
-    }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It's currently at exactly the same OpenShift version 3.11alpha as the
"openshift" image, so this doesn't test anything different. Also, with
cockpit-kubernetes being phased out, and OpenShift concentrating on 4.0
now, this image has outlived its purpose. Let's remove it to speed up
our tests.