### PR TITLE
storage: Fix makedirs() invocation for Python 2

### DIFF
--- a/pkg/storaged/nfs-mounts.py
+++ b/pkg/storaged/nfs-mounts.py
@@ -139,6 +139,10 @@ def monitor():
             process_fstab()
             report()
 
+def mkdir_if_necessary(path):
+    if not os.path.exists(path):
+        os.makedirs(path)
+
 def rmdir_if_empty(path):
     try:
         os.rmdir(path)
@@ -149,7 +153,7 @@ def rmdir_if_empty(path):
 def update(entry, new_fields):
     old_fields = entry["fields"]
     if old_fields[1] != new_fields[1]:
-        os.makedirs(new_fields[1], exist_ok=True)
+        mkdir_if_necessary(new_fields[1])
     if entry["mounted"]:
         if (new_fields[0] == old_fields[0]
             and new_fields[1] == old_fields[1]
@@ -169,7 +173,7 @@ def update(entry, new_fields):
     modify_tab("/etc/fstab", lambda fields: new_fields if fields == old_fields else fields)
 
 def add(new_fields):
-    os.makedirs(new_fields[1], exist_ok=True)
+    mkdir_if_necessary(new_fields[1])
     mount({ "fields": new_fields })
     modify_tab("/etc/fstab", lambda fields: new_fields if fields is None else fields)
 
@@ -182,7 +186,7 @@ def remove(entry):
 
 def mount(entry):
     fields = entry["fields"]
-    os.makedirs(fields[1], exist_ok=True)
+    mkdir_if_necessary(fields[1])
     subprocess.check_call([ "mount",
                             "-t", fields[2],
                             "-o", fields[3],

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -75,7 +75,7 @@ def tap_output(machine):
     for t in json_info['tests']:
         test_status = t['status']
         test_name_tmp = os.path.basename(t['id']).split(":", 1)
-        test_name = f"{test_name_tmp[0]} ({test_name_tmp[1]})"
+        test_name = test_name_tmp[0] + " " + test_name_tmp[1]
         test_log = t['logfile']
         test_time_string = "duration: %ds" % t['time']
         test_fail_reason = str(t['fail_reason'])

--- a/test/avocado/selenium-kdump.py
+++ b/test/avocado/selenium-kdump.py
@@ -3,7 +3,6 @@
 from testlib_avocado.seleniumlib import SeleniumTest, clickable, visible
 import os
 import sys
-import subprocess
 
 machine_test_dir = os.path.dirname(os.path.realpath(__file__))
 if machine_test_dir not in sys.path:

--- a/test/avocado/testlib_avocado/seleniumlib.py
+++ b/test/avocado/testlib_avocado/seleniumlib.py
@@ -263,7 +263,7 @@ This function is only for internal purposes:
         output = None
         methods = [item for item in dir(Select) if not item.startswith("_")]
         if select_function not in methods:
-            raise AttributeError(f"You used bad parameter for selected_function param, allowed are {methods}")
+            raise AttributeError("You used bad parameter for selected_function param, allowed are %s" % methods)
         for _ in range(self.default_try):
             try:
                 s1 = Select(element)
@@ -279,7 +279,7 @@ This function is only for internal purposes:
             element = self._relocate_element(element)
         if failure:
             self.take_screenshot(fatal=False)
-            raise SeleniumElementFailure(f"Unable to Select in element {failure}")
+            raise SeleniumElementFailure("Unable to Select in element %s" % failure)
         return output
 
     def select_by_text(self, element, value):
@@ -287,7 +287,6 @@ This function is only for internal purposes:
 
     def select_by_value(self, element, value):
         return self.select(element=element, select_function="select_by_value", value=value)
-
 
     def wait(self, method, text, baseelement, overridetry, fatal, cond, jscheck, text_):
         """


### PR DESCRIPTION
Revert this part of commit a61672abcbe so that it continues to work on
RHEL 7, i. e. with Python 2.