### PR TITLE
all: Make external channels work with a UrlRoot

### DIFF
--- a/pkg/apps/utils.jsx
+++ b/pkg/apps/utils.jsx
@@ -49,8 +49,9 @@ export function icon_url(path_or_url) {
         queryobj.external = { "content-type": "image/svg+xml" };
     }
 
+    var prefix = (new URL(cockpit.transport.uri("channel/" + cockpit.transport.csrf_token))).pathname;
     var query = window.btoa(JSON.stringify(queryobj));
-    return "/cockpit/channel/" + cockpit.transport.csrf_token + '?' + query;
+    return prefix + '?' + query;
 }
 
 export const ProgressBar = ({ title, data }) => {

--- a/pkg/machines/components/vnc.jsx
+++ b/pkg/machines/components/vnc.jsx
@@ -50,6 +50,7 @@ class Vnc extends React.Component {
         }
 
         cockpit.transport.wait(() => {
+            const prefix = (new URL(cockpit.transport.uri("channel/" + cockpit.transport.csrf_token))).pathname;
             const query = JSON.stringify({
                 payload: "stream",
                 protocol: "binary",
@@ -58,7 +59,7 @@ class Vnc extends React.Component {
                 port: parseInt(consoleDetail.tlsPort || consoleDetail.port, 10),
             });
             this.setState({
-                path: `cockpit/channel/${cockpit.transport.csrf_token}?${window.btoa(query)}`,
+                path: `${prefix.slice(1)}?${window.btoa(query)}`,
             });
         });
     }

--- a/pkg/playground/speed.js
+++ b/pkg/playground/speed.js
@@ -188,8 +188,9 @@ function download(ev) {
     start = Date.now();
     total = 0;
 
+    var prefix = (new URL(cockpit.transport.uri("channel/" + cockpit.transport.csrf_token))).pathname;
     var query = window.btoa(JSON.stringify(options));
-    window.open("/cockpit/channel/" + cockpit.transport.csrf_token + "?" + query);
+    window.open(prefix + "?" + query);
 }
 
 function stop() {

--- a/pkg/sosreport/index.js
+++ b/pkg/sosreport/index.js
@@ -120,7 +120,8 @@ function sos_create() {
                         "content-type": "application/x-xz, application/octet-stream"
                     }
                 }));
-                sos_archive_url = "/cockpit/channel/" + cockpit.transport.csrf_token + '?' + query;
+                var prefix = (new URL(cockpit.transport.uri("channel/" + cockpit.transport.csrf_token))).pathname;
+                sos_archive_url = prefix + '?' + query;
                 $("#sos-progress, #sos-error").hide();
                 $("#sos-alert, #sos-download").show();
                 $("#sos-cancel").text(_("Close"));

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -479,12 +479,14 @@ class Browser:
         else:
             self.click(sel + ' button:first-child')
 
-    def login_and_go(self, path=None, user=None, host=None, authorized=True):
+    def login_and_go(self, path=None, user=None, host=None, authorized=True, urlroot=None):
         if user is None:
             user = self.default_user
         href = path
         if not href:
             href = "/"
+        if urlroot:
+            href = urlroot + href
         if host:
             href = "/@" + host + href
         self.open(href)
@@ -778,9 +780,9 @@ class MachineCase(unittest.TestCase):
             self.check_browser_errors()
         shutil.rmtree(self.tmpdir)
 
-    def login_and_go(self, path=None, user=None, host=None, authorized=True, tls=False):
+    def login_and_go(self, path=None, user=None, host=None, authorized=True, urlroot=None, tls=False):
         self.machine.start_cockpit(host, tls=tls)
-        self.browser.login_and_go(path, user=user, host=host, authorized=authorized)
+        self.browser.login_and_go(path, user=user, host=host, authorized=authorized, urlroot=urlroot)
 
     allow_core_dumps = False
 

--- a/test/containers/check-kubernetes-openshift
+++ b/test/containers/check-kubernetes-openshift
@@ -34,12 +34,14 @@ from testlib import *
 from testvm import VirtMachine
 
 class OCBrowser(Browser):
-    def login_and_go(self, path=None, user=None, host=None, authorized=None):
+    def login_and_go(self, path=None, user=None, host=None, authorized=None, urlroot=None):
         if user is None:
             user = self.default_user
         href = path
         if not href:
             href = "/"
+        if urlroot:
+            href = urlroot + href
         if host:
             href = "/@" + host + href
         self.open(href)

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -79,7 +79,7 @@ class TestApps(PackageCase):
         self.allow_journal_messages("org.freedesktop.PackageKit.*org.freedesktop.DBus.Error.NoReply.*")
         self.machine.execute("pkcon -y install appstream-data-test")
 
-    def testBasic(self):
+    def testBasic(self, urlroot=""):
         b = self.browser
         m = self.machine
 
