### PR TITLE
ssh: Gracefully handle failing g_hmac_new()

### DIFF
--- a/src/ssh/cockpitsshknownhosts.c
+++ b/src/ssh/cockpitsshknownhosts.c
@@ -374,6 +374,11 @@ matches_hashed (const gchar *line,
 
   // Generate the sha1 hmac
   hmac = g_hmac_new (G_CHECKSUM_SHA1, (guchar *)copied, salt_length);
+  if (!hmac)
+    {
+      g_message ("unable to create SHA1 HMAC");
+      goto out;
+    }
   g_hmac_update (hmac, (guchar *)host, strlen (host));
   g_hmac_get_digest (hmac, generated_hash, &generated_length);
 


### PR DESCRIPTION
This function could fail if glib doesn't support HMAC or SHA1, e. g.
because it is in FIPS mode.

This only affects building against libssh 0.7, i. e. RHEL/CentOS 7 and
Debian 9. In newer operating systems with libssh 0.8, this entire file
is not built.

Fixes #12016
https://gitlab.gnome.org/GNOME/glib/merge_requests/897