### PR TITLE
Add support for http → https redirection in proxy mode

### DIFF
--- a/doc/man/cockpit-ws.xml
+++ b/doc/man/cockpit-ws.xml
@@ -172,9 +172,6 @@ getcert request -f ${CERT_FILE} -k ${KEY_FILE} -D $(hostname --fqdn) -C "sed -n 
             </citerefentry>
             configuration file, it will override this default.
           </para>
-          <para>
-            This option implies <option>--no-tls</option>.
-          </para>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/doc/man/cockpit-ws.xml
+++ b/doc/man/cockpit-ws.xml
@@ -175,6 +175,16 @@ getcert request -f ${CERT_FILE} -k ${KEY_FILE} -D $(hostname --fqdn) -C "sed -n 
         </listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>--proxy-tls-redirect</option></term>
+        <listitem>
+          <para>
+            Enable redirection of unencrypted http requests to https (TLS) in <option>--no-tls</option> mode.
+            Use this when running <command>cockpit-ws</command> behind a reverse http proxy that also
+            supports https, but does no redirection from http to https by itself.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>--local-ssh</option></term>
         <listitem>
           <para>

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -33,8 +33,11 @@ extern gsize cockpit_webserver_request_maximum;
 typedef enum {
   COCKPIT_WEB_SERVER_NONE = 0,
   COCKPIT_WEB_SERVER_FOR_TLS_PROXY = 1 << 0,
+  /* http → https redirection for non-localhost addresses */
   COCKPIT_WEB_SERVER_REDIRECT_TLS = 1 << 1,
-  COCKPIT_WEB_SERVER_FLAGS_MAX = 1 << 2
+  /* http → https redirection for reverse proxy setups: Look at Host: header instead of connection IP */
+  COCKPIT_WEB_SERVER_REDIRECT_TLS_PROXY = 1 << 2,
+  COCKPIT_WEB_SERVER_FLAGS_MAX = 1 << 3
 } CockpitWebServerFlags;
 
 

--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -486,7 +486,7 @@ test_webserver_noredirect_localhost (TestCase *tc,
   g_assert (cockpit_web_server_get_flags (tc->web_server) == COCKPIT_WEB_SERVER_REDIRECT_TLS);
 
   g_signal_connect (tc->web_server, "handle-resource", G_CALLBACK (on_shell_index_html), NULL);
-  resp = perform_http_request (tc->localport, "GET /shell/index.html HTTP/1.0\r\nHost:test\r\n\r\n", NULL);
+  resp = perform_http_request (tc->localport, "GET /shell/index.html HTTP/1.0\r\nHost: localhost\r\n\r\n", NULL);
   cockpit_assert_strmatch (resp, "HTTP/* 200 *\r\n*");
   g_free (resp);
 }
@@ -516,6 +516,46 @@ test_webserver_noredirect_override (TestCase *tc,
 
   g_signal_connect (tc->web_server, "handle-resource", G_CALLBACK (on_shell_index_html), NULL);
   resp = perform_http_request (tc->hostport, "GET /shell/index.html HTTP/1.0\r\nHost:test\r\n\r\n", NULL);
+  cockpit_assert_strmatch (resp, "HTTP/* 200 *\r\n*");
+  g_free (resp);
+}
+
+static const TestFixture fixture_proxy_redirect = {
+    .local_only = TRUE,
+    .server_flags = COCKPIT_WEB_SERVER_REDIRECT_TLS | COCKPIT_WEB_SERVER_REDIRECT_TLS_PROXY,
+};
+
+static void
+test_webserver_proxy_redirect (TestCase *tc,
+                               gconstpointer data)
+{
+  gchar *resp;
+
+  /* request from remote host gets redirected */
+  g_signal_connect (tc->web_server, "handle-resource", G_CALLBACK (on_shell_index_html), NULL);
+  resp = perform_http_request (tc->localport, "GET /shell/index.html HTTP/1.0\r\nHost: test\r\n\r\n", NULL);
+  cockpit_assert_strmatch (resp, "HTTP/* 301 *\r\nLocation: https://*");
+  g_free (resp);
+
+  /* request from localhost doesn't redirect */
+  resp = perform_http_request (tc->localport, "GET /shell/index.html HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n", NULL);
+  cockpit_assert_strmatch (resp, "HTTP/* 200 *\r\n*");
+  g_free (resp);
+
+  resp = perform_http_request (tc->localport, "GET /shell/index.html HTTP/1.0\r\nHost: [::1]\r\n\r\n", NULL);
+  cockpit_assert_strmatch (resp, "HTTP/* 200 *\r\n*");
+  g_free (resp);
+
+  /* hostname:port variants of localhost */
+  resp = perform_http_request (tc->localport, "GET /shell/index.html HTTP/1.0\r\nHost: localhost:1234\r\n\r\n", NULL);
+  cockpit_assert_strmatch (resp, "HTTP/* 200 *\r\n*");
+  g_free (resp);
+
+  resp = perform_http_request (tc->localport, "GET /shell/index.html HTTP/1.0\r\nHost: 127.0.0.1:1234\r\n\r\n", NULL);
+  cockpit_assert_strmatch (resp, "HTTP/* 200 *\r\n*");
+  g_free (resp);
+
+  resp = perform_http_request (tc->localport, "GET /shell/index.html HTTP/1.0\r\nHost: [::1]:1234\r\n\r\n", NULL);
   cockpit_assert_strmatch (resp, "HTTP/* 200 *\r\n*");
   g_free (resp);
 }
