### PR TITLE
common: Drop glib usage from cockpitconf

### DIFF
--- a/src/common/cockpitconf.h
+++ b/src/common/cockpitconf.h
@@ -20,34 +20,33 @@
 #ifndef COCKPIT_CONF_H__
 #define COCKPIT_CONF_H__
 
-#include <glib.h>
-
-G_BEGIN_DECLS
-
 #define COCKPIT_CONF_SSH_SECTION "Ssh-Login"
 
-const gchar *   cockpit_conf_string           (const gchar *section,
-                                               const gchar *field);
+#include <stdbool.h>
+#include <stdint.h>
+
+const char *   cockpit_conf_string           (const char *section,
+                                              const char *field);
 
 
-const gchar **  cockpit_conf_strv             (const gchar *section,
-                                               const gchar *field,
-                                               gchar delimiter);
+const char **  cockpit_conf_strv             (const char *section,
+                                              const char *field,
+                                              char delimiter);
 
-gboolean        cockpit_conf_bool             (const gchar *section,
-                                               const gchar *field,
-                                               gboolean defawlt);
+bool           cockpit_conf_bool             (const char *section,
+                                              const char *field,
+                                              bool defawlt);
 
-guint           cockpit_conf_guint            (const gchar *section,
-                                               const gchar *field,
-                                               guint default_value,
-                                               guint64 max,
-                                               guint64 min);
+unsigned       cockpit_conf_uint             (const char *section,
+                                              const char *field,
+                                              unsigned default_value,
+                                              unsigned max,
+                                              unsigned min);
 
-const gchar * const * cockpit_conf_get_dirs   (void);
+const char * const * cockpit_conf_get_dirs   (void);
 
-void            cockpit_conf_cleanup          (void);
+void           cockpit_conf_cleanup          (void);
 
-void            cockpit_conf_init             (void);
+void           cockpit_conf_init             (void);
 
 #endif /* COCKPIT_CONF_H__ */

--- a/src/common/cockpitmemory.h
+++ b/src/common/cockpitmemory.h
@@ -25,4 +25,19 @@
 void     cockpit_memory_clear            (void *data,
                                           ssize_t length);
 
+/* variants of glibc functions that abort() on ENOMEM */
+void*    mallocx                         (size_t size);
+char*    strdupx                         (const char *s);
+
+char*    strndupx                        (const char *s,
+                                          size_t n);
+
+__attribute__((__format__ (__printf__, 2, 3)))
+int      asprintfx                       (char **strp,
+                                          const char *fmt, ...);
+
+void*    reallocarrayx                   (void *ptr,
+                                          size_t nmemb,
+                                          size_t size);
+
 #endif /* __COCKPIT_MEMORY_H__ */

--- a/src/common/test-config.c
+++ b/src/common/test-config.c
@@ -86,26 +86,47 @@ test_get_guint (void)
 static void
 test_get_strvs (void)
 {
-  const gchar **comma = NULL;
-  const gchar **space = NULL;
-  const gchar **one = NULL;
+  const gchar **list = NULL;
 
   cockpit_config_file = SRCDIR "/src/ws/mock-config/cockpit/cockpit.conf";
 
   g_assert_null (cockpit_conf_strv ("bad-section", "value", ' '));
   g_assert_null (cockpit_conf_strv ("Section1", "value", ' '));
 
-  one = cockpit_conf_strv ("Section2", "value1", ' ');
-  g_assert_cmpstr (one[0], ==, "string");
+  /* empty list */
+  list = cockpit_conf_strv ("Section2", "empty", ':');
+  g_assert_null (list[0]);
 
-  space = cockpit_conf_strv ("Section2", "value2", ' ');
-  g_assert_cmpstr (space[0], ==, "commas,");
-  g_assert_cmpstr (space[1], ==, "or");
-  g_assert_cmpstr (space[2], ==, "spaces");
+  /* list with one element */
+  list = cockpit_conf_strv ("Section2", "value1", ' ');
+  g_assert_cmpstr (list[0], ==, "string");
+  g_assert_null (list[1]);
 
-  comma = cockpit_conf_strv ("Section2", "value2", ',');
-  g_assert_cmpstr (comma[0], ==, "commas");
-  g_assert_cmpstr (comma[1], ==, " or spaces");
+  /* list with space separator */
+  list = cockpit_conf_strv ("Section2", "value2", ' ');
+  g_assert_cmpstr (list[0], ==, "commas,");
+  g_assert_cmpstr (list[1], ==, "or");
+  g_assert_cmpstr (list[2], ==, "spaces");
+  g_assert_null (list[3]);
+
+  /* list with comma separator */
+  list = cockpit_conf_strv ("Section2", "value3", ',');
+  g_assert_cmpstr (list[0], ==, "commas");
+  g_assert_cmpstr (list[1], ==, " or spaces");
+  g_assert_null (list[2]);
+
+  /* list with only a separator */
+  list = cockpit_conf_strv ("Section2", "emptystrv", ':');
+  g_assert_cmpstr (list[0], ==, "");
+  g_assert_cmpstr (list[1], ==, "");
+  g_assert_null (list[2]);
+
+  /* list with empty value in the middle */
+  list = cockpit_conf_strv ("Section2", "strvemptyitems", ':');
+  g_assert_cmpstr (list[0], ==, "one");
+  g_assert_cmpstr (list[1], ==, "");
+  g_assert_cmpstr (list[2], ==, "three");
+  g_assert_null (list[3]);
 
   cockpit_conf_cleanup ();
 }

