### PR TITLE
tests: Stop allowing to click on invisible buttons

### DIFF
--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -98,11 +98,11 @@ function ph_attr_contains (sel, attr, val)
     return ph_attr(sel, attr).indexOf(val) > -1;
 }
 
-function ph_mouse(sel, type, x, y, btn, force) {
+function ph_mouse(sel, type, x, y, btn, ctrlKey, shiftKey, altKey, metaKey) {
     let el = ph_find(sel);
 
     /* The element has to be visible, and not collapsed */
-    if (!force && el.offsetWidth <= 0 && el.offsetHeight <= 0)
+    if (el.offsetWidth <= 0 && el.offsetHeight <= 0)
         throw sel + " is not visible";
 
     /* The event has to actually work */
@@ -137,7 +137,11 @@ function ph_mouse(sel, type, x, y, btn, force) {
         screenY: top + y,
         clientX: left + x,
         clientY: top + y,
-        button: btn
+        button: btn,
+        ctrlKey: ctrlKey || false,
+        shiftKey: shiftKey || false,
+        altKey: altKey || false,
+        metaKey: metaKey || false
     });
 
     el.dispatchEvent(ev);
@@ -156,7 +160,7 @@ function ph_set_checked (sel, val)
         throw sel + " is not checkable";
 
     if (el.checked != val)
-        ph_mouse(sel, "click", 0, 0, 0, true);
+        ph_mouse(sel, "click", 0, 0, 0);
 }
 
 function ph_is_visible (sel)

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -203,15 +203,12 @@ class Browser:
         #    hash = "/@" + host + hash
         self.call_js_func('ph_go', hash)
 
-    def mouse(self, selector, type, x=0, y=0, btn=0, force=False):
-        if force:
-            self.wait_present(selector)
-        else:
-            self.wait_visible(selector)
-        self.call_js_func('ph_mouse', selector, type, x, y, btn, force)
+    def mouse(self, selector, type, x=0, y=0, btn=0, ctrlKey=False, shiftKey=False, altKey=False, metaKey=False):
+        self.wait_visible(selector)
+        self.call_js_func('ph_mouse', selector, type, x, y, btn, ctrlKey, shiftKey, altKey, metaKey)
 
-    def click(self, selector, force=False):
-        self.mouse(selector, "click", 0, 0, 0, force)
+    def click(self, selector):
+        self.mouse(selector, "click", 0, 0, 0)
 
     def val(self, selector):
         self.wait_visible(selector)

--- a/test/verify/check-active-pages
+++ b/test/verify/check-active-pages
@@ -35,11 +35,8 @@ class TestActivePages(MachineCase):
         def showPagesAssertCount(count):
             # check the pages and make sure there is only one page loaded
             b.switch_to_top()
-            b.click("#navbar-dropdown")
-            # we won't wait for the entry to be visible, since that requires a special key combination
-            # since it's a developer feature and not immediately obvious to everyone
-            # that's also why we force this click event
-            b.click("#active-pages", force=True)
+            b.mouse("#navbar-dropdown", "click", altKey=True)
+            b.click("#active-pages")
             b.wait_present("#active-pages-dialog")
             b.call_js_func("ph_count_check", "#active-pages-dialog tbody", count)
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -106,7 +106,7 @@ class TestKdump(MachineCase):
         if m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
             # minimal nfs validation
             settingsLink = "a:contains('locally in /var/crash')"
-            b.click(settingsLink, True)
+            b.click(settingsLink)
             b.set_val("#kdump-settings-location", "nfs")
             mountInput = "#kdump-settings-nfs-mount"
             b.set_input_text(mountInput, ":/var/crash")
@@ -118,7 +118,7 @@ class TestKdump(MachineCase):
             b.click("button.btn-default:contains('Cancel')")
 
             # test compression
-            b.click(settingsLink, True)
+            b.click(settingsLink)
             b.click("#kdump-settings-compression")
             pathInput = "#kdump-settings-local-directory"
             b.click("button.btn-primary:contains('Apply')")
