### PR TITLE
containers: Bump unit-tests to Ubuntu 19.04 [no-test]

### DIFF
--- a/containers/Makefile.am
+++ b/containers/Makefile.am
@@ -10,17 +10,3 @@ ws-container:
 ws-container-shell:
 	sudo docker run -ti --rm --publish=9001:9090 \
 		cockpit/ws /bin/bash
-
-UNIT_TESTS_DIR = $(srcdir)/containers/unit-tests
-
-unit-tests-container:
-	sudo docker build -t cockpit/unit-tests $(UNIT_TESTS_DIR)
-	sudo docker tag  cockpit/unit-tests:latest docker.io/cockpit/unit-tests:latest
-	sudo docker build --build-arg arch=i386 -t cockpit/unit-tests:i386 $(UNIT_TESTS_DIR)
-	sudo docker tag  cockpit/unit-tests:i386 docker.io/cockpit/unit-tests:i386
-
-unit-tests-container-run:
-	sudo docker run --shm-size=512M -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests
-
-unit-tests-container-shell:
-	sudo docker run --shm-size=512M -ti --rm -v $(abs_srcdir):/source:ro cockpit/unit-tests /bin/bash

--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -1,38 +1,21 @@
-FROM ubuntu:16.04
+ARG debian_arch=amd64
+FROM ${debian_arch}/ubuntu:19.04
 
-ARG arch=amd64
-
-# dependencies which must be installed for the target architecture
-# we must do cross-builds on i386 as phantomjs is not available for i386
-ARG _crossdeps="libglib2.0-dev libgudev-1.0-dev libjson-glib-dev libkeyutils-dev liblvm2-dev libnm-glib-dev \
-    libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev \
-    libssh-dev libsystemd-dev libkrb5-dev libgnutls28-dev \
-    glib-networking glib-networking-dbg libc6-dbg libglib2.0-0-dbg pkg-config"
-
-# HACK: Avoid libssh security update, it breaks keyboard-interactive (https://bugs.debian.org/913870)
-RUN dpkg --add-architecture ${arch} && echo ${arch} > /arch && apt-get update && \
-    apt-get install -y --no-install-recommends build-essential gcc-multilib clang python3 \
-      autoconf automake gdb gtk-doc-tools intltool libjavascript-minifier-xs-perl libjson-perl valgrind \
-      xmlto xsltproc npm nodejs-legacy git libfontconfig1 dbus ssh curl chromium-browser appstream-util \
-      $(for p in ${_crossdeps}; do echo $p:${arch}; done) && \
-    apt-get install -y --allow-downgrades libssh-dev:${arch}=0.6.3-4.3 libssh-4:${arch}=0.6.3-4.3 && \
-    echo 'deb http://archive.ubuntu.com/ubuntu bionic universe' > /etc/apt/sources.list.d/stable.list && \
-    apt-get update && \
-    apt-get install -y pyflakes pyflakes3 python3-pep8 && \
-    apt-get clean
-
-# use latest npm/node
-# add system user to avoid same UIDs as host's source volume
-RUN npm install -g n && n stable && \
-    adduser --system --gecos "Builder" builder
+ARG personality=linux64
+COPY setup.sh /
+RUN ${personality} /setup.sh ${personality} && rm -rf /setup.sh
 
 # HACK: Working around Node.js screwing around with stdio
-ENV NODE_PATH /usr/local/bin/nodejs
-RUN mv /usr/local/bin/node /usr/local/bin/nodejs
-ADD turd-polish /usr/local/bin/node
+ENV NODE_PATH /usr/local/bin/node.lts
+COPY turd-polish /usr/local/bin/node
 
+# 'builder' user created in setup.sh
 USER builder
 ENV LANG=C.UTF-8
 
 VOLUME /source
+ENTRYPOINT ["/entrypoint"]
 CMD ["/source/containers/unit-tests/run.sh"]
+
+# for filtering from our 'exec' script
+LABEL org.cockpit-project.container=unit-tests

--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -11,35 +11,50 @@ will re-use an already existing `node_modules/` directory.
 
 ## Building
 
-In a built cockpit tree you can run
-
-    $ make unit-tests-container
-
-which will build the `cockpit/unit-tests` and `cockpit/unit-tests:i386`
-containers.
+The `build` script will build the `cockpit/unit-tests` and
+`cockpit/unit-tests:i386` containers.  It should be run as root.
 
 ## Running tests
 
-Tests in that container for the default configuration get started with
+Tests in that container get started with the `start` script.  By default, this
+script runs the unit tests on amd64.  The script accepts a number of arguments
+to modify its behaviour:
 
