### PR TITLE
bots: Fix tests-scan crash if a project doesn't have master tests

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -466,7 +466,7 @@ def cockpit_tasks(api, update, branch_contexts, repo, pull_data, pull_number, sh
             for proj_repo in REPO_BRANCH_CONTEXT:
                 if proj_repo == "cockpit-project/cockpit":
                     continue
-                for context in REPO_BRANCH_CONTEXT[proj_repo]["master"]:
+                for context in REPO_BRANCH_CONTEXT[proj_repo].get("master", []):
                     repo_context = context + "@" + proj_repo
 
                     status = statuses.get(repo_context, {})


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "bots/tests-scan", line 511, in <module>
    sys.exit(main())
  File "bots/tests-scan", line 169, in main
    results = scan_for_pull_tasks(api, policy, opts, opts.repo)
  File "bots/tests-scan", line 490, in scan_for_pull_tasks
    results = cockpit_tasks(api, not opts.dry, policy, repo, opts.pull_data, opts.pull_number, opts.sha, opts.amqp)
  File "bots/tests-scan", line 469, in cockpit_tasks
    for context in REPO_BRANCH_CONTEXT[proj_repo]["master"]:
KeyError: 'master'
```