### PR TITLE
bots: Fix triggered tests for openshift image refreshes

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -78,8 +78,8 @@ TRIGGERS = {
         "verify/ubuntu-stable"
     ],
     "openshift": [
-        "verify/fedora-30",
-        "verify/rhel-7-6"
+        "verify/rhel-7-6",
+        "verify/rhel-7-7",
     ],
     "ipa": [
         "verify/fedora-30",


### PR DESCRIPTION
OpenShift tests don't run on fedora-30 any more, as cockpit-kubernetes
is not packaged there. Run rhel-7-7 instead.