### PR TITLE
machines: fix inspecting VM Disks tab when the disk resides on an inactive pool

### DIFF
--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -625,6 +625,8 @@ LIBVIRT_DBUS_PROVIDER = {
                         dispatch(updateOrAddStoragePool(Object.assign({}, dumpxmlParams, props), updateOnly));
                         if (props.active)
                             dispatch(getStorageVolumes({ connectionName, poolName: dumpxmlParams.name }));
+                        else
+                            dispatch(updateStorageVolumes({ connectionName, poolName: dumpxmlParams.name, volumes: [] }));
                     })
                     .catch(ex => console.warn('GET_STORAGE_POOL action failed failed for path', objPath, ex));
         };

--- a/pkg/machines/libvirt-virsh.js
+++ b/pkg/machines/libvirt-virsh.js
@@ -281,7 +281,10 @@ LIBVIRT_PROVIDER = {
                             const poolInfoParams = parseStoragePoolInfo(poolInfo);
 
                             dispatch(updateOrAddStoragePool(Object.assign({}, dumpxmlParams, poolInfoParams)));
-                            dispatch(getStorageVolumes({ connectionName, poolName: name }));
+                            if (poolInfoParams.active)
+                                dispatch(getStorageVolumes({ connectionName, poolName: name }));
+                            else
+                                dispatch(updateStorageVolumes({ connectionName, poolName: name, volumes: [] }));
                         });
             }
         };

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -825,6 +825,16 @@ class TestMachines(NetworkCase):
             b.wait_present("#vm-subVmTest1-disks-adddisk-dialog-add:disabled")
             b.click("label:contains(Use Existing)")
             b.wait_present("#vm-subVmTest1-disks-adddisk-dialog-add:disabled")
+            b.click(".modal-footer button:contains(Cancel)")
+
+            # Make sure that trying to inspect the Disks tab will just show the fields that are available when a pool is inactive
+            b.reload()
+            b.enter_page('/machines')
+            b.wait_in_text("body", "Virtual Machines")
+            b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
+            b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
+            # Check that usage information can't be fetched since the pool is inactive
+            b.wait_not_present("#vm-subVmTest1-disks-vdd-used")
 
     def testVmNICs(self):
         b = self.browser


### PR DESCRIPTION
There are places in cockpit-machines codebase which asume that
storagePool.volumes is always an array.
Such example was the code showing the VM Disks tab.
Inactive pools don't have volume information however, which resulted in
the relevant code to crash when the involved pool was inactive.

Make sure to have an empty array as value to 'volumes' key to avoid such
issues.