### PR TITLE
bots: Enable automatic weldr/lorax tests on fedora-30

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -68,10 +68,10 @@ REPO_BRANCH_CONTEXT = {
         ],
     },
     'weldr/lorax': {
-        'master': [],
-        # can be triggered manually for now, needs https://github.com/weldr/lorax/pull/689 before doing it automatically
-        '_manual': [
+        'master': [
             'cockpit/fedora-30',
+        ],
+        '_manual': [
             'cockpit/rhel-8-0',
             'cockpit/rhel-8-1',
         ],


### PR DESCRIPTION
https://github.com/weldr/lorax/pull/689 landed now.