### PR TITLE
storage: Collect all software devices into one panel

### DIFF
--- a/pkg/lib/cockpit-components-install-dialog.jsx
+++ b/pkg/lib/cockpit-components-install-dialog.jsx
@@ -50,12 +50,14 @@ function format_to_fragments(fmt, arg) {
  * (If you do anyway, the resulting D-Bus errors will be shown to the user.)
  */
 
-export function install_dialog(pkg) {
+export function install_dialog(pkg, options) {
     var data = null;
     var error_message = null;
     var progress_message = null;
     var cancel = null;
     var done = null;
+
+    options = options || { };
 
     var prom = new Promise((resolve, reject) => { done = f => { if (f) resolve(); else reject(); } });
 
@@ -100,10 +102,10 @@ export function install_dialog(pkg) {
 
         const body = {
             id: "dialog",
-            title: _("Install Software"),
+            title: options.title || _("Install Software"),
             body: (
                 <div className="modal-body scroll">
-                    <p>{ format_to_fragments(_("$0 will be installed."), missing_name) }</p>
+                    <p>{ format_to_fragments(options.text || _("$0 will be installed."), missing_name) }</p>
                     { remove_details }
                     { extra_details }
                 </div>

--- a/pkg/storaged/mdraids-panel.jsx
+++ b/pkg/storaged/mdraids-panel.jsx
@@ -20,134 +20,114 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import { OverviewSidePanel, OverviewSidePanelRow } from "./overview.jsx";
+import { OverviewSidePanelRow } from "./overview.jsx";
 import {
     fmt_size, mdraid_name, block_name,
     get_available_spaces, prepare_available_spaces
 } from "./utils.js";
-import { StorageButton } from "./storage-controls.jsx";
 import { dialog_open, TextInput, SelectOne, SelectSpaces } from "./dialog.jsx";
 
 const _ = cockpit.gettext;
 
-export class MDRaidsPanel extends React.Component {
-    render() {
-        var client = this.props.client;
+const MDRaidRow = ({ client, path }) => {
+    const mdraid = client.mdraids[path];
+    const block = client.mdraids_block[path];
 
-        function create_mdraid() {
-            dialog_open({
-                Title: _("Create RAID Device"),
-                Fields: [
-                    TextInput("name", _("Name"), { }),
-                    SelectOne("level", _("RAID Level"),
+    return (
+        <OverviewSidePanelRow client={client}
+                              kind="array"
+                              name={mdraid_name(mdraid)}
+                              devname={block && block_name(block)}
+                              detail={fmt_size(mdraid.Size) + " " + _("RAID Device")}
+                              go={() => cockpit.location.go(["mdraid", mdraid.UUID])}
+                              job_path={path} />
+    );
+};
+
+export function mdraid_rows(client) {
+    function cmp_mdraid(path_a, path_b) {
+        // TODO - ignore host part
+        return client.mdraids[path_a].Name.localeCompare(client.mdraids[path_b].Name);
+    }
+
+    return Object.keys(client.mdraids).sort(cmp_mdraid)
+            .map(p => <MDRaidRow key={p} client={client} path={p} />);
+}
+
+export function create_mdraid(client) {
+    dialog_open({
+        Title: _("Create RAID Device"),
+        Fields: [
+            TextInput("name", _("Name"), { }),
+            SelectOne("level", _("RAID Level"),
+                      {
+                          value: "raid5",
+                          choices: [
+                              {
+                                  value: "raid0",
+                                  title: _("RAID 0 (Stripe)")
+                              },
+                              {
+                                  value: "raid1",
+                                  title: _("RAID 1 (Mirror)")
+                              },
+                              {
+                                  value: "raid4",
+                                  title: _("RAID 4 (Dedicated Parity)")
+                              },
                               {
                                   value: "raid5",
-                                  choices: [
-                                      {
-                                          value: "raid0",
-                                          title: _("RAID 0 (Stripe)")
-                                      },
-                                      {
-                                          value: "raid1",
-                                          title: _("RAID 1 (Mirror)")
-                                      },
-                                      {
-                                          value: "raid4",
-                                          title: _("RAID 4 (Dedicated Parity)")
-                                      },
-                                      {
-                                          value: "raid5",
-                                          title: _("RAID 5 (Distributed Parity)")
-                                      },
-                                      {
-                                          value: "raid6",
-                                          title: _("RAID 6 (Double Distributed Parity)")
-                                      },
-                                      {
-                                          value: "raid10",
-                                          title: _("RAID 10 (Stripe of Mirrors)")
-                                      }
-                                  ]
-                              }),
-                    SelectOne("chunk", _("Chunk Size"),
+                                  title: _("RAID 5 (Distributed Parity)")
+                              },
                               {
-                                  value: "512",
-                                  visible: function (vals) {
-                                      return vals.level != "raid1";
-                                  },
-                                  choices: [
-                                      { value: "4", title: _("4 KiB") },
-                                      { value: "8", title: _("8 KiB") },
-                                      { value: "16", title: _("16 KiB") },
-                                      { value: "32", title: _("32 KiB") },
-                                      { value: "64", title: _("64 KiB") },
-                                      { value: "128", title: _("128 KiB") },
-                                      { value: "512", title: _("512 KiB") },
-                                      { value: "1024", title: _("1 MiB") },
-                                      { value: "2048", title: _("2 MiB") }
-                                  ]
-                              }),
-                    SelectSpaces("disks", _("Disks"),
-                                 {
-                                     empty_warning: _("No disks are available."),
-                                     validate: function (disks, vals) {
-                                         var disks_needed = vals.level == "raid6" ? 4 : 2;
-                                         if (disks.length < disks_needed)
-                                             return cockpit.format(_("At least $0 disks are needed."),
-                                                                   disks_needed);
-                                     },
-                                     spaces: get_available_spaces(client)
-                                 })
-                ],
-                Action: {
-                    Title: _("Create"),
-                    action: function (vals) {
-                        return prepare_available_spaces(client, vals.disks).then(paths =>
-                            client.manager.MDRaidCreate(paths, vals.level,
-                                                        vals.name, (vals.chunk || 0) * 1024,
-                                                        { }));
-                    }
-                }
-            });
+                                  value: "raid6",
+                                  title: _("RAID 6 (Double Distributed Parity)")
+                              },
+                              {
+                                  value: "raid10",
+                                  title: _("RAID 10 (Stripe of Mirrors)")
+                              }
+                          ]
+                      }),
+            SelectOne("chunk", _("Chunk Size"),
+                      {
+                          value: "512",
+                          visible: function (vals) {
+                              return vals.level != "raid1";
+                          },
+                          choices: [
+                              { value: "4", title: _("4 KiB") },
+                              { value: "8", title: _("8 KiB") },
+                              { value: "16", title: _("16 KiB") },
+                              { value: "32", title: _("32 KiB") },
+                              { value: "64", title: _("64 KiB") },
+                              { value: "128", title: _("128 KiB") },
+                              { value: "512", title: _("512 KiB") },
+                              { value: "1024", title: _("1 MiB") },
+                              { value: "2048", title: _("2 MiB") }
+                          ]
+                      }),
+            SelectSpaces("disks", _("Disks"),
+                         {
+                             empty_warning: _("No disks are available."),
+                             validate: function (disks, vals) {
+                                 var disks_needed = vals.level == "raid6" ? 4 : 2;
+                                 if (disks.length < disks_needed)
+                                     return cockpit.format(_("At least $0 disks are needed."),
+                                                           disks_needed);
+                             },
+                             spaces: get_available_spaces(client)
+                         })
+        ],
+        Action: {
+            Title: _("Create"),
+            action: function (vals) {
+                return prepare_available_spaces(client, vals.disks).then(paths => {
+                    return client.manager.MDRaidCreate(paths, vals.level,
+                                                       vals.name, (vals.chunk || 0) * 1024,
+                                                       { });
+                });
+            }
         }
-
-        function cmp_mdraid(path_a, path_b) {
-            // TODO - ignore host part
-            return client.mdraids[path_a].Name.localeCompare(client.mdraids[path_b].Name);
-        }
-
-        function make_mdraid(path) {
-            var mdraid = client.mdraids[path];
-            var block = client.mdraids_block[path];
-
-            return (
-                <OverviewSidePanelRow client={client}
-                                      kind="array"
-                                      name={mdraid_name(mdraid)}
-                                      devname={block && block_name(block)}
-                                      detail={fmt_size(mdraid.Size)}
-                                      go={() => cockpit.location.go(["mdraid", mdraid.UUID])}
-                                      job_path={path}
-                                      key={path} />
-            );
-        }
-
-        var mdraids = Object.keys(client.mdraids).sort(cmp_mdraid)
-                .map(make_mdraid);
-
-        var actions = (
-            <StorageButton kind="primary" onClick={create_mdraid} id="create-mdraid">
-                <span className="fa fa-plus" />
-            </StorageButton>
-        );
-
-        return (
-            <OverviewSidePanel id="mdraids"
-                               title={_("RAID Devices")}
-                               empty_text={_("No storage set up as RAID")}
-                               actions={actions}>
-                { mdraids }
-            </OverviewSidePanel>
-        );
-    }
+    });
 }

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -24,9 +24,7 @@ import { StoragePlots } from "./plot.jsx";
 
 import { FilesystemsPanel } from "./fsys-panel.jsx";
 import { NFSPanel } from "./nfs-panel.jsx";
-import { MDRaidsPanel } from "./mdraids-panel.jsx";
-import { VGroupsPanel } from "./vgroups-panel.jsx";
-import { VDOsPanel } from "./vdos-panel.jsx";
+import { ThingsPanel } from "./things-panel.jsx";
 import { IscsiPanel } from "./iscsi-panel.jsx";
 import { DrivesPanel } from "./drives-panel.jsx";
 import { OthersPanel } from "./others-panel.jsx";
@@ -135,11 +133,9 @@ export class Overview extends React.Component {
                     <StorageLogsPanel />
                 </div>
                 <div className="col-md-4 col-lg-3 storage-sidebar">
-                    <MDRaidsPanel client={client} />
-                    <VGroupsPanel client={client} />
-                    <VDOsPanel client={client} />
-                    <IscsiPanel client={client} />
+                    <ThingsPanel client={client} />
                     <DrivesPanel client={client} highlight={this.state.highlight} />
+                    <IscsiPanel client={client} />
                     <OthersPanel client={client} />
                 </div>
             </div>

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -58,7 +58,8 @@ class StorageControl extends React.Component {
 
         if (excuse) {
             return (
-                <OverlayTrigger overlay={ <Tooltip id="tip-storage">{excuse}</Tooltip> } placement="top">
+                <OverlayTrigger overlay={ <Tooltip id="tip-storage">{excuse}</Tooltip> }
+                                placement={this.props.excuse_placement || "top"}>
                     { this.props.content(excuse) }
                 </OverlayTrigger>
             );
@@ -247,5 +248,33 @@ export class StorageUsageBar extends React.Component {
                 variant={fraction > this.props.critical ? ProgressVariant.danger : ProgressVariant.info}
                 measureLocation={ProgressMeasureLocation.outside} />
         );
+    }
+}
+
+export class StorageMenuItem extends React.Component {
+    render() {
+        return <li><a onClick={this.props.onClick}>{this.props.children}</a></li>;
+    }
+}
+
+export class StorageBarMenu extends React.Component {
+    render() {
+        const { children, label } = this.props;
+
+        function toggle(excuse) {
+            const classes = "btn btn-primary" + (excuse ? " disabled" : "");
+            return (
+                <button className={classes} type="button" data-toggle="dropdown" aria-label={label}>
+                    <span className="fa fa-bars" />
+                </button>);
+        }
+
+        return (
+            <div className="dropdown">
+                <StorageControl content={toggle} excuse_placement="bottom" />
+                <ul className="dropdown-menu dropdown-menu-right" role="menu">
+                    {children}
+                </ul>
+            </div>);
     }
 }

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -723,3 +723,7 @@ td.storage-action {
 .sidepanel-row .spinner {
     display: inline-block;
 }
+
+.panel-heading {
+    position: static;
+}

--- a/pkg/storaged/things-panel.jsx
+++ b/pkg/storaged/things-panel.jsx
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import { install_dialog } from "cockpit-components-install-dialog.jsx";
+
+import { OverviewSidePanel } from "./overview.jsx";
+import { create_mdraid, mdraid_rows } from "./mdraids-panel.jsx";
+import { create_vgroup, vgroup_rows } from "./vgroups-panel.jsx";
+import { vdo_feature, create_vdo, vdo_rows } from "./vdos-panel.jsx";
+import { StorageBarMenu, StorageMenuItem } from "./storage-controls.jsx";
+
+const _ = cockpit.gettext;
+
+export class ThingsPanel extends React.Component {
+    render() {
+        const { client } = this.props;
+
+        // See OptionalPanel for a description of the "feature"
+        // argument here.
+
+        function menu_item(feature, title, action) {
+            const feature_enabled = !feature || feature.is_enabled();
+            const required_package = feature && feature.package;
+
+            if (!feature_enabled && !(required_package && client.features.packagekit))
+                return null;
+
+            function install_then_action() {
+                if (!feature_enabled) {
+                    install_dialog(required_package, feature.dialog_options).then(
+                        () => {
+                            feature.enable().then(action);
+                        },
+                        () => null /* ignore cancel */);
+                } else {
+                    action();
+                }
+            }
+
+            return <StorageMenuItem onClick={install_then_action}>{title}</StorageMenuItem>;
+        }
+
+        const lvm2_feature = {
+            is_enabled: () => client.features.lvm2
+        };
+
+        const actions = (
+            <StorageBarMenu id="devices-menu" label={_("Create Devices")}>
+                { menu_item(null, _("Create RAID Device"), () => create_mdraid(client)) }
+                { menu_item(lvm2_feature, _("Create Volume Group"), () => create_vgroup(client)) }
+                { menu_item(vdo_feature(client), _("Create VDO Device"), () => create_vdo(client)) }
+            </StorageBarMenu>);
+
+        var devices = [].concat(
+            mdraid_rows(client),
+            vgroup_rows(client),
+            vdo_rows(client));
+
+        return (
+            <OverviewSidePanel id="devices"
+                               title={_("Devices")}
+                               actions={actions}
+                               empty_text={_("No Devices")}
+                               show_all_text={cockpit.format(_("Show all $0 devices"), devices.length)}
+                               client={client}>
+                { devices }
+            </OverviewSidePanel>
+        );
+    }
+}

--- a/pkg/storaged/utilsx.jsx
+++ b/pkg/storaged/utilsx.jsx
@@ -19,11 +19,15 @@
 
 import React from "react";
 
-// TODO - generalize this to arbitrary number of arguments (when needed)
-export function fmt_to_fragments(fmt, arg) {
-    var index = fmt.indexOf("$0");
-    if (index >= 0)
-        return <>{fmt.slice(0, index)}{arg}{fmt.slice(index + 2)}</>;
-    else
-        return fmt;
+export function fmt_to_fragments(fmt) {
+    const args = Array.prototype.slice.call(arguments, 1);
+
+    function replace(part) {
+        if (part[0] == "$") {
+            return args[parseInt(part.slice(1))];
+        } else
+            return part;
+    }
+
+    return React.createElement.apply(null, [React.Fragment, { }].concat(fmt.split(/(\$[0-9]+)/g).map(replace)));
 }

--- a/pkg/storaged/vgroups-panel.jsx
+++ b/pkg/storaged/vgroups-panel.jsx
@@ -20,105 +20,79 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import { OverviewSidePanel, OverviewSidePanelRow } from "./overview.jsx";
+import { OverviewSidePanelRow } from "./overview.jsx";
 import {
     fmt_size, validate_lvm2_name,
     get_available_spaces, prepare_available_spaces
 } from "./utils.js";
-import { StorageButton } from "./storage-controls.jsx";
 import { dialog_open, TextInput, SelectSpaces } from "./dialog.jsx";
 
 const _ = cockpit.gettext;
 
-export class VGroupsPanel extends React.Component {
-    render() {
-        var client = this.props.client;
+const VGroupRow = ({ client, path }) => {
+    const vgroup = client.vgroups[path];
 
-        function create_vgroup() {
-            function find_vgroup(name) {
-                for (var p in client.vgroups) {
-                    if (client.vgroups[p].Name == name)
-                        return client.vgroups[p];
-                }
-                return null;
-            }
+    return (
+        <OverviewSidePanelRow client={client}
+                              kind="array"
+                              name={vgroup.Name}
+                              devname={"/dev/" + vgroup.Name + "/"}
+                              detail={fmt_size(vgroup.Size) + " " + _("Volume Group")}
+                              go={() => cockpit.location.go(["vg", vgroup.Name])}
+                              job_path={path} />
+    );
+};
 
-            var name;
-            for (var i = 0; i < 1000; i++) {
-                name = "vgroup" + i.toFixed();
-                if (!find_vgroup(name))
-                    break;
-            }
-
-            dialog_open({
-                Title: _("Create Volume Group"),
-                Fields: [
-                    TextInput("name", _("Name"),
-                              {
-                                  value: name,
-                                  validate: validate_lvm2_name
-                              }),
-                    SelectSpaces("disks", _("Disks"),
-                                 {
-                                     empty_warning: _("No disks are available."),
-                                     validate: function (disks) {
-                                         if (disks.length === 0)
-                                             return _("At least one disk is needed.");
-                                     },
-                                     spaces: get_available_spaces(client)
-                                 })
-                ],
-                Action: {
-                    Title: _("Create"),
-                    action: function (vals) {
-                        return prepare_available_spaces(client, vals.disks).then(paths =>
-                            client.manager_lvm2.VolumeGroupCreate(vals.name, paths, { }));
-                    }
-                }
-            });
-        }
-
-        function cmp_vgroup(path_a, path_b) {
-            return client.vgroups[path_a].Name.localeCompare(client.vgroups[path_b].Name);
-        }
-
-        function make_vgroup(path) {
-            var vgroup = client.vgroups[path];
-
-            return (
-                <OverviewSidePanelRow client={client}
-                                      kind="array"
-                                      name={vgroup.Name}
-                                      devname={"/dev/" + vgroup.Name + "/"}
-                                      detail={fmt_size(vgroup.Size)}
-                                      go={() => cockpit.location.go(["vg", vgroup.Name])}
-                                      job_path={path}
-                                      key={path} />
-            );
-        }
-
-        var vgroups = Object.keys(client.vgroups).sort(cmp_vgroup)
-                .map(make_vgroup);
-
-        var actions = (
-            <StorageButton kind="primary" onClick={create_vgroup} id="create-volume-group">
-                <span className="fa fa-plus" />
-            </StorageButton>
-        );
-
-        var lvm2_feature = {
-            is_enabled: () => client.features.lvm2
-        };
-
-        return (
-            <OverviewSidePanel id="vgroups"
-                               title={_("Volume Groups")}
-                               empty_text={_("No volume groups created")}
-                               actions={actions}
-                               client={client}
-                               feature={lvm2_feature}>
-                { vgroups }
-            </OverviewSidePanel>
-        );
+export function vgroup_rows(client) {
+    function cmp_vgroup(path_a, path_b) {
+        return client.vgroups[path_a].Name.localeCompare(client.vgroups[path_b].Name);
     }
+
+    return Object.keys(client.vgroups).sort(cmp_vgroup)
+            .map(p => <VGroupRow key={p} client={client} path={p} />);
+}
+
+export function create_vgroup(client) {
+    function find_vgroup(name) {
+        for (var p in client.vgroups) {
+            if (client.vgroups[p].Name == name)
+                return client.vgroups[p];
+        }
+        return null;
+    }
+
+    var name;
+    for (var i = 0; i < 1000; i++) {
+        name = "vgroup" + i.toFixed();
+        if (!find_vgroup(name))
+            break;
+    }
+
+    dialog_open({
+        Title: _("Create Volume Group"),
+        Fields: [
+            TextInput("name", _("Name"),
+                      {
+                          value: name,
+                          validate: validate_lvm2_name
+                      }),
+            SelectSpaces("disks", _("Disks"),
+                         {
+                             empty_warning: _("No disks are available."),
+                             validate: function (disks) {
+                                 if (disks.length === 0)
+                                     return _("At least one disk is needed.");
+                             },
+                             spaces: get_available_spaces(client)
+                         })
+        ],
+        Action: {
+            Title: _("Create"),
+            action: function (vals) {
+                return prepare_available_spaces(client, vals.disks).then(paths => {
+                    client.manager_lvm2.VolumeGroupCreate(vals.name, paths, { });
+                });
+            }
+        }
+    });
 }

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -31,13 +31,10 @@ class TestStorage(StorageCase):
         self.allow_authorize_journal_messages()
         self.login_and_go("/storage", authorized=False)
 
-        btn = "#create-mdraid"
-        self.browser.wait_present(btn)
-        self.browser.wait_attr(btn, "disabled", "")
+        b.wait_present("#devices [data-toggle=dropdown].disabled")
 
         b.relogin('/storage', authorized=True)
-        self.browser.wait_present(btn)
-        self.browser.wait_attr(btn, "disabled", None)
+        self.browser.wait_present("#devices [data-toggle=dropdown]:not(.disabled)")
 
         b.wait_in_text("#drives", "VirtIO")
         b.wait_not_in_text("#drives", "Show all")

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -40,15 +40,15 @@ class TestStorage(StorageCase):
         # Create a volume group with a logical volume with a encrypted
         # filesystem.
 
-        b.click('#create-volume-group')
+        self.devices_dropdown('Create Volume Group')
         self.dialog_wait_open()
         self.dialog_set_val('name', "TEST")
         self.dialog_set_val('disks', {"DISK1": True})
         self.dialog_apply()
         self.dialog_wait_close()
-        b.wait_in_text('#vgroups', "TEST")
+        b.wait_in_text('#devices', "TEST")
 
-        b.click('#vgroups tr:contains("TEST")')
+        b.click('#devices tr:contains("TEST")')
         b.wait_present('#storage-detail')
         b.click("button:contains(Create new Logical Volume)")
         self.dialog({'purpose': "block",
@@ -110,15 +110,15 @@ class TestStorage(StorageCase):
 
         # Now do the same with a MDRAID
 
-        self.dialog_with_retry(trigger=lambda: b.click('#create-mdraid'),
+        self.dialog_with_retry(trigger=lambda: self.devices_dropdown('Create RAID Device'),
                                expect=lambda: (self.dialog_is_present('disks', "DISK1") and
                                                self.dialog_is_present('disks', "DISK2")),
                                values={"name": "ARR",
                                        "disks": {"DISK1": True,
                                                  "DISK2": True}})
-        b.wait_in_text('#mdraids', "ARR")
+        b.wait_in_text('#devices', "ARR")
 
-        b.click('#mdraids tr:contains("ARR")')
+        b.click('#devices tr:contains("ARR")')
         b.wait_present('#storage-detail')
         self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -47,7 +47,8 @@ class TestStorage(StorageCase):
 
         # Create a volume group out of two disks
         m.execute("vgcreate TEST1 %s %s" % (dev_1, dev_2))
-        b.wait_in_text("#vgroups", "TEST1")
+        b.wait_in_text("#devices", "TEST1")
+        b.wait_in_text("#devices", "/dev/TEST1/")
         b.click('tr:contains("TEST1")')
         b.wait_visible("#storage-detail")
         b.wait_in_text("#detail-sidebar", "DISK1")
@@ -103,22 +104,21 @@ class TestStorage(StorageCase):
         b.go("#/")
         b.wait_visible("#storage")
         m.execute("vgremove -f TEST1")
-        b.wait_not_in_text("#vgroups", "TEST1")
+        b.wait_not_in_text("#devices", "TEST1")
 
         # create volume group in the UI
-        b.wait_visible('#create-volume-group')
 
-        self.dialog_with_retry(trigger=lambda: b.click('#create-volume-group'),
+        self.dialog_with_retry(trigger=lambda: self.devices_dropdown("Create Volume Group"),
                                expect=lambda: (self.dialog_is_present('disks', "DISK1") and
                                                self.dialog_is_present('disks', "DISK2") and
                                                self.dialog_check({"name": "vgroup0"})),
                                values={"disks": {"DISK1": True,
                                                  "DISK2": True}})
 
-        b.wait_in_text("#vgroups", "vgroup0")
+        b.wait_in_text("#devices", "vgroup0")
 
         # Check that the next name is "vgroup1"
-        b.click('#create-volume-group')
+        self.devices_dropdown("Create Volume Group")
         self.dialog_wait_open()
         self.dialog_wait_val("name", "vgroup1")
         self.dialog_cancel()
@@ -237,13 +237,12 @@ class TestStorage(StorageCase):
         m.execute('parted -s /dev/sdb mktable gpt')
 
         # Create a volume group out of DISK1
-        b.wait_visible('#create-volume-group')
-        self.dialog_with_retry(trigger=lambda: b.click('#create-volume-group'),
+        self.dialog_with_retry(trigger=lambda: self.devices_dropdown('Create Volume Group'),
                                expect=lambda: self.dialog_is_present(
                                    'disks', "unpartitioned space on QEMU QEMU HARDDISK (DISK1)"),
                                values={"disks": {"DISK1": True}})
 
-        b.wait_in_text("#vgroups", "vgroup0")
+        b.wait_in_text("#devices", "vgroup0")
         b.click('tr:contains("vgroup0")')
         b.wait_present('#storage-detail')
 
@@ -268,7 +267,7 @@ class TestStorage(StorageCase):
         b.wait_in_text("#drives", "DISK1")
 
         m.execute("vgcreate TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
-        b.wait_in_text("#vgroups", "TEST")
+        b.wait_in_text("#devices", "TEST")
         b.click('tr:contains("TEST")')
         b.wait_visible("#storage-detail")
 

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -101,7 +101,7 @@ class TestStorage(StorageCase):
         b.wait_in_text("#drives", "DISK3")
         b.wait_in_text("#drives", "DISK4")
 
-        b.click("#create-mdraid")
+        self.devices_dropdown('Create RAID Device')
         self.dialog_wait_open()
         self.dialog_wait_val("level", "raid5")
         self.dialog_apply()
@@ -117,9 +117,9 @@ class TestStorage(StorageCase):
         self.dialog_set_val("name", "ARR")
         self.dialog_apply()
         self.dialog_wait_close()
-        b.wait_in_text("#mdraids", "ARR")
+        b.wait_in_text("#devices", "ARR")
 
-        b.click('#mdraids tr:contains("ARR")')
+        b.click('#devices tr:contains("ARR")')
         b.wait_present('#storage-detail')
 
         self.wait_states({"QEMU QEMU HARDDISK (DISK1)": "In Sync",
@@ -234,7 +234,7 @@ class TestStorage(StorageCase):
         self.confirm()
         with b.wait_timeout(120):
             b.wait_visible("#storage")
-            b.wait_not_in_text("#mdraids", "ARR")
+            b.wait_not_in_text("#devices", "ARR")
 
     def testNotRemovingDisks(self):
         m = self.machine
@@ -253,16 +253,16 @@ class TestStorage(StorageCase):
         b.wait_in_text("#drives", "DISK2")
         b.wait_in_text("#drives", "DISK3")
 
-        b.click("#create-mdraid")
+        self.devices_dropdown('Create RAID Device')
         self.dialog_wait_open()
         self.dialog_set_val("level", "raid5")
         self.dialog_set_val("disks", {"DISK1": True, "DISK2": True})
         self.dialog_set_val("name", "ARR")
         self.dialog_apply()
         self.dialog_wait_close()
-        b.wait_in_text("#mdraids", "ARR")
+        b.wait_in_text("#devices", "ARR")
 
-        b.click('#mdraids tr:contains("ARR")')
+        b.click('#devices tr:contains("ARR")')
         b.wait_present('#storage-detail')
 
         self.wait_states({"QEMU QEMU HARDDISK (DISK1)": "In Sync",

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -87,7 +87,7 @@ class TestStorage(StorageCase):
 
         # Check that neither is offered as a free block device
         b.go("#/")
-        b.click('#create-volume-group')
+        self.devices_dropdown('Create Volume Group')
         self.dialog_wait_open()
         check_free_block_devices([])
         self.dialog_cancel()
@@ -105,7 +105,7 @@ class TestStorage(StorageCase):
 
         # Check that (exactly) the primary device is offered as free
         b.go("#/")
-        b.click('#create-volume-group')
+        self.devices_dropdown('Create Volume Group')
         self.dialog_wait_open()
         check_free_block_devices(["/dev/mapper/mpatha"])
         self.dialog_cancel()

--- a/test/verify/check-storage-raid1
+++ b/test/verify/check-storage-raid1
@@ -37,7 +37,7 @@ class TestStorage(StorageCase):
         b.wait_in_text("#drives", "DISK1")
         b.wait_in_text("#drives", "DISK2")
 
-        b.click("#create-mdraid")
+        self.devices_dropdown('Create RAID Device')
         self.dialog_wait_open()
         self.dialog_set_val("level", "raid1")
         self.dialog_set_val("disks", {"DISK1": True, "DISK2": True})
@@ -45,7 +45,7 @@ class TestStorage(StorageCase):
         # The dialog should make sure that the Chunk size is ignored (has to be 0 for RAID 1)
         self.dialog_apply()
         self.dialog_wait_close()
-        b.wait_in_text("#mdraids", "SOMERAID")
+        b.wait_in_text("#devices", "SOMERAID")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -45,8 +45,8 @@ class TestStorage(StorageCase):
 
         m.execute("vgcreate TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
         m.execute("lvcreate TEST -n vol -L 200m")
-        b.wait_in_text("#vgroups", "TEST")
-        b.click('#vgroups tr:contains("TEST")')
+        b.wait_in_text("#devices", "TEST")
+        b.click('#devices tr:contains("TEST")')
         b.wait_visible("#storage-detail")
         self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
 
@@ -180,8 +180,8 @@ class TestStorage(StorageCase):
 
         m.execute("vgcreate TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
         m.execute("lvcreate TEST -n vol -L 200m")
-        b.wait_in_text("#vgroups", "TEST")
-        b.click('#vgroups tr:contains("TEST")')
+        b.wait_in_text("#devices", "TEST")
+        b.click('#devices tr:contains("TEST")')
         b.wait_visible("#storage-detail")
         self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
 
@@ -235,8 +235,8 @@ class TestStorage(StorageCase):
 
         m.execute("vgcreate TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
         m.execute("lvcreate TEST -n vol -L 200m")
-        b.wait_in_text("#vgroups", "TEST")
-        b.click('#vgroups tr:contains("TEST")')
+        b.wait_in_text("#devices", "TEST")
+        b.click('#devices tr:contains("TEST")')
         b.wait_visible("#storage-detail")
         self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
 

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -67,7 +67,7 @@ mkpart logical ext2 24 48"""
             blocks = [block for block in blocks if "/dev/ram" not in block]
             return len(blocks) == 2 and "/dev/sda6" in blocks[0] and "/dev/sdb" in blocks[1]
 
-        self.dialog_with_retry(trigger=lambda: b.click('#create-mdraid'),
+        self.dialog_with_retry(trigger=lambda: self.devices_dropdown('Create RAID Device'),
                                expect=check_free_block_devices,
                                values=None)
 

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -32,31 +32,32 @@ class TestStorage(StorageCase):
         self.login_and_go("/storage")
 
         if m.execute("which vdo || true") == "":
-            b.wait_not_present("#vdos")
+            b.click("#devices [data-toggle=dropdown]")
+            b.wait_not_present("#devices .dropdown a:contains('VDO')")
             return
 
         # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1616247
         m.execute("depmod")
 
-        b.wait_visible("#vdos")
+        b.wait_visible("#devices")
 
         # Make a logical volume for use as the backing device.
         m.add_disk("10G", serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
         m.execute("vgcreate vdo_vgroup /dev/sda && lvcreate -n lvol -L 5G vdo_vgroup")
-        b.wait_in_text("#vgroups", "vdo_vgroup")
+        b.wait_in_text("#devices", "vdo_vgroup")
 
         # Create VDO
 
-        b.click("#create-vdo")
+        self.devices_dropdown("Create VDO Device")
         self.dialog_wait_open()
         self.dialog_wait_val("name", "vdo0")
         self.dialog_set_val("space", {"/dev/vdo_vgroup/lvol": True})
         self.dialog_apply()
         self.dialog_wait_close()
 
-        b.wait_in_text("#vdos", "vdo0")
-        b.click("#vdos tr:contains(vdo0)")
+        b.wait_in_text("#devices", "vdo0")
+        b.click("#devices tr:contains(vdo0)")
         b.wait_visible("#storage-detail")
 
         def detail(index):
@@ -117,7 +118,7 @@ class TestStorage(StorageCase):
         b.click('.panel-heading:contains("VDO") button:contains("Delete")')
         self.confirm()
         b.wait_visible("#storage")
-        b.wait_not_in_text("#vdos", "vdo0")
+        b.wait_not_in_text("#devices", "vdo0")
 
     def testBrokenVdo(self):
         m = self.machine
@@ -126,10 +127,11 @@ class TestStorage(StorageCase):
         self.login_and_go("/storage")
 
         if m.execute("which vdo || true") == "":
-            b.wait_not_present("#vdos")
+            b.click("#devices [data-toggle=dropdown]")
+            b.wait_not_present("#devices .dropdown a:contains('VDO')")
             return
 
-        b.wait_visible("#vdos")
+        b.wait_visible("#devices")
 
         m.add_disk("10G", serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
@@ -168,12 +170,12 @@ config: !Configuration
   version: 538380551
 """)
 
-        b.wait_in_text("#vdos", "vdo0")
-        b.click("#vdos tr:contains(vdo0)")
+        b.wait_in_text("#devices", "vdo0")
+        b.click("#devices tr:contains(vdo0)")
 
         b.click("#storage-detail .alert-danger button:contains('Remove device')")
         b.wait_visible("#storage")
-        b.wait_not_in_text("#vdos", "vdo0")
+        b.wait_not_in_text("#devices", "vdo0")
 
     def testBrokenVdoConfig(self):
         m = self.machine
@@ -182,10 +184,11 @@ config: !Configuration
         self.login_and_go("/storage")
 
         if m.execute("which vdo || true") == "":
-            b.wait_not_present("#vdos")
+            b.click("#devices [data-toggle=dropdown]")
+            b.wait_not_present("#devices .dropdown a:contains('VDO')")
             return
 
-        b.wait_visible("#vdos")
+        b.wait_visible("#devices")
 
         # Install a valid configuration file
         m.write("/etc/vdoconf.yml", """
@@ -221,7 +224,7 @@ config: !Configuration
   version: 538380551
 """)
 
-        b.wait_in_text("#vdos", "vdo0")
+        b.wait_in_text("#devices", "vdo0")
 
         # Install a broken configuration file
         m.write("/etc/vdoconf.yml", """
@@ -231,7 +234,7 @@ config: !Configuration
       blah: 12
 """)
 
-        b.wait_not_in_text("#vdos", "vdo0")
+        b.wait_not_in_text("#devices", "vdo0")
 
         # Install a valid configuration file again
         m.write("/etc/vdoconf.yml", """
@@ -267,7 +270,7 @@ config: !Configuration
   version: 538380551
 """)
 
-        b.wait_in_text("#vdos", "vdo1")
+        b.wait_in_text("#devices", "vdo1")
 
 
 class TestStoragePackages(StorageCase, PackageCase):
@@ -286,16 +289,14 @@ class TestStoragePackages(StorageCase, PackageCase):
         m.execute("pkcon refresh")
 
         self.login_and_go("/storage")
-        b.click("button:contains('Install VDO support')")
 
+        self.devices_dropdown("Create VDO Device")
         self.dialog_wait_open()
-        b.wait_in_text("#dialog", "vdo will be installed")
+        b.wait_in_text("#dialog", "The vdo package must be installed")
         b.wait_in_text("#dialog", "Total size:")
         self.dialog_apply()
-        self.dialog_wait_close()
-
-        b.wait_present("#vdos button .fa-plus")
-
+        # A new dialog opens immediately
+        b.wait_in_text("#dialog", "Create VDO Device")
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -59,6 +59,10 @@ class StorageCase(MachineCase):
 
         self.browser.wait(step)
 
+    def devices_dropdown(self, title):
+        self.browser.click("#devices .dropdown [data-toggle=dropdown]")
+        self.browser.click("#devices .dropdown a:contains('%s')" % title)
+
     # Content
 
     def content_row_tbody(self, index):


### PR DESCRIPTION
The reasons for doing this is to remove clutter from the UI for things that people don't have and don't care about.  For example, if you are not interested in VDO, the empty VDO panel is just distracting and uses space. With this, adding one more entry to the "Create" menu has little cost, and to show this, I have added "Create Loop Device", which is not something that we would want to have a dedicated panel for, I guess.


## For release notes

![image](https://user-images.githubusercontent.com/3228183/65592201-cda8f000-df96-11e9-9096-0c642628fc41.png)
