### PR TITLE
docker: Change menu label to "Docker Containers"

### DIFF
--- a/pkg/docker/manifest.json.in
+++ b/pkg/docker/manifest.json.in
@@ -6,7 +6,7 @@
 
     "menu": {
         "index": {
-            "label": "Containers",
+            "label": "Docker Containers",
             "order": 50
         }
     },

--- a/test/avocado/selenium-docker.py
+++ b/test/avocado/selenium-docker.py
@@ -16,7 +16,7 @@ class DockerTestSuite(SeleniumTest):
 
     def test10ContainerTab(self):
         self.login()
-        self.click(self.wait_link('Containers', cond=clickable))
+        self.click(self.wait_link('Docker Containers', cond=clickable))
         self.wait_frame("docker")
         if self.wait_xpath("//*[@data-action='docker-start']", fatal=False, overridetry=5, cond=clickable):
             self.click(self.wait_xpath("//*[@data-action='docker-start']", cond=clickable))

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -565,7 +565,7 @@ CMD ["/bin/sh"]
         # crash in container
         m.execute('docker exec crashing_container sh -c "sleep 5 & sleep 1; pkill -ABRT sleep"')
 
-        # login and go to docker page (Containers)
+        # login and go to docker page (Docker Containers)
         self.login_and_go("/docker")
 
         sel = "#containers-containers .listing-ct-item .listing-ct-toggle"


### PR DESCRIPTION
To disambiguate it from "Podman Containers" from cockpit-podman, and
also to point out that this does not handle LXC, nspawn, or other
container technologies.