### PR TITLE
bots: Stop testing Cockpit master on RHEL/CentOS 7

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -28,11 +28,9 @@ from task import github, REDHAT_STORE
 
 TRIGGERS = {
     "centos-7": [
-        "verify/centos-7",
         "cockpit/centos-7@cockpit-project/starter-kit",
     ],
     "continuous-atomic": [
-        "verify/continuous-atomic",
         "cockpit/continuous-atomic@cockpit-project/cockpit-ostree",
     ],
     "debian-testing": [
@@ -88,13 +86,7 @@ TRIGGERS = {
         "verify/ubuntu-1804",
         "verify/debian-stable"
     ],
-    "rhel-7-6": [
-        "verify/rhel-7-6",
-        "verify/rhel-7-6-distropkg",
-        "verify/rhel-atomic"  # builds in rhel-7-6
-    ],
     "rhel-7-7": [
-        "verify/rhel-7-7",
         "cockpit/rhel-7-7/firefox@weldr/cockpit-composer",
     ],
     "rhel-8-0": [
@@ -105,7 +97,6 @@ TRIGGERS = {
         "cockpit/rhel-8-1/chrome@weldr/cockpit-composer",
     ],
     "rhel-atomic": [
-        "verify/rhel-atomic",
         "cockpit/rhel-atomic@cockpit-project/cockpit-ostree",
     ]
 }

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -24,11 +24,11 @@ MAX_PRIORITY = 9
 REPO_BRANCH_CONTEXT = {
     'cockpit-project/cockpit': {
         'master': ['avocado/fedora', 'container/bastion',
-            'selenium/firefox', 'selenium/chrome', 'verify/centos-7', 'verify/debian-stable',
-            'verify/debian-testing', 'verify/fedora-30', 'verify/fedora-atomic',
-            'verify/ubuntu-1804', 'verify/ubuntu-stable', 'verify/rhel-7-6-distropkg',
-            'verify/rhel-7-7', 'verify/rhel-8-0-distropkg', 'verify/rhel-atomic', 'selenium/edge',
-            'verify/rhel-8-1',
+            'selenium/firefox', 'selenium/chrome', 'selenium/edge',
+            'verify/debian-stable', 'verify/debian-testing',
+            'verify/ubuntu-1804', 'verify/ubuntu-stable',
+            'verify/fedora-30', 'verify/fedora-atomic',
+            'verify/rhel-8-0-distropkg', 'verify/rhel-8-1',
         ],
         'rhel-7.6': ['avocado/fedora', 'container/kubernetes', 'container/bastion',
             'selenium/firefox', 'selenium/chrome', 'verify/rhel-7-6',
@@ -45,7 +45,7 @@ REPO_BRANCH_CONTEXT = {
         'rhel-8.1': ['verify/rhel-8-1',
         ],
         # These can be triggered manually with bots/tests-trigger
-        '_manual': ['verify/continuous-atomic', 'verify/fedora-i386', 'verify/fedora-testing',
+        '_manual': ['verify/fedora-i386', 'verify/fedora-testing',
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
7.7 was the last RHEL release where we did a full rebase, from now on it
will just be bug fixes. These releases are now being maintained from the
rhel-7.* branches.

So drop the centos-7, rhel-7-6-distropkg, rhel-7-7, and rhel-atomic
branches from cockpit master PRs.