-    $ make unit-tests-container-run
+ - `CC=othercc` to set the `CC` environment variable inside the container (ie:
+   to build with a different compiler)
+ - `:tag` to specify a different tag to use for the `cockpit/unit-tests` image
+   (eg: `i386`)
+ - `shell` to specify that an interactive shell should be launched instead of
+   running the unit tests
 
-or equivalently with
+Some examples:
 
-    $ sudo docker run --shm-size=512M -ti --volume `pwd`:/source:ro cockpit/unit-tests
+    $ sudo ./start           # run the unit tests on amd64
 
-You can pass `--env=CC=clang` to build with Clang instead of gcc, or run
-`cockpit/unit-tests:i386` to run on a 32 bit architecture.
+    $ sudo ./start CC=clang  # run the unit tests on amd64, compiled with clang
+
+    $ sudo ./start :i386     # run the unit tests on i386
 
 ## Debugging tests
 
 For interactive debugging, run a shell in the container:
 
-    $ make unit-tests-container-shell
+    $ sudo ./start shell     # start an interactive shell on i386
 
-or start the container with `bash` as the entry point.
+You will find the cockpit source tree (from the host) mounted at `/source` in
+the container.
+
 `/source/containers/unit-tests/run.sh` will start the builds and test run, then
 you can investigate in the build tree at `/tmp/source/`.
+
+`/source/containers/unit-tests/run.sh` also includes a `--build` argument which
+will checkout and build the source, but not run any tests.
+
+You can also attach to another container using the provided `exec` script.  For example:
+
+    $ sudo ./exec uname -a   # run a command as the "builder" user
+
+    $ sudo ./exec --root     # start a shell as root
 
 ## More Info
 

--- a/containers/unit-tests/build
+++ b/containers/unit-tests/build
@@ -1,0 +1,8 @@
+#!/bin/sh -ex
+
+dir=$(dirname "$0")
+
+docker build --build-arg debian_arch=amd64 --build-arg personality=linux64 -t cockpit/unit-tests ${dir}
+docker tag  cockpit/unit-tests:latest docker.io/cockpit/unit-tests:latest
+docker build --build-arg debian_arch=i386 --build-arg personality=linux32 -t cockpit/unit-tests:i386 ${dir}
+docker tag  cockpit/unit-tests:i386 docker.io/cockpit/unit-tests:i386

--- a/containers/unit-tests/exec
+++ b/containers/unit-tests/exec
@@ -1,0 +1,46 @@
+#!/bin/sh -e
+
+checkargs() { test $# -eq $1; }
+
+filter='label=org.cockpit-project.container=unit-tests'
+defaultargs='-it'
+defaultcmd='/bin/bash'
+args=''
+id=''
+
+while test $# -gt 0; do
+  case "$1" in
+    --root) args="$args -uroot";;
+    --id=*) id="${1#--id=}";;
+    -it) args="$args -it"; defaultargs='';;
+    --) break;;
+    --*) printf 'usage: %s [--root] [--id=<id>] [-it] cmd...\n' "$0"; exit 1;;
+    *) break;;
+  esac
+  shift
+done
+
+if [ -z "$id" ]; then
+  id="$(docker ps -qf "${filter}")"
+
+  if checkargs 2 $id; then :
+  elif checkargs 1 $id; then
+    echo 'Cannot find any running cockpit/unit-tests container'
+    exit 1
+  else
+    echo 'More than one running cockpit-unit/tests container:'
+    echo
+    docker ps -f "${filter}" | sed -e 's/^/  /'
+    echo
+    echo 'Use --id= to specify which one.'
+    exit 1
+  fi
+fi
+
+if test $# -eq 0; then
+  args="$args $defaultargs"
+  set -- $defaultcmd
+fi
+
+set -ex
+exec docker exec ${args} -- "${id}" "$@"

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -27,19 +27,6 @@ git clone /source /tmp/source
 [ ! -d /source/node_modules ] || cp -r /source/node_modules /tmp/source/
 cd /tmp/source
 
-# cross-build flags
-ARCH=$(cat /arch)
-case $ARCH in
-    amd64) ;;
-    i386)
-        export CFLAGS=-m32
-        export LDFLAGS=-m32
-        ;;
-    *)
-        echo "Unknown architecture '$ARCH'" >&2
-        exit 1
-esac
-
 if [ -d bots ]; then
     # Set GITHUB_BASE so that "import task" works without failure.
     # https://github.com/cockpit-project/cockpit/issues/10578
