### PR TITLE
bots: Don't make assumption about the exit code of the test runner

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -279,7 +279,7 @@ class PullTask(object):
             message = "Tests passed"
             mark_passed()
         else:
-            message = "{0} tests failed".format(ret)
+            message = "Tests failed with code {0}".format(ret)
             mark_failed()
             ret = 0 # A failure, but not for this script
         sink.status["message"] = message


### PR DESCRIPTION
It very often is the number of tests that have failed, but not always.