### PR TITLE
machines: Alter memory available helpblock

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1168,6 +1168,9 @@ class TestMachines(NetworkCase):
                                                             os_vendor=config.NOVELL_VENDOR,
                                                             os_name=config.NOVELL_NETWARE_4), {"Source": "Source should start with"})
 
+        # memory
+        checkDialogFormValidationTest(TestMachines.VmDialog(self, storage_size=1, memory_size=0), {"Memory": "Memory must not be 0"})
+
         # start vm
         checkDialogFormValidationTest(TestMachines.VmDialog(self, storage_size=1,
                                                             os_vendor=config.NOVELL_VENDOR,

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1538,7 +1538,7 @@ class TestMachines(NetworkCase):
 
         def __init__(self, test_obj, name=None,
                      sourceType='file', sourceTypeSecondChoice=None, location='',
-                     memory_size=1, memory_size_unit='GiB',
+                     memory_size=256, memory_size_unit='MiB',
                      storage_size=None, storage_size_unit='GiB',
                      os_vendor=None,
                      os_name=None,


### PR DESCRIPTION
Won't allow user to input 0 as memory value and use round calculated
memory available downwards.

There are 2 reason why round memory available downwards:
- Spinner in input field rounds maxValue downwards, so this will
bring consistenci into value inputted by spinner vs value inputted
by text input field.
- If we use round, value might be rounded upwards, thus value exceeding
actual memory available might be shown.
