### PR TITLE
test/check-subscriptions: Fix check for "Not Subscribed"

### DIFF
--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -244,7 +244,7 @@ class TestSubscriptions(MachineCase):
         b.click(product_selector)
         details_selector = "tr.listing-ct-panel:contains('Snowy OS Premium Architecture Bits')"
         b.wait_in_text(details_selector, "6050")
-        b.wait_not_in_text(details_selector, "Not Subscribed")
+        b.wait_in_text(details_selector, "Not Subscribed")
         # collapse again
         b.click(product_selector)
 


### PR DESCRIPTION
The condition was backwards, but it passed anyway since there is a
short time after expanding the list where the contents isn't in there
yet.