### PR TITLE
bots: Create download for image-download doesn't create dir

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -192,6 +192,7 @@ def download(dest, force, state, quiet, stores):
 
 # Calculate a place to put images where links are not committed in git
 def state_target(path):
+    os.makedirs(DATA, mode=0o775, exist_ok=True)
     return os.path.join(DATA, path)
 
 # Calculate a place to put images where links are committed in git


### PR DESCRIPTION
The output directory for image-download --state doesn't
create the right directory for outputting the images. This
results in failures when doing test data training.

 * [x] tests-data tests-train-1.jsonl.gz