### PR TITLE
bots: Temporarily disable host key checking for the sink

### DIFF
--- a/bots/task/sink.py
+++ b/bots/task/sink.py
@@ -40,7 +40,10 @@ class Sink(object):
 
         # Start a gzip and cat processes
         self.ssh = subprocess.Popen([
-            "ssh", "-o", "ServerAliveInterval=30", host, "--",
+            "ssh",
+            # HACK: fix sink host keys and knownhosts on our infra
+            "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "-o", "CheckHostIP=no",
+            "-o", "ServerAliveInterval=30", host, "--",
             "python", "sink", identifier
         ], stdin=subprocess.PIPE)
 


### PR DESCRIPTION
We are going to deploy the sink as a kubernetes service. Until we fix
that to have a known and static host key, disable host key checking.

This is a bit ugly, but with our existing sinks being both broken,
finding a replacement is urgent.