### PR TITLE
common: use the GObject type declaration macros

### DIFF
--- a/src/bridge/cockpitinternalmetrics.c
+++ b/src/bridge/cockpitinternalmetrics.c
@@ -41,7 +41,7 @@
  * A #CockpitMetrics channel that pulls data from internal sources
  */
 
-static void cockpit_samples_interface_init (CockpitSamplesIface *iface);
+static void cockpit_samples_interface_init (CockpitSamplesInterface *iface);
 
 #define COCKPIT_INTERNAL_METRICS(o) \
   (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_INTERNAL_METRICS, CockpitInternalMetrics))
@@ -557,7 +557,7 @@ cockpit_internal_metrics_class_init (CockpitInternalMetricsClass *klass)
 }
 
 static void
-cockpit_samples_interface_init (CockpitSamplesIface *iface)
+cockpit_samples_interface_init (CockpitSamplesInterface *iface)
 {
   iface->sample = cockpit_internal_metrics_sample;
 }

--- a/src/bridge/cockpitpacketchannel.c
+++ b/src/bridge/cockpitpacketchannel.c
@@ -89,7 +89,7 @@ static void  start_input         (CockpitPacketChannel *self);
 
 static void  start_output        (CockpitPacketChannel *self);
 
-static void  cockpit_packet_channel_flow_iface (CockpitFlowIface *iface);
+static void  cockpit_packet_channel_flow_iface (CockpitFlowInterface *iface);
 
 #define COCKPIT_PACKET_CHANNEL(o) (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_PACKET_CHANNEL, \
                                    CockpitPacketChannel))
@@ -548,7 +548,7 @@ cockpit_packet_channel_throttle (CockpitFlow *flow,
 }
 
 static void
-cockpit_packet_channel_flow_iface (CockpitFlowIface *iface)
+cockpit_packet_channel_flow_iface (CockpitFlowInterface *iface)
 {
   iface->throttle = cockpit_packet_channel_throttle;
 }

--- a/src/bridge/cockpitsamples.c
+++ b/src/bridge/cockpitsamples.c
@@ -21,11 +21,10 @@
 
 #include "cockpitsamples.h"
 
-typedef CockpitSamplesIface CockpitSamplesInterface;
 G_DEFINE_INTERFACE (CockpitSamples, cockpit_samples, 0);
 
 static void
-cockpit_samples_default_init (CockpitSamplesIface *iface)
+cockpit_samples_default_init (CockpitSamplesInterface *iface)
 {
 
 }
