### PR TITLE
bots: Test cockpit-podman on RHEL 8.1

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -103,6 +103,7 @@ TRIGGERS = {
     "rhel-8-1": [
         "verify/rhel-8-1",
         "cockpit/rhel-8-1/chrome@weldr/cockpit-composer",
+        "cockpit/rhel-8-1@cockpit-project/cockpit-podman",
     ],
     "rhel-atomic": [
         "verify/rhel-atomic",

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -65,6 +65,7 @@ REPO_BRANCH_CONTEXT = {
         'master': [
             'cockpit/fedora-29',
             'cockpit/fedora-30',
+            'cockpit/rhel-8-1',
         ],
     },
     'weldr/lorax': {


### PR DESCRIPTION
Because we finally can! (High time..)

 - [x] Test in [PR #131](https://github.com/cockpit-project/cockpit-podman/pull/131) succeeds