### PR TITLE
lib: Drop btn-onoff-ct leftovers

### DIFF
--- a/pkg/kdump/kdump.css
+++ b/pkg/kdump/kdump.css
@@ -30,15 +30,6 @@
     white-space: nowrap;
 }
 
-.btn-onoff-ct {
-    margin-right: 5px;
-}
-
-.btn-onoff-ct + .spinner-sm {
-    /* Adding margin bumps small spinner up to normal widget height */
-    margin: 5px 0;
-}
-
 #kdump-settings-dialog {
     width: 400px;
 }

--- a/pkg/lib/page.css
+++ b/pkg/lib/page.css
@@ -131,60 +131,6 @@ a.disabled:hover {
    background-color: #e0e0e0;
 }
 
-
-/* On/off switch */
-
-.btn-onoff-ct {
-    margin: 1px 0px;
-    text-transform: uppercase;
-}
-
-.btn-onoff-ct .btn {
-    color: transparent;
-    border-color: var(--color-gray-4);
-    padding: 2px 6px 1px 6px;
-    background-color: white;
-    background-image: linear-gradient(to bottom, rgb(250, 250, 250) 0px, rgb(237, 237, 237) 100%);
-    -webkit-box-shadow: none;
-    box-shadow: none;
-    width: 37px;
-}
-
-.btn-onoff-ct .btn:first-child {
-    border-right: #00435F;
-}
-
-.btn-onoff-ct .btn:last-child {
-    border-left: #00435F;
-    padding-left: 5px;
-}
-
-.btn-onoff-ct .btn.active {
-    background-image: none;
-    width: 36px;
-}
-
-.btn-onoff-ct .btn.active:first-child {
-    background-color: var(--color-link);
-    color: white;
-    border-right: 1px solid #0071b0;
-}
-
-.btn-onoff-ct .btn.active:last-child {
-    color: var(--color-text);
-    border-left: 1px solid #d6d6d6;
-}
-
-.btn-onoff-ct .btn.disabled {
-    pointer-events: none;
-    color: transparent !important;
-}
-
-.btn-onoff-ct .btn.active.disabled {
-    background-color: var(--color-subtle-copy) !important;
-    color: white !important;
-}
-
 /* Small list inside a dialog */
 /* Alert fixups */
 

--- a/pkg/lib/patterns.js
+++ b/pkg/lib/patterns.js
@@ -1,11 +1,4 @@
 import $ from 'jquery';
-import cockpit from 'cockpit';
-
-var unique_number = 0;
-function unique() {
-    unique_number += 1;
-    return "unique" + -(new Date()) + -unique_number;
-}
 
 /* Dialog Patterns */
 
