### PR TITLE
containers: Prefer podman over docker [no-test]

### DIFF
--- a/containers/Makefile.am
+++ b/containers/Makefile.am
@@ -3,13 +3,16 @@ KUBERNETES_DIR = $(srcdir)/containers/kubernetes
 
 CLEANFILES += $(KUBERNETES_DIR)/rpms
 
+# container runtime: prefer podman if available
+CR := $(shell which podman 2>/dev/null || echo sudo docker)
+
 kubernetes-container:
 	rm -rf $(KUBERNETES_DIR)/rpms && mkdir -p $(KUBERNETES_DIR)/rpms
 	cd $(KUBERNETES_DIR)/rpms && $(abs_srcdir)/tools/make-rpms
-	sudo docker build -t cockpit/kubernetes $(KUBERNETES_DIR)
+	$(CR) build -t cockpit/kubernetes $(KUBERNETES_DIR)
 
 kubernetes-container-shell:
-	sudo docker run -ti --rm --publish=9001:9090 \
+	$(CR) run -ti --rm --publish=9001:9090 \
 		--env KUBERNETES_SERVICE_HOST=10.111.112.101 \
 		--env KUBERNETES_SERVICE_PORT=8443 \
 		--env OPENSHIFT_OAUTH_PROVIDER_URL=https://10.111.112.101:8443 \
@@ -19,7 +22,7 @@ kubernetes-container-shell:
 		cockpit/kubernetes /bin/bash
 
 registry-container-shell:
-	sudo docker run -ti --rm --publish=9001:9090 \
+	$(CR) run -ti --rm --publish=9001:9090 \
 		--env KUBERNETES_SERVICE_HOST=10.111.112.101 \
 		--env KUBERNETES_SERVICE_PORT=8443 \
 		--env OPENSHIFT_OAUTH_PROVIDER_URL=https://10.111.112.101:8443 \
@@ -37,22 +40,22 @@ CLEANFILES += $(WS_DIR)/rpms
 ws-container:
 	rm -rf $(WS_DIR)/rpms && mkdir -p $(WS_DIR)/rpms
 	cd $(WS_DIR)/rpms && $(abs_srcdir)/tools/make-rpms
-	sudo docker build -t cockpit/ws $(WS_DIR)
+	$(CR) build -t cockpit/ws $(WS_DIR)
 
 ws-container-shell:
-	sudo docker run -ti --rm --publish=9001:9090 \
+	$(CR) run -ti --rm --publish=9001:9090 \
 		cockpit/ws /bin/bash
 
 UNIT_TESTS_DIR = $(srcdir)/containers/unit-tests
 
 unit-tests-container:
-	sudo docker build -t cockpit/unit-tests $(UNIT_TESTS_DIR)
-	sudo docker tag  cockpit/unit-tests:latest docker.io/cockpit/unit-tests:latest
-	sudo docker build --build-arg arch=i386 -t cockpit/unit-tests:i386 $(UNIT_TESTS_DIR)
-	sudo docker tag  cockpit/unit-tests:i386 docker.io/cockpit/unit-tests:i386
+	$(CR) build -t cockpit/unit-tests $(UNIT_TESTS_DIR)
+	$(CR) tag  cockpit/unit-tests:latest docker.io/cockpit/unit-tests:latest
+	$(CR) build --build-arg arch=i386 -t cockpit/unit-tests:i386 $(UNIT_TESTS_DIR)
+	$(CR) tag  cockpit/unit-tests:i386 docker.io/cockpit/unit-tests:i386
 
 unit-tests-container-run:
-	sudo docker run --shm-size=512M -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests
+	$(CR) run --shm-size=512M -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests
 
 unit-tests-container-shell:
-	sudo docker run --shm-size=512M -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests /bin/bash
+	$(CR) run --shm-size=512M -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests /bin/bash

--- a/containers/README.md
+++ b/containers/README.md
@@ -10,8 +10,8 @@ Contributing
 
 Here are some commands to use while hacking on the containers. Replace
 'xxx' with the name of the container. That is the name of the directory.
-When running docker the 'sudo' command will be used to get necessary
-privileges.
+If podman is installed, it will be used to build/run the containers, otherwise
+it falls back to `sudo docker`.
 
 Build the given container:
 
@@ -24,7 +24,7 @@ Run the given built container and log in interactively as a shell:
 ### Developing UI running a docker container
 
 An alternative development environment when developing the Cockpit UI is to
-mount local code into the cockpit Docker container. In this example we run the
+mount local code into the cockpit container. In this example we run the
 cockpit/kubernetes container to connect to a remote kubernetes server. Replace
 OPENSHIFTHOSTNAME with the IP or HOSTNAME of your OpenShift server.
 

--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -26,7 +26,7 @@ Tests in that container for the default configuration get started with
 
 or equivalently with
 
-    $ sudo docker run --shm-size=512M -ti --volume `pwd`:/source:ro cockpit/unit-tests
+    $ podman run --shm-size=512M -ti --volume `pwd`:/source:ro cockpit/unit-tests
 
 You can pass `--env=CC=clang` to build with Clang instead of gcc, or run
 `cockpit/unit-tests:i386` to run on a 32 bit architecture.


### PR DESCRIPTION
We can build and run the containers  without root with podman, and it's
the preferred CLI on Fedora and RHEL 8.