### PR TITLE
naughty: Close 11566: kvdo broken on current rhel-8-1: kernel version mismatch

### DIFF
--- a/bots/naughty/rhel-8/11566-kvdo-missing
+++ b/bots/naughty/rhel-8/11566-kvdo-missing
@@ -1,4 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-storage-vdo", line *, in testVdo
-*
-warning: vdo: ERROR - Kernel module kvdo not installed


### PR DESCRIPTION
Known issue which has not occurred in 27 days

kvdo broken on current rhel-8-1: kernel version mismatch

Fixes #11566