@@ -66,7 +53,7 @@ fi
 # not yet been able to figure out what is putting it non-blocknig.
 python3 -c "import fcntl, os; map(lambda fd: fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) &~ os.O_NONBLOCK), [0, 1, 2])"
 
-if [ "$ARCH" = amd64 ]; then
+if dpkg-architecture --is amd64; then
     # run distcheck on main arch
     make distcheck 2>&1
 else

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -1,0 +1,90 @@
+#!/bin/sh -ex
+
+personality="$1"
+
+dependencies="\
+    appstream-util \
+    autoconf \
+    automake \
+    build-essential \
+    chromium-browser \
+    clang python3 \
+    curl \
+    dbus \
+    gcc-multilib \
+    gdb \
+    git \
+    glib-networking \
+    glib-networking-dbgsym\
+    gtk-doc-tools \
+    intltool \
+    libc6-dbg \
+    libfontconfig1 \
+    libglib2.0-0-dbgsym \
+    libglib2.0-dev \
+    libgnutls28-dev \
+    libgudev-1.0-dev \
+    libjavascript-minifier-xs-perl \
+    libjson-glib-dev \
+    libjson-perl \
+    libkeyutils-dev \
+    libkrb5-dev \
+    liblvm2-dev \
+    libnm-glib-dev \
+    libpam0g-dev \
+    libpcp-import1-dev \
+    libpcp-pmda3-dev \
+    libpcp3-dev \
+    libpolkit-agent-1-dev \
+    libpolkit-gobject-1-dev \
+    libssh-4-dbgsym \
+    libssh-dev \
+    libsystemd-dev \
+    pkg-config \
+    pyflakes3 \
+    python3-pep8 \
+    ssh \
+    strace \
+    valgrind \
+    xmlto \
+    xsltproc \
+"
+
+tee /entrypoint <<EOF
+#!/bin/sh -e
+
+echo -n "Host: " && uname -srvm
+
+. /usr/lib/os-release
+echo -n "Container: \${NAME} \${VERSION} / " && ${personality} uname -nrvm
+echo
+
+set -ex
+exec ${personality} -- "\$@"
+EOF
+chmod +x /entrypoint
+
+apt-get update
+apt-get install -y --no-install-recommends gnupg2 eatmydata
+
+echo "deb http://ddebs.ubuntu.com disco main universe" > /etc/apt/sources.list.d/ddebs.list
+echo "deb http://ddebs.ubuntu.com disco-updates main universe" >> /etc/apt/sources.list.d/ddebs.list
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F2EDC64DC5AEE1F6B9C621F0C8CAB6595FDFF622
+apt-get update
+
+eatmydata apt-get install -y --no-install-recommends ${dependencies}
+
+# install the npm package for just long enough to install npm from upstream
+eatmydata apt-get install -y npm
+npm install -g n
+n -a x64 lts    # no more 32bit builds, but libc6:amd64 is always installed
+rm /usr/local/bin/node
+ln -s "`n bin lts`" /usr/local/bin/node.lts
+NODE_PATH="$(n bin lts)"
+eatmydata apt-get remove -y npm nodejs
+
+apt-get clean
+
+
+
+adduser --system --gecos "Builder" builder

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -1,0 +1,20 @@
+#!/bin/sh -e
+
+top_srcdir=$(realpath -m "$0"/../../..)
+image=cockpit/unit-tests:latest
+flags=''
+cmd=''
+
+while test $# -gt 0; do
+  case "$1" in
+    CC=*) ccarg="--env=$1";;
+    shell) flags=-it; cmd=/bin/bash;;
+    :*) image=cockpit/unit-tests"$1";;
+    *) echo "Unknown option '$1'"; exit 1;;
+  esac
+  shift
+done
+
+set -ex
+exec docker run --shm-size=512M --volume "${top_srcdir}":/source:ro \
+       ${ccarg:+"$ccarg"} $flags -- "$image" $cmd


### PR DESCRIPTION
This tests on a less ancient toolchain, more recent libssh, and gives us
a more recent pyflakes which is able to spot a lot more errors.

The main repo -dbg packages are mostly gone now, so enable the dbgsym
repository (as per https://wiki.ubuntu.com/DebuggingProgramCrash) and
install the corresponding -dbgsym packages instead.

Stop installing and using the "g" npm module, the distro's nodejs is now
recent enough.

Use eatmydata to install the bulk of packages for faster container
creation.

 - [x] Fix false-positive memleaks with glib 2.60: PR #11776 
 - [x] Ignore GSocketClient leak in glib 2.60: PR #11781
 - [x] Don't resolve ``localhost`` for mocked systems: PR #11617
 - [x] Set key exchange algorithms in mock-sshd on 32bit: PR #11910