### PR TITLE
Robustify testNetworkSettings by waiting for the networks to get inactive before undefining

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -403,10 +403,11 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         # Remove all Virtual Networks and confirm that trying to choose
         # Virtual Networks type for a NIC disables the save button
-        m.execute("virsh net-destroy test_network && virsh net-destroy default && virsh net-undefine test_network && virsh net-undefine default")
-        b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-count", "0")
+        m.execute("virsh net-destroy test_network && virsh net-destroy default")
         b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-notification:nth-of-type(1)", "0")
+        m.execute("virsh net-undefine test_network && virsh net-undefine default")
         b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-notification:nth-of-type(2)", "0")
+        b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-count", "0")
 
         # Remove the network interface
         m.execute("virsh detach-interface --persistent --type network --domain subVmTest1")


### PR DESCRIPTION
There is currently a race condition making this test fail often. It
looks like that destroying and undefining the network right after emits
almost concurrent events, and the UI state is not updated correctly.

Although this deserves an actual fix let's robustify this tests by
waiting for the networks to get deactivated before detaching.

Some cleanup in the singal handlers will come as a followup.