### PR TITLE
bots: Mitigate fundamental race condition in image-refresh

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -133,7 +133,7 @@ def run(image, verbose=False, **kwargs):
 
     branch = task.branch(image, "images: Update {0} image".format(image), pathspec="bots/images", **kwargs)
     if branch:
-        pull = task.pull(branch, **kwargs)
+        pull = task.pull(branch, run_tests=False, **kwargs)
 
         # we want to validate all image refreshes with external projects
         task.label(pull, ["test-external"])
@@ -146,4 +146,4 @@ def run(image, verbose=False, **kwargs):
                 "description": github.NOT_TESTED_DIRECT })
 
 if __name__ == '__main__':
-    task.main(function=run, title="Refresh image", run_tests=False)
+    task.main(function=run, title="Refresh image")

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -21,16 +21,19 @@
 import os
 import subprocess
 import sys
+import time
 
 import task
 from task import github, REDHAT_STORE
 
 TRIGGERS = {
     "centos-7": [
-        "verify/centos-7"
+        "verify/centos-7",
+        "cockpit/centos-7@cockpit-project/starter-kit",
     ],
     "continuous-atomic": [
-        "verify/continuous-atomic"
+        "verify/continuous-atomic",
+        "cockpit/continuous-atomic@cockpit-project/cockpit-ostree",
     ],
     "debian-testing": [
         "verify/debian-testing"
@@ -43,6 +46,7 @@ TRIGGERS = {
         "verify/fedora-atomic",
         "container/kubernetes",
         "container/bastion",
+        "cockpit/fedora-29@cockpit-project/cockpit-podman",
     ],
     "fedora-30": [
         "verify/fedora-30",
@@ -50,9 +54,18 @@ TRIGGERS = {
         "selenium/firefox",
         "selenium/edge",
         "avocado/fedora",
+        "cockpit/fedora-30@cockpit-project/starter-kit",
+        "cockpit/fedora-30@cockpit-project/cockpit-podman",
+        "cockpit/fedora-30@weldr/lorax",
+        "cockpit/fedora-30/live-iso@weldr/lorax",
+        "cockpit/fedora-30/qcow2@weldr/lorax",
+        "cockpit/fedora-30/chrome@weldr/cockpit-composer",
+        "cockpit/fedora-30/firefox@weldr/cockpit-composer",
+        "cockpit/fedora-30/edge@weldr/cockpit-composer",
     ],
     "fedora-atomic": [
-        "verify/fedora-atomic"
+        "verify/fedora-atomic",
+        "cockpit/fedora-atomic@cockpit-project/cockpit-ostree",
     ],
     "fedora-testing": [
         "verify/fedora-testing"
@@ -85,15 +98,18 @@ TRIGGERS = {
     ],
     "rhel-7-7": [
         "verify/rhel-7-7",
+        "cockpit/rhel-7-7/firefox@weldr/cockpit-composer",
     ],
     "rhel-8-0": [
         "verify/rhel-8-0"
     ],
     "rhel-8-1": [
-        "verify/rhel-8-1"
+        "verify/rhel-8-1",
+        "cockpit/rhel-8-1/chrome@weldr/cockpit-composer",
     ],
     "rhel-atomic": [
-        "verify/rhel-atomic"
+        "verify/rhel-atomic",
+        "cockpit/rhel-atomic@cockpit-project/cockpit-ostree",
     ]
 }
 
@@ -135,15 +151,21 @@ def run(image, verbose=False, **kwargs):
     if branch:
         pull = task.pull(branch, run_tests=False, **kwargs)
 
-        # we want to validate all image refreshes with external projects
-        task.label(pull, ["test-external"])
-
         # Trigger this pull request
         api = github.GitHub()
-        head = api.get("pulls/{}".format(pull["number"]))["head"]["sha"]
+        head = pull["head"]["sha"]
         for trigger in triggers:
             api.post("statuses/{0}".format(head), { "state": "pending", "context": trigger,
                 "description": github.NOT_TESTED_DIRECT })
+
+        # Wait until all of the statuses are present so the no-test label can
+        # safely be removed by the task api
+        for retry in range(20):
+            if all(status in triggers for status in api.statuses(head).keys()):
+                break
+            time.sleep(3)
+        else:
+            raise RuntimeError("Failed to confirm the presence of all triggers")
 
 if __name__ == '__main__':
     task.main(function=run, title="Refresh image")

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -138,11 +138,7 @@ def begin(publish, name, context, issue):
         number = issue["number"]
         identifier = "{0}-{1}-{2}".format(name, number, current)
         title = issue["title"]
-        # Multiple failures would duplicate [no-test] in the title
-        if "[no-test]" in title:
-            wip = "WIP: {0}: {1}".format(hostname, title)
-        else:
-            wip = "WIP: {0}: [no-test] {1}".format(hostname, title)
+        wip = "WIP: {0}: [no-test] {1}".format(hostname, title)
         requests = [ {
             "method": "POST",
             "resource": api.qualify("issues/{0}".format(number)),
@@ -194,7 +190,7 @@ def begin(publish, name, context, issue):
 
     return publishing
 
-def finish(publishing, ret, name, context, issue, run_tests):
+def finish(publishing, ret, name, context, issue):
     if not publishing:
         return
 
@@ -224,15 +220,10 @@ def finish(publishing, ret, name, context, issue, run_tests):
         # The sink wants us to escape colons :S
         body = checklist.body.replace(':', '::')
 
-        # Multiple failures would duplicate [no-test] in the title
-        if run_tests or "[no-test]" in issue["title"]:
-            title = issue["title"]
-        else:
-            title = "[no-test] {0}".format(issue["title"])
         requests = [ {
             "method": "POST",
             "resource": api.qualify("issues/{0}".format(number)),
-            "data": { "title": title, "body": body }
+            "data": { "title": "{0}".format(issue["title"]), "body": body }
         } ]
 
         # Close the issue if it's not a pull request, successful, and all tasks done
@@ -259,7 +250,6 @@ def run(context, function, **kwargs):
     number = kwargs.get("issue", None)
     publish = kwargs.get("publish", "")
     name = kwargs["name"]
-    run_tests = kwargs.get("run_tests", True)
 
     issue = None
     if number:
@@ -286,7 +276,7 @@ def run(context, function, **kwargs):
     except:
         traceback.print_exc()
     finally:
-        finish(publishing, ret, name, context, issue, run_tests)
+        finish(publishing, ret, name, context, issue)
     return ret or 0
 
 # Check if the given files that match @pathspec are stale
@@ -415,11 +405,10 @@ def branch(context, message, pathspec=".", issue=None, branch=None, push=True, *
 
     return "{0}:{1}".format(user, branch)
 
-def pull(branch, body=None, issue=None, base="master", labels=['bot'], **kwargs):
+def pull(branch, body=None, issue=None, base="master", labels=['bot'], run_tests=True, **kwargs):
     if "pull" in kwargs:
         return kwargs["pull"]
 
-    run_tests = kwargs.get("run_tests", True)
     data = {
         "head": branch,
         "base": base,

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -455,6 +455,16 @@ def pull(branch, body=None, issue=None, base="master", labels=['bot'], run_tests
         (user, branch) = branch.split(":")
         push_branch(user, branch, True)
 
+        # Make sure we return the updated pull data
+        for retry in range(20):
+            new_data = api.get("pulls/{}".format(pull["number"]))
+            if pull["head"]["sha"] != new_data["head"]["sha"]:
+                pull = new_data
+                break
+            time.sleep(3)
+        else:
+            raise RuntimeError("Failed to retrieve updated pull data after force pushing")
+
     return pull
 
 def label(issue, labels=['bot']):

--- a/bots/task/test-task
+++ b/bots/task/test-task
@@ -40,6 +40,12 @@ DATA = {
     "/repos/project/repo/issues/3333": {
         "title": "The issue title"
     },
+    "/repos/project/repo/pulls/1234": {
+        "title": "Task title",
+        "number": 1234,
+        "body": "This is the body",
+        "head": {"sha": "abcdef"},
+    },
     "/users/user/repos": [{"full_name": "project/repo"}]
 }
 
@@ -80,6 +86,7 @@ def mockServer():
                 data = json.loads(self.rfile.read(content_len).decode('utf-8'))
                 data["number"] = 1234
                 data["body"] = "This is the body"
+                data["head"] = {"sha": "abcde"}
                 self.replyJson(data)
             elif self.path == "/repos/project/repo/issues/1234/comments":
                 content_len = int(self.headers.get('content-length'))


### PR DESCRIPTION
Depending on the tests-external label inside of the image-refresh task
would depend on a race: it would expect that the task finishes and
removes no-test from the title before the webhook has called all of its
tests-scans on the direct triggers. And as the status events do not
include the pull data, this would be a race.

To avoid this race, poll for the updated head after force-pushing,
trigger all the external tests manually, and then poll that all those
statuses are present before letting the task finish and removing the
no-test from the title.

---

###### I tested this numerous times on my own repo [example](https://github.com/Gundersanne/cockpit/pull/74).
