### PR TITLE
Revert "tests: Don't resolve ``localhost`` for mocked systems"

### DIFF
--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -87,7 +87,7 @@ setup (TestCase *tc,
 
   /* Automatically chosen by the web server */
   g_object_get (tc->web_server, "port", &port, NULL);
-  tc->localport = g_strdup_printf ("127.0.0.1:%d", port);
+  tc->localport = g_strdup_printf ("localhost:%d", port);
   if (str)
     tc->hostport = g_strdup_printf ("%s:%d", str, port);
   if (inet)


### PR DESCRIPTION
This reverts commit 9f22c8ce37ddd3b943ea319586f1aa4caa7675a1.

This was always meant to be a temporary workaround.

Closes #11909

- [x] Fix the [gio bug](https://gitlab.gnome.org/GNOME/glib/merge_requests/865) and have it available in distros