### PR TITLE
tests: robustify testNetworkState for cockpit-machines

### DIFF
--- a/pkg/machines/actions/store-actions.js
+++ b/pkg/machines/actions/store-actions.js
@@ -140,10 +140,10 @@ export function updateLibvirtState(state) {
     };
 }
 
-export function updateOrAddNetwork(props) {
+export function updateOrAddNetwork(props, updateOnly) {
     return {
         type: UPDATE_ADD_NETWORK,
-        payload: { network: props },
+        payload: { network: props, updateOnly },
     };
 }
 

--- a/pkg/machines/actions/store-actions.js
+++ b/pkg/machines/actions/store-actions.js
@@ -154,10 +154,10 @@ export function updateOrAddNodeDevice(props) {
     };
 }
 
-export function updateOrAddStoragePool(props) {
+export function updateOrAddStoragePool(props, updateOnly) {
     return {
         type: UPDATE_ADD_STORAGE_POOL,
-        payload: { storagePool: props },
+        payload: { storagePool: props, updateOnly },
     };
 }
 

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -511,6 +511,7 @@ LIBVIRT_DBUS_PROVIDER = {
     GET_NETWORK({
         id: objPath,
         connectionName,
+        updateOnly,
     }) {
         let props = {};
 
@@ -535,7 +536,7 @@ LIBVIRT_DBUS_PROVIDER = {
                     })
                     .then(xml => {
                         const network = parseNetDumpxml(xml);
-                        dispatch(updateOrAddNetwork(Object.assign({}, props, network)));
+                        dispatch(updateOrAddNetwork(Object.assign({}, props, network), updateOnly));
                     })
                     .catch(ex => console.warn('GET_NETWORK action failed failed for path', objPath, ex));
         };
@@ -1135,8 +1136,10 @@ function startEventMonitorNetworks(connectionName, dispatch) {
             switch (eventType) {
             case Enum.VIR_NETWORK_EVENT_DEFINED:
             case Enum.VIR_NETWORK_EVENT_STARTED:
-            case Enum.VIR_NETWORK_EVENT_STOPPED:
                 dispatch(getNetwork({ connectionName, id:objPath }));
+                break;
+            case Enum.VIR_NETWORK_EVENT_STOPPED:
+                dispatch(getNetwork({ connectionName, id:objPath, updateOnly: true }));
                 break;
             case Enum.VIR_NETWORK_EVENT_UNDEFINED:
                 dispatch(undefineNetwork({ connectionName, id:objPath }));

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -582,6 +582,7 @@ LIBVIRT_DBUS_PROVIDER = {
     GET_STORAGE_POOL({
         id: objPath,
         connectionName,
+        updateOnly,
     }) {
         let dumpxmlParams;
         let props = {};
@@ -611,7 +612,7 @@ LIBVIRT_DBUS_PROVIDER = {
                         props.allocation = poolInfo[0][2];
                         props.available = poolInfo[0][3];
 
-                        dispatch(updateOrAddStoragePool(Object.assign({}, dumpxmlParams, props)));
+                        dispatch(updateOrAddStoragePool(Object.assign({}, dumpxmlParams, props), updateOnly));
                         if (props.active)
                             dispatch(getStorageVolumes({ connectionName, poolName: dumpxmlParams.name }));
                     })
@@ -1175,9 +1176,11 @@ function startEventMonitorStoragePools(connectionName, dispatch) {
             switch (eventType) {
             case Enum.VIR_STORAGE_POOL_EVENT_DEFINED:
             case Enum.VIR_STORAGE_POOL_EVENT_STARTED:
-            case Enum.VIR_STORAGE_POOL_EVENT_STOPPED:
             case Enum.VIR_STORAGE_POOL_EVENT_CREATED:
                 dispatch(getStoragePool({ connectionName, id:objPath }));
+                break;
+            case Enum.VIR_STORAGE_POOL_EVENT_STOPPED:
+                dispatch(getStoragePool({ connectionName, id:objPath, updateOnly: true }));
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_UNDEFINED:
                 dispatch(undefineStoragePool({ connectionName, id:objPath }));

--- a/pkg/machines/reducers.js
+++ b/pkg/machines/reducers.js
@@ -270,10 +270,10 @@ function storagePools(state, action) {
                 .filter(storagePool => (connectionName !== storagePool.connectionName || id != storagePool.id));
     }
     case UPDATE_ADD_STORAGE_POOL: {
-        const { storagePool } = action.payload;
+        const { storagePool, updateOnly, } = action.payload;
         const connectionName = storagePool.connectionName;
         const index = getFirstIndexOfResource(state, 'id', storagePool.id, connectionName);
-        if (index < 0) {
+        if (index < 0 && !updateOnly) {
             return [...state, storagePool];
         }
         const updatedStoragePool = Object.assign({}, state[index], storagePool);

--- a/pkg/machines/reducers.js
+++ b/pkg/machines/reducers.js
@@ -107,11 +107,11 @@ function networks(state, action) {
                 .filter(network => (connectionName !== network.connectionName || id != network.id));
     }
     case UPDATE_ADD_NETWORK: {
-        const { network } = action.payload;
+        const { network, updateOnly } = action.payload;
         const connectionName = network.connectionName;
         const index = network.id ? getFirstIndexOfResource(state, 'id', network.id, connectionName)
             : getFirstIndexOfResource(state, 'name', network.name, connectionName);
-        if (index < 0) { // add
+        if (index < 0 && !updateOnly) { // add
             return [...state, network];
         }
 

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -485,8 +485,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.click("#activate-network-test_network2-{0}".format(connectionName))
         b.wait_in_text("#network-test_network2-{0}-state".format(connectionName), "active")
         # check virsh state
-        active = m.execute("virsh net-info test_network2 | grep 'Active:' | awk '{print $2}'").strip()
-        self.assertEqual(active, "yes")
+        wait(lambda: "yes" == m.execute("virsh net-info test_network2 | grep 'Active:' | awk '{print $2}'").strip(), tries=5)
 
         # deactivate network
         b.wait_present("#deactivate-network-test_network2-{0}".format(connectionName))
@@ -494,8 +493,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("#network-test_network2-{0}-state".format(connectionName), "inactive")
         b.wait_present("#activate-network-test_network2-{0}".format(connectionName))
         # check virsh state
-        active = m.execute("virsh net-info test_network2 | grep 'Active:' | awk '{print $2}'").strip()
-        self.assertEqual(active, "no")
+        wait(lambda: "no" == m.execute("virsh net-info test_network2 | grep 'Active:' | awk '{print $2}'").strip(), tries=5)
 
     def testNetworks(self):
         b = self.browser


### PR DESCRIPTION
This test was failing from time to time because virsh was returning 'no' for
the active property even though we already received a signal that the
Network got active from the DBus API.

I haven't figured out why virsh might return wrong data the first time,
and I can't reproduce locally either. So, let's give it some time to react to
the event by waiting for the answer to be correct.