### PR TITLE
firewall: make the "Add ... to zone" label dynamic

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -433,6 +433,7 @@ class AddServicesModal extends React.Component {
         }
 
         var addText = this.state.custom ? _("Add Ports") : _("Add Services");
+        var zonesText = this.state.custom ? _("Add ports to the following zones:") : _("Add services to following zones:");
         return (
             <Modal id="add-services-dialog" show onHide={this.props.close}>
                 <Modal.Header>
@@ -443,7 +444,7 @@ class AddServicesModal extends React.Component {
                         { firewall.activeZones.size > 1 &&
                             <React.Fragment>
                                 <form className="ct-form-layout horizontal">
-                                    <label htmlFor="zone-input">{ _("Add services to following zones:") }</label>
+                                    <label htmlFor="zone-input">{zonesText}</label>
                                     <fieldset id="zone-input">
                                         { Array.from(firewall.activeZones).sort((a, b) => a.localeCompare(b))
                                                 .map(z =>


### PR DESCRIPTION
Change the "Add services to the following zones" label to "ports" to
reflect the user's choice of the "Custom ports" option in the same way
that the dialog title is changed.

Fixes #11834