### PR TITLE
bots: fix 'no-test' label [no-test]

### DIFF
--- a/bots/push-rewrite
+++ b/bots/push-rewrite
@@ -67,7 +67,7 @@ def main():
     tests_disabled = "no-test" in labels or "[no-test]" in pull["title"]
     # add no-test label to prevent tests bring triggered
     if not tests_disabled:
-        label(pull, { "labels": list(labels) + ["no-test"] })
+        label(pull, { "labels": labels + ["no-test"] })
 
     git("push", "--force-with-lease=" + opts.branch + ":" + remote, opts.remote, opts.branch + ":" + opts.branch)
 

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -471,7 +471,7 @@ def label(issue, labels=['bot']):
 def labels_of_pull(pull):
     if "labels" not in pull:
         pull["labels"] = api.get("issues/{0}/labels".format(pull["number"]))
-    return map(lambda label: label["name"], pull["labels"])
+    return list(map(lambda label: label["name"], pull["labels"]))
 
 def comment(issue, comment):
     try:

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -433,7 +433,7 @@ def cockpit_tasks(api, update, branch_contexts, repo, pull_data, pull_number, sh
                 return False
             if base != "master":  # bots/ is always taken from master branch
                 return False
-            if LABEL_TEST_EXTERNAL in labels_of_pull(pull):  # already checked before?
+            if LABEL_TEST_EXTERNAL in labels:  # already checked before?
                 return True
 
             if not have:

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -310,21 +310,20 @@ def prioritize(status, title, labels, priority, context, number):
 
     # Ignore context when the PR has [no-test] in the title or as label, unless
     # the context was directly triggered
-    if (('no-test' in list(labels) or '[no-test]' in title) and
+    if (('no-test' in labels or '[no-test]' in title) and
         status.get("description", "") != github.NOT_TESTED_DIRECT):
         logging.info("Skipping '{0}' on #{1} because it is no-test".format(context, number))
         priority = 0
         update = None
 
     if priority > 0:
-        values = list(labels)
-        if "priority" in values:
+        if "priority" in labels:
             priority += 2
-        if "blocked" in values:
+        if "blocked" in labels:
             priority -= 1
 
         # Pull requests where the title starts with WIP get penalized
-        if title.startswith("WIP") or "needswork" in values:
+        if title.startswith("WIP") or "needswork" in labels:
             priority -= 1
 
         # Is testing already in progress?


### PR DESCRIPTION
The labels_of_pull() function was returning a map, but in some cases the
return value was being evaluated more than once.  The first evaluation
would be fine, but all evaluations after the first would just see an
empty list (since the values had already been consumed).

Let's just return a list here to avoid the problem.

We can also take the chance to simplify code in a few other places since
we now have a list.