### PR TITLE
firewall: show zone names in "Add services" dialog

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -448,7 +448,7 @@ class AddServicesModal extends React.Component {
                                         { Array.from(firewall.activeZones).sort((a, b) => a.localeCompare(b))
                                                 .map(z =>
                                                     <label className="radio" key={z}>
-                                                        <input type="checkbox" value={z} onChange={this.onToggleZone} />{ z }{ z === firewall.defaultZone && " " + _("(default)") }
+                                                        <input type="checkbox" value={z} onChange={this.onToggleZone} />{ firewall.zones[z].name || z }{ z === firewall.defaultZone && " " + _("(default)") }
                                                     </label>) }
                                     </fieldset>
                                 </form>


### PR DESCRIPTION
Previously we were showing zone IDs here, which was inconsistent with
what we show in the Zones list on the main firewall page.  Show the
human-friendly name instead.

Fixes #11836