### PR TITLE
machines: Fix volume's xml parsing of format element

### DIFF
--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -841,7 +841,7 @@ export function parseStorageVolumeDumpxml(connectionName, storageVolumeXml, id_o
     const physicalElem = storageVolumeElem.getElementsByTagName('physical')[0];
     const physical = physicalElem ? physicalElem.childNodes[0].nodeValue : NaN;
     const formatElem = storageVolumeElem.getElementsByTagName('format')[0];
-    const format = formatElem.getAttribute('type');
+    const format = formatElem ? formatElem.getAttribute('type') : undefined;
     return {
         connectionName,
         name,


### PR DESCRIPTION
Let's take into consideration that format element in storage volume's xml may be optional.

Closes: #11983