### PR TITLE
test: Retry more in check-storage-mdraid

### DIFF
--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -30,12 +30,6 @@ def info_field(name, image_name):
 
 class TestStorage(StorageCase):
 
-    def tearDown(self):
-        # HACK - for debugging https://github.com/cockpit-project/cockpit/issues/2924
-        print(self.machine.execute("parted -s /dev/md127 print || true"))
-        print(self.machine.execute("lsblk || true"))
-        MachineCase.tearDown(self)
-
     def wait_states(self, states):
         self.browser.wait_js_func("""(function(states) {
           var found = { };
@@ -54,9 +48,10 @@ class TestStorage(StorageCase):
         })""", states)
 
     def raid_add_disk(self, name):
-        self.dialog_with_retry(trigger=lambda: self.browser.click('#detail-sidebar .panel-heading button'),
-                               expect=lambda: self.dialog_is_present('disks', name),
-                               values={"disks": {name: True}})
+        self.dialog_open_with_retry(trigger=lambda: self.browser.click('#detail-sidebar .panel-heading button'),
+                                    expect=lambda: self.dialog_is_present('disks', name))
+        self.dialog_set_val("disks", { name: True })
+        self.dialog_apply_with_retry()
 
     def raid_remove_disk(self, name):
         self.browser.click('#detail-sidebar tr:contains("%s") button' % name)
@@ -81,10 +76,11 @@ class TestStorage(StorageCase):
                 except Error as ex:
                     if not ex.msg.startswith('timeout'):
                         raise
-                    self.browser.wait_present(".modal-dialog")
-                    self.browser.wait_in_text(".modal-dialog", "Error stopping RAID array /dev/md127")
-                    self.browser.click(".modal-dialog div.modal-footer button.btn-default")
-                    self.browser.wait_not_present(".modal-dialog")
+                    print("Stopping failed, retrying...")
+                    if self.browser.is_present("#dialog"):
+                        self.browser.wait_in_text("#dialog", "Error stopping RAID array /dev/md127")
+                        self.dialog_cancel()
+                        self.dialog_wait_close()
                     do_click()
             else:
                 self.fail("Timed out waiting for array to get stopped")

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -348,7 +348,7 @@ class StorageCase(MachineCase):
     #   This is also done by repeatedly opening a dialog until all
     #   needed block devices are listed.
 
-    def dialog_with_retry(self, trigger, values, expect):
+    def dialog_open_with_retry(self, trigger, expect):
         def setup():
             trigger()
             self.dialog_wait_open()
@@ -363,6 +363,19 @@ class StorageCase(MachineCase):
             self.dialog_cancel()
             self.dialog_wait_close()
         self.retry(setup, check, teardown)
+
+    def dialog_apply_with_retry(self):
+        def step():
+            try:
+                self.dialog_apply()
+                self.dialog_wait_close()
+            except Error as ex:
+                return False
+            return True
+        self.browser.wait(step)
+
+    def dialog_with_retry(self, trigger, values, expect):
+        self.dialog_open_with_retry(trigger, expect)
         if values:
             for f in values:
                 self.dialog_set_val(f, values[f])


### PR DESCRIPTION
Adding a disk might fail temporarily but pressing "Apply" a couple of
times should eventually succeed.

Additionally, the code for retrying the "Stop" action didn't work
anymore with the new dialog code and sometimes no error dialog will
open at all.