### PR TITLE
storage: Polish interior layout of the side panels

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -171,10 +171,6 @@ client.swap_sizes = instance_sampler([ { name: "swapdev.length" },
     { name: "swapdev.free" },
 ], "direct");
 
-client.blockdev_io = instance_sampler([ { name: "block.device.read", derive: "rate" },
-    { name: "block.device.written", derive: "rate" }
-]);
-
 /* Derived indices.
  */
 

--- a/pkg/storaged/drives-panel.jsx
+++ b/pkg/storaged/drives-panel.jsx
@@ -27,19 +27,6 @@ const _ = cockpit.gettext;
 const C_ = cockpit.gettext;
 
 export class DrivesPanel extends React.Component {
-    constructor () {
-        super();
-        this.on_io_samples = () => { this.setState({}) };
-    }
-
-    componentDidMount() {
-        this.props.client.blockdev_io.addEventListener("changed", this.on_io_samples);
-    }
-
-    componentWillUnmount() {
-        this.props.client.blockdev_io.removeEventListener("changed", this.on_io_samples);
-    }
-
     render() {
         var props = this.props;
         var client = props.client;
@@ -75,7 +62,6 @@ export class DrivesPanel extends React.Component {
                 return null;
 
             var dev = decode_filename(block.Device).replace(/^\/dev\//, "");
-            var io = client.blockdev_io.data[dev];
 
             var name = drive_name(drive);
             var classification = classify_drive(drive);
@@ -103,7 +89,6 @@ export class DrivesPanel extends React.Component {
                 <OverviewSidePanelRow client={client}
                                       name={name}
                                       detail={desc}
-                                      stats={io}
                                       highlight={dev == props.highlight}
                                       go={() => cockpit.location.go([ dev ])}
                                       job_path={path}

--- a/pkg/storaged/drives-panel.jsx
+++ b/pkg/storaged/drives-panel.jsx
@@ -21,7 +21,7 @@ import cockpit from "cockpit";
 import React from "react";
 
 import { OverviewSidePanel, OverviewSidePanelRow } from "./overview.jsx";
-import { fmt_size, drive_name, decode_filename } from "./utils.js";
+import { fmt_size, drive_name, decode_filename, block_name } from "./utils.js";
 
 const _ = cockpit.gettext;
 const C_ = cockpit.gettext;
@@ -67,11 +67,7 @@ export class DrivesPanel extends React.Component {
             var classification = classify_drive(drive);
             var size_str = fmt_size(drive.Size);
             var desc;
-            if (classification == "hdd") {
-                desc = size_str + " " + C_("storage", "Hard Disk");
-            } else if (classification == "ssd") {
-                desc = size_str + " " + C_("storage", "Solid-State Disk");
-            } else if (classification == "removable") {
+            if (classification == "removable") {
                 if (drive.Size === 0)
                     desc = C_("storage", "Removable Drive");
                 else
@@ -80,14 +76,15 @@ export class DrivesPanel extends React.Component {
                 desc = C_("storage", "Optical Drive");
             } else {
                 if (drive.Size === 0)
-                    desc = C_("storage", "Drive");
+                    desc = C_("Drive");
                 else
-                    desc = size_str + " " + C_("storage", "Drive");
+                    desc = size_str;
             }
 
             return (
                 <OverviewSidePanelRow client={client}
                                       name={name}
+                                      devname={block_name(block)}
                                       detail={desc}
                                       highlight={dev == props.highlight}
                                       go={() => cockpit.location.go([ dev ])}

--- a/pkg/storaged/mdraids-panel.jsx
+++ b/pkg/storaged/mdraids-panel.jsx
@@ -22,7 +22,7 @@ import React from "react";
 
 import { OverviewSidePanel, OverviewSidePanelRow } from "./overview.jsx";
 import {
-    fmt_size, mdraid_name,
+    fmt_size, mdraid_name, block_name,
     get_available_spaces, prepare_available_spaces
 } from "./utils.js";
 import { StorageButton } from "./storage-controls.jsx";
@@ -103,11 +103,13 @@ export class MDRaidsPanel extends React.Component {
 
         function make_mdraid(path) {
             var mdraid = client.mdraids[path];
+            var block = client.mdraids_block[path];
 
             return (
                 <OverviewSidePanelRow client={client}
                                       kind="array"
                                       name={mdraid_name(mdraid)}
+                                      devname={block && block_name(block)}
                                       detail={fmt_size(mdraid.Size)}
                                       go={() => cockpit.location.go([ "mdraid", mdraid.UUID ])}
                                       job_path={path}

--- a/pkg/storaged/others-panel.jsx
+++ b/pkg/storaged/others-panel.jsx
@@ -53,7 +53,7 @@ export class OthersPanel extends React.Component {
                 <OverviewSidePanelRow client={client}
                                       kind={false}
                                       testkey={dev}
-                                      name={name}
+                                      devname={block_name(block)}
                                       detail={cockpit.format(_("$0 Block Device"), fmt_size(block.Size))}
                                       go={() => cockpit.location.go([ dev ])}
                                       job_path={path}

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -89,29 +89,26 @@ export class OverviewSidePanelRow extends React.Component {
             return this.props.go();
         };
 
-        let job_spinner = (client.path_jobs[job_path]
-            ? <span className="spinner spinner-sm" />
-            : null);
-
-        let warning_triangle = (client.path_warnings[job_path]
-            ? <span className="pficon pficon-warning-triangle-o" />
-            : null);
+        let decoration = null;
+        if (this.props.actions)
+            decoration = <div className="sidepanel-row-decoration">{this.props.actions}</div>;
+        else if (client.path_jobs[job_path])
+            decoration = <div className="sidepanel-row-decoration spinner spinner-sm" />;
+        else if (client.path_warnings[job_path])
+            decoration = <div className="sidepanel-row-decoration pficon pficon-warning-triangle-o" />;
 
         return (
             <tr data-testkey={this.props.testkey}
                 onClick={this.props.go ? go : null} className={this.props.highlight ? "highlight-ct" : ""}>
-                <td className="storage-icon">
-                    { this.props.kind !== false
-                        ? <img src={"images/storage-" + (this.props.kind || "disk") + ".png"} />
-                        : null
-                    }
-                </td>
-                <td className="row storage-disk-info">
-                    <h3 className="storage-disk-name">{this.props.name}</h3>
-                    <div className="storage-disk-size">{this.props.detail}</div>
-                </td>
-                <td className="storage-icon storage-disk-extended">
-                    { this.props.actions || job_spinner || warning_triangle }
+                <td className={"sidepanel-row " + (this.props.highlight ? "highlight-ct" : "")}>
+                    <div className="sidepanel-row-body">
+                        <div className="sidepanel-row-name">{this.props.name}</div>
+                        <div className="sidepanel-row-info">
+                            <div className="sidepanel-row-detail">{this.props.detail}</div>
+                            <div className="sidepanel-row-devname">{this.props.devname}</div>
+                        </div>
+                    </div>
+                    {decoration}
                 </td>
             </tr>
         );

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -20,8 +20,6 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import { fmt_rate } from "./utils.js";
-
 import { StoragePlots } from "./plot.jsx";
 
 import { FilesystemsPanel } from "./fsys-panel.jsx";
@@ -111,15 +109,6 @@ export class OverviewSidePanelRow extends React.Component {
                 <td className="row storage-disk-info">
                     <h3 className="storage-disk-name">{this.props.name}</h3>
                     <div className="storage-disk-size">{this.props.detail}</div>
-                    { this.props.stats
-                        ? <div className="storage-disk-rates">
-                            <div className="storage-disk-rate-read"><abbr title="read">R</abbr>: {fmt_rate(this.props.stats[0])}</div>
-                            { "\n" }
-                            { "\n" }
-                            <div className="storage-disk-rate-write"><abbr title="write">W</abbr>: {fmt_rate(this.props.stats[1])}</div>
-                        </div>
-                        : null
-                    }
                 </td>
                 <td className="storage-icon storage-disk-extended">
                     { this.props.actions || job_spinner || warning_triangle }

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -26,6 +26,7 @@
     text-align: center;
     margin: 5px;
     color: var(--color-gray-9);
+    font-size: var(--pf-global--FontSize--sm);
 }
 
 #storage .storage-mounts .table {
@@ -80,12 +81,6 @@
     height: 43px;
 }
 
-@media (max-width: 1814px) {
-    #storage .storage-disk-size {
-        width: 100%;
-    }
-}
-
 #storage .create-storage {
     margin-bottom: 10px;
 }
@@ -108,7 +103,6 @@
 }
 
 #storage .storage-sidebar .table td {
-    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     vertical-align: top;
@@ -126,39 +120,6 @@
 #storage_raids .row span.raid-size,
 #storage_vgs .row span.vg-size {
     text-align: right;
-}
-
-#storage .storage-sidebar .storage-disk-size {
-    padding-right: 5px;
-}
-
-#storage .storage-sidebar .storage-disk-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.storage-disk-info {
-    font-size: var(--pf-global--FontSize--xs);
-}
-
-.storage-disk-info h3 {
-    font-size: var(--pf-global--FontSize--sm);
-    margin: 0;
-    padding: 0;
-}
-
-.storage-disk-size {
-    margin: 0.125rem 0 0.25rem;
-}
-
-.storage-disk-rates {
-    display: flex;
-    justify-content: space-between;
-}
-
-.storage-disk-rate-read,
-.storage-disk-rate-write {
-    width: calc(50% - 0.5rem);
 }
 
 @media (min-width: 768px) {
@@ -728,4 +689,40 @@ td.storage-action {
 
 .ct-form-box {
     margin-bottom: 1em;
+}
+
+/* Overview side panels */
+
+#storage .storage-sidebar .table {
+    table-layout: fixed;
+}
+
+.sidepanel-row {
+    display: flex;
+    flex-direction: row;
+}
+
+.sidepanel-row-detail {
+    margin-right: 0.5em;
+}
+
+.sidepanel-row-body {
+    flex: auto;
+}
+
+.sidepanel-row-info {
+    font-size: var(--pf-global--FontSize--xs);
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+}
+
+.sidepanel-row-decoration {
+    align-self: center;
+    white-space: nowrap;
+    margin-left: 1em;
+}
+
+.sidepanel-row .spinner {
+    display: inline-block;
 }

--- a/pkg/storaged/vdos-panel.jsx
+++ b/pkg/storaged/vdos-panel.jsx
@@ -137,6 +137,7 @@ export class VDOsPanel extends React.Component {
                 <OverviewSidePanelRow client={client}
                                       kind="array"
                                       name={vdo.name}
+                                      devname={vdo.dev}
                                       detail={fmt_size(vdo.logical_size)}
                                       go={() => cockpit.location.go([ "vdo", vdo.name ])}
                                       job_path={block && block.path}

--- a/pkg/storaged/vgroups-panel.jsx
+++ b/pkg/storaged/vgroups-panel.jsx
@@ -88,6 +88,7 @@ export class VGroupsPanel extends React.Component {
                 <OverviewSidePanelRow client={client}
                                       kind="array"
                                       name={vgroup.Name}
+                                      devname={"/dev/" + vgroup.Name + "/"}
                                       detail={fmt_size(vgroup.Size)}
                                       go={() => cockpit.location.go([ "vg", vgroup.Name ])}
                                       job_path={path}

--- a/test/selenium/selenium-storage.py
+++ b/test/selenium/selenium-storage.py
@@ -25,7 +25,7 @@ class StorageTestSuite(SeleniumTest):
         self.wait_id("drives")
         self.click(self.wait_xpath("//*[@data-testkey='%s']" % other_shortname, cond=clickable))
         self.wait_id('storage-detail')
-        self.wait_text(other_discname, element="div")
+        self.wait_xpath("//*[@id='storage-detail']//div[contains(text(), '%s')]" % other_discname)
         self.wait_text("Capacity", element="label")
         self.wait_text("1000 MiB", element="span")
         self.click(self.wait_link('Storage', cond=clickable))


### PR DESCRIPTION
The name now uses the whole width of the row.

- Use a flexbox instead of a table (but keep the table for easy
  borders and highlighting).

- Remove the icon since every row in a panel has the same icon anyway.

- Add the filename of the block device.

### For release notes

The side panel of the Storage page does not truncate names anymore and shows names in `/dev`.

![image](https://user-images.githubusercontent.com/3228183/63687717-0033c180-c80e-11e9-9348-d4648f55448d.png)
