### PR TITLE
naughty: Close 11477: joining IPA domain causes SELinux violation: avc: denied { getattr } for comm="ipa-submit"

### DIFF
--- a/bots/naughty/rhel-7/11477-selinux-ipa-submit-getattr
+++ b/bots/naughty/rhel-7/11477-selinux-ipa-submit-getattr
@@ -1,2 +1,0 @@
-Error: type=1400 * avc:  denied  { getattr } * comm="ipa-submit"
-


### PR DESCRIPTION
Known issue which has not occurred in 21 days

joining IPA domain causes SELinux violation: avc: denied { getattr } for comm="ipa-submit"

Fixes #11477