@@ -936,6 +976,8 @@ main (int argc,
               setup, test_webserver_noredirect_exception, teardown);
   g_test_add ("/web-server/no-redirect-override", TestCase, &fixture_with_cert,
               setup, test_webserver_noredirect_override, teardown);
+  g_test_add ("/web-server/proxy-redirect", TestCase, &fixture_proxy_redirect,
+              setup, test_webserver_proxy_redirect, teardown);
 
   g_test_add ("/web-server/handle-resource", TestCase, NULL,
               setup, test_handle_resource, teardown);

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -45,6 +45,7 @@ static gint      opt_port         = 9090;
 static gchar     *opt_address     = NULL;
 static gboolean  opt_no_tls       = FALSE;
 static gboolean  opt_for_tls_proxy    = FALSE;
+static gboolean  opt_proxy_tls_redirect = FALSE;
 static gboolean  opt_local_ssh    = FALSE;
 static gchar     *opt_local_session = NULL;
 static gboolean  opt_version      = FALSE;
@@ -55,6 +56,9 @@ static GOptionEntry cmd_entries[] = {
   {"no-tls", 0, 0, G_OPTION_ARG_NONE, &opt_no_tls, "Don't use TLS", NULL},
   {"for-tls-proxy", 0, 0, G_OPTION_ARG_NONE, &opt_for_tls_proxy,
       "Act behind a https-terminating proxy: accept only https:// origins by default",
+      NULL},
+  {"proxy-tls-redirect", 0, 0, G_OPTION_ARG_NONE, &opt_proxy_tls_redirect,
+      "Redirect http requests to https even with --no-tls (useful for running behind a http reverse proxy)",
       NULL},
   {"local-ssh", 0, 0, G_OPTION_ARG_NONE, &opt_local_ssh, "Log in locally via SSH", NULL },
   {"local-session", 0, 0, G_OPTION_ARG_STRING, &opt_local_session,
@@ -154,6 +158,11 @@ main (int argc,
       g_printerr ("--for-tls-proxy and --no-tls are mutually exclusive");
       goto out;
     }
+  if (opt_for_tls_proxy && opt_proxy_tls_redirect)
+    {
+      g_printerr ("--for-tls-proxy (running behind a https proxy) and --proxy-tls-redirect (running behind a http proxy) are mutually exclusive");
+      goto out;
+    }
 
   if (opt_version)
     {
@@ -207,8 +216,13 @@ main (int argc,
 
   if (opt_for_tls_proxy)
     server_flags |= COCKPIT_WEB_SERVER_FOR_TLS_PROXY;
-  if (!opt_no_tls && !cockpit_conf_bool ("WebService", "AllowUnencrypted", FALSE))
-    server_flags |= COCKPIT_WEB_SERVER_REDIRECT_TLS;
+  if (!cockpit_conf_bool ("WebService", "AllowUnencrypted", FALSE))
+    {
+      if (!opt_no_tls)
+        server_flags |= COCKPIT_WEB_SERVER_REDIRECT_TLS;
+      if (opt_proxy_tls_redirect)
+        server_flags |= COCKPIT_WEB_SERVER_REDIRECT_TLS | COCKPIT_WEB_SERVER_REDIRECT_TLS_PROXY;
+    }
 
   server = cockpit_web_server_new (opt_address,
                                    opt_port,

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -54,7 +54,7 @@ static GOptionEntry cmd_entries[] = {
   {"address", 'a', 0, G_OPTION_ARG_STRING, &opt_address, "Address to bind to (binds on all addresses if unset)", "ADDRESS"},
   {"no-tls", 0, 0, G_OPTION_ARG_NONE, &opt_no_tls, "Don't use TLS", NULL},
   {"for-tls-proxy", 0, 0, G_OPTION_ARG_NONE, &opt_for_tls_proxy,
-      "Act behind a https-terminating proxy: accept only https:// origins by default; implies --no-tls",
+      "Act behind a https-terminating proxy: accept only https:// origins by default",
       NULL},
   {"local-ssh", 0, 0, G_OPTION_ARG_NONE, &opt_local_ssh, "Log in locally via SSH", NULL },
   {"local-session", 0, 0, G_OPTION_ARG_STRING, &opt_local_session,
@@ -147,6 +147,13 @@ main (int argc,
   g_option_context_add_main_entries (context, cmd_entries, NULL);
   if (!g_option_context_parse (context, &argc, &argv, &error))
     goto out;
+
+  /* check mutually exclusive options */
+  if (opt_for_tls_proxy && opt_no_tls)
+    {
+      g_printerr ("--for-tls-proxy and --no-tls are mutually exclusive");
+      goto out;
+    }
 
   if (opt_version)
     {

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -207,7 +207,7 @@ main (int argc,
 
   if (opt_for_tls_proxy)
     server_flags |= COCKPIT_WEB_SERVER_FOR_TLS_PROXY;
-  if (!cockpit_conf_bool ("WebService", "AllowUnencrypted", FALSE))
+  if (!opt_no_tls && !cockpit_conf_bool ("WebService", "AllowUnencrypted", FALSE))
     server_flags |= COCKPIT_WEB_SERVER_REDIRECT_TLS;
 
   server = cockpit_web_server_new (opt_address,

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -436,8 +436,8 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 
     @skipImage("missing socat", "fedora-atomic")
-    @skipImage("Added in PR #11813", "rhel-8-0-distropkg")
-    def testReverseTlsProxy(self):
+    @skipImage("Added in PR #11813 and #12141", "rhel-8-0-distropkg")
+    def testReverseProxy(self):
         m = self.machine
         b = self.browser
 
@@ -445,10 +445,13 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
         m.upload(["../src/bridge/mock-server.crt", "../src/bridge/mock-server.key"], "/tmp")
         m.spawn("socat OPENSSL-LISTEN:9090,reuseaddr,fork,cert=/tmp/mock-server.crt,"
                 "key=/tmp/mock-server.key,verify=0 TCP:localhost:9099",
-                "socat.log")
+                "socat-tls.log")
+
+        # and another proxy for plain http
+        m.spawn("socat TCP-LISTEN:9091,reuseaddr,fork TCP:localhost:9099", "socat.log")
 
         # ws with plain --no-tls should fail after login with mismatching Origin (expected http, got https)
-        m.spawn("su -s /bin/sh -c '%s --no-tls -p 9099 -a 127.0.0.1' cockpit-ws" % self.ws_executable,
+        m.spawn("su -s /bin/sh -c '%s --no-tls -p 9099' cockpit-ws" % self.ws_executable,
                 "ws-notls.log")
         m.wait_for_cockpit_running(tls=True)
 
@@ -469,8 +472,12 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
 
         wait(lambda: "received request from bad Origin" in m.execute("journalctl -b -t cockpit-ws"))
 
-        # sanity check: HTTP does not work
+        # sanity check: unencrypted http through SSL proxy does not work
         m.execute("! curl http://localhost:9090")
+
+        # does not redirect to https (through plain http proxy)
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9091"))
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://172.27.0.15:9091"))
 
         m.execute("pkill -e cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
         # this page failure is reeally noisy
@@ -510,6 +517,18 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
         # should have https:// URLs in Content-Security-Policy
         out = m.execute("curl --insecure --head https://localhost:9090/")
         self.assertIn("Content-Security-Policy: connect-src 'self' https://localhost:9090 wss://localhost:9090;", out)
+
+        # sanity check: does not redirect to https (through plain http proxy) -- this isn't a supported mode, though!
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9091"))
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://172.27.0.15:9091"))
+
+        # ws with --proxy-tls-redirect redirects non-localhost to https
+        m.execute("pkill -e cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
+        m.spawn("su -s /bin/sh -c '%s --proxy-tls-redirect --no-tls -p 9099 -a 127.0.0.1' cockpit-ws" % self.ws_executable,
+                "ws-proxy-tls-redirect.log")
+        m.wait_for_cockpit_running(tls=True)
+        self.assertIn("HTTP/1.1 301 Moved Permanently", m.execute("curl --silent --head http://172.27.0.15:9091"))
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9091"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
See individual commits for details. This is groundwork for PR #12068.

 - [x] preparation: small redirection cleanups: PR #12150

### Release note:
cockpit-ws now supports redirecting unencrypted http to https (TLS) even when running in `--no-tls` mode. Use this when running <command>cockpit-ws</command> behind a reverse http proxy that also supports https, but does no redirection from http to https by itself. This is enabled with the new `--proxy-tls-redirect` option.
