### PR TITLE
Use /usr/bin/env python3 instead of /usr/bin/python3

### DIFF
--- a/bots/example-task
+++ b/bots/example-task
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/flakes-refresh
+++ b/bots/flakes-refresh
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/bots/github-info
+++ b/bots/github-info
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-create
+++ b/bots/image-create
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.

--- a/bots/image-customize
+++ b/bots/image-customize
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.

--- a/bots/image-download
+++ b/bots/image-download
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-prepare
+++ b/bots/image-prepare
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.

--- a/bots/image-prune
+++ b/bots/image-prune
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/image-upload
+++ b/bots/image-upload
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/bots/inspect-queue
+++ b/bots/inspect-queue
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/issues-review
+++ b/bots/issues-review
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import time

--- a/bots/koji-build
+++ b/bots/koji-build
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/learn-trigger
+++ b/bots/learn-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/make-checkout
+++ b/bots/make-checkout
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/naughty-prune
+++ b/bots/naughty-prune
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/naughty-trigger
+++ b/bots/naughty-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/npm-trigger
+++ b/bots/npm-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/npm-update
+++ b/bots/npm-update
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/po-refresh
+++ b/bots/po-refresh
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/po-trigger
+++ b/bots/po-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/push-rewrite
+++ b/bots/push-rewrite
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 # push-rewrite -- Force push to a PR after rewriting history, with benefits.
 #

--- a/bots/run-queue
+++ b/bots/run-queue
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/cache.py
+++ b/bots/task/cache.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/sink.py
+++ b/bots/task/sink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/test-cache
+++ b/bots/task/test-cache
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/test-checklist
+++ b/bots/task/test-checklist
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/test-github
+++ b/bots/task/test-github
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/task/test-policy
+++ b/bots/task/test-policy
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/bots/task/test-task
+++ b/bots/task/test-task
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/test-bots
+++ b/bots/test-bots
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/tests-score
+++ b/bots/tests-score
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/bots/tests-trigger
+++ b/bots/tests-trigger
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import sys


### PR DESCRIPTION
https://github.com/weldr/lorax/ has recently started using these
bots and it runs on RHEL 7 where we have Python3 via software
collections.

This change allows running the bot scripts on machines where
Python3 is not installed system wide!