### PR TITLE
bots: Eliminate tap.py symlink

### DIFF
--- a/bots/tap.py
+++ b/bots/tap.py
@@ -1,1 +1,0 @@
-../test/common/tap.py

--- a/bots/test-bots
+++ b/bots/test-bots
@@ -25,8 +25,6 @@ import unittest
 
 sys.dont_write_bytecode = True
 
-import tap
-
 BOTS_DIR = os.path.dirname(__file__)
 
 def main():
@@ -38,7 +36,7 @@ def main():
         module = imp.load_source(name.replace("-", "_"), filename)
         suite.addTest(loader.loadTestsFromModule(module))
 
-    runner = tap.TapRunner()
+    runner = unittest.TextTestRunner()
     result = runner.run(suite)
     if result.wasSuccessful():
         return 0


### PR DESCRIPTION
tap.py lives in cockpit's tests, and the symlink from bots/ is ugly as
we want bots/ to be standalone. It's only being used by test-bots, where
we really don't care about TAP output. Use the plain unittest runner
instead.