### PR TITLE
Fix no test race [no-test]

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -133,7 +133,7 @@ def run(image, verbose=False, **kwargs):
 
     branch = task.branch(image, "images: Update {0} image".format(image), pathspec="bots/images", **kwargs)
     if branch:
-        pull = task.pull(branch, run_tests=False, **kwargs)
+        pull = task.pull(branch, **kwargs)
 
         # Trigger this pull request
         head = pull["head"]["sha"]
@@ -146,4 +146,4 @@ def run(image, verbose=False, **kwargs):
         task.label(pull, ["test-external"])
 
 if __name__ == '__main__':
-    task.main(function=run, title="Refresh image")
+    task.main(function=run, title="Refresh image", run_tests=False)

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -138,7 +138,11 @@ def begin(publish, name, context, issue):
         number = issue["number"]
         identifier = "{0}-{1}-{2}".format(name, number, current)
         title = issue["title"]
-        wip = "WIP: {0}: [no-test] {1}".format(hostname, title)
+        # Multiple failures would duplicate [no-test] in the title
+        if "[no-test]" in title:
+            wip = "WIP: {0}: {1}".format(hostname, title)
+        else:
+            wip = "WIP: {0}: [no-test] {1}".format(hostname, title)
         requests = [ {
             "method": "POST",
             "resource": api.qualify("issues/{0}".format(number)),
@@ -190,7 +194,7 @@ def begin(publish, name, context, issue):
 
     return publishing
 
-def finish(publishing, ret, name, context, issue):
+def finish(publishing, ret, name, context, issue, run_tests):
     if not publishing:
         return
 
@@ -220,10 +224,15 @@ def finish(publishing, ret, name, context, issue):
         # The sink wants us to escape colons :S
         body = checklist.body.replace(':', '::')
 
+        # Multiple failures would duplicate [no-test] in the title
+        if run_tests or "[no-test]" in issue["title"]:
+            title = issue["title"]
+        else:
+            title = "[no-test] {0}".format(issue["title"])
         requests = [ {
             "method": "POST",
             "resource": api.qualify("issues/{0}".format(number)),
-            "data": { "title": "{0}".format(issue["title"]), "body": body }
+            "data": { "title": title, "body": body }
         } ]
 
         # Close the issue if it's not a pull request, successful, and all tasks done
@@ -250,6 +259,7 @@ def run(context, function, **kwargs):
     number = kwargs.get("issue", None)
     publish = kwargs.get("publish", "")
     name = kwargs["name"]
+    run_tests = kwargs.get("run_tests", True)
 
     issue = None
     if number:
@@ -276,7 +286,7 @@ def run(context, function, **kwargs):
     except:
         traceback.print_exc()
     finally:
-        finish(publishing, ret, name, context, issue)
+        finish(publishing, ret, name, context, issue, run_tests)
     return ret or 0
 
 # Check if the given files that match @pathspec are stale
@@ -405,10 +415,11 @@ def branch(context, message, pathspec=".", issue=None, branch=None, push=True, *
 
     return "{0}:{1}".format(user, branch)
 
-def pull(branch, body=None, issue=None, base="master", labels=['bot'], run_tests=True, **kwargs):
+def pull(branch, body=None, issue=None, base="master", labels=['bot'], **kwargs):
     if "pull" in kwargs:
         return kwargs["pull"]
 
+    run_tests = kwargs.get("run_tests", True)
     data = {
         "head": branch,
         "base": base,


### PR DESCRIPTION
As the rename and force push are not synchronous, if run_tests=False,
never remove the [no-test] from the title, thus eliminating the race entirely.

---
Refresh leaves [no-test] in title:
https://github.com/Gundersanne/cockpit/pull/27

Other tasks remove the [no-test] after:
https://github.com/Gundersanne/cockpit/pull/30