### PR TITLE
Revert "package.json: Update xterm package dependency"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "term.js-cockpit": "0.0.11",
     "throttle-debounce": "2.1.0",
     "uuid": "3.3.2",
-    "xterm": "3.13.0"
+    "xterm": "3.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
This reverts commit 55f71b8c65143223f3b08a9ecd65edaf4cf88f29.

The reverted commit was introduced in #11797 but later on was noticed
that sometimes xterm can crash. Reported to https://github.com/xtermjs/xterm.js/issues/2082