### PR TITLE
test: Wait for non-disabled button in TestFirewall.testAddServices

### DIFF
--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -224,6 +224,7 @@ class TestFirewall(MachineCase):
             b.click("tr[data-row-id='{}'] .btn.pficon-delete".format(service))
             for zone in zones:
                 b.click("#remove-services-dialog input[value={}]".format(zone))
+            b.wait_present("#remove-services-dialog button.btn-primary:not([disabled])")
             b.click("#remove-services-dialog button.btn-primary")
             b.wait_not_present("#remove-services-dialog")
             b.wait_not_present("tr[data-row-id='{}']".format(service))


### PR DESCRIPTION
When removing a service, the button is initially disabled, until reading
the zones is complete.