### PR TITLE
tools: Drop custom patch application

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -116,7 +116,6 @@ BuildRequires: libxslt-devel
 BuildRequires: docbook-style-xsl
 BuildRequires: glib-networking
 BuildRequires: sed
-BuildRequires: git
 
 BuildRequires: glib2-devel >= 2.37.4
 BuildRequires: systemd-devel
@@ -157,20 +156,6 @@ Suggests: cockpit-selinux
 
 %prep
 %setup -q -n cockpit-%{version}
-
-# Apply patches using git in order to support binary patches. Note that
-# we also reset mtimes since patches should be "complete" and include both
-# generated and source file changes
-# Keep this in sync with tools/debian/rules.
-if [ -n "%{patches}" ]; then
-    git init
-    git config user.email "unused@example.com" && git config user.name "Unused"
-    git config core.autocrlf false && git config core.safecrlf false && git config gc.auto 0
-    git add -f . && git commit -a -q -m "Base" && git tag -a initial --message="initial"
-    git am --whitespace=nowarn %{patches}
-    touch -r $(git diff --name-only initial..HEAD) .git Makefile.in
-    rm -rf .git
-fi
 
 %build
 exec 2>&1

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Cockpit <cockpit@cockpit-project.org>
 Build-Depends: debhelper (>= 10),
                dpkg-dev (>= 1.17.14),
-               git,
                intltool,
                libssh-dev,
                zlib1g-dev,

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -17,32 +17,7 @@ endif
 %:
 	dh $@
 
-# Apply patches using git in order to support binary patches. Note that
-# we also reset mtimes since patches should be "complete" and include both
-# generated and source file changes.
-# Keep this in sync with tools/cockpit.spec.
-debian/git-patches-applied:
-	set -ex; if [ -d debian/git-patches ]; then \
-		git init; \
-		git config user.email "unused@example.com"; git config user.name "Unused"; \
-		git config core.autocrlf false; git config core.safecrlf false && git config gc.auto 0; \
-		git add -f . && git commit -a -q -m "Base" && git tag -a initial --message="initial"; \
-		git am --whitespace=nowarn debian/git-patches/*.patch; \
-		touch -r $$(git diff --name-only initial..HEAD) .git; \
-	fi
-	touch $@
-
-# unapply our git patches
-override_dh_clean:
-	if [ -d .git ] && [ -e debian/git-patches-applied ]; then \
-		git reset --hard initial; \
-		git clean -fdx; \
-		rm -rf .git; \
-	fi
-	rm -f debian/git-patches-applied
-	dh_clean
-
-override_dh_auto_configure: debian/git-patches-applied
+override_dh_auto_configure:
 	dh_auto_configure -- \
 		--with-networkmanager-needs-root=yes \
 		--with-cockpit-user=cockpit-ws \


### PR DESCRIPTION
We moved to doing upstream point releases for stable branches a while
ago, and since then haven't used this complicated and brittle patch
application mechanism.

For patching bugs in the C code, distros can use their standard patch
mechanisms, and we won't go back to the mess of patching webpack and
autotools files.