### PR TITLE
sv.po: Improve translation of "asset"

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -1012,7 +1012,7 @@ msgstr "Arkitektur"
 
 #: pkg/systemd/index.html:92
 msgid "Asset Tag"
-msgstr "Tillgångsetikett"
+msgstr "Inventariebeteckning"
 
 #: pkg/storaged/mdraids-panel.jsx:79
 msgid "At least $0 disks are needed."


### PR DESCRIPTION
"Tillgång" is used (for Eng. "asset") primarily when talking about financial assets or when talking about assets in a financial report or context. For everyday use when talking about various hardware items (or general office furniture), "inventarier" is better.