### PR TITLE
tests: fix testDelete from machineslib which was checking wrong console file

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -950,7 +950,7 @@ class TestMachines(NetworkCase):
 
         # Try to delete a paused VM
         name = "paused-test-vm"
-        self.startVm(name)
+        args = self.startVm(name)
 
         b.click("tbody tr[data-row-id=vm-{0}] th".format(name)) # click on the row header
 


### PR DESCRIPTION
When creating the new VM to test the deletion of paused VMs, I forgot to
get the new args variable, and I kept checking the args from the
previous VM run, which made the test fail inconsistently.