### PR TITLE
test: Check http → https redirection

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -226,6 +226,19 @@ class TestConnection(MachineCase):
             # fixed in PR #11279
             self.assertTrue(cookie["secure"])
 
+        # http on localhost should not redirect to https
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --head http://127.0.0.1:9090"))
+        # http on other IP should redirect to https
+        output = m.execute("curl --head http://172.27.0.15:9090")
+        self.assertIn("HTTP/1.1 301 Moved Permanently", output)
+        self.assertIn("Location: https://172.27.0.15:9090/", output)
+        # enable AllowUnencrypted, this disables redirect
+        m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nAllowUnencrypted=true" > /etc/cockpit/cockpit.conf')
+        m.restart_cockpit()
+        # now it should not redirect
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --head http://127.0.0.1:9090"))
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --head http://172.27.0.15:9090"))
+
     def testConfigOrigins(self):
         m = self.machine
         m.execute(


### PR DESCRIPTION
Ensure that cockpit redirects http requests on non-localhost IP to https
by default, and that the `AllowUnencrypted` config option disables this.