@@ -36,7 +35,7 @@ cockpit_samples_sample (CockpitSamples *self,
                         const gchar *instance,
                         gint64 value)
 {
-  CockpitSamplesIface *iface;
+  CockpitSamplesInterface *iface;
 
   iface = COCKPIT_SAMPLES_GET_IFACE (self);
   g_return_if_fail (iface != NULL);

--- a/src/bridge/cockpitsamples.h
+++ b/src/bridge/cockpitsamples.h
@@ -27,12 +27,12 @@ G_BEGIN_DECLS
 #define COCKPIT_TYPE_SAMPLES            (cockpit_samples_get_type ())
 #define COCKPIT_SAMPLES(inst)            (G_TYPE_CHECK_INSTANCE_CAST ((inst), COCKPIT_TYPE_SAMPLES, CockpitSamples))
 #define COCKPIT_IS_SAMPLES(inst)         (G_TYPE_CHECK_INSTANCE_TYPE ((inst), COCKPIT_TYPE_SAMPLES))
-#define COCKPIT_SAMPLES_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_SAMPLES, CockpitSamplesIface))
+#define COCKPIT_SAMPLES_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_SAMPLES, CockpitSamplesInterface))
 
 typedef struct _CockpitSamples CockpitSamples;
-typedef struct _CockpitSamplesIface CockpitSamplesIface;
+typedef struct _CockpitSamplesInterface CockpitSamplesInterface;
 
-struct _CockpitSamplesIface {
+struct _CockpitSamplesInterface {
   GTypeInterface parent_iface;
 
   void       (* sample)           (CockpitSamples *samples,

--- a/src/bridge/cockpitstream.c
+++ b/src/bridge/cockpitstream.c
@@ -85,7 +85,7 @@ static guint cockpit_stream_sig_rejected_cert;
 
 static void  cockpit_close_later (CockpitStream *self);
 
-static void  cockpit_stream_flow_iface_init (CockpitFlowIface *iface);
+static void  cockpit_stream_flow_iface_init (CockpitFlowInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (CockpitStream, cockpit_stream, G_TYPE_OBJECT,
                          G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_FLOW, cockpit_stream_flow_iface_init));
@@ -1051,7 +1051,7 @@ cockpit_stream_throttle (CockpitFlow *flow,
 }
 
 static void
-cockpit_stream_flow_iface_init (CockpitFlowIface *iface)
+cockpit_stream_flow_iface_init (CockpitFlowInterface *iface)
 {
   iface->throttle = cockpit_stream_throttle;
 }

--- a/src/common/cockpitchannel.c
+++ b/src/common/cockpitchannel.c
@@ -130,7 +130,7 @@ enum {
 
 static guint cockpit_channel_sig_closed;
 
-static void    cockpit_channel_flow_iface_init     (CockpitFlowIface *iface);
+static void    cockpit_channel_flow_iface_init     (CockpitFlowInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (CockpitChannel, cockpit_channel, G_TYPE_OBJECT,
                          G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_FLOW, cockpit_channel_flow_iface_init));
@@ -1142,7 +1142,7 @@ cockpit_channel_throttle (CockpitFlow *flow,
 }
 
 static void
-cockpit_channel_flow_iface_init (CockpitFlowIface *iface)
+cockpit_channel_flow_iface_init (CockpitFlowInterface *iface)
 {
   iface->throttle = cockpit_channel_throttle;
 }

--- a/src/common/cockpitchannel.h
+++ b/src/common/cockpitchannel.h
@@ -40,7 +40,6 @@ typedef struct _CockpitChannelPrivate CockpitChannelPrivate;
 struct _CockpitChannel
 {
   GObject parent;
-  CockpitChannelPrivate *priv;
 };
 
 struct _CockpitChannelClass

--- a/src/common/cockpitchannel.h
+++ b/src/common/cockpitchannel.h
@@ -28,19 +28,7 @@
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_CHANNEL            (cockpit_channel_get_type ())
-#define COCKPIT_CHANNEL(o)              (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_CHANNEL, CockpitChannel))
-#define COCKPIT_IS_CHANNEL(o)           (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_CHANNEL))
-#define COCKPIT_CHANNEL_CLASS(k)        (G_TYPE_CHECK_CLASS_CAST((k), COCKPIT_TYPE_CHANNEL, CockpitChannelClass))
-#define COCKPIT_CHANNEL_GET_CLASS(o)    (G_TYPE_INSTANCE_GET_CLASS ((o), COCKPIT_TYPE_CHANNEL, CockpitChannelClass))
-
-typedef struct _CockpitChannel        CockpitChannel;
-typedef struct _CockpitChannelClass   CockpitChannelClass;
-typedef struct _CockpitChannelPrivate CockpitChannelPrivate;
-
-struct _CockpitChannel
-{
-  GObject parent;
-};
+G_DECLARE_DERIVABLE_TYPE(CockpitChannel, cockpit_channel, COCKPIT, CHANNEL, GObject)
 
 struct _CockpitChannelClass
 {
@@ -65,8 +53,6 @@ struct _CockpitChannelClass
   void        (* close)       (CockpitChannel *channel,
                                const gchar *problem);
 };
-
-GType               cockpit_channel_get_type          (void) G_GNUC_CONST;
 
 void                cockpit_channel_prepare           (CockpitChannel *self);
 

--- a/src/common/cockpitflow.c
+++ b/src/common/cockpitflow.c
@@ -34,13 +34,12 @@
 
 #include "cockpitflow.h"
 
-typedef CockpitFlowIface CockpitFlowInterface;
 G_DEFINE_INTERFACE (CockpitFlow, cockpit_flow, 0);
 
 static guint cockpit_flow_signal_pressure = 0;
 
 static void
-cockpit_flow_default_init (CockpitFlowIface *iface)
+cockpit_flow_default_init (CockpitFlowInterface *iface)
 {
   /**
    * CockpitFlow::pressure:
@@ -67,7 +66,7 @@ void
 cockpit_flow_throttle (CockpitFlow *flow,
                        CockpitFlow *controlling)
 {
-  CockpitFlowIface *iface;
+  CockpitFlowInterface *iface;
 
   g_return_if_fail (COCKPIT_IS_FLOW (flow));
   g_return_if_fail (controlling == NULL || COCKPIT_IS_FLOW (controlling));

--- a/src/common/cockpitflow.h
+++ b/src/common/cockpitflow.h
@@ -25,12 +25,7 @@
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_FLOW             (cockpit_flow_get_type ())
-#define COCKPIT_FLOW(inst)            (G_TYPE_CHECK_INSTANCE_CAST ((inst), COCKPIT_TYPE_FLOW, CockpitFlow))
-#define COCKPIT_IS_FLOW(inst)         (G_TYPE_CHECK_INSTANCE_TYPE ((inst), COCKPIT_TYPE_FLOW))
-#define COCKPIT_FLOW_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_FLOW, CockpitFlowInterface))
-
-typedef struct _CockpitFlow CockpitFlow;
-typedef struct _CockpitFlowInterface CockpitFlowInterface;
+G_DECLARE_INTERFACE(CockpitFlow, cockpit_flow, COCKPIT, FLOW, GObject)
 
 struct _CockpitFlowInterface {
   GTypeInterface parent_iface;
@@ -38,8 +33,6 @@ struct _CockpitFlowInterface {
   void       (* throttle)         (CockpitFlow *flow,
                                    CockpitFlow *controlling);
 };
-
-GType               cockpit_flow_get_type        (void) G_GNUC_CONST;
 
 void                cockpit_flow_throttle        (CockpitFlow *flow,
                                                   CockpitFlow *controller);

--- a/src/common/cockpitflow.h
+++ b/src/common/cockpitflow.h
@@ -27,12 +27,12 @@ G_BEGIN_DECLS
 #define COCKPIT_TYPE_FLOW             (cockpit_flow_get_type ())
 #define COCKPIT_FLOW(inst)            (G_TYPE_CHECK_INSTANCE_CAST ((inst), COCKPIT_TYPE_FLOW, CockpitFlow))
 #define COCKPIT_IS_FLOW(inst)         (G_TYPE_CHECK_INSTANCE_TYPE ((inst), COCKPIT_TYPE_FLOW))
-#define COCKPIT_FLOW_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_FLOW, CockpitFlowIface))
+#define COCKPIT_FLOW_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_FLOW, CockpitFlowInterface))
 
 typedef struct _CockpitFlow CockpitFlow;
-typedef struct _CockpitFlowIface CockpitFlowIface;
+typedef struct _CockpitFlowInterface CockpitFlowInterface;
 
-struct _CockpitFlowIface {
+struct _CockpitFlowInterface {
   GTypeInterface parent_iface;
 
   void       (* throttle)         (CockpitFlow *flow,

--- a/src/common/cockpitloopback.c
+++ b/src/common/cockpitloopback.c
@@ -26,10 +26,6 @@ struct _CockpitLoopback {
   GQueue addresses;
 };
 
-struct _CockpitLoopbackClass {
-  GSocketAddressEnumeratorClass parent_class;
-};
-
 static void cockpit_loopback_connectable_iface (GSocketConnectableIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (CockpitLoopback, cockpit_loopback, G_TYPE_SOCKET_ADDRESS_ENUMERATOR,

--- a/src/common/cockpitloopback.h
+++ b/src/common/cockpitloopback.h
@@ -25,13 +25,7 @@
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_LOOPBACK         (cockpit_loopback_get_type ())
-#define COCKPIT_LOOPBACK(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_LOOPBACK, CockpitLoopback))
-#define COCKPIT_IS_LOOPBACK(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_LOOPBACK))
-
-typedef struct _CockpitLoopback        CockpitLoopback;
-typedef struct _CockpitLoopbackClass   CockpitLoopbackClass;
-
-GType                 cockpit_loopback_get_type     (void) G_GNUC_CONST;
+G_DECLARE_FINAL_TYPE(CockpitLoopback, cockpit_loopback, COCKPIT, LOOPBACK, GSocketAddressEnumerator)
 
 GSocketConnectable *  cockpit_loopback_new          (guint16 port);
 

--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -138,7 +138,7 @@ static void  set_problem_from_errno (CockpitPipe *self,
 static void  cockpit_pipe_throttle  (CockpitFlow *flow,
                                      CockpitFlow *controlling);
 
-static void  cockpit_pipe_flow_iface_init (CockpitFlowIface *iface);
+static void  cockpit_pipe_flow_iface_init (CockpitFlowInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (CockpitPipe, cockpit_pipe, G_TYPE_OBJECT,
                          G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_FLOW, cockpit_pipe_flow_iface_init));
@@ -1708,7 +1708,7 @@ cockpit_pipe_throttle (CockpitFlow *flow,
 }
 
 static void
-cockpit_pipe_flow_iface_init (CockpitFlowIface *iface)
+cockpit_pipe_flow_iface_init (CockpitFlowInterface *iface)
 {
   iface->throttle = cockpit_pipe_throttle;
 }

--- a/src/common/cockpitpipe.h
+++ b/src/common/cockpitpipe.h
@@ -32,18 +32,7 @@ typedef enum {
 } CockpitPipeFlags;
 
 #define COCKPIT_TYPE_PIPE         (cockpit_pipe_get_type ())
-#define COCKPIT_PIPE(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_PIPE, CockpitPipe))
-#define COCKPIT_IS_PIPE(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_PIPE))
-#define COCKPIT_PIPE_CLASS(k)     (G_TYPE_CHECK_CLASS_CAST ((k), COCKPIT_TYPE_PIPE, CockpitPipeClass))
-#define COCKPIT_PIPE_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), COCKPIT_TYPE_PIPE, CockpitPipeClass))
-
-typedef struct _CockpitPipe        CockpitPipe;
-typedef struct _CockpitPipeClass   CockpitPipeClass;
-typedef struct _CockpitPipePrivate CockpitPipePrivate;
-
-struct _CockpitPipe {
-  GObject parent_instance;
-};
+G_DECLARE_DERIVABLE_TYPE(CockpitPipe, cockpit_pipe, COCKPIT, PIPE, GObject)
 
 struct _CockpitPipeClass {
   GObjectClass parent_class;
@@ -57,8 +46,6 @@ struct _CockpitPipeClass {
   void        (* close)       (CockpitPipe *pipe,
                                const gchar *problem);
 };
-
-GType              cockpit_pipe_get_type     (void) G_GNUC_CONST;
 
 CockpitPipe *      cockpit_pipe_new          (const gchar *name,
                                               gint in_fd,

--- a/src/common/cockpitpipe.h
+++ b/src/common/cockpitpipe.h
@@ -43,7 +43,6 @@ typedef struct _CockpitPipePrivate CockpitPipePrivate;
 
 struct _CockpitPipe {
   GObject parent_instance;
-  CockpitPipePrivate *priv;
 };
 
 struct _CockpitPipeClass {

--- a/src/common/cockpitpipetransport.c
+++ b/src/common/cockpitpipetransport.c
@@ -52,10 +52,6 @@ struct _CockpitPipeTransport {
   gulong close_sig;
 };
 
-struct _CockpitPipeTransportClass {
-  CockpitTransportClass parent_class;
-};
-
 enum {
     PROP_0,
     PROP_NAME,

--- a/src/common/cockpitpipetransport.h
+++ b/src/common/cockpitpipetransport.h
@@ -28,15 +28,7 @@
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_PIPE_TRANSPORT         (cockpit_pipe_transport_get_type ())
-#define COCKPIT_PIPE_TRANSPORT(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_PIPE_TRANSPORT, CockpitPipeTransport))
-#define COCKPIT_IS_PIPE_TRANSPORT(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_PIPE_TRANSPORT))
-#define COCKPIT_PIPE_TRANSPORT_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), COCKPIT_TYPE_PIPE_TRANSPORT, CockpitPipeTransportClass))
-#define COCKPIT_IS_PIPE_TRANSPORT_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), COCKPIT_TYPE_PIPE_TRANSPORT))
-
-typedef struct _CockpitPipeTransport        CockpitPipeTransport;
-typedef struct _CockpitPipeTransportClass   CockpitPipeTransportClass;
-
-GType              cockpit_pipe_transport_get_type   (void) G_GNUC_CONST;
+G_DECLARE_FINAL_TYPE(CockpitPipeTransport, cockpit_pipe_transport, COCKPIT, PIPE_TRANSPORT, CockpitTransport)
 
 CockpitTransport * cockpit_pipe_transport_new        (CockpitPipe *pipe);
 

--- a/src/common/cockpittransport.h
+++ b/src/common/cockpittransport.h
@@ -26,18 +26,7 @@
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_TRANSPORT            (cockpit_transport_get_type ())
-#define COCKPIT_TRANSPORT(o)              (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_TRANSPORT, CockpitTransport))
-#define COCKPIT_IS_TRANSPORT(o)           (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_TRANSPORT))
-#define COCKPIT_TRANSPORT_CLASS(k)        (G_TYPE_CHECK_CLASS_CAST((k), COCKPIT_TYPE_TRANSPORT, CockpitTransportClass))
-#define COCKPIT_TRANSPORT_GET_CLASS(o)    (G_TYPE_INSTANCE_GET_CLASS ((o), COCKPIT_TYPE_TRANSPORT, CockpitTransportClass))
-
-typedef struct _CockpitTransport        CockpitTransport;
-typedef struct _CockpitTransportClass   CockpitTransportClass;
-typedef struct _CockpitTransportPrivate CockpitTransportPrivate;
-
-struct _CockpitTransport {
-  GObject parent;
-};
+G_DECLARE_DERIVABLE_TYPE(CockpitTransport, cockpit_transport, COCKPIT, TRANSPORT, GObject)
 
 struct _CockpitTransportClass
 {
@@ -73,8 +62,6 @@ struct _CockpitTransportClass
   void        (* close)       (CockpitTransport *transport,
                                const gchar *problem);
 };
-
-GType       cockpit_transport_get_type       (void) G_GNUC_CONST;
 
 void        cockpit_transport_send           (CockpitTransport *transport,
                                               const gchar *channel,

--- a/src/common/cockpittransport.h
+++ b/src/common/cockpittransport.h
@@ -37,7 +37,6 @@ typedef struct _CockpitTransportPrivate CockpitTransportPrivate;
 
 struct _CockpitTransport {
   GObject parent;
-  CockpitTransportPrivate *priv;
 };
 
 struct _CockpitTransportClass

--- a/src/common/cockpitwebfilter.c
+++ b/src/common/cockpitwebfilter.c
@@ -27,11 +27,10 @@
  * A filter used to filter the output of a CockpitWebResponse.
  */
 
-typedef CockpitWebFilterIface CockpitWebFilterInterface;
 G_DEFINE_INTERFACE (CockpitWebFilter, cockpit_web_filter, 0);
 
 static void
-cockpit_web_filter_default_init (CockpitWebFilterIface *iface)
+cockpit_web_filter_default_init (CockpitWebFilterInterface *iface)
 {
 
 }
@@ -54,7 +53,7 @@ cockpit_web_filter_push (CockpitWebFilter *filter,
                          void (* function) (gpointer, GBytes *),
                          gpointer data)
 {
-  CockpitWebFilterIface *iface;
+  CockpitWebFilterInterface *iface;
 
   iface = COCKPIT_WEB_FILTER_GET_IFACE (filter);
   g_return_if_fail (iface != NULL);

--- a/src/common/cockpitwebfilter.h
+++ b/src/common/cockpitwebfilter.h
@@ -25,12 +25,7 @@
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_WEB_FILTER            (cockpit_web_filter_get_type ())
-#define COCKPIT_WEB_FILTER(inst)            (G_TYPE_CHECK_INSTANCE_CAST ((inst), COCKPIT_TYPE_WEB_FILTER, CockpitWebFilter))
-#define COCKPIT_IS_WEB_FILTER(inst)         (G_TYPE_CHECK_INSTANCE_TYPE ((inst), COCKPIT_TYPE_WEB_FILTER))
-#define COCKPIT_WEB_FILTER_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_WEB_FILTER, CockpitWebFilterInterface))
-
-typedef struct _CockpitWebFilter CockpitWebFilter;
-typedef struct _CockpitWebFilterInterface CockpitWebFilterInterface;
+G_DECLARE_INTERFACE(CockpitWebFilter, cockpit_web_filter, COCKPIT, WEB_FILTER, GObject)
 
 struct _CockpitWebFilterInterface {
   GTypeInterface parent_iface;
@@ -40,8 +35,6 @@ struct _CockpitWebFilterInterface {
                                   void (* function) (gpointer, GBytes *),
                                   gpointer data);
 };
-
-GType               cockpit_web_filter_get_type     (void) G_GNUC_CONST;
 
 void                cockpit_web_filter_push         (CockpitWebFilter *filter,
                                                      GBytes *queue,

--- a/src/common/cockpitwebfilter.h
+++ b/src/common/cockpitwebfilter.h
@@ -27,12 +27,12 @@ G_BEGIN_DECLS
 #define COCKPIT_TYPE_WEB_FILTER            (cockpit_web_filter_get_type ())
 #define COCKPIT_WEB_FILTER(inst)            (G_TYPE_CHECK_INSTANCE_CAST ((inst), COCKPIT_TYPE_WEB_FILTER, CockpitWebFilter))
 #define COCKPIT_IS_WEB_FILTER(inst)         (G_TYPE_CHECK_INSTANCE_TYPE ((inst), COCKPIT_TYPE_WEB_FILTER))
-#define COCKPIT_WEB_FILTER_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_WEB_FILTER, CockpitWebFilterIface))
+#define COCKPIT_WEB_FILTER_GET_IFACE(inst)  (G_TYPE_INSTANCE_GET_INTERFACE ((inst), COCKPIT_TYPE_WEB_FILTER, CockpitWebFilterInterface))
 
 typedef struct _CockpitWebFilter CockpitWebFilter;
-typedef struct _CockpitWebFilterIface CockpitWebFilterIface;
+typedef struct _CockpitWebFilterInterface CockpitWebFilterInterface;
 
-struct _CockpitWebFilterIface {
+struct _CockpitWebFilterInterface {
   GTypeInterface parent_iface;
 
   void       (* push)            (CockpitWebFilter *filter,

--- a/src/common/cockpitwebinject.c
+++ b/src/common/cockpitwebinject.c
@@ -47,7 +47,7 @@ typedef struct _CockpitInjectClass {
   GObjectClass parent_class;
 } CockpitWebInjectClass;
 
-static void cockpit_web_filter_inject_iface (CockpitWebFilterIface *iface);
+static void cockpit_web_filter_inject_iface (CockpitWebFilterInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (CockpitWebInject, cockpit_web_inject, G_TYPE_OBJECT,
                          G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_WEB_FILTER, cockpit_web_filter_inject_iface)
@@ -187,7 +187,7 @@ cockpit_web_inject_push (CockpitWebFilter *filter,
 }
 
 static void
-cockpit_web_filter_inject_iface (CockpitWebFilterIface *iface)
+cockpit_web_filter_inject_iface (CockpitWebFilterInterface *iface)
 {
   iface->push = cockpit_web_inject_push;
 }

--- a/src/common/cockpitwebinject.c
+++ b/src/common/cockpitwebinject.c
@@ -43,10 +43,6 @@ struct _CockpitWebInject {
   guint injected;
 };
 
-typedef struct _CockpitInjectClass {
-  GObjectClass parent_class;
-} CockpitWebInjectClass;
-
 static void cockpit_web_filter_inject_iface (CockpitWebFilterInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (CockpitWebInject, cockpit_web_inject, G_TYPE_OBJECT,

--- a/src/common/cockpitwebinject.h
+++ b/src/common/cockpitwebinject.h
@@ -25,12 +25,7 @@
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_WEB_INJECT         (cockpit_web_inject_get_type ())
-#define COCKPIT_WEB_INJECT(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_WEB_INJECT, CockpitWebInject))
-#define COCKPIT_IS_WEB_INJECT(o)        (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_WEB_INJECT))
-
-typedef struct _CockpitWebInject CockpitWebInject;
-
-GType               cockpit_web_inject_get_type     (void) G_GNUC_CONST;
+G_DECLARE_FINAL_TYPE(CockpitWebInject, cockpit_web_inject, COCKPIT, WEB_INJECT, GObject)
 
 CockpitWebFilter *  cockpit_web_inject_new          (const gchar *marker,
                                                      GBytes *inject,

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -100,7 +100,7 @@ typedef struct {
 
 static guint signal__done;
 
-static void      cockpit_web_response_flow_iface_init      (CockpitFlowIface *iface);
+static void      cockpit_web_response_flow_iface_init      (CockpitFlowInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (CockpitWebResponse, cockpit_web_response, G_TYPE_OBJECT,
                          G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_FLOW, cockpit_web_response_flow_iface_init));
@@ -1939,7 +1939,7 @@ cockpit_web_response_get_protocol (CockpitWebResponse *self,
 }
 
 static void
-cockpit_web_response_flow_iface_init (CockpitFlowIface *iface)
+cockpit_web_response_flow_iface_init (CockpitFlowInterface *iface)
 {
   /* No implementation */
 }

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -91,10 +91,6 @@ struct _CockpitWebResponse {
   GList *filters;
 };
 
-typedef struct {
-  GObjectClass parent;
-} CockpitWebResponseClass;
-
 /* A megabyte is when we start to consider queue full enough */
 #define QUEUE_PRESSURE 1024UL * 1024UL
 

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -29,8 +29,7 @@ G_BEGIN_DECLS
 #define COCKPIT_RESOURCE_PACKAGE_VALID "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
 
 #define COCKPIT_TYPE_WEB_RESPONSE         (cockpit_web_response_get_type ())
-#define COCKPIT_WEB_RESPONSE(o)           (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_WEB_RESPONSE, CockpitWebResponse))
-#define COCKPIT_IS_WEB_RESPONSE(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_WEB_RESPONSE))
+G_DECLARE_FINAL_TYPE(CockpitWebResponse, cockpit_web_response, COCKPIT, WEB_RESPONSE, GObject)
 
 typedef enum {
   COCKPIT_WEB_RESPONSE_NONE = 0,
@@ -59,8 +58,6 @@ typedef struct _CockpitWebResponse        CockpitWebResponse;
 extern const gchar *  cockpit_web_exception_escape_root;
 
 extern const gchar *  cockpit_web_failure_resource;
-
-GType                 cockpit_web_response_get_type      (void) G_GNUC_CONST;
 
 CockpitWebResponse *  cockpit_web_response_new           (GIOStream *io,
                                                           const gchar *original_path,

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -42,8 +42,6 @@ gboolean cockpit_webserver_want_certificate = FALSE;
 guint cockpit_webserver_request_timeout = 30;
 gsize cockpit_webserver_request_maximum = 4096;
 
-typedef struct _CockpitWebServerClass CockpitWebServerClass;
-
 struct _CockpitWebServer {
   GObject parent_instance;
 
@@ -61,10 +59,6 @@ struct _CockpitWebServer {
   GSocketService *socket_service;
   GMainContext *main_context;
   GHashTable *requests;
-};
-
-struct _CockpitWebServerClass {
-  GObjectClass parent_class;
 };
 
 enum

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -25,10 +25,7 @@
 G_BEGIN_DECLS
 
 #define COCKPIT_TYPE_WEB_SERVER  (cockpit_web_server_get_type ())
-#define COCKPIT_WEB_SERVER(o)    (G_TYPE_CHECK_INSTANCE_CAST ((o), COCKPIT_TYPE_WEB_SERVER, CockpitWebServer))
-#define COCKPIT_IS_WEB_SERVER(o) (G_TYPE_CHECK_INSTANCE_TYPE ((o), COCKPIT_TYPE_WEB_SERVER))
-
-typedef struct _CockpitWebServer CockpitWebServer;
+G_DECLARE_FINAL_TYPE(CockpitWebServer, cockpit_web_server, COCKPIT, WEB_SERVER, GObject)
 
 extern guint cockpit_webserver_request_timeout;
 extern gsize cockpit_webserver_request_maximum;
@@ -39,8 +36,6 @@ typedef enum {
   COCKPIT_WEB_SERVER_FLAGS_MAX = 1 << 1
 } CockpitWebServerFlags;
 
-
-GType              cockpit_web_server_get_type      (void) G_GNUC_CONST;
 
 CockpitWebServer * cockpit_web_server_new           (const gchar *address,
                                                      gint port,

--- a/src/common/mock-pressure.c
+++ b/src/common/mock-pressure.c
@@ -24,7 +24,7 @@
 typedef GObject MockPressure;
 typedef GObjectClass MockPressureClass;
 
-static void   mock_pressure_flow_iface_init   (CockpitFlowIface *iface);
+static void   mock_pressure_flow_iface_init   (CockpitFlowInterface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (MockPressure, mock_pressure, G_TYPE_OBJECT,
                          G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_FLOW, mock_pressure_flow_iface_init));
@@ -42,7 +42,7 @@ mock_pressure_class_init (MockPressureClass *klass)
 }
 
 static void
-mock_pressure_flow_iface_init (CockpitFlowIface *iface)
+mock_pressure_flow_iface_init (CockpitFlowInterface *iface)
 {
   /* No implementation */
 }

--- a/src/websocket/websocketconnection.c
+++ b/src/websocket/websocketconnection.c
@@ -156,7 +156,7 @@ struct _WebSocketConnectionPrivate
 /* The queue size above which we consider applying back pressure */
 #define QUEUE_PRESSURE       1UL * 1024UL * 1024UL /* 1 megabyte */
 
-static void    web_socket_connection_flow_iface_init        (CockpitFlowIface *iface);
+static void    web_socket_connection_flow_iface_init        (CockpitFlowInterface *iface);
 
 G_DEFINE_ABSTRACT_TYPE_WITH_CODE (WebSocketConnection, web_socket_connection, G_TYPE_OBJECT,
                                   G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_FLOW, web_socket_connection_flow_iface_init));
@@ -1915,7 +1915,7 @@ _web_socket_connection_get_main_context (WebSocketConnection *self)
 }
 
 static void
-web_socket_connection_flow_iface_init (CockpitFlowIface *iface)
+web_socket_connection_flow_iface_init (CockpitFlowInterface *iface)
 {
   iface->throttle = web_socket_connection_throttle;
 }

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -126,9 +126,8 @@ main (int argc,
   g_autoptr(GMainLoop) loop = NULL;
   g_autofree gchar *login_html = NULL;
   g_autofree gchar *login_po_html = NULL;
-  CockpitWebServer *server = NULL;
+  g_autoptr(CockpitWebServer) server = NULL;
   CockpitHandlerData data;
-  CockpitPipe *pipe = NULL;
   int outfd = -1;
 
   signal (SIGPIPE, SIG_IGN);
@@ -246,6 +245,7 @@ main (int argc,
 
   if (opt_local_session)
     {
+      g_autoptr(CockpitPipe) pipe = NULL;
       struct passwd *pwd;
 
       if (g_str_equal (opt_local_session, "-"))
@@ -267,7 +267,6 @@ main (int argc,
           goto out;
         }
       cockpit_auth_local_async (data.auth, pwd->pw_name, pipe, on_local_ready, g_object_ref (server));
-      g_object_unref (pipe);
     }
   else
     {
@@ -290,7 +289,6 @@ out:
     close (outfd);
   if (error)
     g_printerr ("cockpit-ws: %s\n", error->message);
-  g_clear_object (&server);
   g_clear_object (&data.auth);
   if (data.os_release)
     g_hash_table_unref (data.os_release);


### PR DESCRIPTION
Update our classes to make use of the G_DECLARE_DERIVABLE_TYPE() and
G_DECLARE_FINAL_TYPE() macros.
    
In addition to being a net reduction in code size, we gain support for
some nice additional features, such as g_autoptr().
    
Closes #12092
