### PR TITLE
ssh execute, write to stdout and stderr of sys in case it is not redirected

### DIFF
--- a/bots/machine/machine_core/ssh_connection.py
+++ b/bots/machine/machine_core/ssh_connection.py
@@ -323,7 +323,7 @@ class SSHConnection(object):
                             proc.stdout.close()
                         else:
                             if self.verbose:
-                                os.write(sys.stdout.fileno(), data)
+                                os.write(sys.__stdout__.fileno(), data)
                             output += data.decode('utf-8', 'replace')
                     elif fd == stderr_fd:
                         data = os.read(fd, 1024)
@@ -331,7 +331,7 @@ class SSHConnection(object):
                             rset.remove(stderr_fd)
                             proc.stderr.close()
                         elif not quiet or self.verbose:
-                            os.write(sys.stderr.fileno(), data)
+                            os.write(sys.__stderr__.fileno(), data)
                 for fd in ret[1]:
                     if fd == stdin_fd:
                         if input:


### PR DESCRIPTION
should fix issue within avocado test, in case ``sys.stderr/stdout`` are redirected to logger so that attribute ``fileno`` does not exist