@@ -221,70 +214,6 @@ $.fn.dialog = function dialog(action /* ... */) {
 window.addEventListener("hashchange", function() {
     $(".modal").modal("hide");
 });
-
-/*
- * OnOff switch pattern
- */
-
-function onoff_refresh(sel) {
-    /* During testing, no Cockpit dependency */
-    const _ = cockpit.gettext || function(x) { return x };
-
-    sel = sel.find(".btn-onoff-ct").addBack()
-            .filter(".btn-onoff-ct");
-    sel.each(function(x, el) {
-        var self = $(el)
-                .attr("data-toggle", "buttons")
-                .addClass("btn-group");
-        var value = self.onoff("value");
-        var buttons = self.find(".btn");
-        var name = self.find("input").first()
-                .attr("name") || unique();
-        var i, input, text;
-        for (i = buttons.length; i < 2; i++) {
-            input = $('<input type="radio" autocomplete="off">');
-            text = document.createTextNode(i === 0 ? _("On") : _("Off"));
-            self.append($('<label class="btn">').append(input, text));
-            buttons = null;
-        }
-        buttons = buttons || self.find(".btn");
-        buttons.find("input").attr("name", name);
-        onoff_change(self, !!value);
-    });
-    return sel;
-}
-
-function onoff_value(sel) {
-    return sel.find(".btn").first()
-            .hasClass("active");
-}
-
-function onoff_change(sel, value) {
-    return sel.each(function(i, el) {
-        var buttons = $(el).find(".btn");
-        buttons.first().toggleClass("active", !!value)
-                .find("input")
-                .prop("checked", !!value);
-        buttons.last().toggleClass("active", !value)
-                .find("input")
-                .prop("checked", !value);
-    });
-}
-
-$.fn.onoff = function onoff(action /* ... */) {
-    if (arguments.length === 0 || action == "refresh") {
-        return onoff_refresh(this);
-    } else if (action === "value") {
-        if (arguments.length === 1)
-            return onoff_value(this);
-        else
-            return onoff_change(this, arguments[1]);
-    } else if (action == "disabled") {
-        return this.find(".btn").toggleClass("disabled", arguments[1]);
-    } else {
-        console.warn("unknown switch action: " + action);
-    }
-};
 
 /* ----------------------------------------------------------------------------
  * Sliders

--- a/pkg/playground/jquery-patterns.html
+++ b/pkg/playground/jquery-patterns.html
@@ -221,58 +221,6 @@
         <thead>
             <tr>
                 <td colspan="2">
-                    <h3>Expandable Listing: Panel header is row</h3>
-                </td>
-            </tr>
-        </thead>
-        <tbody>
-            <tr class="listing-ct-item listing-ct-head">
-                <th>id_rsa</th>
-                <td></td>
-                <td class="listing-ct-tight listing-ct-actions">
-                    <div class="btn-group btn-onoff-ct" data-toggle="buttons">
-                        <label class="btn"><input type="radio" autocomplete="off">On</label>
-                        <label class="btn active"><input type="radio" autocomplete="off" checked>Off</label>
-                    </div>
-                </td>
-            </tr>
-            <tr class="listing-ct-body">
-                <td colspan="3">
-                    the body
-                </td>
-            </tr>
-        </tbody>
-        <tbody>
-            <tr class="listing-ct-item listing-ct-head">
-                <th>id_rsa</th>
-                <td></td>
-                <td class="listing-ct-tight listing-ct-actions">
-                    <div class="btn-group btn-onoff-ct" data-toggle="buttons">
-                        <label class="btn"><input type="radio" autocomplete="off">On</label>
-                        <label class="btn active"><input type="radio" autocomplete="off" checked>Off</label>
-                    </div>
-                </td>
-            </tr>
-            <tr class="listing-ct-panel">
-                <td colspan="3">
-                    <ul class="nav nav-tabs nav-tabs-pf">
-                        <li><a href="#">Tree</a></li>
-                        <li class="active"><a href="#">Packages</a></li>
-                    </ul>
-                </td>
-            </tr>
-            <tr class="listing-ct-body">
-                <td colspan="3">
-                    The body
-                </td>
-            </tr>
-        </tbody>
-    </table>
-
-    <table class="listing-ct">
-        <thead>
-            <tr>
-                <td colspan="2">
                     <h3>Listing with Timeline</h3>
                 </td>
             </tr>

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -698,14 +698,6 @@ iframe.container-frame {
         max-height: 500px;
     }
 
-    .btn-onoff-ct .btn {
-        padding-top: 1px;
-        padding-bottom: 1px;
-        height: 24px;
-        line-height: 24px;
-        display: inline;
-    }
-
     table.credential-listing {
         margin-top: 0px;
         width: 100%;

--- a/src/base1/cockpit.css
+++ b/src/base1/cockpit.css
@@ -461,59 +461,6 @@ a {
     background: #f0f0f0;
 }
 
-/* On/off switch */
-
-.btn-onoff-ct {
-    margin: 1px 0px;
-    text-transform: uppercase;
-}
-
-.btn-onoff-ct .btn {
-    color: transparent;
-    border-color: #B7B7B7;
-    padding: 2px 6px 1px 6px;
-    background-color: white;
-    background-image: linear-gradient(to bottom, rgb(250, 250, 250) 0px, rgb(237, 237, 237) 100%);
-    -webkit-box-shadow: none;
-    box-shadow: none;
-    width: 37px;
-}
-
-.btn-onoff-ct .btn:first-child {
-    border-right: #00435F;
-}
-
-.btn-onoff-ct .btn:last-child {
-    border-left: #00435F;
-    padding-left: 5px;
-}
-
-.btn-onoff-ct .btn.active {
-    background-image: none;
-    width: 36px;
-}
-
-.btn-onoff-ct .btn.active:first-child {
-    background-color: #0086CF;
-    color: white;
-    border-right: 1px solid #0071b0;
-}
-
-.btn-onoff-ct .btn.active:last-child {
-    color: #000;
-    border-left: 1px solid #d6d6d6;
-}
-
-.btn-onoff-ct .btn.disabled {
-    pointer-events: none;
-    color: transparent !important;
-}
-
-.btn-onoff-ct .btn.active.disabled {
-    background-color: #888 !important;
-    color: white !important;
-}
-
 /* Listing pattern */
 
 table.listing-ct {


### PR DESCRIPTION
All our On/Off switches got dropped in commit a2b0d7d386. Drop the
.onoff() pattern function and CSS for good now.