### PR TITLE
Automatically start tests for lorax on RHEL 7

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -87,7 +87,8 @@ REPO_BRANCH_CONTEXT = {
             'cockpit/rhel-8-1/azure',
             'cockpit/rhel-8-1/openstack',
             'cockpit/rhel-8-1/vmware',
-
+        ],
+        'rhel7-extras': [
             'cockpit/rhel-7-7',
             'cockpit/rhel-7-7/live-iso',
             'cockpit/rhel-7-7/qcow2',


### PR DESCRIPTION
All of them have been backported and now PASS, see:
https://github.com/weldr/lorax/pull/765