### PR TITLE
WIP: machines: implement showing per resource information

### DIFF
--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -126,7 +126,7 @@ class App extends React.Component {
 
         return (
             <div>
-                { config.provider.name === 'LibvirtDBus' && pathVms &&
+                { config.provider.name === 'LibvirtDBus' && pathVms && path.length < 2 &&
                 <AggregateStatusCards networks={networks} storagePools={storagePools} />
                 }
                 {Object.keys(this.state.notifications).length > 0 &&

--- a/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
+++ b/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
@@ -97,8 +97,23 @@ export class StoragePoolVolumesTab extends React.Component {
                                 header: true,
                             }
                         ];
+                        const vmUsingVolumeList = isVolumeUsed[volume.name].map(vmName => ({ name: vmName, id: vms.find(vm => vm.name == vmName).uuid }));
+
                         columns.push(
-                            { name: (<div id={`${storagePoolIdPrefix}-volume-${volume.name}-usedby`}>{(isVolumeUsed[volume.name] || []).join(', ')}</div>), }
+                            { name: (
+                                <div id={`${storagePoolIdPrefix}-volume-${volume.name}-usedby`}>
+                                    {(vmUsingVolumeList || [])
+                                            .map(vm => {
+                                                return (<a onClick={() => cockpit.location.go(['vms', vm.id])}> {vm.name} </a>);
+                                            })
+                                            .reduce((result, item) => {
+                                                if (result.length != 0)
+                                                    return [result, ', ', item];
+                                                else
+                                                    return [item]
+                                            }, [])}
+                                </div>),
+                            }
                         );
                         columns.push(
                             { name: (<div id={`${storagePoolIdPrefix}-volume-${volume.name}-size`}>{`${allocation} / ${capacity} GB`}</div>), }

--- a/pkg/machines/hostvmslist.less
+++ b/pkg/machines/hostvmslist.less
@@ -1,0 +1,50 @@
+
+// This css was copied over from docker.css
+// There is a lot of hardcoded px, should be done  in cleaner way
+// Ask for garrets help here
+.content-filter {
+    background: #f5f5f5;
+    border-bottom: 1px solid #ddd;
+    padding: 10px 16px 10px 20px;
+    position: fixed;
+    width: 100%;
+    top: 0px;
+    right: 0px;
+    z-index: 1;
+    height: 50px;
+}
+
+.content-filter + div {
+    margin-top: 70px;
+}
+
+.content-filter h3 {
+    display: inline;
+    font-size: 18px;
+    line-height: 28px;
+}
+
+.content-filter i {
+    font-size: 24px;
+    position: relative;
+    padding-right: 3px;
+}
+
+.content-filter i.fa {
+    margin-top: 2px;
+    font-size: 18px;
+    line-height: 28px;
+}
+
+.content-filter a {
+    padding-left: 30px;
+}
+
+dl.listing-ct-body {
+    max-width: 100%;
+}
+
+#vm-details .listing-ct-inline {
+    padding-left: 20px;
+    padding-right: 20px;
+}

--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -188,7 +188,8 @@ export function parseDumpxml(dispatch, connectionName, domXml, id_overwrite) {
     const metadataElem = getSingleOptionalElem(domainElem, "metadata");
 
     const name = domainElem.getElementsByTagName("name")[0].childNodes[0].nodeValue;
-    const id = id_overwrite || domainElem.getElementsByTagName("uuid")[0].childNodes[0].nodeValue;
+    const uuid = domainElem.getElementsByTagName("uuid")[0].childNodes[0].nodeValue;
+    const id = id_overwrite || uuid;
     const osType = osTypeElem.nodeValue;
     const osBoot = parseDumpxmlForOsBoot(osBootElems);
     const arch = osTypeElem.getAttribute("arch");
@@ -224,6 +225,7 @@ export function parseDumpxml(dispatch, connectionName, domXml, id_overwrite) {
         connectionName,
         name,
         id,
+        uuid,
         osType,
         osBoot,
         arch,


### PR DESCRIPTION
This is a POC, which allows us to have a per resource page in cockpit-machines. (Similarly as we have in other pages, Storage, Docker etc)
This will enable linking to the resource details when mentioning them in other pages.
As an example I have implemented linking Vms when referring them in the storage volumes tab.

![vm-detail-page](https://user-images.githubusercontent.com/14921356/59620482-3f1e0a80-912d-11e9-8b10-0ff5952da408.png)


![volume-vm-usage-tab](https://user-images.githubusercontent.com/14921356/59620481-3f1e0a80-912d-11e9-81c8-c7f1c35c68d5.png)

