### PR TITLE
machines: remove btn-danger class from all lifecycle operation buttons

### DIFF
--- a/pkg/machines/components/dropdownButtons.jsx
+++ b/pkg/machines/components/dropdownButtons.jsx
@@ -44,7 +44,7 @@ const DropdownButtons = ({ buttons }) => {
 
         const caretId = buttons[0]['id'] ? `${buttons[0]['id']}-caret` : undefined;
         return (<div className='btn-group dropdown-buttons-container' key={`dropdown-${caretId}`}>
-            <button className='btn btn-default btn-danger' id={buttons[0].id} onClick={mouseClick(buttons[0].action)}>
+            <button className='btn btn-default' id={buttons[0].id} onClick={mouseClick(buttons[0].action)}>
                 {buttons[0].title}
             </button>
             <button data-toggle='dropdown' className='btn btn-default dropdown-toggle'>
@@ -57,7 +57,7 @@ const DropdownButtons = ({ buttons }) => {
     }
 
     return (<div className='btn-group'>
-        <button className='btn btn-default btn-danger' onClick={mouseClick(buttons[0].action)} id={buttons[0]['id']}>
+        <button className='btn btn-default' onClick={mouseClick(buttons[0].action)} id={buttons[0]['id']}>
             {buttons[0].title}
         </button>
     </div>);

--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -87,14 +87,14 @@ const VmActions = ({ vm, config, dispatch, onStart, onInstall, onReboot, onForce
 
     let run = null;
     if (config.provider.canRun(state, hasInstallPhase)) {
-        run = (<button key='action-run' className="btn btn-default btn-danger" onClick={mouseClick(onStart)} id={`${id}-run`}>
+        run = (<button key='action-run' className="btn btn-default" onClick={mouseClick(onStart)} id={`${id}-run`}>
             {_("Run")}
         </button>);
     }
 
     let install = null;
     if (config.provider.canInstall(state, hasInstallPhase)) {
-        install = (<button key='action-install' className="btn btn-default btn-danger" onClick={mouseClick(onInstall)} id={`${id}-install`}>
+        install = (<button key='action-install' className="btn btn-default" onClick={mouseClick(onInstall)} id={`${id}-install`}>
             {_("Install")}
         </button>);
     }


### PR DESCRIPTION
Previously install, shutoff, force shutoff, restart, force restart
buttons had btn-danger class.
These operation should not be marked a dangerous, there are normal
operations.
