### PR TITLE
bots: Add naughty for SELinux dhclient regression on RHEL 8.1

### DIFF
--- a/bots/naughty/rhel-8/12057-selinux-dhclient-tmpfs
+++ b/bots/naughty/rhel-8/12057-selinux-dhclient-tmpfs
@@ -1,0 +1,1 @@
+audit: type=1400 * avc:  denied  { write } * comm="dhclient" name="NetworkManager" dev="tmpfs"


### PR DESCRIPTION
Related to PR #12056

Known issue #12057
Downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=1720070