### PR TITLE
bots: Bump external test timeout to 2 hours

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -368,7 +368,7 @@ class PullTask(object):
             cmd = [ "timeout", "90m", os.path.join(test, "containers", "run-tests"),
                     "--container", value]
         elif prefix == "cockpit":
-            cmd = [ "timeout", "90m", os.path.join(test, "run") ]
+            cmd = [ "timeout", "120m", os.path.join(test, "run") ]
         else:
             ret = "Unknown context"
 


### PR DESCRIPTION
Current weldr/lorax tests take slightly over 90 minutes. They will be
sped up soon, but let's not block on that.