### PR TITLE
naughty: Close 11660: SELinux is preventing pmdalinux from module_request access on the system labeled kernel_t

### DIFF
--- a/bots/naughty/fedora-30/11660-module-request
+++ b/bots/naughty/fedora-30/11660-module-request
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { module_request } for * comm="pmdalinux"


### PR DESCRIPTION
Known issue which has not occurred in 23 days

SELinux is preventing pmdalinux from module_request access on the system labeled kernel_t

Fixes #11660