### PR TITLE
test: Add public method for executing JS through Selenium

### DIFF
--- a/test/avocado/selenium-kdump.py
+++ b/test/avocado/selenium-kdump.py
@@ -51,7 +51,7 @@ class TestKdump(SeleniumTest):
         self.requirements()
         if os.environ.get("BROWSER") == 'edge':
             # HACK: Edge does not see elements (kdump menu entry) which are below the visible window area
-            self._driver_excecute('''document.querySelector("#host-nav a[href='/kdump']").scrollIntoView()''')
+            self.execute_script('''document.querySelector("#host-nav a[href='/kdump']").scrollIntoView()''')
         self.click(self.wait_link("Kernel Dump"))
         self.wait_frame("localhost/kdump")
         self.base_element = self.wait_id("app", jscheck=True)

--- a/test/avocado/testlib_avocado/seleniumlib.py
+++ b/test/avocado/testlib_avocado/seleniumlib.py
@@ -179,7 +179,7 @@ class SeleniumTest(Test):
         except WebDriverException as e:
             self.log.info("ERR: Unable to get logs: " + e.msg)
 
-    def _driver_excecute(self, *args, fatal=True):
+    def execute_script(self, *args, fatal=True):
 
         try:
             return self.driver.execute_script(*args)
@@ -197,7 +197,7 @@ This function is only for internal purposes:
     It via javascript check that attribute data-loaded is in element
         """
         if javascript_operations:
-            return self._driver_excecute("return arguments[0].getAttribute('data-loaded')", element)
+            return self.execute_script("return arguments[0].getAttribute('data-loaded')", element)
         else:
             return True
 
@@ -207,7 +207,7 @@ This function is only for internal purposes:
         for foo in range(0, self.default_try):
             try:
                 if javascript_operations:
-                    self._driver_excecute("arguments[0].click();", element)
+                    self.execute_script("arguments[0].click();", element)
                 else:
                     element.click()
                 failure = None
@@ -235,8 +235,8 @@ This function is only for internal purposes:
             self.take_screenshot(fatal=False)
             raise SeleniumElementFailure('Unable to SEND_KEYS to element ({})'.format(e))
         if javascript_operations:
-            self._driver_excecute('var ev = new Event("change", { bubbles: true, cancelable: false }); arguments[0].dispatchEvent(ev);', element)
-            self._driver_excecute('var ev = new Event("change", { bubbles: true, cancelable: false }); arguments[0].dispatchEvent(ev);', element)
+            self.execute_script('var ev = new Event("change", { bubbles: true, cancelable: false }); arguments[0].dispatchEvent(ev);', element)
+            self.execute_script('var ev = new Event("change", { bubbles: true, cancelable: false }); arguments[0].dispatchEvent(ev);', element)
 
     def check_box(self, element, checked=True):
         try:


### PR DESCRIPTION
Fix the typo in `_driver_excecute()` and make the method public as we
now use it outside of seleniumlib.py. Rename it to `execute_script()` to
mirror the Selenium webdriver method, to clarify what it does.