### PR TITLE
kubernetes: fix a broken symlink

### DIFF
--- a/pkg/kubernetes/styles/image-widgets.css
+++ b/pkg/kubernetes/styles/image-widgets.css
@@ -1,1 +1,0 @@
-../../../lib/registry-image-widgets/dist/image-widgets.css


### PR DESCRIPTION
This symlink has been broken since we stopped using Bowie.  With npm,
the packages are now under node_modules/.