### PR TITLE
base1: Build PatternFly from less files, add overrides

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -84,8 +84,8 @@ GZ_RULE = \
 	gzip -n -c $< > $@.tmp && $(MV) $@.tmp $@
 
 UGLIFY_JS = $(srcdir)/node_modules/.bin/uglifyjs
-
 CLEAN_CSS = $(srcdir)/node_modules/.bin/cleancss
+LESSC = $(srcdir)/node_modules/.bin/lessc
 
 MIN_JS_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -58,18 +58,25 @@ dist/base1/cockpit.min.css.map: dist/base1/cockpit.min.css
 dist/base1/patternfly.min.css.map: dist/base1/patternfly.min.css
 
 # Modify the patternfly files appropriately
-dist/base1/patternfly-base.css: dist/base1/patternfly.css.map
+dist/base1/patternfly.css.map: dist/base1/patternfly-base.css
+dist/base1/patternfly-base.css: src/base1/patternfly-overrides.less
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	sed -f $(srcdir)/tools/patternfly.sed $(srcdir)/node_modules/patternfly/dist/css/patternfly.css > $@.tmp && $(MV) $@.tmp $@
-dist/base1/patternfly.css.map:
-	$(V_COPY) $(MKDIR_P) $(dir $@) && \
-	cp $(srcdir)/node_modules/patternfly/dist/css/patternfly.css.map $@.tmp && $(MV) $@.tmp $@
-dist/base1/patternfly-additions.css: dist/base1/patternfly-additions.css.map
+	F=$(srcdir)/node_modules/patternfly/dist/less/patternfly.less && \
+	sed '/@import "variables.less"/ s^$$^\n@import "../../../../src/base1/patternfly-overrides.less";^' $$F > $$F.patched && \
+	$(LESSC) --source-map=dist/base1/patternfly.css.map --source-map-include-source $$F.patched $@.tmp && \
+	sed -i -f $(srcdir)/tools/patternfly.sed $@.tmp && \
+	rm $$F.patched && \
+	$(MV) $@.tmp $@
+
+dist/base1/patternfly-additions.css.map: dist/base1/patternfly-additions.css
+dist/base1/patternfly-additions.css: src/base1/patternfly-overrides.less
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	sed -f $(srcdir)/tools/patternfly.sed $(srcdir)/node_modules/patternfly/dist/css/patternfly-additions.css > $@.tmp && $(MV) $@.tmp $@
-dist/base1/patternfly-additions.css.map:
-	$(V_COPY) $(MKDIR_P) $(dir $@) && \
-	cp $(srcdir)/node_modules/patternfly/dist/css/patternfly-additions.css.map $@.tmp && $(MV) $@.tmp $@
+	F=$(srcdir)/node_modules/patternfly/dist/less/patternfly-additions.less && \
+	sed '/@import "variables.less"/ s^$$^\n@import "../../../../src/base1/patternfly-overrides.less";^' $$F > $$F.patched && \
+	$(LESSC) --source-map=$@.map --source-map-include-source $$F.patched $@.tmp && \
+	sed -i -f $(srcdir)/tools/patternfly.sed $@.tmp && \
+	rm $$F.patched && \
+	$(MV) $@.tmp $@
 
 dist/base1/fonts/fontawesome.woff:
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
@@ -210,6 +217,7 @@ EXTRA_DIST += \
 	src/base1/cockpit.js \
 	src/base1/deprecated.js \
 	src/base1/manifest.json \
+	src/base1/patternfly-overrides.less \
 	src/base1/simple-tap.js \
 	src/base1/test-dbus-common.js \
 	$(base_DATA) \

--- a/src/base1/patternfly-overrides.less
+++ b/src/base1/patternfly-overrides.less
@@ -1,0 +1,1 @@
+// Global Cockpit overrides for PatternFly variables

--- a/tools/patternfly.sed
+++ b/tools/patternfly.sed
@@ -3,6 +3,3 @@ s/src: url.*glyphicons-halflings-regular.woff.*/src: url('fonts\/glyphicons.woff
 s/src: url.*fontawesome-webfont.woff.*/src: url('fonts\/fontawesome.woff?v=4.2.0') format('woff');/
 s/src: url.*PatternFlyIcons-webfont.woff.*/src: url('fonts\/patternfly.woff') format('woff');/
 s/src:.*url.*OpenSans-\([^'"]*\).woff.*/src: url('..\/..\/static\/fonts\/OpenSans-\1.woff') format('woff');/
-s/url('..\/img\//url('images\//
-s/url("..\/img\//url("images\//
-


### PR DESCRIPTION
Don't use the precompiled *.css files, but build them ourselves. This
will allow us to modify PF variables for tweaking the design globally in
the new file src/base1/patternfly-overrides.less.  See issue #11913 for
details.

Keep the post-lessc seddery of font paths. While there are some PF
variables for them, like `@font-path`, we don't ship all fonts in the
same directory (or even package), so this can't be expressed with just
variables.