### PR TITLE
ssh: Set key exchange algorithms in mock-sshd

### DIFF
--- a/src/ssh/mock-sshd.c
+++ b/src/ssh/mock-sshd.c
@@ -575,6 +575,12 @@ mock_ssh_server (const gchar *server_addr,
   ssh_bind_options_set (sshbind, SSH_BIND_OPTIONS_RSAKEY, SRCDIR "/src/ssh/mock_rsa_key");
   ssh_bind_options_set (sshbind, SSH_BIND_OPTIONS_DSAKEY, SRCDIR "/src/ssh/mock_dsa_key");
 
+  /* Known issue with recent libssh versions on 32bits: avoid using
+   * curve25519-sha256.  See https://bugs.libssh.org/T151
+   */
+  if (sizeof (void *) == 4)
+    ssh_options_set (state.session, SSH_OPTIONS_KEY_EXCHANGE, "ecdh-sha2-nistp256, diffie-hellman-group18-sha512, diffie-hellman-group16-sha512, diffie-hellman-group-exchange-sha256, diffie-hellman-group14-sha1, diffie-hellman-group1-sha1, diffie-hellman-group-exchange-sha1");
+
   if (ssh_bind_listen (sshbind) < 0)
     {
       g_critical ("couldn't listen on socket: %s", ssh_get_error (sshbind));

--- a/tools/libssh.supp
+++ b/tools/libssh.supp
@@ -27,3 +27,20 @@
    fun:hmac_init
    ...
 }
+
+# the bignum math in ecdh-sha2-nistp256 throws so many errors about
+# uninitialised memory usage that it causes semaphore to hang
+{
+   libssh_i386_cond
+   Memcheck:Cond
+   ...
+   obj:/usr/lib/i386-linux-gnu/libssh.so.4.4.1
+   ...
+}
+{
+   libssh_i386_value4
+   Memcheck:Value4
+   ...
+   obj:/usr/lib/i386-linux-gnu/libssh.so.4.4.1
+   ...
+}


### PR DESCRIPTION
Here's a branch from Sanne to fix the libssh failures.

Upstream bug: https://bugs.libssh.org/T151

Closes #11910