### PR TITLE
naughty: Close 8871: Fedora 28: SELinux denies port binding to rpcbind.service

### DIFF
--- a/bots/naughty/fedora-29/8871-selinux-rpcbind
+++ b/bots/naughty/fedora-29/8871-selinux-rpcbind
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { name_bind } for * comm="rpcbind"

--- a/bots/naughty/rhel-8/8871-selinux-rpcbind
+++ b/bots/naughty/rhel-8/8871-selinux-rpcbind
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): avc:  denied  { name_bind } for * comm="rpcbind"


### PR DESCRIPTION
Known issue which has not occurred in 24 days

Fedora 28: SELinux denies port binding to rpcbind.service

Fixes #8871