### PR TITLE
bots: Drop verify/fedora-29 test from image-refresh

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -42,7 +42,6 @@ TRIGGERS = {
         "verify/debian-stable"
     ],
     "fedora-29": [
-        "verify/fedora-29",
         "verify/fedora-atomic",
         "container/bastion",
         "cockpit/fedora-29@cockpit-project/cockpit-podman",


### PR DESCRIPTION
This was dropped in commit 499c0cb7e.