### PR TITLE
WIP: ws: Include the RedHat font

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -330,13 +330,41 @@ OPENSANS_FONTS = \
 	dist/fonts/OpenSans-SemiboldItalic-webfont.woff \
 	$(NULL)
 
-dist/fonts/%.woff:
+REDHATTEXT_FONTS = \
+	dist/fonts/RedHatText-Bold.woff2 \
+	dist/fonts/RedHatText-BoldItalic.woff2 \
+	dist/fonts/RedHatText-Italic.woff2 \
+	dist/fonts/RedHatText-Medium.woff2 \
+	dist/fonts/RedHatText-MediumItalic.woff2 \
+	dist/fonts/RedHatText-Regular.woff2 \
+	$(NULL)
+
+REDHATDISPLAY_FONTS = \
+	dist/fonts/RedHatDisplay-Black.woff2 \
+	dist/fonts/RedHatDisplay-BlackItalic.woff2 \
+	dist/fonts/RedHatDisplay-Bold.woff2 \
+	dist/fonts/RedHatDisplay-BoldItalic.woff2 \
+	dist/fonts/RedHatDisplay-Italic.woff2 \
+	dist/fonts/RedHatDisplay-Medium.woff2 \
+	dist/fonts/RedHatDisplay-MediumItalic.woff2 \
+	dist/fonts/RedHatDisplay-Regular.woff2 \
+	$(NULL)
+
+dist/fonts/OpenSans-%.woff:
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cp -L $(subst dist/fonts,$(srcdir)/node_modules/patternfly/dist/fonts,$@) $@.tmp && $(MV) $@.tmp $@
 
-EXTRA_DIST += $(OPENSANS_FONTS)
+dist/fonts/RedHatText-%.woff2:
+	$(V_COPY) $(MKDIR_P) $(dir $@) && \
+	cp -L $(subst dist/fonts,$(srcdir)/node_modules/@redhat/redhat-font/webfonts/RedHatText,$@) $@.tmp && $(MV) $@.tmp $@
 
-MAINTAINERCLEANFILES += $(OPENSANS_FONTS)
+dist/fonts/RedHatDisplay-%.woff2:
+	$(V_COPY) $(MKDIR_P) $(dir $@) && \
+	cp -L $(subst dist/fonts,$(srcdir)/node_modules/@redhat/redhat-font/webfonts/RedHatDisplay,$@) $@.tmp && $(MV) $@.tmp $@
+
+EXTRA_DIST += $(OPENSANS_FONTS) $(REDHATTEXT_FONTS) $(REDHATDISPLAY_FONTS)
+
+MAINTAINERCLEANFILES += $(OPENSANS_FONTS) $(REDHATTEXT_FONTS) $(REDHATDISPLAY_FONTS)
 
 if ENABLE_DOC
 

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -65,7 +65,7 @@ GUIDE_XSLT = \
 	doc/guide/version-greater-or-equal.xsl \
 	$(NULL)
 
-GUIDE_FONTS = $(subst dist/fonts/,dist/guide/html/,$(OPENSANS_FONTS))
+GUIDE_FONTS = $(subst dist/fonts/,dist/guide/html/,$(REDHATTEXT_FONTS))
 
 EXTRA_DIST += \
 	$(GUIDE_DOCBOOK) \
@@ -92,7 +92,7 @@ MAINTAINERCLEANFILES += \
 	*.tmp \
 	$(NULL)
 
-dist/guide/html/%.woff: dist/fonts/%.woff
+dist/guide/html/%.woff2: dist/fonts/%.woff2
 	$(COPY_RULE)
 
 dist/guide/html/index.html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUIDE_STATIC) $(GUIDE_XSLT) $(GUIDE_FONTS)

--- a/doc/guide/static/style.css
+++ b/doc/guide/static/style.css
@@ -1,34 +1,22 @@
 @import url("gtk-doc.css");
 
+/* keep this in sync with node_modules/@redhat/redhat-font/webfonts/red-hat-font.css */
 @font-face {
-  font-family: 'Open Sans';
-  font-style: normal;
-  font-weight: 300;
-  src: url('OpenSans-Light-webfont.woff') format('woff');
-}
-@font-face {
-  font-family: 'Open Sans';
+  font-family: "RedHatText";
+  src: url("./RedHatText-Regular.woff2") format("woff2");
+  /* Modern Browsers */
   font-style: normal;
   font-weight: 400;
-  src: url('OpenSans-Regular-webfont.woff') format('woff');
+  text-rendering: optimizeLegibility;
 }