@@ -126,7 +126,7 @@ class TestKdump(MachineCase):
             m.execute("cat /etc/kdump.conf | grep -qE 'makedumpfile.*-c.*'")
 
             # generate a valid kdump config with ssh target
-            b.click(settingsLink, True)
+            b.click(settingsLink)
             b.set_val("#kdump-settings-location", "ssh")
             sshInput = "#kdump-settings-ssh-server"
             b.set_input_text(sshInput, "root@localhost")
@@ -150,7 +150,7 @@ class TestKdump(MachineCase):
         # try to change the path to a directory that doesn't exist
         customPath = "/var/crash2"
         settingsLink = "a:contains('Remote over SSH')"
-        b.click(settingsLink, True)
+        b.click(settingsLink)
         b.set_val("#kdump-settings-location", "local")
         pathInput = "#kdump-settings-local-directory"
         b.set_input_text(pathInput, customPath)

--- a/test/verify/check-networking-vlan
+++ b/test/verify/check-networking-vlan
@@ -45,10 +45,10 @@ class TestNetworking(NetworkCase):
         b.wait_popup("network-vlan-settings-dialog")
         if m.image == "rhel-7-6-distropkg":
             b.click("#network-vlan-settings-dialog tr:contains('Parent') button")
-            b.click("#network-vlan-settings-dialog tr:contains('Parent') li[value='%s'] a" % iface, True)
+            b.click("#network-vlan-settings-dialog tr:contains('Parent') li[value='%s'] a" % iface)
         else:
             b.click("#network-vlan-settings-body form .btn-group button")
-            b.click("#network-vlan-settings-body form div ul li[value='%s'] a" % iface, True)
+            b.click("#network-vlan-settings-body form div ul li[value='%s'] a" % iface)
         b.set_val("#network-vlan-settings-interface-name-input", "tvlan")
         b.set_val("#network-vlan-settings-vlan-id-input", "123")
         b.click("#network-vlan-settings-dialog button:contains('Apply')")

--- a/test/verify/check-networking-vlan
+++ b/test/verify/check-networking-vlan
@@ -44,8 +44,10 @@ class TestNetworking(NetworkCase):
         b.click("button:contains('Add VLAN')")
         b.wait_popup("network-vlan-settings-dialog")
         if m.image == "rhel-7-6-distropkg":
+            b.click("#network-vlan-settings-dialog tr:contains('Parent') button")
             b.click("#network-vlan-settings-dialog tr:contains('Parent') li[value='%s'] a" % iface, True)
         else:
+            b.click("#network-vlan-settings-body form .btn-group button")
             b.click("#network-vlan-settings-body form div ul li[value='%s'] a" % iface, True)
         b.set_val("#network-vlan-settings-interface-name-input", "tvlan")
         b.set_val("#network-vlan-settings-vlan-id-input", "123")

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -130,7 +130,7 @@ class VolumeTests(object):
         b.wait_present(".pvc-listing")
 
         b.wait_present("tbody[data-id='default/mock-volume-claim']")
-        b.click("tbody[data-id='default/mock-volume-claim'] td:last-child button.btn-danger", force=True)
+        b.click("tbody[data-id='default/mock-volume-claim'] td:last-child button.btn-danger")
 
         b.wait_in_text("modal-dialog .modal-body", "mock-volume-claim")
         b.wait_in_text("modal-dialog .modal-body ul", "mock-volume-")


### PR DESCRIPTION
`mouse` function had option `force` which made it possible to click on
invisible buttons. However this is a bad practice.

This was in the code mostly because in `check-active-pages` the dropdown
menu was needed to be opened while holding `alt` key down.

This commit teaches the mouse function to also simulate holding down
special keys.

In three other tests `force` was used pointlessly.

I just grepd where `click` with force was used. Possibly I missed some other places - but full test run should show me what I forgot.