### PR TITLE
tools: Fix for git worktree

### DIFF
--- a/tools/git-version-gen
+++ b/tools/git-version-gen
@@ -10,7 +10,7 @@ if [ $# -ne 1 ]; then
 fi
 
 generate() {
-	if [ -d $BASE/../.git ]; then
+	if [ -e $BASE/../.git ]; then
         cd $BASE/..
 		git describe | sed 's/-[0-9]\+-g.*/.x/'
 	else

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -95,7 +95,7 @@ else
 fi
 
 # Valid JSON files
-if [ -d .git ]; then
+if [ -e .git ]; then
     for f in $(git ls-tree --name-only -r --full-name HEAD | grep '\.json$'); do
         if ! python3 -m json.tool $f /dev/null; then
             echo "ERROR: $f is invalid JSON" >&2


### PR DESCRIPTION
git worktrees have a .git file instead of a directory. Relax the file
type tests in our tools to get along with these.