### PR TITLE
session: Circumvent user shell stdout noise

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -132,6 +132,15 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.open("/system")
             b.wait_not_visible("#option-group")
 
+        if not m.atomic_image:
+            # login with user shell that prints some stdout/err noise
+            # having stdout output in ~/.bashrc confuses docker, so don't run on Atomic
+            m.execute("echo 'echo noise-rc-out; echo noise-rc-err >&2' >> ~admin/.bashrc")
+            m.execute("echo 'echo noise-profile-out; echo noise-profile-err >&2' >> ~admin/.profile")
+            login("admin", "foobar")
+            b.expect_load()
+            b.wait_present("#content")
+
         self.allow_journal_messages("Returning error-response ... with reason .*",
                                     "pam_unix\(cockpit:auth\): authentication failure; .*",
                                     "pam_unix\(cockpit:auth\): check pass; user unknown",

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -92,8 +92,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # Login as admin
         b.open("/system")
         login("admin", "foobar")
-        with b.wait_timeout(10):
-            b.expect_load()
+        b.expect_load()
         b.wait_present("#content")
         b.wait_text('#content-user-name', 'Administrator')
 
@@ -228,8 +227,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.set_val('#conversation-input', '123foobar!@#')
         b.click('#login-button')
 
-        with b.wait_timeout(10):
-            b.expect_load()
+        b.expect_load()
         b.wait_present("#content")
         b.wait_text('#content-user-name', 'Administrator')
 
@@ -286,8 +284,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.set_val('#conversation-input', '42')
         b.click('#login-button')
 
-        with b.wait_timeout(10):
-            b.expect_load()
+        b.expect_load()
         b.wait_present("#content")
         b.wait_text('#content-user-name', 'Administrator')
 


### PR DESCRIPTION
session: Circumvent user shell stdout noise
  
Commit a9375441df7 caused Cockpit logins to fail if the user's ~/.bashrc
or ~/.profile writes anything to stdout. That interferes with the
protocol and causes an error like

    incorrect protocol: received invalid length prefix

To avoid this, route the shell's stdout to stderr (so that we can still
see it in the logs) and pass session's stdout to cockpit-bridge through
fd 3. This assumes that the shell supports `>&3` input redirection,
which is the case for any POSIX shell (ash, bash, ksh, dash, zsh) and at
least tcsh.

https://bugzilla.redhat.com/show_bug.cgi?id=1710604