### PR TITLE
Add another option for determining where to store images

### DIFF
--- a/bots/image-create
+++ b/bots/image-create
@@ -59,11 +59,7 @@ class MachineBuilder:
         tempdir = testvm.get_temp_dir()
         self.machine = machine
 
-        try:
-            os.makedirs(tempdir, 0o750)
-        except OSError as ex:
-            if ex.errno != errno.EEXIST:
-                raise
+        os.makedirs(tempdir, 0o750, exist_ok=True)
 
         # Use a tmp filename
         self.target_file = self.machine.image_file
@@ -73,8 +69,7 @@ class MachineBuilder:
     def bootstrap_system(self):
         assert not self.machine._domain
 
-        if not os.path.exists(self.machine.run_dir):
-            os.makedirs(self.machine.run_dir, 0o750)
+        os.makedirs(self.machine.run_dir, 0o750, exist_ok=True)
 
         bootstrap_script = os.path.join(testvm.SCRIPTS_DIR, "%s.bootstrap" % (self.machine.image, ))
 
@@ -170,8 +165,7 @@ class MachineBuilder:
     def save(self):
         data_dir = testvm.get_images_data_dir()
 
-        if not os.path.exists(data_dir):
-            os.makedirs(data_dir, 0o750)
+        os.makedirs(data_dir, 0o750, exist_ok=True)
 
         if not os.path.exists(self.machine.image_file):
             raise testvm.Failure("Nothing to save.")

--- a/bots/image-create
+++ b/bots/image-create
@@ -33,7 +33,6 @@ import tempfile
 
 BOTS = os.path.abspath(os.path.dirname(__file__))
 BASE = os.path.normpath(os.path.join(BOTS, ".."))
-TEMP = os.path.join(os.environ.get("TEST_DATA", BASE), "tmp")
 
 from machine import testvm
 
