### PR TITLE
storage: Fix name of manifest in AppStream data

### DIFF
--- a/pkg/storaged/org.cockpit-project.cockpit-storaged.metainfo.xml
+++ b/pkg/storaged/org.cockpit-project.cockpit-storaged.metainfo.xml
@@ -11,7 +11,7 @@
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
-  <launchable type="cockpit-manifest">storaged</launchable>
+  <launchable type="cockpit-manifest">storage</launchable>
   <url type="homepage">https://cockpit-project.org/</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
 </component>


### PR DESCRIPTION
The page and manifest is called "storage" is far as Cockpit is
concerned, "storaged" is just the package and directory name.