### PR TITLE
bridge: Implement 'packet' payload

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -561,8 +561,6 @@ AM_PATH_PYTHON([2.7])
 
 AC_SUBST(PAM_LIBS)
 
-AC_DEFINE([MAX_PACKET_SIZE], [65536], [Maximum size of packet messages])
-
 AC_OUTPUT([
 Makefile
 doc/guide/version

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -809,6 +809,29 @@ process will be sent a SIGTERM signal.
 Additionally, a "options" control message may be sent in this channel
 to change the "batch", "latency", and "window" options.
 
+Payload: packet
+---------------
+
+Raw data is sent back and forth to as messages to a socket. The message
+boundaries correspond exactly to the messages sent over the socket.
+
+If the channel is not binary, then non-UTF-8 data is forced into UTF-8
+with a replacement character.
+
+Additional "open" command options should be specified with a channel of
+this payload type:
+
+ * "unix": Open a channel with the given unix socket.
+ * "max-size": The maximum possible size of a message. Default is 64K
+   Supports up to 128K. Messages larger than this will be truncated.
+
+If an "done" is sent to the bridge on this channel, then the socket
+input is shutdown. The channel will send an "done" when the output of the socket
+or pipe is done.
+
+Additionally, a "options" control message may be sent in this channel
+to change the "max-size" options.
+
 Payload: fswatch1
 -----------------
 

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -28,6 +28,8 @@ libcockpit_stub_a_SOURCES = \
 	src/bridge/cockpitinteracttransport.h \
 	src/bridge/cockpitpackages.c \
 	src/bridge/cockpitpackages.h \
+	src/bridge/cockpitpacketchannel.c \
+	src/bridge/cockpitpacketchannel.h \
 	src/bridge/cockpitpaths.c \
 	src/bridge/cockpitpaths.h \
 	src/bridge/cockpitpeer.c \
@@ -154,6 +156,7 @@ BRIDGE_CHECKS = \
 	test-paths \
 	test-rules \
 	test-pipe-channel \
+	test-packet-channel \
 	test-packages \
 	test-peer \
 	test-dbus-meta \
@@ -227,6 +230,12 @@ test_stream_LDADD = $(libcockpit_bridge_LIBS)
 test_process_SOURCES = src/bridge/test-process.c
 test_process_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
 test_process_LDADD = $(libcockpit_bridge_LIBS)
+
+test_packet_channel_SOURCES = \
+	src/bridge/test-packet-channel.c \
+	src/common/mock-transport.c src/common/mock-transport.h
+test_packet_channel_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
+test_packet_channel_LDADD = $(libcockpit_bridge_LIBS)
 
 test_pipe_channel_SOURCES = \
 	src/bridge/test-pipe-channel.c \

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -30,6 +30,7 @@
 #include "cockpitinteracttransport.h"
 #include "cockpitnullchannel.h"
 #include "cockpitpackages.h"
+#include "cockpitpacketchannel.h"
 #include "cockpitpipechannel.h"
 #include "cockpitinternalmetrics.h"
 #include "cockpitpolkitagent.h"
@@ -70,6 +71,7 @@ static CockpitPayloadType payload_types[] = {
   { "http-stream1", cockpit_http_stream_get_type },
   { "http-stream2", cockpit_http_stream_get_type },
   { "stream", cockpit_pipe_channel_get_type },
+  { "packet", cockpit_packet_channel_get_type },
   { "fsread1", cockpit_fsread_get_type },
   { "fsreplace1", cockpit_fsreplace_get_type },
   { "fswatch1", cockpit_fswatch_get_type },

--- a/src/bridge/cockpitpacketchannel.c
+++ b/src/bridge/cockpitpacketchannel.c
@@ -1,0 +1,680 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitpacketchannel.h"
+
+#include "cockpitconnect.h"
+
+#include "common/cockpitflow.h"
+#include "common/cockpitjson.h"
+#include "common/cockpitunicode.h"
+#include "common/cockpitunixfd.h"
+
+#include <gio/gunixsocketaddress.h>
+#include <glib-unix.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <string.h>
+#include <errno.h>
+
+/**
+ * CockpitPacketChannel:
+ *
+ * A #CockpitChannel that sends messages from a regular seqpacket socket.
+ * Support for dgram sockets should also fit in here rather well, but is
+ * not implemented at the current time.
+ *
+ * The payload type for this channel is 'stream'.
+ */
+
+#define DEF_PACKET_SIZE  (64UL * 1024UL)
+
+/* Sadly this is limited by the max size of our WebSocket payload */
+#define MAX_PACKET_SIZE  (128UL * 1024UL)
+
+/* Several megabytes is when we start to consider queue full enough */
+#define QUEUE_PRESSURE   (128UL * DEF_PACKET_SIZE)
+
+enum {
+    CREATED = 0,
+    CONNECTING,
+    RELAYING,
+    CLOSED
+};
+
+typedef struct {
+  CockpitChannel parent;
+  GMainContext *context;
+  gchar *name;
+  gint state;
+  gsize max_size;
+
+  int fd;
+  GSource *in_source;
+  gboolean in_done;
+  GSource *out_source;
+  GQueue *out_queue;
+  gboolean out_done;
+  gsize out_queued;
+
+  /* Pressure which throttles input on this pipe */
+  CockpitFlow *pressure;
+  gulong pressure_sig;
+} CockpitPacketChannel;
+
+typedef struct {
+  CockpitChannelClass parent_class;
+} CockpitPacketChannelClass;
+
+static void  start_input         (CockpitPacketChannel *self);
+
+static void  start_output        (CockpitPacketChannel *self);
+
+static void  cockpit_packet_channel_flow_iface (CockpitFlowIface *iface);
+
+#define COCKPIT_PACKET_CHANNEL(o) (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_PACKET_CHANNEL, \
+                                   CockpitPacketChannel))
+
+G_DEFINE_TYPE_WITH_CODE (CockpitPacketChannel, cockpit_packet_channel, COCKPIT_TYPE_CHANNEL,
+                         G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_FLOW, cockpit_packet_channel_flow_iface));
+
+static void
+stop_output (CockpitPacketChannel *self)
+{
+  g_assert (self->out_source != NULL);
+  g_source_destroy (self->out_source);
+  g_source_unref (self->out_source);
+  self->out_source = NULL;
+}
+
+static void
+stop_input (CockpitPacketChannel *self)
+{
+  g_assert (self->in_source != NULL);
+  g_source_destroy (self->in_source);
+  g_source_unref (self->in_source);
+  self->in_source = NULL;
+}
+
+static void
+close_with_errno (CockpitPacketChannel *self,
+                  const gchar *message,
+                  int errn)
+{
+  const gchar *problem = NULL;
+
+  if (errn == EPERM || errn == EACCES)
+    problem = "access-denied";
+  else if (errn == ENOENT || errn == ECONNREFUSED)
+    problem = "not-found";
+
+  if (problem)
+    {
+      g_message ("%s: %s: %s", self->name, message, g_strerror (errn));
+    }
+  else
+    {
+      g_warning ("%s: %s: %s", self->name, message, g_strerror (errn));
+      problem = "internal-error";
+    }
+
+  cockpit_channel_close (COCKPIT_CHANNEL (self), problem);
+}
+
+static void
+close_maybe (CockpitPacketChannel *self)
+{
+  if (self->state < CLOSED)
+    {
+      if (self->in_done && self->out_done)
+        {
+          g_debug ("%s: input and output done", self->name);
+          cockpit_channel_close (COCKPIT_CHANNEL (self), NULL);
+        }
+    }
+}
+
+static gboolean
+dispatch_input (gint fd,
+                GIOCondition cond,
+                gpointer user_data)
+{
+  CockpitPacketChannel *self = (CockpitPacketChannel *)user_data;
+  GByteArray *buffer;
+  GBytes *message;
+  gssize ret = 0;
+  int errn;
+
+  g_return_val_if_fail (self->in_source, FALSE);
+
+  buffer = g_byte_array_new ();
+
+  /*
+   * Enable clean shutdown by not reading when we just get
+   * G_IO_HUP. Note that when we get G_IO_ERR we do want to read
+   * just so we can get the appropriate detailed error message.
+   */
+  if (cond != G_IO_HUP)
+    {
+      g_byte_array_set_size (buffer, self->max_size);
+      g_debug ("%s: reading input %x", self->name, cond);
+      ret = recv (self->fd, buffer->data, buffer->len, 0);
+
+      errn = errno;
+      if (ret < 0)
+        {
+          if (errn == EAGAIN || errn == EINTR)
+            {
+              g_byte_array_free (buffer, TRUE);
+              return TRUE;
+            }
+          else if (errn == ECONNRESET)
+            {
+              g_debug ("couldn't read: %s", g_strerror (errn));
+              ret = 0;
+            }
+          else
+            {
+              g_byte_array_free (buffer, TRUE);
+              close_with_errno (self, "couldn't read", errn);
+              return FALSE;
+            }
+        }
+
+      g_byte_array_set_size (buffer, ret);
+    }
+
+  if (ret == 0)
+    {
+      g_debug ("%s: end of input", self->name);
+      cockpit_channel_control (COCKPIT_CHANNEL (self), "done", NULL);
+      self->in_done = TRUE;
+      stop_input (self);
+    }
+
+  g_object_ref (self);
+
+  message = g_byte_array_free_to_bytes (buffer);
+  cockpit_channel_send (COCKPIT_CHANNEL (self), message, FALSE);
+  g_bytes_unref (message);
+
+  if (self->in_done)
+    close_maybe (self);
+
+  g_object_unref (self);
+  return TRUE;
+}
+
+static gboolean
+dispatch_connect (CockpitPacketChannel *self)
+{
+  socklen_t slen;
+  int error;
+
+  slen = sizeof (error);
+  if (getsockopt (self->fd, SOL_SOCKET, SO_ERROR, &error, &slen) != 0)
+    {
+      g_warning ("%s: couldn't get connection result", self->name);
+      cockpit_channel_close (COCKPIT_CHANNEL (self), "internal-error");
+    }
+  else if (error == EINPROGRESS)
+    {
+      /* keep connecting */
+    }
+  else if (error != 0)
+    {
+      close_with_errno (self, "couldn't connect", error);
+    }
+  else
+    {
+      self->state = RELAYING;
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+static gboolean
+dispatch_output (gint fd,
+                 GIOCondition cond,
+                 gpointer user_data)
+{
+  CockpitPacketChannel *self = (CockpitPacketChannel *)user_data;
+  gconstpointer data;
+  gsize before, size;
+  gssize ret;
+
+  /* A non-blocking connect is processed here */
+  if (self->state == CONNECTING && !dispatch_connect (self))
+    return TRUE;
+
+  g_return_val_if_fail (self->out_source, FALSE);
+
+  before = self->out_queued;
+
+  while (self->out_queue->head)
+    {
+      data = g_bytes_get_data (self->out_queue->head->data, &size);
+      ret = send (self->fd, data, size, 0);
+
+      if (ret < 0)
+        {
+          if (errno == EAGAIN && errno == EINTR)
+            {
+              break;
+            }
+          else
+            {
+              close_with_errno (self, "couldn't write", errno);
+              return FALSE;
+            }
+        }
+      else
+        {
+          g_bytes_unref (g_queue_pop_head (self->out_queue));
+          g_assert (size <= self->out_queued);
+          self->out_queued -= size;
+        }
+    }
+
+  /*
+   * If we're controlling another flow, turn it on again when our output
+   * buffer size becomes less than the low mark.
+   */
+  if (before >= QUEUE_PRESSURE && self->out_queued < QUEUE_PRESSURE)
+    cockpit_flow_emit_pressure (COCKPIT_FLOW (self), FALSE);
+
+  if (self->out_queue->head)
+    return TRUE;
+
+  g_debug ("%s: output queue empty", self->name);
+
+  /* If all messages are done, then stop polling out fd */
+  stop_output (self);
+
+  if (self->out_done)
+    {
+      g_debug ("%s: end of output", self->name);
+
+      /* And if closing, then we need to shutdown the output fd */
+      if (shutdown (self->fd, SHUT_WR) < 0)
+        close_with_errno (self, "couldn't shutdown fd", errno);
+    }
+
+  close_maybe (self);
+
+  return TRUE;
+}
+
+static void
+cockpit_packet_channel_recv (CockpitChannel *channel,
+                             GBytes *message)
+{
+  CockpitPacketChannel *self = COCKPIT_PACKET_CHANNEL (channel);
+  gsize before, size;
+
+  if (self->state >= CLOSED)
+    return;
+
+  size = g_bytes_get_size (message);
+  before = self->out_queued;
+  g_return_if_fail (G_MAXSIZE - size > self->out_queued);
+  self->out_queued += size;
+  g_queue_push_tail (self->out_queue, g_bytes_ref (message));
+
+  /*
+   * If we have too much data queued, and are controlling another flow
+   * tell it to stop sending data, each time we cross over the high bound.
+   */
+  if (before < QUEUE_PRESSURE && self->out_queued >= QUEUE_PRESSURE)
+    cockpit_flow_emit_pressure (COCKPIT_FLOW (self), TRUE);
+
+  if (!self->out_source && self->fd >= 0)
+    start_output (self);
+}
+
+static gboolean
+cockpit_packet_channel_control (CockpitChannel *channel,
+                                const gchar *command,
+                                JsonObject *message)
+{
+  CockpitPacketChannel *self = COCKPIT_PACKET_CHANNEL (channel);
+  gboolean ret = TRUE;
+  gint64 size = 0;
+
+  /* New set of options for channel */
+  if (g_str_equal (command, "options"))
+    {
+      if (!cockpit_json_get_int (message, "max-size", self->max_size, &size) ||
+          size < 1 || size > MAX_PACKET_SIZE)
+        {
+          cockpit_channel_fail (channel, "protocol-error",
+                                "invalid \"max-size\" option for channel");
+          goto out;
+        }
+
+      self->max_size = size;
+    }
+
+  /* Channel input from frontend is done */
+  else if (g_str_equal (command, "done"))
+    {
+      self->out_done = TRUE;
+      if (!self->out_source)
+        start_output (self);
+    }
+
+  else
+    {
+      ret = FALSE;
+    }
+
+out:
+  return ret;
+}
+
+static void
+cockpit_packet_channel_close (CockpitChannel *channel,
+                              const gchar *problem)
+{
+  CockpitPacketChannel *self = COCKPIT_PACKET_CHANNEL (channel);
+
+  if (self->state >= CLOSED)
+    return;
+
+  self->state = CLOSED;
+
+  if (self->in_source)
+    stop_input (self);
+  self->in_done = TRUE;
+  if (self->out_source)
+    stop_output (self);
+  self->out_done = TRUE;
+
+  if (self->fd != -1)
+    {
+      close (self->fd);
+      self->fd = -1;
+    }
+
+  COCKPIT_CHANNEL_CLASS (cockpit_packet_channel_parent_class)->close (channel, problem);
+}
+
+static void
+cockpit_packet_channel_init (CockpitPacketChannel *self)
+{
+  self->fd = -1;
+  self->state = CREATED;
+  self->max_size = DEF_PACKET_SIZE;
+  self->out_queue = g_queue_new ();
+  self->context = g_main_context_ref_thread_default ();
+}
+
+static int
+packet_channel_connect (CockpitPacketChannel *self,
+                        GSocketAddress *address)
+{
+  gsize native_len;
+  gpointer native;
+  int sock = -1;
+
+  g_return_val_if_fail (G_IS_SOCKET_ADDRESS (address), -1);
+
+  sock = socket (g_socket_address_get_family (address), SOCK_SEQPACKET, 0);
+  if (sock < 0)
+    {
+      close_with_errno (self, "couldn't open socket", errno);
+    }
+  else
+    {
+      if (!g_unix_set_fd_nonblocking (sock, TRUE, NULL))
+        {
+          close (sock);
+          g_return_val_if_reached (-1);
+        }
+
+      native_len = g_socket_address_get_native_size (address);
+      native = g_malloc (native_len);
+      if (!g_socket_address_to_native (address, native, native_len, NULL))
+        {
+          close (sock);
+          g_return_val_if_reached (-1);
+        }
+      if (connect (sock, native, native_len) < 0)
+        {
+          if (errno == EINPROGRESS)
+            {
+              self->state = CONNECTING;
+            }
+          else
+            {
+              close_with_errno (self, "couldn't connect", errno);
+              close (sock);
+              sock = -1;
+            }
+        }
+      else
+        {
+          self->state = RELAYING;
+        }
+      g_free (native);
+    }
+
+  return sock;
+}
+
+static void
+start_output (CockpitPacketChannel *self)
+{
+  g_assert (self->out_source == NULL);
+  self->out_source = cockpit_unix_fd_source_new (self->fd, G_IO_OUT);
+  g_source_set_name (self->out_source, "packet-output");
+  g_source_set_callback (self->out_source, (GSourceFunc)dispatch_output, self, NULL);
+  g_source_attach (self->out_source, self->context);
+}
+
+static void
+start_input (CockpitPacketChannel *self)
+{
+  g_assert (self->in_source == NULL);
+  self->in_source = cockpit_unix_fd_source_new (self->fd, G_IO_IN);
+  g_source_set_name (self->in_source, "packet-input");
+  g_source_set_callback (self->in_source, (GSourceFunc)dispatch_input, self, NULL);
+  g_source_attach (self->in_source, self->context);
+}
+
+static void
+on_throttle_pressure (GObject *object,
+                      gboolean throttle,
+                      gpointer user_data)
+{
+  CockpitPacketChannel *self = COCKPIT_PACKET_CHANNEL (user_data);
+  if (throttle)
+    {
+      if (self->in_source != NULL)
+        {
+          g_debug ("%s: applying back pressure in pipe", self->name);
+          stop_input (self);
+        }
+    }
+  else
+    {
+      if (self->in_source == NULL && !self->in_done)
+        {
+          g_debug ("%s: relieving back pressure in pipe", self->name);
+          start_input (self);
+        }
+    }
+}
+
+static void
+cockpit_packet_channel_throttle (CockpitFlow *flow,
+                                 CockpitFlow *controlling)
+{
+  CockpitPacketChannel *self = COCKPIT_PACKET_CHANNEL (flow);
+
+  if (self->pressure)
+    {
+      g_signal_handler_disconnect (self->pressure, self->pressure_sig);
+      g_object_remove_weak_pointer (G_OBJECT (self->pressure), (gpointer *)&self->pressure);
+      self->pressure = NULL;
+    }
+
+  if (controlling)
+    {
+      self->pressure = controlling;
+      g_object_add_weak_pointer (G_OBJECT (self->pressure), (gpointer *)&self->pressure);
+      self->pressure_sig = g_signal_connect (controlling, "pressure", G_CALLBACK (on_throttle_pressure), self);
+    }
+}
+
+static void
+cockpit_packet_channel_flow_iface (CockpitFlowIface *iface)
+{
+  iface->throttle = cockpit_packet_channel_throttle;
+}
+
+static void
+cockpit_packet_channel_prepare (CockpitChannel *channel)
+{
+  CockpitPacketChannel *self = COCKPIT_PACKET_CHANNEL (channel);
+  GSocketAddress *address;
+  JsonObject *options;
+  int sock;
+
+  COCKPIT_CHANNEL_CLASS (cockpit_packet_channel_parent_class)->prepare (channel);
+  options = cockpit_channel_get_options (channel);
+
+  /* Support our options in the open message too */
+  cockpit_packet_channel_control (channel, "options", options);
+  if (self->state >= CLOSED)
+    return;
+
+  address = cockpit_connect_parse_address (channel, &self->name);
+  if (!address)
+    {
+      cockpit_channel_close (channel, "internal-error");
+      return;
+    }
+
+  sock = packet_channel_connect (self, address);
+  g_object_unref (address);
+
+  if (sock < 0)
+    {
+      cockpit_channel_close (channel, "internal-error");
+      return;
+    }
+  else
+    {
+      self->fd = sock;
+      start_input (self);
+      start_output (self);
+    }
+
+  cockpit_channel_ready (channel, NULL);
+}
+
+static void
+cockpit_packet_channel_dispose (GObject *object)
+{
+  CockpitPacketChannel *self = COCKPIT_PACKET_CHANNEL (object);
+
+  cockpit_packet_channel_throttle (COCKPIT_FLOW (self), NULL);
+  g_assert (self->pressure == NULL);
+
+  if (self->state < CLOSED)
+    cockpit_channel_close (COCKPIT_CHANNEL (self), "terminated");
+
+  while (self->out_queue->head)
+    g_bytes_unref (g_queue_pop_head (self->out_queue));
+  self->out_queued = 0;
+
+  G_OBJECT_CLASS (cockpit_packet_channel_parent_class)->dispose (object);
+}
+
+static void
+cockpit_packet_channel_finalize (GObject *object)
+{
+  CockpitPacketChannel *self = COCKPIT_PACKET_CHANNEL (object);
+  g_assert (self->state == CLOSED);
+  g_assert (self->fd < 0);
+  g_assert (!self->in_source);
+  g_assert (!self->out_source);
+  g_queue_free (self->out_queue);
+  g_free (self->name);
+
+  if (self->context)
+    g_main_context_unref (self->context);
+
+  G_OBJECT_CLASS (cockpit_packet_channel_parent_class)->finalize (object);
+}
+
+static void
+cockpit_packet_channel_class_init (CockpitPacketChannelClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  CockpitChannelClass *channel_class = COCKPIT_CHANNEL_CLASS (klass);
+
+  gobject_class->dispose = cockpit_packet_channel_dispose;
+  gobject_class->finalize = cockpit_packet_channel_finalize;
+
+  channel_class->prepare = cockpit_packet_channel_prepare;
+  channel_class->control = cockpit_packet_channel_control;
+  channel_class->recv = cockpit_packet_channel_recv;
+  channel_class->close = cockpit_packet_channel_close;
+}
+
+/**
+ * cockpit_packet_channel_open:
+ * @transport: the transport to send/receive messages on
+ * @channel_id: the channel id
+ * @unix_path: the UNIX socket path to communicate with
+ *
+ * This function is mainly used by tests. The usual way
+ * to get a #CockpitPacketChannel is via cockpit_channel_open()
+ *
+ * Returns: (transfer full): the new channel
+ */
+CockpitChannel *
+cockpit_packet_channel_open (CockpitTransport *transport,
+                             const gchar *channel_id,
+                             const gchar *unix_path)
+{
+  CockpitChannel *channel;
+  JsonObject *options;
+
+  g_return_val_if_fail (channel_id != NULL, NULL);
+
+  options = json_object_new ();
+  json_object_set_string_member (options, "unix", unix_path);
+  json_object_set_string_member (options, "payload", "packet");
+
+  channel = g_object_new (COCKPIT_TYPE_PACKET_CHANNEL,
+                          "transport", transport,
+                          "id", channel_id,
+                          "options", options,
+                          NULL);
+
+  json_object_unref (options);
+  return channel;
+}

--- a/src/bridge/cockpitpacketchannel.h
+++ b/src/bridge/cockpitpacketchannel.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2014 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COCKPIT_PACKET_CHANNEL_H__
+#define COCKPIT_PACKET_CHANNEL_H__
+
+#include <gio/gio.h>
+
+#include "common/cockpitchannel.h"
+
+G_BEGIN_DECLS
+
+#define COCKPIT_TYPE_PACKET_CHANNEL                  (cockpit_packet_channel_get_type ())
+
+GType              cockpit_packet_channel_get_type   (void) G_GNUC_CONST;
+
+CockpitChannel *   cockpit_packet_channel_open       (CockpitTransport *transport,
+                                                      const gchar *channel_id,
+                                                      const gchar *unix_path);
+
+#endif /* COCKPIT_PACKET_CHANNEL_H__ */

--- a/src/bridge/test-packet-channel.c
+++ b/src/bridge/test-packet-channel.c
@@ -1,0 +1,645 @@
+
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitpacketchannel.h"
+
+#include "common/cockpitjson.h"
+#include "common/cockpittest.h"
+#include "common/mock-transport.h"
+
+#include <json-glib/json-glib.h>
+
+#include <glib/gstdio.h>
+#include <gio/gunixsocketaddress.h>
+
+#include <sys/socket.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+/* -----------------------------------------------------------------------------
+ * Test
+ */
+
+typedef struct {
+  GSocket *listen_sock;
+  GSource *listen_source;
+  guint listen_tag;
+  GSocket *conn_sock;
+  GSource *conn_source;
+  MockTransport *transport;
+  CockpitChannel *channel;
+  gchar *channel_problem;
+  gchar *unix_path;
+  gchar *temp_file;
+} TestCase;
+
+typedef struct {
+  const gchar *payload;
+  gboolean delay_listen;
+} Fixture;
+
+static gboolean
+on_socket_input (GSocket *socket,
+                 GIOCondition cond,
+                 gpointer user_data)
+{
+  gchar buffer[128 * 1024];
+  GError *error = NULL;
+  gssize ret, wret;
+
+  ret = g_socket_receive (socket, buffer, sizeof (buffer), NULL, &error);
+  g_assert_no_error (error);
+
+  if (ret == 0)
+    {
+      g_socket_shutdown (socket, FALSE, TRUE, &error);
+      g_assert_no_error (error);
+      return FALSE;
+    }
+
+  g_assert (ret > 0);
+  wret = g_socket_send (socket, buffer, ret, NULL, &error);
+  g_assert_no_error (error);
+  g_assert (wret == ret);
+  return TRUE;
+}
+
+static gboolean
+on_socket_connection (GSocket *socket,
+                      GIOCondition cond,
+                      gpointer user_data)
+{
+  TestCase *tc = user_data;
+  GError *error = NULL;
+
+  g_assert (tc->conn_source == NULL);
+  tc->conn_sock = g_socket_accept (tc->listen_sock, NULL, &error);
+  g_assert_no_error (error);
+
+  tc->conn_source = g_socket_create_source (tc->conn_sock, G_IO_IN, NULL);
+  g_source_set_callback (tc->conn_source, (GSourceFunc)on_socket_input, tc, NULL);
+  g_source_attach (tc->conn_source, NULL);
+
+  /* Only one connection */
+  return FALSE;
+}
+
+static void
+setup (TestCase *tc,
+       gconstpointer data)
+{
+  const Fixture *fixture = data;
+  GSocketAddress *address;
+  GError *error = NULL;
+
+  tc->temp_file = g_strdup ("/tmp/cockpit-test-XXXXXX");
+  g_assert (close (g_mkstemp (tc->temp_file)) == 0);
+  tc->unix_path = g_strconcat (tc->temp_file, ".sock", NULL);
+
+  address = g_unix_socket_address_new (tc->unix_path);
+
+  tc->listen_sock = g_socket_new (G_SOCKET_FAMILY_UNIX, G_SOCKET_TYPE_SEQPACKET,
+                                  G_SOCKET_PROTOCOL_DEFAULT, &error);
+  g_assert_no_error (error);
+
+  g_socket_bind (tc->listen_sock, address, TRUE, &error);
+  g_assert_no_error (error);
+
+  g_socket_listen (tc->listen_sock, &error);
+  g_assert_no_error (error);
+
+  tc->listen_source = g_socket_create_source (tc->listen_sock, G_IO_IN, NULL);
+  g_source_set_callback (tc->listen_source, (GSourceFunc)on_socket_connection, tc, NULL);
+
+  if (!fixture || !fixture->delay_listen)
+    g_source_attach (tc->listen_source, NULL);
+
+  g_object_unref (address);
+
+  tc->transport = g_object_new (mock_transport_get_type (), NULL);
+}
+
+static void
+on_closed_get_problem (CockpitChannel *channel,
+                       const gchar *problem,
+                       gpointer user_data)
+{
+  gchar **retval = user_data;
+  g_assert (retval != NULL && *retval == NULL);
+  *retval = g_strdup (problem ? problem : "");
+}
+
+static void
+setup_channel (TestCase *tc,
+               gconstpointer data)
+{
+  setup (tc, data);
+
+  tc->channel = cockpit_packet_channel_open (COCKPIT_TRANSPORT (tc->transport), "548", tc->unix_path);
+  g_signal_connect (tc->channel, "closed", G_CALLBACK (on_closed_get_problem), &tc->channel_problem);
+}
+
+static void
+teardown (TestCase *tc,
+          gconstpointer data)
+{
+  if (tc->conn_source)
+    {
+      g_source_destroy (tc->conn_source);
+      g_source_unref (tc->conn_source);
+    }
+  if (tc->listen_source)
+    {
+      g_source_destroy (tc->listen_source);
+      g_source_unref (tc->listen_source);
+    }
+  g_clear_object (&tc->listen_sock);
+  g_clear_object (&tc->conn_sock);
+
+  g_unlink (tc->unix_path);
+  g_free (tc->unix_path);
+  g_unlink (tc->temp_file);
+  g_free (tc->temp_file);
+
+  g_object_unref (tc->transport);
+
+  if (tc->channel)
+    {
+      g_object_add_weak_pointer (G_OBJECT (tc->channel), (gpointer *)&tc->channel);
+      g_object_unref (tc->channel);
+      g_assert (tc->channel == NULL);
+    }
+
+  g_free (tc->channel_problem);
+
+  cockpit_assert_expected ();
+}
+
+static void
+expect_control_message (JsonObject *options,
+                        const gchar *command,
+                        const gchar *expected_channel,
+                        ...) G_GNUC_NULL_TERMINATED;
+
+static void
+expect_control_message (JsonObject *options,
+                        const gchar *expected_command,
+                        const gchar *expected_channel,
+                        ...)
+{
+  const gchar *expect_option;
+  const gchar *expect_value;
+  const gchar *value;
+  JsonNode *node;
+  va_list va;
+
+  g_assert (options != NULL);
+  g_assert_cmpstr (json_object_get_string_member (options, "command"), ==, expected_command);
+  g_assert_cmpstr (json_object_get_string_member (options, "channel"), ==, expected_channel);
+
+  va_start (va, expected_channel);
+  for (;;) {
+      expect_option = va_arg (va, const gchar *);
+      if (!expect_option)
+        break;
+      expect_value = va_arg (va, const gchar *);
+
+      value = NULL;
+      node = json_object_get_member (options, expect_option);
+      if (node && JSON_NODE_HOLDS_VALUE (node) && json_node_get_value_type (node) == G_TYPE_STRING)
+        value = json_node_get_string (node);
+
+      g_assert_cmpstr (value, ==, expect_value);
+  }
+  va_end (va);
+}
+
+
+static void
+test_echo (TestCase *tc,
+           gconstpointer unused)
+{
+  GBytes *payload;
+  GBytes *sent;
+
+  payload = g_bytes_new ("Marmalaade!", 11);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "548", payload);
+  g_bytes_unref (payload);
+
+  while (mock_transport_count_sent (tc->transport) < 2)
+    g_main_context_iteration (NULL, TRUE);
+
+  sent = mock_transport_pop_channel (tc->transport, "548");
+  cockpit_assert_bytes_eq (sent, "Marmalaade!", 11);
+}
+
+static void
+test_large (TestCase *tc,
+           gconstpointer unused)
+{
+  JsonObject *object;
+  GBytes *sent;
+  GBytes *options;
+  GBytes *a, *b, *c;
+  gchar *big;
+  gchar *too_big;
+  gchar *maximum;
+
+  /* Send something big: Should make it through */
+  big = g_strnfill (32 * 1024, 'a');
+  a = g_bytes_new_take (big, strlen (big));
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "548", a);
+
+  /* Send something too big: Should be truncated */
+  too_big = g_strnfill (80 * 1024, 'b');
+  b = g_bytes_new_take (too_big, strlen (too_big));
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "548", b);
+
+  while (mock_transport_count_sent (tc->transport) < 3)
+    g_main_context_iteration (NULL, TRUE);
+
+  /* Set the max-size to massive */
+  object = cockpit_transport_build_json ("channel", "548", "command", "options", NULL);
+  json_object_set_int_member (object, "max-size", 128 * 1024);
+  options = cockpit_json_write_bytes (object);
+  json_object_unref (object);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), NULL, options);
+
+  /* Send something too big again: This time not truncated */
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "548", b);
+
+  /* Lastly send the full maximum */
+  maximum = g_strnfill (128 * 1024, 'c');
+  c = g_bytes_new_take (maximum, strlen (maximum));
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "548", c);
+
+  while (mock_transport_count_sent (tc->transport) < 5)
+    g_main_context_iteration (NULL, TRUE);
+
+  sent = mock_transport_pop_channel (tc->transport, "548");
+  cockpit_assert_bytes_eq (sent, big, strlen (big));
+
+  sent = mock_transport_pop_channel (tc->transport, "548");
+  cockpit_assert_bytes_eq (sent, too_big, 64 * 1024); /* Truncated */
+
+  sent = mock_transport_pop_channel (tc->transport, "548");
+  cockpit_assert_bytes_eq (sent, too_big, strlen (too_big));
+
+  sent = mock_transport_pop_channel (tc->transport, "548");
+  cockpit_assert_bytes_eq (sent, maximum, strlen (maximum));
+
+  g_bytes_unref (a);
+  g_bytes_unref (b);
+  g_bytes_unref (c);
+  g_bytes_unref (options);
+}
+
+static const Fixture fixture_connect_in_progress = { .delay_listen = TRUE };
+
+static gboolean
+on_idle_listen (gpointer data)
+{
+  TestCase *tc = data;
+  g_source_attach (tc->listen_source, NULL);
+  return FALSE;
+}
+
+static void
+test_connect_in_progress (TestCase *tc,
+                          gconstpointer unused)
+{
+  GBytes *payload;
+  GBytes *sent;
+
+  payload = g_bytes_new ("Marmalaade!", 11);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "548", payload);
+  g_bytes_unref (payload);
+
+  /* Attach listen source when idle */
+  g_idle_add (on_idle_listen, tc);
+
+  while (mock_transport_count_sent (tc->transport) < 2)
+    g_main_context_iteration (NULL, TRUE);
+
+  sent = mock_transport_pop_channel (tc->transport, "548");
+  cockpit_assert_bytes_eq (sent, "Marmalaade!", 11);
+}
+
+
+static void
+test_shutdown (TestCase *tc,
+               gconstpointer unused)
+{
+  GBytes *payload;
+  GError *error = NULL;
+  JsonObject *sent;
+
+  payload = cockpit_transport_build_control ("channel", "548", "command", "done", NULL);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), NULL, payload);
+  g_bytes_unref (payload);
+
+  /* Wait until the socket has opened */
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /*
+   * Close down the write end of the socket (what
+   * CockpitPacketChannel is reading from)
+   */
+  g_socket_shutdown (tc->conn_sock, FALSE, TRUE, &error);
+  g_assert_no_error (error);
+
+  while (tc->channel_problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert_cmpstr (tc->channel_problem, ==, "");
+  sent = mock_transport_pop_control (tc->transport);
+  expect_control_message (sent, "ready", "548", NULL);
+  sent = mock_transport_pop_control (tc->transport);
+  expect_control_message (sent, "done", "548", NULL);
+
+  sent = mock_transport_pop_control (tc->transport);
+  expect_control_message (sent, "close", "548", "problem", NULL, NULL);
+}
+
+static void
+test_close_normal (TestCase *tc,
+                   gconstpointer unused)
+{
+  GBytes *payload;
+  GBytes *sent;
+  JsonObject *control;
+
+  /* Wait until the socket has opened */
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  payload = g_bytes_new ("Marmalaade!", 11);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "548", payload);
+  cockpit_channel_close (tc->channel, NULL);
+  g_bytes_unref (payload);
+
+  /* Wait until channel closes */
+  while (tc->channel_problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /* Shouldn't have had a chance to send message */
+  g_assert_cmpstr (tc->channel_problem, ==, "");
+  sent = mock_transport_pop_channel (tc->transport, "548");
+  g_assert (sent == NULL);
+
+  control = mock_transport_pop_control (tc->transport);
+  expect_control_message (control, "ready", "548", NULL);
+
+  control = mock_transport_pop_control (tc->transport);
+  expect_control_message (control, "close", "548", "problem", NULL, NULL);
+}
+
+static void
+test_close_problem (TestCase *tc,
+                    gconstpointer unused)
+{
+  GBytes *sent;
+
+  /* Wait until the socket has opened */
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  sent = g_bytes_new ("Marmalaade!", 11);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "548", sent);
+  g_bytes_unref (sent);
+  cockpit_channel_close (tc->channel, "boooyah");
+
+  /* Wait until channel closes */
+  while (tc->channel_problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  /* Should have sent no payload and control */
+  g_assert_cmpstr (tc->channel_problem, ==, "boooyah");
+  g_assert (mock_transport_pop_channel (tc->transport, "548") == NULL);
+  expect_control_message (mock_transport_pop_control (tc->transport), "ready", "548", NULL);
+  expect_control_message (mock_transport_pop_control (tc->transport),
+                          "close", "548", "problem", "boooyah", NULL);
+}
+
+static void
+test_recv_invalid (TestCase *tc,
+                   gconstpointer unused)
+{
+  GError *error = NULL;
+  GBytes *converted;
+
+  /* Wait until the socket has opened */
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert_cmpint (g_socket_send (tc->conn_sock, "\x00Marmalaade!\x00", 13, NULL, &error), ==, 13);
+  g_assert_no_error (error);
+
+  while (mock_transport_count_sent (tc->transport) < 2)
+    g_main_context_iteration (NULL, TRUE);
+
+  converted = g_bytes_new ("\xef\xbf\xbd""Marmalaade!""\xef\xbf\xbd", 17);
+  g_assert (g_bytes_equal (converted, mock_transport_pop_channel (tc->transport, "548")));
+  g_bytes_unref (converted);
+}
+
+
+static gboolean
+add_remainder (gpointer user_data)
+{
+  GSocket *socket = user_data;
+  GError *error = NULL;
+  g_assert_cmpint (g_socket_send (socket, "\x94\x80", 2, NULL, &error), ==, 2);
+  g_assert_no_error (error);
+  return FALSE;
+}
+
+static void
+print_gbytes (GBytes *bytes)
+{
+    gsize i, len;
+    const char* data;
+
+    data = g_bytes_get_data (bytes, &len);
+    g_assert (data);
+    for (i = 0; i < len; ++i)
+      g_printf ("%X", data[i]);
+    puts("");
+}
+
+static void
+test_send_invalid (TestCase *tc,
+                   gconstpointer unused)
+{
+  GBytes *converted;
+  GBytes *sent;
+
+  sent = g_bytes_new ("Oh \x00Marma\x00laade!", 16);
+  cockpit_transport_emit_recv (COCKPIT_TRANSPORT (tc->transport), "548", sent);
+  g_bytes_unref (sent);
+
+  while (mock_transport_count_sent (tc->transport) < 2)
+    g_main_context_iteration (NULL, TRUE);
+
+  converted = g_bytes_new ("Oh \xef\xbf\xbd""Marma""\xef\xbf\xbd""laade!", 20);
+  g_assert (g_bytes_equal (converted, mock_transport_pop_channel (tc->transport, "548")));
+  g_bytes_unref (converted);
+}
+
+static void
+test_recv_valid_batched (TestCase *tc,
+                         gconstpointer unused)
+{
+  GError *error = NULL;
+  GBytes *converted;
+  GBytes *received;
+
+  /* Wait until the socket has opened */
+  while (tc->conn_sock == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert_cmpint (g_socket_send (tc->conn_sock, "Marmalaade!\xe2", 12, NULL, &error), ==, 12);
+  g_assert_no_error (error);
+
+  g_timeout_add (100, add_remainder, tc->conn_sock);
+
+  while (mock_transport_count_sent (tc->transport) < 2)
+    g_main_context_iteration (NULL, TRUE);
+
+  converted = g_bytes_new ("Marmalaade!\xe2\x94\x80", 14);
+  received = mock_transport_combine_output (tc->transport, "548", NULL);
+  if (!g_bytes_equal (converted, received))
+    {
+      g_test_fail ();
+      puts ("ERROR: unexpected output\nconverted:");
+      print_gbytes (converted);
+      puts ("received:");
+      print_gbytes (received);
+    }
+  g_bytes_unref (converted);
+  g_bytes_unref (received);
+}
+
+static void
+test_fail_not_found (void)
+{
+  CockpitTransport *transport;
+  CockpitChannel *channel;
+  gchar *problem = NULL;
+
+  cockpit_expect_message ("*couldn't connect*");
+
+  transport = g_object_new (mock_transport_get_type (), NULL);
+  channel = cockpit_packet_channel_open (transport, "1", "/non-existent");
+  g_assert (channel != NULL);
+
+  /* Even through failure is on open, should not have closed yet */
+  g_signal_connect (channel, "closed", G_CALLBACK (on_closed_get_problem), &problem);
+
+  while (problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert_cmpstr (problem, ==, "not-found");
+  g_free (problem);
+  g_object_unref (channel);
+  g_object_unref (transport);
+
+  cockpit_assert_expected ();
+}
+
+static void
+test_fail_access_denied (void)
+{
+  CockpitTransport *transport;
+  CockpitChannel *channel;
+  gchar *unix_path;
+  gchar *problem = NULL;
+  gint fd;
+
+  if (geteuid () == 0)
+    {
+      cockpit_test_skip ("running as root");
+      return;
+    }
+
+  cockpit_expect_message ("*couldn't connect*");
+
+  unix_path = g_strdup ("/tmp/cockpit-test-XXXXXX.sock");
+  fd = g_mkstemp (unix_path);
+  g_assert_cmpint (fd, >=, 0);
+
+  /* Take away all permissions from the file */
+  g_assert_cmpint (fchmod (fd, 0000), ==, 0);
+
+  transport = g_object_new (mock_transport_get_type (), NULL);
+  channel = cockpit_packet_channel_open (transport, "1", unix_path);
+  g_assert (channel != NULL);
+
+  /* Even through failure is on open, should not have closed yet */
+  g_signal_connect (channel, "closed", G_CALLBACK (on_closed_get_problem), &problem);
+
+  while (problem == NULL)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_assert_cmpstr (problem, ==, "access-denied");
+  g_free (problem);
+  g_free (unix_path);
+  close (fd);
+  g_object_unref (channel);
+  g_object_unref (transport);
+
+  cockpit_assert_expected ();
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  g_test_add ("/packet-channel/echo", TestCase, NULL,
+              setup_channel, test_echo, teardown);
+  g_test_add ("/packet-channel/large", TestCase, NULL,
+              setup_channel, test_large, teardown);
+  g_test_add ("/packet-channel/connect-in-progress",
+              TestCase, &fixture_connect_in_progress,
+              setup_channel, test_connect_in_progress, teardown);
+  g_test_add ("/packet-channel/shutdown", TestCase, NULL,
+              setup_channel, test_shutdown, teardown);
+  g_test_add ("/packet-channel/close-normal", TestCase, NULL,
+              setup_channel, test_close_normal, teardown);
+  g_test_add ("/packet-channel/close-problem", TestCase, NULL,
+              setup_channel, test_close_problem, teardown);
+  g_test_add ("/packet-channel/invalid-send", TestCase, NULL,
+              setup_channel, test_send_invalid, teardown);
+  g_test_add ("/packet-channel/invalid-recv", TestCase, NULL,
+              setup_channel, test_recv_invalid, teardown);
+  g_test_add ("/packet-channel/valid-recv-batched", TestCase, NULL,
+              setup_channel, test_recv_valid_batched, teardown);
+
+  g_test_add_func ("/packet-channel/fail/not-found", test_fail_not_found);
+  g_test_add_func ("/packet-channel/fail/access-denied", test_fail_access_denied);
+
+  return g_test_run ();
+}

--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -60,6 +60,8 @@
  *    when its output queue is too large
  */
 
+#define DEF_PACKET_SIZE  (64UL * 1024UL)
+
 enum {
   PROP_0,
   PROP_NAME,
@@ -310,9 +312,9 @@ dispatch_input (gint fd,
    */
   if (cond != G_IO_HUP)
     {
-      g_byte_array_set_size (self->priv->in_buffer, len + MAX_PACKET_SIZE);
+      g_byte_array_set_size (self->priv->in_buffer, len + DEF_PACKET_SIZE);
       g_debug ("%s: reading input %x", self->priv->name, cond);
-      ret = read (self->priv->in_fd, self->priv->in_buffer->data + len, MAX_PACKET_SIZE);
+      ret = read (self->priv->in_fd, self->priv->in_buffer->data + len, DEF_PACKET_SIZE);
 
       errn = errno;
       if (ret < 0)


### PR DESCRIPTION
This is for SeqPacket Unix sockets and SCTP connections.
It relays messages with the same framing as sent over
the connections. There is a maximum size above which the
messages are truncated.