### PR TITLE
machines: drop bsd, pc98 and sun format types for disk type pools

### DIFF
--- a/pkg/machines/components/storagePools/createStoragePoolDialog.jsx
+++ b/pkg/machines/components/storagePools/createStoragePoolDialog.jsx
@@ -197,7 +197,7 @@ const StoragePoolInitiatorRow = ({ onValueChanged, dialogValues }) => {
 const StoragePoolSourceRow = ({ onValueChanged, dialogValues }) => {
     let validationState;
     let placeholder;
-    const diskPoolSourceFormatTypes = ['dos', 'dvh', 'gpt', 'mac', 'bsd', 'pc98', 'sun'];
+    const diskPoolSourceFormatTypes = ['dos', 'dvh', 'gpt', 'mac'];
 
     if (dialogValues.type == 'netfs') {
         validationState = dialogValues.source.dir.length == 0 && dialogValues.validationFailed.source ? 'error' : undefined;


### PR DESCRIPTION
Libvirt support for these types is genuinely broken and marked as not fix.
See https://bugzilla.redhat.com/show_bug.cgi?id=980349

They are indeed not common so I just drop the from the UI, I don't think
it worths to ask support for these from libvirt.