### PR TITLE
ws: Add --for-tls-proxy option

### DIFF
--- a/bots/machine/machine_core/machine.py
+++ b/bots/machine/machine_core/machine.py
@@ -272,11 +272,11 @@ class Machine(ssh_connection.SSHConnection):
         cmd = "dnsmasq --domain=cockpit.lan --interface=\"$(grep -l '{mac}' /sys/class/net/*/address | cut -d / -f 5)\" --bind-dynamic"
         self.execute(cmd.format(mac=mac))
 
-    def wait_for_cockpit_running(self, address="localhost", port=9090, seconds=30):
+    def wait_for_cockpit_running(self, address="localhost", port=9090, seconds=30, tls=False):
         WAIT_COCKPIT_RUNNING = """#!/bin/sh
-        until curl -s --connect-timeout 2 --max-time 3 http://%s:%s >/dev/null; do
+        until curl --insecure --silent --connect-timeout 2 --max-time 3 %s://%s:%s >/dev/null; do
             sleep 0.5;
         done;
-        """ % (address, port)
+        """ % (tls and "https" or "http", address, port)
         with timeout.Timeout(seconds=seconds, error_message="Timeout while waiting for cockpit to start"):
             self.execute(script=WAIT_COCKPIT_RUNNING)

--- a/doc/man/cockpit-ws.xml
+++ b/doc/man/cockpit-ws.xml
@@ -42,6 +42,7 @@
       <arg><option>--port</option> <replaceable>PORT</replaceable></arg>
       <arg><option>--address</option> <replaceable>ADDRESS</replaceable></arg>
       <arg><option>--no-tls</option></arg>
+      <arg><option>--for-tls-proxy</option></arg>
       <arg><option>--local-ssh</option></arg>
       <arg><option>--local-session</option> <replaceable>BRIDGE</replaceable></arg>
     </cmdsynopsis>
@@ -155,6 +156,23 @@ getcert request -f ${CERT_FILE} -k ${KEY_FILE} -D $(hostname --fqdn) -C "sed -n 
         <listitem>
           <para>
             Don't use TLS.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>--for-tls-proxy</option></term>
+        <listitem>
+          <para>
+            Tell <command>cockpit-ws</command> that it is running behind a local reverse proxy that
+            does the TLS termination. Then Cockpit accepts only https:// origins, instead of http:
+            ones by default. However, if <literal>Origins</literal> is set in the
+            <citerefentry>
+              <refentrytitle>cockpit.conf</refentrytitle><manvolnum>5</manvolnum>
+            </citerefentry>
+            configuration file, it will override this default.
+          </para>
+          <para>
+            This option implies <option>--no-tls</option>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -41,6 +41,12 @@ CockpitWebServer * cockpit_web_server_new           (const gchar *address,
                                                      GCancellable *cancellable,
                                                      GError **error);
 
+CockpitWebServer * cockpit_web_server_new_for_tls_proxy (const gchar *address,
+                                                         gint port,
+                                                         GTlsCertificate *certificate,
+                                                         GCancellable *cancellable,
+                                                         GError **error);
+
 void               cockpit_web_server_start         (CockpitWebServer *self);
 
 gboolean           cockpit_web_server_add_socket    (CockpitWebServer *self,
@@ -63,6 +69,8 @@ void               cockpit_web_server_set_redirect_tls     (CockpitWebServer *se
                                                             gboolean          redirect_tls);
 
 gboolean           cockpit_web_server_get_redirect_tls     (CockpitWebServer *self);
+
+gboolean           cockpit_web_server_get_for_tls_proxy    (CockpitWebServer *self);
 
 G_END_DECLS
 

--- a/src/ws/cockpitchannelsocket.c
+++ b/src/ws/cockpitchannelsocket.c
@@ -191,7 +191,8 @@ cockpit_channel_socket_open (CockpitWebService *service,
                              const gchar *path,
                              GIOStream *io_stream,
                              GHashTable *headers,
-                             GByteArray *input_buffer)
+                             GByteArray *input_buffer,
+                             gboolean for_tls_proxy)
 {
   CockpitChannelSocket *self = NULL;
   WebSocketDataType data_type;
@@ -225,7 +226,7 @@ cockpit_channel_socket_open (CockpitWebService *service,
   self->data_type = data_type;
 
   self->socket = cockpit_web_service_create_socket ((const gchar **)protocols, original_path,
-                                                     io_stream, headers, input_buffer);
+                                                     io_stream, headers, input_buffer, for_tls_proxy);
   self->socket_open = g_signal_connect (self->socket, "open", G_CALLBACK (on_socket_open), self);
   self->socket_message = g_signal_connect (self->socket, "message", G_CALLBACK (on_socket_message), self);
   self->socket_close = g_signal_connect (self->socket, "close", G_CALLBACK (on_socket_close), self);

--- a/src/ws/cockpitchannelsocket.h
+++ b/src/ws/cockpitchannelsocket.h
@@ -31,7 +31,8 @@ void                 cockpit_channel_socket_open     (CockpitWebService *service
                                                       const gchar *path,
                                                       GIOStream *io_stream,
                                                       GHashTable *headers,
-                                                      GByteArray *input_buffer);
+                                                      GByteArray *input_buffer,
+                                                      gboolean for_tls_proxy);
 
 G_END_DECLS
 

--- a/src/ws/cockpitwebservice.h
+++ b/src/ws/cockpitwebservice.h
@@ -47,7 +47,8 @@ void                 cockpit_web_service_socket      (CockpitWebService *self,
                                                       const gchar *path,
                                                       GIOStream *io_stream,
                                                       GHashTable *headers,
-                                                      GByteArray *input_buffer);
+                                                      GByteArray *input_buffer,
+                                                      gboolean for_tls_proxy);
 
 CockpitCreds *       cockpit_web_service_get_creds   (CockpitWebService *self);
 
@@ -57,7 +58,8 @@ WebSocketConnection *   cockpit_web_service_create_socket    (const gchar **prot
                                                               const gchar *path,
                                                               GIOStream *io_stream,
                                                               GHashTable *headers,
-                                                              GByteArray *input_buffer);
+                                                              GByteArray *input_buffer,
+                                                              gboolean for_tls_proxy);
 
 gchar *                 cockpit_web_service_unique_channel   (CockpitWebService *self);
 

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -764,6 +764,7 @@ on_message_get_bytes (WebSocketConnection *ws,
 static void
 test_socket_unauthenticated (void)
 {
+  CockpitWebServer *server;
   WebSocketConnection *client;
   GBytes *received = NULL;
   GIOStream *io_a, *io_b;
@@ -773,8 +774,12 @@ test_socket_unauthenticated (void)
   const gchar *unused;
   gchar *channel;
   JsonObject *options;
+  GError *error = NULL;
 
   make_io_streams (&io_a, &io_b);
+
+  server = cockpit_web_server_new (NULL, 0, NULL, NULL, &error);
+  g_assert_no_error (error);
 
   client = g_object_new (WEB_SOCKET_TYPE_CLIENT,
                          "url", "ws://127.0.0.1/unused",
@@ -787,7 +792,7 @@ test_socket_unauthenticated (void)
   /* Matching the above origin */
   cockpit_ws_default_host_header = "127.0.0.1";
 
-  g_assert (cockpit_handler_socket (NULL, "/cockpit/socket", "/cockpit/socket",
+  g_assert (cockpit_handler_socket (server, "/cockpit/socket", "/cockpit/socket",
                                     "GET", io_b, NULL, NULL, NULL));
 
   g_signal_connect (client, "message", G_CALLBACK (on_message_get_bytes), &received);
@@ -818,6 +823,7 @@ test_socket_unauthenticated (void)
 
   g_object_unref (io_a);
   g_object_unref (io_b);
+  g_object_unref (server);
 }
 
 int

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -390,7 +390,7 @@ on_handle_stream_socket (CockpitWebServer *server,
       g_signal_handler_disconnect (transport, handler);
     }
 
-  cockpit_web_service_socket (service, path, io_stream, headers, input);
+  cockpit_web_service_socket (service, path, io_stream, headers, input, FALSE /* for_tls_proxy */);
 
   /* Keeps ref on itself until it closes */
   g_object_unref (service);
@@ -506,7 +506,7 @@ on_handle_stream_external (CockpitWebServer *server,
           upgrade = g_hash_table_lookup (headers, "Upgrade");
           if (upgrade && g_ascii_strcasecmp (upgrade, "websocket") == 0)
             {
-              cockpit_channel_socket_open (service, open, path, path, io_stream, headers, input);
+              cockpit_channel_socket_open (service, open, path, path, io_stream, headers, input, FALSE /* for_tls_proxy */);
               handled = TRUE;
             }
           else

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -27,6 +27,12 @@ from testlib import *
 
 class TestConnection(MachineCase):
 
+    def setUp(self):
+        super().setUp()
+        self.ws_executable = "/usr/libexec/cockpit-ws"
+        if "debian" in self.machine.image or "ubuntu" in self.machine.image:
+            self.ws_executable = "/usr/lib/cockpit/cockpit-ws"
+
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -291,11 +297,7 @@ class TestConnection(MachineCase):
         self.assertTrue(m.execute("ls /test/cockpit/ws-certs.d/*"))
         self.assertFalse(m.execute("ls /etc/cockpit/ws-certs.d/* || true"))
 
-        executable = "/usr/libexec/cockpit-ws"
-        if "debian" in m.image or "ubuntu" in m.image:
-            executable = "/usr/lib/cockpit/cockpit-ws"
-
-        m.execute("XDG_CONFIG_DIRS=/test XDG_DATA_DIRS=/test {} --port 9000 --address 127.0.0.1 0<&- &>/dev/null &".format(executable))
+        m.execute("XDG_CONFIG_DIRS=/test XDG_DATA_DIRS=/test {} --port 9000 --address 127.0.0.1 0<&- &>/dev/null &".format(self.ws_executable))
 
         # The port may not be available immediately, so wait for it
         wait(lambda: 'A Custom Title' in m.execute('curl -s -k https://localhost:9000/'))
@@ -367,13 +369,9 @@ class TestConnection(MachineCase):
     def testLocalSession(self):
         m = self.machine
 
-        if "debian" in m.image or "ubuntu" in m.image:
-            cockpit_ws = "/usr/lib/cockpit/cockpit-ws"
-        else:
-            cockpit_ws = "/usr/libexec/cockpit-ws"
-
         # start ws with --local-session, let it spawn bridge; ensure that this works without /etc/cockpit/
-        m.spawn("su - -c 'G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local-session=cockpit-bridge' admin" % cockpit_ws,
+        m.spawn("su - -c 'G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 "
+                "--local-session=cockpit-bridge' admin" % self.ws_executable,
                 "cockpit-ws-local")
         m.wait_for_cockpit_running('127.0.0.90', 9999)
         # System frame should work directly, no login page
@@ -388,7 +386,7 @@ class TestConnection(MachineCase):
         script = '''#!/bin/bash -eu
 coproc env G_MESSAGES_DEBUG=all cockpit-bridge
 G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local-session=- <&${COPROC[0]} >&${COPROC[1]}
-''' % cockpit_ws
+''' % self.ws_executable
         m.execute(["tee", "/tmp/local.sh"], input=script)
         m.execute("chmod a+x /tmp/local.sh")
         m.spawn("su - -c /tmp/local.sh admin", "local.sh")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -437,6 +437,68 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 
+    @skipImage("missing socat", "fedora-atomic", "rhel-atomic", "continuous-atomic", "centos-7")
+    @skipImage("Added in PR #11813", "rhel-7-6-distropkg", "rhel-8-0-distropkg")
+    def testReverseTlsProxy(self):
+        m = self.machine
+        b = self.browser
+
+        # set up a poor man's reverse TLS proxy with socat
+        m.upload(["../src/bridge/mock-server.crt", "../src/bridge/mock-server.key"], "/tmp")
+        m.spawn("socat OPENSSL-LISTEN:9090,reuseaddr,fork,cert=/tmp/mock-server.crt,"
+                "key=/tmp/mock-server.key,verify=0 TCP:localhost:9099",
+                "socat.log")
+
+        # ws with plain --no-tls should fail after login with mismatching Origin (expected http, got https)
+        m.spawn("su -s /bin/sh -c '%s --no-tls -p 9099 -a 127.0.0.1' cockpit-ws" % self.ws_executable,
+                "ws-notls.log")
+        m.wait_for_cockpit_running(tls=True)
+
+        b.ignore_ssl_certificate_errors(True)
+        b.open("https://%s:%s/system" % (b.address, b.port))
+        b.wait_visible("#login")
+        b.set_val("#login-user-input", "admin")
+        b.set_val("#login-password-input", "foobar")
+        b.click('#login-button')
+        b.expect_load()
+
+        def check_wss_log():
+            for log in self.browser.get_js_log():
+                if 'Error during WebSocket handshake: Unexpected response code: 403' in log:
+                    return True
+            return False
+        wait(check_wss_log)
+
+        wait(lambda: "received request from bad Origin" in m.execute("journalctl -b -t cockpit-ws"))
+
+        # sanity check: HTTP does not work
+        m.execute("! curl http://localhost:9090")
+
+        m.execute("pkill -e cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
+        # this page failure is reeally noisy
+        self.allow_authorize_journal_messages()
+        self.allow_journal_messages(".*No authentication agent found.*")
+        self.allow_journal_messages("couldn't register polkit authentication agent.*")
+        self.allow_journal_messages("received request from bad Origin.*")
+        self.allow_journal_messages(".*invalid handshake.*")
+        self.allow_browser_errors(".*received unsupported version in init message.*")
+        self.allow_browser_errors(".*received message before init.*")
+        self.allow_browser_errors("Error reading machine id")
+
+        # ws with --for-tls-proxy accepts only https origins, thus should work
+        m.spawn("su -s /bin/sh -c '%s --for-tls-proxy -p 9099 -a 127.0.0.1' cockpit-ws" % self.ws_executable,
+                "ws-fortlsproxy.log")
+        m.wait_for_cockpit_running(tls=True)
+        b.open("https://%s:%s/system" % (b.address, b.port))
+        b.wait_visible("#login")
+        b.set_val("#login-user-input", "admin")
+        b.set_val("#login-password-input", "foobar")
+        b.click('#login-button')
+        b.expect_load()
+        b.wait_visible('#content')
+        b.enter_page("/system")
+        b.logout()
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
If cockpit-ws runs behind a reverse proxy that does the TLS termination,
it rejects non-GnuTLS connections with a https:// origin with

    received request from bad Origin: https://localhost:9090

This previously required setting `Origins` in cockpit.conf to make this
work. Introduce a new `--for-tls-proxy` option to cockpit-ws which
switches the default Origin checking to https-only. With that, no
cockpit.conf modifications are required for local proxies.

This is implemented by a new `for-tls-proxy` property in
`CockpitWebServer`, which gets plumbed through the Origins check in
`cockpit_web_service_create_socket()`.

This is mostly intended for the upcoming external "cockpit-tls" proxy
which externalizes TLS termination, so that this does not have to modify
cockpit.conf or inspect/modify the HTTP stream. But it's generally
applicable to any local reverse TLS proxy.

Fix test-handlers to not call cockpit_handler_socket() with a NULL
server, so that reading the property does not cause a warning.

TODO:
 - [x] WebServer unit test (?)
 - [x] manpage update
 - [x] add socat to debian/ubuntu images for the new test: PR #11815 
 - [x] add socat to rhel images for the new test: PR #11816