### PR TITLE
bots: Fetch tree in prune if refs is not found

### DIFF
--- a/bots/image-prune
+++ b/bots/image-prune
@@ -63,6 +63,7 @@ def get_refs(open_pull_requests=True, offline=False):
         if offline:
             raise Exception("Unable to consider open pull requests when in offline mode")
         for p in github.GitHub().pulls():
+            subprocess.call(["git", "fetch", "origin", "pull/{0}/head".format(p["number"])])
             refs["pull request #{} ({})".format(p["number"], p["title"])] = p["head"]["sha"]
 
     git_cmd = "show-ref" if offline else "ls-remote"

--- a/bots/image-prune
+++ b/bots/image-prune
@@ -154,7 +154,7 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
         path = os.path.join(testvm.get_images_data_dir(), filename)
         if not force and (enough_disk_space() and os.lstat(path).st_mtime > expiry_threshold):
             continue
-        if os.path.isfile(path) and (path.endswith(".xz") or path.endswith(".qcow2") or path.endswith(".partial")) and path not in targets:
+        if os.path.isfile(path) and (path.endswith(".xz") or path.endswith(".qcow2") or path.endswith(".partial")) and filename not in targets:
             if not quiet or dryrun:
                 sys.stderr.write("Pruning {0}\n".format(filename))
             if not dryrun:


### PR DESCRIPTION
It may happen that after open PRs are scanned it references commits that
are not locally available and therefore `git ls-tree` fails.

This commit gives it two chances, if first fails with tree error, it
tries to fetch the commit and then tries again.

I hope that "origin" is right and thats how whatever runs prune has upstream set up.