### PR TITLE
bots: Bump selenium/edge timeout

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -362,7 +362,7 @@ class PullTask(object):
         elif prefix == "selenium":
             if value not in ['firefox', 'chrome', 'edge']:
                 ret = "Unknown browser for selenium test"
-            cmd = [ "timeout", "60m", os.path.join(test, "avocado", "run-tests"),
+            cmd = [ "timeout", (value == 'edge') and "90m" or "60m", os.path.join(test, "avocado", "run-tests"),
                     "--quick", "--selenium-tests", "--browser", value]
         elif prefix == "image" or prefix == "container":
             cmd = [ "timeout", "90m", os.path.join(test, "containers", "run-tests"),


### PR DESCRIPTION
Since the addition of a lot more Machines tests in PR #11737, the
selenium/edge test is now timing out a lot. Bump its timeout.