### PR TITLE
build: Build fonts into dist/static/fonts

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -130,10 +130,10 @@ Violations of some rules can be fixed automatically by:
 
 Rules configuration can be found in the `.eslintrc.json` file.
 
-## Working on your local machine
+## Working on your local machine: Cockpit's session pages
 
 It's easy to set up your local Linux machine for rapid development of Cockpit's
-JavaScript code. First install Cockpit on your local machine as described in:
+JavaScript code (in pkg/). First install Cockpit on your local machine as described in:
 
 https://cockpit-project.org/running.html
 
@@ -158,6 +158,25 @@ To make Cockpit again use the installed code, rather than that from your
 git checkout directory, run the following, and log into Cockpit again:
 
     $ rm ~/.local/share/cockpit
+
+## Working on your local machine: Web server resources
+
+To test changes to the login page or any other resources, you can bind-mount
+the build tree's `dist/static/` directory over the  system one:
+
+    $ sudo mount -o bind dist/static/ /usr/share/cockpit/static/
+
+Likewise, to test changes to the branding, use
+
+    $ sudo mount -o bind src/branding/ /usr/share/cockpit/branding/
+
+After that, run `systemctl stop cockpit.service` to ensure that the web server
+restarts on the next browser request.
+
+To make Cockpit again use the system-installed code, simply umount these again:
+
+   $ sudo umount /usr/share/cockpit/static/ /usr/share/cockpit/branding/
+   $ systemctl stop cockpit.service
 
 ## Working on Cockpit using Vagrant
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -313,51 +313,53 @@ install-data-hook::
 	chgrp wheel $(DESTDIR)$(localstatedir)/lib/cockpit || true
 	chmod 775 $(DESTDIR)$(localstatedir)/lib/cockpit
 
+FONTSDIR = dist/static/fonts
+
 # Fonts are used by multiple things so put them here
 OPENSANS_FONTS = \
-	dist/fonts/OpenSans-Bold-webfont.woff \
-	dist/fonts/OpenSans-BoldItalic-webfont.woff \
-	dist/fonts/OpenSans-ExtraBold-webfont.woff  \
-	dist/fonts/OpenSans-ExtraBoldItalic-webfont.woff \
-	dist/fonts/OpenSans-Italic-webfont.woff \
-	dist/fonts/OpenSans-Light-webfont.woff \
-	dist/fonts/OpenSans-LightItalic-webfont.woff \
-	dist/fonts/OpenSans-Regular-webfont.woff \
-	dist/fonts/OpenSans-Semibold-webfont.woff \
-	dist/fonts/OpenSans-SemiboldItalic-webfont.woff \
+	$(FONTSDIR)/OpenSans-Bold-webfont.woff \
+	$(FONTSDIR)/OpenSans-BoldItalic-webfont.woff \
+	$(FONTSDIR)/OpenSans-ExtraBold-webfont.woff  \
+	$(FONTSDIR)/OpenSans-ExtraBoldItalic-webfont.woff \
+	$(FONTSDIR)/OpenSans-Italic-webfont.woff \
+	$(FONTSDIR)/OpenSans-Light-webfont.woff \
+	$(FONTSDIR)/OpenSans-LightItalic-webfont.woff \
+	$(FONTSDIR)/OpenSans-Regular-webfont.woff \
+	$(FONTSDIR)/OpenSans-Semibold-webfont.woff \
+	$(FONTSDIR)/OpenSans-SemiboldItalic-webfont.woff \
 	$(NULL)
 
 REDHATTEXT_FONTS = \
-	dist/fonts/RedHatText-Bold.woff2 \
-	dist/fonts/RedHatText-BoldItalic.woff2 \
-	dist/fonts/RedHatText-Italic.woff2 \
-	dist/fonts/RedHatText-Medium.woff2 \
-	dist/fonts/RedHatText-MediumItalic.woff2 \
-	dist/fonts/RedHatText-Regular.woff2 \
+	$(FONTSDIR)/RedHatText-Bold.woff2 \
+	$(FONTSDIR)/RedHatText-BoldItalic.woff2 \
+	$(FONTSDIR)/RedHatText-Italic.woff2 \
+	$(FONTSDIR)/RedHatText-Medium.woff2 \
+	$(FONTSDIR)/RedHatText-MediumItalic.woff2 \
+	$(FONTSDIR)/RedHatText-Regular.woff2 \
 	$(NULL)
 
 REDHATDISPLAY_FONTS = \
