### PR TITLE
[no-test] test: Close browser when avocado finishes

### DIFF
--- a/test/avocado/testlib_avocado/cockpit.py
+++ b/test/avocado/testlib_avocado/cockpit.py
@@ -56,6 +56,7 @@ class Cockpit():
         #        state = self.get_state()
         self.label = ("avocado")
         self.browser = Browser("localhost", self.label)
+        self.atcleanup(self.browser.cdp.kill)
         self.journal_start = re.sub('.*cursor: ', '',
                                     subprocess.check_output("journalctl --show-cursor -n0 -o cat || true", shell=True).decode("utf-8"))
 


### PR DESCRIPTION
When avocado starts its own browser it never closes it.

Since avocado tests spawn this process and it does not get cleaned up, the main
process holds stdout/err "busy" and therefore the test hangs
indefinitely.

Possibly related https://bugzilla.mindrot.org/show_bug.cgi?id=2071