### PR TITLE
bots: add naughty for podman crash on fedora-30

### DIFF
--- a/bots/naughty/fedora-30/12098-podman-image-deletion-listing-crash-2
+++ b/bots/naughty/fedora-30/12098-podman-image-deletion-listing-crash-2
@@ -1,0 +1,3 @@
+# testRunImage (__main__.TestApplication)
+*
+* warning: Failed to do *: {"name":"ConnectionClosed","parameters":{}}*


### PR DESCRIPTION
Same issue as in 12098-podman-image-deletion-listing-crash, but in the
second case the tests fails before reaching the teardown, so crashes
from journal messages don't appear in the test logs.

Reported issue on libpod repository https://github.com/containers/libpod/issues/3316
Known issue #12098