### PR TITLE
ws: Fix "Secure" cookie flag with --for-tls-proxy

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1550,7 +1550,10 @@ cockpit_auth_login_finish (CockpitAuth *self,
 
       if (headers)
         {
-          force_secure = connection ? !G_IS_SOCKET_CONNECTION (connection) : TRUE;
+          if (self->flags & COCKPIT_AUTH_FOR_TLS_PROXY)
+            force_secure = TRUE;
+          else
+            force_secure = connection ? !G_IS_SOCKET_CONNECTION (connection) : TRUE;
           cookie_name = application_cookie_name (cockpit_creds_get_application (creds));
           cookie_b64 = g_base64_encode ((guint8 *)session->cookie, strlen (session->cookie));
           header = g_strdup_printf ("%s=%s; Path=/; %s HttpOnly",
@@ -1583,12 +1586,14 @@ out:
 }
 
 CockpitAuth *
-cockpit_auth_new (gboolean login_loopback)
+cockpit_auth_new (gboolean login_loopback,
+                  CockpitAuthFlags flags)
 {
   CockpitAuth *self = g_object_new (COCKPIT_TYPE_AUTH, NULL);
   const gchar *max_startups_conf;
   gint count = 0;
 
+  self->flags = flags;
   self->login_loopback = login_loopback;
 
   if (cockpit_ws_max_startups == NULL)

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -31,6 +31,11 @@
 
 G_BEGIN_DECLS
 
+typedef enum {
+  COCKPIT_AUTH_NONE = 0,
+  COCKPIT_AUTH_FOR_TLS_PROXY = 1 << 0,
+} CockpitAuthFlags;
+
 #define MAX_AUTH_TIMEOUT 900
 #define MIN_AUTH_TIMEOUT 1
 
@@ -47,6 +52,7 @@ struct _CockpitAuth
 {
   GObject parent_instance;
 
+  CockpitAuthFlags flags;
   GBytes *key;
   GHashTable *sessions;
   GHashTable *conversations;
@@ -67,7 +73,7 @@ struct _CockpitAuthClass
 
 GType           cockpit_auth_get_type        (void) G_GNUC_CONST;
 
-CockpitAuth *   cockpit_auth_new             (gboolean login_loopback);
+CockpitAuth *   cockpit_auth_new             (gboolean login_loopback, CockpitAuthFlags flags);
 
 gchar *         cockpit_auth_nonce           (CockpitAuth *self);
 

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -189,7 +189,7 @@ main (int argc,
   loop = g_main_loop_new (NULL, FALSE);
 
   data.os_release = cockpit_system_load_os_release ();
-  data.auth = cockpit_auth_new (opt_local_ssh);
+  data.auth = cockpit_auth_new (opt_local_ssh, opt_for_tls_proxy ? COCKPIT_AUTH_FOR_TLS_PROXY : COCKPIT_AUTH_NONE);
   roots = setup_static_roots (data.os_release);
 
   data.branding_roots = (const gchar **)roots;

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -43,7 +43,7 @@ static void
 setup (Test *test,
        gconstpointer data)
 {
-  test->auth = cockpit_auth_new (FALSE);
+  test->auth = cockpit_auth_new (FALSE, COCKPIT_AUTH_NONE);
 }
 
 static void
@@ -58,7 +58,7 @@ setup_normal (Test *test,
               gconstpointer data)
 {
   cockpit_config_file = SRCDIR "/src/ws/mock-config/cockpit/cockpit.conf";
-  test->auth = cockpit_auth_new (FALSE);
+  test->auth = cockpit_auth_new (FALSE, COCKPIT_AUTH_NONE);
 }
 
 static void
@@ -66,7 +66,7 @@ setup_alt_config (Test *test,
               gconstpointer data)
 {
   cockpit_config_file = SRCDIR "/src/ws/mock-config/cockpit/cockpit-alt.conf";
-  test->auth = cockpit_auth_new (FALSE);
+  test->auth = cockpit_auth_new (FALSE, COCKPIT_AUTH_NONE);
 }
 
 static void
@@ -1073,7 +1073,7 @@ setup_startups (Test *test,
   if (fix->warn)
     cockpit_expect_warning ("Illegal MaxStartups spec*");
 
-  test->auth = cockpit_auth_new (FALSE);
+  test->auth = cockpit_auth_new (FALSE, COCKPIT_AUTH_NONE);
 }
 
 static void

--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -122,7 +122,7 @@ static void
 setup (TestCase *tc,
        gconstpointer data)
 {
-  tc->auth = cockpit_auth_new (TRUE);
+  tc->auth = cockpit_auth_new (TRUE, COCKPIT_AUTH_NONE);
   setup_mock_sshd (tc);
 }
 

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -101,7 +101,7 @@ base_setup (Test *test)
   /* Other test->data fields are fine NULL */
   memset (&test->data, 0, sizeof (test->data));
 
-  test->auth = cockpit_auth_new (FALSE);
+  test->auth = cockpit_auth_new (FALSE, COCKPIT_AUTH_NONE);
   test->roots = cockpit_web_response_resolve_roots (static_roots);
   test->login_html = g_strdup(SRCDIR "/src/ws/login.html");
 

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -64,7 +64,7 @@ setup (TestCase *test,
   if (!mock_kdc_available)
     return;
 
-  test->auth = cockpit_auth_new (FALSE);
+  test->auth = cockpit_auth_new (FALSE, COCKPIT_AUTH_NONE);
 
   mock_kdc_up ();
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -497,7 +497,16 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
         b.expect_load()
         b.wait_visible('#content')
         b.enter_page("/system")
+        # cookie should be marked as secure, as for the browser it's https
+        cookie = b.cookie("cockpit")
+        self.assertTrue(cookie["httpOnly"])
+        self.assertTrue(cookie["secure"])
         b.logout()
+        # deleted cookie after logout should be marked as secure
+        cookie = b.cookie("cockpit")
+        self.assertEqual(cookie["value"], "deleted")
+        self.assertTrue(cookie["httpOnly"])
+        self.assertTrue(cookie["secure"])
 
         # should have https:// URLs in Content-Security-Policy
         out = m.execute("curl --insecure --head https://localhost:9090/")


### PR DESCRIPTION
We expect the login cookie to be marked as "Secure" if ws is running
behind a TLS proxy. So introduce flags to CockpitAuth as well, similar
to commit 5c865ad8 and commit 34a8913.