-	dist/fonts/RedHatDisplay-Black.woff2 \
-	dist/fonts/RedHatDisplay-BlackItalic.woff2 \
-	dist/fonts/RedHatDisplay-Bold.woff2 \
-	dist/fonts/RedHatDisplay-BoldItalic.woff2 \
-	dist/fonts/RedHatDisplay-Italic.woff2 \
-	dist/fonts/RedHatDisplay-Medium.woff2 \
-	dist/fonts/RedHatDisplay-MediumItalic.woff2 \
-	dist/fonts/RedHatDisplay-Regular.woff2 \
+	$(FONTSDIR)/RedHatDisplay-Black.woff2 \
+	$(FONTSDIR)/RedHatDisplay-BlackItalic.woff2 \
+	$(FONTSDIR)/RedHatDisplay-Bold.woff2 \
+	$(FONTSDIR)/RedHatDisplay-BoldItalic.woff2 \
+	$(FONTSDIR)/RedHatDisplay-Italic.woff2 \
+	$(FONTSDIR)/RedHatDisplay-Medium.woff2 \
+	$(FONTSDIR)/RedHatDisplay-MediumItalic.woff2 \
+	$(FONTSDIR)/RedHatDisplay-Regular.woff2 \
 	$(NULL)
 
-dist/fonts/OpenSans-%.woff:
+$(FONTSDIR)/OpenSans-%.woff:
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
-	cp -L $(subst dist/fonts,$(srcdir)/node_modules/patternfly/dist/fonts,$@) $@.tmp && $(MV) $@.tmp $@
+	cp -L $(subst $(FONTSDIR),$(srcdir)/node_modules/patternfly/dist/fonts,$@) $@.tmp && $(MV) $@.tmp $@
 
-dist/fonts/RedHatText-%.woff2:
+$(FONTSDIR)/RedHatText-%.woff2:
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
-	cp -L $(subst dist/fonts,$(srcdir)/node_modules/@redhat/redhat-font/webfonts/RedHatText,$@) $@.tmp && $(MV) $@.tmp $@
+	cp -L $(subst $(FONTSDIR),$(srcdir)/node_modules/@redhat/redhat-font/webfonts/RedHatText,$@) $@.tmp && $(MV) $@.tmp $@
 
-dist/fonts/RedHatDisplay-%.woff2:
+$(FONTSDIR)/RedHatDisplay-%.woff2:
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
-	cp -L $(subst dist/fonts,$(srcdir)/node_modules/@redhat/redhat-font/webfonts/RedHatDisplay,$@) $@.tmp && $(MV) $@.tmp $@
+	cp -L $(subst $(FONTSDIR),$(srcdir)/node_modules/@redhat/redhat-font/webfonts/RedHatDisplay,$@) $@.tmp && $(MV) $@.tmp $@
 
 EXTRA_DIST += $(OPENSANS_FONTS) $(REDHATTEXT_FONTS) $(REDHATDISPLAY_FONTS)
 

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -62,7 +62,7 @@ GUIDE_XSLT = \
 	doc/guide/version-greater-or-equal.xsl \
 	$(NULL)
 
-GUIDE_FONTS = $(subst dist/fonts/,dist/guide/html/,$(REDHATTEXT_FONTS))
+GUIDE_FONTS = $(subst dist/static/fonts/,dist/guide/html/,$(REDHATTEXT_FONTS))
 
 EXTRA_DIST += \
 	$(GUIDE_DOCBOOK) \
@@ -89,7 +89,7 @@ MAINTAINERCLEANFILES += \
 	*.tmp \
 	$(NULL)
 
-dist/guide/html/%.woff2: dist/fonts/%.woff2
+dist/guide/html/%.woff2: dist/static/fonts/%.woff2
 	$(COPY_RULE)
 
 dist/guide/html/index.html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUIDE_STATIC) $(GUIDE_XSLT) $(GUIDE_FONTS)


### PR DESCRIPTION
This makes the build tree's dist/static/ directory look like the
installed /usr/share/cockpit/static/. This allows a developer to
bind-mount the former onto the latter, to test changes to the login page
or other web server resources without having to modify their system.

Explain in HACKING.md how to do that.