--- a/src/common/test-config.c
+++ b/src/common/test-config.c
@@ -68,18 +68,18 @@ test_get_bool (void)
 }
 
 static void
-test_get_guint (void)
+test_get_uint (void)
 {
   cockpit_config_file = SRCDIR "/src/ws/mock-config/cockpit/cockpit.conf";
 
-  g_assert_cmpuint (cockpit_conf_guint ("bad-section", "value", 1, 999, 0), ==,  1);
-  g_assert_cmpuint (cockpit_conf_guint ("Section2", "missing", 1, 999, 0), ==,  1);
-  g_assert_cmpuint (cockpit_conf_guint ("Section2", "mixed", 10, 999, 0), ==,  10);
-  g_assert_cmpuint (cockpit_conf_guint ("Section2", "value1", 10, 999, 0), ==,  10);
-  g_assert_cmpuint (cockpit_conf_guint ("Section2", "toolarge", 10, 999, 0), ==,  10);
-  g_assert_cmpuint (cockpit_conf_guint ("Section2", "one", 10, 999, 0), ==,  1);
-  g_assert_cmpuint (cockpit_conf_guint ("Section2", "one", 1, 999, 2), ==,  2);
-  g_assert_cmpuint (cockpit_conf_guint ("Section2", "one", 1, 0, 0), ==,  0);
+  g_assert_cmpuint (cockpit_conf_uint ("bad-section", "value", 1, 999, 0), ==,  1);
+  g_assert_cmpuint (cockpit_conf_uint ("Section2", "missing", 1, 999, 0), ==,  1);
+  g_assert_cmpuint (cockpit_conf_uint ("Section2", "mixed", 10, 999, 0), ==,  10);
+  g_assert_cmpuint (cockpit_conf_uint ("Section2", "value1", 10, 999, 0), ==,  10);
+  g_assert_cmpuint (cockpit_conf_uint ("Section2", "toolarge", 10, 999, 0), ==,  10);
+  g_assert_cmpuint (cockpit_conf_uint ("Section2", "one", 10, 999, 0), ==,  1);
+  g_assert_cmpuint (cockpit_conf_uint ("Section2", "one", 1, 999, 2), ==,  2);
+  g_assert_cmpuint (cockpit_conf_uint ("Section2", "one", 1, 0, 0), ==,  0);
   cockpit_conf_cleanup ();
 }
 
@@ -157,7 +157,7 @@ main (int argc,
   cockpit_test_init (&argc, &argv);
 
   g_test_add_func ("/conf/test-bool", test_get_bool);
-  g_test_add_func ("/conf/test-guint", test_get_guint);
+  g_test_add_func ("/conf/test-uint", test_get_uint);
   g_test_add_func ("/conf/test-strings", test_get_strings);
   g_test_add_func ("/conf/test-strvs", test_get_strvs);
   g_test_add_func ("/conf/fail_load", test_fail_load);

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -443,8 +443,8 @@ timeout_option (const gchar *name,
                 const gchar *type,
                 guint default_value)
 {
-  return cockpit_conf_guint (type, name, default_value,
-                             MAX_AUTH_TIMEOUT, MIN_AUTH_TIMEOUT);
+  return cockpit_conf_uint (type, name, default_value,
+                            MAX_AUTH_TIMEOUT, MIN_AUTH_TIMEOUT);
 }
 
 static const gchar *

--- a/src/ws/mock-config/cockpit/cockpit.conf
+++ b/src/ws/mock-config/cockpit/cockpit.conf
@@ -1,8 +1,15 @@
+# initial comment
+
 [Section1]
 
-[Section2]
+ [Section2]
 value1 = string
-value2 = commas, or spaces
+  value2=commas, or spaces
+value3 = commas, or spaces 
+empty =
+emptystrv = :
+strvemptyitems = one::three
+# another comment
 true = TRUE
 truelower = true
 yes = YES


### PR DESCRIPTION
This makes it possible to share with the upcoming cockpit-tls, which
must not use GLib/GObject.

Rename cockpit_conf_guint() to cockpit_conf_uint() to reflect the data
type changes.

For simplicity this uses a single linked list for storing the data
instead of a hashtable of hashtable. These are being called so rarely,
and cockpit.conf files are so small that it's not worth all this
overhead.

Also, stop supporting parsing the same key strv with different
delimiters. This is unrealistic to happen in practice (and doesn't), and
it would significantly complicate the caching.