### PR TITLE
machines: Fix configuration of multiple settings on running VM

### DIFF
--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -213,7 +213,7 @@ LIBVIRT_DBUS_PROVIDER = {
         connectionName,
         devices,
     }) {
-        return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [0], TIMEOUT)
+        return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], TIMEOUT)
                 .then(domXml => {
                     let updatedXML = updateBootOrder(domXml, devices);
                     return call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'DomainDefineXML', [updatedXML], TIMEOUT);
@@ -238,7 +238,7 @@ LIBVIRT_DBUS_PROVIDER = {
         flags |= Enum.VIR_DOMAIN_AFFECT_CONFIG;
 
         // Error handling inside the modal dialog this function is called
-        return clientLibvirt[connectionName].call(objPath, 'org.libvirt.Domain', 'GetXMLDesc', [0], TIMEOUT)
+        return clientLibvirt[connectionName].call(objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], TIMEOUT)
                 .then(domXml => {
                     let updatedXml = updateNetworkIface({
                         domXml: domXml[0],
@@ -786,7 +786,7 @@ LIBVIRT_DBUS_PROVIDER = {
         threads,
         isRunning
     }) {
-        return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [0], TIMEOUT)
+        return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], TIMEOUT)
                 .then(domXml => {
                     let updatedXML = updateVCPUSettings(domXml[0], count, max, sockets, cores, threads);
                     return call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'DomainDefineXML', [updatedXML], TIMEOUT);

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -304,6 +304,43 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("#vm-subVmTest1-state", "paused")
         b.wait_attr("#vm-subVmTest1-disks-vdf-detach", "disabled", "")
 
+    def testMultipleSettings(self):
+        b = self.browser
+
+        self.startVm("subVmTest1")
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual Machines")
+        b.wait_in_text("tbody tr th", "subVmTest1")
+
+        b.click("tbody tr th") # click on the row header
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+
+        # Change Boot Order setting
+        bootOrder = b.text("#vm-subVmTest1-boot-order")
+        b.click("#vm-subVmTest1-boot-order") # Open dialog
+        b.wait_present(".modal-body")
+        b.click("#vm-subVmTest1-order-modal-device-row-0 #vm-subVmTest1-order-modal-down") # Change order
+        b.click("#vm-subVmTest1-order-modal-save") # Save
+        b.wait_not_present(".modal-body")
+
+        # Change vCPUs setting
+        b.click("#vm-subVmTest1-vcpus-count") # Open dialog
+        b.wait_present(".modal-body")
+        b.set_input_text("#machines-vcpu-max-field", "3") # Change values
+        b.set_input_text("#machines-vcpu-count-field", "3")
+        b.click("#machines-vcpu-modal-dialog-apply") # Save
+        b.wait_not_present(".modal-body")
+
+        # Shut off domain
+        b.click("#vm-subVmTest1-off-caret")
+        b.click("#vm-subVmTest1-forceOff")
+        b.wait_in_text("#vm-subVmTest1-state", "shut off")
+
+        # Check both changes have been applied
+        b.wait_not_in_text("#vm-subVmTest1-boot-order", bootOrder)
+        b.wait_in_text("#vm-subVmTest1-vcpus-count", "3")
+
     def testNetworkSettings(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Right now user can configure only one settings which takes effect after
shutting down a VM (e.g. vcpus, bootorder, network interface) at a time.

Every change gets lost if user changes another configuration.

**Example**: Have a running VM, change vcpus settings, then change
boot order setting, vcpus new configuration gets lost.

This is caused because we use non-updated active XML to change configuration
and update VM.

So instead we should use inactive XML for these changes.