+
 @font-face {
-  font-family: 'Open Sans';
-  font-style: normal;
-  font-weight: 600;
-  src: url('OpenSans-Semibold-webfont.woff') format('woff');
-}
-@font-face {
-  font-family: 'Open Sans';
+  font-family: "RedHatText";
+  src: url("./RedHatText-Medium.woff2") format("woff2");
+  /* Modern Browsers */
   font-style: normal;
   font-weight: 700;
-  src: url('OpenSans-Bold-webfont.woff') format('woff');
-}
-@font-face {
-  font-family: 'Open Sans';
-  font-style: normal;
-  font-weight: 800;
-  src: url('OpenSans-ExtraBold-webfont.woff') format('woff');
+  text-rendering: optimizeLegibility;
 }
 
 H1.guides {
@@ -46,7 +34,7 @@ H2.guides {
 DIV.guides {
 	margin-left: 20px;
 	margin-right: 20px;
-	font-family: 'Open Sans', Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
+	font-family: 'RedHatText', Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
 	font-size: 11pt;
 }
 
@@ -57,7 +45,7 @@ DIV.guides > p {
 DIV.guides > A {
 	margin-left: 40px;
 	margin-right: 20px;
-	font-size: 13px;
+	font-size: 12px;
 	line-height: 200%;
         display: block;
 }
@@ -86,7 +74,7 @@ TABLE.navigation TH:first-child {
 
 .shortcuts a {
 	color: white !important;
-	font-family: 'Open Sans', Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
+	font-family: 'RedHatText', Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
 }
 
 P.title {
@@ -130,7 +118,7 @@ DIV.index,
 DIV.footer,
 DIV.section,
 DIV.part {
-	font-family: 'Open Sans', Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
+	font-family: 'RedHatText', Verdana, Arial, 'Bitstream Vera Sans', Helvetica, sans-serif;
 	font-size: 11pt;
 	line-height: 160%;
 }
@@ -180,7 +168,7 @@ PRE.programlisting {
 }
 
 DIV.variablelist TABLE {
-	font-size: 11pt;
+	font-size: 13pt;
 	line-height: 150%;
         margin-left: 0px;
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@babel/polyfill": "7.4.4",
     "@patternfly/react-console": "1.10.50",
+    "@redhat/redhat-font": "git+https://github.com/RedHatOfficial/RedHatFont.git#2.2.0",
     "angular": "1.3.20",
     "angular-bootstrap-npm": "0.13.4",
     "angular-gettext": "2.3.11",

--- a/src/base1/patternfly-overrides.less
+++ b/src/base1/patternfly-overrides.less
@@ -1,1 +1,5 @@
 // Global Cockpit overrides for PatternFly variables
+
+// Fonts
+@import (inline, once) "../../node_modules/@redhat/redhat-font/webfonts/red-hat-font.css";
+@font-family-base: "RedHatText", "Open Sans", Helvetica, Arial, sans-serif;

--- a/src/common/fail.html
+++ b/src/common/fail.html
@@ -7,7 +7,7 @@
     <style>
 	body {
             margin: 0;
-            font-family: "Open Sans", Helvetica, Arial, sans-serif;
+            font-family: "RedHatDisplay", "Open Sans", Helvetica, Arial, sans-serif;
             font-size: 12px;
             line-height: 1.66666667;
             color: #333333;
@@ -24,16 +24,16 @@
             margin: 0 0 10px;
         }
         @font-face {
-            font-family: 'Open Sans';
+            font-family: 'RedHatDisplay';
             font-style: normal;
             font-weight: 300;
-            src: url('/cockpit/static/fonts/OpenSans-Light-webfont.woff') format('woff');
+            src: url('/cockpit/static/fonts/RedHatDisplay-Medium.woff2') format('woff');
         }
         @font-face {
             font-family: 'Open Sans';
             font-style: normal;
-            font-weight: 400;
-            src: url('/cockpit/static/fonts/OpenSans-Regular-webfont.woff') format('woff');
+            font-weight: 300;
+            src: url('/cockpit/static/fonts/OpenSans-Light-webfont.woff') format('woff');
         }
         .blank-slate-pf {
             text-align: center;

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -35,7 +35,7 @@ dist/static/login.po.%.html: src/ws/%.po src/ws/po.empty.html
 	$(MV) $@.tmp $@
 
 staticfontsdir = $(staticdir)/fonts
-staticfonts_DATA = $(OPENSANS_FONTS)
+staticfonts_DATA = $(OPENSANS_FONTS) $(REDHATTEXT_FONTS) $(REDHATDISPLAY_FONTS)
 
 MAINTAINERCLEANFILES += \
 	dist/static/login.html \

--- a/src/ws/login.css
+++ b/src/ws/login.css
@@ -8,7 +8,7 @@ html {
 }
 body {
   margin: 0;
-  font-family: "Open Sans", Helvetica, Arial, sans-serif;
+  font-family: "RedHatText", Helvetica, Arial, sans-serif;
   font-size: 12px;
   line-height: 1.66666667;
   color: #333333;
@@ -345,16 +345,16 @@ label {
   background-image: none;
 }
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'RedHatText';
   font-style: normal;
   font-weight: 400;
-  src: url('cockpit/static/fonts/OpenSans-Regular-webfont.woff') format('woff');
+  src: url('cockpit/static/fonts/RedHatText-Regular.woff2') format('woff2');
 }
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'RedHatText';
   font-style: normal;
   font-weight: 700;
-  src: url('cockpit/static/fonts/OpenSans-Bold-webfont.woff') format('woff');
+  src: url('cockpit/static/fonts/RedHatText-Medium.woff2') format('woff2');
 }
 .form-control:hover {
   border-color: #7BB2DD;

--- a/tools/patternfly.sed
+++ b/tools/patternfly.sed
@@ -3,3 +3,4 @@ s/src: url.*glyphicons-halflings-regular.woff.*/src: url('fonts\/glyphicons.woff
 s/src: url.*fontawesome-webfont.woff.*/src: url('fonts\/fontawesome.woff?v=4.2.0') format('woff');/
 s/src: url.*PatternFlyIcons-webfont.woff.*/src: url('fonts\/patternfly.woff') format('woff');/
 s/src:.*url.*OpenSans-\([^'"]*\).woff.*/src: url('..\/..\/static\/fonts\/OpenSans-\1.woff') format('woff');/
+s/src:.*url.*RedHat\([a-zA-Z]\+-[^.]*\).*/src: url('..\/..\/static\/fonts\/RedHat\1.woff2') format('woff2');/


### PR DESCRIPTION
Make it the preferred font for Cockpit pages. We can't switch to it
exclusively, as older or newer pages/bridge may run against an
older/newer cockpit-ws (which ships the fonts). For the same reason ws
still needs to ship the Open Sans fonts for a while.

Use it in the HTML guide as well.

Preparatory work for issue #11914 

 - [x] Requires and builds on top of PF-Less PR #12001
 - [x] Update font on login page
 - [x] Update font on bridge fail page