### PR TITLE
machines: remove lvm2 from supported disk pool format types

### DIFF
--- a/pkg/machines/components/storagePools/createStoragePoolDialog.jsx
+++ b/pkg/machines/components/storagePools/createStoragePoolDialog.jsx
@@ -197,7 +197,7 @@ const StoragePoolInitiatorRow = ({ onValueChanged, dialogValues }) => {
 const StoragePoolSourceRow = ({ onValueChanged, dialogValues }) => {
     let validationState;
     let placeholder;
-    const diskPoolSourceFormatTypes = ['dos', 'dvh', 'gpt', 'mac', 'bsd', 'pc98', 'sun', 'lvm2'];
+    const diskPoolSourceFormatTypes = ['dos', 'dvh', 'gpt', 'mac', 'bsd', 'pc98', 'sun'];
 
     if (dialogValues.type == 'netfs') {
         validationState = dialogValues.source.dir.length == 0 && dialogValues.validationFailed.source ? 'error' : undefined;


### PR DESCRIPTION
There is not lvm2 partition table type. (See man parted)
This list was copied from https://libvirt.org/storage.html which has
lvm2 listed incorrectly as partition table type.