### PR TITLE
Don't keep the Network Tab component mounted if it's not active

### DIFF
--- a/pkg/machines/components/vm/vm.jsx
+++ b/pkg/machines/components/vm/vm.jsx
@@ -54,7 +54,7 @@ const Vm = ({ vm, config, hostDevices, storagePools, onStart, onInstall, onShutd
         { name: overviewTabName, renderer: VmOverviewTab, data: { vm, config, dispatch, nodeDevices } },
         { name: usageTabName, renderer: VmUsageTab, data: { vm, onUsageStartPolling, onUsageStopPolling }, presence: 'onlyActive' },
         { name: disksTabName, renderer: VmDisksTab, data: { vm, config, storagePools, onUsageStartPolling, onUsageStopPolling, dispatch, onAddErrorNotification }, presence: 'onlyActive' },
-        { name: networkTabName, renderer: VmNetworkTab, data: { vm, dispatch, config, hostDevices, networks, onAddErrorNotification } },
+        { name: networkTabName, renderer: VmNetworkTab, presence: 'onlyActive', data: { vm, dispatch, config, hostDevices, networks, onAddErrorNotification } },
         { name: consolesTabName, renderer: Consoles, data: { vm, config, dispatch } },
     ];
 


### PR DESCRIPTION
Not keeping it mounted will allow for the IPs to be re-fetched each time
that a user switches away and back to that tab.