### PR TITLE
firewall: make the "Failed to add service" error message dynamic

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -234,7 +234,7 @@ class AddServicesModal extends React.Component {
         p.then(() => this.props.close())
                 .catch(error => {
                     this.setState({
-                        dialogError: _("Failed to add service"),
+                        dialogError: this.state.custom ? _("Failed to add port") : _("Failed to add service"),
                         dialogErrorDetail: error.name + ": " + error.message,
                     });
                 });


### PR DESCRIPTION
Similar condition exists for the modal dialog title.