### PR TITLE
package: Set up terser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "style-loader": "~0.13.1",
     "uglify-js": "^3.4.9",
     "webpack": "^4.17.1",
-    "webpack-cli": "^3.1.0"
+    "webpack-cli": "^3.1.0",
+    "terser": "4.0.0"
   },
   "scripts": {
     "eslint": "eslint --ext .js --ext .jsx pkg/",


### PR DESCRIPTION
This package is pulled as dependency. However in new version 4.0.1 is
bug which break our build. Set this to version 4.0.0 for now.

See https://github.com/terser-js/terser/issues/380

And yes, I don't know how to limit it as just other package dependency, but I think that for now it is good enough fix, as this should be resolved very soon.