### PR TITLE
test: Give more resources to windows-10 VM

### DIFF
--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -210,7 +210,7 @@ def run_avocado(avocado_tests, verbose, browser, download_logs, sit):
 
     if use_selenium:
         if 'edge' in browser:
-            windows = testvm.VirtMachine(image='windows-10', verbose=verbose, networking=network.host())
+            windows = testvm.VirtMachine(image='windows-10', memory_mb=4096, cpus=2, verbose=verbose, networking=network.host())
         else:
             selenium = testvm.VirtMachine(image="selenium", verbose=verbose, networking=network.host())
 


### PR DESCRIPTION
With the default 1 GiB RAM/1 CPU, the selenium/edge test is just too
slow.