### PR TITLE
bots: Use correct import

### DIFF
--- a/bots/learn-tests
+++ b/bots/learn-tests
@@ -37,7 +37,7 @@ sys.dont_write_bytecode = True
 
 import task
 
-from machines import testvm
+from machine import testvm
 
 BOTS = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
The directory is called "machine" not "machines".

I noticed this while looking into bots logs.