### PR TITLE
tools, bots: Stop bringing libvirt package as a dependency of cockpit-machines

### DIFF
--- a/bots/images/scripts/rhel.setup
+++ b/bots/images/scripts/rhel.setup
@@ -120,6 +120,7 @@ json-glib \
 kexec-tools \
 libssh \
 libvirt-client \
+libvirt-daemon-kvm \
 NetworkManager-team \
 openssl \
 PackageKit \
@@ -170,7 +171,6 @@ if [ "$IMAGE" = "centos-7" ]; then
     COCKPIT_DEPS="${COCKPIT_DEPS/redhat-logos/}"
 fi
 if [ "${IMAGE#rhel-7}" != "$IMAGE" ] || [ "$IMAGE" == "centos-7" ]; then
-    COCKPIT_DEPS="$COCKPIT_DEPS libvirt"
     COCKPIT_DEPS="$COCKPIT_DEPS kubernetes-client"
 fi
 if [ "$IMAGE" = "rhel-7-7" ]; then
@@ -187,7 +187,7 @@ if [ "${IMAGE#rhel-8*}" != "$IMAGE" ]; then
     COCKPIT_DEPS="${COCKPIT_DEPS/atomic /}"
     COCKPIT_DEPS="${COCKPIT_DEPS/docker /}"
     COCKPIT_DEPS="${COCKPIT_DEPS} podman"
-    COCKPIT_DEPS="${COCKPIT_DEPS} libvirt-daemon-kvm libvirt-dbus"
+    COCKPIT_DEPS="${COCKPIT_DEPS} libvirt-dbus"
     TEST_PACKAGES="${TEST_PACKAGES} libvirt-daemon-config-network"
     # Install node for external Composer tests, they use our rhel-* images
     TEST_PACKAGES="${TEST_PACKAGES} nodejs"

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -684,7 +684,7 @@ Requires: cockpit-system >= %{required_base}
 %if 0%{?rhel} == 7
 Requires: libvirt
 %else
-Requires: (libvirt-daemon-kvm or libvirt)
+Requires: libvirt-daemon-kvm
 %endif
 Requires: libvirt-client
 %if 0%{?fedora} || 0%{?rhel} >= 8
@@ -713,7 +713,7 @@ Requires: cockpit-system >= %{required_base}
 %if 0%{?rhel} == 7
 Requires: libvirt
 %else
-Requires: (libvirt-daemon-kvm or libvirt)
+Requires: libvirt-daemon-kvm
 %endif
 Requires: libvirt-client
 


### PR DESCRIPTION
The test images should also not contain libvirt, libvirt-daemon-kvm is
sufficient.

In fact users that don't have libvirt-daemon-kvm installed but only
libvirt package will face issues with installing VMs from ISO URLs,
because qemu-block-curl is not dependency of the libvirt package and
that package provides this functionality.