### PR TITLE
naughty: Close 11724: SELinux is preventing iscsid from 'map' accesses

### DIFF
--- a/bots/naughty/fedora-30/11724-selinux-denies-iscsid-from-map
+++ b/bots/naughty/fedora-30/11724-selinux-denies-iscsid-from-map
@@ -1,1 +1,0 @@
-audit: type=1400 * avc:  denied  { map } * comm="iscsid" path="/usr/lib/modules/*/modules.dep.bin"

--- a/bots/naughty/rhel-8/11724-selinux-denies-iscsid-from-map
+++ b/bots/naughty/rhel-8/11724-selinux-denies-iscsid-from-map
@@ -1,1 +1,0 @@
-audit: type=1400 * avc:  denied  { map } * comm="iscsid" path="/usr/lib/modules/*/modules.dep.bin"


### PR DESCRIPTION
Known issue which has not occurred in 22 days

SELinux is preventing iscsid from 'map' accesses

Fixes #11724