### PR TITLE
networking: replace 'Members' with 'Interfaces' when refering to slave ifaces in bonding dialog

### DIFF
--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -263,7 +263,7 @@
       <input id="network-bond-settings-interface-name-input" class="form-control"
              value="{{interface_name}}"/>
 
-      <label class="control-label" translatable="yes">Members</label>
+      <label class="control-label" translatable="yes">Interfaces</label>
       <div id="network-bond-settings-members">
       {{! member interfaces will be rendered into here as a list of checkboxes }}
       </div>

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2983,7 +2983,7 @@ PageNetworkInterface.prototype = {
             }
 
             $('#network-interface-slaves thead th:first-child')
-                    .text(cs.type == "bond" ? _("Members") : _("Ports"));
+                    .text(cs.type == "bond" ? _("Interfaces") : _("Ports"));
 
             con.Slaves.forEach(function (slave_con) {
                 slave_con.Interfaces.forEach(function(iface) {


### PR DESCRIPTION
The man pages of nmcli use the terminology 'master interface' and 'slave
interfaces', so using 'interfaces' instead of 'members' should not be
misleading for people familiar with the CLI options.

Fixes #12017