### PR TITLE
bots: Enable manual tests for weldr/lorax [no-test]

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -67,6 +67,15 @@ REPO_BRANCH_CONTEXT = {
             'cockpit/fedora-30',
         ],
     },
+    'weldr/lorax': {
+        'master': [],
+        # can be triggered manually for now, needs https://github.com/weldr/lorax/pull/689 before doing it automatically
+        '_manual': [
+            'cockpit/fedora-30',
+            'cockpit/rhel-8-0',
+            'cockpit/rhel-8-1',
+        ],
+    },
     'weldr/cockpit-composer': {
         'master': [
             'cockpit/fedora-29/chrome',


### PR DESCRIPTION
This is being prepared in https://github.com/weldr/lorax/pull/689. Once
a test on a particular OS works, it can be moved over to `'master'`.