### PR TITLE
 docker: add capabilities and privileged support

### DIFF
--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -264,6 +264,10 @@ div.spinner {
     max-width: 8em;
 }
 
+.containers-run-capabilitiesclaim input {
+    max-width: 8em;
+}
+
 #select-linked-containers .form-group {
     width: 80%;
 }

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -396,6 +396,40 @@
     </form>
   </script>
 
+  <script id="capabilities-claim-tmpl" type="x-template/mustache">
+    <form class="form-inline">
+      <button type="button" class="btn btn-default fa fa-plus"></button>
+      <button type="button" class="btn btn-default pficon-close"></button>
+      <div class="form-group">
+        <div class="btn-group dropdown capability-option">
+          <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+            <span translatable="yes">Add</span>
+            <div class="caret"></div>
+          </button>
+          <ul class="dropdown-menu">
+            <li><a tabindex="0" value="Add" translate>Add</a></li>
+            <li><a tabindex="0" value="Drop" translate>Drop</a></li>
+          </ul>
+        </div>
+        <div class="btn-group dropdown claim-capability">
+          <label>{{claim_capability_label}}</label>
+          <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+              <span><span translatable="yes">cap.</span></span>
+              <div class="caret"></div>
+          </button>
+          <ul class="dropdown-menu">
+              {{#capabilities}}<li><a tabindex="0" value="{{.}}">{{.}}</a></li>{{/capabilities}}
+          </ul>
+      </div>
+      <div hidden>
+        <span class="help-block"></span>
+      </div>
+      <div hidden>
+        <span class="help-block"></span>
+      </div>
+    </form>
+  </script>
+
   <script id="container-link-tmpl" type="x-template/mustache">
     <form class="form-inline dialog-wrapper">
       <button type="button" class="btn btn-default fa fa-plus"></button>
@@ -510,6 +544,37 @@
                     <span translatable="yes">Expose container ports</span>
                   </label>
                   <div id="select-exposed-ports" class="containers-run-portmapping containers-run-inline">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td><label class="control-label" for="containers-run-privileged" translatable="yes">Privileged</label></td>
+                <td colspan="4">
+                  <label>
+                    <input type="checkbox" id="containers-run-privileged" checked="false"/>
+                    <span translatable="yes">Enable</span>
+                </label>
+                </td>
+              </tr>
+              <tr>
+                <td><label class="control-label" for="add-all-capabilities" translatable="yes">Capabilities</label></td>
+                <td colspan="4">
+                  <label>
+                    <input type="checkbox" name="add-all-capabilities" id="add-all-capabilities" checked="false"/>
+                    <span translatable="yes">Add ALL</span>
+                    <input type="checkbox" name="drop-all-capabilities" id="drop-all-capabilities" checked="false"/>
+                    <span translatable="yes">Drop ALL</span>
+                  </label>
+                </td>
+              </tr>
+              <tr>
+                <td><label class="control-label" for="claim-capabilities" translatable="yes"></label></td>
+                <td colspan="4">
+                  <label>
+                    <input type="checkbox" name="claim-capabilities" id="claim-capabilities" checked="false"/>
+                    <span translatable="yes">Choose specific Linux capabilities</span>
+                  </label>
+                  <div id="select-claimed-capabilities" class="containers-run-capabilitiesclaim containers-run-inline">
                   </div>
                 </td>
               </tr>

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -250,9 +250,16 @@ $(function() {
 
         /* uncheck add-all-capabilities button by default */
         $('#add-all-capabilities').prop('checked', false);
+        $('#add-all-capabilities').prop('disabled', false);
 
         /* uncheck drop-all-capabilities button by default */
         $('#drop-all-capabilities').prop('checked', false);
+        $('#drop-all-capabilities').prop('disabled', false);
+
+        /* uncheck claim-capabilities button by default */
+        $('#claim-capabilities').prop('checked', false);
+        $('#claim-capabilities').prop('disabled', false);
+        $('#select-claimed-capabilities').hide();
 
         /* delete any old capabilities claiming entries */
         var capabilities_claiming = $('#select-claimed-capabilities');

--- a/pkg/docker/run.js
+++ b/pkg/docker/run.js
@@ -35,6 +35,7 @@ $(function() {
     var cpu_slider = new util.CpuSlider($("#containers-run-image-cpu"), 2, 1000000);
 
     var container_names = [];
+    var capabilities_keys = [];
     var image = null;
 
     (function() {
@@ -68,6 +69,18 @@ $(function() {
             if ($(this).prop('checked')) {
                 if (items.children().length === 0)
                     erenderer();
+                items.show();
+            } else {
+                items.hide();
+            }
+        });
+
+        var crenderer = capabilities_renderer();
+        $('#claim-capabilities').on('change', function() {
+            var items = $('#select-claimed-capabilities');
+            if ($(this).prop('checked')) {
+                if (items.children().length === 0)
+                    crenderer();
                 items.show();
             } else {
                 items.hide();
@@ -234,6 +247,43 @@ $(function() {
         } else {
             $('#claim-envvars').prop('checked', false);
         }
+
+        /* uncheck add-all-capabilities button by default */
+        $('#add-all-capabilities').prop('checked', false);
+
+        /* uncheck drop-all-capabilities button by default */
+        $('#drop-all-capabilities').prop('checked', false);
+
+        /* delete any old capabilities claiming entries */
+        var capabilities_claiming = $('#select-claimed-capabilities');
+        capabilities_claiming.empty();
+
+        function parse_capabilities(string) {
+            string = string.substring(
+                string.lastIndexOf("Bounding set") + 14,
+                string.lastIndexOf("\nSecurebits")
+            );
+            capabilities_keys = string.split(",");
+            for (var i = 0; i < capabilities_keys.length; i++) {
+                capabilities_keys[i] = capabilities_keys[i].replace(/cap_/g, '').toUpperCase();
+            }
+        }
+
+        var process = cockpit.spawn(["capsh", "--print"]);
+        process.stream(function(data) {
+            parse_capabilities(data);
+        });
+
+        if (capabilities_claiming.children().length > 0) {
+            $('#claim-capabilities').prop('checked', true);
+            /* make sure the capabilities are visible */
+            capabilities_claiming.show();
+        } else {
+            $('#claim-capabilities').prop('checked', false);
+        }
+
+        /* uncheck containers-run-privileged button by default */
+        $('#containers-run-privileged').prop('checked', false);
 
         var restart_policy_select_button = $('#restart-policy-select > button span.pull-left');
         restart_policy_select_button.text(_("No"));
@@ -549,6 +599,76 @@ $(function() {
         return render;
     }
 
+    /* Uncheck and disable whole capabilities section */
+    $("#containers-run-privileged").click(function() {
+        if ($('#containers-run-privileged').prop('checked')) {
+            $('#add-all-capabilities').prop('checked', false);
+            $('#add-all-capabilities').prop('disabled', true);
+            $('#drop-all-capabilities').prop('checked', false);
+            $('#drop-all-capabilities').prop('disabled', true);
+            $('#claim-capabilities').prop('checked', false);
+            $('#claim-capabilities').prop('disabled', true);
+            $('#select-claimed-capabilities').hide();
+        } else {
+            $('#add-all-capabilities').prop('disabled', false);
+            $('#drop-all-capabilities').prop('disabled', false);
+            $('#claim-capabilities').prop('disabled', false);
+        }
+    });
+
+    $("#add-all-capabilities").click(function() {
+        if ($('#add-all-capabilities').prop('checked'))
+            $('#drop-all-capabilities').prop('disabled', true);
+        else
+            $('#drop-all-capabilities').prop('disabled', false);
+    });
+
+    $("#drop-all-capabilities").click(function() {
+        if ($('#drop-all-capabilities').prop('checked'))
+            $('#add-all-capabilities').prop('disabled', true);
+        else
+            $('#add-all-capabilities').prop('disabled', false);
+    });
+
+    function capabilities_renderer() {
+        var template = $("#capabilities-claim-tmpl").html();
+        mustache.parse(template);
+
+        function add_row() {
+            render();
+        }
+
+        function remove_row(e) {
+            var parent = $(e.target).closest("form");
+            parent.remove();
+            var children = $('#select-claimed-capabilities').children();
+            if (children.length === 0)
+                $("#claim-capabilities").attr("checked", false);
+            else
+                children.find("input[duplicate]").trigger("change");
+        }
+
+        function render(capabilities) {
+            var row = $(mustache.render(template, {
+                capabilities: capabilities_keys,
+                claim_capability_label: _("cap."),
+            }));
+            row.children("button.fa-plus").on('click', add_row);
+            row.children("button.pficon-close").on('click', remove_row);
+            var capability_option = row.find("div .capability-option");
+            capability_option.find('a').on('click', function() {
+                capability_option.find("button span").text($(this).text());
+            });
+            var capability_select = row.find("div .claim-capability");
+            capability_select.find('a').on('click', function() {
+                capability_select.find("button span").text($(this).text());
+            });
+            $("#select-claimed-capabilities").append(row);
+        }
+
+        return render;
+    }
+
     function link_renderer() {
         var template = $("#container-link-tmpl").html();
         mustache.parse(template);
@@ -601,6 +721,8 @@ $(function() {
         var links = [];
         var exposed_ports = { };
         var claimed_envvars = [ ];
+        var claimed_add_capabilities = [ ];
+        var claimed_drop_capabilities = [ ];
         if ($('#expose-ports').prop('checked')) {
             $('#select-exposed-ports').children('form')
                     .each(function() {
@@ -675,6 +797,34 @@ $(function() {
                     });
         }
 
+        if ($("#add-all-capabilities").prop('checked'))
+            claimed_add_capabilities.push("ALL");
+        else if ($("#drop-all-capabilities").prop('checked'))
+            claimed_drop_capabilities.push("ALL");
+
+        if ($("#claim-capabilities").prop('checked')) {
+            $("#select-claimed-capabilities form").each(function() {
+                var element = $(this).find('button span')
+                        .map(function(idx, elem) {
+                            return $(elem).text();
+                        })
+                        .get();
+                var capability_option = element[0];
+                var capability_key = element[1];
+
+                switch (capability_option) {
+                case 'Add':
+                    claimed_add_capabilities.push(capability_key);
+                    break;
+                case 'Drop':
+                    claimed_drop_capabilities.push(capability_key);
+                    break;
+                default:
+                    break;
+                }
+            });
+        }
+
         if ($("#link-containers").prop('checked')) {
             $("#select-linked-containers form").each(function() {
                 var element = $(this);
@@ -686,6 +836,7 @@ $(function() {
         }
 
         var tty = $("#containers-run-image-with-terminal").prop('checked');
+        var privileged = $("#containers-run-privileged").prop('checked');
         var img_name = null;
         if (image.ActualRepoTags && image.ActualRepoTags.length > 0) {
             img_name = image.ActualRepoTags[0];
@@ -711,6 +862,9 @@ $(function() {
                 "PortBindings": port_bindings,
                 "Binds": volume_bindings,
                 "Links": links,
+                "CapAdd": claimed_add_capabilities,
+                "CapDrop": claimed_drop_capabilities,
+                "Privileged": privileged,
                 "RestartPolicy": {
                     "Name": $("#restart-policy-select > button span.pull-left").data('name'),
                     "MaximumRetryCount": parseInt($("#restart-policy-retries").val(), 10) || 0

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -404,6 +404,143 @@ CMD ["/bin/sh"]
 
         self.allow_journal_messages('.*denied.*name_connect.*docker.*')
 
+    def testPrivileged(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute("systemctl start docker || systemctl start docker-latest")
+
+        self.login_and_go("/docker")
+        b.wait_in_text("#containers-images", "busybox:latest")
+
+        # Select to view all running containers
+        b.set_val("#containers-containers-filter", "all")
+
+        # Create an updated image
+        m.execute("mkdir /var/tmp/container-probe")
+        m.execute("""echo -e '
+FROM busybox
+CMD ["/bin/sh"]
+' > /var/tmp/container-probe/Dockerfile""")
+        image_name = "test/container-probe"
+        m.execute("docker build -t %s /var/tmp/container-probe" % (image_name))
+        m.execute("rm -rf /var/tmp/container-probe")
+
+        # Wait for it to appear
+        b.wait_in_text("#containers-images", image_name)
+
+        # Run it and add privileged flag via the ui
+        b.click("#containers-images tr:contains(\"%s\") button.fa-play" % (image_name))
+        b.wait_popup("containers_run_image_dialog")
+        b.set_val("#containers-run-image-name", "PROBE5")
+        b.set_val("#containers-run-image-command", "/bin/sh")
+        b.click("#containers-run-privileged")
+        b.click("#containers-run-image-run")
+        b.wait_popdown("containers_run_image_dialog")
+        b.wait_in_text("#containers-containers", "PROBE5")
+
+        # Check privileged status
+        info = json.loads(m.execute('docker inspect PROBE5'))
+        self.assertEqual(info[0]["HostConfig"]["Privileged"], True)
+
+        # Run another container without privileged flag via the ui
+        b.click("#containers-images tr:contains(\"%s\") button.fa-play" % (image_name))
+        b.wait_popup("containers_run_image_dialog")
+        b.set_val("#containers-run-image-name", "PROBE6")
+        b.set_val("#containers-run-image-command", "/bin/sh")
+        b.click("#containers-run-image-run")
+        b.wait_popdown("containers_run_image_dialog")
+        b.wait_in_text("#containers-containers", "PROBE6")
+
+        # Check output of the probe
+        b.click('#containers-containers tr:contains("PROBE6")')
+        b.wait_visible("#container-details")
+
+        # Check privileged status
+        info = json.loads(m.execute('docker inspect PROBE6'))
+        self.assertEqual(info[0]["HostConfig"]["Privileged"], False)
+
+        self.allow_journal_messages('.*denied.*name_connect.*docker.*')
+
+    def testCapabilities(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute("systemctl start docker || systemctl start docker-latest")
+
+        self.login_and_go("/docker")
+        b.wait_in_text("#containers-images", "busybox:latest")
+
+        # Select to view all running containers
+        b.set_val("#containers-containers-filter", "all")
+
+        # Create an updated image
+        m.execute("mkdir /var/tmp/container-probe")
+        m.execute("""echo -e '
+FROM busybox
+CMD ["/bin/sh"]
+' > /var/tmp/container-probe/Dockerfile""")
+        image_name = "test/container-probe"
+        m.execute("docker build -t %s /var/tmp/container-probe" % (image_name))
+        m.execute("rm -rf /var/tmp/container-probe")
+
+        # Wait for it to appear
+        b.wait_in_text("#containers-images", image_name)
+
+        # Run it and add/drop set of capabilities
+        b.click("#containers-images tr:contains(\"%s\") button.fa-play" % (image_name))
+        b.wait_popup("containers_run_image_dialog")
+        b.set_val("#containers-run-image-name", "PROBE7")
+        b.set_val("#containers-run-image-command", "/bin/sh")
+
+        # add ALL capabilities and drop specific one
+        b.click("#add-all-capabilities")
+        b.click("claim-capabilities")
+        b.wait_visible("#select-claimed-capabilities:parent")
+        b.click("#select-claimed-capabilities form:last-child .capability-option button")
+        b.click("#select-claimed-capabilities form:last-child .capability-option a[value='Drop']")
+        b.wait_in_text("#select-claimed-capabilities form:last-child .capability-option button", "Drop")
+        b.click("#select-claimed-capabilities form:last-child .claim-capability button")
+        b.click("#select-claimed-capabilities form:last-child .claim-capability a[value='CHOWN']")
+        b.wait_in_text("#select-claimed-capabilities form:last-child .capability-option button", "CHOWN")
+
+        b.click("#containers-run-image-run")
+        b.wait_popdown("containers_run_image_dialog")
+        b.wait_in_text("#containers-containers", "PROBE7")
+
+        # Check added/dropped capabilities
+        info = json.loads(m.execute('docker inspect PROBE7'))
+        self.assertEqual(info[0]["HostConfig"]["CapAdd"], "ALL")
+        self.assertEqual(info[0]["HostConfig"]["CapDrop"], "CHOWN")
+
+        # Run aonther container with different add/drop set of capabilities
+        b.click("#containers-images tr:contains(\"%s\") button.fa-play" % (image_name))
+        b.wait_popup("containers_run_image_dialog")
+        b.set_val("#containers-run-image-name", "PROBE8")
+        b.set_val("#containers-run-image-command", "/bin/sh")
+
+        # drop ALL capabilities and add specific one
+        b.click("#drop-all-capabilities")
+        b.click("claim-capabilities")
+        b.wait_visible("#select-claimed-capabilities:parent")
+        b.click("#select-claimed-capabilities form:last-child .capability-option button")
+        b.click("#select-claimed-capabilities form:last-child .capability-option a[value='Add']")
+        b.wait_in_text("#select-claimed-capabilities form:last-child .capability-option button", "Add")
+        b.click("#select-claimed-capabilities form:last-child .claim-capability button")
+        b.click("#select-claimed-capabilities form:last-child .claim-capability a[value='MKNOD']")
+        b.wait_in_text("#select-claimed-capabilities form:last-child .capability-option button", "MKNOD")
+
+        b.click("#containers-run-image-run")
+        b.wait_popdown("containers_run_image_dialog")
+        b.wait_in_text("#containers-containers", "PROBE8")
+
+        # Check added/dropped capabilities
+        info = json.loads(m.execute('docker inspect PROBE8'))
+        self.assertEqual(info[0]["HostConfig"]["CapAdd"], "MKNOD")
+        self.assertEqual(info[0]["HostConfig"]["CapDrop"], "ALL")
+
+        self.allow_journal_messages('.*denied.*name_connect.*docker.*')
+
     @skipImage("No Cockpit on Atomic with Docker stopped", "fedora-atomic")
     @skipImage("No cockpit-docker on i386", "fedora-i386")
     def testFailure(self):


### PR DESCRIPTION
Added options for running container with:
* privileged mode
* all Linux capabilities added/dropped
* add/drop specific Linux capabilities (multiple)

Implements https://github.com/cockpit-project/cockpit/issues/10637
