### PR TITLE
[no-test] Revert "bots: Add naughty for podman missing parameter"

### DIFF
--- a/bots/naughty/fedora-30/11902-podman-no-env-parameter
+++ b/bots/naughty/fedora-30/11902-podman-no-env-parameter
@@ -1,6 +1,0 @@
-# testRunImage (__main__.TestApplication)
-*
-*File "test/check-application", line *, in testRunImage
-*b.wait_not_present("div.modal-dialog")
-*
-*testlib.Error: timeout


### PR DESCRIPTION
This reverts commit ef456ad8067cf68f1a00954508e58deb96831d92.

This was fixed in https://github.com/cockpit-project/cockpit-podman/pull/105
Closes #11902