### PR TITLE
tools: Add missing ssh-agent build dependency

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -122,6 +122,7 @@ BuildRequires: systemd-devel
 BuildRequires: pcp-libs-devel
 BuildRequires: krb5-server
 BuildRequires: gdb
+BuildRequires: openssh-clients
 
 # For documentation
 BuildRequires: xmlto


### PR DESCRIPTION
It previously was a dependency of git, which got dropped in commit 84ba3c821041.