### PR TITLE
[no-test] bots: add bridge-utils package in RHEL and Debian images

### DIFF
--- a/bots/images/scripts/debian.setup
+++ b/bots/images/scripts/debian.setup
@@ -50,6 +50,7 @@ packagekit \
 
 TEST_PACKAGES="\
 acl \
+bridge-utils \
 curl \
 firewalld \
 gdb \

--- a/bots/images/scripts/rhel.setup
+++ b/bots/images/scripts/rhel.setup
@@ -150,6 +150,7 @@ sssd-dbus \
 "
 
 TEST_PACKAGES="\
+bridge-utils \
 valgrind \
 gdb \
 nmap-ncat \


### PR DESCRIPTION
testNetworkSettings for cockpit-machines needs brctl command to create a
bridge.

 * [ ] FAIL: image-refresh rhel-8-0
 * [ ] FAIL: image-refresh rhel-8-1
 * [x] image-refresh debian-testing

Note: debian-stable image doesn't need to be updated now, since libvirt-dbus is missing from there, and the test will not be executed there now anyway.