### PR TITLE
test: Add another expected restart message

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -876,6 +876,7 @@ class MachineCase(unittest.TestCase):
                                     ".*couldn't create polkit session subject: No session for pid.*",
                                     "We are no longer a registered authentication agent.",
                                     ".*: failed to retrieve resource: terminated",
+                                    ".*: external channel failed: terminated",
                                     'audit:.*denied.*comm="systemd-user-se".*nologin.*',
 
                                     'localhost: dropping message while waiting for child to exit',


### PR DESCRIPTION
This fixes tests randomly failing with

      File "test/common/testlib.py", line 779, in tearDown
        self.check_journal_messages()
      File "test/common/testlib.py", line 956, in check_journal_messages
        raise Error(first)
    testlib.Error: /base1/fonts/fontawesome.woff: external channel failed: terminated