### PR TITLE
naughty: Close 11614: SELinux denies iscsid { read } for modules.dep.bin and modules.softdep

### DIFF
--- a/bots/naughty/fedora-30/11614-selinux-denying-iscsi_tcp-module-load
+++ b/bots/naughty/fedora-30/11614-selinux-denying-iscsi_tcp-module-load
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-machines-dbus", line *, in testStoragePoolsCreate
-    source={"host": "127.0.0.1", "source_path": target_iqn}

--- a/bots/naughty/rhel-8/11614-selinux-denying-iscsi_tcp-module-load
+++ b/bots/naughty/rhel-8/11614-selinux-denying-iscsi_tcp-module-load
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "/build/cockpit/bots/../test/verify/check-machines-dbus", line *, in testStoragePoolsCreate
-    source={"host": "127.0.0.1", "source_path": target_iqn}


### PR DESCRIPTION
Known issue which has not occurred in 21 days

SELinux denies iscsid { read } for modules.dep.bin and modules.softdep

Fixes #11614