@@ -57,17 +56,18 @@ if args.image in ["candlepin", "continuous-atomic", "fedora-atomic", "ipa", "rhe
 
 class MachineBuilder:
     def __init__(self, machine):
+        tempdir = testvm.get_temp_dir()
         self.machine = machine
 
         try:
-            os.makedirs(TEMP, 0o750)
+            os.makedirs(tempdir, 0o750)
         except OSError as ex:
             if ex.errno != errno.EEXIST:
                 raise
 
         # Use a tmp filename
         self.target_file = self.machine.image_file
-        fp, self.machine.image_file = tempfile.mkstemp(dir=TEMP, prefix=self.machine.image, suffix=".qcow2")
+        fp, self.machine.image_file = tempfile.mkstemp(dir=tempdir, prefix=self.machine.image, suffix=".qcow2")
         os.close(fp)
 
     def bootstrap_system(self):

--- a/bots/image-create
+++ b/bots/image-create
@@ -76,7 +76,7 @@ class MachineBuilder:
         if not os.path.exists(self.machine.run_dir):
             os.makedirs(self.machine.run_dir, 0o750)
 
-        bootstrap_script = os.path.join(BOTS, "images", "scripts", "%s.bootstrap" % (self.machine.image, ))
+        bootstrap_script = os.path.join(testvm.SCRIPTS_DIR, "%s.bootstrap" % (self.machine.image, ))
 
 
         if os.path.isfile(bootstrap_script):
@@ -89,11 +89,11 @@ class MachineBuilder:
         self.machine.start()
         try:
             self.machine.wait_boot(timeout_sec=120)
-            self.machine.upload([ os.path.join(BOTS, "images", "scripts", "lib") ], "/var/lib/testvm")
+            self.machine.upload([ os.path.join(testvm.SCRIPTS_DIR, "lib") ], "/var/lib/testvm")
             self.machine.upload([script], "/var/tmp/SETUP")
             if source:
                 self.machine.upload([source], "/var/tmp")
-            self.machine.upload([ os.path.join(BOTS, "images", "scripts", "lib", "base") ],
+            self.machine.upload([ os.path.join(testvm.SCRIPTS_DIR, "lib", "base") ],
                                 "/var/tmp/cockpit-base")
 
             if "rhel" in self.machine.image:
@@ -139,7 +139,7 @@ class MachineBuilder:
         self.bootstrap_system()
 
         # gather the scripts, separated by reboots
-        script = os.path.join(BOTS, "images", "scripts", "%s.setup" % (self.machine.image, ))
+        script = os.path.join(testvm.SCRIPTS_DIR, "%s.setup" % (self.machine.image, ))
 
         if not os.path.exists(script):
             return
@@ -168,8 +168,7 @@ class MachineBuilder:
             raise testvm.Failure("Unable to verify that machine boot works.")
 
     def save(self):
-        data_dir = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
-        images_dir = os.path.join(BOTS, "images")
+        data_dir = testvm.get_images_data_dir()
 
         if not os.path.exists(data_dir):
             os.makedirs(data_dir, 0o750)
@@ -199,8 +198,8 @@ class MachineBuilder:
             os.unlink(self.target_file)
         os.symlink(name, self.target_file)
 
-        # Handle alternate TEST_DATA
-        image_file = os.path.join(images_dir, name)
+        # Handle alternate images data directory
+        image_file = os.path.join(testvm.IMAGES_DIR, name)
         if not os.path.exists(image_file):
             os.symlink(os.path.abspath(data_file), image_file)
 

--- a/bots/image-customize
+++ b/bots/image-customize
@@ -57,7 +57,7 @@ args.base_image = testvm.get_test_image(args.base_image)
 # Create the necessary layered image for the build/install
 def prepare_install_image(base_image, install_image):
     if "/" not in base_image:
-        base_image = os.path.join(BOTS, "images", base_image)
+        base_image = os.path.join(testvm.IMAGES_DIR, base_image)
     if "/" not in install_image:
         install_image = os.path.join(os.path.join(TEST, "images"), os.path.basename(install_image))
 

--- a/bots/image-customize
+++ b/bots/image-customize
@@ -64,8 +64,7 @@ def prepare_install_image(base_image, install_image):
     # In vm-customize we don't force recreate images
     if not os.path.exists(install_image):
         install_image_dir = os.path.dirname(install_image)
-        if not os.path.exists(install_image_dir):
-            os.makedirs(install_image_dir)
+        os.makedirs(install_image_dir, exist_ok=True)
         base_image = os.path.realpath(base_image)
         qcow2_image = "{0}.qcow2".format(install_image)
         subprocess.check_call([ "qemu-img", "create", "-q", "-f", "qcow2",

--- a/bots/image-download
+++ b/bots/image-download
@@ -56,15 +56,13 @@ DEFAULT = [
 ]
 
 BOTS = os.path.dirname(os.path.realpath(__file__))
-IMAGES = os.path.join(BOTS, "..", "bots", "images")
-DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
 
 DEVNULL = open("/dev/null", "r+")
 EPOCH = "Thu, 1 Jan 1970 00:00:00 GMT"
 
 def find(name, stores, latest, quiet):
     found = [ ]
-    ca = os.path.join(BOTS, "images", "files", "ca.pem")
+    ca = os.path.join(testvm.IMAGES_DIR, "files", "ca.pem")
 
     for store in stores:
         url = urllib.parse.urlparse(store)
@@ -196,12 +194,13 @@ def download(dest, force, state, quiet, stores):
 
 # Calculate a place to put images where links are not committed in git
 def state_target(path):
-    os.makedirs(DATA, mode=0o775, exist_ok=True)
-    return os.path.join(DATA, path)
+    data_dir = testvm.get_images_data_dir()
+    os.makedirs(data_dir, mode=0o775, exist_ok=True)
+    return os.path.join(data_dir, path)
 
 # Calculate a place to put images where links are committed in git
 def committed_target(image):
-    link = os.path.join(IMAGES, image)
+    link = os.path.join(testvm.IMAGES_DIR, image)
     if not os.path.islink(link):
         raise RuntimeError("image link does not exist: " + image)
 
@@ -214,17 +213,17 @@ def committed_target(image):
         relative_dir = os.path.dirname(os.path.abspath(link))
         full_dest = os.path.join(relative_dir, dest)
 
-    dest = os.path.join(DATA, dest)
+    dest = os.path.join(testvm.get_images_data_dir(), dest)
 
     # We have the file but there is not valid link
     if os.path.exists(dest):
         try:
-            os.symlink(dest, os.path.join(IMAGES, os.readlink(link)))
+            os.symlink(dest, os.path.join(testvm.IMAGES_DIR, os.readlink(link)))
         except FileExistsError:
             pass
 
     # The image file in the images directory, may be same as dest
-    image_file = os.path.join(IMAGES, os.readlink(link))
+    image_file = os.path.join(testvm.IMAGES_DIR, os.readlink(link))
 
     # Double check that symlink in place but never make a cycle.
     if os.path.abspath(dest) != os.path.abspath(image_file):
@@ -253,8 +252,9 @@ def wait_lock(target):
         raise TimeoutError("timed out waiting for concurrent downloads of %s\n" % target)
 
 def download_images(image_list, force, quiet, state, store):
-    if not os.path.exists(DATA):
-        os.makedirs(DATA)
+    data_dir = testvm.get_images_data_dir()
+    if not os.path.exists(data_dir):
+        os.makedirs(data_dir)
 
     # A default set of images are all links in git.  These links have
     # no directory part.  Other links might exist, such as the
@@ -263,8 +263,8 @@ def download_images(image_list, force, quiet, state, store):
     if not image_list:
         image_list = []
         if not state:
-            for filename in os.listdir(IMAGES):
-                link = os.path.join(IMAGES, filename)
+            for filename in os.listdir(testvm.IMAGES_DIR):
+                link = os.path.join(testvm.IMAGES_DIR, filename)
                 if os.path.islink(link) and os.path.dirname(os.readlink(link)) == "":
                     image_list.append(filename)
 

--- a/bots/image-download
+++ b/bots/image-download
@@ -253,8 +253,7 @@ def wait_lock(target):
 
 def download_images(image_list, force, quiet, state, store):
     data_dir = testvm.get_images_data_dir()
-    if not os.path.exists(data_dir):
-        os.makedirs(data_dir)
+    os.makedirs(data_dir, exist_ok=True)
 
     # A default set of images are all links in git.  These links have
     # no directory part.  Other links might exist, such as the

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -66,8 +66,8 @@ def main():
         sys.stderr.write("image-prepare: use of --install-only with --build-only is incompatible\n")
         return 2
 
-    # Default to putting build output in the TEST_DATA directory
-    results = os.path.join(os.environ.get("TEST_DATA", BASE), "tmp", "build-results")
+    # Default to putting build output in the tmp/build-results directory
+    results = os.path.join(testvm.get_temp_dir(), "build-results")
 
     # Make sure any images are downloaded
     try:

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -96,14 +96,14 @@ def main():
 
 def upload_scripts(machine, args):
     machine.execute("rm -rf /var/lib/testvm")
-    machine.upload([ os.path.join(BOTS, "images", "scripts", "lib") ], "/var/lib/testvm")
-    machine.upload([ os.path.join(BOTS, "images", "scripts", "%s.install" % machine.image) ], "/var/tmp")
+    machine.upload([ os.path.join(testvm.SCRIPTS_DIR, "lib") ], "/var/lib/testvm")
+    machine.upload([ os.path.join(testvm.SCRIPTS_DIR, "%s.install" % machine.image) ], "/var/tmp")
     machine.upload([ os.path.join(BASE, "containers") ], "/var/tmp")
 
 # Create the necessary layered image for the build/install
 def prepare_install_image(base_image):
     if "/" not in base_image:
-        base_image = os.path.join(BOTS, "images", base_image)
+        base_image = os.path.join(testvm.IMAGES_DIR, base_image)
     test_images = os.path.join(TEST, "images")
     if not os.path.exists(test_images):
         os.makedirs(test_images)

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -105,8 +105,7 @@ def prepare_install_image(base_image):
     if "/" not in base_image:
         base_image = os.path.join(testvm.IMAGES_DIR, base_image)
     test_images = os.path.join(TEST, "images")
-    if not os.path.exists(test_images):
-        os.makedirs(test_images)
+    os.makedirs(test_images, exist_ok=True)
     install_image = os.path.join(test_images, os.path.basename(base_image))
     base_image = os.path.realpath(testvm.get_test_image(base_image))
     qcow2_image = "{0}.qcow2".format(install_image)

--- a/bots/image-prune
+++ b/bots/image-prune
@@ -31,9 +31,9 @@ from contextlib import contextmanager
 
 from task import github
 
+from machine import testvm
+
 BOTS = os.path.dirname(os.path.realpath(__file__))
-IMAGES = os.path.join(BOTS, "..", "bots", "images")
-DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
 
 # threshold in G below which unreferenced qcow2 images will be pruned, even if they aren't old
 PRUNE_THRESHOLD_G = float(os.environ.get("PRUNE_THRESHOLD_G", 15))
@@ -134,8 +134,8 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
         targets = get_image_names(quiet, open_pull_requests, offline)
 
     # what we have in the current checkout might already have been added by its branch, but check anyway
-    for filename in os.listdir(IMAGES):
-        path = os.path.join(IMAGES, filename)
+    for filename in os.listdir(testvm.IMAGES_DIR):
+        path = os.path.join(testvm.IMAGES_DIR, filename)
 
         # only consider original image entries as trustworthy sources and ignore non-links
         if path.endswith(".qcow2") or path.endswith(".partial") or not os.path.islink(path):
@@ -143,7 +143,7 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
 
         target = os.readlink(path)
         if not os.path.isabs(target):
-            targets.add(os.path.join(IMAGES, target))
+            targets.add(os.path.join(testvm.IMAGES_DIR, target))
             targets.add(os.path.join(DATA, target))
         else:
             targets.add(target)
@@ -160,8 +160,8 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
                 os.unlink(path)
 
     # now prune broken links
-    for filename in os.listdir(IMAGES):
-        path = os.path.join(IMAGES, filename)
+    for filename in os.listdir(testvm.IMAGES_DIR):
+        path = os.path.join(testvm.IMAGES_DIR, filename)
 
         # don't prune original image entries and ignore non-links
         if not path.endswith(".qcow2") or not os.path.islink(path):
@@ -176,8 +176,8 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
 
 def every_image():
     result = []
-    for filename in os.listdir(IMAGES):
-        link = os.path.join(IMAGES, filename)
+    for filename in os.listdir(testvm.IMAGES_DIR):
+        link = os.path.join(testvm.IMAGES_DIR, filename)
         if os.path.islink(link):
             result.append(filename)
     return result

--- a/bots/image-upload
+++ b/bots/image-upload
@@ -35,9 +35,9 @@ import subprocess
 import sys
 import urllib.parse
 
+from machine import testvm
+
 BOTS = os.path.dirname(__file__)
-IMAGES = os.path.join(BOTS, "images")
-DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
 
 def upload(store, source):
     ca = os.path.join(BOTS, "images", "files", "ca.pem")
@@ -93,15 +93,16 @@ def main():
     parser.add_argument('image', nargs='*')
     args = parser.parse_args()
 
+    data_dir = testvm.get_images_data_dir()
     sources = []
     for image in args.image:
         if args.state:
-            source = os.path.join(DATA, image)
+            source = os.path.join(data_dir, image)
         else:
-            link = os.path.join(IMAGES, image)
+            link = os.path.join(testvm.IMAGES_DIR, image)
             if not os.path.islink(link):
                 parser.error("image link does not exist: " + image)
-            source = os.path.join(DATA, os.readlink(link))
+            source = os.path.join(data_dir, os.readlink(link))
         if not os.path.isfile(source):
             parser.error("image does not exist: " + image)
         sources.append(source)

--- a/bots/images/scripts/atomic.bootstrap
+++ b/bots/images/scripts/atomic.bootstrap
@@ -20,8 +20,8 @@
 
 set -ex
 
-out=$1
-base=$2
+out="$1"
+base="$2"
 
 redirect_base=$(curl -s -w "%{redirect_url}" "$base" -o /dev/null)
 if [ -n "$redirect_base" ]; then
@@ -29,7 +29,7 @@ if [ -n "$redirect_base" ]; then
 fi
 
 # Lookup the newest base image recursively
-url=$base
+url="$base"
 while [ $# -gt 2 ]; do
     fragment="$3"
 
@@ -37,8 +37,8 @@ while [ $# -gt 2 ]; do
 	    backref="$4"
 	    pattern="$5"
 
-	    result=`wget -q -O- $url | grep -oE "$pattern" | sed -E "s/${pattern}/\\\\${backref} \\0/" | sort -V -k1 | tail -1`
-	    fragment=`echo $result | cut -f2 -d' '`
+	    result="`wget -q -O- $url | grep -oE "$pattern" | sed -E "s/${pattern}/\\\\${backref} \\0/" | sort -V -k1 | tail -1`"
+	    fragment="`echo $result | cut -f2 -d' '`"
 
 
 	    if [ -z "$fragment" ]; then
@@ -57,15 +57,15 @@ done
 
 # we link to the file so wget can properly detect if we have already downloaded it
 # note that due to mirroring, timestamp comparison can result in unnecessary downloading
-out_base=`dirname $out`
+out_base="`dirname $out`"
 intermediate="$out_base/$fragment"
 
 if [ "$intermediate" != "$out" ]; then
-    wget --no-clobber --directory-prefix=$out_base $base/$fragment
-    cp $intermediate $out
+    wget --no-clobber --directory-prefix="$out_base" "$base/$fragment"
+    cp "$intermediate" "$out"
 else
-    rm -f $out
-    wget --directory-prefix=$out_base $base/$fragment
+    rm -f "$out"
+    wget --directory-prefix="$out_base" "$base/$fragment"
 fi
 
 # Make the image be at least 12 Gig.  During boot, docker-storage-setup

--- a/bots/images/scripts/atomic.bootstrap
+++ b/bots/images/scripts/atomic.bootstrap
@@ -55,23 +55,17 @@ while [ $# -gt 2 ]; do
     shift
 done
 
-if [ -n "$TEST_DATA" -a -f "$TEST_DATA/$fragment" ]; then
-    echo Using "$TEST_DATA/$fragment"
-    cp "$TEST_DATA/$fragment" "$out"
+# we link to the file so wget can properly detect if we have already downloaded it
+# note that due to mirroring, timestamp comparison can result in unnecessary downloading
+out_base=`dirname $out`
+intermediate="$out_base/$fragment"
+
+if [ "$intermediate" != "$out" ]; then
+    wget --no-clobber --directory-prefix=$out_base $base/$fragment
+    cp $intermediate $out
 else
-
-    # we link to the file so wget can properly detect if we have already downloaded it
-    # note that due to mirroring, timestamp comparison can result in unnecessary downloading
-    out_base=`dirname $out`
-    intermediate="$out_base/$fragment"
-
-    if [ "$intermediate" != "$out" ]; then
-        wget --no-clobber --directory-prefix=$out_base $base/$fragment
-        cp $intermediate $out
-    else
-        rm -f $out
-        wget --directory-prefix=$out_base $base/$fragment
-    fi
+    rm -f $out
+    wget --directory-prefix=$out_base $base/$fragment
 fi
 
 # Make the image be at least 12 Gig.  During boot, docker-storage-setup

--- a/bots/learn-tests
+++ b/bots/learn-tests
@@ -37,11 +37,12 @@ sys.dont_write_bytecode = True
 
 import task
 
+from machines import testvm
+
 BOTS = os.path.dirname(os.path.realpath(__file__))
-DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
 
 def run(url_or_file, verbose=False, dry=False, **kwargs):
-    # Default set of training data, retrieve it and use from DATA directory
+    # Default set of training data, retrieve it and use from data directory
     if not url_or_file:
         url_or_file = TRAINING_DATA
 
@@ -61,7 +62,7 @@ def run(url_or_file, verbose=False, dry=False, **kwargs):
     if "/" not in filename and not os.path.exists(filename):
         if not dry:
             subprocess.check_call([ os.path.join(BOTS, "image-download"), "--state", filename ])
-        filename = os.path.join(DATA, filename)
+        filename = os.path.join(testvm.get_images_data_dir(), filename)
     train(filename, url, verbose)
 
 # Does 'tail -F' on an HTTP URL

--- a/bots/machine/machine_core/constants.py
+++ b/bots/machine/machine_core/constants.py
@@ -26,6 +26,7 @@ MACHINE_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 BOTS_DIR = os.path.dirname(MACHINE_DIR)
 BASE_DIR = os.path.dirname(BOTS_DIR)
 TEST_DIR = os.path.join(BASE_DIR, "test")
+GIT_DIR = os.path.join(BASE_DIR, ".git")
 
 IMAGES_DIR = os.path.join(BOTS_DIR, "images")
 SCRIPTS_DIR = os.path.join(IMAGES_DIR, "scripts")

--- a/bots/machine/machine_core/directories.py
+++ b/bots/machine/machine_core/directories.py
@@ -20,7 +20,7 @@
 import os
 import subprocess
 
-from .constants import BOTS_DIR, GIT_DIR
+from .constants import BOTS_DIR, BASE_DIR, GIT_DIR
 
 def get_git_config(variable):
     if not os.path.exists(GIT_DIR):
@@ -45,3 +45,12 @@ def get_images_data_dir():
             _images_data_dir = os.path.join(os.environ.get("TEST_DATA", BOTS_DIR), "images")
 
     return _images_data_dir
+
+_temp_dir = None
+def get_temp_dir():
+    global _temp_dir
+
+    if _temp_dir is None:
+        _temp_dir = os.path.join(os.environ.get("TEST_DATA", BASE_DIR), "tmp")
+
+    return _temp_dir

--- a/bots/machine/machine_core/directories.py
+++ b/bots/machine/machine_core/directories.py
@@ -18,14 +18,30 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import subprocess
 
-from .constants import BOTS_DIR
+from .constants import BOTS_DIR, GIT_DIR
+
+def get_git_config(variable):
+    if not os.path.exists(GIT_DIR):
+        return None
+
+    try:
+        myenv = os.environ.copy()
+        myenv["GIT_DIR"] = GIT_DIR
+        return subprocess.check_output(["git", "config", variable], universal_newlines=True, env=myenv).strip()
+
+    except (OSError, subprocess.CalledProcessError): # 'git' not in PATH, or cmd fails
+        return None
 
 _images_data_dir = None
 def get_images_data_dir():
     global _images_data_dir
 
     if _images_data_dir is None:
-        _images_data_dir = os.path.join(os.environ.get("TEST_DATA", BOTS_DIR), "images")
+        _images_data_dir = get_git_config('cockpit.bots.images-data-dir')
+
+        if _images_data_dir is None:
+            _images_data_dir = os.path.join(os.environ.get("TEST_DATA", BOTS_DIR), "images")
 
     return _images_data_dir

--- a/bots/machine/machine_core/directories.py
+++ b/bots/machine/machine_core/directories.py
@@ -2,7 +2,7 @@
 
 # This file is part of Cockpit.
 #
-# Copyright (C) 2013 Red Hat, Inc.
+# Copyright (C) 2019 Red Hat, Inc.
 #
 # Cockpit is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by
@@ -19,18 +19,13 @@
 
 import os
 
-# Images which are Atomic based
-ATOMIC_IMAGES = ["rhel-atomic", "fedora-atomic", "continuous-atomic"]
+from .constants import BOTS_DIR
 
-MACHINE_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-BOTS_DIR = os.path.dirname(MACHINE_DIR)
-BASE_DIR = os.path.dirname(BOTS_DIR)
-TEST_DIR = os.path.join(BASE_DIR, "test")
+_images_data_dir = None
+def get_images_data_dir():
+    global _images_data_dir
 
-IMAGES_DIR = os.path.join(BOTS_DIR, "images")
-SCRIPTS_DIR = os.path.join(IMAGES_DIR, "scripts")
+    if _images_data_dir is None:
+        _images_data_dir = os.path.join(os.environ.get("TEST_DATA", BOTS_DIR), "images")
 
-DEFAULT_IDENTITY_FILE = os.path.join(MACHINE_DIR, "identity")
-
-TEST_OS_DEFAULT = "fedora-30"
-DEFAULT_IMAGE = os.environ.get("TEST_OS", TEST_OS_DEFAULT)
+    return _images_data_dir

--- a/bots/machine/machine_core/machine_virtual.py
+++ b/bots/machine/machine_core/machine_virtual.py
@@ -355,11 +355,7 @@ class VirtMachine(Machine):
     def _start_qemu(self):
         self._cleanup()
 
-        try:
-            os.makedirs(self.run_dir, 0o750)
-        except OSError as ex:
-            if ex.errno != errno.EEXIST:
-                raise
+        os.makedirs(self.run_dir, 0o750, exist_ok=True)
 
         def execute(*args):
             self.message(*args)
@@ -615,11 +611,7 @@ class VirtMachine(Machine):
     def add_disk(self, size=None, serial=None, path=None, type='raw'):
         index = len(self._disks)
 
-        try:
-            os.makedirs(self.run_dir, 0o750)
-        except OSError as ex:
-            if ex.errno != errno.EEXIST:
-                raise
+        os.makedirs(self.run_dir, 0o750, exist_ok=True)
 
         if path:
             (unused, image) = tempfile.mkstemp(suffix='.qcow2', prefix=os.path.basename(path), dir=self.run_dir)

--- a/bots/machine/machine_core/machine_virtual.py
+++ b/bots/machine/machine_core/machine_virtual.py
@@ -33,6 +33,7 @@ import time
 from .exceptions import Failure, RepeatableFailure
 from .machine import Machine
 from .constants import TEST_DIR, BOTS_DIR
+from .directories import get_temp_dir
 
 MEMORY_MB = 1024
 
@@ -321,7 +322,7 @@ class VirtMachine(Machine):
         Machine.__init__(self, image=image, **args)
 
         base_dir = os.path.dirname(BOTS_DIR)
-        self.run_dir = os.path.join(os.environ.get("TEST_DATA", base_dir), "tmp", "run")
+        self.run_dir = os.path.join(get_temp_dir(), "run")
 
         self.virt_connection = self._libvirt_connection(hypervisor = "qemu:///session")
 

--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -32,9 +32,9 @@ from machine_core.exceptions import Failure, RepeatableFailure
 from machine_core.machine_virtual import VirtMachine, VirtNetwork, get_build_image, get_test_image
 from machine_core.constants import BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT
 from machine_core.cli import cmd_cli
-from machine_core.directories import get_images_data_dir
+from machine_core.directories import get_images_data_dir, get_temp_dir
 
-__all__ = [Timeout, Machine, Failure, RepeatableFailure, VirtMachine, VirtNetwork, get_build_image, get_test_image, get_images_data_dir, BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT]
+__all__ = [Timeout, Machine, Failure, RepeatableFailure, VirtMachine, VirtNetwork, get_build_image, get_test_image, get_images_data_dir, get_temp_dir, BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT]
 
 # This can be used as helper program for tests not written in Python: Run given
 # image name until SIGTERM or SIGINT; the image must exist in test/images/;

--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -30,10 +30,11 @@ from machine_core.timeout import Timeout
 from machine_core.machine import Machine
 from machine_core.exceptions import Failure, RepeatableFailure
 from machine_core.machine_virtual import VirtMachine, VirtNetwork, get_build_image, get_test_image
-from machine_core.constants import BOTS_DIR, TEST_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT
+from machine_core.constants import BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT
 from machine_core.cli import cmd_cli
+from machine_core.directories import get_images_data_dir
 
-__all__ = [Timeout, Machine, Failure, RepeatableFailure, VirtMachine, VirtNetwork, get_build_image, get_test_image, BOTS_DIR, TEST_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT]
+__all__ = [Timeout, Machine, Failure, RepeatableFailure, VirtMachine, VirtNetwork, get_build_image, get_test_image, get_images_data_dir, BOTS_DIR, TEST_DIR, IMAGES_DIR, SCRIPTS_DIR, DEFAULT_IMAGE, TEST_OS_DEFAULT]
 
 # This can be used as helper program for tests not written in Python: Run given
 # image name until SIGTERM or SIGINT; the image must exist in test/images/;

--- a/bots/task/cache.py
+++ b/bots/task/cache.py
@@ -75,8 +75,7 @@ class Cache(object):
     # Write a resource to the cache in an atomic way
     def write(self, resource, contents):
         path = os.path.join(self.directory, urllib.parse.quote(resource, safe=''))
-        if not os.path.exists(self.directory):
-            os.makedirs(self.directory)
+        os.makedirs(self.directory, exist_ok=True)
         (fd, temp) = tempfile.mkstemp(dir=self.directory)
         with os.fdopen(fd, 'w') as fp:
             json.dump(contents, fp)

--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -84,8 +84,7 @@ class Logger(object):
         month = time.strftime("%Y%m")
         self.path = os.path.join(directory, "{0}-{1}.log".format(hostname, month))
 
-        if not os.path.exists(directory):
-            os.makedirs(directory)
+        os.makedirs(directory, exist_ok=True)
 
     # Yes, we open the file each time
     def write(self, value):

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -38,11 +38,12 @@ sys.dont_write_bytecode = True
 
 import task
 
+from machine import testvm
+
 # The number of days of previous closed pull requests to learn from
 SINCE_DAYS = 120
 
 BOTS = os.path.abspath(os.path.dirname(__file__))
-DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
 SEEDED = set()
 SINKS = { }
 
@@ -55,7 +56,7 @@ def run(filename, verbose=False, dry=False, **kwargs):
         if "/" not in filename and not os.path.exists(filename):
             if not dry:
                 subprocess.check_call([ os.path.join(BOTS, "image-download"), "--state", filename ])
-            filename = os.path.join(DATA, filename)
+            filename = os.path.join(testvm.get_images_data_dir(), filename)
         (outfd, outname) = tempfile.mkstemp(prefix=os.path.basename(filename), dir=os.path.dirname(filename))
         os.close(outfd)
         output = gzip.open(outname, 'wb')

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -233,11 +233,7 @@ class PullTask(object):
             return "Downloading of additional images failed"
 
         # COMPAT: Create a legacy tmp/run directory to prevent races during testing
-        try:
-            os.makedirs(os.path.join(BASE, "test", "tmp", "run"))
-        except OSError as ex:
-            if ex.errno != errno.EEXIST:
-                raise
+        os.makedirs(os.path.join(BASE, "test", "tmp", "run"), exist_ok=True)
 
         # Now actually run the prepare tooling
         cmd = [ os.path.join(BOTS, "image-prepare") ]

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -42,7 +42,6 @@ except ImportError:
     get_test_image = lambda i: i
 
 BOTS = os.path.dirname(os.path.realpath(__file__))
-DATA = os.path.join(os.environ.get("TEST_DATA", BOTS), "images")
 
 def main():
     script = os.path.basename(__file__)

--- a/pkg/storaged/nfs-mounts.py
+++ b/pkg/storaged/nfs-mounts.py
@@ -139,10 +139,6 @@ def monitor():
             process_fstab()
             report()
 
-def mkdir_if_necessary(path):
-    if not os.path.exists(path):
-        os.makedirs(path)
-
 def rmdir_if_empty(path):
     try:
         os.rmdir(path)
@@ -153,7 +149,7 @@ def rmdir_if_empty(path):
 def update(entry, new_fields):
     old_fields = entry["fields"]
     if old_fields[1] != new_fields[1]:
-        mkdir_if_necessary(new_fields[1])
+        os.makedirs(new_fields[1], exist_ok=True)
     if entry["mounted"]:
         if (new_fields[0] == old_fields[0]
             and new_fields[1] == old_fields[1]
@@ -173,7 +169,7 @@ def update(entry, new_fields):
     modify_tab("/etc/fstab", lambda fields: new_fields if fields == old_fields else fields)
 
 def add(new_fields):
-    mkdir_if_necessary(new_fields[1])
+    os.makedirs(new_fields[1], exist_ok=True)
     mount({ "fields": new_fields })
     modify_tab("/etc/fstab", lambda fields: new_fields if fields is None else fields)
 
@@ -186,7 +182,7 @@ def remove(entry):
 
 def mount(entry):
     fields = entry["fields"]
-    mkdir_if_necessary(fields[1])
+    os.makedirs(fields[1], exist_ok=True)
     subprocess.check_call([ "mount",
                             "-t", fields[2],
                             "-o", fields[3],

--- a/test/README.md
+++ b/test/README.md
@@ -90,6 +90,12 @@ You can set these environment variables to configure the test suite:
                    the Chrome Debug Protocol, on the given port. Don't use this
                    with parallel tests.
 
+In addition, you can also set the `cockpit.bots.images-data-dir` variable with
+`git config` to the location to store the (unprepared) virtual machine images.
+This takes precedence over `TEST_DATA`.  For example:
+
+    $ git config cockpit.bots.images-data-dir ~/.cockpit-bots/images
+
 ## Test machines and their images
 
 The code under test is executed in one or more dedicated virtual

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -40,8 +40,7 @@ avocado_results_dir = "/root/avocado_results"
 arg_attachments_dir = os.environ.get("TEST_ATTACHMENTS", None)
 if not arg_attachments_dir:
     arg_attachments_dir = os.getcwd()
-if not os.path.exists(arg_attachments_dir):
-    os.makedirs(arg_attachments_dir)
+os.makedirs(arg_attachments_dir, exist_ok=True)
 
 def prepare_kdump_test(machine):
     # enable kernel kdump support

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1375,8 +1375,8 @@ def test_main(options=None, suite=None, attachments=None, **kwargs):
     opts.address = getattr(opts, "address", None)
     opts.browser = getattr(opts, "browser", None)
     opts.attachments = os.environ.get("TEST_ATTACHMENTS", attachments)
-    if opts.attachments and not os.path.exists(opts.attachments):
-        os.makedirs(opts.attachments)
+    if opts.attachments:
+        os.makedirs(opts.attachments, exist_ok=True)
 
     import __main__
     if len(opts.tests) > 0:

--- a/test/vm-run
+++ b/test/vm-run
@@ -109,8 +109,7 @@ try:
         if not os.path.lexists(kubeconfig):
             d = os.path.dirname(kubeconfig)
             src = os.path.abspath(os.path.join(parent.BOTS_DIR, "images", "files", "openshift.kubeconfig"))
-            if not os.path.exists(d):
-                os.makedirs(d)
+            os.makedirs(d, exist_ok=True)
             sys.stderr.write("image-run: linking kubeconfig into ~/.kube/config\n")
             os.symlink(src, kubeconfig)
 


### PR DESCRIPTION
Consider this pull request as a request for comments.

I hate setting `TEST_DATA`, so I added a new git-config variable, `cockpit.bots.images-data-dir` to determine the directory to store the images.  I think this is even better than `TEST_DATA` because (in addition to not being an unnamespaced global environment variable), it only stores the image files, allowing some of the other tree-specific stuff to be kept in its default locations.

It turns out that the code to figure out the various ways in which we use `TEST_DATA` was copied around quite a lot.  This cleans up nearly everything except for a single use in `task/github.py` which I'm not really sure what to do about...