### PR TITLE
common: Return correct value in async connection

### DIFF
--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -509,7 +509,7 @@ dispatch_connect (CockpitPipe *self)
       return TRUE;
     }
 
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean


### PR DESCRIPTION
When asynchronously connecting and evaluating the
result (via getsockopt) make sure to try again
if the initial read doesn't work. By returning FALSE
here the caller will not process this as an
actual readable socket.

This is split out from #11872

I could not find a way to test this since on AF_UNIX or local connections it seems that connect() is hard to make fail during an async connection.