### PR TITLE
Revert "bots: Temporarily disable host key checking for the sink"

### DIFF
--- a/bots/task/sink.py
+++ b/bots/task/sink.py
@@ -40,10 +40,7 @@ class Sink(object):
 
         # Start a gzip and cat processes
         self.ssh = subprocess.Popen([
-            "ssh",
-            # HACK: fix sink host keys and knownhosts on our infra
-            "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "-o", "CheckHostIP=no",
-            "-o", "ServerAliveInterval=30", host, "--",
+            "ssh", "-o", "ServerAliveInterval=30", host, "--",
             "python", "sink", identifier
         ], stdin=subprocess.PIPE)
 


### PR DESCRIPTION
This was a thinko -- this can be handled in the ssh config in the secrets.

Reverts cockpit-project/cockpit#12124