### PR TITLE
build: Ship integration tests in release tarballs again

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -371,7 +371,7 @@ dump-dist-gzip:
 # Subdirectories to distribute everything that's committed to git
 COMMITTED_DIST = \
 	tools/ \
-	test/common \
+	test \
 	$(NULL)
 
 # Build up the distribution using $COMMITTED_DIST and include node_modules licenses


### PR DESCRIPTION
Revert commit 1379a9ee9d3. It's still useful to have the integration
tests in the release, as they always match the shipped code and thus
it's not (or less) necessary to maintain stable branches just for
running the tests downstream.