### PR TITLE
test: Fix pyflakes warnings

### DIFF
--- a/test/avocado/selenium-hwinfo.py
+++ b/test/avocado/selenium-hwinfo.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
+
+from testlib_avocado.seleniumlib import SeleniumTest, clickable, visible
 import os
 import sys
 
 machine_test_dir = os.path.dirname(os.path.realpath(__file__))
 if machine_test_dir not in sys.path:
     sys.path.insert(1, machine_test_dir)
-
-from testlib_avocado.seleniumlib import SeleniumTest, clickable, visible
 
 
 class TestHWinfo(SeleniumTest):

--- a/test/avocado/selenium-kdump.py
+++ b/test/avocado/selenium-kdump.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python3
-import os
-import sys
-import time
-machine_test_dir = os.path.dirname(os.path.realpath(__file__))
-if machine_test_dir not in sys.path:
-    sys.path.insert(1, machine_test_dir)
 
 from selenium.webdriver.support.select import Select
 from testlib_avocado.seleniumlib import SeleniumTest, clickable, visible
+import os
+import sys
+
+machine_test_dir = os.path.dirname(os.path.realpath(__file__))
+if machine_test_dir not in sys.path:
+    sys.path.insert(1, machine_test_dir)
 
 
 class TestKdump(SeleniumTest):
@@ -19,7 +19,6 @@ class TestKdump(SeleniumTest):
 {}    *(rw,sync,no_root_squash)
     """.format(share)
     export_file = '/etc/exports'
-
 
     def requirements(self):
         execs = [


### PR DESCRIPTION
This commit fixes following warnings: (introduced in #11837)

test/avocado/selenium-kdump.py:4: 'time' imported but unused
test/avocado/selenium-hwinfo.py:9:1: E402 module level import not at top of file
test/avocado/selenium-kdump.py:9:1: E402 module level import not at top of file
test/avocado/selenium-kdump.py:10:1: E402 module level import not at top of file
test/avocado/selenium-kdump.py:24:5: E303 too many blank lines (2)