### PR TITLE
bots: Add mvollmer/subscription-manager to tests-scan

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -88,6 +88,11 @@ REPO_BRANCH_CONTEXT = {
         ],
         'rhel-8.1': ['cockpit/rhel-8-1/chrome', 'cockpit/rhel-8-1/firefox', 'cockpit/rhel-8-1/edge'
         ],
+    },
+    'mvollmer/subscription-manager': {
+        '_manual': [
+            'cockpit/rhel-8-0',
+        ],
     }
 }
 


### PR DESCRIPTION
This is for testing and demonstration.  The ultimate goal is to
replace this with candlepin/subscription-manager.