### PR TITLE
bots: Fix image-download --state when file is skipped

### DIFF
--- a/bots/image-download
+++ b/bots/image-download
@@ -178,6 +178,10 @@ def download(dest, force, state, quiet, stores):
             cmd.append("-C")
             cmd.append("-")
 
+    # Always create the destination file (because --state)
+    else:
+        open(temp, 'a').close()
+
     curl = subprocess.Popen(cmd)
     ret = curl.wait()
     if ret != 0:


### PR DESCRIPTION
When used with --state the image-download only downloads files
if it is newer than the existing file. However the recent changes
for continuing a partial download unfortunately regressed this
behavior.

This commit should fix it. #11457 removes the use of tempfile
which created a zero length file. This restores that behavior.

 * [x] tests-data tests-train-1.jsonl.gz
