### PR TITLE
package.json: Pin down eslint-plugin-react to avoid 7.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react": "7.13.0",
     "eslint-plugin-standard": "^4.0.0",
     "exports-loader": "~0.6.3",
     "extend": "~3.0.0",


### PR DESCRIPTION
7.14.0 has a grave bug which breaks our build:
https://github.com/yannickcr/eslint-plugin-react/issues/2319

Until the fix is released, pin down to the previous version.