@@ -88,8 +88,11 @@ class TestApps(PackageCase):
 
         m.execute("rm -rf /usr/share/metainfo /usr/share/app-info /var/cache/app-info")
 
+        if urlroot != "":
+            m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot=%s" > /etc/cockpit/cockpit.conf' % urlroot)
+
         m.start_cockpit()
-        b.login_and_go("/apps")
+        b.login_and_go("/apps", urlroot=urlroot)
         b.wait_present(".app-list-empty")
 
         self.createAppStreamPackage("app-1", "1.0", "1")
@@ -97,7 +100,7 @@ class TestApps(PackageCase):
 
         b.click(".app-list tr:contains('An application for testing')")
         b.wait_present('.app-links a[href="https://app-1.com"]')
-        b.wait_present('.app img[src^="/cockpit/channel/"]')
+        b.wait_present('.app img[src^="%s/cockpit/channel/"]' % urlroot)
         b.click(".breadcrumb a:contains('Applications')")
 
         b.wait_visible("#list-page")
@@ -105,13 +108,16 @@ class TestApps(PackageCase):
 
         b.click(".app-list tr:contains('app-1') button:contains('Install')")
         b.wait_present(".app-list tr:contains('app-1') button:contains('Remove')")
-        b.wait_present(".app-list tr:contains('app-1') img[src^='/cockpit/channel/']")
+        b.wait_present(".app-list tr:contains('app-1') img[src^='%s/cockpit/channel/']" % urlroot)
         m.execute("test -f /stamp-app-1-1.0-1")
 
         b.click(".app-list tr:contains('app-1') button:contains('Remove')")
         b.wait_present(".app-list tr:contains('app-1') button:contains('Install')")
-        b.wait_present(".app-list tr:contains('app-1') img[src^='/cockpit/channel/']")
+        b.wait_present(".app-list tr:contains('app-1') img[src^='%s/cockpit/channel/']" % urlroot)
         m.execute("! test -f /stamp-app-1-1.0-1")
+
+    def testWithUrlRoot(self):
+        self.testBasic(urlroot="/webcon")
 
     def testL10N(self):
         b = self.browser

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -31,7 +31,7 @@ from testlib import *
 @skipImage("No sosreport", "continuous-atomic")
 class TestSOS(MachineCase):
 
-    def testBasic(self):
+    def testBasic(self, urlroot=""):
         b = self.browser
         m = self.machine
 
@@ -42,7 +42,10 @@ only-plugins=release,date,host
 threads=2
 """)
 
-        self.login_and_go("/sosreport")
+        if urlroot != "":
+            m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot=%s" > /etc/cockpit/cockpit.conf' % urlroot)
+
+        self.login_and_go("/sosreport", urlroot=urlroot)
 
         b.click('[data-target="#sos"]')
         b.wait_visible("#sos")
@@ -65,6 +68,10 @@ threads=2
             tar.getmember(os.path.join(tar.getnames()[0], "etc/os-release"))
 
         self.allow_journal_messages('.*comm="sosreport".*')
+
+    @skipImage("Fixed in PR #11853", "rhel-7-6-distropkg", "rhel-8-0-distropkg")
+    def testWithUrlRoot(self):
+        self.testBasic(urlroot="/webcon")
 
     @skipImage("Not supported", "continuous-atomic", "fedora-atomic", "rhel-atomic")
     def testAppStream(self):

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -883,12 +883,15 @@ class TestMachines(NetworkCase):
         self.assertEqual(b.attr("#dynamically-generated-file", "href"),
                          u"data:application/x-virt-viewer,%5Bvirt-viewer%5D%0Atype%3Dspice%0Ahost%3D127.0.0.1%0Aport%3D5900%0Adelete-this-file%3D1%0Afullscreen%3D0%0A")
 
-    def testInlineConsole(self):
+    def testInlineConsole(self, urlroot=""):
         b = self.browser
 
         self.startVm("subVmTest1", graphics='vnc')
 
-        self.login_and_go("/machines")
+        if urlroot != "":
+            self.machine.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot=%s" > /etc/cockpit/cockpit.conf' % urlroot)
+
+        self.login_and_go("/machines", urlroot=urlroot)
         b.wait_in_text("body", "Virtual Machines")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
@@ -899,6 +902,9 @@ class TestMachines(NetworkCase):
 
         # since VNC is defined for this VM, the view for "In-Browser Viewer" is rendered by default
         b.wait_present(".toolbar-pf-results canvas")
+
+    def testInlineConsoleWithUrlRoot(self, urlroot=""):
+        self.testInlineConsole(urlroot="/webcon")
 
     def testDelete(self):
         b = self.browser


### PR DESCRIPTION
When a UrlRoot was in use, almost all URLs for external channels would
forget to include it.

The effect was that diagnostic reports can't be downloaded,
applications don't have icons, and virtual machine consoles don't
work.