### PR TITLE
po: Refresh all files

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-25 16:06+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2018-05-03 04:56+0000\n"
 "Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
 "Language-Team: Catalan\n"
 "Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -22,19 +22,15 @@ msgstr ""
 msgid " (shared with the OS)"
 msgstr " (compartit amb el SO)"
 
-#: pkg/kubernetes/views/node-delete.html:8
-msgid " 1\"Do you want to delete the following Nodes?"
-msgstr " 1\"Voleu suprimir els següents nodes?"
-
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "Dispositiu de blocs $0"
 
-#: pkg/storaged/mdraid-details.jsx:193
+#: pkg/storaged/mdraid-details.jsx:192
 msgid "$0 Chunk Size"
 msgstr "$0 de mida del tros"
 
-#: pkg/storaged/mdraid-details.jsx:191
+#: pkg/storaged/mdraid-details.jsx:190
 msgid "$0 Disks"
 msgstr "$0 discs"
 
@@ -83,16 +79,16 @@ msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr ""
 
 #: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:213
+#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "falta $0 disc"
 msgstr[1] "falten $0 discs"
 
 #: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:34
-#: pkg/playground/translate.js:37
+#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
@@ -132,10 +128,10 @@ msgstr ""
 "ho, cerqueu-ho a GNOME Software o executeu el següent:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:237
-#: pkg/storaged/mdraid-details.jsx:290 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:203
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr ""
 
@@ -175,27 +171,11 @@ msgstr[1] "$0 actualitzacions"
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 utilitzats de $1 ($2 estalviat)"
 
-#: pkg/ovirt/components/vcpuModal.jsx:98
-msgid "$0 vCPU Details"
-msgstr ""
-
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:871
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0% lliure"
-msgstr[1] "$0% lliures"
-
-#: pkg/kubernetes/scripts/nodes.js:873
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0% utilitzat"
-msgstr[1] "$0% utilitzats"
-
-#: pkg/storaged/vgroup-details.jsx:118
+#: pkg/storaged/vgroup-details.jsx:117
 msgid "$0, $1 free"
 msgstr "$0 amb $1 lliures"
 
@@ -221,19 +201,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${desc} de ${size}"
 
-#: pkg/subscriptions/subscriptions-client.js:197
-msgid "'Organization' required to register."
-msgstr ""
-
-#: pkg/subscriptions/subscriptions-client.js:201
-msgid "'Organization' required when using activation keys."
-msgstr ""
-
-#: pkg/networkmanager/firewall.jsx:547
+#: pkg/networkmanager/firewall.jsx:549
 msgid "(Optional)"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:616
+#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(predeterminat)"
@@ -523,12 +495,8 @@ msgstr "Monitoratge ARP"
 msgid "ARP Ping"
 msgstr "Ping ARP"
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr ""
-
 #: pkg/shell/index.html:56 pkg/shell/index.html:82 pkg/shell/simple.html:42
-#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
+#: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Quant a Cockpit"
 
@@ -536,19 +504,9 @@ msgstr "Quant a Cockpit"
 msgid "Access"
 msgstr "Accés"
 
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
-msgid "Access Modes"
-msgstr "Modes d'accés"
-
-#: pkg/kubernetes/views/project-modify.html:49
 #: node_modules/registry-image-widgets/views/imagestream-body.html:12
 msgid "Access Policy"
 msgstr "Política d'accés"
-
-#: pkg/subscriptions/subscriptions-view.jsx:213
-msgid "Access denied"
-msgstr "Accés denegat"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -566,18 +524,13 @@ msgstr "El compte no està disponible o no es pot editar."
 msgid "Accounts"
 msgstr "Comptes"
 
-#: pkg/users/local.js:335 pkg/users/local.js:642
+#: pkg/users/local.js:339 pkg/users/local.js:646
 msgctxt "page-title"
 msgid "Accounts"
 msgstr "Comptes"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:183
-msgid "Action"
-msgstr "Acció"
-
-#: pkg/machines/components/networks/network.jsx:147
-#: pkg/machines/components/storagePools/storagePool.jsx:167
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Activa"
@@ -585,10 +538,6 @@ msgstr "Activa"
 #: pkg/storaged/jobs-panel.jsx:68
 msgid "Activating $target"
 msgstr "S'està activant $target"
-
-#: pkg/subscriptions/subscriptions-register.jsx:168
-msgid "Activation Key"
-msgstr "Clau d'activació"
 
 #: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
 msgid "Active"
@@ -598,7 +547,7 @@ msgstr "Activa"
 msgid "Active Backup"
 msgstr "Còpia de seguretat activa"
 
-#: pkg/shell/index.html:59 pkg/shell/stub.html:49 pkg/shell/active-pages.js:95
+#: pkg/shell/index.html:59 pkg/shell/active-pages.js:95
 msgid "Active Pages"
 msgstr "Pàgines actives"
 
@@ -606,13 +555,9 @@ msgstr "Pàgines actives"
 msgid "Active since"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:922
+#: pkg/networkmanager/firewall.jsx:924
 msgid "Active zones"
 msgstr ""
-
-#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
-msgid "Actual"
-msgstr "Real"
 
 #: pkg/networkmanager/interfaces.js:1980
 msgid "Adaptive load balancing"
@@ -622,16 +567,11 @@ msgstr "Balanceig de càrrega adaptativa"
 msgid "Adaptive transmit load balancing"
 msgstr "Balanceig de càrrega de transmissió adaptativa"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/add-role-dialog.html:8
-#: pkg/kubernetes/views/add-user-dialog.html:27
-#: pkg/kubernetes/views/node-add.html:50
-#: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:534
-#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/vgroup-details.jsx:63
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Afegeix"
 
@@ -651,11 +591,7 @@ msgstr "Afegeix un enllaç"
 msgid "Add Bridge"
 msgstr "Afegeix un pont"
 
-#: pkg/kubernetes/views/node-add.html:3
-msgid "Add Cluster Node"
-msgstr "Afegeix un node de clúster"
-
-#: pkg/machines/components/diskAdd.jsx:356
+#: pkg/machines/components/diskAdd.jsx:360
 msgid "Add Disk"
 msgstr ""
 
@@ -663,55 +599,20 @@ msgstr ""
 msgid "Add Disks"
 msgstr "Afegeix discs"
 
-#: pkg/kubernetes/views/add-group-dialog.html:3
-msgid "Add Group"
-msgstr "Afegeix un grup"
-
 #: pkg/storaged/crypto-keyslots.jsx:200
 msgid "Add Key"
 msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html:34
-msgid "Add Kubernetes Node"
-msgstr "Afegeix un node Kubernetes"
 
 #: pkg/lib/machine-add.html:4
 msgid "Add Machine to Dashboard"
 msgstr "Afegeix la màquina al tauler de control"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:4
-#: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/group-panel.html:29
-#: pkg/kubernetes/views/project-body.html:108
-#: pkg/kubernetes/views/user-group-add.html:3
-msgid "Add Member"
-msgstr "Afegeix un membre"
-
-#: pkg/kubernetes/views/user-body.html:67
-#: pkg/kubernetes/views/user-panel.html:76
-msgid "Add Membership"
-msgstr "Afegeix una pertinença"
-
-#: pkg/kubernetes/views/auth-form.html:11
-#: pkg/kubernetes/views/auth-form.html:20
-msgid "Add New Cluster"
-msgstr "Afegeix un clúster nou"
-
-#: pkg/kubernetes/views/auth-form.html:67
-#: pkg/kubernetes/views/auth-form.html:76
-msgid "Add New User"
-msgstr "Afegeix un usuari nou"
-
 #: pkg/networkmanager/firewall.jsx:457
 msgid "Add Ports"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html:3
-msgid "Add Role"
-msgstr "Afegeix un rol"
-
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:872
-#: pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
+#: pkg/networkmanager/firewall.jsx:886
 msgid "Add Services"
 msgstr "Afegeix serveis"
 
@@ -723,17 +624,12 @@ msgstr "Afegeix emmagatzematge"
 msgid "Add Team"
 msgstr "Afegeix un equip"
 
-#: pkg/kubernetes/views/add-user-dialog.html:3
-#: pkg/kubernetes/views/project-listing.html:83
-msgid "Add User"
-msgstr "Afegeix un usuari"
-
 #: pkg/networkmanager/index.html:113
 msgid "Add VLAN"
 msgstr "Afegeix una VLAN"
 
-#: pkg/networkmanager/firewall.jsx:698 pkg/networkmanager/firewall.jsx:878
-#: pkg/networkmanager/firewall.jsx:889
+#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
+#: pkg/networkmanager/firewall.jsx:891
 msgid "Add Zone"
 msgstr ""
 
@@ -744,10 +640,6 @@ msgstr "Afegeix un portal iSCSI"
 #: pkg/shell/index.html:172 pkg/users/index.html:414
 msgid "Add key"
 msgstr "Afegeix una clau"
-
-#: pkg/kubernetes/views/user-add-membership.html:3
-msgid "Add membership"
-msgstr "Afegeix una pertinença"
 
 #: pkg/networkmanager/firewall.jsx:458
 msgid "Add ports to the following zones:"
@@ -761,7 +653,7 @@ msgstr "Afegeix una clau pública"
 msgid "Add services to following zones:"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:774
+#: pkg/networkmanager/firewall.jsx:776
 msgid "Add zone"
 msgstr ""
 
@@ -791,7 +683,7 @@ msgstr "DNS addicional $val"
 msgid "Additional DNS Search Domains $val"
 msgstr "Dominis de cerca DNS addicionals $val"
 
-#: pkg/docker/index.html:307
+#: pkg/docker/index.html:309
 msgid "Additional Storage"
 msgstr "Emmagatzematge addicional"
 
@@ -803,14 +695,11 @@ msgstr "Adreça addicional $val"
 msgid "Additional packages:"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:29
-#: pkg/kubernetes/views/dashboard-page.html:157
-#: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
+#: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:77 pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:107
+#: pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adreça"
 
@@ -827,44 +716,18 @@ msgid "Address is not a valid URL"
 msgstr ""
 
 #: pkg/machines/components/desktopConsole.jsx:153
-#: pkg/ovirt/components/VmOverviewColumn.jsx:53
 msgid "Address:"
 msgstr "Adreça:"
 
-#: pkg/kubernetes/views/details-page.html:37
 #: pkg/networkmanager/interfaces.js:3309
 msgid "Addresses"
 msgstr "Adreces"
-
-#: pkg/kubernetes/views/service-modify.html:25
-msgid "Adjust"
-msgstr "Ajusta"
-
-#: pkg/kubernetes/views/pv-modify.html:3
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "Ajusta el volum persistent '{{ item.metadata.name }}'"
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html:3
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "Ajusta el controlador de replicació {{ item.metadata.name }}"
-
-#: pkg/kubernetes/views/route-modify.html:3
-msgid "Adjust Route"
-msgstr "Ajusta la ruta"
-
-#: pkg/kubernetes/views/service-modify.html:3
-msgid "Adjust Service"
-msgstr "Ajusta el servei"
-
-#: pkg/kubernetes/views/project-body.html:56
-msgid "Admin"
-msgstr "Administrador"
 
 #: org.cockpit-project.cockpit-bridge.policy.in.h:1
 msgid "Administration with Cockpit Web Console"
 msgstr ""
 
-#: pkg/realmd/operation.js:336
+#: pkg/realmd/operation.js:335
 msgid "Administrator Password"
 msgstr "Contrasenya de l'administrador"
 
@@ -900,49 +763,21 @@ msgstr "Tots"
 msgid "All In One"
 msgstr "Tot en un"
 
-#: pkg/kubernetes/views/filter-project.html:4
-msgid "All Projects"
-msgstr "Tots els projectes"
-
-#: pkg/kubernetes/views/details-page.html:6
-msgid "All Types"
-msgstr "Tots els tipus"
-
 #: pkg/docker/storage.jsx:381
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
 msgstr ""
 
-#: pkg/kubernetes/views/dashboard-page.html:112
-msgid "All healthy"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:74
-msgid "All images"
-msgstr "Totes les imatges"
-
-#: pkg/kubernetes/views/dashboard-page.html:69
-msgid "All in use"
-msgstr "Tots en ús"
-
-#: pkg/kubernetes/views/dashboard-page.html:37
-msgid "All running"
-msgstr "Tot en execució"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:36
-msgid "All running virtual machines will be turned off."
-msgstr "S'apagaran totes les màquines virtuals."
-
-#: pkg/networkmanager/firewall.jsx:749
+#: pkg/networkmanager/firewall.jsx:751
 msgid "Allowed Addresses"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:935
+#: pkg/networkmanager/firewall.jsx:937
 msgid "Allowed Services"
 msgstr "Serveis permesos"
 
-#: pkg/docker/index.html:548 pkg/docker/util.js:108
+#: pkg/docker/index.html:550 pkg/docker/util.js:108
 msgid "Always"
 msgstr "Sempre"
 
@@ -950,17 +785,11 @@ msgstr "Sempre"
 msgid "Always attach"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
-#: pkg/kubernetes/views/route-body.html:27
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Anotacions"
 
-#: pkg/kubernetes/scripts/projects.js:1044
-msgid "Anonymous: Allow all unauthenticated users to pull images"
-msgstr "Anònim: permet que tots els usuaris no autenticats recuperin imatges"
-
-#: pkg/systemd/terminal.jsx:94
+#: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr ""
 
@@ -973,11 +802,10 @@ msgstr "Aplicacions"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235
-#: pkg/ovirt/components/vcpuModal.jsx:104 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Aplica"
 
@@ -1006,7 +834,6 @@ msgid "Applying updates failed"
 msgstr "Ha fallat l'aplicació de les actualitzacions"
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
-#: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Architecture"
 msgstr "Arquitectura"
 
@@ -1018,8 +845,8 @@ msgstr "Etiqueta de recurs"
 msgid "At least $0 disks are needed."
 msgstr "Com a mínim es necessiten $0 discs."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Com a mínim es necessita un disc."
 
@@ -1035,9 +862,8 @@ msgstr "Registre d'auditoria"
 msgid "Authenticating"
 msgstr "S'està autenticant"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
 #: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Autenticació"
 
@@ -1063,7 +889,7 @@ msgstr ""
 msgid "Authentication required"
 msgstr "Autenticació requerida"
 
-#: pkg/docker/index.html:700
+#: pkg/docker/index.html:702
 #: node_modules/registry-image-widgets/views/image-body.html:12
 #: pkg/docker/containers-view.jsx:413
 msgid "Author"
@@ -1076,7 +902,7 @@ msgstr "Claus SSH públiques autoritzades"
 #: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
 #: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
 #: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:339
+#: pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automàtic"
 
@@ -1096,10 +922,6 @@ msgstr ""
 msgid "Automatic Updates"
 msgstr "Actualitzacions automàtiques"
 
-#: pkg/ovirt/components/OVirtTab.jsx:81
-msgid "Automatically selected host"
-msgstr "Amfitrió seleccionat automàticament"
-
 #: pkg/machines/components/libvirtSlate.jsx:90
 msgid "Automatically start libvirt on boot"
 msgstr "Inicia automàticament libvirt amb l'arrencada"
@@ -1112,9 +934,9 @@ msgstr "Automàticament mitjançant NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Automàticament mitjançant servidors NTP específics"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:155
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
 
@@ -1135,10 +957,6 @@ msgstr "Objectius disponibles en $0"
 #: pkg/dashboard/index.html:163
 msgid "Avatar"
 msgstr "Avatar"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
 
 #: pkg/systemd/hwinfo.jsx:92
 msgid "BIOS"
@@ -1167,18 +985,6 @@ msgstr "S'han passat dades dolentes al mecanisme del passwd1"
 #: pkg/networkmanager/index.html:333
 msgid "Balancer"
 msgstr "Eina de balanceig"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-msgid "Base Template"
-msgstr "Plantilla base"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Base template"
-msgstr "Plantilla base"
-
-#: pkg/ovirt/components/OVirtTab.jsx:106 pkg/ovirt/components/OVirtTab.jsx:113
-msgid "Base template:"
-msgstr "Plantilla base:"
 
 #: pkg/systemd/init.js:729
 msgid "Before"
@@ -1221,12 +1027,8 @@ msgstr "Enllaç"
 msgid "Bond Settings"
 msgstr "Ajusts de l'enllaç"
 
-#: pkg/kubernetes/views/node-body.html:17
-msgid "Boot ID"
-msgstr "Id. d'arrencada"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:312
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:153
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:164
 msgid "Boot Order"
 msgstr ""
 
@@ -1285,10 +1087,8 @@ msgstr "Bus"
 msgid "Bus Expansion Chassis"
 msgstr ""
 
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:270
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:603
-#: pkg/kubernetes/scripts/nodes.js:711 pkg/kubernetes/scripts/nodes.js:818
-#: pkg/systemd/hwinfo.jsx:108
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:272
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
 msgid "CPU"
 msgstr "CPU"
 
@@ -1305,28 +1105,20 @@ msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Estat de la CPU"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:154
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:165
 msgid "CPU Type"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "Utilització de la CPU: $0%"
-
-#: pkg/docker/index.html:469 pkg/docker/index.html:641
+#: pkg/docker/index.html:471 pkg/docker/index.html:643
 msgid "CPU priority"
 msgstr "Prioritat de CPU"
 
-#: pkg/docker/index.html:217
+#: pkg/docker/index.html:218
 msgid "CPU usage:"
 msgstr "Ús de la CPU:"
 
-#: pkg/ovirt/provider.js:256
-msgid "CREATE VM action failed"
-msgstr "Ha fallat l'acció CREATE VM"
-
-#: pkg/machines/components/diskAdd.jsx:235
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
@@ -1346,79 +1138,44 @@ msgstr "No es pot suprimir mentre estigui desbloquejat"
 msgid "Can't load image"
 msgstr "No es pot carregar la imatge"
 
-#: pkg/dashboard/index.html:175 pkg/docker/index.html:563
-#: pkg/docker/index.html:597 pkg/docker/index.html:661
-#: pkg/docker/index.html:715 pkg/docker/index.html:755
-#: pkg/docker/index.html:784 pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/add-role-dialog.html:7
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/image-delete.html:7
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/user-group-add.html:29
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
-#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:477 pkg/networkmanager/index.html:501
-#: pkg/networkmanager/index.html:525 pkg/networkmanager/index.html:549
-#: pkg/networkmanager/index.html:573 pkg/networkmanager/index.html:597
-#: pkg/networkmanager/index.html:621 pkg/networkmanager/index.html:645
-#: pkg/networkmanager/index.html:669 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:81 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/systemd/index.html:332
+#: pkg/dashboard/index.html:175 pkg/docker/index.html:565
+#: pkg/docker/index.html:599 pkg/docker/index.html:663
+#: pkg/docker/index.html:717 pkg/docker/index.html:757
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
+#: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
+#: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
+#: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:85
-#: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:649
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:531
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:485
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:558 pkg/networkmanager/firewall.jsx:626
-#: pkg/networkmanager/firewall.jsx:769
-#: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:415
 msgid "Cannot connect to an unknown machine"
 msgstr "No es pot connectar a una màquina desconeguda"
-
-#: src/ws/cockpitcertificate.c:483
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr ""
 
 #: src/base1/cockpit.js:4031
 msgid "Cannot forward login credentials"
@@ -1428,8 +1185,6 @@ msgstr ""
 msgid "Cannot schedule event in the past"
 msgstr "No es pot planificar un esdeveniment del passat"
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
 #: pkg/machines/components/vmDisksTab.jsx:70
 msgid "Capacity"
 msgstr "Capacitat"
@@ -1438,18 +1193,7 @@ msgstr "Capacitat"
 msgid "Carrier"
 msgstr "Portadora"
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html:97
-msgid "Ceph Monitors"
-msgstr ""
-
-#: pkg/docker/index.html:662 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
-#: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:333
+#: pkg/docker/index.html:664 pkg/systemd/index.html:333
 #: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
 #: pkg/storaged/iscsi-panel.jsx:181
 msgid "Change"
@@ -1475,31 +1219,19 @@ msgstr "Canvia el perfil"
 msgid "Change System Time"
 msgstr "Canvia l'hora del sistema"
 
-#: pkg/kubernetes/views/user-modify.html:3
-msgid "Change User"
-msgstr "Canvia l'usuari"
-
 #: pkg/storaged/iscsi-panel.jsx:176
 msgid "Change iSCSI Initiator Name"
 msgstr "Canvia el nom d'iniciador iSCSI"
-
-#: pkg/kubernetes/views/imagestream-modify.html:4
-msgid "Change image stream"
-msgstr "Canvia el flux d'imatges"
 
 #: pkg/storaged/crypto-keyslots.jsx:247
 msgid "Change passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/project-modify.html:10
-msgid "Change project"
-msgstr "Canvia el projecte"
-
-#: pkg/docker/index.html:228
+#: pkg/docker/index.html:229
 msgid "Change resource limits"
 msgstr "Canvia els límits dels recursos"
 
-#: pkg/docker/index.html:612
+#: pkg/docker/index.html:614
 msgid "Change resources limits"
 msgstr "Canvia els límits dels recursos"
 
@@ -1507,10 +1239,10 @@ msgstr "Canvia els límits dels recursos"
 msgid "Change the settings"
 msgstr "Canvia els ajusts"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr ""
 
@@ -1556,25 +1288,13 @@ msgstr "Comprovació per si hi ha actualitzacions..."
 msgid "Checking installed software"
 msgstr ""
 
-#: pkg/shell/index.html:117 pkg/shell/simple.html:85 pkg/shell/stub.html:100
+#: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "Seleccioneu l'idioma per utilitzar amb l'aplicació"
 
 #: pkg/storaged/mdraids-panel.jsx:57
 msgid "Chunk Size"
 msgstr "Mida del tros"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
-msgid "Claim"
-msgstr "Reclama"
-
-#: pkg/kubernetes/views/pvc-body.html:4
-msgid "Claim Name"
-msgstr "Nom de la reclamació"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Class"
@@ -1597,42 +1317,26 @@ msgid ""
 "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:88
-msgid "Client Certificate"
-msgstr "Certificat de client"
-
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:736 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/systemd/index.html:278
-#: pkg/systemd/services.html:363 pkg/systemd/services.html:381
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:126 pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Tanca"
 
 #: pkg/shell/active-pages.js:103
 msgid "Close Selected Pages"
 msgstr "Tanca les pàgines seleccionades"
-
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
-#: pkg/ovirt/components/App.jsx:107
-msgid "Cluster"
-msgstr "Clúster"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:128
-msgid "Cluster Templates"
-msgstr "Plantilles de clúster"
-
-#: pkg/ovirt/components/ClusterVms.jsx:174
-msgid "Cluster Virtual Machines"
-msgstr "Màquines virtuals del clúster"
 
 #: src/ws/login.js:346
 msgid "Cockpit authentication is configured incorrectly."
@@ -1670,7 +1374,7 @@ msgstr ""
 "produeix un error en el terminal, es pot observar en la interfície de les "
 "publicacions de Cockpit."
 
-#: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
+#: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr ""
 "Cockpit és una interfície interactiva d'administració del servidor Linux."
@@ -1708,10 +1412,10 @@ msgstr "Cockpit no ha pogut contactar amb {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1747,12 +1451,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Ús combinat de $0 nucli de CPU"
 msgstr[1] "Ús combinat de $0 nuclis de CPU"
 
-#: pkg/networkmanager/firewall.jsx:527
+#: pkg/networkmanager/firewall.jsx:529
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
-#: pkg/docker/index.html:269 pkg/docker/index.html:445
-#: pkg/docker/index.html:706 pkg/systemd/services.html:427
+#: pkg/docker/index.html:271 pkg/docker/index.html:447
+#: pkg/docker/index.html:708 pkg/systemd/services.html:427
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1763,7 +1467,7 @@ msgstr "Ordre"
 msgid "Command can't be empty"
 msgstr "L'ordre no pot estar en blanc"
 
-#: pkg/docker/index.html:163
+#: pkg/docker/index.html:164
 msgid "Command:"
 msgstr "Ordre:"
 
@@ -1771,12 +1475,12 @@ msgstr "Ordre:"
 msgid "Comment"
 msgstr "Comentari"
 
-#: pkg/docker/index.html:137 pkg/docker/index.html:716
+#: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
 msgstr "Consigna"
 
-#: pkg/docker/index.html:676
+#: pkg/docker/index.html:678
 msgid "Commit Image"
 msgstr "Consigna la imatge"
 
@@ -1800,8 +1504,8 @@ msgstr "Compatible amb els sistemes moderns i els discs durs > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Comprimeix els estavellaments per estalviar espai"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Compressió"
 
@@ -1817,21 +1521,9 @@ msgstr ""
 msgid "Condition failed"
 msgstr "Ha fallat la condició"
 
-#: pkg/kubernetes/views/node-add.html:24
-msgid "Configuration"
-msgstr "Configuració"
-
 #: pkg/networkmanager/interfaces.js:2725
 msgid "Configure"
 msgstr "Configura"
-
-#: pkg/kubernetes/views/node-add.html:42
-msgid "Configure Flannel networking"
-msgstr "Configura la xarxa Flannel"
-
-#: pkg/kubernetes/views/node-add.html:32
-msgid "Configure Kubelet and Proxy"
-msgstr "Configura Kubelet i el servidor intermediari"
 
 #: pkg/docker/storage.jsx:331
 msgid "Configure storage..."
@@ -1854,21 +1546,13 @@ msgstr "Confirmació"
 msgid "Confirm New Password"
 msgstr "Confirmació de la contrasenya nova"
 
-#: pkg/ovirt/components/OVirtTab.jsx:65
-msgid "Confirm migration"
-msgstr "Confirmació de la migració"
-
-#: pkg/ovirt/components/VdsmView.jsx:95
-msgid "Confirm reload:"
-msgstr "Confirmació de la recàrrega:"
+#: pkg/machines/components/networks/networkDelete.jsx:95
+msgid "Confirm deletion of the Virtual Network"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Confirm removal with passphrase"
 msgstr ""
-
-#: pkg/ovirt/components/VdsmView.jsx:108
-msgid "Confirm save:"
-msgstr "Confirmació del desament:"
 
 #: pkg/systemd/init.js:728
 msgid "Conflicted By"
@@ -1878,8 +1562,6 @@ msgstr ""
 msgid "Conflicts"
 msgstr ""
 
-#: pkg/kubernetes/views/auth-form.html:130
-#: pkg/kubernetes/views/auth-rejected-cert.html:33
 #: pkg/lib/machine-unknown-hostkey.html:22
 msgid "Connect"
 msgstr "Connecta"
@@ -1891,10 +1573,6 @@ msgstr "Connecta automàticament"
 #: src/ws/login.html:74
 msgid "Connect to"
 msgstr "Connecta't a"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:102
-msgid "Connect to oVirt Engine"
-msgstr "Connecta't al motor d'oVirt"
 
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "Connect with any $0 viewer application."
@@ -1925,33 +1603,21 @@ msgstr "S'està connectant al dimoni de SETroubleshoot..."
 msgid "Connecting to Virtualization Service"
 msgstr "Connexió al servei de virtualització"
 
-#: pkg/shell/indexes.js:411
+#: pkg/shell/indexes.js:410
 msgid "Connecting to the machine"
 msgstr "S'està connectant a la màquina"
 
-#: pkg/kubernetes/index.html:104 pkg/kubernetes/registry.html:71
-msgid "Connecting..."
-msgstr "S'està connectant..."
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:568
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Connexió"
 
-#: pkg/kubernetes/views/auth-dialog.html:4 pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:406
 msgid "Connection Error"
 msgstr "Error de connexió"
-
-#: pkg/kubernetes/scripts/connection.js:512
-msgid "Connection Error: $0"
-msgstr "Error de connexió: $0"
-
-#: pkg/kubernetes/views/auth-dialog.html:3
-msgid "Connection Settings"
-msgstr "Ajusts de la connexió"
 
 #: src/base1/cockpit.js:4027
 msgid "Connection has timed out."
@@ -1973,34 +1639,23 @@ msgstr "Tipus de consola"
 msgid "Consoles"
 msgstr "Consoles"
 
-#: pkg/realmd/operation.js:274
+#: pkg/realmd/operation.js:273
 msgid "Contacted domain"
 msgstr ""
 
-#: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
-#: pkg/kubernetes/views/container-page-inline.html:2
-#: pkg/kubernetes/views/container-panel.html:4
-#: pkg/kubernetes/views/image-page.html:23
+#: pkg/docker/console.html:4
 #: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Contenidor"
 
-#: pkg/users/local.js:748
+#: pkg/users/local.js:752
 msgid "Container Administrator"
 msgstr "Administrador del contenidor"
 
-#: pkg/kubernetes/views/container-body.html:10
-msgid "Container ID"
-msgstr "Id. de contenidor"
-
-#: pkg/docker/index.html:438 pkg/docker/index.html:618
-#: pkg/docker/index.html:682
+#: pkg/docker/index.html:440 pkg/docker/index.html:620
+#: pkg/docker/index.html:684
 msgid "Container Name"
 msgstr "Nom del contenidor"
-
-#: pkg/kubernetes/views/node-body.html:21
-msgid "Container Runtime Version"
-msgstr "Versió de l'entorn d'execució del contenidor"
 
 #: pkg/docker/util.js:506
 msgid ""
@@ -2013,15 +1668,12 @@ msgstr ""
 msgid "Container is currently running."
 msgstr "El contenidor s'està executant actualment."
 
-#: pkg/docker/index.html:141
+#: pkg/docker/index.html:133
 msgid "Container:"
 msgstr "Contenidor:"
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:287
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
-#: pkg/kubernetes/views/dashboard-page.html:158
-#: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:375
+#: pkg/docker/index.html:23 pkg/docker/index.html:289
+#: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "Contenidors"
 
@@ -2035,12 +1687,12 @@ msgid "Content"
 msgstr "Contingut"
 
 #: src/base1/test-locale.js:42 src/base1/test-locale.js:53
-#: pkg/playground/translate.js:22
+#: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Control"
 
 #: src/base1/test-locale.js:43 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:25
+#: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
 msgstr "Control"
@@ -2054,7 +1706,6 @@ msgid "Copy"
 msgstr ""
 
 #: pkg/machines/components/vcpuModal.jsx:209
-#: pkg/ovirt/components/vcpuModal.jsx:67
 msgid "Cores per socket"
 msgstr ""
 
@@ -2065,18 +1716,6 @@ msgstr "No s'han pogut afegir tots els discs"
 #: pkg/lib/machine-change-port.html:4
 msgid "Could not contact {{host}}"
 msgstr "No s'ha pogut contactar amb {{host}}"
-
-#: pkg/kubernetes/views/dashboard-page.html:142
-msgid "Could not list services"
-msgstr "No s'han pogut llistar els serveis"
-
-#: src/ws/cockpitcertificate.c:531
-msgid "Could not parse PEM-encoded certificate"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:498
-msgid "Could not parse PEM-encoded private key"
-msgstr ""
 
 #: pkg/docker/storage.jsx:468
 msgid "Could not reset the storage pool"
@@ -2090,30 +1729,13 @@ msgstr "No s'han pogut canviar els grups de l'usuari"
 msgid "Couldn't change user password"
 msgstr "No s'ha pogut canviar la contrasenya de l'usuari"
 
-#: pkg/kubernetes/index.html:105 pkg/kubernetes/registry.html:72
-msgid "Couldn't connect to server"
-msgstr "No s'ha pogut connectar al servidor"
-
-#: pkg/shell/indexes.js:414
+#: pkg/shell/indexes.js:413
 msgid "Couldn't connect to the machine"
 msgstr "No s'ha pogut connectar a la màquina"
 
 #: src/bridge/cockpitdbussetup.c:544
 msgid "Couldn't create new users"
 msgstr "No s'han pogut crear els nous usuaris"
-
-#: pkg/kubernetes/scripts/connection.js:510
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:957
-msgid "Couldn't find running API server"
-msgstr "No s'ha pogut trobar el servidor de l'API en execució"
-
-#: pkg/subscriptions/subscriptions-view.jsx:218
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"No s'ha pogut obtenir l'estat de subscripció del sistema. Assegureu-vos que "
-"subscription-manager estigui instal·lat."
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -2135,14 +1757,12 @@ msgstr "Ubicació del bolcat de l'estavellament"
 msgid "Crash system"
 msgstr ""
 
-#: pkg/kubernetes/views/add-group-dialog.html:19
-#: pkg/kubernetes/views/project-modify.html:72 pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:652
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:488
-#: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/users/index.html:199
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Crea"
 
@@ -2150,17 +1770,13 @@ msgstr "Crea"
 msgid "Create Logical Volume"
 msgstr "Crea un volum lògic"
 
-#: pkg/machines/components/diskAdd.jsx:487
+#: pkg/machines/components/diskAdd.jsx:515
 msgid "Create New"
 msgstr ""
 
 #: pkg/users/index.html:52 pkg/users/index.html:163
 msgid "Create New Account"
 msgstr "Crea un compte nou"
-
-#: pkg/ovirt/components/App.jsx:162
-msgid "Create New VM"
-msgstr "Crea una MV nova"
 
 #: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
 msgid "Create Partition"
@@ -2186,7 +1802,7 @@ msgstr "Crea l'informe"
 msgid "Create Snapshot"
 msgstr "Crea una instantània"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:522
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
 msgid "Create Storage Pool"
 msgstr ""
 
@@ -2206,8 +1822,7 @@ msgstr "Crea temporitzadors"
 msgid "Create VDO Device"
 msgstr "Crea un dispositiu VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:685
-#: pkg/ovirt/components/ClusterTemplates.jsx:81
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
 msgid "Create VM"
 msgstr "Crea la MV"
 
@@ -2219,14 +1834,6 @@ msgstr "Crea un grup de volums"
 msgid "Create diagnostic report"
 msgstr "Crea l'informe de diagnòstic"
 
-#: pkg/kubernetes/scripts/images.js:643
-msgid "Create empty image stream"
-msgstr "Crea un flux d'imatges buit"
-
-#: pkg/kubernetes/views/imagestream-modify.html:3
-msgid "Create image stream"
-msgstr "Crea un flux d'imatges"
-
 #: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
 #: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
 msgid "Create it"
@@ -2236,16 +1843,12 @@ msgstr "Crea-ho"
 msgid "Create new Logical Volume"
 msgstr "Crea un volum lògic nou"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/kubernetes/views/replicationcontroller-body.html:7
-#: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:129
-#: pkg/docker/containers-view.jsx:412 pkg/docker/containers-view.jsx:683
+#: pkg/docker/containers-view.jsx:129 pkg/docker/containers-view.jsx:412
+#: pkg/docker/containers-view.jsx:683
 msgid "Created"
 msgstr "Creat"
 
-#: pkg/docker/index.html:152
+#: pkg/docker/index.html:153
 msgid "Created:"
 msgstr "Creat:"
 
@@ -2297,7 +1900,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "S'està creant el grup de volums $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:554
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
 msgid "Creation of VM $0 failed"
 msgstr ""
 
@@ -2325,23 +1928,19 @@ msgstr "Arrencada actual"
 msgid "Custom"
 msgstr "Personalitzat"
 
-#: pkg/networkmanager/firewall.jsx:521
+#: pkg/networkmanager/firewall.jsx:523
 msgid "Custom Ports"
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:103
-msgid "Custom URL"
-msgstr "URL personalitzat"
 
 #: pkg/storaged/format-dialog.jsx:118
 msgid "Custom encryption options"
 msgstr "Opcions personalitzades de xifrat"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Opcions personalitzades de muntatge"
 
-#: pkg/networkmanager/firewall.jsx:716
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Custom zones"
 msgstr ""
 
@@ -2361,10 +1960,6 @@ msgstr "DNS"
 #: pkg/networkmanager/interfaces.js:2656
 msgid "DNS $val"
 msgstr "DNS $val"
-
-#: pkg/kubernetes/views/pod-body.html:14
-msgid "DNS Policy"
-msgstr "Política del DNS"
 
 #: pkg/networkmanager/interfaces.js:3320
 msgid "DNS Search Domains"
@@ -2386,8 +1981,8 @@ msgstr "Tauler de control"
 msgid "Data Used"
 msgstr "Dades utilitzades"
 
-#: pkg/machines/components/networks/network.jsx:143
-#: pkg/machines/components/storagePools/storagePool.jsx:163
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Desactiva"
@@ -2408,10 +2003,9 @@ msgstr ""
 msgid "Deduplication"
 msgstr "Deduplicació"
 
-#: pkg/docker/index.html:357 pkg/docker/index.html:361
+#: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: node_modules/registry-image-widgets/views/image-config.html:10
 #: pkg/storaged/format-dialog.jsx:68
-#: pkg/subscriptions/subscriptions-register.jsx:102
 msgid "Default"
 msgstr "Predeterminat"
 
@@ -2419,37 +2013,26 @@ msgstr "Predeterminat"
 msgid "Delay"
 msgstr "Retard"
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:246
-#: pkg/kubernetes/views/image-delete.html:8
-#: pkg/kubernetes/views/imagestream-delete.html:8
-#: pkg/kubernetes/views/item-delete.html:11
-#: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/project-delete.html:9
-#: pkg/kubernetes/views/pv-delete.html:11
-#: pkg/kubernetes/views/pvc-delete.html:15
-#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/machines/components/networks/networkDelete.jsx:86
+#: pkg/machines/components/networks/networkDelete.jsx:103
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:300 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:214 pkg/storaged/vgroup-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Suprimeix"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1179
+#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Suprimeix $0"
-
-#: pkg/playground/translate.html:189
-msgid "Delete '{{ name }}'"
-msgstr "Suprimeix '{{ name }}'"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
 msgid "Delete Content"
@@ -2459,25 +2042,10 @@ msgstr ""
 msgid "Delete Files"
 msgstr "Suprimeix els fitxers"
 
-#: pkg/kubernetes/views/node-delete.html:4
-msgid "Delete Node"
-msgstr "Suprimeix el node"
-
-#: pkg/kubernetes/views/pv-delete.html:3
-msgid "Delete Persistent Volume"
-msgstr "Suprimeix el volum persistent"
-
-#: pkg/kubernetes/views/pvc-delete.html:3
-msgid "Delete Persistent Volume Claim"
-msgstr "Suprimeix la reclamació del volum persistent"
-
-#: pkg/kubernetes/views/project-delete.html:3
-msgid "Delete Project"
-msgstr "Suprimeix el projecte"
-
-#: pkg/kubernetes/views/nodes-page.html:3
-msgid "Delete Selected"
-msgstr "Suprimeix la selecció"
+#: pkg/machines/components/networks/networkDelete.jsx:92
+#, fuzzy
+msgid "Delete Network $0"
+msgstr "Suprimeix $0"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
 msgid "Delete Storage Pool $0"
@@ -2487,17 +2055,9 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr "Suprimeix els fitxers d'emmagatzematge associats:"
 
-#: pkg/kubernetes/views/imagestream-delete.html:3
-msgid "Delete image stream"
-msgstr "Suprimeix el flux d'imatges"
-
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html:3
-msgid "Delete {{ item.kind }}"
-msgstr "Suprimeix {{ item.kind }}"
 
 #: pkg/storaged/jobs-panel.jsx:53 pkg/storaged/jobs-panel.jsx:67
 msgid "Deleting $target"
@@ -2509,13 +2069,7 @@ msgid ""
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/kubernetes/views/item-delete.html:7
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-
-#: pkg/storaged/mdraid-details.jsx:301
+#: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "La supressió d'un dispositiu RAID n'esborrarà totes les dades."
 
@@ -2523,7 +2077,7 @@ msgstr "La supressió d'un dispositiu RAID n'esborrarà totes les dades."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Si suprimiu un dispositiu VDO, s'esborraran totes les dades."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "La supressió d'un contenidor n'esborrarà totes les dades."
 
@@ -2535,7 +2089,7 @@ msgstr "La supressió d'un volum lògic n'esborrarà totes les dades."
 msgid "Deleting a partition will delete all data in it."
 msgstr "La supressió d'una partició n'esborrarà totes les dades."
 
-#: pkg/storaged/vgroup-details.jsx:213
+#: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
 msgstr "La supressió d'un grup de volums n'esborrarà totes les dades."
 
@@ -2549,44 +2103,11 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "S'està suprimint el grup de volums $target"
 
-#: pkg/kubernetes/views/dashboard-page.html:131
-#: pkg/kubernetes/views/deploy.html:62
-msgid "Deploy"
-msgstr "Desplega"
-
-#: pkg/kubernetes/views/deploy.html:3
-msgid "Deploy Application"
-msgstr "Desplega l'aplicació"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:22
-msgid "Deployment Causes"
-msgstr "Causes del desplegament"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:12
-#: pkg/kubernetes/views/deploymentconfig-panel.html:8
-msgid "Deployment Config"
-msgstr "Configuració de desplegament"
-
-#: pkg/kubernetes/views/details-page.html:98
-#: pkg/kubernetes/scripts/details.js:220
-msgid "Deployment Configs"
-msgstr "Configuracions de desplegaments"
-
-#: pkg/kubernetes/views/project-listing.html:15
-#: pkg/kubernetes/views/project-listing.html:54
-#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:413
+#: pkg/systemd/services.html:413
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:725
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
 msgid "Description"
 msgstr "Descripció"
-
-#: pkg/ovirt/components/OVirtTab.jsx:146
-#: pkg/ovirt/components/VmOverviewColumn.jsx:52
-msgid "Description:"
-msgstr "Descripció:"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2596,16 +2117,15 @@ msgstr "Escriptori"
 msgid "Detachable"
 msgstr ""
 
-#: pkg/kubernetes/index.html:67 pkg/shell/index.html:229
-#: pkg/docker/containers-view.jsx:336 pkg/docker/containers-view.jsx:504
-#: pkg/docker/containers-view.jsx:514 pkg/docker/containers-view.jsx:642
-#: pkg/networkmanager/firewall.jsx:94 pkg/packagekit/updates.jsx:383
-#: pkg/subscriptions/subscriptions-view.jsx:232 pkg/systemd/host.js:745
+#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
+#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Detalls"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2627,7 +2147,6 @@ msgstr "Informes de diagnòstic"
 msgid "Digest"
 msgstr ""
 
-#: pkg/kubernetes/views/volume-body.html:28
 #: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
@@ -2659,7 +2178,7 @@ msgid "Disconnect"
 msgstr "Desconnecta"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:604
+#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
 msgid "Disconnected"
 msgstr "Desconnectat"
 
@@ -2667,7 +2186,6 @@ msgstr "Desconnectat"
 msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:836
 #: pkg/storaged/vdos-panel.jsx:55
 msgid "Disk"
 msgstr "Disc"
@@ -2680,15 +2198,11 @@ msgstr ""
 msgid "Disk I/O"
 msgstr "E/S de disc"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Utilització del disc: $0%"
-
-#: pkg/machines/components/diskAdd.jsx:461
+#: pkg/machines/components/diskAdd.jsx:489
 msgid "Disk failed to be attached"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:443
+#: pkg/machines/components/diskAdd.jsx:468
 msgid "Disk failed to be created"
 msgstr ""
 
@@ -2700,9 +2214,9 @@ msgstr "El disc està bé"
 msgid "Disk passphrase"
 msgstr ""
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Discs"
 
@@ -2711,58 +2225,9 @@ msgid "Disks cannot be removed from $0 VMs"
 msgstr ""
 
 #: pkg/shell/index.html:52 pkg/shell/index.html:114 pkg/shell/simple.html:38
-#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
+#: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Idioma de visualització"
-
-#: pkg/kubernetes/views/project-modify.html:31
-msgid "Display name"
-msgstr "Nom a mostrar"
-
-#: pkg/kubernetes/views/add-role-dialog.html:5
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "Voleu afegir el rol '{{ fields.displayRole }}'?"
-
-#: pkg/kubernetes/views/imagestream-delete.html:5
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"Voleu suprimir el flux d'imatges '{{stream.metadata.namespace}}/{{stream."
-"metadata.name}}'?"
-
-#: pkg/kubernetes/views/pv-delete.html:6
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "Voleu suprimir el volum persistent '{{item.metadata.name}}'?"
-
-#: pkg/kubernetes/views/pvc-delete.html:6
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html:6
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "Voleu suprimir {{ item.kind }} '{{item.metadata.name}}'?"
-
-#: pkg/kubernetes/views/node-delete.html:7
-msgid "Do you want to delete this Node?"
-msgstr "Voleu suprimir aquest node?"
-
-#: pkg/kubernetes/views/image-delete.html:5
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"Voleu suprimir la imatge etiquetada com a '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:5
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
-msgstr ""
-"Voleu suprimir el rol '{{ fields.displayRole }}' del membre {{ fields.member."
-"metadata.name }}?"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2777,15 +2242,15 @@ msgid "Docking Station"
 msgstr ""
 
 #: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
-#: pkg/realmd/operation.js:123
+#: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Domini"
 
-#: pkg/realmd/operation.js:192
+#: pkg/realmd/operation.js:191
 msgid "Domain $0 could not be contacted"
 msgstr "No s'ha pogut contactar amb el domini $0"
 
-#: pkg/realmd/operation.js:279
+#: pkg/realmd/operation.js:278
 msgid "Domain $0 is not supported"
 msgstr "El domini $0 no és compatible"
 
@@ -2810,15 +2275,11 @@ msgstr "No repeteixis"
 msgid "Don't overwrite existing data"
 msgstr "No sobreescriguis les dades existents"
 
-#: pkg/kubernetes/scripts/images.js:633
-msgid "Don't pull images automatically"
-msgstr "No recuperis automàticament les imatges"
-
 #: pkg/sosreport/index.html:63
 msgid "Done!"
 msgstr "Fet!"
 
-#: pkg/docker/index.html:598
+#: pkg/docker/index.html:600
 msgid "Download"
 msgstr "Baixa"
 
@@ -2855,11 +2316,7 @@ msgctxt "storage"
 msgid "Drive"
 msgstr "Unitat"
 
-#: pkg/kubernetes/views/volume-body.html:128
-msgid "Driver"
-msgstr "Controlador"
-
-#: pkg/storaged/drives-panel.jsx:119
+#: pkg/storaged/drives-panel.jsx:120
 msgid "Drives"
 msgstr "Unitats"
 
@@ -2888,10 +2345,6 @@ msgstr ""
 msgid "Edit image stream"
 msgstr "Edita el flux d'imatges"
 
-#: pkg/ovirt/components/VdsmView.jsx:125
-msgid "Edit the vdsm.conf"
-msgstr "Edita el fitxer vdsm.conf"
-
 #: pkg/storaged/crypto-keyslots.jsx:535
 msgid "Editing a key requires a free slot"
 msgstr ""
@@ -2905,25 +2358,21 @@ msgid "Embedded PC"
 msgstr ""
 
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:13
+#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Buida"
 
 #: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:19
+#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Buit"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Directori buit"
 
 #: pkg/storaged/jobs-panel.jsx:75
 msgid "Emptying $target"
 msgstr "S'està buidant $target"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:151
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:162
 msgid "Emulated Machine"
 msgstr ""
 
@@ -2984,23 +2433,6 @@ msgstr "Xifratge"
 msgid "Encryption Options"
 msgstr "Opcions de xifrat"
 
-#: pkg/kubernetes/views/pv-modify.html:93
-msgid "Endpoint"
-msgstr "Extrem"
-
-#: pkg/kubernetes/views/volume-body.html:40
-msgid "Endpoint Name"
-msgstr "Nom de l'extrem"
-
-#: pkg/kubernetes/views/service-page.html:14
-#: pkg/kubernetes/views/service-panel.html:9
-msgid "Endpoints"
-msgstr "Extrems"
-
-#: pkg/subscriptions/subscriptions-view.jsx:39
-msgid "Ends"
-msgstr "Acaba"
-
 #: pkg/selinux/setroubleshoot-view.jsx:299
 msgid "Enforce policy:"
 msgstr "Aplica la política:"
@@ -3013,17 +2445,13 @@ msgstr ""
 msgid "Enter IP address or host name"
 msgstr "Introduïu l'adreça IP o el nom d'amfitrió"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:74
-msgid "Enter New VM name"
-msgstr "Introduïu el nom de la nova MV"
-
 #: pkg/lib/machine-change-auth.html:57
 msgid ""
 "Entering a different password here means you will need to retype it every "
 "time you reconnect to this machine"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:752
+#: pkg/networkmanager/firewall.jsx:754
 msgid "Entire subnet"
 msgstr ""
 
@@ -3036,7 +2464,7 @@ msgstr "Entrada"
 msgid "Entrypoint"
 msgstr "Extrem"
 
-#: pkg/docker/index.html:526 pkg/kubernetes/views/container-body.html:26
+#: pkg/docker/index.html:528
 #: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Entorn"
@@ -3058,19 +2486,15 @@ msgid "Errata:"
 msgstr "Fe d'errates:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:99
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1472
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Error"
 
 #: pkg/systemd/logs.html:59
 msgid "Error and above"
 msgstr ""
-
-#: pkg/kubernetes/scripts/connection.js:646
-msgid "Error getting certificate details: $0"
-msgstr "Error en obtenir els detalls del certificat: $0"
 
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
@@ -3092,10 +2516,6 @@ msgstr "Error mentre se suprimia l'alerta: $0"
 msgid "Error while setting SELinux mode: '$0'"
 msgstr "Error mentre s'establia el mode de SELinux: '$0'"
 
-#: pkg/kubernetes/scripts/connection.js:85
-msgid "Error writing kubectl config"
-msgstr "Error en escriure la configuració de kubectl"
-
 #: pkg/networkmanager/index.html:658
 msgid "Ethernet MAC"
 msgstr "MAC d'ethernet"
@@ -3112,23 +2532,23 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Tot"
 
-#: pkg/networkmanager/firewall.jsx:534
+#: pkg/networkmanager/firewall.jsx:536
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:542
+#: pkg/networkmanager/firewall.jsx:544
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
-#: pkg/users/local.js:473 pkg/users/local.js:1417
+#: pkg/users/local.js:477 pkg/users/local.js:1421
 msgid "Excellent password"
 msgstr "Contrasenya excel·lent"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:222
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
 msgid "Existing Disk Image"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -3140,7 +2560,7 @@ msgstr "Sortida $ExitCode"
 msgid "Expansion Chassis"
 msgstr ""
 
-#: pkg/docker/index.html:508
+#: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "Exposa els ports del contenidor"
 
@@ -3152,14 +2572,6 @@ msgstr "Partició estesa"
 msgid "FAILED"
 msgstr "FALLAT"
 
-#: pkg/ovirt/provider.js:130
-msgid "FORCEOFF action failed: $0"
-msgstr ""
-
-#: pkg/ovirt/components/InstallationDialog.jsx:47
-msgid "FQDN"
-msgstr "FQDN"
-
 #: pkg/networkmanager/interfaces.js:842
 msgid "Failed"
 msgstr "Ha fallat"
@@ -3169,14 +2581,19 @@ msgid "Failed to add machine: $0"
 msgstr "No s'ha pogut afegir la màquina: $0"
 
 #: pkg/networkmanager/firewall.jsx:237
+#, fuzzy
+msgid "Failed to add port"
+msgstr "Ha fallat el canvi de contrasenya"
+
+#: pkg/networkmanager/firewall.jsx:237
 msgid "Failed to add service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:679
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Ha fallat el canvi de contrasenya"
 
@@ -3200,11 +2617,15 @@ msgstr "Ha fallat l'edició de la màquina: $0"
 msgid "Failed to enable tuned"
 msgstr "Ha fallat l'habilitació de tuned"
 
+#: pkg/machines/components/vmnetworktab.jsx:55
+msgid "Failed to fetch the IP addresses of the interfaces present in $0"
+msgstr ""
+
 #: pkg/users/index.html:393
 msgid "Failed to load authorized keys."
 msgstr "Ha fallat la càrrega de les claus autoritzades."
 
-#: pkg/networkmanager/firewall.jsx:589
+#: pkg/networkmanager/firewall.jsx:591
 msgid "Failed to remove service"
 msgstr ""
 
@@ -3223,10 +2644,6 @@ msgstr "Ha fallat el canvi de perfil"
 #: pkg/machines/components/vcpuModal.jsx:193
 msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "Fibre Channel"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:92
 #: pkg/machines/components/vmDiskColumns.jsx:42
@@ -3249,22 +2666,11 @@ msgstr "Muntatge del sistema de fitxers"
 msgid "Filesystem Name"
 msgstr "Nom del sistema de fitxers"
 
-#: pkg/kubernetes/views/pv-modify.html:181
-#: pkg/kubernetes/views/volume-body.html:6
-#: pkg/kubernetes/views/volume-body.html:16
-#: pkg/kubernetes/views/volume-body.html:62
-#: pkg/kubernetes/views/volume-body.html:83
-#: pkg/kubernetes/views/volume-body.html:91
-#: pkg/kubernetes/views/volume-body.html:120
-#: pkg/kubernetes/views/volume-body.html:132
-msgid "Filesystem Type"
-msgstr "Tipus de sistema de fitxers"
-
 #: pkg/storaged/fsys-panel.jsx:103
 msgid "Filesystems"
 msgstr "Sistemes de fitxers"
 
-#: pkg/networkmanager/firewall.jsx:490
+#: pkg/networkmanager/firewall.jsx:491
 msgid "Filter Services"
 msgstr "Filtra els serveis"
 
@@ -3272,30 +2678,18 @@ msgstr "Filtra els serveis"
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Empremta"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:913 pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
 msgid "Firewall"
 msgstr "Tallafoc"
 
-#: pkg/networkmanager/firewall.jsx:861
+#: pkg/networkmanager/firewall.jsx:863
 msgid "Firewall is not available"
 msgstr "El tallafoc no està disponible"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/views/volume-body.html:125
-msgid "Flocker Dataset Name"
-msgstr ""
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:35
 msgid "Follows docker repo"
@@ -3329,10 +2723,9 @@ msgstr "Obliga el canvi de contrasenya"
 msgid "Force remove passphrase in $0"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:167
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:258
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formata"
 
@@ -3393,11 +2786,7 @@ msgstr ""
 msgid "Full Name"
 msgstr "Nom complet"
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "Disc persistent GCE"
-
-#: pkg/docker/index.html:183
+#: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "Passarel·la:"
 
@@ -3414,25 +2803,13 @@ msgstr "S'està generant l'informe"
 msgid "Get new image"
 msgstr "Obtén una imatge nova"
 
-#: pkg/machines/components/diskAdd.jsx:162
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Dipòsit git"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster FS"
-
-#: pkg/kubernetes/scripts/volumes.js:877
-msgid "GlusterFS"
-msgstr "GlusterFS"
 
 #: pkg/systemd/logs.js:199
 msgid "Go to"
@@ -3448,11 +2825,6 @@ msgstr "Vés a l'aplicació"
 msgid "Go to now"
 msgstr "Vés a ara"
 
-#: pkg/kubernetes/views/project-body.html:3
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Grant additional push or admin access to specific members below."
-msgstr ""
-
 #: pkg/machines/components/consoles.jsx:51
 msgid "Graphics Console (VNC)"
 msgstr "Consola gràfica (VNC)"
@@ -3460,20 +2832,6 @@ msgstr "Consola gràfica (VNC)"
 #: pkg/machines/components/consoles.jsx:60
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Consola gràfica al visualitzador d'escriptoris"
-
-#: pkg/kubernetes/views/group-page.html:21
-#: pkg/kubernetes/views/group-panel.html:12
-msgid "Group Members"
-msgstr "Membres del grup"
-
-#: pkg/kubernetes/views/user-add-membership.html:9
-msgid "Group or Project"
-msgstr "Grup o projecte"
-
-#: pkg/kubernetes/views/project-listing.html:48
-#: pkg/kubernetes/views/user-delete.html:14
-msgid "Groups"
-msgstr "Grups"
 
 #: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
 #: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
@@ -3496,15 +2854,6 @@ msgstr "Fes créixer la mida lògica de $0"
 #: pkg/storaged/vdo-details.jsx:130
 msgid "Grow to take all space"
 msgstr "Fes créixer per agafar tot l'espai"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "HA"
-msgstr "HA"
-
-#: pkg/ovirt/components/OVirtTab.jsx:128
-msgid "HA:"
-msgstr "HA:"
 
 #: pkg/networkmanager/index.html:252
 msgid "Hair Pin mode"
@@ -3539,19 +2888,14 @@ msgstr "Informació del maquinari"
 msgid "Hello time $hello_time"
 msgstr "Hello time $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:73
-#: pkg/kubernetes/views/route-body.html:9
-#: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:150
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47
-#: pkg/ovirt/components/App.jsx:103 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:334
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Amfitrió"
 
@@ -3560,29 +2904,21 @@ msgid "Host Device"
 msgstr ""
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:155
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
 msgid "Host Name"
 msgstr "Nom d'amfitrió"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:869
-msgid "Host Path"
-msgstr "Camí a l'amfitrió"
 
 #: src/base1/cockpit.js:4023
 msgid "Host key is incorrect"
 msgstr "La clau d'amfitrió és incorrecta"
 
-#: pkg/realmd/operation.js:602
+#: pkg/realmd/operation.js:601
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:161
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
 msgid "Host should not be empty"
 msgstr ""
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:75
-msgid "Host to Maintenance"
-msgstr "Amfitrió a manteniment"
 
 #: pkg/systemd/services.html:499
 msgid "Hour : Minute"
@@ -3600,24 +2936,20 @@ msgstr "Hores"
 msgid "I/O Wait"
 msgstr "Espera d'E/S"
 
-#: pkg/kubernetes/views/node-body.html:10
-#: pkg/kubernetes/views/service-body.html:9
-msgid "IP"
-msgstr "IP"
-
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
+#: pkg/machines/components/vmnetworktab.jsx:133
 msgid "IP Address"
 msgstr "Adreça IP"
 
-#: pkg/docker/index.html:175
+#: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "Adreça IP:"
 
-#: pkg/docker/index.html:179
+#: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "Longitud del prefix IP:"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "IP Range"
 msgstr ""
 
@@ -3649,10 +2981,6 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr "Ajusts d'IPv6"
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:873
-msgid "ISCSI"
-msgstr "ISCSI"
-
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
@@ -3661,7 +2989,7 @@ msgstr "Id"
 msgid "Id $id"
 msgstr "Id. $id"
 
-#: pkg/docker/index.html:148
+#: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "Id:"
 
@@ -3669,17 +2997,6 @@ msgstr "Id:"
 #: node_modules/registry-image-widgets/views/image-listing.html:7
 msgid "Identifier"
 msgstr "Identificador"
-
-#: pkg/kubernetes/views/user-page.html:22
-#: pkg/kubernetes/views/user-panel.html:18
-msgid "Identities"
-msgstr "Identitats"
-
-#: pkg/kubernetes/views/add-user-dialog.html:17
-#: pkg/kubernetes/views/project-listing.html:91
-#: pkg/kubernetes/views/user-modify.html:17
-msgid "Identity"
-msgstr "Identitat"
 
 #: pkg/storaged/crypto-keyslots.jsx:325
 msgid "If tang-show-keys is not available, run the following:"
@@ -3689,9 +3006,7 @@ msgstr ""
 msgid "Ignore"
 msgstr "Ignora"
 
-#: pkg/docker/index.html:268 pkg/docker/index.html:431
-#: pkg/kubernetes/views/container-body.html:6
-#: pkg/kubernetes/views/image-page.html:15
+#: pkg/docker/index.html:270 pkg/docker/index.html:433
 #: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
@@ -3701,33 +3016,13 @@ msgstr "Imatge"
 msgid "Image $0"
 msgstr "Imatge $0"
 
-#: pkg/users/local.js:749
+#: pkg/users/local.js:753
 msgid "Image Builder"
 msgstr ""
 
-#: pkg/kubernetes/views/container-body.html:8
-msgid "Image ID"
-msgstr "Id. d'imatge"
-
-#: pkg/kubernetes/views/volume-body.html:58
-msgid "Image Name"
-msgstr "Nom de la imatge"
-
-#: pkg/kubernetes/registry.html:23
-msgid "Image Registry"
-msgstr "Registre d'imatges"
-
-#: pkg/docker/index.html:578
+#: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Cerca de la imatge"
-
-#: pkg/kubernetes/views/imagestream-page.html:16
-msgid "Image Stream"
-msgstr "Flux d'imatges"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:135
-msgid "Image commands"
-msgstr "Ordres de la imatge"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:41
 msgid "Image count"
@@ -3737,14 +3032,10 @@ msgstr "Nombre d'imatges"
 msgid "Image stream"
 msgstr "Flux d'imatges"
 
-#: pkg/docker/index.html:156
+#: pkg/docker/index.html:157
 msgid "Image:"
 msgstr "Imatge:"
 
-#: pkg/kubernetes/index.html:81 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
-#: pkg/kubernetes/views/registry-dashboard-page.html:19
 #: pkg/docker/containers-view.jsx:711
 msgid "Images"
 msgstr "Imatges"
@@ -3757,10 +3048,6 @@ msgstr "Imatges"
 #: pkg/docker/containers-view.jsx:109
 msgid "Images and running containers"
 msgstr "Imatges i contenidors en execució"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:17
-msgid "Images by project"
-msgstr "Imatges per projecte"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:15
 #: node_modules/registry-image-widgets/views/imagestream-body.html:16
@@ -3775,14 +3062,9 @@ msgstr "Les imatges poden ser recuperades per usuaris o grups autenticats"
 #: node_modules/registry-image-widgets/views/imagestream-body.html:25
 #: node_modules/registry-image-widgets/views/imagestream-body.html:26
 msgid "Images may only be pulled by specific users or groups"
-msgstr ""
-"Les imatges només poden ser recuperades per usuaris o grups específics"
+msgstr "Les imatges només poden ser recuperades per usuaris o grups específics"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:54
-msgid "Images pushed recently"
-msgstr ""
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:632
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
 msgstr "Inicia automàticament la MV"
 
@@ -3790,21 +3072,10 @@ msgstr "Inicia automàticament la MV"
 msgid "In Sync"
 msgstr "En sincronització"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:171
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:81
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:6
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
 msgstr ""
 
 #: pkg/lib/machine-sync-users.html:50
@@ -3812,8 +3083,8 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Per sincronitzar els usuaris, cal que inicieu la sessió a "
-"{{#strong}}{{host}}{{/strong}}."
+"Per sincronitzar els usuaris, cal que inicieu la sessió a {{#strong}}{{host}}"
+"{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
 #: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
@@ -3824,7 +3095,7 @@ msgstr "Inactiu"
 msgid "Inactive volume"
 msgstr "Volum inactiu"
 
-#: pkg/networkmanager/firewall.jsx:730
+#: pkg/networkmanager/firewall.jsx:732
 msgid "Included services"
 msgstr ""
 
@@ -3848,17 +3119,17 @@ msgstr ""
 msgid "Initializing..."
 msgstr "S'està inicialitzant..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:177
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:188
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Instal·la"
 
@@ -3887,25 +3158,21 @@ msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr ""
 "Instal·leu setroubleshoot-server per resoldre els esdeveniments de SELinux."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:226
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
 msgid "Installation Source"
 msgstr "Origen d'instal·lació"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:212
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
 msgid "Installation Source Type"
 msgstr "Tipus d'origen d'instal·lació"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:113
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
 msgid "Installation Source should not be empty"
 msgstr "L'origen d'instal·lació no pot estar en blanc"
 
 #: pkg/packagekit/updates.jsx:59
 msgid "Installed"
 msgstr "Instal·lat"
-
-#: pkg/subscriptions/subscriptions-view.jsx:245
-msgid "Installed products"
-msgstr "Productes instal·lats"
 
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:51
@@ -3920,17 +3187,13 @@ msgstr ""
 msgid "Instantiate"
 msgstr "Instancia"
 
-#: pkg/kubernetes/views/pv-modify.html:170
-#: pkg/kubernetes/views/volume-body.html:81
-msgid "Interface"
-msgstr "Interfície"
-
 #: pkg/machines/components/nicEdit.jsx:123
 msgid "Interface Type"
 msgstr ""
 
-#: pkg/networkmanager/index.html:108 pkg/networkmanager/firewall.jsx:735
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Interfícies"
 
@@ -3946,15 +3209,11 @@ msgstr "Error intern"
 msgid "Invalid address $0"
 msgstr "Adreça no vàlida $0"
 
-#: pkg/subscriptions/subscriptions-client.js:195
-msgid "Invalid credentials"
-msgstr "Credencials no vàlides"
-
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Format de data no vàlid"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Format no vàlid de la data i l'hora"
 
@@ -3962,7 +3221,7 @@ msgstr "Format no vàlid de la data i l'hora"
 msgid "Invalid date format."
 msgstr "Format de data no vàlid."
 
-#: pkg/users/local.js:1237
+#: pkg/users/local.js:1241
 msgid "Invalid expiration date"
 msgstr "Data de venciment no vàlida"
 
@@ -3970,7 +3229,7 @@ msgstr "Data de venciment no vàlida"
 msgid "Invalid file permissions"
 msgstr "Permisos de fitxer no vàlids"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
 msgid "Invalid filename"
 msgstr "nom de fitxer no vàlid"
 
@@ -3982,7 +3241,7 @@ msgstr "Clau no vàlida"
 msgid "Invalid metric $0"
 msgstr "Mètrica no vàlida $0"
 
-#: pkg/users/local.js:1313
+#: pkg/users/local.js:1317
 msgid "Invalid number of days"
 msgstr "Nombre de dies no vàlid"
 
@@ -4010,7 +3269,7 @@ msgstr "Prefix o màscara de xarxa no vàlid $0"
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Format d'hora no vàlid"
 
@@ -4019,7 +3278,6 @@ msgid "Invalid time zone"
 msgstr "Zona horària no vàlida"
 
 #: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
-#: pkg/subscriptions/subscriptions-client.js:193
 msgid "Invalid username or password"
 msgstr "El nom d'usuari o la contrasenya no són vàlids"
 
@@ -4039,19 +3297,19 @@ msgstr ""
 msgid "Jobs"
 msgstr "Treballs"
 
-#: pkg/realmd/operation.js:117
+#: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "Uneix-te"
 
-#: pkg/realmd/operation.js:597
+#: pkg/realmd/operation.js:596
 msgid "Join Domain"
 msgstr "Uneix-te a un domini"
 
-#: pkg/realmd/operation.js:116
+#: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "Uneix-te a un domini"
 
-#: pkg/realmd/operation.js:506
+#: pkg/realmd/operation.js:505
 msgid "Joining this domain is not supported"
 msgstr "La unió a aquest domini no està admesa"
 
@@ -4098,14 +3356,6 @@ msgstr "Kernel"
 msgid "Kernel Dump"
 msgstr "Bolcat del kernel"
 
-#: pkg/kubernetes/views/node-body.html:19
-msgid "Kernel Version"
-msgstr "Versió del kernel"
-
-#: pkg/kubernetes/views/volume-body.html:67
-msgid "Key Ring Path"
-msgstr "Camí a l'anell de claus"
-
 #: pkg/storaged/crypto-keyslots.jsx:563
 msgid "Key slots with unknown types can not be edited here"
 msgstr ""
@@ -4130,23 +3380,10 @@ msgstr ""
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:23
-msgid "Kubelet Version"
-msgstr "Versió de Kubelet"
-
-#: pkg/kubernetes/index.html:23
-msgid "Kubernetes Cluster"
-msgstr "Clúster Kubernetes"
-
 #: pkg/networkmanager/index.html:377
 msgid "LACP Key"
 msgstr "Clau LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: pkg/kubernetes/views/replicationcontroller-body.html:17
-#: pkg/kubernetes/views/route-body.html:22
-#: pkg/kubernetes/views/service-body.html:26
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Etiquetes"
@@ -4163,17 +3400,9 @@ msgstr "Les últimes 24 hores"
 msgid "Last 7 days"
 msgstr "Els últims 7 dies"
 
-#: pkg/kubernetes/views/node-body.html:49
-msgid "Last Heartbeat"
-msgstr "Últim batec"
-
 #: pkg/users/index.html:100
 msgid "Last Login"
 msgstr "Últim inici de sessió"
-
-#: pkg/kubernetes/views/node-body.html:51
-msgid "Last Status Change"
-msgstr "Últim canvi d'estat"
 
 #: pkg/systemd/init.js:284
 msgid "Last Trigger"
@@ -4186,11 +3415,6 @@ msgstr "Últim cop actualitzat"
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
 msgstr "Última comprovació: fa $0"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
-#: pkg/kubernetes/views/details-page.html:107
-msgid "Latest Version"
-msgstr "Última versió"
 
 #: pkg/machines/components/desktopConsole.jsx:128
 msgid "Launch Remote Viewer"
@@ -4215,14 +3439,13 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Deixeu-ho en blanc per connectar a aquesta màquina amb "
 "l'usuari{{#default_user}} ({{default_user}}){{/default_user}}, que ha "
 "iniciat actualment la sessió. Si introduïu un altre nom d'usuari, sempre "
 "s'utilitzarà aquest usuari quan es connecti a aquesta màquina."
 
-#: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
+#: pkg/shell/index.html:90 pkg/shell/simple.html:66
 msgid "Licensed under:"
 msgstr "Llicenciat sota:"
 
@@ -4246,7 +3469,7 @@ msgstr "Retard del baixament de l'enllaç"
 msgid "Link local"
 msgstr "Enllaç local"
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:499
 msgid "Link to another container"
 msgstr "Enllaça a un altre contenidor"
 
@@ -4254,11 +3477,11 @@ msgstr "Enllaça a un altre contenidor"
 msgid "Link up delay"
 msgstr "Retard de l'aixecament de l'enllaç"
 
-#: pkg/docker/index.html:493
+#: pkg/docker/index.html:495
 msgid "Links"
 msgstr "Enllaços"
 
-#: pkg/docker/index.html:195
+#: pkg/docker/index.html:196
 msgid "Links:"
 msgstr "Enllaços:"
 
@@ -4282,13 +3505,9 @@ msgstr "Ha fallat la càrrega de les actualitzacions disponibles"
 msgid "Loading available updates, please wait..."
 msgstr "S'estan carregant les actualitzacions disponibles, espereu..."
 
-#: pkg/ovirt/components/VdsmView.jsx:34
-msgid "Loading data ..."
-msgstr "S'estan carregant les dades..."
-
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "S'està carregant..."
 
@@ -4304,7 +3523,7 @@ msgstr "Discs locals"
 msgid "Local Filesystem"
 msgstr "Sistema de fitxers local"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:218
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
 msgid "Local Install Media"
 msgstr ""
 
@@ -4324,7 +3543,7 @@ msgstr "Bloqueja"
 msgid "Lock Account"
 msgstr "Bloqueja el compte"
 
-#: pkg/users/local.js:879 pkg/users/local.js:1218
+#: pkg/users/local.js:883 pkg/users/local.js:1222
 msgid "Lock account on $0"
 msgstr "Bloqueja el compte el $0"
 
@@ -4336,7 +3555,7 @@ msgstr "S'està bloquejant $target"
 msgid "Log In"
 msgstr "Inicia la sessió"
 
-#: pkg/shell/index.html:70 pkg/shell/simple.html:46 pkg/shell/stub.html:53
+#: pkg/shell/index.html:70 pkg/shell/simple.html:46
 msgid "Log Out"
 msgstr "Tanca la sessió"
 
@@ -4352,19 +3571,11 @@ msgstr "Inicia la sessió a {{host}}"
 msgid "Log in with your server user account."
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:116
-msgid "Log into OpenShift command line tools:"
-msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:101
-msgid "Log into the registry:"
-msgstr ""
-
 #: pkg/systemd/index.html:65
 msgid "Log messages"
 msgstr "Missatges del registre"
 
-#: pkg/users/local.js:961
+#: pkg/users/local.js:965
 msgid "Logged In"
 msgstr "Autenticat"
 
@@ -4375,12 +3586,6 @@ msgstr "Lògica"
 #: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
 msgid "Logical Size"
 msgstr "Mida lògica"
-
-#: pkg/kubernetes/views/pv-modify.html:159
-#: pkg/kubernetes/views/volume-body.html:79
-#: pkg/kubernetes/views/volume-body.html:118
-msgid "Logical Unit Number"
-msgstr "Número de la unitat lògica"
 
 #: pkg/storaged/utils.js:197
 msgid "Logical Volume"
@@ -4394,10 +3599,6 @@ msgstr "Volum lògic (instantània)"
 msgid "Logical Volume of $0"
 msgstr "Volum lògic de $0"
 
-#: pkg/subscriptions/subscriptions-register.jsx:144
-msgid "Login"
-msgstr "Usuari"
-
 #: src/ws/login.js:300
 msgid "Login Again"
 msgstr "Torna a iniciar la sessió"
@@ -4410,10 +3611,6 @@ msgstr ""
 msgid "Login Password"
 msgstr "Contrasenya d'inici de sessió"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:96
-msgid "Login commands"
-msgstr "Ordres d'inici de sessió"
-
 #: src/base1/cockpit.js:4015
 msgid "Login failed"
 msgstr "Ha fallat l'inici de sessió"
@@ -4422,17 +3619,11 @@ msgstr "Ha fallat l'inici de sessió"
 msgid "Login has escalated admin privileges"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-client.js:199
-msgid "Login/password or activation key required to register."
-msgstr ""
-"Per registrar es requereix un usuari/contrasenya o una clau d'activació."
-
 #: src/ws/login.js:301
 msgid "Logout Successful"
 msgstr "S'ha tancat la sessió amb èxit"
 
-#: pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82
 msgid "Logs"
 msgstr "Registres"
 
@@ -4452,17 +3643,13 @@ msgstr ""
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:102
+#: pkg/machines/components/vmnetworktab.jsx:132
 msgid "MAC Address"
 msgstr "Adreça MAC"
 
-#: pkg/docker/index.html:187
+#: pkg/docker/index.html:188
 msgid "MAC Address:"
 msgstr "Adreça MAC:"
-
-#: pkg/ovirt/provider.js:283
-msgid "MIGRATE action failed"
-msgstr "Ha fallat l'acció MIGRATE"
 
 #: pkg/networkmanager/interfaces.js:1985
 msgid "MII (Recommended)"
@@ -4484,7 +3671,7 @@ msgstr ""
 msgid "Mac Address"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:95
+#: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "Id. de màquina"
 
@@ -4503,10 +3690,6 @@ msgstr ""
 #: pkg/storaged/crypto-keyslots.jsx:319
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:457
-msgid "Manifest"
-msgstr "Manifest"
 
 #: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
 msgid "Manual"
@@ -4562,16 +3745,6 @@ msgid ""
 "between 1 and $0"
 msgstr ""
 
-#: pkg/kubernetes/views/volume-body.html:34
-msgid "Medium"
-msgstr "Mitjà"
-
-#: pkg/kubernetes/views/project-listing.html:92
-#: pkg/kubernetes/views/user-body.html:4
-#: pkg/kubernetes/views/user-panel.html:27
-msgid "Member of"
-msgstr "Membre de"
-
 #: pkg/storaged/content-views.jsx:345
 msgid "Member of RAID Device"
 msgstr "Membre del dispositiu RAID"
@@ -4580,26 +3753,11 @@ msgstr "Membre del dispositiu RAID"
 msgid "Member of RAID Device $0"
 msgstr "Membre del dispositiu RAID $0"
 
-#: pkg/kubernetes/views/project-listing.html:16
-#: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/index.html:266 pkg/networkmanager/interfaces.js:2986
-msgid "Members"
-msgstr "Membres"
-
-#: pkg/kubernetes/views/project-page.html:29
-#: pkg/kubernetes/views/user-page.html:25
-#: pkg/kubernetes/views/user-panel.html:11
-msgid "Membership"
-msgstr "Pertinença"
-
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:271
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:608
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:827
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:304
+#: pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
 #: pkg/machines/components/vmOverviewTab.jsx:74
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Memory"
 msgstr "Memòria"
 
@@ -4612,38 +3770,32 @@ msgstr "Memòria"
 msgid "Memory & Swap"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Utilització de la memòria:  $0%"
-
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
 msgid "Memory could not be saved"
 msgstr ""
 
-#: pkg/docker/index.html:452 pkg/docker/index.html:624
+#: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "Límit de memòria"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#, fuzzy
+msgid "Memory must not be 0"
+msgstr "Ús de la memòria: "
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
 msgstr ""
 
-#: pkg/docker/index.html:210
+#: pkg/docker/index.html:211
 msgid "Memory usage:"
 msgstr "Ús de la memòria: "
-
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
-msgid "Message"
-msgstr "Missatge"
 
 #: pkg/systemd/shutdown.js:79
 msgid "Message to logged in users"
 msgstr "Missatge per als usuaris que hagin iniciat la sessió"
 
-#: pkg/kubernetes/views/image-page.html:29
-#: pkg/kubernetes/views/imagestream-page.html:30
 #: node_modules/registry-image-widgets/views/image-panel.html:15
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
@@ -4653,17 +3805,13 @@ msgstr "Metadades"
 msgid "Metadata Used"
 msgstr "Metadades utilitzades"
 
-#: pkg/docker/index.html:466 pkg/docker/index.html:638
-#: pkg/machines/components/diskAdd.jsx:159
-#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/docker/index.html:468 pkg/docker/index.html:640
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
-
-#: pkg/ovirt/components/OVirtTab.jsx:70
-msgid "Migrate To:"
-msgstr "Migra a:"
 
 #: pkg/lib/machine-info.js:98
 msgid "Mini PC"
@@ -4693,13 +3841,9 @@ msgstr "Mode"
 msgid "Model"
 msgstr "Model"
 
-#: pkg/machines/components/vmnetworktab.jsx:93
+#: pkg/machines/components/vmnetworktab.jsx:123
 msgid "Model type"
 msgstr "Tipus de model"
-
-#: pkg/kubernetes/views/user-modify.html:27
-msgid "Modify"
-msgstr "Modifica"
 
 #: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:45
 #: pkg/storaged/jobs-panel.jsx:52
@@ -4722,11 +3866,7 @@ msgstr "Interval del monitoratge"
 msgid "Monitoring Targets"
 msgstr "Objectius del monitoratge"
 
-#: pkg/kubernetes/views/volume-body.html:54
-msgid "Monitors"
-msgstr "Monitors"
-
-#: pkg/realmd/operation.js:530
+#: pkg/realmd/operation.js:529
 msgid "More"
 msgstr "Més"
 
@@ -4739,31 +3879,27 @@ msgstr "Més informació"
 msgid "More details"
 msgstr "Més detalls"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Munta"
 
-#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
-msgid "Mount Location"
-msgstr "Ubicació del muntatge"
-
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Opcions de muntatge"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Punt de muntatge"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Munta a l'arrencada"
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:521
 msgid "Mount container volumes"
 msgstr "Munta els volums del contenidor"
 
@@ -4779,7 +3915,7 @@ msgstr "El punt de muntatge no pot estar en blanc."
 msgid "Mount point must start with \"/\"."
 msgstr "El punt de muntatge ha de començar amb «/»."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Munta només de lectura"
 
@@ -4803,11 +3939,7 @@ msgstr ""
 msgid "NAT to $0"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:865
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:140
 msgid "NFS Mount"
 msgstr "Muntatge NFS"
 
@@ -4819,7 +3951,7 @@ msgstr "Muntatges NFS"
 msgid "NFS Support not installed"
 msgstr ""
 
-#: pkg/machines/components/vmnetworktab.jsx:67
+#: pkg/machines/components/vmnetworktab.jsx:97
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
@@ -4831,54 +3963,29 @@ msgstr "Ping NSNA"
 msgid "NTP Server"
 msgstr "Servidor NTP"
 
-#: pkg/docker/index.html:267 pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/containers-listing.html:11
-#: pkg/kubernetes/views/dashboard-page.html:156
-#: pkg/kubernetes/views/dashboard-page.html:198
-#: pkg/kubernetes/views/details-page.html:34
-#: pkg/kubernetes/views/details-page.html:70
-#: pkg/kubernetes/views/details-page.html:103
-#: pkg/kubernetes/views/details-page.html:137
-#: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/service-modify.html:9
-#: pkg/kubernetes/views/user-modify.html:9
-#: pkg/kubernetes/views/volume-body.html:31
-#: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:119
+#: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
 #: pkg/networkmanager/index.html:319
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:181
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Nom"
 
@@ -4910,7 +4017,7 @@ msgstr "El nom no pot contenir el caràcter «$0»."
 msgid "Name cannot contain whitespace."
 msgstr "El nom no pot contenir l'espai en blanc."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:82
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
 msgid "Name should not be empty"
 msgstr "El nom no pot estar en blanc"
@@ -4918,26 +4025,6 @@ msgstr "El nom no pot estar en blanc"
 #: pkg/machines/components/networks/networkOverviewTab.jsx:36
 msgid "Name: "
 msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
-#: pkg/kubernetes/views/details-page.html:36
-#: pkg/kubernetes/views/details-page.html:72
-#: pkg/kubernetes/views/details-page.html:105
-#: pkg/kubernetes/views/details-page.html:139
-#: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
-#: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
-#: pkg/kubernetes/views/service-body.html:5
-#: pkg/kubernetes/views/volumes-page.html:59
-msgid "Namespace"
-msgstr "Espai de noms"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "L'espai de noms no pot estar en blanc."
 
 #: pkg/systemd/host.js:1348
 msgid "Need at least one NTP server"
@@ -4948,19 +4035,18 @@ msgid "Netmask"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:613
 msgid "Network"
 msgstr "Xarxa"
 
-#: pkg/machines/components/networks/network.jsx:117
+#: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/networks/network.jsx:129
+#: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
 msgid "Network Boot (PXE)"
 msgstr ""
 
@@ -4972,7 +4058,7 @@ msgstr ""
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:177
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Network Selection does not support PXE."
 msgstr ""
 
@@ -4993,7 +4079,7 @@ msgid "NetworkManager is not running."
 msgstr ""
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:914
 msgid "Networking"
 msgstr "Xarxa"
 
@@ -5011,21 +4097,17 @@ msgstr "Registres de la xarxa"
 msgid "Networks"
 msgstr "Xarxes"
 
-#: pkg/users/local.js:963
+#: pkg/users/local.js:967
 msgid "Never"
 msgstr "Mai"
 
-#: pkg/users/index.html:297 pkg/users/local.js:868
+#: pkg/users/index.html:297 pkg/users/local.js:872
 msgid "Never expire password"
 msgstr "Mai venç la contrasenya"
 
-#: pkg/users/index.html:258 pkg/users/local.js:876
+#: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "No es bloqueja mai el compte"
-
-#: pkg/kubernetes/views/project-listing.html:46
-msgid "New Group"
-msgstr "Grup nou"
 
 #: pkg/storaged/nfs-details.jsx:140
 msgid "New NFS Mount"
@@ -5035,32 +4117,17 @@ msgstr "Muntatge NFS nou"
 msgid "New Password"
 msgstr "Contrasenya nova"
 
-#: pkg/kubernetes/views/project-listing.html:7
-msgid "New Project"
-msgstr "Projecte nou"
-
 #: pkg/machines/components/diskAdd.jsx:132
 msgid "New Volume Name"
 msgstr ""
-
-#: pkg/kubernetes/views/images-page.html:11
-#: pkg/kubernetes/views/registry-dashboard-page.html:86
-msgid "New image stream"
-msgstr "Flux d'imatges nou"
 
 #: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "No s'ha acceptat la nova contrasenya"
-
-#: pkg/kubernetes/views/project-modify.html:4
-#: pkg/kubernetes/views/registry-dashboard-page.html:9
-#: pkg/kubernetes/views/registry-dashboard-page.html:48
-msgid "New project"
-msgstr "Projecte nou"
 
 #: pkg/realmd/operation.html:82 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
@@ -5074,9 +4141,8 @@ msgstr "Següent execució"
 msgid "Nice"
 msgstr "Nice"
 
-#: pkg/docker/index.html:542 pkg/docker/index.html:546 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/kubernetes/scripts/volumes.js:998
-#: pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
 msgid "No"
 msgstr "No"
 
@@ -5100,35 +4166,18 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Cap emmagatzematge NFS preparat"
 
-#: src/ws/cockpitcertificate.c:522
-msgid "No PEM-encoded certificate found"
-msgstr ""
-
-#: src/ws/cockpitcertificate.c:488
-msgid "No PEM-encoded private key found"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html:39
-msgid "No Pods are using this claim"
-msgstr ""
-
 #: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "No SELinux alerts."
 msgstr "Sense alertes de SELinux."
 
-#: pkg/machines/components/diskAdd.jsx:193
-#: pkg/machines/components/diskAdd.jsx:205
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:216
 msgid "No Storage Pools available"
 msgstr ""
 
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr ""
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:29
-#: pkg/ovirt/components/ClusterVms.jsx:36
-msgid "No VM found in oVirt."
-msgstr "No s'ha trobat cap MV a oVirt."
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
@@ -5138,11 +4187,7 @@ msgstr "No hi ha cap MV en execució o definida en aquest amfitrió"
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html:10
-msgid "No Volume Bound"
-msgstr ""
-
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/networkmanager/firewall.jsx:926
 msgid "No active zones"
 msgstr ""
 
@@ -5158,7 +4203,7 @@ msgstr "Sense especificar l'àlies"
 msgid "No applications installed or available"
 msgstr "No hi ha cap aplicació instal·lada o disponible"
 
-#: pkg/sosreport/index.js:128
+#: pkg/sosreport/index.js:129
 msgid "No archive has been created."
 msgstr "No s'ha creat cap arxiu."
 
@@ -5194,7 +4239,7 @@ msgstr "Sense contenidors"
 msgid "No containers that match the current filter"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:727
+#: pkg/networkmanager/firewall.jsx:729
 msgid "No description available"
 msgstr ""
 
@@ -5202,9 +4247,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "No s'ha proporcionat cap descripció."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "No hi ha disponible cap disc."
 
@@ -5212,7 +4257,7 @@ msgstr "No hi ha disponible cap disc."
 msgid "No disks defined for this VM"
 msgstr "No hi ha definit cap disc per a aquesta MV"
 
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:121
 msgid "No drives attached"
 msgstr "Sense unitats connectades"
 
@@ -5223,10 +4268,6 @@ msgstr ""
 #: pkg/storaged/content-views.jsx:700
 msgid "No free space"
 msgstr "Sense espai lliure"
-
-#: pkg/kubernetes/views/project-listing.html:74
-msgid "No groups are present."
-msgstr ""
 
 #: pkg/systemd/index.html:29
 msgid "No host keys found."
@@ -5244,21 +4285,13 @@ msgstr "No hi ha present cap flux d'imatges."
 msgid "No images"
 msgstr "Sense imatges"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:80
-msgid "No images pushed"
-msgstr ""
-
 #: pkg/docker/containers-view.jsx:707
 msgid "No images that match the current filter"
 msgstr ""
 
-#: pkg/apps/utils.jsx:95
+#: pkg/apps/utils.jsx:96
 msgid "No installation package found for this application."
 msgstr "No s'ha trobat cap paquet d'instal·lació per a aquesta aplicació."
-
-#: pkg/subscriptions/subscriptions-view.jsx:246
-msgid "No installed products on the system."
-msgstr "No hi ha cap producte instal·lat al sistema."
 
 #: pkg/storaged/crypto-keyslots.jsx:520
 msgid "No keys added"
@@ -5282,14 +4315,7 @@ msgstr ""
 "kernel (p. ex. a /etc/default/grub) per reservar memòria en temps "
 "d'arrencada. Exemple: crashkernel=512M"
 
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr ""
-"Sense seleccionar el fitxer de metadades. Si us plau, seleccioneu un fitxer "
-"de metadades del Kubernetes."
-
-#: pkg/machines/components/vmnetworktab.jsx:40
+#: pkg/machines/components/vmnetworktab.jsx:70
 msgid "No network interfaces defined for this VM"
 msgstr "No s'ha definit cap interfície de xarxa per aquesta MV"
 
@@ -5301,15 +4327,7 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/kubernetes/views/dashboard-page.html:117
-msgid "No nodes in cluster"
-msgstr "Cap node al clúster"
-
-#: pkg/ovirt/components/App.jsx:61
-msgid "No oVirt connection"
-msgstr ""
-
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:939
 msgid "No open ports"
 msgstr ""
 
@@ -5317,27 +4335,7 @@ msgstr ""
 msgid "No partitioning"
 msgstr "Sense particionatge"
 
-#: pkg/kubernetes/views/dashboard-page.html:40
-msgid "No pods deployed"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:6
-msgid "No pods replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/node-capacity.html:11
-msgid "No pods scheduled"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html:10
-msgid "No pods selected"
-msgstr ""
-
-#: pkg/kubernetes/views/project-listing.html:37
-msgid "No projects are present."
-msgstr ""
-
-#: pkg/users/local.js:449
+#: pkg/users/local.js:453
 msgid "No real name specified"
 msgstr "Sense especificar el nom real"
 
@@ -5377,48 +4375,17 @@ msgstr ""
 msgid "No updates pending"
 msgstr "No hi ha actualitzacions pendents"
 
-#: pkg/users/local.js:444
+#: pkg/users/local.js:448
 msgid "No user name specified"
 msgstr "Sense especificar el nom d'usuari"
-
-#: pkg/kubernetes/views/project-listing.html:112
-msgid "No users are present."
-msgstr "No hi ha usuaris presents."
 
 #: pkg/storaged/vgroups-panel.jsx:114
 msgid "No volume groups created"
 msgstr "Cap grup de volums creat"
 
-#: pkg/kubernetes/views/volumes-page.html:44
-msgid "No volumes are present."
-msgstr "No hi ha volums presents."
-
-#: pkg/kubernetes/views/dashboard-page.html:73
-msgid "No volumes in use"
-msgstr "Sense volums en ús"
-
-#: pkg/kubernetes/views/containers-listing.html:15
-#: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
-#: pkg/kubernetes/views/topology-page.html:38
-msgid "Node"
-msgstr "Node"
-
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
-#: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
-msgid "Nodes"
-msgstr "Nodes"
-
-#: pkg/kubernetes/views/topology-page.html:39
-msgid "Nodes are the machines that run your containers."
-msgstr "Els nodes són les màquines que executen els vostres contenidors."
-
-#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
-#: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:732
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Cap"
 
@@ -5426,23 +4393,13 @@ msgstr "Cap"
 msgid "None (Isolated Network)"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
-#: pkg/kubernetes/scripts/nodes.js:319
+#: pkg/playground/translate.html:29
 msgid "Not Ready"
 msgstr "No a punt"
-
-#: pkg/kubernetes/scripts/details.js:496 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "No és un nombre vàlid de rèpliques"
 
 #: pkg/lib/credentials.js:255
 msgid "Not a valid private key"
 msgstr "No és una clau privada vàlida"
-
-#: pkg/kubernetes/scripts/details.js:547
-msgid "Not a valid value for Host"
-msgstr "No és un valor vàlid per a l'amfitrió"
 
 #: pkg/docker/index.html:57
 msgid "Not authorized to access Docker on this system"
@@ -5460,11 +4417,6 @@ msgstr "No disponible"
 msgid "Not connected"
 msgstr "No connectat"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
-#: pkg/kubernetes/views/details-page.html:122
-msgid "Not deployed"
-msgstr "No desplegat"
-
 #: pkg/storaged/lvol-tabs.jsx:369
 msgid "Not enough space to grow."
 msgstr ""
@@ -5481,7 +4433,7 @@ msgstr "No muntat"
 msgid "Not permitted to perform this action."
 msgstr "No es permet realitzar aquesta acció."
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Not running"
 msgstr "No s'està executant"
 
@@ -5505,32 +4457,9 @@ msgstr ""
 msgid "Notice and above"
 msgstr ""
 
-#: pkg/ovirt/components/vcpuModal.jsx:55
-msgid "Number of virtual CPUs that gonna be used."
-msgstr ""
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
-#: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
-msgid "OK"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html:13
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "OS"
-msgstr "SO"
-
-#: pkg/ovirt/components/OVirtTab.jsx:148
-msgid "OS Type:"
-msgstr "Tipus de SO:"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:274
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
 msgid "OS Vendor"
 msgstr ""
-
-#: pkg/kubernetes/views/nodes-page.html:19
-msgid "OS Versions"
-msgstr "Versions del SO"
 
 #: pkg/selinux/setroubleshoot-view.jsx:394
 msgid "Occurred $0"
@@ -5556,7 +4485,7 @@ msgstr "Contrasenya antiga"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Contrasenya antiga no acceptada"
 
@@ -5568,7 +4497,7 @@ msgstr "On"
 msgid "On Build"
 msgstr "Amb la construcció"
 
-#: pkg/docker/index.html:547 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/init.js:731
 msgid "On Failure"
 msgstr "Amb la fallada"
 
@@ -5588,7 +4517,7 @@ msgid ""
 "socket\"."
 msgstr ""
 
-#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:338
+#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
 msgstr "Contrasenya d'un sol cop"
 
@@ -5614,7 +4543,7 @@ msgstr "Només es permeten lletres, números, : , _ , . , @ , -."
 msgid "Only editable when the guest is shut off"
 msgstr ""
 
-#: pkg/shell/index.html:43 pkg/shell/simple.html:29 pkg/shell/stub.html:33
+#: pkg/shell/index.html:43 pkg/shell/simple.html:29
 msgid "Ooops!"
 msgstr "Ooops!"
 
@@ -5622,8 +4551,8 @@ msgstr "Ooops!"
 msgid "Open"
 msgstr ""
 
-#: pkg/kubernetes/views/nodes-page.html:42 pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+#: pkg/systemd/index.html:98
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
 msgid "Operating System"
 msgstr "Sistema operatiu"
 
@@ -5631,27 +4560,24 @@ msgstr "Sistema operatiu"
 msgid "Operation '$operation' on $target"
 msgstr "L'operació '$operation' en $target"
 
+#: pkg/machines/components/storagePools/storagePool.jsx:175
+#: pkg/machines/components/storagePools/storagePool.jsx:180
+#, fuzzy
+msgid "Operation is in progress"
+msgstr "Inici de sessió d'oVirt en progrés"
+
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Unitat òptica"
 
-#: pkg/ovirt/components/OVirtTab.jsx:157
-msgid "Optimized for:"
-msgstr "Optimitzat per:"
-
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:134
-#: pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
 msgid "Options"
 msgstr "Opcions"
 
 #: src/ws/login.html:125
 msgid "Or use a bundled browser"
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:180
-msgid "Organization"
-msgstr "Organització"
 
 #: pkg/lib/machine-info.js:64
 msgid "Other"
@@ -5670,11 +4596,9 @@ msgstr "Altres dispositius"
 msgid "Other Options"
 msgstr "Altres opcions"
 
-#: pkg/docker/index.html:297 pkg/kubernetes/index.html:43
-#: pkg/kubernetes/registry.html:43
-#: pkg/machines/components/networks/network.jsx:71
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Visió de conjunt"
 
@@ -5685,10 +4609,6 @@ msgstr "Sobreescriu les dades existents amb zeros"
 #: pkg/systemd/hwinfo.jsx:249
 msgid "PCI"
 msgstr "PCI"
-
-#: pkg/kubernetes/views/volume-body.html:4
-msgid "PD Name"
-msgstr ""
 
 #: pkg/packagekit/updates.jsx:501
 msgid "Package information"
@@ -5722,8 +4642,7 @@ msgstr ""
 msgid "Part of "
 msgstr "Part de"
 
-#: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:141
 msgid "Partition"
 msgstr "Partició"
 
@@ -5759,13 +4678,11 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Les contrasenyes no coincideixen"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
 #: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
-#: pkg/subscriptions/subscriptions-register.jsx:89
-#: pkg/subscriptions/subscriptions-register.jsx:156
 msgid "Password"
 msgstr "Contrasenya"
 
@@ -5781,7 +4698,7 @@ msgstr "La contrasenya no és acceptable"
 msgid "Password is too weak"
 msgstr "La contrasenya és massa feble"
 
-#: pkg/users/local.js:870
+#: pkg/users/local.js:874
 msgid "Password must be changed"
 msgstr "S'ha de canviar la contrasenya"
 
@@ -5802,11 +4719,7 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Enganxeu aquí el contingut del fitxer de la vostra clau SSH pública"
 
-#: pkg/kubernetes/views/pv-modify.html:126
-#: pkg/kubernetes/views/volume-body.html:37
-#: pkg/kubernetes/views/volume-body.html:49
-#: pkg/kubernetes/views/volume-body.html:101 pkg/systemd/services.html:126
-#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
 msgid "Path"
 msgstr "Camí"
 
@@ -5822,7 +4735,7 @@ msgstr "Cost del camí $path_cost"
 msgid "Path on Server"
 msgstr "Camí al servidor"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:129
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
 msgid "Path on host's filesystem"
 msgstr ""
 
@@ -5834,7 +4747,7 @@ msgstr "El camí al servidor no pot estar en blanc."
 msgid "Path on server must start with \"/\"."
 msgstr "El camí al servidor ha de començar amb «/»."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:154
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
 msgid "Path to ISO file on host's file system"
 msgstr "Camí al fitxer ISO al sistema de fitxers de l'amfitrió"
 
@@ -5849,10 +4762,6 @@ msgstr "Camins"
 #: pkg/machines/components/vm/vmActions.jsx:77
 msgid "Pause"
 msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html:53
-msgid "Pending Volume Claims"
-msgstr "Reclamacions de volums pendents"
 
 #: pkg/systemd/index.html:152
 msgid "Performance Profile"
@@ -5874,18 +4783,10 @@ msgstr "Permís denegat"
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html:14
-msgid "Persistent Volumes"
-msgstr "Volums persistents"
-
-#: pkg/kubernetes/views/pod-body.html:16
-msgid "Phase"
-msgstr "Fase"
 
 #: pkg/storaged/vdo-details.jsx:277
 msgid "Physical"
@@ -5899,11 +4800,11 @@ msgstr ""
 msgid "Physical Volume"
 msgstr "Volum físic"
 
-#: pkg/storaged/vgroup-details.jsx:134
+#: pkg/storaged/vgroup-details.jsx:133
 msgid "Physical Volumes"
 msgstr "Volums físics"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:210
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -5927,10 +4828,10 @@ msgstr "Objectiu de ping"
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:210
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Si us plau, confirmeu la supressió de $0"
 
@@ -5938,115 +4839,23 @@ msgstr "Si us plau, confirmeu la supressió de $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Si us plau, confirmeu la supressió forçada de $0"
 
-#: pkg/storaged/mdraid-details.jsx:244 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Confirmeu l'aturada de $0"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:34
-msgid "Please confirm, the host shall be switched to maintenance mode."
-msgstr "Confirmeu que l'amfitrió s'ha de canviar al mode de manteniment."
-
-#: pkg/kubernetes/scripts/dashboard.js:439
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Si us plau, creeu un altre espai de noms per a $0 \"$1\""
-
-#: pkg/machines/components/diskAdd.jsx:425
+#: pkg/machines/components/diskAdd.jsx:447
 msgid "Please enter new volume name"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:428
+#: pkg/machines/components/diskAdd.jsx:450
 msgid "Please enter new volume size"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:862
+#: pkg/networkmanager/firewall.jsx:864
 msgid "Please install the $0 package"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:582
-msgid "Please provide a GlusterFS volume name"
-msgstr "Si us plau, proporcioneu un nom de volum GlusterFS"
-
-#: pkg/kubernetes/scripts/connection.js:550
-msgid "Please provide a username"
-msgstr "Si us plau, proporcioneu un nom d'usuari vàlid"
-
-#: pkg/kubernetes/scripts/volumes.js:640
-msgid "Please provide a valid NFS server"
-msgstr "Si us plau, proporcioneu un servidor NFS vàlid"
-
-#: pkg/kubernetes/scripts/connection.js:535
-msgid "Please provide a valid address"
-msgstr "Si us plau, proporcioneu una adreça vàlida"
-
-#: pkg/kubernetes/scripts/volumes.js:810
-msgid "Please provide a valid filesystem type"
-msgstr "Si us plau, proporcioneu un tipus de sistema de fitxers vàlid"
-
-#: pkg/kubernetes/scripts/volumes.js:818
-msgid "Please provide a valid interface"
-msgstr "Proporcioneu una interfície vàlida"
-
-#: pkg/kubernetes/scripts/volumes.js:802
-msgid "Please provide a valid logical unit number"
-msgstr "Si us plau, proporcioneu un nombre vàlid d'unitat lògica"
-
-#: pkg/kubernetes/scripts/volumes.js:483
-msgid "Please provide a valid name"
-msgstr "Si us plau, proporcioneu un nom vàlid"
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Si us plau, proporcioneu un espai de noms vàlid."
-
-#: pkg/kubernetes/scripts/volumes.js:648 pkg/kubernetes/scripts/volumes.js:703
-msgid "Please provide a valid path"
-msgstr "Si us plau, proporcioneu un camí vàlid"
-
-#: pkg/kubernetes/scripts/volumes.js:794
-msgid "Please provide a valid qualified name"
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:491
-msgid "Please provide a valid storage capacity."
-msgstr "Si us plau, proporcioneu una capacitat d'emmagatzematge vàlida."
-
-#: pkg/kubernetes/scripts/volumes.js:786
-msgid "Please provide a valid target"
-msgstr "Si us plau, proporcioneu un objectiu vàlid"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:83
-msgid ""
-"Please provide fully qualified domain name and port of the oVirt engine."
-msgstr ""
-"Proporcioneu el nom de domini plenament qualificat i el port del motor oVirt."
-""
-
-#: pkg/ovirt/components/InstallationDialog.jsx:137
-msgid ""
-"Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-"port (443 by default)"
-msgstr ""
-"Proporcioneu el nom de domini plenament qualificat d'un motor oVirt vàlid i "
-"el port (443 per defecte)."
-
-#: pkg/ovirt/components/ConsoleClientResources.jsx:32
-msgid ""
-"Please refer to oVirt's $0 for more information about Remote Viewer setup."
-msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:475
-msgid "Please select a valid access mode"
-msgstr "Si us plau, seleccioneu un mode d'accés vàlid"
-
-#: pkg/kubernetes/scripts/volumes.js:573
-msgid "Please select a valid endpoint"
-msgstr "Si us plau, seleccioneu un extrem vàlid"
-
-#: pkg/kubernetes/scripts/volumes.js:499
-msgid "Please select a valid policy option."
-msgstr "Si us plau, seleccioneu una opció de política vàlida."
-
-#: pkg/users/local.js:1232
+#: pkg/users/local.js:1236
 msgid "Please specify an expiration date"
 msgstr "Si us plau, especifiqueu una data de venciment"
 
@@ -6062,72 +4871,16 @@ msgstr ""
 msgid "Please try another term"
 msgstr "Si us plau, proveu un altre terme"
 
-#: pkg/kubernetes/scripts/nodes.js:401
-msgid "Please type an address"
-msgstr "Si us plau, teclegeu una adreça"
-
-#: pkg/ovirt/components/ClusterVms.jsx:37
-msgid "Please wait till VMs list is loaded from the server."
-msgstr "Espereu fins que la llista de MV es carregui del servidor."
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:30
-msgid "Please wait till list of templates is loaded from the server."
-msgstr "Espereu fins que la llista de plantilles es carregui del servidor."
-
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Plug"
 msgstr ""
 
-#: pkg/kubernetes/views/containers-listing.html:12
-#: pkg/kubernetes/views/pod-page.html:12
-#: pkg/kubernetes/views/topology-page.html:14
-msgid "Pod"
-msgstr "Pod"
-
-#: pkg/kubernetes/views/pod-body.html:20
-msgid "Pod Address"
-msgstr ""
-
-#: pkg/kubernetes/views/service-endpoint.html:4
-#: pkg/kubernetes/views/service-endpoint.html:9
-msgid "Pod Endpoints"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:4
-msgid "Pod Replicated"
-msgstr ""
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:11
-#: pkg/kubernetes/views/service-endpoint.html:15
-msgid "Pod Selector"
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html:18
-#: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/pv-claim.html:37
-#: pkg/kubernetes/views/replicationcontroller-page.html:17
-#: pkg/kubernetes/views/replicationcontroller-panel.html:12
-#: pkg/kubernetes/scripts/details.js:227
-msgid "Pods"
-msgstr "Pods"
-
-#: pkg/kubernetes/views/topology-page.html:15
-msgid ""
-"Pods contain one or more containers that run together on a node, containing "
-"your application code."
-msgstr ""
-
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Agrupació"
-
-#: pkg/kubernetes/views/volume-body.html:60
-msgid "Pool Name"
-msgstr "Nom de l'agrupació"
 
 #: pkg/storaged/utils.js:191
 msgid "Pool for Thin Logical Volumes"
@@ -6141,16 +4894,11 @@ msgstr "Agrupació per als volums disgregats"
 msgid "Pool for thinly provisioned volumes"
 msgstr ""
 
-#: pkg/kubernetes/views/imagestream-modify.html:45
-msgid "Populate"
-msgstr "Pobla"
-
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:78
-#: pkg/ovirt/components/InstallationDialog.jsx:65
+#: pkg/machines/components/vmnetworktab.jsx:108
 #: pkg/storaged/iscsi-panel.jsx:127
 msgid "Port"
 msgstr "Port"
@@ -6163,15 +4911,14 @@ msgstr ""
 msgid "Portable"
 msgstr "Portable"
 
-#: pkg/docker/index.html:504 pkg/kubernetes/views/container-body.html:12
-#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:213
+#: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
 #: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
 msgid "Ports"
 msgstr "Ports"
 
-#: pkg/docker/index.html:191
+#: pkg/docker/index.html:192
 msgid "Ports:"
 msgstr "Ports:"
 
@@ -6180,7 +4927,6 @@ msgid "Power Options"
 msgstr "Opcions d'energia"
 
 #: pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Preferred number of sockets to expose to the guest."
 msgstr ""
 
@@ -6199,10 +4945,6 @@ msgstr "Longitud del prefix o Màscara de xarxa"
 #: pkg/networkmanager/interfaces.js:826
 msgid "Preparing"
 msgstr "S'està preparant"
-
-#: pkg/ovirt/rephraseUI.js:25
-msgid "Preparing for Maintenance"
-msgstr ""
 
 #: pkg/networkmanager/interfaces.js:3631
 msgid "Preserve"
@@ -6241,11 +4983,6 @@ msgstr "Prioritat $priority"
 msgid "Private"
 msgstr ""
 
-#: pkg/kubernetes/scripts/projects.js:1042
-msgid "Private: Allow only specific users or groups to pull images"
-msgstr ""
-"Privat: permet que només els usuaris o grups específics recuperin imatges"
-
 #: pkg/shell/index.html:39
 msgid "Privileged"
 msgstr ""
@@ -6271,65 +5008,9 @@ msgstr "Procés"
 msgid "Product"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:34
-msgid "Product ID"
-msgstr "Id. del producte"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product name"
-msgstr "Nom del producte"
-
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
-#: pkg/kubernetes/views/details-page.html:35
-#: pkg/kubernetes/views/details-page.html:71
-#: pkg/kubernetes/views/details-page.html:104
-#: pkg/kubernetes/views/details-page.html:138
-#: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/pod-body.html:4
-#: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/route-body.html:4
-#: pkg/kubernetes/views/service-body.html:4
-#: pkg/kubernetes/views/volumes-page.html:58
-msgid "Project"
-msgstr "Projecte"
-
-#: pkg/kubernetes/views/project-body.html:20
-msgid "Project Members"
-msgstr "Membres del projecte"
-
-#: pkg/kubernetes/views/project-body.html:3
-msgid "Project access policy allows anonymous users to pull images."
-msgstr ""
-"La política d'accés de projecte permet que els usuaris anònims recuperin "
-"imatges."
-
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Project access policy allows any authenticated user to pull images."
-msgstr ""
-"La política d'accés públic permet que qualsevol usuari o grup autenticat "
-"recuperi imatges."
-
-#: pkg/kubernetes/views/project-body.html:13
-msgid "Project access policy only allows specific members to access images."
-msgstr ""
-
-#: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
+#: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
 msgstr "Lloc web del projecte"
-
-#: pkg/kubernetes/views/filter-project.html:5
-msgid "Project:"
-msgstr "Projecte:"
-
-#: pkg/kubernetes/index.html:88 pkg/kubernetes/registry.html:55
-#: pkg/kubernetes/views/group-delete.html:10
-#: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
-msgid "Projects"
-msgstr "Projectes"
 
 #: pkg/users/local.js:91
 msgid "Prompting via passwd timed out"
@@ -6353,15 +5034,7 @@ msgstr ""
 msgid "Protocol"
 msgstr "Protocol"
 
-#: pkg/subscriptions/subscriptions-register.jsx:129
-msgid "Proxy"
-msgstr "Servidor intermediari"
-
-#: pkg/kubernetes/views/node-body.html:25
-msgid "Proxy Version"
-msgstr "Versió del servidor intermediari"
-
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Clau pública"
 
@@ -6369,25 +5042,9 @@ msgstr "Clau pública"
 msgid "Public pulling repo"
 msgstr ""
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:152
-msgid "Pull an image:"
-msgstr "Recupera una imatge:"
-
-#: pkg/kubernetes/views/imagestream-modify.html:66
-msgid "Pull from"
-msgstr "Recupera de"
-
-#: pkg/kubernetes/scripts/images.js:635
-msgid "Pull specific tags from another image repository"
-msgstr "Recupera les etiquetes específiques d'un altre dipòsit d'imatges"
-
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Propòsit"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:141
-msgid "Push an image:"
-msgstr ""
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:31
 msgid "QEMU/KVM System connection"
@@ -6397,16 +5054,11 @@ msgstr ""
 msgid "QEMU/KVM User connection"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:148
-#: pkg/kubernetes/views/volume-body.html:77
-msgid "Qualified Name"
-msgstr "Nom qualificat"
-
-#: pkg/storaged/mdraid-details.jsx:186
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 0"
 msgstr "RAID 0"
 
@@ -6414,7 +5066,7 @@ msgstr "RAID 0"
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (segmentació)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 1"
 msgstr "RAID 1"
 
@@ -6422,7 +5074,7 @@ msgstr "RAID 1"
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (rèplica)"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 10"
 msgstr "RAID 10"
 
@@ -6430,7 +5082,7 @@ msgstr "RAID 10"
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (segmentació de rèpliques)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 4"
 msgstr "RAID 4"
 
@@ -6438,7 +5090,7 @@ msgstr "RAID 4"
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (paritat dedicada)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 5"
 msgstr "RAID 5"
 
@@ -6446,7 +5098,7 @@ msgstr "RAID 5"
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (paritat distribuïda)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 6"
 msgstr "RAID 6"
 
@@ -6462,7 +5114,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "Dispositiu RAID"
 
-#: pkg/storaged/mdraid-details.jsx:316 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "Dispositiu RAID $0"
 
@@ -6478,27 +5130,15 @@ msgstr "Nivell RAID"
 msgid "RAID Member"
 msgstr "Membre RAID"
 
-#: pkg/ovirt/provider.js:179
-msgid "REBOOT action failed"
-msgstr "Ha fallat l'acció REBOOT"
-
-#: pkg/ovirt/provider.js:164
-msgid "REBOOT_VM action failed: %s0"
-msgstr ""
-
 #: pkg/lib/machine-info.js:86
 msgid "Rack Mount Chassis"
 msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Dispositiu de blocs rados"
 
 #: pkg/networkmanager/interfaces.js:3632
 msgid "Random"
 msgstr "Aleatòria"
 
-#: pkg/networkmanager/firewall.jsx:757
+#: pkg/networkmanager/firewall.jsx:759
 msgid "Range"
 msgstr ""
 
@@ -6510,42 +5150,15 @@ msgstr ""
 msgid "Raw to a device"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:195
-#: pkg/kubernetes/views/volume-body.html:10
-#: pkg/kubernetes/views/volume-body.html:20
-#: pkg/kubernetes/views/volume-body.html:44
-#: pkg/kubernetes/views/volume-body.html:51
-#: pkg/kubernetes/views/volume-body.html:71
-#: pkg/kubernetes/views/volume-body.html:85
-#: pkg/kubernetes/views/volume-body.html:93
-#: pkg/kubernetes/views/volume-body.html:110
-#: pkg/kubernetes/views/volume-body.html:122
-#: pkg/kubernetes/views/volume-body.html:136
-#: pkg/kubernetes/views/volume-body.html:143
-msgid "Read Only"
-msgstr "Tan sols lectura"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "Lectura i escriptura d'un sol node"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "Lectura i escriptura de diversos nodes"
-
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "Només lectura de diversos nodes"
-
-#: pkg/docker/index.html:363
+#: pkg/docker/index.html:365
 msgid "ReadOnly"
 msgstr "NomésLectura"
 
-#: pkg/docker/index.html:362
+#: pkg/docker/index.html:364
 msgid "ReadWrite"
 msgstr "LecturaEscriptura"
 
@@ -6561,13 +5174,11 @@ msgstr "S'està llegint..."
 msgid "Readonly"
 msgstr "NomésLectura"
 
-#: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
-#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/playground/translate.html:19
 msgid "Ready"
 msgstr "A punt"
 
-#: pkg/playground/translate.html:24 pkg/playground/translate.html:184
+#: pkg/playground/translate.html:24
 msgctxt "verb"
 msgid "Ready"
 msgstr ""
@@ -6588,10 +5199,6 @@ msgstr ""
 msgid "Real host name must be 64 characters or less"
 msgstr "El nom d'amfitrió real pot tenir com a molt 64 caràcters"
 
-#: pkg/kubernetes/views/node-body.html:45
-msgid "Reason"
-msgstr "Motiu"
-
 #: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
 msgid "Reboot"
 msgstr "Rearrencada"
@@ -6606,16 +5213,11 @@ msgstr "Recepció"
 msgid "Recent"
 msgstr "Recent"
 
-#: pkg/kubernetes/views/pv-body.html:6 pkg/kubernetes/views/pv-modify.html:56
-msgid "Reclaim Policy"
-msgstr ""
-
 #: pkg/storaged/format-dialog.jsx:248
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/kubernetes/index.html:108 pkg/kubernetes/registry.html:75
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138 pkg/shell/stub.html:180
+#: pkg/shell/index.html:386 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Torna a connectar"
@@ -6627,10 +5229,6 @@ msgstr "Recuperació"
 #: pkg/storaged/jobs-panel.jsx:65
 msgid "Recovering RAID Device $target"
 msgstr ""
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "Recicla"
 
 #: pkg/docker/storage.jsx:389
 msgid "Reformat and add disks"
@@ -6652,36 +5250,10 @@ msgstr "Es nega a connectar. La clau d'amfitrió no coincideix"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Es nega a connectar. La clau d'amfitrió és desconeguda"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:159
-msgid "Register"
-msgstr "Registra"
-
-#: pkg/kubernetes/views/volumes-page.html:12
-msgid "Register New Volume"
-msgstr "Registra un volum nou"
-
-#: pkg/kubernetes/views/pv-modify.html:4
-msgid "Register Persistent Volume"
-msgstr "Registra un volum persistent"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:108
-msgid "Register oVirt"
-msgstr "Registra l'oVirt"
-
-#: pkg/subscriptions/main.js:73
-msgid "Register system"
-msgstr "Registra el sistema"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:128
-msgid "Registering oVirt to Cockpit"
-msgstr "Registrament d'oVirt a Cockpit"
-
 #: pkg/packagekit/updates.jsx:777
 msgid "Register…"
 msgstr "Registra..."
 
-#: pkg/ovirt/components/App.jsx:62 pkg/ovirt/components/VdsmView.jsx:100
 #: pkg/systemd/init.js:546
 msgid "Reload"
 msgstr "Recarrega"
@@ -6690,7 +5262,7 @@ msgstr "Recarrega"
 msgid "Reload Propagated From"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:202
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
 msgid "Remote URL"
 msgstr "URL remot"
 
@@ -6702,10 +5274,6 @@ msgstr "Remot sobre NFS"
 msgid "Remote over SSH"
 msgstr "Remot sobre SSH"
 
-#: pkg/kubernetes/views/imagestream-modify.html:89
-msgid "Remote registry is insecure"
-msgstr ""
-
 #: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
 msgctxt "storage"
 msgid "Removable Drive"
@@ -6715,13 +5283,9 @@ msgstr "Disc extraïble"
 msgid "Removals:"
 msgstr ""
 
-#: pkg/kubernetes/views/group-delete.html:21
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-delete.html:25
-#: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Suprimeix"
 
@@ -6733,37 +5297,13 @@ msgstr "Suprimeix $0"
 msgid "Remove $0?"
 msgstr ""
 
-#: pkg/kubernetes/views/group-delete.html:3
-msgid "Remove Group"
-msgstr "Suprimeix el grup"
-
-#: pkg/kubernetes/views/user-group-remove.html:3
-msgid "Remove Member"
-msgstr "Suprimeix el membre"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:3
-msgid "Remove Role"
-msgstr "Suprimeix el rol"
-
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove Tang keyserver"
 msgstr ""
 
-#: pkg/kubernetes/views/user-delete.html:3
-msgid "Remove User"
-msgstr "Suprimeix l'usuari"
-
 #: pkg/storaged/vdo-details.jsx:116
 msgid "Remove device"
 msgstr "Treu el dispositiu"
-
-#: pkg/kubernetes/views/image-delete.html:3
-msgid "Remove image tag"
-msgstr "Suprimeix l'etiqueta de la imatge"
-
-#: pkg/kubernetes/views/user-remove-membership.html:3
-msgid "Remove membership"
-msgstr "Suprimeix la pertinença"
 
 #: pkg/storaged/crypto-keyslots.jsx:387
 msgid "Remove passphrase"
@@ -6773,11 +5313,11 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:629
+#: pkg/networkmanager/firewall.jsx:631
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:608
+#: pkg/networkmanager/firewall.jsx:610
 msgid "Remove service from zones"
 msgstr ""
 
@@ -6803,8 +5343,8 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "S'està eliminant el volum físic de $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:187
-#: pkg/storaged/vgroup-details.jsx:235
+#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:234
 msgid "Rename"
 msgstr "Reanomena"
 
@@ -6812,7 +5352,7 @@ msgstr "Reanomena"
 msgid "Rename Logical Volume"
 msgstr "Reanomena el volum lògic"
 
-#: pkg/storaged/vgroup-details.jsx:179
+#: pkg/storaged/vgroup-details.jsx:178
 msgid "Rename Volume Group"
 msgstr "Reanomena un grup de volums"
 
@@ -6849,30 +5389,6 @@ msgstr "Repeteix cada any"
 msgid "Repeat passphrase"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
-#: pkg/kubernetes/views/details-page.html:141
-#: pkg/kubernetes/views/replicationcontroller-body.html:9
-#: pkg/kubernetes/views/replicationcontroller-modify.html:8
-msgid "Replicas"
-msgstr "Rèpliques"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/replicationcontroller-panel.html:10
-#: pkg/kubernetes/views/topology-page.html:22
-msgid "Replication Controller"
-msgstr "Controlador de replicació"
-
-#: pkg/kubernetes/views/details-page.html:132
-#: pkg/kubernetes/scripts/details.js:224
-msgid "Replication Controllers"
-msgstr "Controladors de replicació"
-
-#: pkg/kubernetes/views/topology-page.html:23
-msgid ""
-"Replication controllers dynamically create instances of pods from templates, "
-"and remove pods when necessary."
-msgstr ""
-
 #: pkg/systemd/logs.js:512
 msgid "Report"
 msgstr ""
@@ -6889,28 +5405,16 @@ msgstr ""
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr ""
 
-#: pkg/docker/index.html:688
+#: pkg/docker/index.html:690
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Dipòsit"
 
-#: pkg/kubernetes/views/volume-body.html:24
-msgid "Repository URL"
-msgstr "URl del dipòsit"
-
-#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
-msgid "Requested"
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html:13
-msgid "Requests"
-msgstr "Peticions"
-
-#: pkg/users/local.js:1296
+#: pkg/users/local.js:1300
 msgid "Require password change every $0 days"
 msgstr "Requereix el canvi de la contrasenya cada $0 dies"
 
-#: pkg/users/local.js:872
+#: pkg/users/local.js:876
 msgid "Require password change on $0"
 msgstr "Requereix el canvi de la contrasenya el $0"
 
@@ -6921,10 +5425,6 @@ msgstr ""
 #: pkg/systemd/init.js:717
 msgid "Requires"
 msgstr ""
-
-#: pkg/kubernetes/views/auth-form.html:54
-msgid "Requires Authentication"
-msgstr "Requereix autenticació"
 
 #: pkg/systemd/init.js:718
 msgid "Requisite"
@@ -6938,7 +5438,7 @@ msgstr ""
 msgid "Reserved memory"
 msgstr "Memòria reservada"
 
-#: pkg/docker/index.html:301 pkg/users/index.html:333
+#: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:105
 msgid "Reset"
 msgstr "Restableix"
@@ -6964,26 +5464,22 @@ msgid ""
 "a current disk passphrase."
 msgstr ""
 
-#: pkg/docker/index.html:135 pkg/systemd/index.html:134
+#: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Reinicia"
-
-#: pkg/kubernetes/views/container-body.html:20
-msgid "Restart Count"
-msgstr "Reinicia el compte"
 
 #: pkg/packagekit/updates.jsx:498
 msgid "Restart Now"
 msgstr "Reinicia ara"
 
-#: pkg/docker/index.html:537 pkg/kubernetes/views/pod-body.html:10
+#: pkg/docker/index.html:539
 msgid "Restart Policy"
 msgstr "Reinicia la política"
 
-#: pkg/docker/index.html:171
+#: pkg/docker/index.html:172
 msgid "Restart Policy:"
 msgstr "Reinicia la política:"
 
@@ -7003,52 +5499,27 @@ msgstr "S'està restaurant la connexió"
 msgid "Resume"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr ""
-
-#: pkg/docker/index.html:553
+#: pkg/docker/index.html:555
 msgid "Retries:"
 msgstr "Intents:"
-
-#: pkg/subscriptions/subscriptions-view.jsx:210
-msgid "Retrieving subscription status..."
-msgstr "S'està recuperant l'estat de la subscripció..."
 
 #: src/ws/login.html:57
 msgid "Reuse my password for privileged tasks"
 msgstr "Reutilitza la meva contrasenya per a les tasques privilegiades"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Reutilitza la meva contrasenya per a les tasques privilegiades i per "
 "connectar a altres màquines"
 
-#: pkg/kubernetes/views/volume-body.html:26
-msgid "Revision"
-msgstr "Revisió"
-
-#: pkg/kubernetes/views/user-add-membership.html:28
-#: pkg/kubernetes/views/user-body.html:5
-#: pkg/kubernetes/views/user-panel.html:28
-msgid "Role"
-msgstr "Rol"
-
-#: pkg/kubernetes/views/add-member-role-dialog.html:39
-#: pkg/kubernetes/views/project-body.html:21 pkg/users/index.html:94
+#: pkg/users/index.html:94
 msgid "Roles"
 msgstr "Rols"
 
 #: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
 msgid "Round Robin"
 msgstr "Round Robin"
-
-#: pkg/kubernetes/views/route-page.html:14
-#: pkg/kubernetes/views/route-panel.html:9
-msgid "Route"
-msgstr ""
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:98
 msgid "Route to $0"
@@ -7058,22 +5529,16 @@ msgstr ""
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:65
-#: pkg/kubernetes/scripts/details.js:216 pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3325
 msgid "Routes"
 msgstr "Encaminaments"
 
-#: pkg/docker/index.html:244 pkg/docker/index.html:564
+#: pkg/docker/index.html:253 pkg/docker/index.html:566
 #: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
-#: pkg/ovirt/components/ClusterVms.jsx:92
 msgid "Run"
 msgstr "Executa"
 
-#: pkg/ovirt/components/ClusterVms.jsx:97
-msgid "Run Here"
-msgstr "Executa-ho aquí"
-
-#: pkg/docker/index.html:425
+#: pkg/docker/index.html:427
 msgid "Run Image"
 msgstr "Executa la imatge"
 
@@ -7082,7 +5547,7 @@ msgid "Run as"
 msgstr "Executa com"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:128
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
 msgstr ""
 
@@ -7090,17 +5555,13 @@ msgstr ""
 msgid "Runner"
 msgstr "Runner"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Running"
 msgstr "En execució"
 
 #: pkg/systemd/services.html:123
 msgid "Running Since"
 msgstr ""
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:54
-msgid "Running Since:"
-msgstr "En execució des de:"
 
 #: pkg/selinux/setroubleshoot-view.jsx:364
 msgid "SELinux Access Control Errors"
@@ -7126,14 +5587,6 @@ msgstr "SELinux no està inhabilitat al sistema."
 msgid "SELinux system status is unknown."
 msgstr "Es desconeix l'estat del sistema SELinux."
 
-#: pkg/ovirt/provider.js:440
-msgid "SET VCPU SETTINGS action failed"
-msgstr ""
-
-#: pkg/ovirt/provider.js:111 pkg/ovirt/provider.js:145
-msgid "SHUTDOWN action failed"
-msgstr "Ha fallat l'acció SHUTDOWN"
-
 #: pkg/storaged/jobs-panel.jsx:35
 msgid "SMART self-test of $target"
 msgstr "Autotest SMART de $target."
@@ -7154,14 +5607,6 @@ msgstr "Port SPICE:"
 msgid "SPICE TLS Port:"
 msgstr "Port TLS SPICE:"
 
-#: pkg/ovirt/provider.js:225
-msgid "START action failed"
-msgstr "Ha fallat l'acció START"
-
-#: pkg/ovirt/provider.js:203
-msgid "START_VM action failed: %s0"
-msgstr ""
-
 #: pkg/networkmanager/index.html:228
 msgid "STP Forward delay"
 msgstr "Retard del reenviament STP"
@@ -7178,10 +5623,6 @@ msgstr "Envelliment màxim del missatge STP"
 msgid "STP Priority"
 msgstr "Prioritat STP"
 
-#: pkg/ovirt/provider.js:303
-msgid "SUSPEND action failed"
-msgstr "Ha fallat l'acció SUSPEND"
-
 #: pkg/systemd/services.html:240
 msgid "Saturday"
 msgstr "Dissabte"
@@ -7190,10 +5631,10 @@ msgstr "Dissabte"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/ovirt/components/VdsmView.jsx:114 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
 #: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Desa"
@@ -7216,14 +5657,6 @@ msgid ""
 "current disk passphrase."
 msgstr ""
 
-#: pkg/kubernetes/views/node-capacity.html:9
-msgid "Scheduled Pods"
-msgstr ""
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "Planificació inhabilitada"
-
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
 msgstr ""
@@ -7232,24 +5665,6 @@ msgstr ""
 #: pkg/systemd/init.js:1076
 msgid "Seconds"
 msgstr "segons"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Secret"
-
-#: pkg/kubernetes/views/volume-body.html:106
-msgid "Secret File"
-msgstr "Fitxer secret"
-
-#: pkg/kubernetes/views/volume-body.html:141
-msgid "Secret Name"
-msgstr "Nom secret"
-
-#: pkg/kubernetes/views/volume-body.html:69
-#: pkg/kubernetes/views/volume-body.html:108
-#: pkg/kubernetes/views/volume-body.html:134
-msgid "Secret Volume"
-msgstr "Volum secret"
 
 #: pkg/systemd/index.html:106
 msgid "Secure Shell Keys"
@@ -7267,33 +5682,14 @@ msgstr "Seguretat"
 msgid "Security Updates Available"
 msgstr ""
 
-#: pkg/shell/index.html:123 pkg/shell/simple.html:91 pkg/shell/stub.html:106
+#: pkg/shell/index.html:123 pkg/shell/simple.html:91
 msgid "Select"
 msgstr "Selecciona"
 
-#: pkg/kubernetes/views/file-button.html:4
-msgid "Select Manifest File..."
-msgstr "Selecciona el fitxer del manifest..."
-
-#: pkg/kubernetes/scripts/projects.js:899
-#: pkg/kubernetes/scripts/projects.js:1205
-#: pkg/kubernetes/scripts/projects.js:1335
-msgid "Select Member"
-msgstr ""
-
-#: pkg/kubernetes/scripts/projects.js:901
-#: pkg/kubernetes/scripts/projects.js:1208
-msgid "Select Role"
-msgstr ""
-
-#: pkg/kubernetes/views/topology-page.html:7
-msgid "Select an object to see more details."
-msgstr "Seleccioneu un objecte per veure'n més detalls. "
-
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 "Seleccioneu els usuaris que vulgueu que estiguin sincronitzats amb "
 "{{#strong}}{{host}}{{/strong}}"
@@ -7316,11 +5712,8 @@ msgstr "Enviament"
 msgid "Serial Console"
 msgstr "Consola sèrie"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:116 pkg/storaged/nfs-details.jsx:315
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:65
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Servidor"
 
@@ -7328,7 +5721,7 @@ msgstr "Servidor"
 msgid "Server Address"
 msgstr "Adreça del servidor"
 
-#: pkg/users/local.js:746 pkg/users/local.js:747
+#: pkg/users/local.js:750 pkg/users/local.js:751
 msgid "Server Administrator"
 msgstr "Administrador del servidor"
 
@@ -7352,16 +5745,10 @@ msgstr "El servidor ha tancat la connexió."
 msgid "Servers"
 msgstr "Servidors"
 
-#: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/service-panel.html:8
-#: pkg/kubernetes/views/topology-page.html:30 pkg/systemd/logs.html:66
-#: pkg/networkmanager/firewall.jsx:936 pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Servei"
-
-#: pkg/kubernetes/views/pod-body.html:12
-msgid "Service Account"
-msgstr "Compte del servei"
 
 #: pkg/systemd/services.html:337
 msgid "Service Logs"
@@ -7391,26 +5778,14 @@ msgstr "El servei s'està aturant"
 msgid "Service name"
 msgstr "Nom del servei"
 
-#: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
-#: pkg/systemd/services.html:330 pkg/kubernetes/scripts/details.js:213
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
 #: pkg/networkmanager/firewall.jsx:483
 msgid "Services"
 msgstr "Serveis"
 
-#: pkg/kubernetes/views/topology-page.html:31
-msgid ""
-"Services group pods and provide a common DNS name and an optional, load-"
-"balanced IP address to access them."
-msgstr ""
-
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sessió"
-
-#: pkg/kubernetes/views/service-body.html:20
-msgid "Session Affinity"
-msgstr ""
 
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
@@ -7428,7 +5803,7 @@ msgstr "Estableix la contrasenya"
 msgid "Set Time"
 msgstr "Ajusta l'hora"
 
-#: pkg/docker/index.html:530
+#: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Estableix les variables d'entorn del contenidor"
 
@@ -7461,28 +5836,15 @@ msgstr "Gravetat"
 msgid "Severity:"
 msgstr "Gravetat:"
 
-#: pkg/kubernetes/views/volume-body.html:139
-msgid "Share Name"
-msgstr "Nom de compartició"
-
 #: pkg/networkmanager/interfaces.js:1959
 msgid "Shared"
 msgstr "Compartida"
-
-#: pkg/kubernetes/scripts/projects.js:1043
-msgid "Shared: Allow any authenticated user to pull images"
-msgstr "Compartit: permet que qualsevol usuari autenticat recuperi imatges"
-
-#: pkg/kubernetes/views/container-page-inline.html:14
-#: pkg/kubernetes/views/container-panel.html:9
-msgid "Shell"
-msgstr "Shell"
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Show Performance Options"
 msgstr ""
 
@@ -7490,61 +5852,15 @@ msgstr ""
 msgid "Show all"
 msgstr ""
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:122
 msgid "Show all $0 drives"
 msgstr ""
-
-#: pkg/kubernetes/views/container-page.html:4
-msgid "Show all Containers"
-msgstr "Mostra tots els contenidors"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:8
-msgid "Show all Deployment Configs"
-msgstr "Mostra totes les configuracions de desplegament"
-
-#: pkg/kubernetes/views/node-page.html:8
-msgid "Show all Nodes"
-msgstr "Mostra tots els nodes"
-
-#: pkg/kubernetes/views/pv-page.html:9
-msgid "Show all Persistent Volumes"
-msgstr "Mostra tots els volums persistents"
-
-#: pkg/kubernetes/views/pod-container.html:4
-msgid "Show all Pod Containers"
-msgstr ""
-
-#: pkg/kubernetes/views/pod-page.html:8
-msgid "Show all Pods"
-msgstr "Mostra tots els pods"
-
-#: pkg/kubernetes/views/group-page.html:14
-#: pkg/kubernetes/views/project-page.html:23
-#: pkg/kubernetes/views/user-page.html:16
-msgid "Show all Projects"
-msgstr "Mostra tots els projectes"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:10
-msgid "Show all Replication Controllers"
-msgstr "Mostra tots els controladors de replicació"
-
-#: pkg/kubernetes/views/route-page.html:10
-msgid "Show all Routes"
-msgstr "Mostra tots els encaminaments"
-
-#: pkg/kubernetes/views/service-page.html:8
-msgid "Show all Services"
-msgstr "Mostra tots els serveis"
 
 #: pkg/docker/index.html:128
 msgid "Show all containers"
 msgstr "Mostra tots els contenidors"
 
-#: pkg/kubernetes/views/imagestream-page.html:12
-msgid "Show all image streams"
-msgstr "Mostra tots els fluxos d'imatges"
-
-#: pkg/docker/index.html:254 pkg/kubernetes/views/image-page.html:10
+#: pkg/docker/index.html:249
 msgid "Show all images"
 msgstr "Mostra totes les imatges"
 
@@ -7569,21 +5885,16 @@ msgstr ""
 msgid "Shut Down"
 msgstr "Apaga"
 
-#: pkg/kubernetes/views/container-body.html:18
-msgid "Since"
-msgstr "Des de"
-
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:376
-#: pkg/machines/components/diskAdd.jsx:143
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Mida"
 
@@ -7607,11 +5918,6 @@ msgstr "La mida ha de ser un número"
 msgid "Size must be at least $0"
 msgstr "La mida com a mínim ha de ser $0"
 
-#: pkg/kubernetes/views/auth-form.html:43
-#: pkg/kubernetes/views/auth-rejected-cert.html:11
-msgid "Skip Certificate Verification"
-msgstr "Omet la verificació del certificat"
-
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Slot"
 msgstr "Ranura"
@@ -7621,7 +5927,6 @@ msgid "Slot $0"
 msgstr ""
 
 #: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Sockets"
 msgstr "Sockets"
 
@@ -7662,18 +5967,14 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:914
-msgid "Sorry, I don't know how to modify this volume"
-msgstr ""
-
-#: pkg/networkmanager/firewall.jsx:707
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:476
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:103
+#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Origen"
 
@@ -7681,10 +5982,10 @@ msgstr "Origen"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:217
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:244
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr ""
 
@@ -7692,12 +5993,12 @@ msgstr ""
 msgid "Source URL"
 msgstr "URL d'origen"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:254
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
 msgid "Source path should not be empty"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:108
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr ""
 
@@ -7725,9 +6026,9 @@ msgstr "Instant concret"
 msgid "Stable"
 msgstr "Estable"
 
-#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:320 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Inicia"
 
@@ -7747,7 +6048,7 @@ msgstr ""
 msgid "Start libvirt"
 msgstr "Inicia libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:291
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
 msgid "Start pool when host boots"
 msgstr ""
 
@@ -7759,59 +6060,29 @@ msgstr "S'està iniciant el dispositiu RAID $target"
 msgid "Starting swapspace $target"
 msgstr "S'està iniciant l'espai d'intercanvi $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Starts"
-msgstr "Comença"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
 msgid "Startup"
 msgstr ""
 
-#: pkg/kubernetes/views/container-body.html:16
-#: pkg/kubernetes/views/details-page.html:38
-#: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:127 pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/init.js:285
 msgid "State"
 msgstr "Estat"
 
-#: pkg/docker/index.html:167
+#: pkg/docker/index.html:168
 msgid "State:"
 msgstr "Estat:"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "Stateless"
-msgstr ""
-
-#: pkg/ovirt/components/OVirtTab.jsx:156
-msgid "Stateless:"
-msgstr ""
 
 #: pkg/systemd/services.html:74 pkg/systemd/init.js:207
 msgid "Static"
 msgstr "Estàtic"
 
-#: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/volumes-page.html:21 pkg/systemd/services.html:121
-#: pkg/networkmanager/interfaces.js:2613
-#: pkg/subscriptions/subscriptions-view.jsx:37
+#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
 msgid "Status"
 msgstr "Estat"
-
-#: pkg/subscriptions/subscriptions-view.jsx:162
-msgid "Status: $0"
-msgstr "Estat: $0"
-
-#: pkg/subscriptions/subscriptions-view.jsx:157
-msgid "Status: System isn't registered"
-msgstr "Estat: el sistema no està registrat"
 
 #: pkg/lib/machine-info.js:99
 msgid "Stick PC"
@@ -7821,14 +6092,14 @@ msgstr ""
 msgid "Sticky"
 msgstr ""
 
-#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Atura"
 
-#: pkg/storaged/mdraid-details.jsx:248
+#: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Atura el dispositiu"
 
@@ -7860,8 +6131,8 @@ msgstr "S'està aturant el dispositiu RAID $target"
 msgid "Stopping swapspace $target"
 msgstr "S'està aturant l'espai d'intercanvi $target"
 
-#: pkg/docker/index.html:288 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
+#: pkg/docker/index.html:290 pkg/storaged/index.html:23
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
 #: pkg/storaged/details.jsx:127
 msgid "Storage"
 msgstr "Emmagatzematge"
@@ -7870,11 +6141,11 @@ msgstr "Emmagatzematge"
 msgid "Storage Logs"
 msgstr "Registres de l'emmagatzematge"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:137
+#: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePool.jsx:149
+#: pkg/machines/components/storagePools/storagePool.jsx:153
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
@@ -7882,7 +6153,7 @@ msgstr ""
 msgid "Storage Pool Name"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:437
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
 msgid "Storage Pool failed to be created"
 msgstr ""
 
@@ -7903,7 +6174,7 @@ msgstr ""
 msgid "Storage can not be managed on this system."
 msgstr ""
 
-#: pkg/docker/index.html:302
+#: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Agrupació d'emmagatzematge"
 
@@ -7923,10 +6194,6 @@ msgstr "Contrasenya emmagatzemada"
 msgid "Stored passphrase"
 msgstr "Contrasenya emmagatzemada"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:12
-msgid "Strategy"
-msgstr "Estratègia"
-
 #: pkg/lib/machine-info.js:82
 msgid "Sub Chassis"
 msgstr ""
@@ -7934,10 +6201,6 @@ msgstr ""
 #: pkg/lib/machine-info.js:77
 msgid "Sub Notebook"
 msgstr ""
-
-#: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:177
-msgid "Subscriptions"
-msgstr "Subscripcions"
 
 #: node_modules/registry-image-widgets/views/image-body.html:4
 msgid "Summary"
@@ -7955,10 +6218,6 @@ msgstr ""
 msgid "Support is installed."
 msgstr ""
 
-#: pkg/ovirt/components/VmActions.jsx:40
-msgid "Suspend"
-msgstr "Suspèn"
-
 #: pkg/storaged/content-views.jsx:157
 msgid "Swap"
 msgstr "Intercanvi"
@@ -7972,10 +6231,6 @@ msgstr "Espai d'intercanvi"
 msgid "Swap Used"
 msgstr "Intercanvi utilitzat"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:40
-msgid "Switch Host to Maintenance"
-msgstr "Canvia l'amfitrió a manteniment"
-
 #: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
 msgid "Switch off $0"
 msgstr "Apaga $0"
@@ -7983,14 +6238,6 @@ msgstr "Apaga $0"
 #: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
 msgid "Switch on $0"
 msgstr "Engega $0"
-
-#: pkg/ovirt/provider.js:414
-msgid "Switching host to maintenance mode failed. Received error: "
-msgstr "Ha fallat el canvi de l'amfitrió a manteniment. Error rebut: "
-
-#: pkg/ovirt/provider.js:408
-msgid "Switching host to maintenance mode in progress ..."
-msgstr "Canvi de l'amfitrió a manteniment en progrés..."
 
 #: pkg/networkmanager/interfaces.js:2491
 msgid ""
@@ -8008,10 +6255,6 @@ msgstr ""
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
-msgstr ""
-
-#: pkg/kubernetes/scripts/images.js:634
-msgid "Sync all tags from a remote image repository"
 msgstr ""
 
 #: pkg/lib/machine-sync-users.html:75
@@ -8063,25 +6306,20 @@ msgstr "El sistema està actualitzat"
 msgid "System is up to date"
 msgstr "El sistema està al dia"
 
-#: pkg/docker/index.html:327 pkg/docker/index.html:331
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:329 pkg/docker/index.html:333
+#: pkg/networkmanager/firewall.jsx:938
 msgid "TCP"
 msgstr "TCP"
-
-#: pkg/kubernetes/views/route-body.html:12
-msgid "TLS Termination"
-msgstr "Finalització TLS"
 
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
 msgstr "Tauleta"
 
-#: pkg/docker/index.html:694
+#: pkg/docker/index.html:696
 #: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Etiqueta"
 
-#: pkg/kubernetes/views/imagestream-modify.html:76
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
@@ -8093,25 +6331,16 @@ msgstr "Etiquetes"
 msgid "Tang keyserver"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:137
 #: pkg/machines/components/vm/bootOrderModal.jsx:133
 msgid "Target"
 msgstr "Objectiu"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr ""
 
-#: pkg/kubernetes/views/volume-body.html:75
-msgid "Target Portal"
-msgstr ""
-
-#: pkg/kubernetes/views/volume-body.html:114
-msgid "Target World Wide Names"
-msgstr ""
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:133
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
 msgid "Target path should not be empty"
 msgstr ""
 
@@ -8135,22 +6364,6 @@ msgstr "Ajusts del port de l'equip"
 #: pkg/networkmanager/index.html:514
 msgid "Team Settings"
 msgstr "Ajusts de l'equip"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:15
-#: pkg/kubernetes/views/deploymentconfig-panel.html:10
-#: pkg/kubernetes/views/replicationcontroller-page.html:20
-#: pkg/kubernetes/views/replicationcontroller-panel.html:14
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "Template"
-msgstr "Plantilla"
-
-#: pkg/ovirt/components/App.jsx:111
-msgid "Templates"
-msgstr "Plantilles"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:130
-msgid "Templates of $0 cluster"
-msgstr "Plantilles de clúster $0"
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
@@ -8184,11 +6397,11 @@ msgstr ""
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "L'adreça IP o el nom d'amfitrió no poden contenir espais en blanc."
 
-#: pkg/storaged/mdraid-details.jsx:219
+#: pkg/storaged/mdraid-details.jsx:218
 msgid "The RAID Array is in a degraded state"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:149
+#: pkg/storaged/mdraid-details.jsx:148
 msgid "The RAID device must be running in order to add spare disks."
 msgstr ""
 
@@ -8237,20 +6450,16 @@ msgstr "La MV està en execució."
 msgid "The VM is suspended by guest power management."
 msgstr "La MV està en suspensió per la gestió d'energia del convidat."
 
-#: pkg/users/local.js:1338
+#: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
 msgstr ""
 "El compte '$0' es veurà forçat a canviar de contrasenya el pròxim com que "
 "iniciï la sessió."
 
-#: pkg/kubernetes/scripts/nodes.js:403
-msgid "The address contains invalid characters"
-msgstr "L'adreça conté caràcters no vàlids"
-
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -8261,10 +6470,6 @@ msgstr "La informació recopilada s'emmagatzemarà localment al sistema."
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 
-#: pkg/kubernetes/views/container-page-inline.html:22
-msgid "The container '{{ target }}' does not exist."
-msgstr "El contenidor '{{ target }}' no existeix."
-
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
@@ -8272,20 +6477,12 @@ msgstr ""
 "No s'ha finalitzat la creació d'aquest dispositiu VDO i no es pot utilitzar "
 "aquest dispositiu."
 
-#: pkg/subscriptions/subscriptions-view.jsx:214
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-page.html:25
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "La configuració del desplegament '{{ target }}' no existeix."
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:204
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
 msgid "The directory on the server being exported"
 msgstr ""
 
@@ -8296,8 +6493,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1016
@@ -8306,8 +6502,7 @@ msgid ""
 msgstr ""
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/sosreport/index.html:51
@@ -8318,10 +6513,6 @@ msgid ""
 msgstr ""
 "L'arxiu generat conté dades considerades com a sensibles i el seu contingut "
 "s'ha de revisar abans de passar-ho a un tercer."
-
-#: pkg/kubernetes/views/group-page.html:47
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "El grup '{{ groupName }}' no existeix."
 
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
@@ -8346,31 +6537,15 @@ msgstr ""
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "No es pot treure l'últim volum físic d'un grup de volums."
 
-#: pkg/shell/indexes.js:408
+#: pkg/shell/indexes.js:407
 msgid "The machine is restarting"
 msgstr "La màquina s'està reiniciant"
 
-#: pkg/kubernetes/scripts/details.js:498 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "El nombre màxim de rèpliques és 128"
+#: pkg/machines/components/networks/networkDelete.jsx:76
+msgid "The network could not be deleted"
+msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:411
-msgid "The name contains invalid characters"
-msgstr "El nom conté caràcters no vàlids"
-
-#: pkg/kubernetes/views/node-page.html:23
-msgid "The node '{{ target }}' does not exist."
-msgstr "El node '{{ target }}' no existeix."
-
-#: pkg/kubernetes/views/node-alerts.html:7
-msgid "The node doesn't have enough disk space"
-msgstr "El node no té prou espai lliure al disc"
-
-#: pkg/kubernetes/views/node-alerts.html:11
-msgid "The node doesn't have enough free memory"
-msgstr "El node no té prou memòria lliure al disc"
-
-#: pkg/users/local.js:439 pkg/users/local.js:1395
+#: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
 msgstr "Les contrasenyes no coincideixen"
 
@@ -8378,29 +6553,9 @@ msgstr "Les contrasenyes no coincideixen"
 msgid "The passwords do not match."
 msgstr "Les contrasenyes no coincideixen."
 
-#: pkg/kubernetes/views/pv-page.html:21
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "El volum persistent '{{ target }}' no existeix."
-
-#: pkg/kubernetes/views/pod-page.html:40
-msgid "The pod '{{ target }}' does not exist."
-msgstr "El pod '{{ target }}' no existeix."
-
 #: pkg/machines/components/diskAdd.jsx:80
 msgid "The pool is empty"
 msgstr ""
-
-#: pkg/kubernetes/views/project-page.html:34
-msgid "The project '{{ projName }}' does not exist."
-msgstr "El projecte '{{ projName }}' no existeix."
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:30
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "El controlador de replicació '{{ target }}' no existeix."
-
-#: pkg/kubernetes/views/route-page.html:19
-msgid "The route '{{ target }}' does not exist."
-msgstr "L'encaminament '{{ target }}' no existeix."
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
@@ -8409,10 +6564,6 @@ msgstr ""
 #: pkg/docker/containers-view.jsx:432
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "El fitxer seleccionat no és un manifest d'aplicació Kubernetes vàlid."
 
 #: src/ws/login.js:645
 msgid ""
@@ -8426,22 +6577,9 @@ msgstr ""
 "El servidor ha refusat l'autenticació mitjançant qualsevol dels mètodes "
 "compatibles."
 
-#: pkg/kubernetes/views/auth-rejected-cert.html:2
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-"El servidor utilitza un certificat signat per una autoritat desconeguda."
-
-#: pkg/kubernetes/views/service-page.html:19
-msgid "The service '{{ target }}' does not exist."
-msgstr "El servei '{{ target }}' no existeix."
-
 #: pkg/systemd/hwinfo.jsx:65
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
-
-#: pkg/kubernetes/views/user-page.html:29
-msgid "The user '{{ userName }}' does not exist."
-msgstr "L'usuari '{{ userName }}' no existeix."
 
 #: pkg/systemd/init.js:922
 msgid "The user <b>$0</b> does not have permissions for creating timers"
@@ -8479,7 +6617,7 @@ msgstr "A l'usuari <b>$0</b> no se li permet modificar els noms d'amfitrions"
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "A l'usuari <b>$0</b> no se li permet modificar els ajusts de xarxa"
 
-#: pkg/realmd/operation.js:643
+#: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "A l'usuari <b>$0</b> no se li permet modificar els reialmes"
 
@@ -8492,7 +6630,7 @@ msgstr ""
 msgid "The user <b>$0</b> is not permitted to start or stop services"
 msgstr ""
 
-#: pkg/users/local.js:549
+#: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
@@ -8502,8 +6640,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "La configuració del navegador web impedeix que s'executi Cockpit "
 "(inaccessible $0)"
@@ -8542,11 +6679,6 @@ msgstr ""
 
 #: pkg/storaged/vdo-details.jsx:133
 msgid "This VDO device does not use all of its backing device."
-msgstr ""
-
-#: pkg/kubernetes/views/pvc-delete.html:8
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
 msgstr ""
 
 #: pkg/systemd/init.js:1371
@@ -8599,12 +6731,6 @@ msgstr "Aquest disc no es pot treure quan s'està recuperant el dispositiu."
 msgid "This field cannot be empty."
 msgstr "Aquest camp no pot estar en blanc."
 
-#: pkg/ovirt/components/App.jsx:155
-msgid ""
-"This host is managed by a virtualization manager, so creation of new VMs "
-"from the host is not possible."
-msgstr ""
-
 #: pkg/docker/containers-view.jsx:494
 msgid "This image does not exist."
 msgstr "No existeix aquesta image."
@@ -8620,14 +6746,6 @@ msgstr "La màquina ja ha estat afegida."
 #: pkg/realmd/operation.html:80
 msgid "This may take a while"
 msgstr "Això pot trigar una estona"
-
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-"Aquesta opció només és per a proves de node únic: l'emmagatzematge local no "
-"funcionarà en un clúster de diversos nodes"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
@@ -8666,7 +6784,7 @@ msgstr "Aquesta unitat és una instància de la plantilla $0."
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Aquesta unitat no està dissenyada per estar explícitament activada."
 
-#: pkg/users/local.js:557
+#: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "Aquest nom d'usuari ja existeix"
 
@@ -8678,22 +6796,7 @@ msgstr ""
 "Aquesta versió de cockpit-ws no és compatible amb la connexió a un amfitrió "
 "amb un usuari o port alternatius"
 
-#: pkg/ovirt/components/OVirtTab.jsx:134
-msgid "This virtual machine is not managed by oVirt"
-msgstr "Aquesta màquina virtual no està gestionada per oVirt"
-
-#: pkg/kubernetes/views/pv-delete.html:7
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
-msgstr ""
-
-#: pkg/kubernetes/views/pv-claim.html:23
-msgid "This volume has not been claimed"
-msgstr "Aquest volum no ha estat reclamat"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:369
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
 msgid "This volume is already used by another VM."
 msgstr ""
 
@@ -8724,7 +6827,6 @@ msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Això provarà la configuració de kdump en fer estavellar el kernel."
 
 #: pkg/machines/components/vcpuModal.jsx:212
-#: pkg/ovirt/components/vcpuModal.jsx:70
 msgid "Threads per core"
 msgstr ""
 
@@ -8778,10 +6880,6 @@ msgstr ""
 "Per provar un port diferent, haureu d'actualitzar cockpit-ws a una versió "
 "més recent."
 
-#: pkg/kubernetes/views/auth-form.html:116
-msgid "Token"
-msgstr "Testimoni"
-
 #: pkg/lib/cockpit-components-file-autocomplete.jsx:148
 msgid "Too many files found"
 msgstr "S'han trobat massa fitxers"
@@ -8789,10 +6887,6 @@ msgstr "S'han trobat massa fitxers"
 #: src/base1/cockpit.js:4039
 msgid "Too much data"
 msgstr "Hi ha massa dades"
-
-#: pkg/kubernetes/index.html:61
-msgid "Topology"
-msgstr "Topologia"
 
 #: pkg/docker/storage.jsx:341
 msgid "Total"
@@ -8810,12 +6904,11 @@ msgstr "Torre"
 msgid "Triggered By"
 msgstr ""
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:32 pkg/systemd/init.js:732
+#: pkg/systemd/init.js:732
 msgid "Triggers"
 msgstr "Disparadors"
 
-#: pkg/kubernetes/index.html:109 pkg/shell/index.html:387
-#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/shell/index.html:387 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Soluciona el problema"
@@ -8824,13 +6917,9 @@ msgstr "Soluciona el problema"
 msgid "Trust key"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:703
+#: pkg/networkmanager/firewall.jsx:705
 msgid "Trust level"
 msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:21
-msgid "Trust this certificate for this connection"
-msgstr "Confia en aquest certificat per a aquesta connexió"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -8872,20 +6961,17 @@ msgstr "Tuned no s'està executant"
 msgid "Tuned is off"
 msgstr "Tuned no està aturat"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:84
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Tipus"
 
@@ -8901,16 +6987,11 @@ msgstr "Teclegeu una contrasenya"
 msgid "Type to filter…"
 msgstr "Teclegeu per filtrar..."
 
-#: pkg/kubernetes/views/details-page.html:7
-msgid "Type:"
-msgstr "Tipus:"
-
-#: pkg/docker/index.html:332 pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
-#: pkg/subscriptions/subscriptions-register.jsx:112
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
 msgid "URL"
 msgstr "URL"
 
@@ -8926,17 +7007,9 @@ msgstr "No es poden aplicar els ajusts: $0"
 msgid "Unable to apply this solution automatically"
 msgstr "No es pot aplicar automàticament aquesta solució"
 
-#: pkg/subscriptions/subscriptions-view.jsx:217
-msgid "Unable to connect"
-msgstr "No es pot connectar"
-
 #: src/ws/login.js:649
 msgid "Unable to connect to that address"
 msgstr "No es pot connectar a aquesta adreça"
-
-#: pkg/kubernetes/scripts/dashboard.js:412
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "No es pot descodificar el manifest d'aplicació de Kubernetes."
 
 #: pkg/users/local.js:58
 msgid "Unable to delete root account"
@@ -8954,10 +7027,6 @@ msgstr "No es pot obtenir l'alerta: $0"
 #: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "No es pot arribar al servidor"
-
-#: pkg/kubernetes/scripts/dashboard.js:400
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "No es pot llegir el fitxer del manifest del Kubernetes. Codi $0."
 
 #: pkg/storaged/nfs-details.jsx:282
 msgid "Unable to remove mount"
@@ -8984,16 +7053,15 @@ msgid "Unable to unmount filesystem"
 msgstr "No es pot desmuntar el sistema de fitxers"
 
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
-#: pkg/kubernetes/scripts/charts.js:110
 msgid "Unavailable"
 msgstr "No disponible"
 
-#: pkg/docker/index.html:730 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1481
+#: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
+#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Error inesperat"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:132
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid "Unique name"
 msgstr ""
 
@@ -9002,19 +7070,14 @@ msgstr ""
 msgid "Unit"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
-#: pkg/kubernetes/views/volumes-page.html:35
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:754 pkg/kubernetes/scripts/volumes.js:267
-#: pkg/lib/machine-info.js:65 pkg/networkmanager/interfaces.js:596
-#: pkg/networkmanager/interfaces.js:1067 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2534 pkg/storaged/fsys-tab.jsx:64
-#: pkg/storaged/swap-tab.jsx:57
+#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
+#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Desconegut"
 
@@ -9050,7 +7113,7 @@ msgstr ""
 msgid "Unknown type"
 msgstr ""
 
-#: pkg/docker/index.html:549 pkg/docker/util.js:110
+#: pkg/docker/index.html:551 pkg/docker/util.js:110
 msgid "Unless Stopped"
 msgstr "A menys que s'aturi"
 
@@ -9099,7 +7162,7 @@ msgstr "S'està desmuntat $target"
 msgid "Unnamed"
 msgstr "Sense nom"
 
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Unplug"
 msgstr ""
 
@@ -9115,14 +7178,6 @@ msgstr "Dades no reconegudes"
 #: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
 msgid "Unrecognized data can not be made smaller here."
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-view.jsx:164
-msgid "Unregister"
-msgstr "Desregistra"
-
-#: pkg/subscriptions/subscriptions-view.jsx:170
-msgid "Unregistering system..."
-msgstr "S'està desregistrant el sistema..."
 
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
@@ -9145,7 +7200,11 @@ msgstr "Amfitrió no fiable"
 msgid "Up since $0"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:316
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+msgid "Up to $0 $1 available in the default location"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -9174,13 +7233,9 @@ msgstr ""
 msgid "Updates Available"
 msgstr "Actualitzacions disponibles"
 
-#: pkg/packagekit/updates.jsx:52 pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/packagekit/updates.jsx:52
 msgid "Updating"
 msgstr "S'està actualitzant"
-
-#: pkg/kubernetes/scripts/details.js:654
-msgid "Updating $0..."
-msgstr "S'està actualitzant $0..."
 
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
@@ -9196,20 +7251,15 @@ msgstr[1] "Ús de $0 nuclis de CPU"
 msgid "Use 512 Byte emulation"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:496
+#: pkg/machines/components/diskAdd.jsx:524
 msgid "Use Existing"
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:136
-msgid "Use proxy server"
-msgstr "Utilitza un servidor intermediari"
 
 #: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Utilitza les següents claus per autenticar contra altres sistemes"
 
 #: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
-#: pkg/kubernetes/scripts/nodes.js:829 pkg/kubernetes/scripts/nodes.js:838
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
@@ -9221,18 +7271,13 @@ msgstr "Utilitzat"
 msgid "Used by"
 msgstr ""
 
-#: pkg/docker/index.html:262
+#: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "Utilitzat pels contenidors"
 
-#: pkg/dashboard/index.html:144 pkg/kubernetes/views/auth-form.html:61
-#: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
-#: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/subscriptions/subscriptions-register.jsx:77 pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1584
 msgid "User"
 msgstr "Usuari"
 
@@ -9241,11 +7286,11 @@ msgstr "Usuari"
 msgid "User Name"
 msgstr "Nom d'usuari"
 
-#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:337
+#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:336
 msgid "User Password"
 msgstr "Contrasenya d'usuari"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nom d'usuari"
@@ -9254,18 +7299,9 @@ msgstr "Nom d'usuari"
 msgid "User name cannot be empty"
 msgstr "El nom d'usuari no pot estar en blanc"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:15
-msgid "User or Group"
-msgstr "Usuari o grup"
-
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
-#: pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
 msgid "Username"
 msgstr "Nom d'usuari"
-
-#: pkg/kubernetes/views/project-listing.html:85
-msgid "Users"
-msgstr "Usuaris"
 
 #: pkg/lib/machine-change-auth.html:44
 msgid "Using available credentials"
@@ -9304,14 +7340,6 @@ msgstr ""
 msgid "VDO support not installed"
 msgstr ""
 
-#: pkg/ovirt/components/App.jsx:115
-msgid "VDSM"
-msgstr "VDSM"
-
-#: pkg/ovirt/components/VdsmView.jsx:128
-msgid "VDSM Service Management"
-msgstr "Gestió del servei VDSM"
-
 #: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
 #: pkg/networkmanager/interfaces.js:2906
 msgid "VLAN"
@@ -9341,7 +7369,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1317
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -9365,10 +7393,6 @@ msgstr ""
 msgid "VM $0 failed to start"
 msgstr ""
 
-#: pkg/ovirt/components/VmOverviewColumn.jsx:37
-msgid "VM icon"
-msgstr "Icona de la MV"
-
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
 msgstr "VNC"
@@ -9385,7 +7409,7 @@ msgstr "Port VNC:"
 msgid "VNC TLS Port:"
 msgstr "Port TLS VNC:"
 
-#: pkg/realmd/operation.js:165
+#: pkg/realmd/operation.js:164
 msgid "Validating address"
 msgstr ""
 
@@ -9414,30 +7438,20 @@ msgstr ""
 msgid "Verifying"
 msgstr "S'està verificant"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:110 pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:381
-#: pkg/subscriptions/subscriptions-view.jsx:35 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Versió"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Version num"
-msgstr "Núm. versió"
 
 #: pkg/storaged/jobs-panel.jsx:57
 msgid "Very securely erasing $target"
 msgstr "S'està eliminant de forma molt segura $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Màquines virtuals"
-
-#: pkg/ovirt/components/ClusterVms.jsx:176
-msgid "Virtual Machines of $0 cluster"
-msgstr "Màquines virtuals del clúster $0"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
@@ -9451,14 +7465,11 @@ msgstr "El servei de virtualització  (libvirt) no està actiu"
 msgid "Virtualization Service is Available"
 msgstr "El servei de virtualització està disponible"
 
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
-#: pkg/kubernetes/views/pvc-body.html:6
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:359
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Volum"
 
@@ -9466,7 +7477,7 @@ msgstr "Volum"
 msgid "Volume Group"
 msgstr "Grup de volums"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:233
+#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Grup de volums $0"
 
@@ -9474,32 +7485,16 @@ msgstr "Grup de volums $0"
 msgid "Volume Groups"
 msgstr "Grups de volums"
 
-#: pkg/kubernetes/views/volume-body.html:14
-#: pkg/kubernetes/views/volume-body.html:89
-msgid "Volume ID"
-msgstr "Id. del volum"
-
-#: pkg/kubernetes/views/pv-modify.html:115
-#: pkg/kubernetes/views/volume-body.html:42
-msgid "Volume Name"
-msgstr "Nom del volum"
-
-#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
-msgid "Volume Type"
-msgstr "Tipus del volum"
-
 #: pkg/storaged/lvol-tabs.jsx:410
 msgid "Volume size is $0. Content size is $1."
 msgstr ""
 
-#: pkg/docker/index.html:515 pkg/kubernetes/index.html:74
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:517
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volums"
 
-#: pkg/docker/index.html:199
+#: pkg/docker/index.html:200
 msgid "Volumes:"
 msgstr ""
 
@@ -9516,7 +7511,7 @@ msgstr "S'està esperant"
 msgid "Waiting for details..."
 msgstr "S'estan esperant els detalls..."
 
-#: pkg/apps/utils.jsx:62
+#: pkg/apps/utils.jsx:63
 msgid "Waiting for other programs to finish using the package manager..."
 msgstr ""
 
@@ -9537,10 +7532,6 @@ msgstr ""
 msgid "Warning and above"
 msgstr ""
 
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid "Warning:"
-msgstr "Advertència:"
-
 #: cockpit.appdata.xml.in.h:1
 msgid "Web Console for Linux servers"
 msgstr ""
@@ -9557,23 +7548,15 @@ msgstr ""
 msgid "Weeks"
 msgstr "Setmanes"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:5
-msgid "Welcome to the Image Registry"
-msgstr "Benvingut al registre d'imatges"
-
 #: pkg/storaged/crypto-keyslots.jsx:324
 msgid "What if tang-show-keys is not available?"
 msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html:61
-msgid "When"
-msgstr "Quan"
 
 #: pkg/systemd/terminal.jsx:101
 msgid "White"
 msgstr ""
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:488
 msgid "With terminal"
 msgstr "Amb terminal"
 
@@ -9593,7 +7576,7 @@ msgstr "Contrasenya o nom d'usuari incorrecte"
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:996 pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2593
 msgid "Yes"
 msgstr "Sí"
 
@@ -9611,19 +7594,9 @@ msgstr ""
 "suprimir."
 
 #: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:871 pkg/networkmanager/firewall.jsx:877
+#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
 msgid "You are not authorized to modify the firewall."
 msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:3
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-
-#: pkg/kubernetes/views/dashboard-page.html:150
-msgid "You can deploy an application to your cluster."
-msgstr "Podeu desplegar una aplicació al vostre clúster."
 
 #: pkg/users/index.html:390
 msgid ""
@@ -9642,7 +7615,7 @@ msgstr ""
 msgid "You must wait longer to change your password"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
 msgid ""
 "You need to select the most closely matching OS vendor and Operating System"
 msgstr ""
@@ -9652,14 +7625,6 @@ msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
 msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:112
-msgid ""
-"Your login credentials do not give you access to use the docker registry "
-"from the command line."
-msgstr ""
-"Les vostres credencials d'inici de sessió no us donen accés a utilitzar el "
-"registre de docker des de la línia d'ordres."
 
 #: pkg/packagekit/updates.jsx:865
 msgid ""
@@ -9677,11 +7642,11 @@ msgstr "La vostra sessió ha estat finalitzada."
 msgid "Your session has expired. Please log in again."
 msgstr "La vostra sessió ha vençut. Si us plau, torneu a iniciar la sessió."
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/networkmanager/firewall.jsx:938
 msgid "Zones"
 msgstr ""
 
@@ -9697,8 +7662,12 @@ msgstr "[dades binàries]"
 msgid "[no data]"
 msgstr "[sense dades]"
 
-#: pkg/machines/components/networks/network.jsx:58
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "actiu"
@@ -9733,17 +7702,9 @@ msgstr "bytes"
 msgid "cdrom"
 msgstr "cdrom"
 
-#: pkg/ovirt/rephraseUI.js:35
-msgid "connecting"
-msgstr "connectant"
-
 #: pkg/machines/components/infoRecord.jsx:29
 msgid "control-label $0"
 msgstr ""
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "cores"
-msgstr "nuclis"
 
 #: pkg/machines/helpers.js:193
 msgid "crashed"
@@ -9762,7 +7723,6 @@ msgid "direct"
 msgstr "directe"
 
 #: pkg/machines/helpers.js:177 pkg/machines/helpers.js:180
-#: pkg/ovirt/components/OVirtTab.jsx:123
 msgid "disabled"
 msgstr "inhabilitat"
 
@@ -9770,7 +7730,7 @@ msgstr "inhabilitat"
 msgid "disk"
 msgstr "disc"
 
-#: pkg/machines/helpers.js:238 pkg/ovirt/rephraseUI.js:27
+#: pkg/machines/helpers.js:238
 msgid "down"
 msgstr ""
 
@@ -9778,26 +7738,17 @@ msgstr ""
 msgid "dying"
 msgstr "morint"
 
-#: pkg/realmd/operation.js:299 pkg/realmd/operation.js:305
+#: pkg/realmd/operation.js:298 pkg/realmd/operation.js:304
 msgid "e.g. \"$0\""
 msgstr "p. ex. \"$0\""
 
-#: pkg/kubernetes/scripts/images.js:639
-msgid "eg: my-image-stream"
-msgstr ""
-
 #: pkg/machines/helpers.js:178 pkg/machines/helpers.js:181
-#: pkg/ovirt/components/OVirtTab.jsx:125
 msgid "enabled"
 msgstr "habilitat"
 
 #: pkg/packagekit/updates.jsx:267
 msgid "enhancement"
 msgstr ""
-
-#: pkg/ovirt/rephraseUI.js:28
-msgid "error"
-msgstr "error"
 
 #: pkg/machines/helpers.js:214
 msgid "ethernet"
@@ -9823,7 +7774,7 @@ msgstr ""
 msgid "hostdev"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:182
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
@@ -9839,7 +7790,7 @@ msgstr "Destinacions iSCSI"
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -9847,22 +7798,10 @@ msgstr ""
 msgid "idle"
 msgstr "ociós"
 
-#: pkg/machines/components/networks/network.jsx:58
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "inactiu"
-
-#: pkg/ovirt/rephraseUI.js:29
-msgid "initializing"
-msgstr "inicialitzant"
-
-#: pkg/ovirt/rephraseUI.js:30
-msgid "installation failed"
-msgstr "ha fallat la instal·lació"
-
-#: pkg/ovirt/rephraseUI.js:38
-msgid "installing OS"
-msgstr "instal·lant el SO"
 
 #: pkg/kdump/kdump-view.jsx:376
 msgid "invalid: multiple targets defined"
@@ -9871,10 +7810,6 @@ msgstr "no és vàlid: s'han definit diversos objectius"
 #: pkg/kdump/kdump-view.jsx:493
 msgid "kdump status"
 msgstr "Estat de kdump"
-
-#: pkg/ovirt/rephraseUI.js:39
-msgid "kdumping"
-msgstr ""
 
 #: pkg/docker/run.js:527
 msgid "key"
@@ -9888,10 +7823,6 @@ msgstr ""
 msgid "locally in $0"
 msgstr "localment a $0"
 
-#: pkg/ovirt/rephraseUI.js:31
-msgid "maintenance"
-msgstr "manteniment"
-
 #: pkg/machines/helpers.js:216
 msgid "mcast"
 msgstr "mcast"
@@ -9904,58 +7835,18 @@ msgstr "xarxa"
 msgid "nfs dump target isn't formated as server:path"
 msgstr ""
 
-#: pkg/kubernetes/views/route-body.html:14
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:43
 msgid "no"
 msgstr "no"
 
-#: pkg/ovirt/rephraseUI.js:32
-msgid "non operational"
-msgstr ""
-
-#: pkg/ovirt/rephraseUI.js:33
-msgid "non responsive"
-msgstr ""
-
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
-#: pkg/kubernetes/views/route-body.html:24
-#: pkg/kubernetes/views/route-body.html:29
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "cap"
-
-#: pkg/ovirt/provider.js:62
-msgid "oVirt"
-msgstr "oVirt"
-
-#: pkg/ovirt/components/HostStatus.jsx:37
-msgid "oVirt Host State:"
-msgstr "Estat de l'amfitrió oVirt:"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:35
-msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr ""
-
-#: pkg/ovirt/components/InstallationDialog.jsx:36
-msgid ""
-"oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-"machines-ovirt.config, try as root."
-msgstr ""
-
-#: pkg/ovirt/components/InstallationDialog.jsx:164
-msgid "oVirt installation script failed with following output: "
-msgstr ""
-
-#: pkg/ovirt/components/App.jsx:51
-msgid "oVirt login in progress"
-msgstr "Inici de sessió d'oVirt en progrés"
 
 #: pkg/systemd/host.js:691
 msgid "of $0 CPU core"
@@ -9967,25 +7858,13 @@ msgstr[1] "de $0 nuclis de CPU"
 msgid "paused"
 msgstr "pausa"
 
-#: pkg/ovirt/rephraseUI.js:34
-msgid "pending approval"
-msgstr "pendent d'aprovació"
-
-#: pkg/kubernetes/views/dashboard-page.html:83
-msgid "pending volume claims"
-msgstr "reclamacions de volums pendents"
-
-#: pkg/machines/components/diskAdd.jsx:174
+#: pkg/machines/components/diskAdd.jsx:154
 msgid "qcow2"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:177
+#: pkg/machines/components/diskAdd.jsx:157
 msgid "raw"
 msgstr ""
-
-#: pkg/ovirt/rephraseUI.js:36
-msgid "reboot"
-msgstr "reinicia"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -10007,7 +7886,7 @@ msgstr "cerqueu pel nom, per l'espai de noms o per la descripció"
 msgid "security"
 msgstr ""
 
-#: pkg/docker/index.html:404
+#: pkg/docker/index.html:406
 msgid "select container"
 msgstr "seleccioneu el contenidor"
 
@@ -10015,7 +7894,7 @@ msgstr "seleccioneu el contenidor"
 msgid "server"
 msgstr "servidor"
 
-#: pkg/docker/index.html:483 pkg/docker/index.html:655
+#: pkg/docker/index.html:485 pkg/docker/index.html:657
 msgid "shares"
 msgstr "comparticions"
 
@@ -10034,10 +7913,6 @@ msgstr "apagat"
 #: pkg/machines/helpers.js:191
 msgid "shutdown"
 msgstr "apaga"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "sockets"
-msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:123
 msgid "solution details"
@@ -10059,10 +7934,6 @@ msgstr ""
 msgid "suspended (PM)"
 msgstr "suspès (PM)"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "threads"
-msgstr "fils"
-
 #: pkg/docker/run.js:474
 msgid "to host path"
 msgstr "al camí de l'amfitrió"
@@ -10078,10 +7949,6 @@ msgstr ""
 #: pkg/machines/helpers.js:218
 msgid "udp"
 msgstr "udp"
-
-#: pkg/ovirt/rephraseUI.js:37
-msgid "unassigned"
-msgstr "sense assignar"
 
 #: pkg/lib/cockpit-components-select.jsx:28
 msgid "undefined"
@@ -10100,7 +7967,7 @@ msgstr "objectiu desconegut"
 msgid "unpartitioned space on $0"
 msgstr "espai sense particionar a $0"
 
-#: pkg/machines/helpers.js:237 pkg/ovirt/rephraseUI.js:26
+#: pkg/machines/helpers.js:237
 msgid "up"
 msgstr ""
 
@@ -10109,7 +7976,6 @@ msgid "user"
 msgstr "usuari"
 
 #: pkg/machines/components/vcpuModal.jsx:192
-#: pkg/ovirt/components/vcpuModal.jsx:54
 msgid "vCPU Count"
 msgstr ""
 
@@ -10118,8 +7984,6 @@ msgid "vCPU Maximum"
 msgstr ""
 
 #: pkg/machines/components/vmOverviewTab.jsx:75
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "vCPUs"
 msgstr "vCPU"
 
@@ -10131,12 +7995,16 @@ msgstr "valor"
 msgid "vhostuser"
 msgstr ""
 
-#: pkg/kubernetes/views/route-body.html:13
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+msgid ""
+"virt-install package needs to be installed on the system in order to create "
+"new VMs"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:42
 msgid "yes"
 msgstr "sí"
 
@@ -10147,3 +8015,1122 @@ msgid ""
 msgstr ""
 "{{ condition.message }}. Marca temporal: {{ condition.lastTransitionTime }} "
 "Nombre d'errors: {{ condition.generation }}"
+
+#~ msgid " 1\"Do you want to delete the following Nodes?"
+#~ msgstr " 1\"Voleu suprimir els següents nodes?"
+
+#~ msgid "$0% Free"
+#~ msgid_plural "$0% Free"
+#~ msgstr[0] "$0% lliure"
+#~ msgstr[1] "$0% lliures"
+
+#~ msgid "$0% Used"
+#~ msgid_plural "$0% Used"
+#~ msgstr[0] "$0% utilitzat"
+#~ msgstr[1] "$0% utilitzats"
+
+#~ msgid "Access Modes"
+#~ msgstr "Modes d'accés"
+
+#~ msgid "Access denied"
+#~ msgstr "Accés denegat"
+
+#~ msgid "Action"
+#~ msgstr "Acció"
+
+#~ msgid "Activation Key"
+#~ msgstr "Clau d'activació"
+
+#~ msgid "Actual"
+#~ msgstr "Real"
+
+#~ msgid "Add Cluster Node"
+#~ msgstr "Afegeix un node de clúster"
+
+#~ msgid "Add Group"
+#~ msgstr "Afegeix un grup"
+
+#~ msgid "Add Kubernetes Node"
+#~ msgstr "Afegeix un node Kubernetes"
+
+#~ msgid "Add Member"
+#~ msgstr "Afegeix un membre"
+
+#~ msgid "Add Membership"
+#~ msgstr "Afegeix una pertinença"
+
+#~ msgid "Add New Cluster"
+#~ msgstr "Afegeix un clúster nou"
+
+#~ msgid "Add New User"
+#~ msgstr "Afegeix un usuari nou"
+
+#~ msgid "Add Role"
+#~ msgstr "Afegeix un rol"
+
+#~ msgid "Add User"
+#~ msgstr "Afegeix un usuari"
+
+#~ msgid "Add membership"
+#~ msgstr "Afegeix una pertinença"
+
+#~ msgid "Adjust"
+#~ msgstr "Ajusta"
+
+#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+#~ msgstr "Ajusta el volum persistent '{{ item.metadata.name }}'"
+
+#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
+#~ msgstr "Ajusta el controlador de replicació {{ item.metadata.name }}"
+
+#~ msgid "Adjust Route"
+#~ msgstr "Ajusta la ruta"
+
+#~ msgid "Adjust Service"
+#~ msgstr "Ajusta el servei"
+
+#~ msgid "Admin"
+#~ msgstr "Administrador"
+
+#~ msgid "All Projects"
+#~ msgstr "Tots els projectes"
+
+#~ msgid "All Types"
+#~ msgstr "Tots els tipus"
+
+#~ msgid "All images"
+#~ msgstr "Totes les imatges"
+
+#~ msgid "All in use"
+#~ msgstr "Tots en ús"
+
+#~ msgid "All running"
+#~ msgstr "Tot en execució"
+
+#~ msgid "All running virtual machines will be turned off."
+#~ msgstr "S'apagaran totes les màquines virtuals."
+
+#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
+#~ msgstr ""
+#~ "Anònim: permet que tots els usuaris no autenticats recuperin imatges"
+
+#~ msgid "Automatically selected host"
+#~ msgstr "Amfitrió seleccionat automàticament"
+
+#~ msgid "Azure"
+#~ msgstr "Azure"
+
+#~ msgid "Base Template"
+#~ msgstr "Plantilla base"
+
+#~ msgid "Base template"
+#~ msgstr "Plantilla base"
+
+#~ msgid "Base template:"
+#~ msgstr "Plantilla base:"
+
+#~ msgid "Boot ID"
+#~ msgstr "Id. d'arrencada"
+
+#~ msgid "CPU Utilization: $0%"
+#~ msgstr "Utilització de la CPU: $0%"
+
+#~ msgid "CREATE VM action failed"
+#~ msgstr "Ha fallat l'acció CREATE VM"
+
+#~ msgid "Change User"
+#~ msgstr "Canvia l'usuari"
+
+#~ msgid "Change image stream"
+#~ msgstr "Canvia el flux d'imatges"
+
+#~ msgid "Change project"
+#~ msgstr "Canvia el projecte"
+
+#~ msgid "Claim"
+#~ msgstr "Reclama"
+
+#~ msgid "Claim Name"
+#~ msgstr "Nom de la reclamació"
+
+#~ msgid "Client Certificate"
+#~ msgstr "Certificat de client"
+
+#~ msgid "Cluster"
+#~ msgstr "Clúster"
+
+#~ msgid "Cluster Templates"
+#~ msgstr "Plantilles de clúster"
+
+#~ msgid "Cluster Virtual Machines"
+#~ msgstr "Màquines virtuals del clúster"
+
+#~ msgid "Configuration"
+#~ msgstr "Configuració"
+
+#~ msgid "Configure Flannel networking"
+#~ msgstr "Configura la xarxa Flannel"
+
+#~ msgid "Configure Kubelet and Proxy"
+#~ msgstr "Configura Kubelet i el servidor intermediari"
+
+#~ msgid "Confirm migration"
+#~ msgstr "Confirmació de la migració"
+
+#~ msgid "Confirm reload:"
+#~ msgstr "Confirmació de la recàrrega:"
+
+#~ msgid "Confirm save:"
+#~ msgstr "Confirmació del desament:"
+
+#~ msgid "Connect to oVirt Engine"
+#~ msgstr "Connecta't al motor d'oVirt"
+
+#~ msgid "Connecting..."
+#~ msgstr "S'està connectant..."
+
+#~ msgid "Connection Error: $0"
+#~ msgstr "Error de connexió: $0"
+
+#~ msgid "Connection Settings"
+#~ msgstr "Ajusts de la connexió"
+
+#~ msgid "Container ID"
+#~ msgstr "Id. de contenidor"
+
+#~ msgid "Container Runtime Version"
+#~ msgstr "Versió de l'entorn d'execució del contenidor"
+
+#~ msgid "Could not list services"
+#~ msgstr "No s'han pogut llistar els serveis"
+
+#~ msgid "Couldn't connect to server"
+#~ msgstr "No s'ha pogut connectar al servidor"
+
+#~ msgid "Couldn't find running API server"
+#~ msgstr "No s'ha pogut trobar el servidor de l'API en execució"
+
+#~ msgid ""
+#~ "Couldn't get system subscription status. Please ensure subscription-"
+#~ "manager is installed."
+#~ msgstr ""
+#~ "No s'ha pogut obtenir l'estat de subscripció del sistema. Assegureu-vos "
+#~ "que subscription-manager estigui instal·lat."
+
+#~ msgid "Create New VM"
+#~ msgstr "Crea una MV nova"
+
+#~ msgid "Create empty image stream"
+#~ msgstr "Crea un flux d'imatges buit"
+
+#~ msgid "Create image stream"
+#~ msgstr "Crea un flux d'imatges"
+
+#~ msgid "Custom URL"
+#~ msgstr "URL personalitzat"
+
+#~ msgid "DNS Policy"
+#~ msgstr "Política del DNS"
+
+#~ msgid "Delete '{{ name }}'"
+#~ msgstr "Suprimeix '{{ name }}'"
+
+#~ msgid "Delete Node"
+#~ msgstr "Suprimeix el node"
+
+#~ msgid "Delete Persistent Volume"
+#~ msgstr "Suprimeix el volum persistent"
+
+#~ msgid "Delete Persistent Volume Claim"
+#~ msgstr "Suprimeix la reclamació del volum persistent"
+
+#~ msgid "Delete Project"
+#~ msgstr "Suprimeix el projecte"
+
+#~ msgid "Delete Selected"
+#~ msgstr "Suprimeix la selecció"
+
+#~ msgid "Delete image stream"
+#~ msgstr "Suprimeix el flux d'imatges"
+
+#~ msgid "Delete {{ item.kind }}"
+#~ msgstr "Suprimeix {{ item.kind }}"
+
+#~ msgid "Deploy"
+#~ msgstr "Desplega"
+
+#~ msgid "Deploy Application"
+#~ msgstr "Desplega l'aplicació"
+
+#~ msgid "Deployment Causes"
+#~ msgstr "Causes del desplegament"
+
+#~ msgid "Deployment Config"
+#~ msgstr "Configuració de desplegament"
+
+#~ msgid "Deployment Configs"
+#~ msgstr "Configuracions de desplegaments"
+
+#~ msgid "Description:"
+#~ msgstr "Descripció:"
+
+#~ msgid "Disk Utilization: $0%"
+#~ msgstr "Utilització del disc: $0%"
+
+#~ msgid "Display name"
+#~ msgstr "Nom a mostrar"
+
+#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#~ msgstr "Voleu afegir el rol '{{ fields.displayRole }}'?"
+
+#~ msgid ""
+#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}' image stream?"
+#~ msgstr ""
+#~ "Voleu suprimir el flux d'imatges '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}'?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+#~ msgstr "Voleu suprimir el volum persistent '{{item.metadata.name}}'?"
+
+#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+#~ msgstr "Voleu suprimir {{ item.kind }} '{{item.metadata.name}}'?"
+
+#~ msgid "Do you want to delete this Node?"
+#~ msgstr "Voleu suprimir aquest node?"
+
+#~ msgid ""
+#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+#~ msgstr ""
+#~ "Voleu suprimir la imatge etiquetada com a '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+
+#~ msgid ""
+#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
+#~ "{{ fields.member.metadata.name }}?"
+#~ msgstr ""
+#~ "Voleu suprimir el rol '{{ fields.displayRole }}' del membre {{ fields."
+#~ "member.metadata.name }}?"
+
+#~ msgid "Don't pull images automatically"
+#~ msgstr "No recuperis automàticament les imatges"
+
+#~ msgid "Driver"
+#~ msgstr "Controlador"
+
+#~ msgid "Edit the vdsm.conf"
+#~ msgstr "Edita el fitxer vdsm.conf"
+
+#~ msgid "Empty Directory"
+#~ msgstr "Directori buit"
+
+#~ msgid "Endpoint"
+#~ msgstr "Extrem"
+
+#~ msgid "Endpoint Name"
+#~ msgstr "Nom de l'extrem"
+
+#~ msgid "Endpoints"
+#~ msgstr "Extrems"
+
+#~ msgid "Ends"
+#~ msgstr "Acaba"
+
+#~ msgid "Enter New VM name"
+#~ msgstr "Introduïu el nom de la nova MV"
+
+#~ msgid "Error getting certificate details: $0"
+#~ msgstr "Error en obtenir els detalls del certificat: $0"
+
+#~ msgid "Error writing kubectl config"
+#~ msgstr "Error en escriure la configuració de kubectl"
+
+#~ msgid "FQDN"
+#~ msgstr "FQDN"
+
+#~ msgid "Fibre Channel"
+#~ msgstr "Fibre Channel"
+
+#~ msgid "Filesystem Type"
+#~ msgstr "Tipus de sistema de fitxers"
+
+#~ msgid "Flex"
+#~ msgstr "Flex"
+
+#~ msgid "Flocker"
+#~ msgstr "Flocker"
+
+#~ msgid "GCE Persistent Disk"
+#~ msgstr "Disc persistent GCE"
+
+#~ msgid "Git Repository"
+#~ msgstr "Dipòsit git"
+
+#~ msgid "Gluster FS"
+#~ msgstr "Gluster FS"
+
+#~ msgid "GlusterFS"
+#~ msgstr "GlusterFS"
+
+#~ msgid "Group Members"
+#~ msgstr "Membres del grup"
+
+#~ msgid "Group or Project"
+#~ msgstr "Grup o projecte"
+
+#~ msgid "Groups"
+#~ msgstr "Grups"
+
+#~ msgid "HA"
+#~ msgstr "HA"
+
+#~ msgid "HA:"
+#~ msgstr "HA:"
+
+#~ msgid "Host Path"
+#~ msgstr "Camí a l'amfitrió"
+
+#~ msgid "Host to Maintenance"
+#~ msgstr "Amfitrió a manteniment"
+
+#~ msgid "IP"
+#~ msgstr "IP"
+
+#~ msgid "ISCSI"
+#~ msgstr "ISCSI"
+
+#~ msgid "Identities"
+#~ msgstr "Identitats"
+
+#~ msgid "Identity"
+#~ msgstr "Identitat"
+
+#~ msgid "Image ID"
+#~ msgstr "Id. d'imatge"
+
+#~ msgid "Image Name"
+#~ msgstr "Nom de la imatge"
+
+#~ msgid "Image Registry"
+#~ msgstr "Registre d'imatges"
+
+#~ msgid "Image Stream"
+#~ msgstr "Flux d'imatges"
+
+#~ msgid "Image commands"
+#~ msgstr "Ordres de la imatge"
+
+#~ msgid "Images by project"
+#~ msgstr "Imatges per projecte"
+
+#~ msgid "Installed products"
+#~ msgstr "Productes instal·lats"
+
+#~ msgid "Interface"
+#~ msgstr "Interfície"
+
+#~ msgid "Invalid credentials"
+#~ msgstr "Credencials no vàlides"
+
+#~ msgid "Kernel Version"
+#~ msgstr "Versió del kernel"
+
+#~ msgid "Key Ring Path"
+#~ msgstr "Camí a l'anell de claus"
+
+#~ msgid "Kubelet Version"
+#~ msgstr "Versió de Kubelet"
+
+#~ msgid "Kubernetes Cluster"
+#~ msgstr "Clúster Kubernetes"
+
+#~ msgid "Last Heartbeat"
+#~ msgstr "Últim batec"
+
+#~ msgid "Last Status Change"
+#~ msgstr "Últim canvi d'estat"
+
+#~ msgid "Latest Version"
+#~ msgstr "Última versió"
+
+#~ msgid "Loading data ..."
+#~ msgstr "S'estan carregant les dades..."
+
+#~ msgid "Logical Unit Number"
+#~ msgstr "Número de la unitat lògica"
+
+#~ msgid "Login"
+#~ msgstr "Usuari"
+
+#~ msgid "Login commands"
+#~ msgstr "Ordres d'inici de sessió"
+
+#~ msgid "Login/password or activation key required to register."
+#~ msgstr ""
+#~ "Per registrar es requereix un usuari/contrasenya o una clau d'activació."
+
+#~ msgid "MIGRATE action failed"
+#~ msgstr "Ha fallat l'acció MIGRATE"
+
+#~ msgid "Manifest"
+#~ msgstr "Manifest"
+
+#~ msgid "Medium"
+#~ msgstr "Mitjà"
+
+#~ msgid "Member of"
+#~ msgstr "Membre de"
+
+#~ msgid "Members"
+#~ msgstr "Membres"
+
+#~ msgid "Membership"
+#~ msgstr "Pertinença"
+
+#~ msgid "Memory Utilization: $0%"
+#~ msgstr "Utilització de la memòria:  $0%"
+
+#~ msgid "Message"
+#~ msgstr "Missatge"
+
+#~ msgid "Migrate To:"
+#~ msgstr "Migra a:"
+
+#~ msgid "Modify"
+#~ msgstr "Modifica"
+
+#~ msgid "Monitors"
+#~ msgstr "Monitors"
+
+#~ msgid "Mount Location"
+#~ msgstr "Ubicació del muntatge"
+
+#~ msgid "NFS"
+#~ msgstr "NFS"
+
+#~ msgid "Namespace"
+#~ msgstr "Espai de noms"
+
+#~ msgid "Namespace cannot be empty."
+#~ msgstr "L'espai de noms no pot estar en blanc."
+
+#~ msgid "New Group"
+#~ msgstr "Grup nou"
+
+#~ msgid "New Project"
+#~ msgstr "Projecte nou"
+
+#~ msgid "New image stream"
+#~ msgstr "Flux d'imatges nou"
+
+#~ msgid "New project"
+#~ msgstr "Projecte nou"
+
+#~ msgid "No VM found in oVirt."
+#~ msgstr "No s'ha trobat cap MV a oVirt."
+
+#~ msgid "No installed products on the system."
+#~ msgstr "No hi ha cap producte instal·lat al sistema."
+
+#~ msgid ""
+#~ "No metadata file was selected. Please select a Kubernetes metadata file."
+#~ msgstr ""
+#~ "Sense seleccionar el fitxer de metadades. Si us plau, seleccioneu un "
+#~ "fitxer de metadades del Kubernetes."
+
+#~ msgid "No nodes in cluster"
+#~ msgstr "Cap node al clúster"
+
+#~ msgid "No users are present."
+#~ msgstr "No hi ha usuaris presents."
+
+#~ msgid "No volumes are present."
+#~ msgstr "No hi ha volums presents."
+
+#~ msgid "No volumes in use"
+#~ msgstr "Sense volums en ús"
+
+#~ msgid "Node"
+#~ msgstr "Node"
+
+#~ msgid "Nodes"
+#~ msgstr "Nodes"
+
+#~ msgid "Nodes are the machines that run your containers."
+#~ msgstr "Els nodes són les màquines que executen els vostres contenidors."
+
+#~ msgid "Not a valid number of replicas"
+#~ msgstr "No és un nombre vàlid de rèpliques"
+
+#~ msgid "Not a valid value for Host"
+#~ msgstr "No és un valor vàlid per a l'amfitrió"
+
+#~ msgid "Not deployed"
+#~ msgstr "No desplegat"
+
+#~ msgid "OS"
+#~ msgstr "SO"
+
+#~ msgid "OS Type:"
+#~ msgstr "Tipus de SO:"
+
+#~ msgid "OS Versions"
+#~ msgstr "Versions del SO"
+
+#~ msgid "Optimized for:"
+#~ msgstr "Optimitzat per:"
+
+#~ msgid "Organization"
+#~ msgstr "Organització"
+
+#~ msgid "Pending Volume Claims"
+#~ msgstr "Reclamacions de volums pendents"
+
+#~ msgid "Persistent Volumes"
+#~ msgstr "Volums persistents"
+
+#~ msgid "Phase"
+#~ msgstr "Fase"
+
+#~ msgid "Please confirm, the host shall be switched to maintenance mode."
+#~ msgstr "Confirmeu que l'amfitrió s'ha de canviar al mode de manteniment."
+
+#~ msgid "Please create another namespace for $0 \"$1\""
+#~ msgstr "Si us plau, creeu un altre espai de noms per a $0 \"$1\""
+
+#~ msgid "Please provide a GlusterFS volume name"
+#~ msgstr "Si us plau, proporcioneu un nom de volum GlusterFS"
+
+#~ msgid "Please provide a username"
+#~ msgstr "Si us plau, proporcioneu un nom d'usuari vàlid"
+
+#~ msgid "Please provide a valid NFS server"
+#~ msgstr "Si us plau, proporcioneu un servidor NFS vàlid"
+
+#~ msgid "Please provide a valid address"
+#~ msgstr "Si us plau, proporcioneu una adreça vàlida"
+
+#~ msgid "Please provide a valid filesystem type"
+#~ msgstr "Si us plau, proporcioneu un tipus de sistema de fitxers vàlid"
+
+#~ msgid "Please provide a valid interface"
+#~ msgstr "Proporcioneu una interfície vàlida"
+
+#~ msgid "Please provide a valid logical unit number"
+#~ msgstr "Si us plau, proporcioneu un nombre vàlid d'unitat lògica"
+
+#~ msgid "Please provide a valid name"
+#~ msgstr "Si us plau, proporcioneu un nom vàlid"
+
+#~ msgid "Please provide a valid namespace."
+#~ msgstr "Si us plau, proporcioneu un espai de noms vàlid."
+
+#~ msgid "Please provide a valid path"
+#~ msgstr "Si us plau, proporcioneu un camí vàlid"
+
+#~ msgid "Please provide a valid storage capacity."
+#~ msgstr "Si us plau, proporcioneu una capacitat d'emmagatzematge vàlida."
+
+#~ msgid "Please provide a valid target"
+#~ msgstr "Si us plau, proporcioneu un objectiu vàlid"
+
+#~ msgid ""
+#~ "Please provide fully qualified domain name and port of the oVirt engine."
+#~ msgstr ""
+#~ "Proporcioneu el nom de domini plenament qualificat i el port del motor "
+#~ "oVirt."
+
+#~ msgid ""
+#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
+#~ "port (443 by default)"
+#~ msgstr ""
+#~ "Proporcioneu el nom de domini plenament qualificat d'un motor oVirt vàlid "
+#~ "i el port (443 per defecte)."
+
+#~ msgid "Please select a valid access mode"
+#~ msgstr "Si us plau, seleccioneu un mode d'accés vàlid"
+
+#~ msgid "Please select a valid endpoint"
+#~ msgstr "Si us plau, seleccioneu un extrem vàlid"
+
+#~ msgid "Please select a valid policy option."
+#~ msgstr "Si us plau, seleccioneu una opció de política vàlida."
+
+#~ msgid "Please type an address"
+#~ msgstr "Si us plau, teclegeu una adreça"
+
+#~ msgid "Please wait till VMs list is loaded from the server."
+#~ msgstr "Espereu fins que la llista de MV es carregui del servidor."
+
+#~ msgid "Please wait till list of templates is loaded from the server."
+#~ msgstr "Espereu fins que la llista de plantilles es carregui del servidor."
+
+#~ msgid "Pod"
+#~ msgstr "Pod"
+
+#~ msgid "Pods"
+#~ msgstr "Pods"
+
+#~ msgid "Pool Name"
+#~ msgstr "Nom de l'agrupació"
+
+#~ msgid "Populate"
+#~ msgstr "Pobla"
+
+#~ msgid "Private: Allow only specific users or groups to pull images"
+#~ msgstr ""
+#~ "Privat: permet que només els usuaris o grups específics recuperin imatges"
+
+#~ msgid "Product ID"
+#~ msgstr "Id. del producte"
+
+#~ msgid "Product name"
+#~ msgstr "Nom del producte"
+
+#~ msgid "Project"
+#~ msgstr "Projecte"
+
+#~ msgid "Project Members"
+#~ msgstr "Membres del projecte"
+
+#~ msgid "Project access policy allows anonymous users to pull images."
+#~ msgstr ""
+#~ "La política d'accés de projecte permet que els usuaris anònims recuperin "
+#~ "imatges."
+
+#~ msgid "Project access policy allows any authenticated user to pull images."
+#~ msgstr ""
+#~ "La política d'accés públic permet que qualsevol usuari o grup autenticat "
+#~ "recuperi imatges."
+
+#~ msgid "Project:"
+#~ msgstr "Projecte:"
+
+#~ msgid "Projects"
+#~ msgstr "Projectes"
+
+#~ msgid "Proxy"
+#~ msgstr "Servidor intermediari"
+
+#~ msgid "Proxy Version"
+#~ msgstr "Versió del servidor intermediari"
+
+#~ msgid "Pull an image:"
+#~ msgstr "Recupera una imatge:"
+
+#~ msgid "Pull from"
+#~ msgstr "Recupera de"
+
+#~ msgid "Pull specific tags from another image repository"
+#~ msgstr "Recupera les etiquetes específiques d'un altre dipòsit d'imatges"
+
+#~ msgid "Qualified Name"
+#~ msgstr "Nom qualificat"
+
+#~ msgid "REBOOT action failed"
+#~ msgstr "Ha fallat l'acció REBOOT"
+
+#~ msgid "Rados Block Device"
+#~ msgstr "Dispositiu de blocs rados"
+
+#~ msgid "Read Only"
+#~ msgstr "Tan sols lectura"
+
+#~ msgid "Read and write from a single node"
+#~ msgstr "Lectura i escriptura d'un sol node"
+
+#~ msgid "Read and write from multiple nodes"
+#~ msgstr "Lectura i escriptura de diversos nodes"
+
+#~ msgid "Read only from multiple nodes"
+#~ msgstr "Només lectura de diversos nodes"
+
+#~ msgid "Reason"
+#~ msgstr "Motiu"
+
+#~ msgid "Recycle"
+#~ msgstr "Recicla"
+
+#~ msgid "Register"
+#~ msgstr "Registra"
+
+#~ msgid "Register New Volume"
+#~ msgstr "Registra un volum nou"
+
+#~ msgid "Register Persistent Volume"
+#~ msgstr "Registra un volum persistent"
+
+#~ msgid "Register oVirt"
+#~ msgstr "Registra l'oVirt"
+
+#~ msgid "Register system"
+#~ msgstr "Registra el sistema"
+
+#~ msgid "Registering oVirt to Cockpit"
+#~ msgstr "Registrament d'oVirt a Cockpit"
+
+#~ msgid "Remove Group"
+#~ msgstr "Suprimeix el grup"
+
+#~ msgid "Remove Member"
+#~ msgstr "Suprimeix el membre"
+
+#~ msgid "Remove Role"
+#~ msgstr "Suprimeix el rol"
+
+#~ msgid "Remove User"
+#~ msgstr "Suprimeix l'usuari"
+
+#~ msgid "Remove image tag"
+#~ msgstr "Suprimeix l'etiqueta de la imatge"
+
+#~ msgid "Remove membership"
+#~ msgstr "Suprimeix la pertinença"
+
+#~ msgid "Replicas"
+#~ msgstr "Rèpliques"
+
+#~ msgid "Replication Controller"
+#~ msgstr "Controlador de replicació"
+
+#~ msgid "Replication Controllers"
+#~ msgstr "Controladors de replicació"
+
+#~ msgid "Repository URL"
+#~ msgstr "URl del dipòsit"
+
+#~ msgid "Requests"
+#~ msgstr "Peticions"
+
+#~ msgid "Requires Authentication"
+#~ msgstr "Requereix autenticació"
+
+#~ msgid "Restart Count"
+#~ msgstr "Reinicia el compte"
+
+#~ msgid "Retrieving subscription status..."
+#~ msgstr "S'està recuperant l'estat de la subscripció..."
+
+#~ msgid "Revision"
+#~ msgstr "Revisió"
+
+#~ msgid "Role"
+#~ msgstr "Rol"
+
+#~ msgid "Run Here"
+#~ msgstr "Executa-ho aquí"
+
+#~ msgid "Running Since:"
+#~ msgstr "En execució des de:"
+
+#~ msgid "SHUTDOWN action failed"
+#~ msgstr "Ha fallat l'acció SHUTDOWN"
+
+#~ msgid "START action failed"
+#~ msgstr "Ha fallat l'acció START"
+
+#~ msgid "SUSPEND action failed"
+#~ msgstr "Ha fallat l'acció SUSPEND"
+
+#~ msgid "Scheduling Disabled"
+#~ msgstr "Planificació inhabilitada"
+
+#~ msgid "Secret"
+#~ msgstr "Secret"
+
+#~ msgid "Secret File"
+#~ msgstr "Fitxer secret"
+
+#~ msgid "Secret Name"
+#~ msgstr "Nom secret"
+
+#~ msgid "Secret Volume"
+#~ msgstr "Volum secret"
+
+#~ msgid "Select Manifest File..."
+#~ msgstr "Selecciona el fitxer del manifest..."
+
+#~ msgid "Select an object to see more details."
+#~ msgstr "Seleccioneu un objecte per veure'n més detalls. "
+
+#~ msgid "Service Account"
+#~ msgstr "Compte del servei"
+
+#~ msgid "Share Name"
+#~ msgstr "Nom de compartició"
+
+#~ msgid "Shared: Allow any authenticated user to pull images"
+#~ msgstr "Compartit: permet que qualsevol usuari autenticat recuperi imatges"
+
+#~ msgid "Shell"
+#~ msgstr "Shell"
+
+#~ msgid "Show all Containers"
+#~ msgstr "Mostra tots els contenidors"
+
+#~ msgid "Show all Deployment Configs"
+#~ msgstr "Mostra totes les configuracions de desplegament"
+
+#~ msgid "Show all Nodes"
+#~ msgstr "Mostra tots els nodes"
+
+#~ msgid "Show all Persistent Volumes"
+#~ msgstr "Mostra tots els volums persistents"
+
+#~ msgid "Show all Pods"
+#~ msgstr "Mostra tots els pods"
+
+#~ msgid "Show all Projects"
+#~ msgstr "Mostra tots els projectes"
+
+#~ msgid "Show all Replication Controllers"
+#~ msgstr "Mostra tots els controladors de replicació"
+
+#~ msgid "Show all Routes"
+#~ msgstr "Mostra tots els encaminaments"
+
+#~ msgid "Show all Services"
+#~ msgstr "Mostra tots els serveis"
+
+#~ msgid "Show all image streams"
+#~ msgstr "Mostra tots els fluxos d'imatges"
+
+#~ msgid "Since"
+#~ msgstr "Des de"
+
+#~ msgid "Skip Certificate Verification"
+#~ msgstr "Omet la verificació del certificat"
+
+#~ msgid "Starts"
+#~ msgstr "Comença"
+
+#~ msgid "Status: $0"
+#~ msgstr "Estat: $0"
+
+#~ msgid "Status: System isn't registered"
+#~ msgstr "Estat: el sistema no està registrat"
+
+#~ msgid "Strategy"
+#~ msgstr "Estratègia"
+
+#~ msgid "Subscriptions"
+#~ msgstr "Subscripcions"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspèn"
+
+#~ msgid "Switch Host to Maintenance"
+#~ msgstr "Canvia l'amfitrió a manteniment"
+
+#~ msgid "Switching host to maintenance mode failed. Received error: "
+#~ msgstr "Ha fallat el canvi de l'amfitrió a manteniment. Error rebut: "
+
+#~ msgid "Switching host to maintenance mode in progress ..."
+#~ msgstr "Canvi de l'amfitrió a manteniment en progrés..."
+
+#~ msgid "TLS Termination"
+#~ msgstr "Finalització TLS"
+
+#~ msgid "Template"
+#~ msgstr "Plantilla"
+
+#~ msgid "Templates"
+#~ msgstr "Plantilles"
+
+#~ msgid "Templates of $0 cluster"
+#~ msgstr "Plantilles de clúster $0"
+
+#~ msgid "The address contains invalid characters"
+#~ msgstr "L'adreça conté caràcters no vàlids"
+
+#~ msgid "The container '{{ target }}' does not exist."
+#~ msgstr "El contenidor '{{ target }}' no existeix."
+
+#~ msgid "The deployment config '{{ target }}' does not exist."
+#~ msgstr "La configuració del desplegament '{{ target }}' no existeix."
+
+#~ msgid "The group '{{ groupName }}' does not exist."
+#~ msgstr "El grup '{{ groupName }}' no existeix."
+
+#~ msgid "The maximum number of replicas is 128"
+#~ msgstr "El nombre màxim de rèpliques és 128"
+
+#~ msgid "The name contains invalid characters"
+#~ msgstr "El nom conté caràcters no vàlids"
+
+#~ msgid "The node '{{ target }}' does not exist."
+#~ msgstr "El node '{{ target }}' no existeix."
+
+#~ msgid "The node doesn't have enough disk space"
+#~ msgstr "El node no té prou espai lliure al disc"
+
+#~ msgid "The node doesn't have enough free memory"
+#~ msgstr "El node no té prou memòria lliure al disc"
+
+#~ msgid "The persistent volume '{{ target }}' does not exist."
+#~ msgstr "El volum persistent '{{ target }}' no existeix."
+
+#~ msgid "The pod '{{ target }}' does not exist."
+#~ msgstr "El pod '{{ target }}' no existeix."
+
+#~ msgid "The project '{{ projName }}' does not exist."
+#~ msgstr "El projecte '{{ projName }}' no existeix."
+
+#~ msgid "The replication controller '{{ target }}' does not exist."
+#~ msgstr "El controlador de replicació '{{ target }}' no existeix."
+
+#~ msgid "The route '{{ target }}' does not exist."
+#~ msgstr "L'encaminament '{{ target }}' no existeix."
+
+#~ msgid "The selected file is not a valid Kubernetes application manifest."
+#~ msgstr ""
+#~ "El fitxer seleccionat no és un manifest d'aplicació Kubernetes vàlid."
+
+#~ msgid "The server uses a certificate signed by an unknown authority."
+#~ msgstr ""
+#~ "El servidor utilitza un certificat signat per una autoritat desconeguda."
+
+#~ msgid "The service '{{ target }}' does not exist."
+#~ msgstr "El servei '{{ target }}' no existeix."
+
+#~ msgid "The user '{{ userName }}' does not exist."
+#~ msgstr "L'usuari '{{ userName }}' no existeix."
+
+#~ msgid ""
+#~ "This option is for single node testing only – local storage will not work "
+#~ "in a multi-node cluster"
+#~ msgstr ""
+#~ "Aquesta opció només és per a proves de node únic: l'emmagatzematge local "
+#~ "no funcionarà en un clúster de diversos nodes"
+
+#~ msgid "This virtual machine is not managed by oVirt"
+#~ msgstr "Aquesta màquina virtual no està gestionada per oVirt"
+
+#~ msgid "This volume has not been claimed"
+#~ msgstr "Aquest volum no ha estat reclamat"
+
+#~ msgid "Token"
+#~ msgstr "Testimoni"
+
+#~ msgid "Topology"
+#~ msgstr "Topologia"
+
+#~ msgid "Trust this certificate for this connection"
+#~ msgstr "Confia en aquest certificat per a aquesta connexió"
+
+#~ msgid "Type:"
+#~ msgstr "Tipus:"
+
+#~ msgid "Unable to connect"
+#~ msgstr "No es pot connectar"
+
+#~ msgid "Unable to decode Kubernetes application manifest."
+#~ msgstr "No es pot descodificar el manifest d'aplicació de Kubernetes."
+
+#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
+#~ msgstr "No es pot llegir el fitxer del manifest del Kubernetes. Codi $0."
+
+#~ msgid "Unregister"
+#~ msgstr "Desregistra"
+
+#~ msgid "Unregistering system..."
+#~ msgstr "S'està desregistrant el sistema..."
+
+#~ msgid "Updating $0..."
+#~ msgstr "S'està actualitzant $0..."
+
+#~ msgid "Use proxy server"
+#~ msgstr "Utilitza un servidor intermediari"
+
+#~ msgid "User or Group"
+#~ msgstr "Usuari o grup"
+
+#~ msgid "Users"
+#~ msgstr "Usuaris"
+
+#~ msgid "VDSM"
+#~ msgstr "VDSM"
+
+#~ msgid "VDSM Service Management"
+#~ msgstr "Gestió del servei VDSM"
+
+#~ msgid "VM icon"
+#~ msgstr "Icona de la MV"
+
+#~ msgid "Version num"
+#~ msgstr "Núm. versió"
+
+#~ msgid "Virtual Machines of $0 cluster"
+#~ msgstr "Màquines virtuals del clúster $0"
+
+#~ msgid "Volume ID"
+#~ msgstr "Id. del volum"
+
+#~ msgid "Volume Name"
+#~ msgstr "Nom del volum"
+
+#~ msgid "Volume Type"
+#~ msgstr "Tipus del volum"
+
+#~ msgid "Warning:"
+#~ msgstr "Advertència:"
+
+#~ msgid "Welcome to the Image Registry"
+#~ msgstr "Benvingut al registre d'imatges"
+
+#~ msgid "When"
+#~ msgstr "Quan"
+
+#~ msgid "You can deploy an application to your cluster."
+#~ msgstr "Podeu desplegar una aplicació al vostre clúster."
+
+#~ msgid ""
+#~ "Your login credentials do not give you access to use the docker registry "
+#~ "from the command line."
+#~ msgstr ""
+#~ "Les vostres credencials d'inici de sessió no us donen accés a utilitzar "
+#~ "el registre de docker des de la línia d'ordres."
+
+#~ msgid "connecting"
+#~ msgstr "connectant"
+
+#~ msgid "cores"
+#~ msgstr "nuclis"
+
+#~ msgid "error"
+#~ msgstr "error"
+
+#~ msgid "initializing"
+#~ msgstr "inicialitzant"
+
+#~ msgid "installation failed"
+#~ msgstr "ha fallat la instal·lació"
+
+#~ msgid "installing OS"
+#~ msgstr "instal·lant el SO"
+
+#~ msgid "maintenance"
+#~ msgstr "manteniment"
+
+#~ msgid "oVirt"
+#~ msgstr "oVirt"
+
+#~ msgid "oVirt Host State:"
+#~ msgstr "Estat de l'amfitrió oVirt:"
+
+#~ msgid "pending approval"
+#~ msgstr "pendent d'aprovació"
+
+#~ msgid "pending volume claims"
+#~ msgstr "reclamacions de volums pendents"
+
+#~ msgid "reboot"
+#~ msgstr "reinicia"
+
+#~ msgid "threads"
+#~ msgstr "fils"
+
+#~ msgid "unassigned"
+#~ msgstr "sense assignar"

--- a/po/cs.po
+++ b/po/cs.po
@@ -10,14 +10,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 04:52+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-06-26 02:54+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
 "Language-Team: Czech\n"
 "Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
 
@@ -137,10 +137,10 @@ msgstr ""
 "GNOME Software nebo spusťte následující:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 je právě používáno"
 
@@ -544,8 +544,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Účty"
 
-#: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Aktivovat"
@@ -584,10 +584,10 @@ msgid "Adaptive transmit load balancing"
 msgstr "Přizpůsobující se rozkládání přenosové zátěže odesílání"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Přidat"
@@ -832,10 +832,10 @@ msgstr "Aplikace"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Použít"
 
@@ -876,8 +876,8 @@ msgstr "Inventární štítek"
 msgid "At least $0 disks are needed."
 msgstr "Je vyžadováno alespoň $0 disků."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Je vyžadován alespoň 1 disk."
 
@@ -893,8 +893,8 @@ msgstr "Záznam auditu"
 msgid "Authenticating"
 msgstr "Ověřování"
 
-#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
-#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Ověření"
 
@@ -970,8 +970,8 @@ msgstr "Automatické použití NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Automatické použití uvedených NTP serverů"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "Automatické spouštění"
@@ -1157,8 +1157,8 @@ msgstr "Priorita procesoru"
 msgid "CPU usage:"
 msgstr "Využití procesoru:"
 
-#: pkg/machines/components/diskAdd.jsx:246
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr "Mezipaměť"
 
@@ -1181,35 +1181,35 @@ msgstr "Obraz se nedaří smazat"
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:560
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:560 pkg/networkmanager/firewall.jsx:628
-#: pkg/networkmanager/firewall.jsx:771 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Storno"
 
@@ -1280,10 +1280,10 @@ msgstr "Změnit limity prostředků"
 msgid "Change the settings"
 msgstr "Změnit nastavení"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Změny se projeví až po vypnutí virt. stroje"
 
@@ -1368,15 +1368,16 @@ msgid "Client Software"
 msgstr "Klientský software"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
-#: pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Zavřít"
 
@@ -1461,10 +1462,10 @@ msgstr "Cockpit se nepodařilo spojit s {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit se nepodařilo přihlásit k {{#strong}}{{host}}{{/strong}}. "
 "{{#can_sync}}Můžete vyzkoušet {{#sync_link}}synchronizovat uživatele{{/"
@@ -1566,8 +1567,8 @@ msgstr "Kompatibilní s moderním systémem a pevnými disky > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Komprimovat výpisy paměti z havárií pro úsporu místa"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Komprese"
 
@@ -1674,9 +1675,9 @@ msgstr "Připojování ke stroji"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Spojení"
@@ -1828,9 +1829,9 @@ msgstr "Zhavarovat systém"
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Vytvořit"
 
@@ -2014,7 +2015,7 @@ msgstr "Uživatelsky určené porty"
 msgid "Custom encryption options"
 msgstr "Uživatelsky určené předvolby šifrování"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Uživatelsky určené předvolby připojení"
 
@@ -2060,8 +2061,8 @@ msgstr "Přehled"
 msgid "Data Used"
 msgstr "Využito dat"
 
-#: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Deaktivovat"
@@ -2096,17 +2097,17 @@ msgstr "Prodleva"
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Smazat"
@@ -2159,7 +2160,7 @@ msgstr "Smazání RAID zařízení vymaže veškerá data, která se na něm nac
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Smazání VDO zařízení vymaže veškerá data na něm."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "Smazání kontejneru vymaže veškerá data v něm."
 
@@ -2207,13 +2208,13 @@ msgstr "Odpojitelné"
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:745
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Podrobnosti"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2307,9 +2308,9 @@ msgid "Disk passphrase"
 msgstr "Heslová fráze k disku"
 
 # auto translated by TM merge from project: blivet-gui, version: master, DocId: po/blivet-gui
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Disky"
 
@@ -2591,9 +2592,9 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1476
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Chyba"
 
@@ -2700,7 +2701,7 @@ msgstr "Službu se nepodařilo přidat"
 msgid "Failed to add zone"
 msgstr "Zónu se nepodařilo přidat"
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Nepodařilo se změnit heslo"
 
@@ -2789,7 +2790,7 @@ msgid "Filter by name or description..."
 msgstr "Filtrovat podle názvu nebo popisu…"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Otisk"
 
@@ -2835,10 +2836,9 @@ msgid "Force remove passphrase in $0"
 msgstr "Vynutit odebrání heslové fráze v $0"
 
 # auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
-#: pkg/machines/components/diskAdd.jsx:147
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formát"
 
@@ -2924,11 +2924,11 @@ msgid "Get new image"
 msgstr "Získat nový obraz"
 
 # auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
-#: pkg/machines/components/diskAdd.jsx:186
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
 
@@ -3017,9 +3017,9 @@ msgid "Hide Performance Options"
 msgstr "Předvolby pro výkonnost"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
 #: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Počítač"
@@ -3212,8 +3212,7 @@ msgstr "Synchronní"
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
-msgstr ""
-"Ve většině uspořádání, macvtap nefunguje pro komunikaci hostitel-host."
+msgstr "Ve většině uspořádání, macvtap nefunguje pro komunikaci hostitel-host."
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
@@ -3266,9 +3265,9 @@ msgid "Initiator IQN should not be empty"
 msgstr "IQN iniciátoru by mělo být vyplněné"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Nainstalovat"
 
@@ -3334,8 +3333,8 @@ msgstr "Typ rozhraní"
 
 # auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:737 pkg/networkmanager/firewall.jsx:925
-#: pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Rozhraní"
 
@@ -3352,11 +3351,11 @@ msgstr "Vnitřní chyba"
 msgid "Invalid address $0"
 msgstr "Neplatná adresa $0"
 
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Neplatný formát data"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Neplatný formát data a času"
 
@@ -3412,7 +3411,7 @@ msgstr "Neplatná předpona nebo maska sítě $0"
 msgid "Invalid range"
 msgstr "Neplatný rozsah"
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Neplatný formát času"
 
@@ -3588,7 +3587,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Nevyplňujte pro připojení k tomuto stroji jako právě přihlášený "
 "uživatel{{#default_user}} ({{default_user}}){{/default_user}}. Pokud zadáte "
@@ -3655,9 +3653,9 @@ msgstr "Načtení dostupných aktualizací se nezdařilo"
 msgid "Loading available updates, please wait..."
 msgstr "Načítání dostupných aktualizací, čekejte…"
 
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Načítání…"
 
@@ -3967,10 +3965,10 @@ msgstr "Využito metadat"
 
 # auto translated by TM merge from project: libbytesize, version: master, DocId: libbytesize
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
-#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -4045,24 +4043,24 @@ msgstr "Více informací"
 msgid "More details"
 msgstr "Další podrobnosti"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Připojit (mount)"
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Předvolby připojení"
 
 # auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Přípojný bod"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Připojit při startu"
 
@@ -4082,7 +4080,7 @@ msgstr "Přípojný bod je třeba vyplnit."
 msgid "Mount point must start with \"/\"."
 msgstr "Je třeba, aby popis přípojného bodu začínal na „/“."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Připojit pouze pro čtení"
 
@@ -4139,22 +4137,21 @@ msgstr "NTP server"
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Název"
 
@@ -4297,7 +4294,7 @@ msgstr "Název pro nový svazek"
 msgid "New passphrase"
 msgstr "Nová heslová fráze"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Nové heslo nebylo přijato"
 
@@ -4420,9 +4417,9 @@ msgstr "Není k dispozici žádný popis"
 msgid "No description provided."
 msgstr "Není poskytnut žádný popis."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Nejsou k dispozici žádné disky."
 
@@ -4558,8 +4555,8 @@ msgid "No volume groups created"
 msgstr "Nejsou vytvořené žádné skupiny svazků"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:734
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Žádný"
 
@@ -4661,7 +4658,7 @@ msgstr "Původní heslo"
 msgid "Old passphrase"
 msgstr "Původní heslová fráze"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Původní heslo nebylo přijato"
 
@@ -4779,9 +4776,9 @@ msgid "Other Options"
 msgstr "Ostatní volby"
 
 # auto translated by TM merge from project: Fedora Release Notes, version: f23, DocId: pot/Overview
-#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Přehled"
 
@@ -4866,10 +4863,10 @@ msgid "Passphrases do not match"
 msgstr "Zadání heslové fráze se neshodují"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "Heslo"
@@ -4977,8 +4974,8 @@ msgstr "Přístup zamítnut"
 msgid "Persistence"
 msgstr "Trvalost"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr "Trvalé"
 
@@ -5022,9 +5019,9 @@ msgstr "Cíl pro ping"
 msgid "Pizza Box"
 msgstr "Velikost „krabice od pizzy“"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Potvrďte smazání $0"
@@ -5033,7 +5030,7 @@ msgstr "Potvrďte smazání $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Potvrďte vynucené smazání $0"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Potvrďte zastavení $0"
 
@@ -5070,11 +5067,10 @@ msgid "Plug"
 msgstr "Připojit"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Úložiště"
 
@@ -5239,7 +5235,7 @@ msgstr "Propaguje načíst znovu k"
 msgid "Protocol"
 msgstr "Protokol"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Veřejná část klíče"
 
@@ -5320,7 +5316,7 @@ msgstr "RAID skříň"
 msgid "RAID Device"
 msgstr "RAID zařízení"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "RAID zařízení $0"
 
@@ -5492,9 +5488,9 @@ msgid "Removals:"
 msgstr "Odebrání:"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Odebrat"
 
@@ -5685,8 +5681,8 @@ msgstr ""
 
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Restartovat"
 
@@ -5727,8 +5723,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Použít mé heslo i pro privilegované úlohy"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Použít mé heslo i pro privilegované úlohy a připojování k dalším strojům"
 
@@ -5854,10 +5849,11 @@ msgid "Saturdays"
 msgstr "Soboty"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Uložit"
 
@@ -5913,8 +5909,8 @@ msgstr "Vybrat"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 "Vyberte uživatele které chcete synchronizovat s {{#strong}}{{host}}{{/"
 "strong}}"
@@ -5938,8 +5934,8 @@ msgid "Serial Console"
 msgstr "Sériová konzole"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Server"
 
@@ -6124,15 +6120,14 @@ msgstr "Vypnout"
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/diskAdd.jsx:167
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Velikost"
 
@@ -6214,10 +6209,10 @@ msgid "Sorted from least trusted to most trusted"
 msgstr "Seřazeno od nejméně po nejvíce důvěryhodné"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
-#: pkg/machines/components/diskAdd.jsx:504
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Zdroj"
 
@@ -6225,10 +6220,10 @@ msgstr "Zdroj"
 msgid "Source Format"
 msgstr "Zdrojový formát"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Popis umístění zdroje"
 
@@ -6270,8 +6265,8 @@ msgid "Stable"
 msgstr "Stabilní"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Spustit"
 
@@ -6309,8 +6304,8 @@ msgstr "Při spuštění"
 
 # auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
 #: pkg/systemd/init.js:285
 msgid "State"
@@ -6340,8 +6335,8 @@ msgstr "Lepkavé"
 
 # auto translated by TM merge from project: Fedora Media Writer, version: master, DocId: mediawriter
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Zastavit"
@@ -6597,8 +6592,8 @@ msgstr "Tang server s klíči"
 msgid "Target"
 msgstr "Cíl"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Popis umístění cíle"
 
@@ -6722,8 +6717,8 @@ msgstr "Účet „$0“ bude při příštím přihlášení vyzván k vynucené
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Nepodvrženost totožnosti stroje {{#strong}}{{host}}{{/strong}} se nedaří "
 "ověřit. Opravdu chcete pokračovat v připojování?"
@@ -6759,11 +6754,9 @@ msgstr ""
 "Pokračování je zastaví."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Souborový systém je používán přihlašovacími sezeními. Pokračování je zastaví."
-""
 
 #: pkg/storaged/dialog.jsx:1016
 msgid ""
@@ -6772,8 +6765,7 @@ msgstr ""
 "Souborový systém je používán systémovými službami. Pokračování je zastaví."
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "Následující kontejnery závisí na tomto obrazu a přestanou být použitelné."
 
@@ -6916,8 +6908,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "Nastavení webového prohlížeče brání ve spuštění Cockpit (nepřístupné $0)"
 
@@ -6931,7 +6922,6 @@ msgid ""
 "service is not running."
 msgstr ""
 "V systému jsou zařízení s vícero cestami, ale služba multipath není spuštěná."
-""
 
 #: pkg/users/index.html:387
 msgid "There are no authorized public keys for this account."
@@ -6942,8 +6932,8 @@ msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
 msgstr ""
-"Pro odebrání tohoto fyzického svazku není k dispozici dostatek volného místa."
-" Je třeba alespoň $0 dalšího volného prostoru."
+"Pro odebrání tohoto fyzického svazku není k dispozici dostatek volného "
+"místa. Je třeba alespoň $0 dalšího volného prostoru."
 
 #: pkg/storaged/utils.js:193
 msgid "Thin Logical Volume"
@@ -7087,12 +7077,10 @@ msgstr "Tento svazek už je využíván jiným virt. strojem"
 msgid "This volume needs to be activated before it can be resized."
 msgstr ""
 "Než bude možné změnit jeho velikost je třeba, aby tento svazek byl aktivován."
-""
 
 #: src/ws/login.js:122
 msgid "This web browser is too old to run Cockpit (missing $0)"
-msgstr ""
-"Tento webový prohlížeč je příliš starý pro spuštění Cockpit (chybí $0)"
+msgstr "Tento webový prohlížeč je příliš starý pro spuštění Cockpit (chybí $0)"
 
 #: pkg/packagekit/updates.jsx:832
 msgid "This web console will be updated."
@@ -7249,18 +7237,17 @@ msgid "Tuned is off"
 msgstr "Tuned je vypnuté"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Typ"
 
@@ -7366,10 +7353,11 @@ msgstr "Jednotka"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/lib/machine-info.js:65 pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:139
 #: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
 #: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Neznámé"
 
@@ -7589,7 +7577,7 @@ msgid "User Password"
 msgstr "Heslo uživatele"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Uživatelské jméno"
@@ -7744,7 +7732,7 @@ msgstr "Ověřuje se"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Verze"
 
@@ -7752,8 +7740,8 @@ msgstr "Verze"
 msgid "Very securely erasing $target"
 msgstr "Velmi jisté vymazávání $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Virtuální stroje"
@@ -7772,11 +7760,10 @@ msgstr "Virtualizační služba je k dispozici"
 
 # auto translated by TM merge from project: anaconda, version: master, DocId: main
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Svazek"
 
@@ -7905,7 +7892,6 @@ msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr ""
 "V tuto chvíli jste připojení přímo na tento server. Nemůžete ho proto smazat."
-""
 
 #: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
 #: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
@@ -7975,9 +7961,13 @@ msgstr "[binarní data]"
 msgid "[no data]"
 msgstr "[žádná data]"
 
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 # auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
-#: pkg/machines/components/networks/network.jsx:59
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "aktivní"
@@ -8114,8 +8104,8 @@ msgstr "IQN název iSCSI cíle"
 msgid "idle"
 msgstr "nečinný"
 
-#: pkg/machines/components/networks/network.jsx:59
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "neaktivní"
 
@@ -8151,9 +8141,9 @@ msgstr "síť"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "cíl výpisu nfs nemá podobu server:umisteni"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "ne"
@@ -8325,9 +8315,9 @@ msgid ""
 msgstr ""
 
 # auto translated by TM merge from project: Pulseaudio, version: master, DocId: pulseaudio.pot
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "ano"

--- a/po/de.po
+++ b/po/de.po
@@ -14,14 +14,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 04:52+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2018-12-11 10:53+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Zanata 4.6.2\n"
 
@@ -135,10 +135,10 @@ msgstr ""
 "suchen Sie es in der GNOME-Software oder führen Sie Folgendes aus:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 wird aktiv verwendet"
 
@@ -540,8 +540,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Konten"
 
-#: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Aktivieren"
@@ -578,10 +578,10 @@ msgstr "Adaptives Load Balancing (alb)"
 msgid "Adaptive transmit load balancing"
 msgstr "Adaptives Transmit Load Balancing (tlb)"
 
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Hinzufügen"
@@ -817,10 +817,10 @@ msgstr "Anwendungen"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Anwenden"
 
@@ -860,8 +860,8 @@ msgstr "Kennzeichen"
 msgid "At least $0 disks are needed."
 msgstr "Mindestens $0 Datenträger sind nötig."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Mindestens ein Datenträger ist nötig."
 
@@ -878,8 +878,8 @@ msgstr "Audit-Protokoll"
 msgid "Authenticating"
 msgstr "Authentifiziere"
 
-#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
-#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Authentifizierung"
 
@@ -950,8 +950,8 @@ msgstr "Automatisch (NTP)"
 msgid "Automatically using specific NTP servers"
 msgstr "Automatisch (spezifische NTP-Server)"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
@@ -1135,8 +1135,8 @@ msgstr "CPU Priorität"
 msgid "CPU usage:"
 msgstr "CPU auslastung:"
 
-#: pkg/machines/components/diskAdd.jsx:246
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
@@ -1159,35 +1159,35 @@ msgstr "Bild kann nicht geladen werden"
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:560
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:560 pkg/networkmanager/firewall.jsx:628
-#: pkg/networkmanager/firewall.jsx:771 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -1257,10 +1257,10 @@ msgstr "Ressourcenlimits anpassen"
 msgid "Change the settings"
 msgstr "Bridge Port-Einstellungen"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Änderungen werden nach dem Herunterfahren der VM wirksam"
 
@@ -1344,15 +1344,16 @@ msgstr ""
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
-#: pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Schließen"
 
@@ -1441,10 +1442,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit konnte sich nicht anmelden {{#strong}}{{host}}{{/strong}}. "
 "{{#can_sync}}Möglicherweise möchten Sie es versuchen {{#sync_link}}Benutzer "
@@ -1546,8 +1547,8 @@ msgstr "Kompatibel mit modernen Systemen und Festplatten > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Absturzberichte komprimieren um Speicherplatz zu sparen"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Komprimierung"
 
@@ -1653,9 +1654,9 @@ msgid "Connecting to the machine"
 msgstr "Verbindung zur Maschine wird hergestellt"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Verbindung"
@@ -1805,9 +1806,9 @@ msgstr "Crash-System"
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Erstellen"
 
@@ -1992,7 +1993,7 @@ msgstr ""
 msgid "Custom encryption options"
 msgstr "Benutzerdefinierte Verschlüsselungsoptionen"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Kundenspezifische Montageoptionen"
 
@@ -2037,8 +2038,8 @@ msgstr "Dashboard"
 msgid "Data Used"
 msgstr "Verwendete Daten"
 
-#: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Deaktivieren"
@@ -2071,17 +2072,17 @@ msgstr "Verzögerung"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Löschen"
@@ -2136,7 +2137,7 @@ msgstr ""
 "Durch das Löschen eines VDO-Geräts werden alle darauf befindlichen Daten "
 "gelöscht."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 "Das Löschen eines Containers entfernt alle sich darin befindlichen Daten."
@@ -2185,12 +2186,12 @@ msgstr "Abnehmbar"
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:745
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Details"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2281,9 +2282,9 @@ msgstr "Datenträger ist OK"
 msgid "Disk passphrase"
 msgstr "Disk-Passphrase"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Datenträger"
 
@@ -2559,9 +2560,9 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1476
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Fehler"
 
@@ -2665,7 +2666,7 @@ msgstr ""
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Passwort konnte nicht geändert werden"
 
@@ -2752,7 +2753,7 @@ msgstr "Filterdienste"
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Fingerabdruck"
 
@@ -2797,10 +2798,9 @@ msgstr "Kennwort ändern"
 msgid "Force remove passphrase in $0"
 msgstr "Entfernen der Passphrase erzwingen $0"
 
-#: pkg/machines/components/diskAdd.jsx:147
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formatieren"
 
@@ -2879,11 +2879,11 @@ msgstr "Bericht erstellen"
 msgid "Get new image"
 msgstr "Holen Sie sich ein neues Bild"
 
-#: pkg/machines/components/diskAdd.jsx:186
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
 
@@ -2968,9 +2968,9 @@ msgstr "Hello-Zeit $hello_time"
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
 #: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Host"
@@ -3141,8 +3141,7 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/imagestream-body.html:25
 #: node_modules/registry-image-widgets/views/imagestream-body.html:26
 msgid "Images may only be pulled by specific users or groups"
-msgstr ""
-"Bilder dürfen nur von bestimmten Benutzern oder Gruppen gezogen werden"
+msgstr "Bilder dürfen nur von bestimmten Benutzern oder Gruppen gezogen werden"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
@@ -3163,8 +3162,8 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Um Benutzer zu synchronisieren, müssen Sie sich bei anmelden "
-"{{#strong}}{{host}}{{/strong}}."
+"Um Benutzer zu synchronisieren, müssen Sie sich bei anmelden {{#strong}}"
+"{{host}}{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
 #: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
@@ -3207,9 +3206,9 @@ msgstr ""
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Installation"
 
@@ -3273,8 +3272,8 @@ msgid "Interface Type"
 msgstr ""
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:737 pkg/networkmanager/firewall.jsx:925
-#: pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Schnittstellen"
 
@@ -3291,11 +3290,11 @@ msgstr "Interner Fehler"
 msgid "Invalid address $0"
 msgstr "Ungültiger Schlüssel"
 
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "ungültiges Datumsformat"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Ungültiges Datumsformat und ungültiges Zeitformat"
 
@@ -3356,7 +3355,7 @@ msgstr "Ungültiger Port"
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
 
@@ -3532,7 +3531,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Lassen Sie das Feld leer, um sich als aktuell angemeldeter Benutzer mit "
 "diesem System zu verbinden{{#default_user}} ({{default_user}}){{/"
@@ -3601,9 +3599,9 @@ msgstr "Das Laden verfügbarer Updates ist fehlgeschlagen"
 msgid "Loading available updates, please wait..."
 msgstr "Verfügbare Updates werden geladen, bitte warten ..."
 
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Lade..."
 
@@ -3906,10 +3904,10 @@ msgid "Metadata Used"
 msgstr "Verwendete Metadaten"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
-#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -3979,23 +3977,23 @@ msgstr "Mehr Informationen"
 msgid "More details"
 msgstr "Weitere Details"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Einhängen"
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Einhängoptionen"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Einhängestelle"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Am Kofferraum montieren"
 
@@ -4015,7 +4013,7 @@ msgstr "Einhängepunkt darf nicht leer sein."
 msgid "Mount point must start with \"/\"."
 msgstr "Einhängepunkt muss mit \"/\" beginnen."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Mount nur lesen"
 
@@ -4071,22 +4069,21 @@ msgstr "NTP Server"
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Name"
 
@@ -4230,7 +4227,7 @@ msgstr "Neuer Volume-Name"
 msgid "New passphrase"
 msgstr "Neue Passphrase"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Das neue Passwort wurde nicht akzeptiert"
 
@@ -4353,9 +4350,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "Keine Beschreibung angegeben."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Es sind keine Festplatten verfügbar."
 
@@ -4490,8 +4487,8 @@ msgid "No volume groups created"
 msgstr "Keine Datenträgerverbünde erzeugt"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:734
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Kein"
 
@@ -4591,7 +4588,7 @@ msgstr "Altes Passwort"
 msgid "Old passphrase"
 msgstr "Alte Passphrase"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Altes Passwort wurde nicht akzeptiert"
 
@@ -4703,9 +4700,9 @@ msgstr "Andere Geräte"
 msgid "Other Options"
 msgstr "Andere Einstellungen"
 
-#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Überblick"
 
@@ -4787,10 +4784,10 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Passphrasen stimmen nicht überein."
 
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "Passwort"
@@ -4894,8 +4891,8 @@ msgstr "Erlaubnis verweigert"
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr ""
 
@@ -4942,9 +4939,9 @@ msgstr "$target wird gelöscht"
 msgid "Pizza Box"
 msgstr "Pizza-Box"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Bitte bestätigen Sie das Löschen von $0"
@@ -4953,7 +4950,7 @@ msgstr "Bitte bestätigen Sie das Löschen von $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Bitte bestätigen Sie das erzwungene Löschen von $0"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Bitte bestätigen Sie das Stoppen von $0"
 
@@ -4990,11 +4987,10 @@ msgstr "Bitte versuchen Sie es mit einem anderen Begriff"
 msgid "Plug"
 msgstr "Plug"
 
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Pool"
 
@@ -5153,7 +5149,7 @@ msgstr "Propagiert reload to"
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Öffentlicher Schlüssel"
 
@@ -5234,7 +5230,7 @@ msgstr "RAID-Chassis"
 msgid "RAID Device"
 msgstr "RAID-Gerät"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "RAID-Gerät $0"
 
@@ -5405,9 +5401,9 @@ msgstr "Entfernbares Speichergerät"
 msgid "Removals:"
 msgstr "Umzüge:"
 
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Entfernen"
 
@@ -5595,8 +5591,8 @@ msgstr ""
 
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Neustarten"
 
@@ -5638,8 +5634,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Mein Passwort für Administrator-Aufgaben verwenden"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Mein Passwort für Administrator-Aufgaben und zum Verbinden zu anderen "
 "Maschinen verwenden"
@@ -5762,10 +5757,11 @@ msgstr "Samstag"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Speichern"
 
@@ -5786,8 +5782,8 @@ msgid ""
 "Saving a new passphrase requires unlocking the disk. Please provide a "
 "current disk passphrase."
 msgstr ""
-"Das Speichern einer neuen Passphrase erfordert das Entsperren der Festplatte."
-" Bitte geben Sie eine aktuelle Disk-Passphrase an."
+"Das Speichern einer neuen Passphrase erfordert das Entsperren der "
+"Festplatte. Bitte geben Sie eine aktuelle Disk-Passphrase an."
 
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
@@ -5820,8 +5816,8 @@ msgstr "Auswählen"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 "Wählen Sie die Nutzer aus, die mit {{#strong}}{{host}}{{/strong}} "
 "synchronisiert werden sollen"
@@ -5844,8 +5840,8 @@ msgstr "Sende"
 msgid "Serial Console"
 msgstr "Serielle Konsole"
 
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Server"
 
@@ -6025,15 +6021,14 @@ msgstr "Herunterfahren"
 
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/diskAdd.jsx:167
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Größe"
 
@@ -6109,16 +6104,15 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr ""
 "Ein anderes Programm verwendet derzeit den Paketmanager, bitte warten Sie ..."
-""
 
 #: pkg/networkmanager/firewall.jsx:709
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:504
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Quelle"
 
@@ -6126,10 +6120,10 @@ msgstr "Quelle"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Quellpfad"
 
@@ -6171,8 +6165,8 @@ msgid "Stable"
 msgstr "Stabil"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Starten"
 
@@ -6209,8 +6203,8 @@ msgid "Startup"
 msgstr "Anlaufen"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
 #: pkg/systemd/init.js:285
 msgid "State"
@@ -6237,8 +6231,8 @@ msgid "Sticky"
 msgstr "Sticky"
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Stoppen"
@@ -6488,8 +6482,8 @@ msgstr "Tang Keyserver"
 msgid "Target"
 msgstr "Ziel"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Zielpfad"
 
@@ -6546,8 +6540,7 @@ msgstr "Prüfe Verbindung"
 
 #: pkg/docker/storage.jsx:507
 msgid "The Docker storage pool cannot be managed on this system."
-msgstr ""
-"Der Docker Storage Pool kann auf diesem System nicht verwaltet werden."
+msgstr "Der Docker Storage Pool kann auf diesem System nicht verwaltet werden."
 
 #: pkg/lib/machine-dialogs.js:384
 msgid "The IP address or host name cannot contain whitespace."
@@ -6617,16 +6610,15 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Die Authentizität von Host {{#strong}}{{host}}{{/strong}} kann nicht "
 "bestätigt werden. Sind Sie sicher, dass Sie fortfahren wollen?"
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
-msgstr ""
-"Die gesammelten Informationen werden lokal auf dem System gespeichert."
+msgstr "Die gesammelten Informationen werden lokal auf dem System gespeichert."
 
 #: pkg/selinux/setroubleshoot-view.jsx:291
 msgid "The configured state is unknown, it might change on the next boot."
@@ -6661,8 +6653,7 @@ msgstr ""
 "Durch Fortfahren werden diese gestoppt."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Das Dateisystem wird von Anmeldesitzungen verwendet. Durch Fortfahren werden "
 "diese gestoppt."
@@ -6675,8 +6666,7 @@ msgstr ""
 "diese gestoppt."
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "Die folgenden Container hängen von diesem Image ab und werden unbrauchbar."
 
@@ -6780,8 +6770,7 @@ msgstr "Der Benutzer <b>$0</b> darf die Systemzeit nicht ändern"
 
 #: pkg/systemd/init.js:614
 msgid "The user <b>$0</b> is not permitted to enable or disable services"
-msgstr ""
-"Der Benutzer <b>$0</b> darf keine Dienste aktivieren oder deaktivieren"
+msgstr "Der Benutzer <b>$0</b> darf keine Dienste aktivieren oder deaktivieren"
 
 #: pkg/dashboard/list.js:223
 msgid "The user <b>$0</b> is not permitted to manage servers"
@@ -6830,8 +6819,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "Die Konfiguration des Webbrowsers verhindert, dass Cockpit ausgeführt wird "
 "(nicht erreichbar) $0)"
@@ -6850,8 +6838,7 @@ msgstr ""
 
 #: pkg/users/index.html:387
 msgid "There are no authorized public keys for this account."
-msgstr ""
-"Für dieses Konto existieren keine autorisierten öffentlichen Schlüssel"
+msgstr "Für dieses Konto existieren keine autorisierten öffentlichen Schlüssel"
 
 #: pkg/storaged/vgroup-details.jsx:102
 msgid ""
@@ -7079,8 +7066,7 @@ msgstr "So drücken Sie ein Bild in diesen Bildstream:"
 msgid ""
 "To try a different port you will need to upgrade cockpit-ws to a newer "
 "version."
-msgstr ""
-"Um einen anderen Port zu benutzen müssen Sie cockpit-ws aktualisieren."
+msgstr "Um einen anderen Port zu benutzen müssen Sie cockpit-ws aktualisieren."
 
 #: pkg/lib/cockpit-components-file-autocomplete.jsx:148
 msgid "Too many files found"
@@ -7163,18 +7149,17 @@ msgstr "Tuned läuft nicht"
 msgid "Tuned is off"
 msgstr "Tuned ist ausgeschaltet"
 
-#: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Typ"
 
@@ -7276,10 +7261,11 @@ msgstr "Einheit"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/lib/machine-info.js:65 pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:139
 #: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
 #: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -7495,7 +7481,7 @@ msgstr "Benutzername"
 msgid "User Password"
 msgstr "Benutzerpasswort"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Benutzername"
@@ -7645,7 +7631,7 @@ msgid "Verifying"
 msgstr "Überprüfung läuft"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Version"
 
@@ -7653,8 +7639,8 @@ msgstr "Version"
 msgid "Very securely erasing $target"
 msgstr "$target wird sehr sicher gelöscht"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Virtuelle Maschinen"
@@ -7672,11 +7658,10 @@ msgid "Virtualization Service is Available"
 msgstr "Der Virtualisierungsdienst ist verfügbar"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Lautstärke"
 
@@ -7874,8 +7859,12 @@ msgstr "[Binärdaten]"
 msgid "[no data]"
 msgstr "[keine Daten]"
 
-#: pkg/machines/components/networks/network.jsx:59
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "Aktiv"
@@ -8007,8 +7996,8 @@ msgstr ""
 msgid "idle"
 msgstr "im Leerlauf"
 
-#: pkg/machines/components/networks/network.jsx:59
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "Inaktiv"
 
@@ -8045,9 +8034,9 @@ msgstr "Netzwerk"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "Das NFS-Speicherauszugsziel ist nicht als Serverpfad formatiert"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "Nein"
@@ -8215,9 +8204,9 @@ msgid ""
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "Ja"

--- a/po/es.po
+++ b/po/es.po
@@ -19,14 +19,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-25 16:06+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2018-12-11 10:57+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Spanish\n"
 "Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -34,19 +34,15 @@ msgstr ""
 msgid " (shared with the OS)"
 msgstr " (compartido con el SO)"
 
-#: pkg/kubernetes/views/node-delete.html:8
-msgid " 1\"Do you want to delete the following Nodes?"
-msgstr " 1\"¿Quiere eliminar los nodos siguientes?"
-
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0 Dispositivo de Bloque"
 
-#: pkg/storaged/mdraid-details.jsx:193
+#: pkg/storaged/mdraid-details.jsx:192
 msgid "$0 Chunk Size"
 msgstr "$0 tamaño del fragmento"
 
-#: pkg/storaged/mdraid-details.jsx:191
+#: pkg/storaged/mdraid-details.jsx:190
 msgid "$0 Disks"
 msgstr "$0 Discos"
 
@@ -95,16 +91,16 @@ msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 datos + $1 geneal utilizado de $2 ($3)"
 
 #: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:213
+#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "Falta $0 disco"
 msgstr[1] "Faltan $0 discos"
 
 #: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:34
-#: pkg/playground/translate.js:37
+#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
@@ -144,10 +140,10 @@ msgstr ""
 "en \"GNOME Software\" o ejecuta el siguiente comando:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:237
-#: pkg/storaged/mdraid-details.jsx:290 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:203
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 esta en uso actualmente"
 
@@ -189,28 +185,11 @@ msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 usado de $1 ($2 guardado)"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/ovirt/components/vcpuModal.jsx:98
-msgid "$0 vCPU Details"
-msgstr "$0 Detalles vCPU"
-
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "Se instalará $0"
 
-#: pkg/kubernetes/scripts/nodes.js:871
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0 % disponible"
-msgstr[1] "$0 % disponible"
-
-#: pkg/kubernetes/scripts/nodes.js:873
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0 % en uso"
-msgstr[1] "$0 % en uso"
-
-#: pkg/storaged/vgroup-details.jsx:118
+#: pkg/storaged/vgroup-details.jsx:117
 msgid "$0, $1 free"
 msgstr "$0, $1 disponible"
 
@@ -236,19 +215,11 @@ msgstr "${hip}:${hport} → $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/subscriptions/subscriptions-client.js:197
-msgid "'Organization' required to register."
-msgstr "Se necesita «Organización» para efectuar el registro."
-
-#: pkg/subscriptions/subscriptions-client.js:201
-msgid "'Organization' required when using activation keys."
-msgstr "Se necesita «Organización» al utilizar claves de activación."
-
-#: pkg/networkmanager/firewall.jsx:547
+#: pkg/networkmanager/firewall.jsx:549
 msgid "(Optional)"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:616
+#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(predeterminado)"
@@ -510,8 +481,8 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"No se ha instalado una versión compatible de Cockpit en "
-"{{#strong}}{{host}}{{/strong}}."
+"No se ha instalado una versión compatible de Cockpit en {{#strong}}{{host}}"
+"{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:59
 msgid "A disk is needed."
@@ -542,12 +513,8 @@ msgstr "Supervisión ARP"
 msgid "ARP Ping"
 msgstr "Ping ARP"
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "AWS Almacén Elástico de Bloque"
-
 #: pkg/shell/index.html:56 pkg/shell/index.html:82 pkg/shell/simple.html:42
-#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
+#: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Acerca de Cockpit"
 
@@ -555,19 +522,9 @@ msgstr "Acerca de Cockpit"
 msgid "Access"
 msgstr "Acceder"
 
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
-msgid "Access Modes"
-msgstr "Modos de acceso"
-
-#: pkg/kubernetes/views/project-modify.html:49
 #: node_modules/registry-image-widgets/views/imagestream-body.html:12
 msgid "Access Policy"
 msgstr "Normativa de acceso"
-
-#: pkg/subscriptions/subscriptions-view.jsx:213
-msgid "Access denied"
-msgstr "Acceso denegado"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -585,18 +542,13 @@ msgstr "La cuenta no está disponible o no se puede modificar."
 msgid "Accounts"
 msgstr "Cuentas"
 
-#: pkg/users/local.js:335 pkg/users/local.js:642
+#: pkg/users/local.js:339 pkg/users/local.js:646
 msgctxt "page-title"
 msgid "Accounts"
 msgstr "Cuentas"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:183
-msgid "Action"
-msgstr "Acción"
-
-#: pkg/machines/components/networks/network.jsx:147
-#: pkg/machines/components/storagePools/storagePool.jsx:167
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Activar"
@@ -604,10 +556,6 @@ msgstr "Activar"
 #: pkg/storaged/jobs-panel.jsx:68
 msgid "Activating $target"
 msgstr "Activando $target"
-
-#: pkg/subscriptions/subscriptions-register.jsx:168
-msgid "Activation Key"
-msgstr "Clave de activación"
 
 #: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
 msgid "Active"
@@ -617,7 +565,7 @@ msgstr "Activo"
 msgid "Active Backup"
 msgstr "Copia de seguridad activa"
 
-#: pkg/shell/index.html:59 pkg/shell/stub.html:49 pkg/shell/active-pages.js:95
+#: pkg/shell/index.html:59 pkg/shell/active-pages.js:95
 msgid "Active Pages"
 msgstr "Páginas Activas"
 
@@ -625,13 +573,9 @@ msgstr "Páginas Activas"
 msgid "Active since"
 msgstr "Activo desde"
 
-#: pkg/networkmanager/firewall.jsx:922
+#: pkg/networkmanager/firewall.jsx:924
 msgid "Active zones"
 msgstr ""
-
-#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
-msgid "Actual"
-msgstr "Real"
 
 #: pkg/networkmanager/interfaces.js:1980
 msgid "Adaptive load balancing"
@@ -641,16 +585,11 @@ msgstr "Equilibrio de carga adaptativo"
 msgid "Adaptive transmit load balancing"
 msgstr "Equilibrio de carga de transmisión adaptativa"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/add-role-dialog.html:8
-#: pkg/kubernetes/views/add-user-dialog.html:27
-#: pkg/kubernetes/views/node-add.html:50
-#: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:534
-#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/vgroup-details.jsx:63
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Añadir"
 
@@ -670,12 +609,8 @@ msgstr "Añadir vínculo"
 msgid "Add Bridge"
 msgstr "Añadir puente"
 
-#: pkg/kubernetes/views/node-add.html:3
-msgid "Add Cluster Node"
-msgstr "Añadir nodo de agrupación"
-
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:356
+#: pkg/machines/components/diskAdd.jsx:360
 msgid "Add Disk"
 msgstr "Añadir disco"
 
@@ -683,56 +618,21 @@ msgstr "Añadir disco"
 msgid "Add Disks"
 msgstr "Añadir discos"
 
-#: pkg/kubernetes/views/add-group-dialog.html:3
-msgid "Add Group"
-msgstr "Añadir grupo"
-
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/storaged/crypto-keyslots.jsx:200
 msgid "Add Key"
 msgstr "Añadir clave"
 
-#: pkg/kubernetes/views/nodes-page.html:34
-msgid "Add Kubernetes Node"
-msgstr "Añadir nodo de Kubernetes"
-
 #: pkg/lib/machine-add.html:4
 msgid "Add Machine to Dashboard"
 msgstr "Añadir máquina al tablero"
-
-#: pkg/kubernetes/views/add-member-role-dialog.html:4
-#: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/group-panel.html:29
-#: pkg/kubernetes/views/project-body.html:108
-#: pkg/kubernetes/views/user-group-add.html:3
-msgid "Add Member"
-msgstr "Añadir miembro"
-
-#: pkg/kubernetes/views/user-body.html:67
-#: pkg/kubernetes/views/user-panel.html:76
-msgid "Add Membership"
-msgstr "Añadir afiliación"
-
-#: pkg/kubernetes/views/auth-form.html:11
-#: pkg/kubernetes/views/auth-form.html:20
-msgid "Add New Cluster"
-msgstr "Añadir agrupación nueva"
-
-#: pkg/kubernetes/views/auth-form.html:67
-#: pkg/kubernetes/views/auth-form.html:76
-msgid "Add New User"
-msgstr "Añadir usuario nuevo"
 
 #: pkg/networkmanager/firewall.jsx:457
 msgid "Add Ports"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html:3
-msgid "Add Role"
-msgstr "Añadir rol"
-
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:872
-#: pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
+#: pkg/networkmanager/firewall.jsx:886
 msgid "Add Services"
 msgstr "Añadir Servicios"
 
@@ -744,17 +644,12 @@ msgstr "Añadir almacenamiento"
 msgid "Add Team"
 msgstr "Añadir equipo"
 
-#: pkg/kubernetes/views/add-user-dialog.html:3
-#: pkg/kubernetes/views/project-listing.html:83
-msgid "Add User"
-msgstr "Añadir usuario"
-
 #: pkg/networkmanager/index.html:113
 msgid "Add VLAN"
 msgstr "Añadir VLAN"
 
-#: pkg/networkmanager/firewall.jsx:698 pkg/networkmanager/firewall.jsx:878
-#: pkg/networkmanager/firewall.jsx:889
+#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
+#: pkg/networkmanager/firewall.jsx:891
 msgid "Add Zone"
 msgstr ""
 
@@ -765,10 +660,6 @@ msgstr "Agregar portal iSCSI"
 #: pkg/shell/index.html:172 pkg/users/index.html:414
 msgid "Add key"
 msgstr "Añadir clave"
-
-#: pkg/kubernetes/views/user-add-membership.html:3
-msgid "Add membership"
-msgstr "Añadir afiliación"
 
 #: pkg/networkmanager/firewall.jsx:458
 msgid "Add ports to the following zones:"
@@ -782,7 +673,7 @@ msgstr "Añadir clave pública"
 msgid "Add services to following zones:"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:774
+#: pkg/networkmanager/firewall.jsx:776
 msgid "Add zone"
 msgstr ""
 
@@ -814,7 +705,7 @@ msgstr "DNA adicional $val"
 msgid "Additional DNS Search Domains $val"
 msgstr "Búsqueda de Dominios DNA Adicional $val"
 
-#: pkg/docker/index.html:307
+#: pkg/docker/index.html:309
 msgid "Additional Storage"
 msgstr "Almacenamiento Adicional"
 
@@ -827,14 +718,11 @@ msgstr "Dirección adicional $val"
 msgid "Additional packages:"
 msgstr "Paquetes adicionales:"
 
-#: pkg/kubernetes/views/auth-form.html:29
-#: pkg/kubernetes/views/dashboard-page.html:157
-#: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
+#: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:77 pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:107
+#: pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Dirección"
 
@@ -852,44 +740,18 @@ msgid "Address is not a valid URL"
 msgstr "La dirección no es una URL válida"
 
 #: pkg/machines/components/desktopConsole.jsx:153
-#: pkg/ovirt/components/VmOverviewColumn.jsx:53
 msgid "Address:"
 msgstr "Dirección:"
 
-#: pkg/kubernetes/views/details-page.html:37
 #: pkg/networkmanager/interfaces.js:3309
 msgid "Addresses"
 msgstr "Dirección"
-
-#: pkg/kubernetes/views/service-modify.html:25
-msgid "Adjust"
-msgstr "Ajustar"
-
-#: pkg/kubernetes/views/pv-modify.html:3
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "Ajustar Volumen Persistente '{{ item.metadata.name }}'"
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html:3
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "Ajustar el Controlador de Replicación {{ item.metadata.name }}"
-
-#: pkg/kubernetes/views/route-modify.html:3
-msgid "Adjust Route"
-msgstr "Ajustar Ruta"
-
-#: pkg/kubernetes/views/service-modify.html:3
-msgid "Adjust Service"
-msgstr "Ajustar servicio"
-
-#: pkg/kubernetes/views/project-body.html:56
-msgid "Admin"
-msgstr "Administración"
 
 #: org.cockpit-project.cockpit-bridge.policy.in.h:1
 msgid "Administration with Cockpit Web Console"
 msgstr ""
 
-#: pkg/realmd/operation.js:336
+#: pkg/realmd/operation.js:335
 msgid "Administrator Password"
 msgstr "Contraseña de Administrador"
 
@@ -925,14 +787,6 @@ msgstr "Todos"
 msgid "All In One"
 msgstr "Todo En Uno"
 
-#: pkg/kubernetes/views/filter-project.html:4
-msgid "All Projects"
-msgstr "Todos los Proyectos"
-
-#: pkg/kubernetes/views/details-page.html:6
-msgid "All Types"
-msgstr "Todos los Tipos"
-
 #: pkg/docker/storage.jsx:381
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
@@ -941,35 +795,15 @@ msgstr ""
 "Todos los datos en los discos seleccionados serán borrados y los discos "
 "serán añadidos al pool de almacenamiento."
 
-#: pkg/kubernetes/views/dashboard-page.html:112
-msgid "All healthy"
-msgstr "Todo saludable"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:74
-msgid "All images"
-msgstr "Todas las imágenes"
-
-#: pkg/kubernetes/views/dashboard-page.html:69
-msgid "All in use"
-msgstr "Todo en uso"
-
-#: pkg/kubernetes/views/dashboard-page.html:37
-msgid "All running"
-msgstr "Todo corriendo"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:36
-msgid "All running virtual machines will be turned off."
-msgstr "Todas las máquinas virtuales corriendo serán apagadas."
-
-#: pkg/networkmanager/firewall.jsx:749
+#: pkg/networkmanager/firewall.jsx:751
 msgid "Allowed Addresses"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:935
+#: pkg/networkmanager/firewall.jsx:937
 msgid "Allowed Services"
 msgstr "Servicios Permitidos"
 
-#: pkg/docker/index.html:548 pkg/docker/util.js:108
+#: pkg/docker/index.html:550 pkg/docker/util.js:108
 msgid "Always"
 msgstr "Siempre"
 
@@ -977,19 +811,11 @@ msgstr "Siempre"
 msgid "Always attach"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
-#: pkg/kubernetes/views/route-body.html:27
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Anotaciones"
 
-#: pkg/kubernetes/scripts/projects.js:1044
-msgid "Anonymous: Allow all unauthenticated users to pull images"
-msgstr ""
-"Anónimo: Permite a todos los usuarios no autentificados tirar de las "
-"imágenes"
-
-#: pkg/systemd/terminal.jsx:94
+#: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr ""
 
@@ -1002,11 +828,10 @@ msgstr "Aplicaciones"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235
-#: pkg/ovirt/components/vcpuModal.jsx:104 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -1035,7 +860,6 @@ msgid "Applying updates failed"
 msgstr "Falló aplicar actualizaciones. "
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
-#: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Architecture"
 msgstr "Arquitectura"
 
@@ -1047,8 +871,8 @@ msgstr "Etiqueta de Propiedad"
 msgid "At least $0 disks are needed."
 msgstr "Se necesitan al menos $0 discos."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Se necesita al menos un disco."
 
@@ -1064,9 +888,8 @@ msgstr "Registro de auditoria"
 msgid "Authenticating"
 msgstr "Autenticando "
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
 #: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Autenticación"
 
@@ -1092,7 +915,7 @@ msgstr ""
 msgid "Authentication required"
 msgstr "Autentificación requerida"
 
-#: pkg/docker/index.html:700
+#: pkg/docker/index.html:702
 #: node_modules/registry-image-widgets/views/image-body.html:12
 #: pkg/docker/containers-view.jsx:413
 msgid "Author"
@@ -1105,7 +928,7 @@ msgstr "Llaves SSH Públicas Autorizadas"
 #: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
 #: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
 #: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:339
+#: pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automático"
 
@@ -1125,10 +948,6 @@ msgstr ""
 msgid "Automatic Updates"
 msgstr "Actualizaciones Automáticas"
 
-#: pkg/ovirt/components/OVirtTab.jsx:81
-msgid "Automatically selected host"
-msgstr "Host seleccionado automáticamente"
-
 #: pkg/machines/components/libvirtSlate.jsx:90
 msgid "Automatically start libvirt on boot"
 msgstr "Iniciar automáticamente libvirt en el arranque"
@@ -1141,9 +960,9 @@ msgstr "Usando automáticamente NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Usando automáticamente servidores NTP específicos"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:155
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
 
@@ -1164,10 +983,6 @@ msgstr "Objetivos disponibles en $0"
 #: pkg/dashboard/index.html:163
 msgid "Avatar"
 msgstr "Avatar"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
 
 #: pkg/systemd/hwinfo.jsx:92
 msgid "BIOS"
@@ -1196,18 +1011,6 @@ msgstr "Datos malos, pasados para el mecanismo passwd1"
 #: pkg/networkmanager/index.html:333
 msgid "Balancer"
 msgstr "Balanceador"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-msgid "Base Template"
-msgstr "Plantilla Base"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Base template"
-msgstr "Plantilla base"
-
-#: pkg/ovirt/components/OVirtTab.jsx:106 pkg/ovirt/components/OVirtTab.jsx:113
-msgid "Base template:"
-msgstr "Plantilla base:"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/systemd/init.js:729
@@ -1252,12 +1055,8 @@ msgstr "Vínculo"
 msgid "Bond Settings"
 msgstr "Configuración Bond"
 
-#: pkg/kubernetes/views/node-body.html:17
-msgid "Boot ID"
-msgstr "ID de Arranque"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:312
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:153
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:164
 msgid "Boot Order"
 msgstr ""
 
@@ -1316,10 +1115,8 @@ msgstr "Bus"
 msgid "Bus Expansion Chassis"
 msgstr "Chasis de Expansión de Bus"
 
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:270
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:603
-#: pkg/kubernetes/scripts/nodes.js:711 pkg/kubernetes/scripts/nodes.js:818
-#: pkg/systemd/hwinfo.jsx:108
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:272
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
 msgid "CPU"
 msgstr "CPU"
 
@@ -1336,28 +1133,20 @@ msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Estado del CPU"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:154
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:165
 msgid "CPU Type"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "Uso de CPU: $0%"
-
-#: pkg/docker/index.html:469 pkg/docker/index.html:641
+#: pkg/docker/index.html:471 pkg/docker/index.html:643
 msgid "CPU priority"
 msgstr "Prioridad del CPU"
 
-#: pkg/docker/index.html:217
+#: pkg/docker/index.html:218
 msgid "CPU usage:"
 msgstr "Utilización de CPU:"
 
-#: pkg/ovirt/provider.js:256
-msgid "CREATE VM action failed"
-msgstr "Fallo en la acción CREATE VM"
-
-#: pkg/machines/components/diskAdd.jsx:235
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
@@ -1377,79 +1166,44 @@ msgstr "No se puede eliminar mientras está desbloqueado"
 msgid "Can't load image"
 msgstr "No puede cargar imagen"
 
-#: pkg/dashboard/index.html:175 pkg/docker/index.html:563
-#: pkg/docker/index.html:597 pkg/docker/index.html:661
-#: pkg/docker/index.html:715 pkg/docker/index.html:755
-#: pkg/docker/index.html:784 pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/add-role-dialog.html:7
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/image-delete.html:7
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/user-group-add.html:29
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
-#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:477 pkg/networkmanager/index.html:501
-#: pkg/networkmanager/index.html:525 pkg/networkmanager/index.html:549
-#: pkg/networkmanager/index.html:573 pkg/networkmanager/index.html:597
-#: pkg/networkmanager/index.html:621 pkg/networkmanager/index.html:645
-#: pkg/networkmanager/index.html:669 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:81 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/systemd/index.html:332
+#: pkg/dashboard/index.html:175 pkg/docker/index.html:565
+#: pkg/docker/index.html:599 pkg/docker/index.html:663
+#: pkg/docker/index.html:717 pkg/docker/index.html:757
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
+#: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
+#: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
+#: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:85
-#: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:649
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:531
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:485
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:558 pkg/networkmanager/firewall.jsx:626
-#: pkg/networkmanager/firewall.jsx:769
-#: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:415
 msgid "Cannot connect to an unknown machine"
 msgstr "No se puede conectar a una máquina desconocida"
-
-#: src/ws/cockpitcertificate.c:483
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "No se puede descifrar llave privada cifrada con PEM"
 
 #: src/base1/cockpit.js:4031
 msgid "Cannot forward login credentials"
@@ -1459,8 +1213,6 @@ msgstr "No se pueden re-enviar las credenciales de acceso"
 msgid "Cannot schedule event in the past"
 msgstr "No puede planificar un evento en el pasado"
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
 #: pkg/machines/components/vmDisksTab.jsx:70
 msgid "Capacity"
 msgstr "Capacidad"
@@ -1469,18 +1221,7 @@ msgstr "Capacidad"
 msgid "Carrier"
 msgstr "Transporte"
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Montaje del Sistema de Archivos Ceph"
-
-#: pkg/kubernetes/views/volume-body.html:97
-msgid "Ceph Monitors"
-msgstr "Monitores Ceph"
-
-#: pkg/docker/index.html:662 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
-#: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:333
+#: pkg/docker/index.html:664 pkg/systemd/index.html:333
 #: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
 #: pkg/storaged/iscsi-panel.jsx:181
 msgid "Change"
@@ -1506,32 +1247,20 @@ msgstr "Cambiar Perfil"
 msgid "Change System Time"
 msgstr "Cambiar la Hora del Sistema"
 
-#: pkg/kubernetes/views/user-modify.html:3
-msgid "Change User"
-msgstr "Cambiar Usuario"
-
 #: pkg/storaged/iscsi-panel.jsx:176
 msgid "Change iSCSI Initiator Name"
 msgstr "Cambiar Nombre Iniciador de iSCSI "
-
-#: pkg/kubernetes/views/imagestream-modify.html:4
-msgid "Change image stream"
-msgstr "Cambiar flujo de imagen"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/storaged/crypto-keyslots.jsx:247
 msgid "Change passphrase"
 msgstr "Cambiar frase de acceso"
 
-#: pkg/kubernetes/views/project-modify.html:10
-msgid "Change project"
-msgstr "Cambiar proyecto"
-
-#: pkg/docker/index.html:228
+#: pkg/docker/index.html:229
 msgid "Change resource limits"
 msgstr "Cambiar los límites de recurso"
 
-#: pkg/docker/index.html:612
+#: pkg/docker/index.html:614
 msgid "Change resources limits"
 msgstr "Cambiar límites de recursos"
 
@@ -1539,10 +1268,10 @@ msgstr "Cambiar límites de recursos"
 msgid "Change the settings"
 msgstr "Cambiar los ajustes"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Los cambios entrarán en vigor después de apagar la máquina virtual"
 
@@ -1591,25 +1320,13 @@ msgstr "Buscando actualizaciones..."
 msgid "Checking installed software"
 msgstr "Comprobando el software instalado"
 
-#: pkg/shell/index.html:117 pkg/shell/simple.html:85 pkg/shell/stub.html:100
+#: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "Seleccione el idioma del idioma a utilizar en la aplicación"
 
 #: pkg/storaged/mdraids-panel.jsx:57
 msgid "Chunk Size"
 msgstr "Tamaño de la porción"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinder"
-
-#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
-msgid "Claim"
-msgstr "Reclamación"
-
-#: pkg/kubernetes/views/pvc-body.html:4
-msgid "Claim Name"
-msgstr "Nombre de Reclamación"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Class"
@@ -1634,42 +1351,26 @@ msgstr ""
 "Dar click en \"Lanzar Visor Remoto\" descargará un archivo con la extensión ."
 "vv y lo ejecutará $0."
 
-#: pkg/kubernetes/views/auth-form.html:88
-msgid "Client Certificate"
-msgstr "Certificado de Cliente"
-
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:736 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/systemd/index.html:278
-#: pkg/systemd/services.html:363 pkg/systemd/services.html:381
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:126 pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Cerrar"
 
 #: pkg/shell/active-pages.js:103
 msgid "Close Selected Pages"
 msgstr "Cerrar Paginas Seleccionas"
-
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
-#: pkg/ovirt/components/App.jsx:107
-msgid "Cluster"
-msgstr "Cluster"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:128
-msgid "Cluster Templates"
-msgstr "Plantilla de Cluster"
-
-#: pkg/ovirt/components/ClusterVms.jsx:174
-msgid "Cluster Virtual Machines"
-msgstr "Cluster de Máquinas Virtuales"
 
 #: src/ws/login.js:346
 msgid "Cockpit authentication is configured incorrectly."
@@ -1712,7 +1413,7 @@ msgstr ""
 "iniciado con Cockpit. Asimismo, si se produce un error en el terminal, podrá "
 "verlo en la bitácora de Cockpit."
 
-#: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
+#: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit es una interfaz interactiva de gestión de servidores Linux."
 
@@ -1749,16 +1450,15 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit no pudo ingresar en {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}Puede que desee probar a {{#sync_link}}sincronizar usuarios{{/"
-"sync_link}}.{{/can_sync}} Para obtener más opciones de autenticación y "
-"asistencia para solucionar problemas, actualice cockpit-ws a una versión más "
-"reciente."
+"Cockpit no pudo ingresar en {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"Puede que desee probar a {{#sync_link}}sincronizar usuarios{{/sync_link}}.{{/"
+"can_sync}} Para obtener más opciones de autenticación y asistencia para "
+"solucionar problemas, actualice cockpit-ws a una versión más reciente."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1798,12 +1498,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Uso combinado de núcleo de CPU $0"
 msgstr[1] "Uo combinado de núcleos de CPU $0"
 
-#: pkg/networkmanager/firewall.jsx:527
+#: pkg/networkmanager/firewall.jsx:529
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
-#: pkg/docker/index.html:269 pkg/docker/index.html:445
-#: pkg/docker/index.html:706 pkg/systemd/services.html:427
+#: pkg/docker/index.html:271 pkg/docker/index.html:447
+#: pkg/docker/index.html:708 pkg/systemd/services.html:427
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1814,7 +1514,7 @@ msgstr "Orden"
 msgid "Command can't be empty"
 msgstr "La orden no puede estar vacía"
 
-#: pkg/docker/index.html:163
+#: pkg/docker/index.html:164
 msgid "Command:"
 msgstr "Orden:"
 
@@ -1822,12 +1522,12 @@ msgstr "Orden:"
 msgid "Comment"
 msgstr "Comentario"
 
-#: pkg/docker/index.html:137 pkg/docker/index.html:716
+#: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
 msgstr "Consigna"
 
-#: pkg/docker/index.html:676
+#: pkg/docker/index.html:678
 msgid "Commit Image"
 msgstr "Imagen de consigna"
 
@@ -1851,8 +1551,8 @@ msgstr "Compatible con los sistemas modernos y discos duros > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Comprimir volcado de errores para ahorrar espacio"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Compresión"
 
@@ -1868,21 +1568,9 @@ msgstr "La condición $0=$1 no se cumple"
 msgid "Condition failed"
 msgstr "Condición fallida"
 
-#: pkg/kubernetes/views/node-add.html:24
-msgid "Configuration"
-msgstr "Configuración"
-
 #: pkg/networkmanager/interfaces.js:2725
 msgid "Configure"
 msgstr "Configurar"
-
-#: pkg/kubernetes/views/node-add.html:42
-msgid "Configure Flannel networking"
-msgstr "Configurar la red Flannel"
-
-#: pkg/kubernetes/views/node-add.html:32
-msgid "Configure Kubelet and Proxy"
-msgstr "Configurar Kubelet y proxy"
 
 #: pkg/docker/storage.jsx:331
 msgid "Configure storage..."
@@ -1905,22 +1593,14 @@ msgstr "Confirmar"
 msgid "Confirm New Password"
 msgstr "Confirmar Nueva Contraseña"
 
-#: pkg/ovirt/components/OVirtTab.jsx:65
-msgid "Confirm migration"
-msgstr "Confirme migración"
-
-#: pkg/ovirt/components/VdsmView.jsx:95
-msgid "Confirm reload:"
-msgstr "Confirme recarga:"
+#: pkg/machines/components/networks/networkDelete.jsx:95
+msgid "Confirm deletion of the Virtual Network"
+msgstr ""
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Confirm removal with passphrase"
 msgstr "Confirmar eliminación con frase de acceso"
-
-#: pkg/ovirt/components/VdsmView.jsx:108
-msgid "Confirm save:"
-msgstr "Confirme guardar:"
 
 #: pkg/systemd/init.js:728
 msgid "Conflicted By"
@@ -1931,8 +1611,6 @@ msgstr "En conflicto por"
 msgid "Conflicts"
 msgstr "Conflictos"
 
-#: pkg/kubernetes/views/auth-form.html:130
-#: pkg/kubernetes/views/auth-rejected-cert.html:33
 #: pkg/lib/machine-unknown-hostkey.html:22
 msgid "Connect"
 msgstr "Conectar"
@@ -1944,10 +1622,6 @@ msgstr "Conectado automáticamente"
 #: src/ws/login.html:74
 msgid "Connect to"
 msgstr "Conectar a "
-
-#: pkg/ovirt/components/InstallationDialog.jsx:102
-msgid "Connect to oVirt Engine"
-msgstr "Conectar a oVirt Engine"
 
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "Connect with any $0 viewer application."
@@ -1979,33 +1653,21 @@ msgstr "Conectando al demonio SETroubleshoot..."
 msgid "Connecting to Virtualization Service"
 msgstr "Conectando al Servicio de Virtualización"
 
-#: pkg/shell/indexes.js:411
+#: pkg/shell/indexes.js:410
 msgid "Connecting to the machine"
 msgstr "Conectándose a la máquina"
 
-#: pkg/kubernetes/index.html:104 pkg/kubernetes/registry.html:71
-msgid "Connecting..."
-msgstr "Conectando..."
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:568
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Conexión"
 
-#: pkg/kubernetes/views/auth-dialog.html:4 pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:406
 msgid "Connection Error"
 msgstr "Error de Conexión"
-
-#: pkg/kubernetes/scripts/connection.js:512
-msgid "Connection Error: $0"
-msgstr "Error de conexión: $0"
-
-#: pkg/kubernetes/views/auth-dialog.html:3
-msgid "Connection Settings"
-msgstr "Ajustes de Conexión"
 
 #: src/base1/cockpit.js:4027
 msgid "Connection has timed out."
@@ -2028,34 +1690,23 @@ msgstr "Tipo de Consola"
 msgid "Consoles"
 msgstr "Consolas"
 
-#: pkg/realmd/operation.js:274
+#: pkg/realmd/operation.js:273
 msgid "Contacted domain"
 msgstr ""
 
-#: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
-#: pkg/kubernetes/views/container-page-inline.html:2
-#: pkg/kubernetes/views/container-panel.html:4
-#: pkg/kubernetes/views/image-page.html:23
+#: pkg/docker/console.html:4
 #: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Contenedor"
 
-#: pkg/users/local.js:748
+#: pkg/users/local.js:752
 msgid "Container Administrator"
 msgstr "Administrador del Contenedor"
 
-#: pkg/kubernetes/views/container-body.html:10
-msgid "Container ID"
-msgstr "ID de Contenedor"
-
-#: pkg/docker/index.html:438 pkg/docker/index.html:618
-#: pkg/docker/index.html:682
+#: pkg/docker/index.html:440 pkg/docker/index.html:620
+#: pkg/docker/index.html:684
 msgid "Container Name"
 msgstr "Nombre del Contenedor"
-
-#: pkg/kubernetes/views/node-body.html:21
-msgid "Container Runtime Version"
-msgstr "Contenedor de Versión en Tiempo de Ejecución"
 
 #: pkg/docker/util.js:506
 msgid ""
@@ -2068,15 +1719,12 @@ msgstr ""
 msgid "Container is currently running."
 msgstr "El contenedor esta corriendo actualmente"
 
-#: pkg/docker/index.html:141
+#: pkg/docker/index.html:133
 msgid "Container:"
 msgstr "Contenedor:"
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:287
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
-#: pkg/kubernetes/views/dashboard-page.html:158
-#: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:375
+#: pkg/docker/index.html:23 pkg/docker/index.html:289
+#: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "Contenedores"
 
@@ -2090,12 +1738,12 @@ msgid "Content"
 msgstr "Contenido"
 
 #: src/base1/test-locale.js:42 src/base1/test-locale.js:53
-#: pkg/playground/translate.js:22
+#: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Control"
 
 #: src/base1/test-locale.js:43 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:25
+#: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
 msgstr "Control"
@@ -2110,7 +1758,6 @@ msgstr ""
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.6, DocId: cockpit
 #: pkg/machines/components/vcpuModal.jsx:209
-#: pkg/ovirt/components/vcpuModal.jsx:67
 msgid "Cores per socket"
 msgstr "Núcleos por socket"
 
@@ -2121,18 +1768,6 @@ msgstr "No podría añadir todos los discos"
 #: pkg/lib/machine-change-port.html:4
 msgid "Could not contact {{host}}"
 msgstr "No se puedo contactar {{host}}"
-
-#: pkg/kubernetes/views/dashboard-page.html:142
-msgid "Could not list services"
-msgstr "No se pueden listar los servicios"
-
-#: src/ws/cockpitcertificate.c:531
-msgid "Could not parse PEM-encoded certificate"
-msgstr "No es posible descifrar certificado codificado con PEM"
-
-#: src/ws/cockpitcertificate.c:498
-msgid "Could not parse PEM-encoded private key"
-msgstr "No se puede resolver llave privada cifrada con PEM"
 
 #: pkg/docker/storage.jsx:468
 msgid "Could not reset the storage pool"
@@ -2146,30 +1781,13 @@ msgstr "No se pudo cambiar los grupos del usuario"
 msgid "Couldn't change user password"
 msgstr "No se pudo cambiar la contraseña del usuario"
 
-#: pkg/kubernetes/index.html:105 pkg/kubernetes/registry.html:72
-msgid "Couldn't connect to server"
-msgstr "No se pudo conectar al servidor"
-
-#: pkg/shell/indexes.js:414
+#: pkg/shell/indexes.js:413
 msgid "Couldn't connect to the machine"
 msgstr "No se pudo conectar a la máquina"
 
 #: src/bridge/cockpitdbussetup.c:544
 msgid "Couldn't create new users"
 msgstr "No se pueden crear nuevos usuarios"
-
-#: pkg/kubernetes/scripts/connection.js:510
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:957
-msgid "Couldn't find running API server"
-msgstr "No se puede encontrar un servidor API ejecutandose"
-
-#: pkg/subscriptions/subscriptions-view.jsx:218
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"No podría obtener el estado del sistema de suscripción. Por favor asegura "
-"que el gestor de suscripción está instalado."
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -2191,14 +1809,12 @@ msgstr "Localización del volcado de errores"
 msgid "Crash system"
 msgstr "Error del sistema"
 
-#: pkg/kubernetes/views/add-group-dialog.html:19
-#: pkg/kubernetes/views/project-modify.html:72 pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:652
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:488
-#: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/users/index.html:199
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Crear"
 
@@ -2207,17 +1823,13 @@ msgid "Create Logical Volume"
 msgstr "Crear un volumen logico"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.6, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:487
+#: pkg/machines/components/diskAdd.jsx:515
 msgid "Create New"
 msgstr "Crear nuevo"
 
 #: pkg/users/index.html:52 pkg/users/index.html:163
 msgid "Create New Account"
 msgstr "Crear nueva Cuenta"
-
-#: pkg/ovirt/components/App.jsx:162
-msgid "Create New VM"
-msgstr "Crear Nueva VM"
 
 #: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
 msgid "Create Partition"
@@ -2243,7 +1855,7 @@ msgstr "Crear Reporte"
 msgid "Create Snapshot"
 msgstr "Crear Instantánea"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:522
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
 msgid "Create Storage Pool"
 msgstr "Crear grupo de almacenamiento"
 
@@ -2263,8 +1875,7 @@ msgstr "Crear Temporizadores"
 msgid "Create VDO Device"
 msgstr "Crear Dispositivo VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:685
-#: pkg/ovirt/components/ClusterTemplates.jsx:81
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
 msgid "Create VM"
 msgstr "Crear VM"
 
@@ -2276,14 +1887,6 @@ msgstr "Crear un Grupo de Volúmenes"
 msgid "Create diagnostic report"
 msgstr "Crear reporte de diagnóstico"
 
-#: pkg/kubernetes/scripts/images.js:643
-msgid "Create empty image stream"
-msgstr "Crea un flujo de imágenes vacío"
-
-#: pkg/kubernetes/views/imagestream-modify.html:3
-msgid "Create image stream"
-msgstr "Crear un flujo de imagen"
-
 #: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
 #: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
 msgid "Create it"
@@ -2293,16 +1896,12 @@ msgstr "Crearlo"
 msgid "Create new Logical Volume"
 msgstr "Crear un nuevo Volumen Lógico"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/kubernetes/views/replicationcontroller-body.html:7
-#: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:129
-#: pkg/docker/containers-view.jsx:412 pkg/docker/containers-view.jsx:683
+#: pkg/docker/containers-view.jsx:129 pkg/docker/containers-view.jsx:412
+#: pkg/docker/containers-view.jsx:683
 msgid "Created"
 msgstr "Creado"
 
-#: pkg/docker/index.html:152
+#: pkg/docker/index.html:153
 msgid "Created:"
 msgstr "Creado:"
 
@@ -2362,7 +1961,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Creando Grupo de Volumen $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:554
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
 msgid "Creation of VM $0 failed"
 msgstr ""
 
@@ -2390,23 +1989,19 @@ msgstr "Arranque actual"
 msgid "Custom"
 msgstr "Personalizar"
 
-#: pkg/networkmanager/firewall.jsx:521
+#: pkg/networkmanager/firewall.jsx:523
 msgid "Custom Ports"
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:103
-msgid "Custom URL"
-msgstr "URL personal"
 
 #: pkg/storaged/format-dialog.jsx:118
 msgid "Custom encryption options"
 msgstr "Opciones de encriptación personalizadas"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Opciones de montaje personalizadas"
 
-#: pkg/networkmanager/firewall.jsx:716
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Custom zones"
 msgstr ""
 
@@ -2426,10 +2021,6 @@ msgstr "DNS"
 #: pkg/networkmanager/interfaces.js:2656
 msgid "DNS $val"
 msgstr "DNS $val"
-
-#: pkg/kubernetes/views/pod-body.html:14
-msgid "DNS Policy"
-msgstr "Política DNS"
 
 #: pkg/networkmanager/interfaces.js:3320
 msgid "DNS Search Domains"
@@ -2451,8 +2042,8 @@ msgstr "Tablero"
 msgid "Data Used"
 msgstr "Datos Usados"
 
-#: pkg/machines/components/networks/network.jsx:143
-#: pkg/machines/components/storagePools/storagePool.jsx:163
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Desactivar"
@@ -2473,10 +2064,9 @@ msgstr "Depurar y arriba"
 msgid "Deduplication"
 msgstr "Deduplicación"
 
-#: pkg/docker/index.html:357 pkg/docker/index.html:361
+#: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: node_modules/registry-image-widgets/views/image-config.html:10
 #: pkg/storaged/format-dialog.jsx:68
-#: pkg/subscriptions/subscriptions-register.jsx:102
 msgid "Default"
 msgstr "Predeterminado"
 
@@ -2484,37 +2074,26 @@ msgstr "Predeterminado"
 msgid "Delay"
 msgstr "Retraso"
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:246
-#: pkg/kubernetes/views/image-delete.html:8
-#: pkg/kubernetes/views/imagestream-delete.html:8
-#: pkg/kubernetes/views/item-delete.html:11
-#: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/project-delete.html:9
-#: pkg/kubernetes/views/pv-delete.html:11
-#: pkg/kubernetes/views/pvc-delete.html:15
-#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/machines/components/networks/networkDelete.jsx:86
+#: pkg/machines/components/networks/networkDelete.jsx:103
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:300 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:214 pkg/storaged/vgroup-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Eliminar"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1179
+#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Eliminar $0"
-
-#: pkg/playground/translate.html:189
-msgid "Delete '{{ name }}'"
-msgstr "Borrar '{{ nombre }}'"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
 msgid "Delete Content"
@@ -2524,25 +2103,10 @@ msgstr ""
 msgid "Delete Files"
 msgstr "Borrar Ficheros"
 
-#: pkg/kubernetes/views/node-delete.html:4
-msgid "Delete Node"
-msgstr "Borrar Nodo"
-
-#: pkg/kubernetes/views/pv-delete.html:3
-msgid "Delete Persistent Volume"
-msgstr "Borrar Volumen Persitente"
-
-#: pkg/kubernetes/views/pvc-delete.html:3
-msgid "Delete Persistent Volume Claim"
-msgstr "Eliminar la Reclamación de Volumen Persistente"
-
-#: pkg/kubernetes/views/project-delete.html:3
-msgid "Delete Project"
-msgstr "Borrar Proyecto"
-
-#: pkg/kubernetes/views/nodes-page.html:3
-msgid "Delete Selected"
-msgstr "Borrar Seleccionado"
+#: pkg/machines/components/networks/networkDelete.jsx:92
+#, fuzzy
+msgid "Delete Network $0"
+msgstr "Eliminar $0"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
 msgid "Delete Storage Pool $0"
@@ -2552,17 +2116,9 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr "Eliminar archivos de almacenamiento asociados:"
 
-#: pkg/kubernetes/views/imagestream-delete.html:3
-msgid "Delete image stream"
-msgstr "Eliminar el flujo de imágenes"
-
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html:3
-msgid "Delete {{ item.kind }}"
-msgstr "Eliminar {{ item.kind }}"
 
 #: pkg/storaged/jobs-panel.jsx:53 pkg/storaged/jobs-panel.jsx:67
 msgid "Deleting $target"
@@ -2576,15 +2132,7 @@ msgstr ""
 "Eliminando <b>$0</b> romperá la conexión al servidor y hara no disponible la "
 "administración UI."
 
-#: pkg/kubernetes/views/item-delete.html:7
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-"Eliminando un Pod matará todos los contenedores asociados. Los Pods pueden "
-"ser creados automáticamente otra vez en algunos casos."
-
-#: pkg/storaged/mdraid-details.jsx:301
+#: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "Eliminar un dispositivo RAID borrará toda la información en el."
 
@@ -2592,7 +2140,7 @@ msgstr "Eliminar un dispositivo RAID borrará toda la información en el."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Al borrar un dispositivo VDO borrará todos los datos en él."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "Eliminar un contenedor eliminara toda la información en él."
 
@@ -2604,7 +2152,7 @@ msgstr "Eliminar un volumen lógico borrará toda la información en el."
 msgid "Deleting a partition will delete all data in it."
 msgstr "Eliminar una partición borrará toda la información en el."
 
-#: pkg/storaged/vgroup-details.jsx:213
+#: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
 msgstr "Eliminar un grupo de volúmenes borrará toda la información en el."
 
@@ -2618,44 +2166,11 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Borrando Grupo de Volumen $target"
 
-#: pkg/kubernetes/views/dashboard-page.html:131
-#: pkg/kubernetes/views/deploy.html:62
-msgid "Deploy"
-msgstr "Desplegar"
-
-#: pkg/kubernetes/views/deploy.html:3
-msgid "Deploy Application"
-msgstr "Desplegar aplicación"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:22
-msgid "Deployment Causes"
-msgstr "Causas de Despliegue"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:12
-#: pkg/kubernetes/views/deploymentconfig-panel.html:8
-msgid "Deployment Config"
-msgstr "Configuración de Despliegue"
-
-#: pkg/kubernetes/views/details-page.html:98
-#: pkg/kubernetes/scripts/details.js:220
-msgid "Deployment Configs"
-msgstr "Configuración de despliegue"
-
-#: pkg/kubernetes/views/project-listing.html:15
-#: pkg/kubernetes/views/project-listing.html:54
-#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:413
+#: pkg/systemd/services.html:413
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:725
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
 msgid "Description"
 msgstr "Descripción "
-
-#: pkg/ovirt/components/OVirtTab.jsx:146
-#: pkg/ovirt/components/VmOverviewColumn.jsx:52
-msgid "Description:"
-msgstr "Descripción:"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2665,16 +2180,15 @@ msgstr "Escritorio"
 msgid "Detachable"
 msgstr "Desmontable"
 
-#: pkg/kubernetes/index.html:67 pkg/shell/index.html:229
-#: pkg/docker/containers-view.jsx:336 pkg/docker/containers-view.jsx:504
-#: pkg/docker/containers-view.jsx:514 pkg/docker/containers-view.jsx:642
-#: pkg/networkmanager/firewall.jsx:94 pkg/packagekit/updates.jsx:383
-#: pkg/subscriptions/subscriptions-view.jsx:232 pkg/systemd/host.js:745
+#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
+#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Detalles"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2696,7 +2210,6 @@ msgstr "Reportes de diagnostico"
 msgid "Digest"
 msgstr "Digest"
 
-#: pkg/kubernetes/views/volume-body.html:28
 #: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
@@ -2728,7 +2241,7 @@ msgid "Disconnect"
 msgstr "Desconectar"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:604
+#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
 msgid "Disconnected"
 msgstr "Desconectado"
 
@@ -2736,7 +2249,6 @@ msgstr "Desconectado"
 msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr "Desconectado de la consola serie. Pulse el botón Reconectar."
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:836
 #: pkg/storaged/vdos-panel.jsx:55
 msgid "Disk"
 msgstr "Disco"
@@ -2749,15 +2261,11 @@ msgstr ""
 msgid "Disk I/O"
 msgstr "Disco I/O"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Uso de disco: $0%"
-
-#: pkg/machines/components/diskAdd.jsx:461
+#: pkg/machines/components/diskAdd.jsx:489
 msgid "Disk failed to be attached"
 msgstr "Disco no se pudo adjuntar"
 
-#: pkg/machines/components/diskAdd.jsx:443
+#: pkg/machines/components/diskAdd.jsx:468
 msgid "Disk failed to be created"
 msgstr "Disco no se pudo crear"
 
@@ -2770,9 +2278,9 @@ msgstr "Disco está OK"
 msgid "Disk passphrase"
 msgstr "Frase de acceso al disco"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Discos"
 
@@ -2781,60 +2289,9 @@ msgid "Disks cannot be removed from $0 VMs"
 msgstr ""
 
 #: pkg/shell/index.html:52 pkg/shell/index.html:114 pkg/shell/simple.html:38
-#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
+#: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Mostrar Idioma"
-
-#: pkg/kubernetes/views/project-modify.html:31
-msgid "Display name"
-msgstr "Visualizar nombre"
-
-#: pkg/kubernetes/views/add-role-dialog.html:5
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "¿Desea añadir el rol? '{{ fields.displayRole }}'?"
-
-#: pkg/kubernetes/views/imagestream-delete.html:5
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"¿Desea eliminar el flujo de imagen '{{stream.metadata.namespace}}/{{stream."
-"metadata.name}}' ?"
-
-#: pkg/kubernetes/views/pv-delete.html:6
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "¿Desea eliminar el Volumen Persitente '{{item.metadata.name}}'?"
-
-#: pkg/kubernetes/views/pvc-delete.html:6
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-"¿Desea eliminar la Reclamación de Volumen Persistente '{{item.metadata."
-"name}}'?"
-
-#: pkg/kubernetes/views/item-delete.html:6
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "¿Desea eliminar {{ item.kind }} '{{item.metadata.name}}'?"
-
-#: pkg/kubernetes/views/node-delete.html:7
-msgid "Do you want to delete this Node?"
-msgstr "¿Desea eliminar este Nodo?"
-
-#: pkg/kubernetes/views/image-delete.html:5
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"¿Desea borrar la imagen etiquetada como '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:5
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
-msgstr ""
-"¿Desea borrar el rol '{{ fields.displayRole }}' del miembro {{ fields.member."
-"metadata.name }}?"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2849,15 +2306,15 @@ msgid "Docking Station"
 msgstr "Estación de Acoplamiento"
 
 #: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
-#: pkg/realmd/operation.js:123
+#: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Dominio"
 
-#: pkg/realmd/operation.js:192
+#: pkg/realmd/operation.js:191
 msgid "Domain $0 could not be contacted"
 msgstr "Dominio $0 no puede ser contactado"
 
-#: pkg/realmd/operation.js:279
+#: pkg/realmd/operation.js:278
 msgid "Domain $0 is not supported"
 msgstr "Dominio $0 no esta soportado"
 
@@ -2882,15 +2339,11 @@ msgstr "No repetir"
 msgid "Don't overwrite existing data"
 msgstr "No sobreescribir los datos existentes"
 
-#: pkg/kubernetes/scripts/images.js:633
-msgid "Don't pull images automatically"
-msgstr "No tire de las imágenes automáticamente"
-
 #: pkg/sosreport/index.html:63
 msgid "Done!"
 msgstr "Hecho!"
 
-#: pkg/docker/index.html:598
+#: pkg/docker/index.html:600
 msgid "Download"
 msgstr "Descarga"
 
@@ -2929,11 +2382,7 @@ msgctxt "storage"
 msgid "Drive"
 msgstr "Unidad"
 
-#: pkg/kubernetes/views/volume-body.html:128
-msgid "Driver"
-msgstr "Driver"
-
-#: pkg/storaged/drives-panel.jsx:119
+#: pkg/storaged/drives-panel.jsx:120
 msgid "Drives"
 msgstr "Discos"
 
@@ -2962,10 +2411,6 @@ msgstr "Editar Tang keyserver"
 msgid "Edit image stream"
 msgstr "Editar flujo de imagen"
 
-#: pkg/ovirt/components/VdsmView.jsx:125
-msgid "Edit the vdsm.conf"
-msgstr "Editar vdsm.conf"
-
 #: pkg/storaged/crypto-keyslots.jsx:535
 msgid "Editing a key requires a free slot"
 msgstr "Editar una clave requiere una ranura libre"
@@ -2979,25 +2424,21 @@ msgid "Embedded PC"
 msgstr "PC Embebido"
 
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:13
+#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Vaciar"
 
 #: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:19
+#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Vacío"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Directorio vació"
 
 #: pkg/storaged/jobs-panel.jsx:75
 msgid "Emptying $target"
 msgstr "Eliminando el contenido de $target"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:151
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:162
 msgid "Emulated Machine"
 msgstr ""
 
@@ -3061,23 +2502,6 @@ msgstr "Encriptación"
 msgid "Encryption Options"
 msgstr "Opciones de cifrado"
 
-#: pkg/kubernetes/views/pv-modify.html:93
-msgid "Endpoint"
-msgstr "Punto final"
-
-#: pkg/kubernetes/views/volume-body.html:40
-msgid "Endpoint Name"
-msgstr "Nombre del Punto final"
-
-#: pkg/kubernetes/views/service-page.html:14
-#: pkg/kubernetes/views/service-panel.html:9
-msgid "Endpoints"
-msgstr "Puntos finales"
-
-#: pkg/subscriptions/subscriptions-view.jsx:39
-msgid "Ends"
-msgstr "Finales"
-
 #: pkg/selinux/setroubleshoot-view.jsx:299
 msgid "Enforce policy:"
 msgstr "Aplicar la política:"
@@ -3090,10 +2514,6 @@ msgstr "Actualizaciones de Mejora Disponibles"
 msgid "Enter IP address or host name"
 msgstr "Ingrese la dirección IP o el nombre del host"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:74
-msgid "Enter New VM name"
-msgstr "Introducir Nuevo nombre de VM"
-
 #: pkg/lib/machine-change-auth.html:57
 msgid ""
 "Entering a different password here means you will need to retype it every "
@@ -3102,7 +2522,7 @@ msgstr ""
 "Introducir una contraseña diferente aquí significa que necesitará volver a "
 "teclear cada vez que vuelva a esa máquina"
 
-#: pkg/networkmanager/firewall.jsx:752
+#: pkg/networkmanager/firewall.jsx:754
 msgid "Entire subnet"
 msgstr ""
 
@@ -3114,7 +2534,7 @@ msgstr "Entrada"
 msgid "Entrypoint"
 msgstr "Punto de entrada"
 
-#: pkg/docker/index.html:526 pkg/kubernetes/views/container-body.html:26
+#: pkg/docker/index.html:528
 #: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Entorno"
@@ -3136,19 +2556,15 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:99
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1472
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Error"
 
 #: pkg/systemd/logs.html:59
 msgid "Error and above"
 msgstr "Error y arriba"
-
-#: pkg/kubernetes/scripts/connection.js:646
-msgid "Error getting certificate details: $0"
-msgstr "Error al obtener los detalles del certificado: $0"
 
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
@@ -3170,10 +2586,6 @@ msgstr "Error mientras se eliminaba la alerta: $0"
 msgid "Error while setting SELinux mode: '$0'"
 msgstr "Error al establecer modo de SELinux:  '$0'"
 
-#: pkg/kubernetes/scripts/connection.js:85
-msgid "Error writing kubectl config"
-msgstr "Error escribiendo configuración de kubectl"
-
 #: pkg/networkmanager/index.html:658
 msgid "Ethernet MAC"
 msgstr "Ethernet MAC"
@@ -3190,23 +2602,23 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Todo"
 
-#: pkg/networkmanager/firewall.jsx:534
+#: pkg/networkmanager/firewall.jsx:536
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:542
+#: pkg/networkmanager/firewall.jsx:544
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
-#: pkg/users/local.js:473 pkg/users/local.js:1417
+#: pkg/users/local.js:477 pkg/users/local.js:1421
 msgid "Excellent password"
 msgstr "Contraseña excelente "
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:222
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
 msgid "Existing Disk Image"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -3218,7 +2630,7 @@ msgstr "Salió $ExitCode"
 msgid "Expansion Chassis"
 msgstr "Chasis de Expansión"
 
-#: pkg/docker/index.html:508
+#: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "Exponer puertos de contenedores"
 
@@ -3230,14 +2642,6 @@ msgstr "Partición Extendida"
 msgid "FAILED"
 msgstr "Fallido"
 
-#: pkg/ovirt/provider.js:130
-msgid "FORCEOFF action failed: $0"
-msgstr ""
-
-#: pkg/ovirt/components/InstallationDialog.jsx:47
-msgid "FQDN"
-msgstr "FQDN"
-
 #: pkg/networkmanager/interfaces.js:842
 msgid "Failed"
 msgstr "Falló"
@@ -3247,14 +2651,19 @@ msgid "Failed to add machine: $0"
 msgstr "Fallo al agregar maquina: $0"
 
 #: pkg/networkmanager/firewall.jsx:237
+#, fuzzy
+msgid "Failed to add port"
+msgstr "Error al cambiar contraseña"
+
+#: pkg/networkmanager/firewall.jsx:237
 msgid "Failed to add service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:679
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Error al cambiar contraseña"
 
@@ -3278,11 +2687,15 @@ msgstr "Fallo al editar maquina: $0"
 msgid "Failed to enable tuned"
 msgstr "Ha fallado habilitar tuned"
 
+#: pkg/machines/components/vmnetworktab.jsx:55
+msgid "Failed to fetch the IP addresses of the interfaces present in $0"
+msgstr ""
+
 #: pkg/users/index.html:393
 msgid "Failed to load authorized keys."
 msgstr "Fallo al cargar llaves autorizadas."
 
-#: pkg/networkmanager/firewall.jsx:589
+#: pkg/networkmanager/firewall.jsx:591
 msgid "Failed to remove service"
 msgstr ""
 
@@ -3302,10 +2715,6 @@ msgstr "Ha fallado cambiar perfil"
 #: pkg/machines/components/vcpuModal.jsx:193
 msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr "Deben habilitarse menos CPU virtuales de las máximas."
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "Canal de Fibra"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:92
 #: pkg/machines/components/vmDiskColumns.jsx:42
@@ -3328,22 +2737,11 @@ msgstr "Montando Sistema de archivos"
 msgid "Filesystem Name"
 msgstr "Nombre de Sistema de archivos"
 
-#: pkg/kubernetes/views/pv-modify.html:181
-#: pkg/kubernetes/views/volume-body.html:6
-#: pkg/kubernetes/views/volume-body.html:16
-#: pkg/kubernetes/views/volume-body.html:62
-#: pkg/kubernetes/views/volume-body.html:83
-#: pkg/kubernetes/views/volume-body.html:91
-#: pkg/kubernetes/views/volume-body.html:120
-#: pkg/kubernetes/views/volume-body.html:132
-msgid "Filesystem Type"
-msgstr "Tipo de Sistema de archivos"
-
 #: pkg/storaged/fsys-panel.jsx:103
 msgid "Filesystems"
 msgstr "Archivos del sistema"
 
-#: pkg/networkmanager/firewall.jsx:490
+#: pkg/networkmanager/firewall.jsx:491
 msgid "Filter Services"
 msgstr "Filtrar Servicios"
 
@@ -3351,30 +2749,18 @@ msgstr "Filtrar Servicios"
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Fingerprint"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:913 pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
 msgid "Firewall"
 msgstr "Cortafuegos"
 
-#: pkg/networkmanager/firewall.jsx:861
+#: pkg/networkmanager/firewall.jsx:863
 msgid "Firewall is not available"
 msgstr "El cortafuegos no está disponible"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/views/volume-body.html:125
-msgid "Flocker Dataset Name"
-msgstr "Nombre del Conjunto de Datos Flocker"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:35
 msgid "Follows docker repo"
@@ -3408,10 +2794,9 @@ msgstr "Cambio de clave forzado"
 msgid "Force remove passphrase in $0"
 msgstr "Forzar la eliminación de la contraseña en $0"
 
-#: pkg/machines/components/diskAdd.jsx:167
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:258
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formato"
 
@@ -3471,11 +2856,7 @@ msgstr "Desde"
 msgid "Full Name"
 msgstr "Nombre Completo"
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "Disco GCE Persistente"
-
-#: pkg/docker/index.html:183
+#: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "Pasarela:"
 
@@ -3492,25 +2873,13 @@ msgstr "Generando reporte"
 msgid "Get new image"
 msgstr "Obtener nueva imagen"
 
-#: pkg/machines/components/diskAdd.jsx:162
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Repositorio Git"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster FS"
-
-#: pkg/kubernetes/scripts/volumes.js:877
-msgid "GlusterFS"
-msgstr "GlusterFS"
 
 #: pkg/systemd/logs.js:199
 msgid "Go to"
@@ -3526,13 +2895,6 @@ msgstr "Ir a la aplicación"
 msgid "Go to now"
 msgstr "Ir a ahora"
 
-#: pkg/kubernetes/views/project-body.html:3
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Grant additional push or admin access to specific members below."
-msgstr ""
-"Obtener empuje adicional o administrar el acceso a los miembros específicos "
-"de abajo."
-
 #: pkg/machines/components/consoles.jsx:51
 msgid "Graphics Console (VNC)"
 msgstr "Consola Gráfica (VNC)"
@@ -3540,20 +2902,6 @@ msgstr "Consola Gráfica (VNC)"
 #: pkg/machines/components/consoles.jsx:60
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Consola Gráfica en Visualizador de Escritorio"
-
-#: pkg/kubernetes/views/group-page.html:21
-#: pkg/kubernetes/views/group-panel.html:12
-msgid "Group Members"
-msgstr "Miembros del Grupo"
-
-#: pkg/kubernetes/views/user-add-membership.html:9
-msgid "Group or Project"
-msgstr "Grupo o Proyecto"
-
-#: pkg/kubernetes/views/project-listing.html:48
-#: pkg/kubernetes/views/user-delete.html:14
-msgid "Groups"
-msgstr "Grupos"
 
 #: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
 #: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
@@ -3576,15 +2924,6 @@ msgstr "Crece el tamaño lógico de $0"
 #: pkg/storaged/vdo-details.jsx:130
 msgid "Grow to take all space"
 msgstr "Crecer para tomar todo el espacio"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "HA"
-msgstr "HA"
-
-#: pkg/ovirt/components/OVirtTab.jsx:128
-msgid "HA:"
-msgstr "HA:"
 
 #: pkg/networkmanager/index.html:252
 msgid "Hair Pin mode"
@@ -3619,19 +2958,14 @@ msgstr "Información de Hardware"
 msgid "Hello time $hello_time"
 msgstr "Tiempo de saludo $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:73
-#: pkg/kubernetes/views/route-body.html:9
-#: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:150
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47
-#: pkg/ovirt/components/App.jsx:103 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:334
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Anfitrión"
 
@@ -3640,29 +2974,21 @@ msgid "Host Device"
 msgstr ""
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:155
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
 msgid "Host Name"
 msgstr "Nombre de Host"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:869
-msgid "Host Path"
-msgstr "Trayecto del anfitrión"
 
 #: src/base1/cockpit.js:4023
 msgid "Host key is incorrect"
 msgstr "Tecla del Host es incorrecta"
 
-#: pkg/realmd/operation.js:602
+#: pkg/realmd/operation.js:601
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:161
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
 msgid "Host should not be empty"
 msgstr "El anfitrión no debe estar vacío"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:75
-msgid "Host to Maintenance"
-msgstr "Host para Mantenimiento"
 
 #: pkg/systemd/services.html:499
 msgid "Hour : Minute"
@@ -3680,24 +3006,20 @@ msgstr "Horas"
 msgid "I/O Wait"
 msgstr "Espera de E/S"
 
-#: pkg/kubernetes/views/node-body.html:10
-#: pkg/kubernetes/views/service-body.html:9
-msgid "IP"
-msgstr "IP"
-
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
+#: pkg/machines/components/vmnetworktab.jsx:133
 msgid "IP Address"
 msgstr "Dirección IP"
 
-#: pkg/docker/index.html:175
+#: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "Dirección IP:"
 
-#: pkg/docker/index.html:179
+#: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "Longitud de Prefijo IP:"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "IP Range"
 msgstr ""
 
@@ -3729,10 +3051,6 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr "Configuración IPv6"
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:873
-msgid "ISCSI"
-msgstr "ISCSI"
-
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
@@ -3741,7 +3059,7 @@ msgstr "Id"
 msgid "Id $id"
 msgstr "Id $id"
 
-#: pkg/docker/index.html:148
+#: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "Id:"
 
@@ -3749,17 +3067,6 @@ msgstr "Id:"
 #: node_modules/registry-image-widgets/views/image-listing.html:7
 msgid "Identifier"
 msgstr "Identificador"
-
-#: pkg/kubernetes/views/user-page.html:22
-#: pkg/kubernetes/views/user-panel.html:18
-msgid "Identities"
-msgstr "Identidades"
-
-#: pkg/kubernetes/views/add-user-dialog.html:17
-#: pkg/kubernetes/views/project-listing.html:91
-#: pkg/kubernetes/views/user-modify.html:17
-msgid "Identity"
-msgstr "Identidad"
 
 #: pkg/storaged/crypto-keyslots.jsx:325
 msgid "If tang-show-keys is not available, run the following:"
@@ -3769,9 +3076,7 @@ msgstr "Si tang-show-keys no está disponible, ejecuta lo siguiente:"
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: pkg/docker/index.html:268 pkg/docker/index.html:431
-#: pkg/kubernetes/views/container-body.html:6
-#: pkg/kubernetes/views/image-page.html:15
+#: pkg/docker/index.html:270 pkg/docker/index.html:433
 #: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
@@ -3782,33 +3087,13 @@ msgid "Image $0"
 msgstr "Imagén $0"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/users/local.js:749
+#: pkg/users/local.js:753
 msgid "Image Builder"
 msgstr "Creador de imágenes"
 
-#: pkg/kubernetes/views/container-body.html:8
-msgid "Image ID"
-msgstr "ID de Imagen"
-
-#: pkg/kubernetes/views/volume-body.html:58
-msgid "Image Name"
-msgstr "Nombre de Imagen"
-
-#: pkg/kubernetes/registry.html:23
-msgid "Image Registry"
-msgstr "Registro de Imagen"
-
-#: pkg/docker/index.html:578
+#: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Buscar Imagen"
-
-#: pkg/kubernetes/views/imagestream-page.html:16
-msgid "Image Stream"
-msgstr "Corriente de Imagen"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:135
-msgid "Image commands"
-msgstr "Órdenes de imagen"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:41
 msgid "Image count"
@@ -3818,14 +3103,10 @@ msgstr "Conteo de imágenes"
 msgid "Image stream"
 msgstr "Imagen Stream"
 
-#: pkg/docker/index.html:156
+#: pkg/docker/index.html:157
 msgid "Image:"
 msgstr "Imagen:"
 
-#: pkg/kubernetes/index.html:81 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
-#: pkg/kubernetes/views/registry-dashboard-page.html:19
 #: pkg/docker/containers-view.jsx:711
 msgid "Images"
 msgstr "Imágenes"
@@ -3838,10 +3119,6 @@ msgstr "Imágenes"
 #: pkg/docker/containers-view.jsx:109
 msgid "Images and running containers"
 msgstr "Imágenes y contenedores corriendo"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:17
-msgid "Images by project"
-msgstr "Imágenes por proyecto"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:15
 #: node_modules/registry-image-widgets/views/imagestream-body.html:16
@@ -3861,11 +3138,7 @@ msgid "Images may only be pulled by specific users or groups"
 msgstr ""
 "Las imágenes sólo ueden ser utilizadas por usuaior o grupos específicos"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:54
-msgid "Images pushed recently"
-msgstr "Imágenes utilizadas recientemente"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:632
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
 msgstr "Iniciar Inmediatamente VM"
 
@@ -3873,34 +3146,19 @@ msgstr "Iniciar Inmediatamente VM"
 msgid "In Sync"
 msgstr "En Sincronía"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:171
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
 msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:81
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-"Para comenzar a insertar imágenes en el registro, utilice las órdenes "
-"siguientes."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:6
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr ""
-"Con el objetivo de llevar imágenes al registro, usted necesita crear un "
-"proyecto."
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Con el objetivo de sincronizar usuarios, necesita acceder a "
-"{{#strong}}{{host}}{{/strong}}."
+"Con el objetivo de sincronizar usuarios, necesita acceder a {{#strong}}"
+"{{host}}{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
 #: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
@@ -3911,7 +3169,7 @@ msgstr "Inactivo"
 msgid "Inactive volume"
 msgstr "Volumen inactivo"
 
-#: pkg/networkmanager/firewall.jsx:730
+#: pkg/networkmanager/firewall.jsx:732
 msgid "Included services"
 msgstr ""
 
@@ -3936,17 +3194,17 @@ msgstr ""
 msgid "Initializing..."
 msgstr "Inicializando..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:177
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:188
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Instalar"
 
@@ -3979,25 +3237,21 @@ msgstr ""
 "Instale «setroubleshoot-server» para solucionar problemas con sucesos de "
 "SELinux."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:226
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
 msgid "Installation Source"
 msgstr "Fuente de la Instalación"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:212
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
 msgid "Installation Source Type"
 msgstr "Tipo de Fuente de Instalación"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:113
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
 msgid "Installation Source should not be empty"
 msgstr "La Fuente de Instalación no debería estar vacía"
 
 #: pkg/packagekit/updates.jsx:59
 msgid "Installed"
 msgstr "Instalado"
-
-#: pkg/subscriptions/subscriptions-view.jsx:245
-msgid "Installed products"
-msgstr "Productos instalados"
 
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:51
@@ -4013,17 +3267,13 @@ msgstr "Instalando $0"
 msgid "Instantiate"
 msgstr "Instanciar"
 
-#: pkg/kubernetes/views/pv-modify.html:170
-#: pkg/kubernetes/views/volume-body.html:81
-msgid "Interface"
-msgstr "Interfaz"
-
 #: pkg/machines/components/nicEdit.jsx:123
 msgid "Interface Type"
 msgstr ""
 
-#: pkg/networkmanager/index.html:108 pkg/networkmanager/firewall.jsx:735
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Interfaces"
 
@@ -4039,15 +3289,11 @@ msgstr "Error interno"
 msgid "Invalid address $0"
 msgstr "La dirección $0 no es válida"
 
-#: pkg/subscriptions/subscriptions-client.js:195
-msgid "Invalid credentials"
-msgstr "Las credenciales no son válidas"
-
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Formato de fecha inválido"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Formato de fecha y formato de hora inválidos "
 
@@ -4055,7 +3301,7 @@ msgstr "Formato de fecha y formato de hora inválidos "
 msgid "Invalid date format."
 msgstr "El formato de fecha no es válido."
 
-#: pkg/users/local.js:1237
+#: pkg/users/local.js:1241
 msgid "Invalid expiration date"
 msgstr "Fecha de expiración invalida"
 
@@ -4063,7 +3309,7 @@ msgstr "Fecha de expiración invalida"
 msgid "Invalid file permissions"
 msgstr "Permisos de archivo invalidos"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
 msgid "Invalid filename"
 msgstr "Nobre de fichero no válido"
 
@@ -4075,7 +3321,7 @@ msgstr "Llave inválida"
 msgid "Invalid metric $0"
 msgstr "La métrica $0 no es válida"
 
-#: pkg/users/local.js:1313
+#: pkg/users/local.js:1317
 msgid "Invalid number of days"
 msgstr "Numero de días incorrecto."
 
@@ -4103,7 +3349,7 @@ msgstr "El prefijo o la máscara de red $0 no es válido"
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Formato de hora inválido"
 
@@ -4112,7 +3358,6 @@ msgid "Invalid time zone"
 msgstr "El huso horario no es válido"
 
 #: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
-#: pkg/subscriptions/subscriptions-client.js:193
 msgid "Invalid username or password"
 msgstr "Nombre de usuario o contraseña invalidos"
 
@@ -4132,19 +3377,19 @@ msgstr ""
 msgid "Jobs"
 msgstr "Trabajos"
 
-#: pkg/realmd/operation.js:117
+#: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "Unirse"
 
-#: pkg/realmd/operation.js:597
+#: pkg/realmd/operation.js:596
 msgid "Join Domain"
 msgstr "Unirse a Dominio"
 
-#: pkg/realmd/operation.js:116
+#: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "Unirse a un dominio"
 
-#: pkg/realmd/operation.js:506
+#: pkg/realmd/operation.js:505
 msgid "Joining this domain is not supported"
 msgstr "Unirse a este dominio no esta soportado"
 
@@ -4191,14 +3436,6 @@ msgstr "Kernel"
 msgid "Kernel Dump"
 msgstr "Volcado del Kernel"
 
-#: pkg/kubernetes/views/node-body.html:19
-msgid "Kernel Version"
-msgstr "Versión del núcleo"
-
-#: pkg/kubernetes/views/volume-body.html:67
-msgid "Key Ring Path"
-msgstr "Trayecto del llavero"
-
 #: pkg/storaged/crypto-keyslots.jsx:563
 msgid "Key slots with unknown types can not be edited here"
 msgstr "Las ranuras clave con tipos desconocidos no se pueden editar aquí"
@@ -4226,23 +3463,10 @@ msgstr "Dirección del servidor de claves"
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "La eliminación de Keyserver puede evitar el desbloqueo $0."
 
-#: pkg/kubernetes/views/node-body.html:23
-msgid "Kubelet Version"
-msgstr "Versión de Kubelet"
-
-#: pkg/kubernetes/index.html:23
-msgid "Kubernetes Cluster"
-msgstr "Cluster de Kubernetes"
-
 #: pkg/networkmanager/index.html:377
 msgid "LACP Key"
 msgstr "Clave de LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: pkg/kubernetes/views/replicationcontroller-body.html:17
-#: pkg/kubernetes/views/route-body.html:22
-#: pkg/kubernetes/views/service-body.html:26
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Viñetas"
@@ -4259,17 +3483,9 @@ msgstr "Ultimas 24 horas"
 msgid "Last 7 days"
 msgstr "Ultimos 7 dias"
 
-#: pkg/kubernetes/views/node-body.html:49
-msgid "Last Heartbeat"
-msgstr "Último Heartbeat"
-
 #: pkg/users/index.html:100
 msgid "Last Login"
 msgstr "Último inicio de sesión"
-
-#: pkg/kubernetes/views/node-body.html:51
-msgid "Last Status Change"
-msgstr "Último Cambio de Estado"
 
 #: pkg/systemd/init.js:284
 msgid "Last Trigger"
@@ -4282,11 +3498,6 @@ msgstr "Última Actualización"
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
 msgstr "Ultima revisión: $0 atrás"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
-#: pkg/kubernetes/views/details-page.html:107
-msgid "Latest Version"
-msgstr "Última Versión"
 
 #: pkg/machines/components/desktopConsole.jsx:128
 msgid "Launch Remote Viewer"
@@ -4311,14 +3522,13 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Déjelo en blanco para conectarse a esta máquina como el usuario actualmente "
 "conectado {{#default_user}} ({{default_user}}){{/default_user}}. Si usted "
 "introduce un nombre de usuario diferente, se usará siempre ese usuario para "
 "conectarse a esta máquina."
 
-#: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
+#: pkg/shell/index.html:90 pkg/shell/simple.html:66
 msgid "Licensed under:"
 msgstr "Disponible según los términos de:"
 
@@ -4342,7 +3552,7 @@ msgstr "Desvincular demora"
 msgid "Link local"
 msgstr "Enlace local"
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:499
 msgid "Link to another container"
 msgstr "Enlazar con otro contenedor"
 
@@ -4350,11 +3560,11 @@ msgstr "Enlazar con otro contenedor"
 msgid "Link up delay"
 msgstr "Vincular demora"
 
-#: pkg/docker/index.html:493
+#: pkg/docker/index.html:495
 msgid "Links"
 msgstr "Vinculos"
 
-#: pkg/docker/index.html:195
+#: pkg/docker/index.html:196
 msgid "Links:"
 msgstr "Enlaces:"
 
@@ -4378,13 +3588,9 @@ msgstr "Fallo la carga de  las actualizaciones disponibles "
 msgid "Loading available updates, please wait..."
 msgstr "Leyendo actualizaciones disponibles, por favor espere..."
 
-#: pkg/ovirt/components/VdsmView.jsx:34
-msgid "Loading data ..."
-msgstr "Cargando datos ..."
-
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Cargando..."
 
@@ -4400,7 +3606,7 @@ msgstr "Discos locales"
 msgid "Local Filesystem"
 msgstr "Sistema de archivos local"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:218
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
 msgid "Local Install Media"
 msgstr ""
 
@@ -4420,7 +3626,7 @@ msgstr "Bloquear"
 msgid "Lock Account"
 msgstr "Bloquear Cuenta"
 
-#: pkg/users/local.js:879 pkg/users/local.js:1218
+#: pkg/users/local.js:883 pkg/users/local.js:1222
 msgid "Lock account on $0"
 msgstr "Cuenta bloqueada en $0"
 
@@ -4432,7 +3638,7 @@ msgstr "Bloquendo $target"
 msgid "Log In"
 msgstr "Iniciar sesión"
 
-#: pkg/shell/index.html:70 pkg/shell/simple.html:46 pkg/shell/stub.html:53
+#: pkg/shell/index.html:70 pkg/shell/simple.html:46
 msgid "Log Out"
 msgstr "Salir"
 
@@ -4448,19 +3654,11 @@ msgstr "Iniciar sesión en {{host}}"
 msgid "Log in with your server user account."
 msgstr "Acceda con su cuenta de usuario del servidor."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:116
-msgid "Log into OpenShift command line tools:"
-msgstr "Ingrese a las herramientas de consola de OpenShift:"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:101
-msgid "Log into the registry:"
-msgstr "Iniciar sesión en el registro:"
-
 #: pkg/systemd/index.html:65
 msgid "Log messages"
 msgstr "Mensajes de registro"
 
-#: pkg/users/local.js:961
+#: pkg/users/local.js:965
 msgid "Logged In"
 msgstr "Sesión iniciada"
 
@@ -4471,12 +3669,6 @@ msgstr "Logico"
 #: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
 msgid "Logical Size"
 msgstr "Tamaño Lógico"
-
-#: pkg/kubernetes/views/pv-modify.html:159
-#: pkg/kubernetes/views/volume-body.html:79
-#: pkg/kubernetes/views/volume-body.html:118
-msgid "Logical Unit Number"
-msgstr "Número de unidad lógica"
 
 #: pkg/storaged/utils.js:197
 msgid "Logical Volume"
@@ -4490,10 +3682,6 @@ msgstr "Volumen Lógico(Captura)"
 msgid "Logical Volume of $0"
 msgstr "Volumen lógico de $0"
 
-#: pkg/subscriptions/subscriptions-register.jsx:144
-msgid "Login"
-msgstr "Ingresar"
-
 #: src/ws/login.js:300
 msgid "Login Again"
 msgstr "Acceda de Nuevo"
@@ -4506,10 +3694,6 @@ msgstr ""
 msgid "Login Password"
 msgstr "Contraseña de inicio de sesión"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:96
-msgid "Login commands"
-msgstr "Órdenes de ingreso"
-
 #: src/base1/cockpit.js:4015
 msgid "Login failed"
 msgstr "Inicio de sesión fallido"
@@ -4518,18 +3702,11 @@ msgstr "Inicio de sesión fallido"
 msgid "Login has escalated admin privileges"
 msgstr "El inicio de sesión ha aumentado los privilegios de administrador"
 
-#: pkg/subscriptions/subscriptions-client.js:199
-msgid "Login/password or activation key required to register."
-msgstr ""
-"Para registrarse es necesario un usuario y contraseña o una clave de "
-"activación."
-
 #: src/ws/login.js:301
 msgid "Logout Successful"
 msgstr "Logout Exitoso"
 
-#: pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82
 msgid "Logs"
 msgstr "Registros"
 
@@ -4549,17 +3726,13 @@ msgstr "Loncheras"
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:102
+#: pkg/machines/components/vmnetworktab.jsx:132
 msgid "MAC Address"
 msgstr "Dirección MAC"
 
-#: pkg/docker/index.html:187
+#: pkg/docker/index.html:188
 msgid "MAC Address:"
 msgstr "Dirección MAC:"
-
-#: pkg/ovirt/provider.js:283
-msgid "MIGRATE action failed"
-msgstr "Fallo en acción MIGRATE"
 
 #: pkg/networkmanager/interfaces.js:1985
 msgid "MII (Recommended)"
@@ -4581,7 +3754,7 @@ msgstr ""
 msgid "Mac Address"
 msgstr "Dirección MAC"
 
-#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:95
+#: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "Id. de máquina"
 
@@ -4600,10 +3773,6 @@ msgstr "Chasis del Servidor Principal"
 #: pkg/storaged/crypto-keyslots.jsx:319
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Asegúrese de que la clave hash del servidor Tang coincida:"
-
-#: pkg/kubernetes/scripts/dashboard.js:457
-msgid "Manifest"
-msgstr "Manifiesto"
 
 #: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
 msgid "Manual"
@@ -4660,16 +3829,6 @@ msgid ""
 "between 1 and $0"
 msgstr "Número máximo de CPU virtuales asignadas al SO invitado, entre 1 y $0"
 
-#: pkg/kubernetes/views/volume-body.html:34
-msgid "Medium"
-msgstr "Medio"
-
-#: pkg/kubernetes/views/project-listing.html:92
-#: pkg/kubernetes/views/user-body.html:4
-#: pkg/kubernetes/views/user-panel.html:27
-msgid "Member of"
-msgstr "Miembro de"
-
 #: pkg/storaged/content-views.jsx:345
 msgid "Member of RAID Device"
 msgstr "Miembro del dispositivo RAID"
@@ -4678,26 +3837,11 @@ msgstr "Miembro del dispositivo RAID"
 msgid "Member of RAID Device $0"
 msgstr "Miembro del dispositivo RAID $0"
 
-#: pkg/kubernetes/views/project-listing.html:16
-#: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/index.html:266 pkg/networkmanager/interfaces.js:2986
-msgid "Members"
-msgstr "Miembros"
-
-#: pkg/kubernetes/views/project-page.html:29
-#: pkg/kubernetes/views/user-page.html:25
-#: pkg/kubernetes/views/user-panel.html:11
-msgid "Membership"
-msgstr "Afiliación"
-
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:271
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:608
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:827
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:304
+#: pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
 #: pkg/machines/components/vmOverviewTab.jsx:74
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Memory"
 msgstr "Memoria"
 
@@ -4710,38 +3854,32 @@ msgstr "Memoria"
 msgid "Memory & Swap"
 msgstr "Memoria e intercambio"
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Uso de memoria: $0%"
-
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
 msgid "Memory could not be saved"
 msgstr ""
 
-#: pkg/docker/index.html:452 pkg/docker/index.html:624
+#: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "Limite de Memoria "
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#, fuzzy
+msgid "Memory must not be 0"
+msgstr "Uso de memoria:"
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
 msgstr ""
 
-#: pkg/docker/index.html:210
+#: pkg/docker/index.html:211
 msgid "Memory usage:"
 msgstr "Uso de memoria:"
-
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
-msgid "Message"
-msgstr "Mensaje"
 
 #: pkg/systemd/shutdown.js:79
 msgid "Message to logged in users"
 msgstr "Mensaje para usuarios activos "
 
-#: pkg/kubernetes/views/image-page.html:29
-#: pkg/kubernetes/views/imagestream-page.html:30
 #: node_modules/registry-image-widgets/views/image-panel.html:15
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
@@ -4751,17 +3889,13 @@ msgstr "Metadatos"
 msgid "Metadata Used"
 msgstr "Metadatos en uso"
 
-#: pkg/docker/index.html:466 pkg/docker/index.html:638
-#: pkg/machines/components/diskAdd.jsx:159
-#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/docker/index.html:468 pkg/docker/index.html:640
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
-
-#: pkg/ovirt/components/OVirtTab.jsx:70
-msgid "Migrate To:"
-msgstr "Migrar A:"
 
 #: pkg/lib/machine-info.js:98
 msgid "Mini PC"
@@ -4791,13 +3925,9 @@ msgstr "Modo"
 msgid "Model"
 msgstr "Modelo"
 
-#: pkg/machines/components/vmnetworktab.jsx:93
+#: pkg/machines/components/vmnetworktab.jsx:123
 msgid "Model type"
 msgstr "Modelo tipo"
-
-#: pkg/kubernetes/views/user-modify.html:27
-msgid "Modify"
-msgstr "Modificar"
 
 #: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:45
 #: pkg/storaged/jobs-panel.jsx:52
@@ -4820,11 +3950,7 @@ msgstr "Monitorear intervalo"
 msgid "Monitoring Targets"
 msgstr "Monitorear objetivos"
 
-#: pkg/kubernetes/views/volume-body.html:54
-msgid "Monitors"
-msgstr "Monitores"
-
-#: pkg/realmd/operation.js:530
+#: pkg/realmd/operation.js:529
 msgid "More"
 msgstr "Más"
 
@@ -4837,31 +3963,27 @@ msgstr "Mas información"
 msgid "More details"
 msgstr "Más detalles"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Montar"
 
-#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
-msgid "Mount Location"
-msgstr "Ubicación de montaje"
-
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Opciones de Montaje"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Punto de Montaje"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Montar en el arranque"
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:521
 msgid "Mount container volumes"
 msgstr "Montar volúmenes de contenedores"
 
@@ -4877,7 +3999,7 @@ msgstr "El punto de montaje no puede estar vacío."
 msgid "Mount point must start with \"/\"."
 msgstr "El punto de montaje debe empezar con \"/\"."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Montar en sólo lectura"
 
@@ -4901,11 +4023,7 @@ msgstr "Chasis Multisistema"
 msgid "NAT to $0"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:865
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:140
 msgid "NFS Mount"
 msgstr "Montar NFS"
 
@@ -4918,7 +4036,7 @@ msgstr "Montajes NFS"
 msgid "NFS Support not installed"
 msgstr "No está instalado el soporte para NFS"
 
-#: pkg/machines/components/vmnetworktab.jsx:67
+#: pkg/machines/components/vmnetworktab.jsx:97
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
@@ -4930,54 +4048,29 @@ msgstr "«Ping» de NSNA"
 msgid "NTP Server"
 msgstr "Servidor NTP"
 
-#: pkg/docker/index.html:267 pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/containers-listing.html:11
-#: pkg/kubernetes/views/dashboard-page.html:156
-#: pkg/kubernetes/views/dashboard-page.html:198
-#: pkg/kubernetes/views/details-page.html:34
-#: pkg/kubernetes/views/details-page.html:70
-#: pkg/kubernetes/views/details-page.html:103
-#: pkg/kubernetes/views/details-page.html:137
-#: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/service-modify.html:9
-#: pkg/kubernetes/views/user-modify.html:9
-#: pkg/kubernetes/views/volume-body.html:31
-#: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:119
+#: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
 #: pkg/networkmanager/index.html:319
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:181
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Nombre"
 
@@ -5009,7 +4102,7 @@ msgstr "El nombre no puede contener el carácter «$0»."
 msgid "Name cannot contain whitespace."
 msgstr "El nombre no puede contener espacios."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:82
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
 msgid "Name should not be empty"
 msgstr "El nombre no debería estar vacío"
@@ -5017,26 +4110,6 @@ msgstr "El nombre no debería estar vacío"
 #: pkg/machines/components/networks/networkOverviewTab.jsx:36
 msgid "Name: "
 msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
-#: pkg/kubernetes/views/details-page.html:36
-#: pkg/kubernetes/views/details-page.html:72
-#: pkg/kubernetes/views/details-page.html:105
-#: pkg/kubernetes/views/details-page.html:139
-#: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
-#: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
-#: pkg/kubernetes/views/service-body.html:5
-#: pkg/kubernetes/views/volumes-page.html:59
-msgid "Namespace"
-msgstr "Espacio de Nombres"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "El nombre de espacio no puede estar vacio"
 
 #: pkg/systemd/host.js:1348
 msgid "Need at least one NTP server"
@@ -5047,19 +4120,18 @@ msgid "Netmask"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:613
 msgid "Network"
 msgstr "Red"
 
-#: pkg/machines/components/networks/network.jsx:117
+#: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/networks/network.jsx:129
+#: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
 msgid "Network Boot (PXE)"
 msgstr ""
 
@@ -5071,7 +4143,7 @@ msgstr "Sistema de archivos de red"
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:177
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Network Selection does not support PXE."
 msgstr ""
 
@@ -5093,7 +4165,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager no está funcionando."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:914
 msgid "Networking"
 msgstr "Redes"
 
@@ -5111,21 +4183,17 @@ msgstr "Registros de redes"
 msgid "Networks"
 msgstr "Redes"
 
-#: pkg/users/local.js:963
+#: pkg/users/local.js:967
 msgid "Never"
 msgstr "Nunca"
 
-#: pkg/users/index.html:297 pkg/users/local.js:868
+#: pkg/users/index.html:297 pkg/users/local.js:872
 msgid "Never expire password"
 msgstr "La clave nunca expira"
 
-#: pkg/users/index.html:258 pkg/users/local.js:876
+#: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "Cuenta nunca bloqueada"
-
-#: pkg/kubernetes/views/project-listing.html:46
-msgid "New Group"
-msgstr "Grupo nuevo"
 
 #: pkg/storaged/nfs-details.jsx:140
 msgid "New NFS Mount"
@@ -5135,34 +4203,19 @@ msgstr "Nuevo Montaje NFS"
 msgid "New Password"
 msgstr "Nueva contraseña"
 
-#: pkg/kubernetes/views/project-listing.html:7
-msgid "New Project"
-msgstr "Proyecto nuevo"
-
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/machines/components/diskAdd.jsx:132
 msgid "New Volume Name"
 msgstr "Nuevo nombre de volumen"
-
-#: pkg/kubernetes/views/images-page.html:11
-#: pkg/kubernetes/views/registry-dashboard-page.html:86
-msgid "New image stream"
-msgstr "Flujo de imágenes nuevo"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
 msgid "New passphrase"
 msgstr "Nueva frase de acceso"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Nueva contraseña no fue aceptada"
-
-#: pkg/kubernetes/views/project-modify.html:4
-#: pkg/kubernetes/views/registry-dashboard-page.html:9
-#: pkg/kubernetes/views/registry-dashboard-page.html:48
-msgid "New project"
-msgstr "Nuevo proyecto"
 
 #: pkg/realmd/operation.html:82 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
@@ -5176,9 +4229,8 @@ msgstr "En la próxima ejecución"
 msgid "Nice"
 msgstr "Bien"
 
-#: pkg/docker/index.html:542 pkg/docker/index.html:546 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/kubernetes/scripts/volumes.js:998
-#: pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
 msgid "No"
 msgstr "No"
 
@@ -5202,24 +4254,12 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Sin ajustes de montaje NFS"
 
-#: src/ws/cockpitcertificate.c:522
-msgid "No PEM-encoded certificate found"
-msgstr "No se encontró certificado cifrado con PEM"
-
-#: src/ws/cockpitcertificate.c:488
-msgid "No PEM-encoded private key found"
-msgstr "No se encontró llave privada cifrada con PEM"
-
-#: pkg/kubernetes/views/pv-claim.html:39
-msgid "No Pods are using this claim"
-msgstr "Ningún Pods está usando este reclamo"
-
 #: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "No SELinux alerts."
 msgstr "No hay ninguna alerta de SELinux."
 
-#: pkg/machines/components/diskAdd.jsx:193
-#: pkg/machines/components/diskAdd.jsx:205
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:216
 msgid "No Storage Pools available"
 msgstr ""
 
@@ -5229,11 +4269,6 @@ msgstr ""
 "No hay volúmenes de almacenamiento definidos para este grupo de "
 "almacenamiento"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:29
-#: pkg/ovirt/components/ClusterVms.jsx:36
-msgid "No VM found in oVirt."
-msgstr "Mo se ha encontrado VM en oVirt."
-
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
 msgstr "No hay ninguna MV en ejecución o definida en este anfitrión"
@@ -5242,11 +4277,7 @@ msgstr "No hay ninguna MV en ejecución o definida en este anfitrión"
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html:10
-msgid "No Volume Bound"
-msgstr "No hay ningún vínculo de volumen"
-
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/networkmanager/firewall.jsx:926
 msgid "No active zones"
 msgstr ""
 
@@ -5262,7 +4293,7 @@ msgstr "No se ha especificado un alias"
 msgid "No applications installed or available"
 msgstr "No hay aplicaciones instaladas o disponibles"
 
-#: pkg/sosreport/index.js:128
+#: pkg/sosreport/index.js:129
 msgid "No archive has been created."
 msgstr "No archive has been created."
 
@@ -5298,7 +4329,7 @@ msgstr "No hay ningún contenedor"
 msgid "No containers that match the current filter"
 msgstr "Ningún contenedor corresponde al filtro actual"
 
-#: pkg/networkmanager/firewall.jsx:727
+#: pkg/networkmanager/firewall.jsx:729
 msgid "No description available"
 msgstr ""
 
@@ -5306,9 +4337,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "No se ha suministrado descripción."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "No hay discos disponibles."
 
@@ -5316,7 +4347,7 @@ msgstr "No hay discos disponibles."
 msgid "No disks defined for this VM"
 msgstr "No se han definido discos para esta VM"
 
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:121
 msgid "No drives attached"
 msgstr "No hay dispositivos adjuntos"
 
@@ -5327,10 +4358,6 @@ msgstr "No hay ranuras clave gratis"
 #: pkg/storaged/content-views.jsx:700
 msgid "No free space"
 msgstr "No queda espacio disponible"
-
-#: pkg/kubernetes/views/project-listing.html:74
-msgid "No groups are present."
-msgstr "No hay ningún grupo presente."
 
 #: pkg/systemd/index.html:29
 msgid "No host keys found."
@@ -5348,21 +4375,13 @@ msgstr "No hay ningún flujo de imágenes presente."
 msgid "No images"
 msgstr "No hay imágenes"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:80
-msgid "No images pushed"
-msgstr "Sin imágenes empujadas"
-
 #: pkg/docker/containers-view.jsx:707
 msgid "No images that match the current filter"
 msgstr "No hay imágenes que correspondan al filtro actual"
 
-#: pkg/apps/utils.jsx:95
+#: pkg/apps/utils.jsx:96
 msgid "No installation package found for this application."
 msgstr "No se ha encontrado paquete de instalación para esta aplicación."
-
-#: pkg/subscriptions/subscriptions-view.jsx:246
-msgid "No installed products on the system."
-msgstr "No hay ningún producto instalado en el sistema."
 
 #: pkg/storaged/crypto-keyslots.jsx:520
 msgid "No keys added"
@@ -5386,14 +4405,7 @@ msgstr ""
 "del núcleo (p. ej. en /etc/default/grub) para reservar memoria durante el "
 "arranque. Ejemplo: crashkernel=512M"
 
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr ""
-"No se seleccionó un archivo metadata. Por favor seleccione un archivo "
-"metadata Kebernetes."
-
-#: pkg/machines/components/vmnetworktab.jsx:40
+#: pkg/machines/components/vmnetworktab.jsx:70
 msgid "No network interfaces defined for this VM"
 msgstr "No se han definido interfaces de red para esta VM"
 
@@ -5405,15 +4417,7 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/kubernetes/views/dashboard-page.html:117
-msgid "No nodes in cluster"
-msgstr "No hay  nodos en el cluster"
-
-#: pkg/ovirt/components/App.jsx:61
-msgid "No oVirt connection"
-msgstr "Sin conexión oVirt"
-
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:939
 msgid "No open ports"
 msgstr "Sin puertos abiertos"
 
@@ -5421,27 +4425,7 @@ msgstr "Sin puertos abiertos"
 msgid "No partitioning"
 msgstr "No particionar"
 
-#: pkg/kubernetes/views/dashboard-page.html:40
-msgid "No pods deployed"
-msgstr "No se han desplegado pods"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:6
-msgid "No pods replicated"
-msgstr "No se han replicado pods"
-
-#: pkg/kubernetes/views/node-capacity.html:11
-msgid "No pods scheduled"
-msgstr "Sin pods planificados"
-
-#: pkg/kubernetes/views/service-endpoint.html:10
-msgid "No pods selected"
-msgstr "Sin pods seleccionados"
-
-#: pkg/kubernetes/views/project-listing.html:37
-msgid "No projects are present."
-msgstr "No hay proyectos presentes."
-
-#: pkg/users/local.js:449
+#: pkg/users/local.js:453
 msgid "No real name specified"
 msgstr "Nombre real no especificado"
 
@@ -5481,48 +4465,17 @@ msgstr "No hay etiquetas presentes."
 msgid "No updates pending"
 msgstr "No hay actualizaciones pendientes"
 
-#: pkg/users/local.js:444
+#: pkg/users/local.js:448
 msgid "No user name specified"
 msgstr "Nombre de usuario no especificado"
-
-#: pkg/kubernetes/views/project-listing.html:112
-msgid "No users are present."
-msgstr "No hay usuarios presentes."
 
 #: pkg/storaged/vgroups-panel.jsx:114
 msgid "No volume groups created"
 msgstr "No hay grupos de volumen creados"
 
-#: pkg/kubernetes/views/volumes-page.html:44
-msgid "No volumes are present."
-msgstr "No hay volúmenes presentes."
-
-#: pkg/kubernetes/views/dashboard-page.html:73
-msgid "No volumes in use"
-msgstr "No hay volúmenes en uso"
-
-#: pkg/kubernetes/views/containers-listing.html:15
-#: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
-#: pkg/kubernetes/views/topology-page.html:38
-msgid "Node"
-msgstr "Nodo"
-
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
-#: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
-msgid "Nodes"
-msgstr "Nodos"
-
-#: pkg/kubernetes/views/topology-page.html:39
-msgid "Nodes are the machines that run your containers."
-msgstr "Nodos son las computadoras que ejecutan sus contenedores"
-
-#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
-#: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:732
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Ninguno"
 
@@ -5530,23 +4483,13 @@ msgstr "Ninguno"
 msgid "None (Isolated Network)"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
-#: pkg/kubernetes/scripts/nodes.js:319
+#: pkg/playground/translate.html:29
 msgid "Not Ready"
 msgstr "No está listo"
-
-#: pkg/kubernetes/scripts/details.js:496 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "No es un número válido de réplicas"
 
 #: pkg/lib/credentials.js:255
 msgid "Not a valid private key"
 msgstr "No es llave privada valida."
-
-#: pkg/kubernetes/scripts/details.js:547
-msgid "Not a valid value for Host"
-msgstr "No es un valor valido para el host"
 
 #: pkg/docker/index.html:57
 msgid "Not authorized to access Docker on this system"
@@ -5564,11 +4507,6 @@ msgstr "No disponible"
 msgid "Not connected"
 msgstr "No conectado"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
-#: pkg/kubernetes/views/details-page.html:122
-msgid "Not deployed"
-msgstr "No distribuido"
-
 #: pkg/storaged/lvol-tabs.jsx:369
 msgid "Not enough space to grow."
 msgstr ""
@@ -5585,7 +4523,7 @@ msgstr "No montado"
 msgid "Not permitted to perform this action."
 msgstr "No esta permitido ejecutar esta acción."
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Not running"
 msgstr "No esta corriendo"
 
@@ -5609,33 +4547,9 @@ msgstr "Portátil"
 msgid "Notice and above"
 msgstr "Aviso y arriba"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/ovirt/components/vcpuModal.jsx:55
-msgid "Number of virtual CPUs that gonna be used."
-msgstr "Número de CPU virtuales que se usarán."
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
-#: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
-msgid "OK"
-msgstr "OK"
-
-#: pkg/kubernetes/views/node-body.html:13
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "OS"
-msgstr "SO"
-
-#: pkg/ovirt/components/OVirtTab.jsx:148
-msgid "OS Type:"
-msgstr "Tipo de SO:"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:274
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
 msgid "OS Vendor"
 msgstr "Proveedor de SO"
-
-#: pkg/kubernetes/views/nodes-page.html:19
-msgid "OS Versions"
-msgstr "Versiones de SO"
 
 #: pkg/selinux/setroubleshoot-view.jsx:394
 msgid "Occurred $0"
@@ -5662,7 +4576,7 @@ msgstr "Contraseña vieja"
 msgid "Old passphrase"
 msgstr "Frase de acceso vieja"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Contraseña antigua no aceptada"
 
@@ -5674,7 +4588,7 @@ msgstr "Encencido"
 msgid "On Build"
 msgstr "En Construcción"
 
-#: pkg/docker/index.html:547 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/init.js:731
 msgid "On Failure"
 msgstr "Al producirse un fallo"
 
@@ -5696,7 +4610,7 @@ msgstr ""
 "Una vez que se instale Cockpit, habilítelo con \"systemctl enable --now "
 "cockpit.socket\"."
 
-#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:338
+#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
 msgstr "Contraseña de un solo uso"
 
@@ -5722,7 +4636,7 @@ msgstr "Solo se permiten caracteres alfanuméricos y  : , _ , . , @ , -."
 msgid "Only editable when the guest is shut off"
 msgstr ""
 
-#: pkg/shell/index.html:43 pkg/shell/simple.html:29 pkg/shell/stub.html:33
+#: pkg/shell/index.html:43 pkg/shell/simple.html:29
 msgid "Ooops!"
 msgstr "Ooops!"
 
@@ -5730,8 +4644,8 @@ msgstr "Ooops!"
 msgid "Open"
 msgstr ""
 
-#: pkg/kubernetes/views/nodes-page.html:42 pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+#: pkg/systemd/index.html:98
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
 msgid "Operating System"
 msgstr "Sistema Operativo"
 
@@ -5739,27 +4653,24 @@ msgstr "Sistema Operativo"
 msgid "Operation '$operation' on $target"
 msgstr "Actividad '$operation' en $target"
 
+#: pkg/machines/components/storagePools/storagePool.jsx:175
+#: pkg/machines/components/storagePools/storagePool.jsx:180
+#, fuzzy
+msgid "Operation is in progress"
+msgstr "oVirt acceso progresando"
+
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Disco Óptico"
 
-#: pkg/ovirt/components/OVirtTab.jsx:157
-msgid "Optimized for:"
-msgstr "Optimizado para:"
-
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:134
-#: pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
 msgid "Options"
 msgstr "Opciones"
 
 #: src/ws/login.html:125
 msgid "Or use a bundled browser"
 msgstr "O use un navegador incluido"
-
-#: pkg/subscriptions/subscriptions-register.jsx:180
-msgid "Organization"
-msgstr "Organización"
 
 #: pkg/lib/machine-info.js:64
 msgid "Other"
@@ -5778,11 +4689,9 @@ msgstr "Otros dispositivos"
 msgid "Other Options"
 msgstr "Otras Opciones"
 
-#: pkg/docker/index.html:297 pkg/kubernetes/index.html:43
-#: pkg/kubernetes/registry.html:43
-#: pkg/machines/components/networks/network.jsx:71
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Visión conjunta"
 
@@ -5793,10 +4702,6 @@ msgstr "Sobreescribir los datos existentes con ceros"
 #: pkg/systemd/hwinfo.jsx:249
 msgid "PCI"
 msgstr "PCI"
-
-#: pkg/kubernetes/views/volume-body.html:4
-msgid "PD Name"
-msgstr "Nombre de PD"
 
 #: pkg/packagekit/updates.jsx:501
 msgid "Package information"
@@ -5831,8 +4736,7 @@ msgstr "Parte de"
 msgid "Part of "
 msgstr "Parte de"
 
-#: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:141
 msgid "Partition"
 msgstr "Partición"
 
@@ -5869,13 +4773,11 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Palabra de paso no coincide"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
 #: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
-#: pkg/subscriptions/subscriptions-register.jsx:89
-#: pkg/subscriptions/subscriptions-register.jsx:156
 msgid "Password"
 msgstr "Contraseña"
 
@@ -5891,7 +4793,7 @@ msgstr "La contraseña no es aceptable"
 msgid "Password is too weak"
 msgstr "La contraseña en muy débil"
 
-#: pkg/users/local.js:870
+#: pkg/users/local.js:874
 msgid "Password must be changed"
 msgstr "Se debe cambiar la contraseña"
 
@@ -5914,11 +4816,7 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Pegue aquí el contenido de su archivo de clave SSH pública"
 
-#: pkg/kubernetes/views/pv-modify.html:126
-#: pkg/kubernetes/views/volume-body.html:37
-#: pkg/kubernetes/views/volume-body.html:49
-#: pkg/kubernetes/views/volume-body.html:101 pkg/systemd/services.html:126
-#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
 msgid "Path"
 msgstr "Trayecto"
 
@@ -5934,7 +4832,7 @@ msgstr "Costo de trayecto $path_cost"
 msgid "Path on Server"
 msgstr "Ruta sobre el Servidor"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:129
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
 msgid "Path on host's filesystem"
 msgstr "Ruta en el sistema de archivos del host"
 
@@ -5946,7 +4844,7 @@ msgstr "La ruta sobre el servidor no puede estar vacía"
 msgid "Path on server must start with \"/\"."
 msgstr "La ruta sobre el servidor debe empezar con \"/\"."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:154
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
 msgid "Path to ISO file on host's file system"
 msgstr "Ruta al fichero ISO en el sistema de archivos del host"
 
@@ -5961,10 +4859,6 @@ msgstr "Trayectos"
 #: pkg/machines/components/vm/vmActions.jsx:77
 msgid "Pause"
 msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html:53
-msgid "Pending Volume Claims"
-msgstr "Reclamaciones de Volumen Pendientes"
 
 #: pkg/systemd/index.html:152
 msgid "Performance Profile"
@@ -5986,18 +4880,10 @@ msgstr "Permiso denegado"
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html:14
-msgid "Persistent Volumes"
-msgstr "Volúmenes persistentes"
-
-#: pkg/kubernetes/views/pod-body.html:16
-msgid "Phase"
-msgstr "Fase"
 
 #: pkg/storaged/vdo-details.jsx:277
 msgid "Physical"
@@ -6011,11 +4897,11 @@ msgstr ""
 msgid "Physical Volume"
 msgstr "Volumen físico"
 
-#: pkg/storaged/vgroup-details.jsx:134
+#: pkg/storaged/vgroup-details.jsx:133
 msgid "Physical Volumes"
 msgstr "Volúmenea Físicos"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:210
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -6039,10 +4925,10 @@ msgstr "Hacer Ping al Objetivo"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:210
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Por favor confirmar la eliminación de $0"
 
@@ -6050,119 +4936,25 @@ msgstr "Por favor confirmar la eliminación de $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Por favor confirme, forzar el borrado de $0"
 
-#: pkg/storaged/mdraid-details.jsx:244 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Por favor confirma la parada de $0"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:34
-msgid "Please confirm, the host shall be switched to maintenance mode."
-msgstr "Por favor confirme que el host será conmutado a modo mantenimiento."
-
-#: pkg/kubernetes/scripts/dashboard.js:439
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Por favor cree otro nombre de espacio para $0 \"$1\""
-
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:425
+#: pkg/machines/components/diskAdd.jsx:447
 msgid "Please enter new volume name"
 msgstr "Introduzca el nuevo nombre de volumen"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:428
+#: pkg/machines/components/diskAdd.jsx:450
 msgid "Please enter new volume size"
 msgstr "Introduzca el nuevo tamaño de volumen"
 
-#: pkg/networkmanager/firewall.jsx:862
+#: pkg/networkmanager/firewall.jsx:864
 msgid "Please install the $0 package"
 msgstr "Por favor instale el $0 paquete"
 
-#: pkg/kubernetes/scripts/volumes.js:582
-msgid "Please provide a GlusterFS volume name"
-msgstr "Por favor provea un nombre de volumen GlusterFS"
-
-#: pkg/kubernetes/scripts/connection.js:550
-msgid "Please provide a username"
-msgstr "Provea un nombre de usuario"
-
-#: pkg/kubernetes/scripts/volumes.js:640
-msgid "Please provide a valid NFS server"
-msgstr "Por favor provea un servidos NFS valido"
-
-#: pkg/kubernetes/scripts/connection.js:535
-msgid "Please provide a valid address"
-msgstr "Provea una dirección valida"
-
-#: pkg/kubernetes/scripts/volumes.js:810
-msgid "Please provide a valid filesystem type"
-msgstr "Por favor provea un tipo de sistema de archivos valido"
-
-#: pkg/kubernetes/scripts/volumes.js:818
-msgid "Please provide a valid interface"
-msgstr "Por favor provea una interfaz valida"
-
-#: pkg/kubernetes/scripts/volumes.js:802
-msgid "Please provide a valid logical unit number"
-msgstr "Por favor provea un número valido de unidad lógica"
-
-#: pkg/kubernetes/scripts/volumes.js:483
-msgid "Please provide a valid name"
-msgstr "Por favor provea un nombre valido"
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Por favor provea un nombre de espacio valido"
-
-#: pkg/kubernetes/scripts/volumes.js:648 pkg/kubernetes/scripts/volumes.js:703
-msgid "Please provide a valid path"
-msgstr "Proporcione un trayecto válido"
-
-#: pkg/kubernetes/scripts/volumes.js:794
-msgid "Please provide a valid qualified name"
-msgstr "Por favor provea un nombre cualifica valido"
-
-#: pkg/kubernetes/scripts/volumes.js:491
-msgid "Please provide a valid storage capacity."
-msgstr "Por favor provea una capacidad de almacenamiento valida."
-
-#: pkg/kubernetes/scripts/volumes.js:786
-msgid "Please provide a valid target"
-msgstr "Por favor provea un objetivo valido"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:83
-msgid ""
-"Please provide fully qualified domain name and port of the oVirt engine."
-msgstr ""
-"Por favor suministre el nombre completo de dominio y el puerto de la máquina "
-"oVirt."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:137
-msgid ""
-"Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-"port (443 by default)"
-msgstr ""
-"Por favor suministre un nombre de dominio totalmente cualificado (FQDN) de "
-"la máquina oVirt y puerto (443 por defecto)"
-
-#: pkg/ovirt/components/ConsoleClientResources.jsx:32
-msgid ""
-"Please refer to oVirt's $0 for more information about Remote Viewer setup."
-msgstr ""
-"Por favor vea $0 de oVirt para más información sobre el ajuste del "
-"Visualizador Remoto."
-
-#: pkg/kubernetes/scripts/volumes.js:475
-msgid "Please select a valid access mode"
-msgstr "Por favor seleccionar un modo de acceso valido"
-
-#: pkg/kubernetes/scripts/volumes.js:573
-msgid "Please select a valid endpoint"
-msgstr "Por favor seleccione un punto final válido"
-
-#: pkg/kubernetes/scripts/volumes.js:499
-msgid "Please select a valid policy option."
-msgstr "Por favor provea una opción de política valida."
-
-#: pkg/users/local.js:1232
+#: pkg/users/local.js:1236
 msgid "Please specify an expiration date"
 msgstr "Por favor especifique una fecha de expiración"
 
@@ -6178,76 +4970,16 @@ msgstr "Por favor arranque la maquina virtual para acceder a su consola."
 msgid "Please try another term"
 msgstr "Pruebe con otro término"
 
-#: pkg/kubernetes/scripts/nodes.js:401
-msgid "Please type an address"
-msgstr "Por favor escriba una dirección"
-
-#: pkg/ovirt/components/ClusterVms.jsx:37
-msgid "Please wait till VMs list is loaded from the server."
-msgstr "Por favor espere hasta que la lista VMs se cargue desde el servidor."
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:30
-msgid "Please wait till list of templates is loaded from the server."
-msgstr ""
-"Por favor espere hasta que la lista de plantilla se cargue desde el servidor."
-""
-
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Plug"
 msgstr "Enchufe"
 
-#: pkg/kubernetes/views/containers-listing.html:12
-#: pkg/kubernetes/views/pod-page.html:12
-#: pkg/kubernetes/views/topology-page.html:14
-msgid "Pod"
-msgstr "Ranura"
-
-#: pkg/kubernetes/views/pod-body.html:20
-msgid "Pod Address"
-msgstr "Dirección del Pod"
-
-#: pkg/kubernetes/views/service-endpoint.html:4
-#: pkg/kubernetes/views/service-endpoint.html:9
-msgid "Pod Endpoints"
-msgstr "Puntos Finales del Pod"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:4
-msgid "Pod Replicated"
-msgstr "Pod Replicado"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:11
-#: pkg/kubernetes/views/service-endpoint.html:15
-msgid "Pod Selector"
-msgstr "Selector de Pod"
-
-#: pkg/kubernetes/views/dashboard-page.html:18
-#: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/pv-claim.html:37
-#: pkg/kubernetes/views/replicationcontroller-page.html:17
-#: pkg/kubernetes/views/replicationcontroller-panel.html:12
-#: pkg/kubernetes/scripts/details.js:227
-msgid "Pods"
-msgstr "Ranuras"
-
-#: pkg/kubernetes/views/topology-page.html:15
-msgid ""
-"Pods contain one or more containers that run together on a node, containing "
-"your application code."
-msgstr ""
-"Pods contienen uno o mas contenedores que corren juntos sobre un nodo, "
-"conteniendo su código de aplicación."
-
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Grupo"
-
-#: pkg/kubernetes/views/volume-body.html:60
-msgid "Pool Name"
-msgstr "Nombre del grupo"
 
 #: pkg/storaged/utils.js:191
 msgid "Pool for Thin Logical Volumes"
@@ -6261,16 +4993,11 @@ msgstr "Grupo para Volúmenes Finos"
 msgid "Pool for thinly provisioned volumes"
 msgstr "Grupo para volúmenes poco aprovisionados"
 
-#: pkg/kubernetes/views/imagestream-modify.html:45
-msgid "Populate"
-msgstr "Rellenar"
-
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:78
-#: pkg/ovirt/components/InstallationDialog.jsx:65
+#: pkg/machines/components/vmnetworktab.jsx:108
 #: pkg/storaged/iscsi-panel.jsx:127
 msgid "Port"
 msgstr "Puerto"
@@ -6283,15 +5010,14 @@ msgstr ""
 msgid "Portable"
 msgstr "Portable"
 
-#: pkg/docker/index.html:504 pkg/kubernetes/views/container-body.html:12
-#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:213
+#: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
 #: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
 msgid "Ports"
 msgstr "Puertos"
 
-#: pkg/docker/index.html:191
+#: pkg/docker/index.html:192
 msgid "Ports:"
 msgstr "Puertos:"
 
@@ -6300,7 +5026,6 @@ msgid "Power Options"
 msgstr "Opciones de apagado"
 
 #: pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Preferred number of sockets to expose to the guest."
 msgstr "Número preferido de sockets para exponer al invitado."
 
@@ -6319,10 +5044,6 @@ msgstr "Tamaño del prefijo o máscara de red"
 #: pkg/networkmanager/interfaces.js:826
 msgid "Preparing"
 msgstr "Preparando"
-
-#: pkg/ovirt/rephraseUI.js:25
-msgid "Preparing for Maintenance"
-msgstr "Preparando para Mantenimiento"
 
 #: pkg/networkmanager/interfaces.js:3631
 msgid "Preserve"
@@ -6361,10 +5082,6 @@ msgstr "Prioridad $priority"
 msgid "Private"
 msgstr ""
 
-#: pkg/kubernetes/scripts/projects.js:1042
-msgid "Private: Allow only specific users or groups to pull images"
-msgstr "Privado: Permite sólo a usuarios o grupos específicos tirar imágenes"
-
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/shell/index.html:39
 msgid "Privileged"
@@ -6391,67 +5108,9 @@ msgstr "Proceso"
 msgid "Product"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:34
-msgid "Product ID"
-msgstr "ID del Producto"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product name"
-msgstr "Nombre del Producto"
-
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
-#: pkg/kubernetes/views/details-page.html:35
-#: pkg/kubernetes/views/details-page.html:71
-#: pkg/kubernetes/views/details-page.html:104
-#: pkg/kubernetes/views/details-page.html:138
-#: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/pod-body.html:4
-#: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/route-body.html:4
-#: pkg/kubernetes/views/service-body.html:4
-#: pkg/kubernetes/views/volumes-page.html:58
-msgid "Project"
-msgstr "Proyecto"
-
-#: pkg/kubernetes/views/project-body.html:20
-msgid "Project Members"
-msgstr "Miembros del Proyecto"
-
-#: pkg/kubernetes/views/project-body.html:3
-msgid "Project access policy allows anonymous users to pull images."
-msgstr ""
-"Proyecto de política de acceso que permite a usuarios anónimos quitar "
-"imágenes."
-
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Project access policy allows any authenticated user to pull images."
-msgstr ""
-"Proyecto de política de acceso permite a cualquier usuario autenticado "
-"quitar imágenes."
-
-#: pkg/kubernetes/views/project-body.html:13
-msgid "Project access policy only allows specific members to access images."
-msgstr ""
-"Proyecto de política de acceso permite sólo a miembros específicos acceder a "
-"imágenes."
-
-#: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
+#: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
 msgstr "Sitio web del proyecto"
-
-#: pkg/kubernetes/views/filter-project.html:5
-msgid "Project:"
-msgstr "Proyecto:"
-
-#: pkg/kubernetes/index.html:88 pkg/kubernetes/registry.html:55
-#: pkg/kubernetes/views/group-delete.html:10
-#: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
-msgid "Projects"
-msgstr "Proyectos"
 
 #: pkg/users/local.js:91
 msgid "Prompting via passwd timed out"
@@ -6475,15 +5134,7 @@ msgstr "Propaga recargar a"
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: pkg/subscriptions/subscriptions-register.jsx:129
-msgid "Proxy"
-msgstr "Proxy"
-
-#: pkg/kubernetes/views/node-body.html:25
-msgid "Proxy Version"
-msgstr "Versión de Proxy"
-
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Llave pública"
 
@@ -6491,25 +5142,9 @@ msgstr "Llave pública"
 msgid "Public pulling repo"
 msgstr "Repositorio de encuestas públicas"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:152
-msgid "Pull an image:"
-msgstr "Halar una imagen:"
-
-#: pkg/kubernetes/views/imagestream-modify.html:66
-msgid "Pull from"
-msgstr "Extraer desde"
-
-#: pkg/kubernetes/scripts/images.js:635
-msgid "Pull specific tags from another image repository"
-msgstr "Extraer etiquetas específicas desde otro repositorio de imágenes"
-
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Proposito"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:141
-msgid "Push an image:"
-msgstr "Empujar una imagen:"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:31
 msgid "QEMU/KVM System connection"
@@ -6519,16 +5154,11 @@ msgstr "Conexión del sistema QEMU / KVM"
 msgid "QEMU/KVM User connection"
 msgstr "Conexión de usuario QEMU / KVM"
 
-#: pkg/kubernetes/views/pv-modify.html:148
-#: pkg/kubernetes/views/volume-body.html:77
-msgid "Qualified Name"
-msgstr "Nombre Cualificado"
-
-#: pkg/storaged/mdraid-details.jsx:186
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 0"
 msgstr "RAID 0"
 
@@ -6536,7 +5166,7 @@ msgstr "RAID 0"
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (Stripe)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 1"
 msgstr "RAID 1"
 
@@ -6544,7 +5174,7 @@ msgstr "RAID 1"
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (Espejo)"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 10"
 msgstr "RAID 10"
 
@@ -6552,7 +5182,7 @@ msgstr "RAID 10"
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (Arreglo de espejos)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 4"
 msgstr "RAID 4"
 
@@ -6560,7 +5190,7 @@ msgstr "RAID 4"
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (Paridad Dedicada)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 5"
 msgstr "RAID 5"
 
@@ -6568,7 +5198,7 @@ msgstr "RAID 5"
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (Paridad Distribuida)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 6"
 msgstr "RAID 6"
 
@@ -6584,7 +5214,7 @@ msgstr "Chasis RAID"
 msgid "RAID Device"
 msgstr "Dispositivo RAID"
 
-#: pkg/storaged/mdraid-details.jsx:316 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "Dispositivo RAID $0"
 
@@ -6600,27 +5230,15 @@ msgstr "Nivel RAID"
 msgid "RAID Member"
 msgstr "Miembro de RAID"
 
-#: pkg/ovirt/provider.js:179
-msgid "REBOOT action failed"
-msgstr "REBOOT falló acción"
-
-#: pkg/ovirt/provider.js:164
-msgid "REBOOT_VM action failed: %s0"
-msgstr ""
-
 #: pkg/lib/machine-info.js:86
 msgid "Rack Mount Chassis"
 msgstr "Chasis Montado en Rack"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Dispositivo de Bloque Rados"
 
 #: pkg/networkmanager/interfaces.js:3632
 msgid "Random"
 msgstr "Al azar"
 
-#: pkg/networkmanager/firewall.jsx:757
+#: pkg/networkmanager/firewall.jsx:759
 msgid "Range"
 msgstr ""
 
@@ -6632,42 +5250,15 @@ msgstr ""
 msgid "Raw to a device"
 msgstr "Sin procesar a un dispositivo"
 
-#: pkg/kubernetes/views/pv-modify.html:195
-#: pkg/kubernetes/views/volume-body.html:10
-#: pkg/kubernetes/views/volume-body.html:20
-#: pkg/kubernetes/views/volume-body.html:44
-#: pkg/kubernetes/views/volume-body.html:51
-#: pkg/kubernetes/views/volume-body.html:71
-#: pkg/kubernetes/views/volume-body.html:85
-#: pkg/kubernetes/views/volume-body.html:93
-#: pkg/kubernetes/views/volume-body.html:110
-#: pkg/kubernetes/views/volume-body.html:122
-#: pkg/kubernetes/views/volume-body.html:136
-#: pkg/kubernetes/views/volume-body.html:143
-msgid "Read Only"
-msgstr "Solo lectura"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "Lectura y escritura para un solo nodo."
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "Lectura y escritura para nodos multiples"
-
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "Sólo lectura para nodos múltiples"
-
-#: pkg/docker/index.html:363
+#: pkg/docker/index.html:365
 msgid "ReadOnly"
 msgstr "SoloLectura"
 
-#: pkg/docker/index.html:362
+#: pkg/docker/index.html:364
 msgid "ReadWrite"
 msgstr "LecturaEscritura"
 
@@ -6683,13 +5274,11 @@ msgstr "Consultando…"
 msgid "Readonly"
 msgstr "Sólo lectura"
 
-#: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
-#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/playground/translate.html:19
 msgid "Ready"
 msgstr "Listo"
 
-#: pkg/playground/translate.html:24 pkg/playground/translate.html:184
+#: pkg/playground/translate.html:24
 msgctxt "verb"
 msgid "Ready"
 msgstr "Preparado"
@@ -6710,10 +5299,6 @@ msgstr ""
 msgid "Real host name must be 64 characters or less"
 msgstr "El nombre real de anfitrión debe tener 64 caracteres o menos"
 
-#: pkg/kubernetes/views/node-body.html:45
-msgid "Reason"
-msgstr "Razón"
-
 #: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
 msgid "Reboot"
 msgstr "Reiniciar"
@@ -6728,16 +5313,11 @@ msgstr "Recibiendo"
 msgid "Recent"
 msgstr "Reciente"
 
-#: pkg/kubernetes/views/pv-body.html:6 pkg/kubernetes/views/pv-modify.html:56
-msgid "Reclaim Policy"
-msgstr "Normativa de reclamación"
-
 #: pkg/storaged/format-dialog.jsx:248
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/kubernetes/index.html:108 pkg/kubernetes/registry.html:75
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138 pkg/shell/stub.html:180
+#: pkg/shell/index.html:386 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Reconectarse"
@@ -6749,10 +5329,6 @@ msgstr "Recuperando"
 #: pkg/storaged/jobs-panel.jsx:65
 msgid "Recovering RAID Device $target"
 msgstr "Recuperando Dispositivo RAID $target"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "Reciclar"
 
 #: pkg/docker/storage.jsx:389
 msgid "Reformat and add disks"
@@ -6774,36 +5350,10 @@ msgstr "Rechazando conexión. La clave de host no coincide"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Rechazando la conexión. La clave de host es desconocida"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:159
-msgid "Register"
-msgstr "Registrar"
-
-#: pkg/kubernetes/views/volumes-page.html:12
-msgid "Register New Volume"
-msgstr "Registrar volumen nuevo"
-
-#: pkg/kubernetes/views/pv-modify.html:4
-msgid "Register Persistent Volume"
-msgstr "Registrar volumen persistente"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:108
-msgid "Register oVirt"
-msgstr "Registrar oVirt"
-
-#: pkg/subscriptions/main.js:73
-msgid "Register system"
-msgstr "Registrar sistema"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:128
-msgid "Registering oVirt to Cockpit"
-msgstr "Registrando oVirt a Cockpit"
-
 #: pkg/packagekit/updates.jsx:777
 msgid "Register…"
 msgstr "Registro…"
 
-#: pkg/ovirt/components/App.jsx:62 pkg/ovirt/components/VdsmView.jsx:100
 #: pkg/systemd/init.js:546
 msgid "Reload"
 msgstr "Recargar"
@@ -6812,7 +5362,7 @@ msgstr "Recargar"
 msgid "Reload Propagated From"
 msgstr "Recargar propagado desde"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:202
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
 msgid "Remote URL"
 msgstr "URL Remota"
 
@@ -6824,10 +5374,6 @@ msgstr "Remoto a través de NFS"
 msgid "Remote over SSH"
 msgstr "Remoto sobre SSH"
 
-#: pkg/kubernetes/views/imagestream-modify.html:89
-msgid "Remote registry is insecure"
-msgstr "El registro remoto es inseguro"
-
 #: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
 msgctxt "storage"
 msgid "Removable Drive"
@@ -6838,13 +5384,9 @@ msgstr "Disco Removible"
 msgid "Removals:"
 msgstr "Eliminaciones:"
 
-#: pkg/kubernetes/views/group-delete.html:21
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-delete.html:25
-#: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Eliminar"
 
@@ -6857,37 +5399,13 @@ msgstr "Quitar $0"
 msgid "Remove $0?"
 msgstr "¿Quitar $0?"
 
-#: pkg/kubernetes/views/group-delete.html:3
-msgid "Remove Group"
-msgstr "Quitar Grupo"
-
-#: pkg/kubernetes/views/user-group-remove.html:3
-msgid "Remove Member"
-msgstr "Quitar miembro"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:3
-msgid "Remove Role"
-msgstr "Quitar rol"
-
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove Tang keyserver"
 msgstr "Eliminar Tang keyserver"
 
-#: pkg/kubernetes/views/user-delete.html:3
-msgid "Remove User"
-msgstr "Quitar usuario"
-
 #: pkg/storaged/vdo-details.jsx:116
 msgid "Remove device"
 msgstr "Quitar dispositivo"
-
-#: pkg/kubernetes/views/image-delete.html:3
-msgid "Remove image tag"
-msgstr "Remover etiqueta de imagen"
-
-#: pkg/kubernetes/views/user-remove-membership.html:3
-msgid "Remove membership"
-msgstr "Quitar afiliación"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/storaged/crypto-keyslots.jsx:387
@@ -6899,11 +5417,11 @@ msgstr "Eliminar frase de acceso"
 msgid "Remove passphrase in $0?"
 msgstr "¿Eliminar frase de acceso en $0?"
 
-#: pkg/networkmanager/firewall.jsx:629
+#: pkg/networkmanager/firewall.jsx:631
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:608
+#: pkg/networkmanager/firewall.jsx:610
 msgid "Remove service from zones"
 msgstr ""
 
@@ -6932,8 +5450,8 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Eliminando volumen físico de $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:187
-#: pkg/storaged/vgroup-details.jsx:235
+#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:234
 msgid "Rename"
 msgstr "Renombrar"
 
@@ -6941,7 +5459,7 @@ msgstr "Renombrar"
 msgid "Rename Logical Volume"
 msgstr "Cambiar nombre de volumen lógico"
 
-#: pkg/storaged/vgroup-details.jsx:179
+#: pkg/storaged/vgroup-details.jsx:178
 msgid "Rename Volume Group"
 msgstr "Renombrar Grupo de Volumen"
 
@@ -6979,32 +5497,6 @@ msgstr "Repetir cada año"
 msgid "Repeat passphrase"
 msgstr "Repita la frase de acceso"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
-#: pkg/kubernetes/views/details-page.html:141
-#: pkg/kubernetes/views/replicationcontroller-body.html:9
-#: pkg/kubernetes/views/replicationcontroller-modify.html:8
-msgid "Replicas"
-msgstr "Réplicas"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/replicationcontroller-panel.html:10
-#: pkg/kubernetes/views/topology-page.html:22
-msgid "Replication Controller"
-msgstr "Contolador de replicación"
-
-#: pkg/kubernetes/views/details-page.html:132
-#: pkg/kubernetes/scripts/details.js:224
-msgid "Replication Controllers"
-msgstr "Controladores de replicación"
-
-#: pkg/kubernetes/views/topology-page.html:23
-msgid ""
-"Replication controllers dynamically create instances of pods from templates, "
-"and remove pods when necessary."
-msgstr ""
-"Los controladores de replicación crean dinámicamente instancias de pods a "
-"partir de plantillas y eliminan pods cuando es necesario."
-
 #: pkg/systemd/logs.js:512
 msgid "Report"
 msgstr "Informe"
@@ -7021,28 +5513,16 @@ msgstr "Informador 'reporter-ureport' no encontrado."
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr "Informando no tuvo éxito. Intente ejecutar `reporter-ureport -d "
 
-#: pkg/docker/index.html:688
+#: pkg/docker/index.html:690
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Repositorio"
 
-#: pkg/kubernetes/views/volume-body.html:24
-msgid "Repository URL"
-msgstr "URL del repositorio"
-
-#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
-msgid "Requested"
-msgstr "Solicitado"
-
-#: pkg/kubernetes/views/pv-claim.html:13
-msgid "Requests"
-msgstr "Solicitudes"
-
-#: pkg/users/local.js:1296
+#: pkg/users/local.js:1300
 msgid "Require password change every $0 days"
 msgstr "Se requiere que la contraseña cambie cada $0 días"
 
-#: pkg/users/local.js:872
+#: pkg/users/local.js:876
 msgid "Require password change on $0"
 msgstr "Se requiere que la contraseña se cambie en $0"
 
@@ -7056,10 +5536,6 @@ msgstr "Necesitado por"
 msgid "Requires"
 msgstr "Requiere"
 
-#: pkg/kubernetes/views/auth-form.html:54
-msgid "Requires Authentication"
-msgstr "Necesita autenticación"
-
 #: pkg/systemd/init.js:718
 msgid "Requisite"
 msgstr "Requisito"
@@ -7072,7 +5548,7 @@ msgstr "Requisito de"
 msgid "Reserved memory"
 msgstr "Memoria reservada"
 
-#: pkg/docker/index.html:301 pkg/users/index.html:333
+#: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:105
 msgid "Reset"
 msgstr "Reiniciar"
@@ -7100,26 +5576,22 @@ msgid ""
 "a current disk passphrase."
 msgstr ""
 
-#: pkg/docker/index.html:135 pkg/systemd/index.html:134
+#: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Reiniciar"
-
-#: pkg/kubernetes/views/container-body.html:20
-msgid "Restart Count"
-msgstr "Conteo de Reinicios"
 
 #: pkg/packagekit/updates.jsx:498
 msgid "Restart Now"
 msgstr "Reiniciar Ahora"
 
-#: pkg/docker/index.html:537 pkg/kubernetes/views/pod-body.html:10
+#: pkg/docker/index.html:539
 msgid "Restart Policy"
 msgstr "Normativa de reinicios"
 
-#: pkg/docker/index.html:171
+#: pkg/docker/index.html:172
 msgid "Restart Policy:"
 msgstr "Normativa de reinicios:"
 
@@ -7139,52 +5611,27 @@ msgstr "Restableciendo la conexión"
 msgid "Resume"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "Retener"
-
-#: pkg/docker/index.html:553
+#: pkg/docker/index.html:555
 msgid "Retries:"
 msgstr "Reintentos:"
-
-#: pkg/subscriptions/subscriptions-view.jsx:210
-msgid "Retrieving subscription status..."
-msgstr "Obteniendo el estado de la suscripción…"
 
 #: src/ws/login.html:57
 msgid "Reuse my password for privileged tasks"
 msgstr "Reutilizar mi contraseña para tareas privilegiadas"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Reutilizar mi contraseña para tareas con privilegios y para conectar con "
 "otras máquinas"
 
-#: pkg/kubernetes/views/volume-body.html:26
-msgid "Revision"
-msgstr "Revisión"
-
-#: pkg/kubernetes/views/user-add-membership.html:28
-#: pkg/kubernetes/views/user-body.html:5
-#: pkg/kubernetes/views/user-panel.html:28
-msgid "Role"
-msgstr "Rol"
-
-#: pkg/kubernetes/views/add-member-role-dialog.html:39
-#: pkg/kubernetes/views/project-body.html:21 pkg/users/index.html:94
+#: pkg/users/index.html:94
 msgid "Roles"
 msgstr "Roles"
 
 #: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
 msgid "Round Robin"
 msgstr "Round Robin"
-
-#: pkg/kubernetes/views/route-page.html:14
-#: pkg/kubernetes/views/route-panel.html:9
-msgid "Route"
-msgstr "Ruta"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:98
 msgid "Route to $0"
@@ -7194,22 +5641,16 @@ msgstr ""
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:65
-#: pkg/kubernetes/scripts/details.js:216 pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3325
 msgid "Routes"
 msgstr "Rutas"
 
-#: pkg/docker/index.html:244 pkg/docker/index.html:564
+#: pkg/docker/index.html:253 pkg/docker/index.html:566
 #: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
-#: pkg/ovirt/components/ClusterVms.jsx:92
 msgid "Run"
 msgstr "Ejecutar"
 
-#: pkg/ovirt/components/ClusterVms.jsx:97
-msgid "Run Here"
-msgstr "Ejecutar Aquí"
-
-#: pkg/docker/index.html:425
+#: pkg/docker/index.html:427
 msgid "Run Image"
 msgstr "Ejecutar imagen"
 
@@ -7218,7 +5659,7 @@ msgid "Run as"
 msgstr "Ejecutar como"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:128
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
 msgstr ""
 
@@ -7226,17 +5667,13 @@ msgstr ""
 msgid "Runner"
 msgstr "Ejecutor"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Running"
 msgstr "Corriendo"
 
 #: pkg/systemd/services.html:123
 msgid "Running Since"
 msgstr ""
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:54
-msgid "Running Since:"
-msgstr "Ejecutando Desde:"
 
 #: pkg/selinux/setroubleshoot-view.jsx:364
 msgid "SELinux Access Control Errors"
@@ -7262,14 +5699,6 @@ msgstr "Se ha desactivado SELinux en el sistema."
 msgid "SELinux system status is unknown."
 msgstr "Se desconoce el estado de sistema de SELinux."
 
-#: pkg/ovirt/provider.js:440
-msgid "SET VCPU SETTINGS action failed"
-msgstr "Falló la acción SET VCPU SETTINGS"
-
-#: pkg/ovirt/provider.js:111 pkg/ovirt/provider.js:145
-msgid "SHUTDOWN action failed"
-msgstr "SHUTDOWN acción fallada"
-
 #: pkg/storaged/jobs-panel.jsx:35
 msgid "SMART self-test of $target"
 msgstr "SMART auto-diagnóstico de $target"
@@ -7290,14 +5719,6 @@ msgstr "Puerto SPICE:"
 msgid "SPICE TLS Port:"
 msgstr "Puerto SPICE TLS:"
 
-#: pkg/ovirt/provider.js:225
-msgid "START action failed"
-msgstr "START acción fallada"
-
-#: pkg/ovirt/provider.js:203
-msgid "START_VM action failed: %s0"
-msgstr ""
-
 #: pkg/networkmanager/index.html:228
 msgid "STP Forward delay"
 msgstr "Retardo del reenvío STP"
@@ -7314,10 +5735,6 @@ msgstr "Edad máxima del mensaje STP"
 msgid "STP Priority"
 msgstr "Prioridad STP"
 
-#: pkg/ovirt/provider.js:303
-msgid "SUSPEND action failed"
-msgstr "SUSPEND acción fallada"
-
 #: pkg/systemd/services.html:240
 msgid "Saturday"
 msgstr "Sábado"
@@ -7326,10 +5743,10 @@ msgstr "Sábado"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/ovirt/components/VdsmView.jsx:114 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
 #: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Guardar"
@@ -7355,14 +5772,6 @@ msgstr ""
 "Para guardar una nueva frase de acceso hay que desbloquear el disco. Por "
 "favor indique una frase de acceso actual."
 
-#: pkg/kubernetes/views/node-capacity.html:9
-msgid "Scheduled Pods"
-msgstr "Pods Programados"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "Programación deshabilitada "
-
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
 msgstr "PC de Caja Sellada"
@@ -7371,24 +5780,6 @@ msgstr "PC de Caja Sellada"
 #: pkg/systemd/init.js:1076
 msgid "Seconds"
 msgstr "Segundos"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Secreto"
-
-#: pkg/kubernetes/views/volume-body.html:106
-msgid "Secret File"
-msgstr "Fichero Secreto"
-
-#: pkg/kubernetes/views/volume-body.html:141
-msgid "Secret Name"
-msgstr "Nombre Secreto"
-
-#: pkg/kubernetes/views/volume-body.html:69
-#: pkg/kubernetes/views/volume-body.html:108
-#: pkg/kubernetes/views/volume-body.html:134
-msgid "Secret Volume"
-msgstr "Volumen Secreto"
 
 #: pkg/systemd/index.html:106
 msgid "Secure Shell Keys"
@@ -7406,37 +5797,17 @@ msgstr "Seguridad"
 msgid "Security Updates Available"
 msgstr "Actualizaciones de Seguridad Disponibles"
 
-#: pkg/shell/index.html:123 pkg/shell/simple.html:91 pkg/shell/stub.html:106
+#: pkg/shell/index.html:123 pkg/shell/simple.html:91
 msgid "Select"
 msgstr "Seleccionar"
 
-#: pkg/kubernetes/views/file-button.html:4
-msgid "Select Manifest File..."
-msgstr "Seleccione un archivo Manifiesto..."
-
-#: pkg/kubernetes/scripts/projects.js:899
-#: pkg/kubernetes/scripts/projects.js:1205
-#: pkg/kubernetes/scripts/projects.js:1335
-msgid "Select Member"
-msgstr "Seleccione Miembro"
-
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/kubernetes/scripts/projects.js:901
-#: pkg/kubernetes/scripts/projects.js:1208
-msgid "Select Role"
-msgstr "Seleccionar Rol"
-
-#: pkg/kubernetes/views/topology-page.html:7
-msgid "Select an object to see more details."
-msgstr "Selecciona un objeto para ver mas detalles"
-
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Seleccione el usuario con el que le gustaría sincronizar  "
-"{{#strong}}{{host}}{{/strong}}"
+"Seleccione el usuario con el que le gustaría sincronizar  {{#strong}}{{host}}"
+"{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
@@ -7456,11 +5827,8 @@ msgstr "Enviando"
 msgid "Serial Console"
 msgstr "Consola Serie"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:116 pkg/storaged/nfs-details.jsx:315
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:65
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Servidor"
 
@@ -7468,7 +5836,7 @@ msgstr "Servidor"
 msgid "Server Address"
 msgstr "Dirección del Servidor"
 
-#: pkg/users/local.js:746 pkg/users/local.js:747
+#: pkg/users/local.js:750 pkg/users/local.js:751
 msgid "Server Administrator"
 msgstr "Administrador del Servidor"
 
@@ -7492,16 +5860,10 @@ msgstr "El server a cerrado la conexión"
 msgid "Servers"
 msgstr "Servidores"
 
-#: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/service-panel.html:8
-#: pkg/kubernetes/views/topology-page.html:30 pkg/systemd/logs.html:66
-#: pkg/networkmanager/firewall.jsx:936 pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Servicio"
-
-#: pkg/kubernetes/views/pod-body.html:12
-msgid "Service Account"
-msgstr "Cuenta de servicio"
 
 #: pkg/systemd/services.html:337
 msgid "Service Logs"
@@ -7531,28 +5893,14 @@ msgstr "Se está deteniendo el servicio"
 msgid "Service name"
 msgstr "Nombre de servicio"
 
-#: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
-#: pkg/systemd/services.html:330 pkg/kubernetes/scripts/details.js:213
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
 #: pkg/networkmanager/firewall.jsx:483
 msgid "Services"
 msgstr "Servicios"
 
-#: pkg/kubernetes/views/topology-page.html:31
-msgid ""
-"Services group pods and provide a common DNS name and an optional, load-"
-"balanced IP address to access them."
-msgstr ""
-"Agrupan pods de servicios y suministran un nombre DNS común y una dirección "
-"IP opcional con balance de carga para acceder a ellos"
-
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sesión"
-
-#: pkg/kubernetes/views/service-body.html:20
-msgid "Session Affinity"
-msgstr "Afinidad de Sesión"
 
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
@@ -7570,7 +5918,7 @@ msgstr "Establecer contraseña"
 msgid "Set Time"
 msgstr "Ajustar Hora"
 
-#: pkg/docker/index.html:530
+#: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Ajustar variables de entorno del contenedor"
 
@@ -7605,28 +5953,15 @@ msgstr "Severidad"
 msgid "Severity:"
 msgstr "Severidad:"
 
-#: pkg/kubernetes/views/volume-body.html:139
-msgid "Share Name"
-msgstr "Nombre Compartido"
-
 #: pkg/networkmanager/interfaces.js:1959
 msgid "Shared"
 msgstr "Compartido"
-
-#: pkg/kubernetes/scripts/projects.js:1043
-msgid "Shared: Allow any authenticated user to pull images"
-msgstr "Compartido: permitir a cualquier usuario autenticado extraer imágenes"
-
-#: pkg/kubernetes/views/container-page-inline.html:14
-#: pkg/kubernetes/views/container-panel.html:9
-msgid "Shell"
-msgstr "Shell"
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Show Performance Options"
 msgstr ""
 
@@ -7634,61 +5969,15 @@ msgstr ""
 msgid "Show all"
 msgstr ""
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:122
 msgid "Show all $0 drives"
 msgstr ""
-
-#: pkg/kubernetes/views/container-page.html:4
-msgid "Show all Containers"
-msgstr "Mostrar todos los contenedores"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:8
-msgid "Show all Deployment Configs"
-msgstr "Mostrar todas las configuraciones de distribución"
-
-#: pkg/kubernetes/views/node-page.html:8
-msgid "Show all Nodes"
-msgstr "Mostrar todos los nodos"
-
-#: pkg/kubernetes/views/pv-page.html:9
-msgid "Show all Persistent Volumes"
-msgstr "Mostrar todos los volúmenes persistentes"
-
-#: pkg/kubernetes/views/pod-container.html:4
-msgid "Show all Pod Containers"
-msgstr "Mostrar todos los Pod Contenedores"
-
-#: pkg/kubernetes/views/pod-page.html:8
-msgid "Show all Pods"
-msgstr "Mostrar todos los Pods"
-
-#: pkg/kubernetes/views/group-page.html:14
-#: pkg/kubernetes/views/project-page.html:23
-#: pkg/kubernetes/views/user-page.html:16
-msgid "Show all Projects"
-msgstr "Mostrar todos los proyectos"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:10
-msgid "Show all Replication Controllers"
-msgstr "Mostrar todos los Controladores Replicantes"
-
-#: pkg/kubernetes/views/route-page.html:10
-msgid "Show all Routes"
-msgstr "Mostrar todas las rutas"
-
-#: pkg/kubernetes/views/service-page.html:8
-msgid "Show all Services"
-msgstr "Mostrar todos los servicios"
 
 #: pkg/docker/index.html:128
 msgid "Show all containers"
 msgstr "Mostrar todos los contenedores"
 
-#: pkg/kubernetes/views/imagestream-page.html:12
-msgid "Show all image streams"
-msgstr "Mostrar toda la secuencia de imagen"
-
-#: pkg/docker/index.html:254 pkg/kubernetes/views/image-page.html:10
+#: pkg/docker/index.html:249
 msgid "Show all images"
 msgstr "Mostrar todas las imágenes"
 
@@ -7713,21 +6002,16 @@ msgstr ""
 msgid "Shut Down"
 msgstr "Apagar"
 
-#: pkg/kubernetes/views/container-body.html:18
-msgid "Since"
-msgstr "Desde"
-
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:376
-#: pkg/machines/components/diskAdd.jsx:143
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Tamaño"
 
@@ -7751,11 +6035,6 @@ msgstr "Tamaña debe ser un número"
 msgid "Size must be at least $0"
 msgstr "El tamaño debe ser al menos $0"
 
-#: pkg/kubernetes/views/auth-form.html:43
-#: pkg/kubernetes/views/auth-rejected-cert.html:11
-msgid "Skip Certificate Verification"
-msgstr "Saltar la Verificación de Certificado"
-
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Slot"
 msgstr "Espacio"
@@ -7765,7 +6044,6 @@ msgid "Slot $0"
 msgstr "Espacio $0"
 
 #: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Sockets"
 msgstr "Sockets"
 
@@ -7808,18 +6086,14 @@ msgstr ""
 "Algún otro programa está usando actualmente el gestor de paquetes, por favor "
 "espere..."
 
-#: pkg/kubernetes/scripts/volumes.js:914
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "Lo siento, no se como modificar este volumen"
-
-#: pkg/networkmanager/firewall.jsx:707
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:476
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:103
+#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Fuente"
 
@@ -7827,10 +6101,10 @@ msgstr "Fuente"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:217
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:244
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Dirección de origen"
 
@@ -7838,12 +6112,12 @@ msgstr "Dirección de origen"
 msgid "Source URL"
 msgstr "URL Fuente"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:254
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
 msgid "Source path should not be empty"
 msgstr "La ruta de origen no debe estar vacía"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:108
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "La fuente debería empezar con http, ftp o protocolo nfs"
 
@@ -7871,9 +6145,9 @@ msgstr "Hora Específica"
 msgid "Stable"
 msgstr "Estable"
 
-#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:320 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Iniciar"
 
@@ -7894,7 +6168,7 @@ msgstr "Iniciar servicio"
 msgid "Start libvirt"
 msgstr "Inicar libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:291
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
 msgid "Start pool when host boots"
 msgstr "Empezar el pool cuando el host arranque."
 
@@ -7906,59 +6180,29 @@ msgstr "Iniciando dispositivo RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Iniciando espacio de swap $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Starts"
-msgstr "Inicios"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
 msgid "Startup"
 msgstr "Puesta en marcha"
 
-#: pkg/kubernetes/views/container-body.html:16
-#: pkg/kubernetes/views/details-page.html:38
-#: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:127 pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/init.js:285
 msgid "State"
 msgstr "Estado"
 
-#: pkg/docker/index.html:167
+#: pkg/docker/index.html:168
 msgid "State:"
 msgstr "Estado:"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "Stateless"
-msgstr "Sin estado"
-
-#: pkg/ovirt/components/OVirtTab.jsx:156
-msgid "Stateless:"
-msgstr "Sin estado:"
 
 #: pkg/systemd/services.html:74 pkg/systemd/init.js:207
 msgid "Static"
 msgstr "Estático"
 
-#: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/volumes-page.html:21 pkg/systemd/services.html:121
-#: pkg/networkmanager/interfaces.js:2613
-#: pkg/subscriptions/subscriptions-view.jsx:37
+#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
 msgid "Status"
 msgstr "Estado"
-
-#: pkg/subscriptions/subscriptions-view.jsx:162
-msgid "Status: $0"
-msgstr "Estado: $0"
-
-#: pkg/subscriptions/subscriptions-view.jsx:157
-msgid "Status: System isn't registered"
-msgstr "Estado: El sistema no está registrado"
 
 #: pkg/lib/machine-info.js:99
 msgid "Stick PC"
@@ -7968,14 +6212,14 @@ msgstr "Stick PC"
 msgid "Sticky"
 msgstr "Pegajoso"
 
-#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Detener"
 
-#: pkg/storaged/mdraid-details.jsx:248
+#: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Para Dispositivo"
 
@@ -8008,8 +6252,8 @@ msgstr "Deteniendo dispositivo RAID $target"
 msgid "Stopping swapspace $target"
 msgstr "Deteniendo espacio de swap $target"
 
-#: pkg/docker/index.html:288 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
+#: pkg/docker/index.html:290 pkg/storaged/index.html:23
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
 #: pkg/storaged/details.jsx:127
 msgid "Storage"
 msgstr "Almacenamiento"
@@ -8018,11 +6262,11 @@ msgstr "Almacenamiento"
 msgid "Storage Logs"
 msgstr "Bitácoras de Almacenamiento"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:137
+#: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePool.jsx:149
+#: pkg/machines/components/storagePools/storagePool.jsx:153
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
@@ -8030,7 +6274,7 @@ msgstr ""
 msgid "Storage Pool Name"
 msgstr "Nombre del grupo de almacenamiento"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:437
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
 msgid "Storage Pool failed to be created"
 msgstr "No se pudo crear la agrupación de almacenamiento"
 
@@ -8051,7 +6295,7 @@ msgstr ""
 msgid "Storage can not be managed on this system."
 msgstr ""
 
-#: pkg/docker/index.html:302
+#: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Grupo de almacenamiento"
 
@@ -8071,10 +6315,6 @@ msgstr "Frase de paso guardada"
 msgid "Stored passphrase"
 msgstr "Frase de paso almacenada"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:12
-msgid "Strategy"
-msgstr "Estrategia"
-
 #: pkg/lib/machine-info.js:82
 msgid "Sub Chassis"
 msgstr "Sub Chasis"
@@ -8082,10 +6322,6 @@ msgstr "Sub Chasis"
 #: pkg/lib/machine-info.js:77
 msgid "Sub Notebook"
 msgstr "Sub Portátil"
-
-#: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:177
-msgid "Subscriptions"
-msgstr "Suscripciones"
 
 #: node_modules/registry-image-widgets/views/image-body.html:4
 msgid "Summary"
@@ -8103,10 +6339,6 @@ msgstr ""
 msgid "Support is installed."
 msgstr "El soporte está instalado."
 
-#: pkg/ovirt/components/VmActions.jsx:40
-msgid "Suspend"
-msgstr "Suspendido"
-
 #: pkg/storaged/content-views.jsx:157
 msgid "Swap"
 msgstr "Intercambio"
@@ -8120,10 +6352,6 @@ msgstr "Espacio de intercambio"
 msgid "Swap Used"
 msgstr "Swap utilizada"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:40
-msgid "Switch Host to Maintenance"
-msgstr "Conmutar el Host para Mantenimiento"
-
 #: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
 msgid "Switch off $0"
 msgstr "Apagar $0"
@@ -8131,15 +6359,6 @@ msgstr "Apagar $0"
 #: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
 msgid "Switch on $0"
 msgstr "Encender $0"
-
-#: pkg/ovirt/provider.js:414
-msgid "Switching host to maintenance mode failed. Received error: "
-msgstr ""
-"La conmutación del host para modo de mantenimiento fallo. Error recibido:"
-
-#: pkg/ovirt/provider.js:408
-msgid "Switching host to maintenance mode in progress ..."
-msgstr "La conmutación del host a modo mantenimiento progresando..."
 
 #: pkg/networkmanager/interfaces.js:2491
 msgid ""
@@ -8164,10 +6383,6 @@ msgid ""
 msgstr ""
 "Apagando <b>$0</b>  romperá la conexión al servidor y hará la administración "
 "de UI no disponible."
-
-#: pkg/kubernetes/scripts/images.js:634
-msgid "Sync all tags from a remote image repository"
-msgstr "Sincronizar todas las etiquetas desde un repositorio de imagen remoto"
 
 #: pkg/lib/machine-sync-users.html:75
 msgid "Synchronize"
@@ -8218,27 +6433,22 @@ msgstr "Sistema Actualizado"
 msgid "System is up to date"
 msgstr "El sistema está actualizado"
 
-#: pkg/docker/index.html:327 pkg/docker/index.html:331
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:329 pkg/docker/index.html:333
+#: pkg/networkmanager/firewall.jsx:938
 msgid "TCP"
 msgstr ""
 "TCP: Protocolo de Control de Transmisión, por sus siglas en ingles "
 "(Transmission Control Protocol)"
 
-#: pkg/kubernetes/views/route-body.html:12
-msgid "TLS Termination"
-msgstr "Terminación TLS"
-
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
 msgstr "Tableta"
 
-#: pkg/docker/index.html:694
+#: pkg/docker/index.html:696
 #: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Etiquetas"
 
-#: pkg/kubernetes/views/imagestream-modify.html:76
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
@@ -8250,25 +6460,16 @@ msgstr "Etiquetas"
 msgid "Tang keyserver"
 msgstr "Tang keyserver"
 
-#: pkg/kubernetes/views/pv-modify.html:137
 #: pkg/machines/components/vm/bootOrderModal.jsx:133
 msgid "Target"
 msgstr "Objetivo"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Ruta de destino"
 
-#: pkg/kubernetes/views/volume-body.html:75
-msgid "Target Portal"
-msgstr "Portal Objetivo"
-
-#: pkg/kubernetes/views/volume-body.html:114
-msgid "Target World Wide Names"
-msgstr "Nombres Objetivo en todo el Mundo"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:133
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
 msgid "Target path should not be empty"
 msgstr "La ruta de destino no debe estar vacía"
 
@@ -8292,22 +6493,6 @@ msgstr "Ajustes de Puerto de Equipo"
 #: pkg/networkmanager/index.html:514
 msgid "Team Settings"
 msgstr "Ajustes de Equipo"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:15
-#: pkg/kubernetes/views/deploymentconfig-panel.html:10
-#: pkg/kubernetes/views/replicationcontroller-page.html:20
-#: pkg/kubernetes/views/replicationcontroller-panel.html:14
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "Template"
-msgstr "Plantilla"
-
-#: pkg/ovirt/components/App.jsx:111
-msgid "Templates"
-msgstr "Plantillas"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:130
-msgid "Templates of $0 cluster"
-msgstr "Plantilla de cluster $0"
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
@@ -8344,11 +6529,11 @@ msgid "The IP address or host name cannot contain whitespace."
 msgstr ""
 "La dirección IP o el nombre de dominio no puede tener espacios en blanco"
 
-#: pkg/storaged/mdraid-details.jsx:219
+#: pkg/storaged/mdraid-details.jsx:218
 msgid "The RAID Array is in a degraded state"
 msgstr "El Array RAID está en estado degradado"
 
-#: pkg/storaged/mdraid-details.jsx:149
+#: pkg/storaged/mdraid-details.jsx:148
 msgid "The RAID device must be running in order to add spare disks."
 msgstr ""
 "El dispositivo RAID debe estar corriendo con el objetivo de añadir discos de "
@@ -8401,19 +6586,15 @@ msgid "The VM is suspended by guest power management."
 msgstr ""
 "La VM está suspendida por la administración de energía de los invitados."
 
-#: pkg/users/local.js:1338
+#: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
 msgstr ""
 "Se forzará a la cuenta '$0' a cambiar su contraseña en el próximo acceso"
 
-#: pkg/kubernetes/scripts/nodes.js:403
-msgid "The address contains invalid characters"
-msgstr "La dirección contiene caracteres inválidos"
-
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "La autenticidad del host {{#strong}}{{host}}{{/strong}} no se ha podido "
 "establecer.¿Está seguro que desea continuar con la conexión?"
@@ -8427,10 +6608,6 @@ msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 "El estado configurado es desconocido, podría cambiar en el próximo arranque."
 
-#: pkg/kubernetes/views/container-page-inline.html:22
-msgid "The container '{{ target }}' does not exist."
-msgstr "El contenedor '{{ target }}' no existe."
-
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
@@ -8438,23 +6615,13 @@ msgstr ""
 "La creación de este dispositivo VDO no ha finalizado y el dispositivo no "
 "podrá ser usado."
 
-#: pkg/subscriptions/subscriptions-view.jsx:214
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-"El usuario actual no tiene permitido acceder al estado de suscripción al "
-"sistema."
-
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr "El usuario actual no tiene permitido ver información de claves."
 
-#: pkg/kubernetes/views/deploymentconfig-page.html:25
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "La configuración de despliegue '{{ target }}' no existe."
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:204
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
 msgid "The directory on the server being exported"
 msgstr "El directorio en el servidor que se está exportando."
 
@@ -8467,8 +6634,7 @@ msgstr ""
 "servicios del sistema. Procediendo detendrá estos."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "El sistema de archivos está en uso por sesiones de inicio de sesión. "
 "Procediendo detendrá estos."
@@ -8483,8 +6649,7 @@ msgstr ""
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "Los siguientes contenedores dependen de esta imagen y no podrán usarse."
 
@@ -8497,10 +6662,6 @@ msgstr ""
 "El archivo generado contiene datos considerados sensibles y su contenido "
 "debería ser revisados por el organización originaria antes de ser pasado a "
 "cualquier tercero."
-
-#: pkg/kubernetes/views/group-page.html:47
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "El grupo '{{ groupName }}' no existe."
 
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
@@ -8529,31 +6690,16 @@ msgstr "La última ranura de la llave no se puede quitar"
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "El último volumen físico de un grupo de volumen no puede ser quitado."
 
-#: pkg/shell/indexes.js:408
+#: pkg/shell/indexes.js:407
 msgid "The machine is restarting"
 msgstr "La máquina se está reiniciando"
 
-#: pkg/kubernetes/scripts/details.js:498 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "El número maximo de replicas es 128"
+#: pkg/machines/components/networks/networkDelete.jsx:76
+#, fuzzy
+msgid "The network could not be deleted"
+msgstr "La ruta de destino no debe estar vacía"
 
-#: pkg/kubernetes/scripts/nodes.js:411
-msgid "The name contains invalid characters"
-msgstr "El nombre contiene caracteres invalidos"
-
-#: pkg/kubernetes/views/node-page.html:23
-msgid "The node '{{ target }}' does not exist."
-msgstr "El nodo '{{ target }}' no existe."
-
-#: pkg/kubernetes/views/node-alerts.html:7
-msgid "The node doesn't have enough disk space"
-msgstr "El nodo no tiene bastante espacio de disco"
-
-#: pkg/kubernetes/views/node-alerts.html:11
-msgid "The node doesn't have enough free memory"
-msgstr "El nodo no tiene bastante memoria libre"
-
-#: pkg/users/local.js:439 pkg/users/local.js:1395
+#: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
 msgstr "Las contraseñas no coinciden."
 
@@ -8561,30 +6707,10 @@ msgstr "Las contraseñas no coinciden."
 msgid "The passwords do not match."
 msgstr "Las contraseñas no coinciden."
 
-#: pkg/kubernetes/views/pv-page.html:21
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "El volumen presistente '{{ target }}' no existe."
-
-#: pkg/kubernetes/views/pod-page.html:40
-msgid "The pod '{{ target }}' does not exist."
-msgstr "El pod '{{ target }}' no existe."
-
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/machines/components/diskAdd.jsx:80
 msgid "The pool is empty"
 msgstr "El grupo está vacío"
-
-#: pkg/kubernetes/views/project-page.html:34
-msgid "The project '{{ projName }}' does not exist."
-msgstr "El proyecto '{{ projName }}' no existe."
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:30
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "El controlador de replica '{{ target }}' no existe."
-
-#: pkg/kubernetes/views/route-page.html:19
-msgid "The route '{{ target }}' does not exist."
-msgstr "La ruta '{{ target }}' no existe."
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
@@ -8593,12 +6719,6 @@ msgstr "El escaneo desde $time ($type) no encontró vulnerabilidades."
 #: pkg/docker/containers-view.jsx:432
 msgid "The scan from $time ($type) was not successful."
 msgstr "El escaneo desde $time ($type) no tuvo éxito."
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-"El archivo seleccionado no es un archivo de manifiesto de aplicación "
-"kubernetes valido"
 
 #: src/ws/login.js:645
 msgid ""
@@ -8612,21 +6732,9 @@ msgstr ""
 msgid "The server refused to authenticate using any supported methods."
 msgstr "El servido rehusó autenticar usando los métodos soportados."
 
-#: pkg/kubernetes/views/auth-rejected-cert.html:2
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr "El servidor usa un certificado firmado por una autoridad desconocida."
-
-#: pkg/kubernetes/views/service-page.html:19
-msgid "The service '{{ target }}' does not exist."
-msgstr "El servicio '{{ target }}' no existe."
-
 #: pkg/systemd/hwinfo.jsx:65
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
-
-#: pkg/kubernetes/views/user-page.html:29
-msgid "The user '{{ userName }}' does not exist."
-msgstr "El usuario '{{ userName }}' no existe."
 
 #: pkg/systemd/init.js:922
 msgid "The user <b>$0</b> does not have permissions for creating timers"
@@ -8653,8 +6761,7 @@ msgstr "El usuario <b>$0</b> no está autorizado para administrar servidores"
 
 #: pkg/storaged/storage-controls.jsx:73
 msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr ""
-"Al usuario <b>$0</b> no le es permitido administrar el almacenamiento "
+msgstr "Al usuario <b>$0</b> no le es permitido administrar el almacenamiento "
 
 #: pkg/users/local.js:43
 msgid "The user <b>$0</b> is not permitted to modify accounts"
@@ -8670,7 +6777,7 @@ msgstr ""
 "El usuario <b>$0</b> no está autorizado para modificar la configuración de "
 "la red"
 
-#: pkg/realmd/operation.js:643
+#: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "El usuario <b>$0</b> no está autorizado a modificar dominios"
 
@@ -8684,7 +6791,7 @@ msgstr ""
 msgid "The user <b>$0</b> is not permitted to start or stop services"
 msgstr "El usuario <b>$0</b> no puede iniciar ni parar servicios"
 
-#: pkg/users/local.js:549
+#: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
@@ -8694,8 +6801,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "La configuración del navegador evita que se ejecute Cockpit (inaccesible $0)"
 
@@ -8729,19 +6835,11 @@ msgstr "Volumen Lógico Delgado"
 
 #: pkg/storaged/nfs-details.jsx:118
 msgid "This NFS mount is in use and only its options can be changed."
-msgstr ""
-"Este montaje NFS está en uso y solo pueden ser cambiadas sus opciones."
+msgstr "Este montaje NFS está en uso y solo pueden ser cambiadas sus opciones."
 
 #: pkg/storaged/vdo-details.jsx:133
 msgid "This VDO device does not use all of its backing device."
 msgstr "Este dispositivo VDO no usa todos sus dispositivos de respaldo."
-
-#: pkg/kubernetes/views/pvc-delete.html:8
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-"Esta reclamo está en uso. Borrarlo puede causar problemas con los siguientes "
-"pod:"
 
 #: pkg/systemd/init.js:1371
 msgid ""
@@ -8804,14 +6902,6 @@ msgstr ""
 msgid "This field cannot be empty."
 msgstr "Este campo no puede estar vacío."
 
-#: pkg/ovirt/components/App.jsx:155
-msgid ""
-"This host is managed by a virtualization manager, so creation of new VMs "
-"from the host is not possible."
-msgstr ""
-"Este host está gestionado por un gestor de virtualización de modo que la "
-"creación de nuevas VMs desde este host no es posible."
-
 #: pkg/docker/containers-view.jsx:494
 msgid "This image does not exist."
 msgstr "Esta imagen no existe."
@@ -8827,14 +6917,6 @@ msgstr "Esta maquina ya ha sido agregada"
 #: pkg/realmd/operation.html:80
 msgid "This may take a while"
 msgstr "Esto podría tomar un momento"
-
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-"Esta opción es para probar un único nodo solo – el almacenamiento local no "
-"trabajará en un clúster multi nodo"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
@@ -8874,7 +6956,7 @@ msgstr "Esta unidad es una instancia de la plantilla $0 "
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Esta unidad no está diseñada para ser habilitada explícitamente."
 
-#: pkg/users/local.js:557
+#: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "El usuario ya existe"
 
@@ -8886,38 +6968,18 @@ msgstr ""
 "Esta versión de cockpit-ws no soporta conexiones a un servidor con un "
 "usuario o puerto alterno"
 
-#: pkg/ovirt/components/OVirtTab.jsx:134
-msgid "This virtual machine is not managed by oVirt"
-msgstr "Esta máquina virtual no está gestionada por oVirt"
-
-#: pkg/kubernetes/views/pv-delete.html:7
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
-msgstr ""
-"Este volumen ha sido reclamado por {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Eliminarlo romperá el reclamo y puede "
-"causar problemas en cualquier pod que dependa de él."
-
-#: pkg/kubernetes/views/pv-claim.html:23
-msgid "This volume has not been claimed"
-msgstr "Este volumen ni ha sido reclamado"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:369
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
 msgid "This volume is already used by another VM."
 msgstr ""
 
 #: pkg/storaged/lvol-tabs.jsx:186
 msgid "This volume needs to be activated before it can be resized."
-msgstr ""
-"Este volumen necesita ser activado antes de poder modificar el tamaño."
+msgstr "Este volumen necesita ser activado antes de poder modificar el tamaño."
 
 #: src/ws/login.js:122
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr ""
-"Este navegador web es demasiado viejo para ejecutar Cockpit (desaparecido "
-"$0)"
+"Este navegador web es demasiado viejo para ejecutar Cockpit (desaparecido $0)"
 
 #: pkg/packagekit/updates.jsx:832
 msgid "This web console will be updated."
@@ -8938,7 +7000,6 @@ msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Esto probará la configuración kdump bloqueando el núcleo."
 
 #: pkg/machines/components/vcpuModal.jsx:212
-#: pkg/ovirt/components/vcpuModal.jsx:70
 msgid "Threads per core"
 msgstr "Hilos por núcleo"
 
@@ -8991,10 +7052,6 @@ msgstr ""
 "Para tratar un puerto diferente usted va a necesitar actualizar cockpit-ws a "
 "una nueva versión."
 
-#: pkg/kubernetes/views/auth-form.html:116
-msgid "Token"
-msgstr "Ficha"
-
 #: pkg/lib/cockpit-components-file-autocomplete.jsx:148
 msgid "Too many files found"
 msgstr "Encontrados demasiados archivos"
@@ -9002,10 +7059,6 @@ msgstr "Encontrados demasiados archivos"
 #: src/base1/cockpit.js:4039
 msgid "Too much data"
 msgstr "Demasiados datos"
-
-#: pkg/kubernetes/index.html:61
-msgid "Topology"
-msgstr "Topología"
 
 #: pkg/docker/storage.jsx:341
 msgid "Total"
@@ -9024,12 +7077,11 @@ msgstr "Torre"
 msgid "Triggered By"
 msgstr "Desencadenado por"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:32 pkg/systemd/init.js:732
+#: pkg/systemd/init.js:732
 msgid "Triggers"
 msgstr "Disparadores"
 
-#: pkg/kubernetes/index.html:109 pkg/shell/index.html:387
-#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/shell/index.html:387 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Soporte"
@@ -9038,13 +7090,9 @@ msgstr "Soporte"
 msgid "Trust key"
 msgstr "Clave de confianza"
 
-#: pkg/networkmanager/firewall.jsx:703
+#: pkg/networkmanager/firewall.jsx:705
 msgid "Trust level"
 msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:21
-msgid "Trust this certificate for this connection"
-msgstr "Confía en este certificado para esta conexión"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -9086,20 +7134,17 @@ msgstr "Tuned no se esta ejecutando"
 msgid "Tuned is off"
 msgstr "Tuned esta apagado"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:84
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Tipo"
 
@@ -9115,18 +7160,13 @@ msgstr "Introduzca una contraseña"
 msgid "Type to filter…"
 msgstr "Escribir para filtrar..."
 
-#: pkg/kubernetes/views/details-page.html:7
-msgid "Type:"
-msgstr "Teclear:"
-
-#: pkg/docker/index.html:332 pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
 msgid "UDP"
 msgstr ""
 "UDP:  Protocolo de Datagramas de Usuario, por sus siglas en ingles (User "
 "Datagram Protocol)"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
-#: pkg/subscriptions/subscriptions-register.jsx:112
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
 msgid "URL"
 msgstr "URL"
 
@@ -9142,17 +7182,9 @@ msgstr "Incapaz de aplicar los ajustes: $0"
 msgid "Unable to apply this solution automatically"
 msgstr "Incapaz de aplicar esta solución automáticamente"
 
-#: pkg/subscriptions/subscriptions-view.jsx:217
-msgid "Unable to connect"
-msgstr "Incapaz de conectar"
-
 #: src/ws/login.js:649
 msgid "Unable to connect to that address"
 msgstr "Incapaz de conectar a esa dirección"
-
-#: pkg/kubernetes/scripts/dashboard.js:412
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "No es posible decodificar el manifiesto de Kubernetes."
 
 #: pkg/users/local.js:58
 msgid "Unable to delete root account"
@@ -9170,11 +7202,6 @@ msgstr "Incapaz de obtener alerta: $0"
 #: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Imposible conectar al servidor"
-
-#: pkg/kubernetes/scripts/dashboard.js:400
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr ""
-"No es posible leer el manifiesto de la aplicación Kubernetes. Código $0."
 
 #: pkg/storaged/nfs-details.jsx:282
 msgid "Unable to remove mount"
@@ -9201,17 +7228,16 @@ msgid "Unable to unmount filesystem"
 msgstr "Incapaz de desmontar sistema de archivos"
 
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
-#: pkg/kubernetes/scripts/charts.js:110
 msgid "Unavailable"
 msgstr "No Disponible"
 
-#: pkg/docker/index.html:730 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1481
+#: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
+#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Error inesperado"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:132
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid "Unique name"
 msgstr "Nombre único"
 
@@ -9220,19 +7246,14 @@ msgstr "Nombre único"
 msgid "Unit"
 msgstr "Unidad"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
-#: pkg/kubernetes/views/volumes-page.html:35
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:754 pkg/kubernetes/scripts/volumes.js:267
-#: pkg/lib/machine-info.js:65 pkg/networkmanager/interfaces.js:596
-#: pkg/networkmanager/interfaces.js:1067 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2534 pkg/storaged/fsys-tab.jsx:64
-#: pkg/storaged/swap-tab.jsx:57
+#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
+#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -9269,7 +7290,7 @@ msgstr ""
 msgid "Unknown type"
 msgstr "Tipo desconocido"
 
-#: pkg/docker/index.html:549 pkg/docker/util.js:110
+#: pkg/docker/index.html:551 pkg/docker/util.js:110
 msgid "Unless Stopped"
 msgstr "A menos que detenido"
 
@@ -9319,7 +7340,7 @@ msgstr "Desmontando $target"
 msgid "Unnamed"
 msgstr "Sin nombre"
 
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Unplug"
 msgstr "Desenchufar"
 
@@ -9335,14 +7356,6 @@ msgstr "Dato desnocnocido"
 #: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Los datos no reconocidos no se pueden hacer más pequeños aquí."
-
-#: pkg/subscriptions/subscriptions-view.jsx:164
-msgid "Unregister"
-msgstr "No registrado"
-
-#: pkg/subscriptions/subscriptions-view.jsx:170
-msgid "Unregistering system..."
-msgstr "Des-registrando sistema..."
 
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
@@ -9366,7 +7379,11 @@ msgstr "host inseguro"
 msgid "Up since $0"
 msgstr "En marcha desde $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:316
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+msgid "Up to $0 $1 available in the default location"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -9395,13 +7412,9 @@ msgstr ""
 msgid "Updates Available"
 msgstr "Actualizaciones Disponibles"
 
-#: pkg/packagekit/updates.jsx:52 pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/packagekit/updates.jsx:52
 msgid "Updating"
 msgstr "Actualizando"
-
-#: pkg/kubernetes/scripts/details.js:654
-msgid "Updating $0..."
-msgstr "Actualizando $0..."
 
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
@@ -9418,20 +7431,15 @@ msgid "Use 512 Byte emulation"
 msgstr "Usar emulación de 512 Byte"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.6, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:496
+#: pkg/machines/components/diskAdd.jsx:524
 msgid "Use Existing"
 msgstr "Usar existente"
-
-#: pkg/subscriptions/subscriptions-register.jsx:136
-msgid "Use proxy server"
-msgstr "Usar servidor proxy"
 
 #: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Use la siguiente llave para autenticarse en otros sistemas"
 
 #: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
-#: pkg/kubernetes/scripts/nodes.js:829 pkg/kubernetes/scripts/nodes.js:838
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
@@ -9443,18 +7451,13 @@ msgstr "Usado"
 msgid "Used by"
 msgstr ""
 
-#: pkg/docker/index.html:262
+#: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "Utilizado por contenedores"
 
-#: pkg/dashboard/index.html:144 pkg/kubernetes/views/auth-form.html:61
-#: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
-#: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/subscriptions/subscriptions-register.jsx:77 pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1584
 msgid "User"
 msgstr "Usuario"
 
@@ -9463,11 +7466,11 @@ msgstr "Usuario"
 msgid "User Name"
 msgstr "Nombre de usuario"
 
-#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:337
+#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:336
 msgid "User Password"
 msgstr "Contraseña de usuario"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nombre de usuario"
@@ -9476,18 +7479,9 @@ msgstr "Nombre de usuario"
 msgid "User name cannot be empty"
 msgstr "El nombre de usuario no puede estar vacío"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:15
-msgid "User or Group"
-msgstr "Usuario o Grupo"
-
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
-#: pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
 msgid "Username"
 msgstr "Nombre de Usuario"
-
-#: pkg/kubernetes/views/project-listing.html:85
-msgid "Users"
-msgstr "Usuarios"
 
 #: pkg/lib/machine-change-auth.html:44
 msgid "Using available credentials"
@@ -9527,14 +7521,6 @@ msgstr "Los dispositivos de apoyo VDO no se pueden hacer más pequeños"
 msgid "VDO support not installed"
 msgstr "No está instalado el soporte para VDO"
 
-#: pkg/ovirt/components/App.jsx:115
-msgid "VDSM"
-msgstr "VDSM"
-
-#: pkg/ovirt/components/VdsmView.jsx:128
-msgid "VDSM Service Management"
-msgstr "Gestión de Servicio VDSM"
-
 #: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
 #: pkg/networkmanager/interfaces.js:2906
 msgid "VLAN"
@@ -9564,7 +7550,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1317
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -9588,10 +7574,6 @@ msgstr ""
 msgid "VM $0 failed to start"
 msgstr ""
 
-#: pkg/ovirt/components/VmOverviewColumn.jsx:37
-msgid "VM icon"
-msgstr "Icono VM"
-
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
 msgstr "VNC"
@@ -9608,7 +7590,7 @@ msgstr "Puerto VNC:"
 msgid "VNC TLS Port:"
 msgstr "Puerto VNC TLS:"
 
-#: pkg/realmd/operation.js:165
+#: pkg/realmd/operation.js:164
 msgid "Validating address"
 msgstr ""
 
@@ -9638,30 +7620,20 @@ msgstr "Verificar clave"
 msgid "Verifying"
 msgstr "Verificando"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:110 pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:381
-#: pkg/subscriptions/subscriptions-view.jsx:35 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Versión"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Version num"
-msgstr "Número de Versión"
 
 #: pkg/storaged/jobs-panel.jsx:57
 msgid "Very securely erasing $target"
 msgstr "Borrando de forma muy segura $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Máquinas Virtuales"
-
-#: pkg/ovirt/components/ClusterVms.jsx:176
-msgid "Virtual Machines of $0 cluster"
-msgstr "Máquinas Virtuales de $0 cluster"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
@@ -9675,14 +7647,11 @@ msgstr "Servicio de Virtualización (libvirt) No Está Activo"
 msgid "Virtualization Service is Available"
 msgstr "El Servicio de Virtualización Está Disponible"
 
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
-#: pkg/kubernetes/views/pvc-body.html:6
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:359
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Volumen"
 
@@ -9690,7 +7659,7 @@ msgstr "Volumen"
 msgid "Volume Group"
 msgstr "Grupo de Volúmenes"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:233
+#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Grupo de volúmenes $0 "
 
@@ -9698,33 +7667,17 @@ msgstr "Grupo de volúmenes $0 "
 msgid "Volume Groups"
 msgstr "Grupos de Volumen"
 
-#: pkg/kubernetes/views/volume-body.html:14
-#: pkg/kubernetes/views/volume-body.html:89
-msgid "Volume ID"
-msgstr "ID de Volumen"
-
-#: pkg/kubernetes/views/pv-modify.html:115
-#: pkg/kubernetes/views/volume-body.html:42
-msgid "Volume Name"
-msgstr "Nombre de Volumen"
-
-#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
-msgid "Volume Type"
-msgstr "Tipo de Volumen"
-
 #: pkg/storaged/lvol-tabs.jsx:410
 msgid "Volume size is $0. Content size is $1."
 msgstr ""
 
-#: pkg/docker/index.html:515 pkg/kubernetes/index.html:74
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:517
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volúmenes"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/docker/index.html:199
+#: pkg/docker/index.html:200
 msgid "Volumes:"
 msgstr "Volúmenes:"
 
@@ -9741,7 +7694,7 @@ msgstr "Esperando"
 msgid "Waiting for details..."
 msgstr "Esperando detalles..."
 
-#: pkg/apps/utils.jsx:62
+#: pkg/apps/utils.jsx:63
 msgid "Waiting for other programs to finish using the package manager..."
 msgstr ""
 "Esperando que otros programas terminen de usar el gestor de paquetes..."
@@ -9764,10 +7717,6 @@ msgstr "Quiere"
 msgid "Warning and above"
 msgstr "Precaución y arriba"
 
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid "Warning:"
-msgstr "Precaución:"
-
 #: cockpit.appdata.xml.in.h:1
 msgid "Web Console for Linux servers"
 msgstr "Consola web para servidores Linux"
@@ -9784,23 +7733,15 @@ msgstr ""
 msgid "Weeks"
 msgstr "Semanas"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:5
-msgid "Welcome to the Image Registry"
-msgstr "Bienvenidos al Registro de Imagen"
-
 #: pkg/storaged/crypto-keyslots.jsx:324
 msgid "What if tang-show-keys is not available?"
 msgstr "¿Qué pasa si tang-show-keys no está disponible?"
-
-#: pkg/kubernetes/views/volumes-page.html:61
-msgid "When"
-msgstr "Cuando"
 
 #: pkg/systemd/terminal.jsx:101
 msgid "White"
 msgstr ""
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:488
 msgid "With terminal"
 msgstr "Con terminal"
 
@@ -9820,7 +7761,7 @@ msgstr "Nombre de usuario o contraseña equivocada"
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:996 pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2593
 msgid "Yes"
 msgstr "Sí"
 
@@ -9841,21 +7782,9 @@ msgstr ""
 "eliminarlo."
 
 #: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:871 pkg/networkmanager/firewall.jsx:877
+#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
 msgid "You are not authorized to modify the firewall."
 msgstr "Usted no está autorizado a modificar el cortafuegos."
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:3
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-"Usted puede evitar la comprobación del certificado, pero cualquier datos que "
-"envíe al servidor podría ser interceptado por otros."
-
-#: pkg/kubernetes/views/dashboard-page.html:150
-msgid "You can deploy an application to your cluster."
-msgstr "Tu puedes desplegar una aplicación a tu cluster"
 
 #: pkg/users/index.html:390
 msgid ""
@@ -9873,7 +7802,7 @@ msgstr ""
 msgid "You must wait longer to change your password"
 msgstr "Debes esperar más tiempo para cambiar tu contraseña"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
 msgid ""
 "You need to select the most closely matching OS vendor and Operating System"
 msgstr ""
@@ -9886,14 +7815,6 @@ msgstr ""
 "Su navegador se desconectará pero esto no afectará al proceso de "
 "actualización. Usted puede volver a conectar en breves momentos para "
 "continuar vigilando el progreso."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:112
-msgid ""
-"Your login credentials do not give you access to use the docker registry "
-"from the command line."
-msgstr ""
-"Sus credenciales de acceso no le conceden acceso para utilizar el registro "
-"de Docker a partir de la consola."
 
 #: pkg/packagekit/updates.jsx:865
 msgid ""
@@ -9911,11 +7832,11 @@ msgstr "Su sección ha sido terminada"
 msgid "Your session has expired. Please log in again."
 msgstr "Su sección a expirado. Por favor inicie sección otra vez"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/networkmanager/firewall.jsx:938
 msgid "Zones"
 msgstr ""
 
@@ -9931,8 +7852,12 @@ msgstr "[datos binarios]"
 msgid "[no data]"
 msgstr "[no hay datos]"
 
-#: pkg/machines/components/networks/network.jsx:58
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "activo"
@@ -9966,17 +7891,9 @@ msgstr "bytes"
 msgid "cdrom"
 msgstr "cdrom"
 
-#: pkg/ovirt/rephraseUI.js:35
-msgid "connecting"
-msgstr "conectando"
-
 #: pkg/machines/components/infoRecord.jsx:29
 msgid "control-label $0"
 msgstr ""
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "cores"
-msgstr "núcleos"
 
 #: pkg/machines/helpers.js:193
 msgid "crashed"
@@ -9995,7 +7912,6 @@ msgid "direct"
 msgstr "directo"
 
 #: pkg/machines/helpers.js:177 pkg/machines/helpers.js:180
-#: pkg/ovirt/components/OVirtTab.jsx:123
 msgid "disabled"
 msgstr "desactivado"
 
@@ -10003,7 +7919,7 @@ msgstr "desactivado"
 msgid "disk"
 msgstr "disco"
 
-#: pkg/machines/helpers.js:238 pkg/ovirt/rephraseUI.js:27
+#: pkg/machines/helpers.js:238
 msgid "down"
 msgstr "abajo"
 
@@ -10011,26 +7927,17 @@ msgstr "abajo"
 msgid "dying"
 msgstr "agonizante"
 
-#: pkg/realmd/operation.js:299 pkg/realmd/operation.js:305
+#: pkg/realmd/operation.js:298 pkg/realmd/operation.js:304
 msgid "e.g. \"$0\""
 msgstr "p. ej., «$0»"
 
-#: pkg/kubernetes/scripts/images.js:639
-msgid "eg: my-image-stream"
-msgstr "eg: mi secuencia de imagen"
-
 #: pkg/machines/helpers.js:178 pkg/machines/helpers.js:181
-#: pkg/ovirt/components/OVirtTab.jsx:125
 msgid "enabled"
 msgstr "activado"
 
 #: pkg/packagekit/updates.jsx:267
 msgid "enhancement"
 msgstr "mejora"
-
-#: pkg/ovirt/rephraseUI.js:28
-msgid "error"
-msgstr "error"
 
 #: pkg/machines/helpers.js:214
 msgid "ethernet"
@@ -10056,7 +7963,7 @@ msgstr ""
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:182
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
@@ -10072,7 +7979,7 @@ msgstr "Objetivos iSCSI"
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -10080,22 +7987,10 @@ msgstr ""
 msgid "idle"
 msgstr "inactivo"
 
-#: pkg/machines/components/networks/network.jsx:58
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "inactivo"
-
-#: pkg/ovirt/rephraseUI.js:29
-msgid "initializing"
-msgstr "inicializando"
-
-#: pkg/ovirt/rephraseUI.js:30
-msgid "installation failed"
-msgstr "instalación fallada"
-
-#: pkg/ovirt/rephraseUI.js:38
-msgid "installing OS"
-msgstr "instalando SO"
 
 #: pkg/kdump/kdump-view.jsx:376
 msgid "invalid: multiple targets defined"
@@ -10104,10 +7999,6 @@ msgstr "no válido: definidos múltiples objetivos"
 #: pkg/kdump/kdump-view.jsx:493
 msgid "kdump status"
 msgstr "estado de kdump"
-
-#: pkg/ovirt/rephraseUI.js:39
-msgid "kdumping"
-msgstr "kdumping"
 
 #: pkg/docker/run.js:527
 msgid "key"
@@ -10121,10 +8012,6 @@ msgstr "ranura para llaves $0"
 msgid "locally in $0"
 msgstr "localmente en $0"
 
-#: pkg/ovirt/rephraseUI.js:31
-msgid "maintenance"
-msgstr "mantenimiento"
-
 #: pkg/machines/helpers.js:216
 msgid "mcast"
 msgstr "mcast"
@@ -10137,61 +8024,18 @@ msgstr "red"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs dump target no tiene el formato de servidor: ruta"
 
-#: pkg/kubernetes/views/route-body.html:14
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:43
 msgid "no"
 msgstr "no"
 
-#: pkg/ovirt/rephraseUI.js:32
-msgid "non operational"
-msgstr "no operativo"
-
-#: pkg/ovirt/rephraseUI.js:33
-msgid "non responsive"
-msgstr "sin respuesta"
-
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
-#: pkg/kubernetes/views/route-body.html:24
-#: pkg/kubernetes/views/route-body.html:29
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "ninguno"
-
-#: pkg/ovirt/provider.js:62
-msgid "oVirt"
-msgstr "oVirt"
-
-#: pkg/ovirt/components/HostStatus.jsx:37
-msgid "oVirt Host State:"
-msgstr "Estado del Huésped oVirt:"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:35
-msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr ""
-"oVirt Provider el script de instalación falló debido a argumentos perdidos."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:36
-msgid ""
-"oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-"machines-ovirt.config, try as root."
-msgstr ""
-"oVirt Provider el script de instalación falló: No puede escribir en /etc/"
-"cockpit/machines-ovirt.config, inténtelo como root."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:164
-msgid "oVirt installation script failed with following output: "
-msgstr "oVirt script de instalación falló con la siguiente salida: "
-
-#: pkg/ovirt/components/App.jsx:51
-msgid "oVirt login in progress"
-msgstr "oVirt acceso progresando"
 
 #: pkg/systemd/host.js:691
 msgid "of $0 CPU core"
@@ -10203,27 +8047,15 @@ msgstr[1] "de $0 núcleos de CPU"
 msgid "paused"
 msgstr "en pausa"
 
-#: pkg/ovirt/rephraseUI.js:34
-msgid "pending approval"
-msgstr "pendiente de aprobación"
-
-#: pkg/kubernetes/views/dashboard-page.html:83
-msgid "pending volume claims"
-msgstr "pendiente de reclamación de volumen"
-
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:174
+#: pkg/machines/components/diskAdd.jsx:154
 msgid "qcow2"
 msgstr "qcow2"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:177
+#: pkg/machines/components/diskAdd.jsx:157
 msgid "raw"
 msgstr "raw"
-
-#: pkg/ovirt/rephraseUI.js:36
-msgid "reboot"
-msgstr "reiniciar"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -10245,7 +8077,7 @@ msgstr "buscar por nombre, espacio de nombres o descripción"
 msgid "security"
 msgstr "seguridad"
 
-#: pkg/docker/index.html:404
+#: pkg/docker/index.html:406
 msgid "select container"
 msgstr "seleccionar contenedor"
 
@@ -10253,7 +8085,7 @@ msgstr "seleccionar contenedor"
 msgid "server"
 msgstr "servidor"
 
-#: pkg/docker/index.html:483 pkg/docker/index.html:655
+#: pkg/docker/index.html:485 pkg/docker/index.html:657
 msgid "shares"
 msgstr "comparticiones"
 
@@ -10272,10 +8104,6 @@ msgstr "apagar"
 #: pkg/machines/helpers.js:191
 msgid "shutdown"
 msgstr "apagar"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "sockets"
-msgstr "enchufes"
 
 #: pkg/selinux/setroubleshoot-view.jsx:123
 msgid "solution details"
@@ -10297,10 +8125,6 @@ msgstr "el servidor ssh está vacío"
 msgid "suspended (PM)"
 msgstr "suspendido (PM)"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "threads"
-msgstr "hilos"
-
 #: pkg/docker/run.js:474
 msgid "to host path"
 msgstr "al trayecto de anfitrión"
@@ -10317,10 +8141,6 @@ msgstr "traducible"
 #: pkg/machines/helpers.js:218
 msgid "udp"
 msgstr "udp"
-
-#: pkg/ovirt/rephraseUI.js:37
-msgid "unassigned"
-msgstr "no asignado"
 
 #: pkg/lib/cockpit-components-select.jsx:28
 msgid "undefined"
@@ -10339,7 +8159,7 @@ msgstr "destino u objetivo desconocido"
 msgid "unpartitioned space on $0"
 msgstr "espacio no particionado en $0"
 
-#: pkg/machines/helpers.js:237 pkg/ovirt/rephraseUI.js:26
+#: pkg/machines/helpers.js:237
 msgid "up"
 msgstr "arriba"
 
@@ -10349,7 +8169,6 @@ msgstr "usuario"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/machines/components/vcpuModal.jsx:192
-#: pkg/ovirt/components/vcpuModal.jsx:54
 msgid "vCPU Count"
 msgstr "Conteo de CPU virtuales"
 
@@ -10358,8 +8177,6 @@ msgid "vCPU Maximum"
 msgstr "vCPU maximo"
 
 #: pkg/machines/components/vmOverviewTab.jsx:75
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "vCPUs"
 msgstr "vCPUs"
 
@@ -10371,12 +8188,16 @@ msgstr "valor"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/kubernetes/views/route-body.html:13
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+msgid ""
+"virt-install package needs to be installed on the system in order to create "
+"new VMs"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:42
 msgid "yes"
 msgstr "sí"
 
@@ -10387,3 +8208,1425 @@ msgid ""
 msgstr ""
 "{{ condition.message }}. Marca de tiempo: {{ condition.lastTransitionTime }} "
 "Conteo de errores: {{ condition.generation }}"
+
+#~ msgid " 1\"Do you want to delete the following Nodes?"
+#~ msgstr " 1\"¿Quiere eliminar los nodos siguientes?"
+
+# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
+#~ msgid "$0 vCPU Details"
+#~ msgstr "$0 Detalles vCPU"
+
+#~ msgid "$0% Free"
+#~ msgid_plural "$0% Free"
+#~ msgstr[0] "$0 % disponible"
+#~ msgstr[1] "$0 % disponible"
+
+#~ msgid "$0% Used"
+#~ msgid_plural "$0% Used"
+#~ msgstr[0] "$0 % en uso"
+#~ msgstr[1] "$0 % en uso"
+
+#~ msgid "'Organization' required to register."
+#~ msgstr "Se necesita «Organización» para efectuar el registro."
+
+#~ msgid "'Organization' required when using activation keys."
+#~ msgstr "Se necesita «Organización» al utilizar claves de activación."
+
+#~ msgid "AWS Elastic Block Store"
+#~ msgstr "AWS Almacén Elástico de Bloque"
+
+#~ msgid "Access Modes"
+#~ msgstr "Modos de acceso"
+
+#~ msgid "Access denied"
+#~ msgstr "Acceso denegado"
+
+#~ msgid "Action"
+#~ msgstr "Acción"
+
+#~ msgid "Activation Key"
+#~ msgstr "Clave de activación"
+
+#~ msgid "Actual"
+#~ msgstr "Real"
+
+#~ msgid "Add Cluster Node"
+#~ msgstr "Añadir nodo de agrupación"
+
+#~ msgid "Add Group"
+#~ msgstr "Añadir grupo"
+
+#~ msgid "Add Kubernetes Node"
+#~ msgstr "Añadir nodo de Kubernetes"
+
+#~ msgid "Add Member"
+#~ msgstr "Añadir miembro"
+
+#~ msgid "Add Membership"
+#~ msgstr "Añadir afiliación"
+
+#~ msgid "Add New Cluster"
+#~ msgstr "Añadir agrupación nueva"
+
+#~ msgid "Add New User"
+#~ msgstr "Añadir usuario nuevo"
+
+#~ msgid "Add Role"
+#~ msgstr "Añadir rol"
+
+#~ msgid "Add User"
+#~ msgstr "Añadir usuario"
+
+#~ msgid "Add membership"
+#~ msgstr "Añadir afiliación"
+
+#~ msgid "Adjust"
+#~ msgstr "Ajustar"
+
+#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+#~ msgstr "Ajustar Volumen Persistente '{{ item.metadata.name }}'"
+
+#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
+#~ msgstr "Ajustar el Controlador de Replicación {{ item.metadata.name }}"
+
+#~ msgid "Adjust Route"
+#~ msgstr "Ajustar Ruta"
+
+#~ msgid "Adjust Service"
+#~ msgstr "Ajustar servicio"
+
+#~ msgid "Admin"
+#~ msgstr "Administración"
+
+#~ msgid "All Projects"
+#~ msgstr "Todos los Proyectos"
+
+#~ msgid "All Types"
+#~ msgstr "Todos los Tipos"
+
+#~ msgid "All healthy"
+#~ msgstr "Todo saludable"
+
+#~ msgid "All images"
+#~ msgstr "Todas las imágenes"
+
+#~ msgid "All in use"
+#~ msgstr "Todo en uso"
+
+#~ msgid "All running"
+#~ msgstr "Todo corriendo"
+
+#~ msgid "All running virtual machines will be turned off."
+#~ msgstr "Todas las máquinas virtuales corriendo serán apagadas."
+
+#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
+#~ msgstr ""
+#~ "Anónimo: Permite a todos los usuarios no autentificados tirar de las "
+#~ "imágenes"
+
+#~ msgid "Automatically selected host"
+#~ msgstr "Host seleccionado automáticamente"
+
+#~ msgid "Azure"
+#~ msgstr "Azure"
+
+#~ msgid "Base Template"
+#~ msgstr "Plantilla Base"
+
+#~ msgid "Base template"
+#~ msgstr "Plantilla base"
+
+#~ msgid "Base template:"
+#~ msgstr "Plantilla base:"
+
+#~ msgid "Boot ID"
+#~ msgstr "ID de Arranque"
+
+#~ msgid "CPU Utilization: $0%"
+#~ msgstr "Uso de CPU: $0%"
+
+#~ msgid "CREATE VM action failed"
+#~ msgstr "Fallo en la acción CREATE VM"
+
+#~ msgid "Cannot decrypt PEM-encoded private key"
+#~ msgstr "No se puede descifrar llave privada cifrada con PEM"
+
+#~ msgid "Ceph Filesystem Mount"
+#~ msgstr "Montaje del Sistema de Archivos Ceph"
+
+#~ msgid "Ceph Monitors"
+#~ msgstr "Monitores Ceph"
+
+#~ msgid "Change User"
+#~ msgstr "Cambiar Usuario"
+
+#~ msgid "Change image stream"
+#~ msgstr "Cambiar flujo de imagen"
+
+#~ msgid "Change project"
+#~ msgstr "Cambiar proyecto"
+
+#~ msgid "Cinder"
+#~ msgstr "Cinder"
+
+#~ msgid "Claim"
+#~ msgstr "Reclamación"
+
+#~ msgid "Claim Name"
+#~ msgstr "Nombre de Reclamación"
+
+#~ msgid "Client Certificate"
+#~ msgstr "Certificado de Cliente"
+
+#~ msgid "Cluster"
+#~ msgstr "Cluster"
+
+#~ msgid "Cluster Templates"
+#~ msgstr "Plantilla de Cluster"
+
+#~ msgid "Cluster Virtual Machines"
+#~ msgstr "Cluster de Máquinas Virtuales"
+
+#~ msgid "Configuration"
+#~ msgstr "Configuración"
+
+#~ msgid "Configure Flannel networking"
+#~ msgstr "Configurar la red Flannel"
+
+#~ msgid "Configure Kubelet and Proxy"
+#~ msgstr "Configurar Kubelet y proxy"
+
+#~ msgid "Confirm migration"
+#~ msgstr "Confirme migración"
+
+#~ msgid "Confirm reload:"
+#~ msgstr "Confirme recarga:"
+
+#~ msgid "Confirm save:"
+#~ msgstr "Confirme guardar:"
+
+#~ msgid "Connect to oVirt Engine"
+#~ msgstr "Conectar a oVirt Engine"
+
+#~ msgid "Connecting..."
+#~ msgstr "Conectando..."
+
+#~ msgid "Connection Error: $0"
+#~ msgstr "Error de conexión: $0"
+
+#~ msgid "Connection Settings"
+#~ msgstr "Ajustes de Conexión"
+
+#~ msgid "Container ID"
+#~ msgstr "ID de Contenedor"
+
+#~ msgid "Container Runtime Version"
+#~ msgstr "Contenedor de Versión en Tiempo de Ejecución"
+
+#~ msgid "Could not list services"
+#~ msgstr "No se pueden listar los servicios"
+
+#~ msgid "Could not parse PEM-encoded certificate"
+#~ msgstr "No es posible descifrar certificado codificado con PEM"
+
+#~ msgid "Could not parse PEM-encoded private key"
+#~ msgstr "No se puede resolver llave privada cifrada con PEM"
+
+#~ msgid "Couldn't connect to server"
+#~ msgstr "No se pudo conectar al servidor"
+
+#~ msgid "Couldn't find running API server"
+#~ msgstr "No se puede encontrar un servidor API ejecutandose"
+
+#~ msgid ""
+#~ "Couldn't get system subscription status. Please ensure subscription-"
+#~ "manager is installed."
+#~ msgstr ""
+#~ "No podría obtener el estado del sistema de suscripción. Por favor asegura "
+#~ "que el gestor de suscripción está instalado."
+
+#~ msgid "Create New VM"
+#~ msgstr "Crear Nueva VM"
+
+#~ msgid "Create empty image stream"
+#~ msgstr "Crea un flujo de imágenes vacío"
+
+#~ msgid "Create image stream"
+#~ msgstr "Crear un flujo de imagen"
+
+#~ msgid "Custom URL"
+#~ msgstr "URL personal"
+
+#~ msgid "DNS Policy"
+#~ msgstr "Política DNS"
+
+#~ msgid "Delete '{{ name }}'"
+#~ msgstr "Borrar '{{ nombre }}'"
+
+#~ msgid "Delete Node"
+#~ msgstr "Borrar Nodo"
+
+#~ msgid "Delete Persistent Volume"
+#~ msgstr "Borrar Volumen Persitente"
+
+#~ msgid "Delete Persistent Volume Claim"
+#~ msgstr "Eliminar la Reclamación de Volumen Persistente"
+
+#~ msgid "Delete Project"
+#~ msgstr "Borrar Proyecto"
+
+#~ msgid "Delete Selected"
+#~ msgstr "Borrar Seleccionado"
+
+#~ msgid "Delete image stream"
+#~ msgstr "Eliminar el flujo de imágenes"
+
+#~ msgid "Delete {{ item.kind }}"
+#~ msgstr "Eliminar {{ item.kind }}"
+
+#~ msgid ""
+#~ "Deleting a Pod will kill all associated containers. Pods may be "
+#~ "automatically created again in some cases."
+#~ msgstr ""
+#~ "Eliminando un Pod matará todos los contenedores asociados. Los Pods "
+#~ "pueden ser creados automáticamente otra vez en algunos casos."
+
+#~ msgid "Deploy"
+#~ msgstr "Desplegar"
+
+#~ msgid "Deploy Application"
+#~ msgstr "Desplegar aplicación"
+
+#~ msgid "Deployment Causes"
+#~ msgstr "Causas de Despliegue"
+
+#~ msgid "Deployment Config"
+#~ msgstr "Configuración de Despliegue"
+
+#~ msgid "Deployment Configs"
+#~ msgstr "Configuración de despliegue"
+
+#~ msgid "Description:"
+#~ msgstr "Descripción:"
+
+#~ msgid "Disk Utilization: $0%"
+#~ msgstr "Uso de disco: $0%"
+
+#~ msgid "Display name"
+#~ msgstr "Visualizar nombre"
+
+#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#~ msgstr "¿Desea añadir el rol? '{{ fields.displayRole }}'?"
+
+#~ msgid ""
+#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}' image stream?"
+#~ msgstr ""
+#~ "¿Desea eliminar el flujo de imagen '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}' ?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+#~ msgstr "¿Desea eliminar el Volumen Persitente '{{item.metadata.name}}'?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume Claim '{{item.metadata."
+#~ "name}}'?"
+#~ msgstr ""
+#~ "¿Desea eliminar la Reclamación de Volumen Persistente '{{item.metadata."
+#~ "name}}'?"
+
+#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+#~ msgstr "¿Desea eliminar {{ item.kind }} '{{item.metadata.name}}'?"
+
+#~ msgid "Do you want to delete this Node?"
+#~ msgstr "¿Desea eliminar este Nodo?"
+
+#~ msgid ""
+#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+#~ msgstr ""
+#~ "¿Desea borrar la imagen etiquetada como '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+
+#~ msgid ""
+#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
+#~ "{{ fields.member.metadata.name }}?"
+#~ msgstr ""
+#~ "¿Desea borrar el rol '{{ fields.displayRole }}' del miembro {{ fields."
+#~ "member.metadata.name }}?"
+
+#~ msgid "Don't pull images automatically"
+#~ msgstr "No tire de las imágenes automáticamente"
+
+#~ msgid "Driver"
+#~ msgstr "Driver"
+
+#~ msgid "Edit the vdsm.conf"
+#~ msgstr "Editar vdsm.conf"
+
+#~ msgid "Empty Directory"
+#~ msgstr "Directorio vació"
+
+#~ msgid "Endpoint"
+#~ msgstr "Punto final"
+
+#~ msgid "Endpoint Name"
+#~ msgstr "Nombre del Punto final"
+
+#~ msgid "Endpoints"
+#~ msgstr "Puntos finales"
+
+#~ msgid "Ends"
+#~ msgstr "Finales"
+
+#~ msgid "Enter New VM name"
+#~ msgstr "Introducir Nuevo nombre de VM"
+
+#~ msgid "Error getting certificate details: $0"
+#~ msgstr "Error al obtener los detalles del certificado: $0"
+
+#~ msgid "Error writing kubectl config"
+#~ msgstr "Error escribiendo configuración de kubectl"
+
+#~ msgid "FQDN"
+#~ msgstr "FQDN"
+
+#~ msgid "Fibre Channel"
+#~ msgstr "Canal de Fibra"
+
+#~ msgid "Filesystem Type"
+#~ msgstr "Tipo de Sistema de archivos"
+
+#~ msgid "Flex"
+#~ msgstr "Flex"
+
+#~ msgid "Flocker"
+#~ msgstr "Flocker"
+
+#~ msgid "Flocker Dataset Name"
+#~ msgstr "Nombre del Conjunto de Datos Flocker"
+
+#~ msgid "GCE Persistent Disk"
+#~ msgstr "Disco GCE Persistente"
+
+#~ msgid "Git Repository"
+#~ msgstr "Repositorio Git"
+
+#~ msgid "Gluster FS"
+#~ msgstr "Gluster FS"
+
+#~ msgid "GlusterFS"
+#~ msgstr "GlusterFS"
+
+#~ msgid "Grant additional push or admin access to specific members below."
+#~ msgstr ""
+#~ "Obtener empuje adicional o administrar el acceso a los miembros "
+#~ "específicos de abajo."
+
+#~ msgid "Group Members"
+#~ msgstr "Miembros del Grupo"
+
+#~ msgid "Group or Project"
+#~ msgstr "Grupo o Proyecto"
+
+#~ msgid "Groups"
+#~ msgstr "Grupos"
+
+#~ msgid "HA"
+#~ msgstr "HA"
+
+#~ msgid "HA:"
+#~ msgstr "HA:"
+
+#~ msgid "Host Path"
+#~ msgstr "Trayecto del anfitrión"
+
+#~ msgid "Host to Maintenance"
+#~ msgstr "Host para Mantenimiento"
+
+#~ msgid "IP"
+#~ msgstr "IP"
+
+#~ msgid "ISCSI"
+#~ msgstr "ISCSI"
+
+#~ msgid "Identities"
+#~ msgstr "Identidades"
+
+#~ msgid "Identity"
+#~ msgstr "Identidad"
+
+#~ msgid "Image ID"
+#~ msgstr "ID de Imagen"
+
+#~ msgid "Image Name"
+#~ msgstr "Nombre de Imagen"
+
+#~ msgid "Image Registry"
+#~ msgstr "Registro de Imagen"
+
+#~ msgid "Image Stream"
+#~ msgstr "Corriente de Imagen"
+
+#~ msgid "Image commands"
+#~ msgstr "Órdenes de imagen"
+
+#~ msgid "Images by project"
+#~ msgstr "Imágenes por proyecto"
+
+#~ msgid "Images pushed recently"
+#~ msgstr "Imágenes utilizadas recientemente"
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, use the commands below."
+#~ msgstr ""
+#~ "Para comenzar a insertar imágenes en el registro, utilice las órdenes "
+#~ "siguientes."
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, you need to create a "
+#~ "project."
+#~ msgstr ""
+#~ "Con el objetivo de llevar imágenes al registro, usted necesita crear un "
+#~ "proyecto."
+
+#~ msgid "Installed products"
+#~ msgstr "Productos instalados"
+
+#~ msgid "Interface"
+#~ msgstr "Interfaz"
+
+#~ msgid "Invalid credentials"
+#~ msgstr "Las credenciales no son válidas"
+
+#~ msgid "Kernel Version"
+#~ msgstr "Versión del núcleo"
+
+#~ msgid "Key Ring Path"
+#~ msgstr "Trayecto del llavero"
+
+#~ msgid "Kubelet Version"
+#~ msgstr "Versión de Kubelet"
+
+#~ msgid "Kubernetes Cluster"
+#~ msgstr "Cluster de Kubernetes"
+
+#~ msgid "Last Heartbeat"
+#~ msgstr "Último Heartbeat"
+
+#~ msgid "Last Status Change"
+#~ msgstr "Último Cambio de Estado"
+
+#~ msgid "Latest Version"
+#~ msgstr "Última Versión"
+
+#~ msgid "Loading data ..."
+#~ msgstr "Cargando datos ..."
+
+#~ msgid "Log into OpenShift command line tools:"
+#~ msgstr "Ingrese a las herramientas de consola de OpenShift:"
+
+#~ msgid "Log into the registry:"
+#~ msgstr "Iniciar sesión en el registro:"
+
+#~ msgid "Logical Unit Number"
+#~ msgstr "Número de unidad lógica"
+
+#~ msgid "Login"
+#~ msgstr "Ingresar"
+
+#~ msgid "Login commands"
+#~ msgstr "Órdenes de ingreso"
+
+#~ msgid "Login/password or activation key required to register."
+#~ msgstr ""
+#~ "Para registrarse es necesario un usuario y contraseña o una clave de "
+#~ "activación."
+
+#~ msgid "MIGRATE action failed"
+#~ msgstr "Fallo en acción MIGRATE"
+
+#~ msgid "Manifest"
+#~ msgstr "Manifiesto"
+
+#~ msgid "Medium"
+#~ msgstr "Medio"
+
+#~ msgid "Member of"
+#~ msgstr "Miembro de"
+
+#~ msgid "Members"
+#~ msgstr "Miembros"
+
+#~ msgid "Membership"
+#~ msgstr "Afiliación"
+
+#~ msgid "Memory Utilization: $0%"
+#~ msgstr "Uso de memoria: $0%"
+
+#~ msgid "Message"
+#~ msgstr "Mensaje"
+
+#~ msgid "Migrate To:"
+#~ msgstr "Migrar A:"
+
+#~ msgid "Modify"
+#~ msgstr "Modificar"
+
+#~ msgid "Monitors"
+#~ msgstr "Monitores"
+
+#~ msgid "Mount Location"
+#~ msgstr "Ubicación de montaje"
+
+#~ msgid "NFS"
+#~ msgstr "NFS"
+
+#~ msgid "Namespace"
+#~ msgstr "Espacio de Nombres"
+
+#~ msgid "Namespace cannot be empty."
+#~ msgstr "El nombre de espacio no puede estar vacio"
+
+#~ msgid "New Group"
+#~ msgstr "Grupo nuevo"
+
+#~ msgid "New Project"
+#~ msgstr "Proyecto nuevo"
+
+#~ msgid "New image stream"
+#~ msgstr "Flujo de imágenes nuevo"
+
+#~ msgid "New project"
+#~ msgstr "Nuevo proyecto"
+
+#~ msgid "No PEM-encoded certificate found"
+#~ msgstr "No se encontró certificado cifrado con PEM"
+
+#~ msgid "No PEM-encoded private key found"
+#~ msgstr "No se encontró llave privada cifrada con PEM"
+
+#~ msgid "No Pods are using this claim"
+#~ msgstr "Ningún Pods está usando este reclamo"
+
+#~ msgid "No VM found in oVirt."
+#~ msgstr "Mo se ha encontrado VM en oVirt."
+
+#~ msgid "No Volume Bound"
+#~ msgstr "No hay ningún vínculo de volumen"
+
+#~ msgid "No groups are present."
+#~ msgstr "No hay ningún grupo presente."
+
+#~ msgid "No images pushed"
+#~ msgstr "Sin imágenes empujadas"
+
+#~ msgid "No installed products on the system."
+#~ msgstr "No hay ningún producto instalado en el sistema."
+
+#~ msgid ""
+#~ "No metadata file was selected. Please select a Kubernetes metadata file."
+#~ msgstr ""
+#~ "No se seleccionó un archivo metadata. Por favor seleccione un archivo "
+#~ "metadata Kebernetes."
+
+#~ msgid "No nodes in cluster"
+#~ msgstr "No hay  nodos en el cluster"
+
+#~ msgid "No oVirt connection"
+#~ msgstr "Sin conexión oVirt"
+
+#~ msgid "No pods deployed"
+#~ msgstr "No se han desplegado pods"
+
+#~ msgid "No pods replicated"
+#~ msgstr "No se han replicado pods"
+
+#~ msgid "No pods scheduled"
+#~ msgstr "Sin pods planificados"
+
+#~ msgid "No pods selected"
+#~ msgstr "Sin pods seleccionados"
+
+#~ msgid "No projects are present."
+#~ msgstr "No hay proyectos presentes."
+
+#~ msgid "No users are present."
+#~ msgstr "No hay usuarios presentes."
+
+#~ msgid "No volumes are present."
+#~ msgstr "No hay volúmenes presentes."
+
+#~ msgid "No volumes in use"
+#~ msgstr "No hay volúmenes en uso"
+
+#~ msgid "Node"
+#~ msgstr "Nodo"
+
+#~ msgid "Nodes"
+#~ msgstr "Nodos"
+
+#~ msgid "Nodes are the machines that run your containers."
+#~ msgstr "Nodos son las computadoras que ejecutan sus contenedores"
+
+#~ msgid "Not a valid number of replicas"
+#~ msgstr "No es un número válido de réplicas"
+
+#~ msgid "Not a valid value for Host"
+#~ msgstr "No es un valor valido para el host"
+
+#~ msgid "Not deployed"
+#~ msgstr "No distribuido"
+
+# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
+#~ msgid "Number of virtual CPUs that gonna be used."
+#~ msgstr "Número de CPU virtuales que se usarán."
+
+#~ msgid "OK"
+#~ msgstr "OK"
+
+#~ msgid "OS"
+#~ msgstr "SO"
+
+#~ msgid "OS Type:"
+#~ msgstr "Tipo de SO:"
+
+#~ msgid "OS Versions"
+#~ msgstr "Versiones de SO"
+
+#~ msgid "Optimized for:"
+#~ msgstr "Optimizado para:"
+
+#~ msgid "Organization"
+#~ msgstr "Organización"
+
+#~ msgid "PD Name"
+#~ msgstr "Nombre de PD"
+
+#~ msgid "Pending Volume Claims"
+#~ msgstr "Reclamaciones de Volumen Pendientes"
+
+#~ msgid "Persistent Volumes"
+#~ msgstr "Volúmenes persistentes"
+
+#~ msgid "Phase"
+#~ msgstr "Fase"
+
+#~ msgid "Please confirm, the host shall be switched to maintenance mode."
+#~ msgstr "Por favor confirme que el host será conmutado a modo mantenimiento."
+
+#~ msgid "Please create another namespace for $0 \"$1\""
+#~ msgstr "Por favor cree otro nombre de espacio para $0 \"$1\""
+
+#~ msgid "Please provide a GlusterFS volume name"
+#~ msgstr "Por favor provea un nombre de volumen GlusterFS"
+
+#~ msgid "Please provide a username"
+#~ msgstr "Provea un nombre de usuario"
+
+#~ msgid "Please provide a valid NFS server"
+#~ msgstr "Por favor provea un servidos NFS valido"
+
+#~ msgid "Please provide a valid address"
+#~ msgstr "Provea una dirección valida"
+
+#~ msgid "Please provide a valid filesystem type"
+#~ msgstr "Por favor provea un tipo de sistema de archivos valido"
+
+#~ msgid "Please provide a valid interface"
+#~ msgstr "Por favor provea una interfaz valida"
+
+#~ msgid "Please provide a valid logical unit number"
+#~ msgstr "Por favor provea un número valido de unidad lógica"
+
+#~ msgid "Please provide a valid name"
+#~ msgstr "Por favor provea un nombre valido"
+
+#~ msgid "Please provide a valid namespace."
+#~ msgstr "Por favor provea un nombre de espacio valido"
+
+#~ msgid "Please provide a valid path"
+#~ msgstr "Proporcione un trayecto válido"
+
+#~ msgid "Please provide a valid qualified name"
+#~ msgstr "Por favor provea un nombre cualifica valido"
+
+#~ msgid "Please provide a valid storage capacity."
+#~ msgstr "Por favor provea una capacidad de almacenamiento valida."
+
+#~ msgid "Please provide a valid target"
+#~ msgstr "Por favor provea un objetivo valido"
+
+#~ msgid ""
+#~ "Please provide fully qualified domain name and port of the oVirt engine."
+#~ msgstr ""
+#~ "Por favor suministre el nombre completo de dominio y el puerto de la "
+#~ "máquina oVirt."
+
+#~ msgid ""
+#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
+#~ "port (443 by default)"
+#~ msgstr ""
+#~ "Por favor suministre un nombre de dominio totalmente cualificado (FQDN) "
+#~ "de la máquina oVirt y puerto (443 por defecto)"
+
+#~ msgid ""
+#~ "Please refer to oVirt's $0 for more information about Remote Viewer setup."
+#~ msgstr ""
+#~ "Por favor vea $0 de oVirt para más información sobre el ajuste del "
+#~ "Visualizador Remoto."
+
+#~ msgid "Please select a valid access mode"
+#~ msgstr "Por favor seleccionar un modo de acceso valido"
+
+#~ msgid "Please select a valid endpoint"
+#~ msgstr "Por favor seleccione un punto final válido"
+
+#~ msgid "Please select a valid policy option."
+#~ msgstr "Por favor provea una opción de política valida."
+
+#~ msgid "Please type an address"
+#~ msgstr "Por favor escriba una dirección"
+
+#~ msgid "Please wait till VMs list is loaded from the server."
+#~ msgstr ""
+#~ "Por favor espere hasta que la lista VMs se cargue desde el servidor."
+
+#~ msgid "Please wait till list of templates is loaded from the server."
+#~ msgstr ""
+#~ "Por favor espere hasta que la lista de plantilla se cargue desde el "
+#~ "servidor."
+
+#~ msgid "Pod"
+#~ msgstr "Ranura"
+
+#~ msgid "Pod Address"
+#~ msgstr "Dirección del Pod"
+
+#~ msgid "Pod Endpoints"
+#~ msgstr "Puntos Finales del Pod"
+
+#~ msgid "Pod Replicated"
+#~ msgstr "Pod Replicado"
+
+#~ msgid "Pod Selector"
+#~ msgstr "Selector de Pod"
+
+#~ msgid "Pods"
+#~ msgstr "Ranuras"
+
+#~ msgid ""
+#~ "Pods contain one or more containers that run together on a node, "
+#~ "containing your application code."
+#~ msgstr ""
+#~ "Pods contienen uno o mas contenedores que corren juntos sobre un nodo, "
+#~ "conteniendo su código de aplicación."
+
+#~ msgid "Pool Name"
+#~ msgstr "Nombre del grupo"
+
+#~ msgid "Populate"
+#~ msgstr "Rellenar"
+
+#~ msgid "Preparing for Maintenance"
+#~ msgstr "Preparando para Mantenimiento"
+
+#~ msgid "Private: Allow only specific users or groups to pull images"
+#~ msgstr ""
+#~ "Privado: Permite sólo a usuarios o grupos específicos tirar imágenes"
+
+#~ msgid "Product ID"
+#~ msgstr "ID del Producto"
+
+#~ msgid "Product name"
+#~ msgstr "Nombre del Producto"
+
+#~ msgid "Project"
+#~ msgstr "Proyecto"
+
+#~ msgid "Project Members"
+#~ msgstr "Miembros del Proyecto"
+
+#~ msgid "Project access policy allows anonymous users to pull images."
+#~ msgstr ""
+#~ "Proyecto de política de acceso que permite a usuarios anónimos quitar "
+#~ "imágenes."
+
+#~ msgid "Project access policy allows any authenticated user to pull images."
+#~ msgstr ""
+#~ "Proyecto de política de acceso permite a cualquier usuario autenticado "
+#~ "quitar imágenes."
+
+#~ msgid "Project access policy only allows specific members to access images."
+#~ msgstr ""
+#~ "Proyecto de política de acceso permite sólo a miembros específicos "
+#~ "acceder a imágenes."
+
+#~ msgid "Project:"
+#~ msgstr "Proyecto:"
+
+#~ msgid "Projects"
+#~ msgstr "Proyectos"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "Proxy Version"
+#~ msgstr "Versión de Proxy"
+
+#~ msgid "Pull an image:"
+#~ msgstr "Halar una imagen:"
+
+#~ msgid "Pull from"
+#~ msgstr "Extraer desde"
+
+#~ msgid "Pull specific tags from another image repository"
+#~ msgstr "Extraer etiquetas específicas desde otro repositorio de imágenes"
+
+#~ msgid "Push an image:"
+#~ msgstr "Empujar una imagen:"
+
+#~ msgid "Qualified Name"
+#~ msgstr "Nombre Cualificado"
+
+#~ msgid "REBOOT action failed"
+#~ msgstr "REBOOT falló acción"
+
+#~ msgid "Rados Block Device"
+#~ msgstr "Dispositivo de Bloque Rados"
+
+#~ msgid "Read Only"
+#~ msgstr "Solo lectura"
+
+#~ msgid "Read and write from a single node"
+#~ msgstr "Lectura y escritura para un solo nodo."
+
+#~ msgid "Read and write from multiple nodes"
+#~ msgstr "Lectura y escritura para nodos multiples"
+
+#~ msgid "Read only from multiple nodes"
+#~ msgstr "Sólo lectura para nodos múltiples"
+
+#~ msgid "Reason"
+#~ msgstr "Razón"
+
+#~ msgid "Reclaim Policy"
+#~ msgstr "Normativa de reclamación"
+
+#~ msgid "Recycle"
+#~ msgstr "Reciclar"
+
+#~ msgid "Register"
+#~ msgstr "Registrar"
+
+#~ msgid "Register New Volume"
+#~ msgstr "Registrar volumen nuevo"
+
+#~ msgid "Register Persistent Volume"
+#~ msgstr "Registrar volumen persistente"
+
+#~ msgid "Register oVirt"
+#~ msgstr "Registrar oVirt"
+
+#~ msgid "Register system"
+#~ msgstr "Registrar sistema"
+
+#~ msgid "Registering oVirt to Cockpit"
+#~ msgstr "Registrando oVirt a Cockpit"
+
+#~ msgid "Remote registry is insecure"
+#~ msgstr "El registro remoto es inseguro"
+
+#~ msgid "Remove Group"
+#~ msgstr "Quitar Grupo"
+
+#~ msgid "Remove Member"
+#~ msgstr "Quitar miembro"
+
+#~ msgid "Remove Role"
+#~ msgstr "Quitar rol"
+
+#~ msgid "Remove User"
+#~ msgstr "Quitar usuario"
+
+#~ msgid "Remove image tag"
+#~ msgstr "Remover etiqueta de imagen"
+
+#~ msgid "Remove membership"
+#~ msgstr "Quitar afiliación"
+
+#~ msgid "Replicas"
+#~ msgstr "Réplicas"
+
+#~ msgid "Replication Controller"
+#~ msgstr "Contolador de replicación"
+
+#~ msgid "Replication Controllers"
+#~ msgstr "Controladores de replicación"
+
+#~ msgid ""
+#~ "Replication controllers dynamically create instances of pods from "
+#~ "templates, and remove pods when necessary."
+#~ msgstr ""
+#~ "Los controladores de replicación crean dinámicamente instancias de pods a "
+#~ "partir de plantillas y eliminan pods cuando es necesario."
+
+#~ msgid "Repository URL"
+#~ msgstr "URL del repositorio"
+
+#~ msgid "Requested"
+#~ msgstr "Solicitado"
+
+#~ msgid "Requests"
+#~ msgstr "Solicitudes"
+
+#~ msgid "Requires Authentication"
+#~ msgstr "Necesita autenticación"
+
+#~ msgid "Restart Count"
+#~ msgstr "Conteo de Reinicios"
+
+#~ msgid "Retain"
+#~ msgstr "Retener"
+
+#~ msgid "Retrieving subscription status..."
+#~ msgstr "Obteniendo el estado de la suscripción…"
+
+#~ msgid "Revision"
+#~ msgstr "Revisión"
+
+#~ msgid "Role"
+#~ msgstr "Rol"
+
+#~ msgid "Route"
+#~ msgstr "Ruta"
+
+#~ msgid "Run Here"
+#~ msgstr "Ejecutar Aquí"
+
+#~ msgid "Running Since:"
+#~ msgstr "Ejecutando Desde:"
+
+#~ msgid "SET VCPU SETTINGS action failed"
+#~ msgstr "Falló la acción SET VCPU SETTINGS"
+
+#~ msgid "SHUTDOWN action failed"
+#~ msgstr "SHUTDOWN acción fallada"
+
+#~ msgid "START action failed"
+#~ msgstr "START acción fallada"
+
+#~ msgid "SUSPEND action failed"
+#~ msgstr "SUSPEND acción fallada"
+
+#~ msgid "Scheduled Pods"
+#~ msgstr "Pods Programados"
+
+#~ msgid "Scheduling Disabled"
+#~ msgstr "Programación deshabilitada "
+
+#~ msgid "Secret"
+#~ msgstr "Secreto"
+
+#~ msgid "Secret File"
+#~ msgstr "Fichero Secreto"
+
+#~ msgid "Secret Name"
+#~ msgstr "Nombre Secreto"
+
+#~ msgid "Secret Volume"
+#~ msgstr "Volumen Secreto"
+
+#~ msgid "Select Manifest File..."
+#~ msgstr "Seleccione un archivo Manifiesto..."
+
+#~ msgid "Select Member"
+#~ msgstr "Seleccione Miembro"
+
+# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
+#~ msgid "Select Role"
+#~ msgstr "Seleccionar Rol"
+
+#~ msgid "Select an object to see more details."
+#~ msgstr "Selecciona un objeto para ver mas detalles"
+
+#~ msgid "Service Account"
+#~ msgstr "Cuenta de servicio"
+
+#~ msgid ""
+#~ "Services group pods and provide a common DNS name and an optional, load-"
+#~ "balanced IP address to access them."
+#~ msgstr ""
+#~ "Agrupan pods de servicios y suministran un nombre DNS común y una "
+#~ "dirección IP opcional con balance de carga para acceder a ellos"
+
+#~ msgid "Session Affinity"
+#~ msgstr "Afinidad de Sesión"
+
+#~ msgid "Share Name"
+#~ msgstr "Nombre Compartido"
+
+#~ msgid "Shared: Allow any authenticated user to pull images"
+#~ msgstr ""
+#~ "Compartido: permitir a cualquier usuario autenticado extraer imágenes"
+
+#~ msgid "Shell"
+#~ msgstr "Shell"
+
+#~ msgid "Show all Containers"
+#~ msgstr "Mostrar todos los contenedores"
+
+#~ msgid "Show all Deployment Configs"
+#~ msgstr "Mostrar todas las configuraciones de distribución"
+
+#~ msgid "Show all Nodes"
+#~ msgstr "Mostrar todos los nodos"
+
+#~ msgid "Show all Persistent Volumes"
+#~ msgstr "Mostrar todos los volúmenes persistentes"
+
+#~ msgid "Show all Pod Containers"
+#~ msgstr "Mostrar todos los Pod Contenedores"
+
+#~ msgid "Show all Pods"
+#~ msgstr "Mostrar todos los Pods"
+
+#~ msgid "Show all Projects"
+#~ msgstr "Mostrar todos los proyectos"
+
+#~ msgid "Show all Replication Controllers"
+#~ msgstr "Mostrar todos los Controladores Replicantes"
+
+#~ msgid "Show all Routes"
+#~ msgstr "Mostrar todas las rutas"
+
+#~ msgid "Show all Services"
+#~ msgstr "Mostrar todos los servicios"
+
+#~ msgid "Show all image streams"
+#~ msgstr "Mostrar toda la secuencia de imagen"
+
+#~ msgid "Since"
+#~ msgstr "Desde"
+
+#~ msgid "Skip Certificate Verification"
+#~ msgstr "Saltar la Verificación de Certificado"
+
+#~ msgid "Sorry, I don't know how to modify this volume"
+#~ msgstr "Lo siento, no se como modificar este volumen"
+
+#~ msgid "Starts"
+#~ msgstr "Inicios"
+
+#~ msgid "Stateless"
+#~ msgstr "Sin estado"
+
+#~ msgid "Stateless:"
+#~ msgstr "Sin estado:"
+
+#~ msgid "Status: $0"
+#~ msgstr "Estado: $0"
+
+#~ msgid "Status: System isn't registered"
+#~ msgstr "Estado: El sistema no está registrado"
+
+#~ msgid "Strategy"
+#~ msgstr "Estrategia"
+
+#~ msgid "Subscriptions"
+#~ msgstr "Suscripciones"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspendido"
+
+#~ msgid "Switch Host to Maintenance"
+#~ msgstr "Conmutar el Host para Mantenimiento"
+
+#~ msgid "Switching host to maintenance mode failed. Received error: "
+#~ msgstr ""
+#~ "La conmutación del host para modo de mantenimiento fallo. Error recibido:"
+
+#~ msgid "Switching host to maintenance mode in progress ..."
+#~ msgstr "La conmutación del host a modo mantenimiento progresando..."
+
+#~ msgid "Sync all tags from a remote image repository"
+#~ msgstr ""
+#~ "Sincronizar todas las etiquetas desde un repositorio de imagen remoto"
+
+#~ msgid "TLS Termination"
+#~ msgstr "Terminación TLS"
+
+#~ msgid "Target Portal"
+#~ msgstr "Portal Objetivo"
+
+#~ msgid "Target World Wide Names"
+#~ msgstr "Nombres Objetivo en todo el Mundo"
+
+#~ msgid "Template"
+#~ msgstr "Plantilla"
+
+#~ msgid "Templates"
+#~ msgstr "Plantillas"
+
+#~ msgid "Templates of $0 cluster"
+#~ msgstr "Plantilla de cluster $0"
+
+#~ msgid "The address contains invalid characters"
+#~ msgstr "La dirección contiene caracteres inválidos"
+
+#~ msgid "The container '{{ target }}' does not exist."
+#~ msgstr "El contenedor '{{ target }}' no existe."
+
+#~ msgid "The current user isn't allowed to access system subscription status."
+#~ msgstr ""
+#~ "El usuario actual no tiene permitido acceder al estado de suscripción al "
+#~ "sistema."
+
+#~ msgid "The deployment config '{{ target }}' does not exist."
+#~ msgstr "La configuración de despliegue '{{ target }}' no existe."
+
+#~ msgid "The group '{{ groupName }}' does not exist."
+#~ msgstr "El grupo '{{ groupName }}' no existe."
+
+#~ msgid "The maximum number of replicas is 128"
+#~ msgstr "El número maximo de replicas es 128"
+
+#~ msgid "The name contains invalid characters"
+#~ msgstr "El nombre contiene caracteres invalidos"
+
+#~ msgid "The node '{{ target }}' does not exist."
+#~ msgstr "El nodo '{{ target }}' no existe."
+
+#~ msgid "The node doesn't have enough disk space"
+#~ msgstr "El nodo no tiene bastante espacio de disco"
+
+#~ msgid "The node doesn't have enough free memory"
+#~ msgstr "El nodo no tiene bastante memoria libre"
+
+#~ msgid "The persistent volume '{{ target }}' does not exist."
+#~ msgstr "El volumen presistente '{{ target }}' no existe."
+
+#~ msgid "The pod '{{ target }}' does not exist."
+#~ msgstr "El pod '{{ target }}' no existe."
+
+#~ msgid "The project '{{ projName }}' does not exist."
+#~ msgstr "El proyecto '{{ projName }}' no existe."
+
+#~ msgid "The replication controller '{{ target }}' does not exist."
+#~ msgstr "El controlador de replica '{{ target }}' no existe."
+
+#~ msgid "The route '{{ target }}' does not exist."
+#~ msgstr "La ruta '{{ target }}' no existe."
+
+#~ msgid "The selected file is not a valid Kubernetes application manifest."
+#~ msgstr ""
+#~ "El archivo seleccionado no es un archivo de manifiesto de aplicación "
+#~ "kubernetes valido"
+
+#~ msgid "The server uses a certificate signed by an unknown authority."
+#~ msgstr ""
+#~ "El servidor usa un certificado firmado por una autoridad desconocida."
+
+#~ msgid "The service '{{ target }}' does not exist."
+#~ msgstr "El servicio '{{ target }}' no existe."
+
+#~ msgid "The user '{{ userName }}' does not exist."
+#~ msgstr "El usuario '{{ userName }}' no existe."
+
+#~ msgid ""
+#~ "This claim is in use. Deleting it may cause issues with the following pod:"
+#~ msgstr ""
+#~ "Esta reclamo está en uso. Borrarlo puede causar problemas con los "
+#~ "siguientes pod:"
+
+#~ msgid ""
+#~ "This host is managed by a virtualization manager, so creation of new VMs "
+#~ "from the host is not possible."
+#~ msgstr ""
+#~ "Este host está gestionado por un gestor de virtualización de modo que la "
+#~ "creación de nuevas VMs desde este host no es posible."
+
+#~ msgid ""
+#~ "This option is for single node testing only – local storage will not work "
+#~ "in a multi-node cluster"
+#~ msgstr ""
+#~ "Esta opción es para probar un único nodo solo – el almacenamiento local "
+#~ "no trabajará en un clúster multi nodo"
+
+#~ msgid "This virtual machine is not managed by oVirt"
+#~ msgstr "Esta máquina virtual no está gestionada por oVirt"
+
+#~ msgid ""
+#~ "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+#~ "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+#~ "may cause issues with any pods depending on it."
+#~ msgstr ""
+#~ "Este volumen ha sido reclamado por {{ item.item.spec.claimRef."
+#~ "namespace }} / {{ item.item.spec.claimRef.name }}. Eliminarlo romperá el "
+#~ "reclamo y puede causar problemas en cualquier pod que dependa de él."
+
+#~ msgid "This volume has not been claimed"
+#~ msgstr "Este volumen ni ha sido reclamado"
+
+#~ msgid "Token"
+#~ msgstr "Ficha"
+
+#~ msgid "Topology"
+#~ msgstr "Topología"
+
+#~ msgid "Trust this certificate for this connection"
+#~ msgstr "Confía en este certificado para esta conexión"
+
+#~ msgid "Type:"
+#~ msgstr "Teclear:"
+
+#~ msgid "Unable to connect"
+#~ msgstr "Incapaz de conectar"
+
+#~ msgid "Unable to decode Kubernetes application manifest."
+#~ msgstr "No es posible decodificar el manifiesto de Kubernetes."
+
+#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
+#~ msgstr ""
+#~ "No es posible leer el manifiesto de la aplicación Kubernetes. Código $0."
+
+#~ msgid "Unregister"
+#~ msgstr "No registrado"
+
+#~ msgid "Unregistering system..."
+#~ msgstr "Des-registrando sistema..."
+
+#~ msgid "Updating $0..."
+#~ msgstr "Actualizando $0..."
+
+#~ msgid "Use proxy server"
+#~ msgstr "Usar servidor proxy"
+
+#~ msgid "User or Group"
+#~ msgstr "Usuario o Grupo"
+
+#~ msgid "Users"
+#~ msgstr "Usuarios"
+
+#~ msgid "VDSM"
+#~ msgstr "VDSM"
+
+#~ msgid "VDSM Service Management"
+#~ msgstr "Gestión de Servicio VDSM"
+
+#~ msgid "VM icon"
+#~ msgstr "Icono VM"
+
+#~ msgid "Version num"
+#~ msgstr "Número de Versión"
+
+#~ msgid "Virtual Machines of $0 cluster"
+#~ msgstr "Máquinas Virtuales de $0 cluster"
+
+#~ msgid "Volume ID"
+#~ msgstr "ID de Volumen"
+
+#~ msgid "Volume Name"
+#~ msgstr "Nombre de Volumen"
+
+#~ msgid "Volume Type"
+#~ msgstr "Tipo de Volumen"
+
+#~ msgid "Warning:"
+#~ msgstr "Precaución:"
+
+#~ msgid "Welcome to the Image Registry"
+#~ msgstr "Bienvenidos al Registro de Imagen"
+
+#~ msgid "When"
+#~ msgstr "Cuando"
+
+#~ msgid ""
+#~ "You can bypass the certificate check, but any data you send to the server "
+#~ "could be intercepted by others."
+#~ msgstr ""
+#~ "Usted puede evitar la comprobación del certificado, pero cualquier datos "
+#~ "que envíe al servidor podría ser interceptado por otros."
+
+#~ msgid "You can deploy an application to your cluster."
+#~ msgstr "Tu puedes desplegar una aplicación a tu cluster"
+
+#~ msgid ""
+#~ "Your login credentials do not give you access to use the docker registry "
+#~ "from the command line."
+#~ msgstr ""
+#~ "Sus credenciales de acceso no le conceden acceso para utilizar el "
+#~ "registro de Docker a partir de la consola."
+
+#~ msgid "connecting"
+#~ msgstr "conectando"
+
+#~ msgid "cores"
+#~ msgstr "núcleos"
+
+#~ msgid "eg: my-image-stream"
+#~ msgstr "eg: mi secuencia de imagen"
+
+#~ msgid "error"
+#~ msgstr "error"
+
+#~ msgid "initializing"
+#~ msgstr "inicializando"
+
+#~ msgid "installation failed"
+#~ msgstr "instalación fallada"
+
+#~ msgid "installing OS"
+#~ msgstr "instalando SO"
+
+#~ msgid "kdumping"
+#~ msgstr "kdumping"
+
+#~ msgid "maintenance"
+#~ msgstr "mantenimiento"
+
+#~ msgid "non operational"
+#~ msgstr "no operativo"
+
+#~ msgid "non responsive"
+#~ msgstr "sin respuesta"
+
+#~ msgid "oVirt"
+#~ msgstr "oVirt"
+
+#~ msgid "oVirt Host State:"
+#~ msgstr "Estado del Huésped oVirt:"
+
+#~ msgid "oVirt Provider installation script failed due to missing arguments."
+#~ msgstr ""
+#~ "oVirt Provider el script de instalación falló debido a argumentos "
+#~ "perdidos."
+
+#~ msgid ""
+#~ "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
+#~ "machines-ovirt.config, try as root."
+#~ msgstr ""
+#~ "oVirt Provider el script de instalación falló: No puede escribir en /etc/"
+#~ "cockpit/machines-ovirt.config, inténtelo como root."
+
+#~ msgid "oVirt installation script failed with following output: "
+#~ msgstr "oVirt script de instalación falló con la siguiente salida: "
+
+#~ msgid "pending approval"
+#~ msgstr "pendiente de aprobación"
+
+#~ msgid "pending volume claims"
+#~ msgstr "pendiente de reclamación de volumen"
+
+#~ msgid "reboot"
+#~ msgstr "reiniciar"
+
+#~ msgid "sockets"
+#~ msgstr "enchufes"
+
+#~ msgid "threads"
+#~ msgstr "hilos"
+
+#~ msgid "unassigned"
+#~ msgstr "no asignado"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 04:52+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2018-05-12 02:23+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish\n"
 "Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -128,10 +128,10 @@ msgstr ""
 "GNOME Softwaresta, tai aja seuraava komento:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 on aktiivisessa käytössä"
 
@@ -467,8 +467,8 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Yhteensopivaa versiota Cockpitistä ei ole asennettu kohteessa "
-"{{#strong}}{{host}}{{/strong}}."
+"Yhteensopivaa versiota Cockpitistä ei ole asennettu kohteessa {{#strong}}"
+"{{host}}{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:59
 msgid "A disk is needed."
@@ -529,8 +529,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Käyttäjätilit"
 
-#: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Aktivoi"
@@ -567,10 +567,10 @@ msgstr "Mukautuva kuorman tasapainottaja (balance-alb)"
 msgid "Adaptive transmit load balancing"
 msgstr "Mukautuva lähtevän kuorman tasapainottaja (balance-tlb)"
 
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Lisää"
@@ -806,10 +806,10 @@ msgstr "Sovellukset"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Toteuta"
 
@@ -849,8 +849,8 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr "Vähintään $0 levyä tarvitaan."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Vähintään yksi levy tarvitaan."
 
@@ -866,8 +866,8 @@ msgstr "Audit-loki"
 msgid "Authenticating"
 msgstr "Tunnistaudutaan"
 
-#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
-#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Tunnistautuminen"
 
@@ -938,8 +938,8 @@ msgstr "Käytetään automaattisesti NTP:tä"
 msgid "Automatically using specific NTP servers"
 msgstr "Käytetään automaattisesti tiettyjä NTP-palvelimia"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
@@ -1121,8 +1121,8 @@ msgstr "Prosessorin prioriteetti"
 msgid "CPU usage:"
 msgstr "Prosessorin käyttö"
 
-#: pkg/machines/components/diskAdd.jsx:246
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
@@ -1145,35 +1145,35 @@ msgstr ""
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:560
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:560 pkg/networkmanager/firewall.jsx:628
-#: pkg/networkmanager/firewall.jsx:771 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Peru"
 
@@ -1243,10 +1243,10 @@ msgstr "Muuta resurssien rajoja"
 msgid "Change the settings"
 msgstr "Vaihda asetuksia"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr ""
 
@@ -1327,15 +1327,16 @@ msgstr "Painamalla \"Launch Remote Viewer\" lataat .vv-tiedoston ja avaat $0."
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
-#: pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Sulje"
 
@@ -1420,10 +1421,10 @@ msgstr "Cockpit ei saanut yhteyttä kohteeseen {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit ei pystynyt kirjautumaan kohteeseen {{#strong}}{{host}}{{/strong}}. "
 "{{#can_sync}}Haluat ehkä kokeilla {{#sync_link}}käyttäjien synkronointia{{/"
@@ -1443,8 +1444,8 @@ msgid ""
 msgstr ""
 "Cockpit ei pystynyt kirjautumaan kohteeseen {{#strong}}{{host}}{{/strong}}. "
 "Käyttääksesi tätä konetta Cockpitin kanssa sinun tulee ottaa käyttöön jokin "
-"seuraavista todentamismetodeista sshd-konfiguraatiossa kohteessa "
-"{{#strong}}{{host}}{{/strong}}:"
+"seuraavista todentamismetodeista sshd-konfiguraatiossa kohteessa {{#strong}}"
+"{{host}}{{/strong}}:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1518,15 +1519,14 @@ msgstr "Yhteensopiva kaikkien järjestelmien ja laitteiden kanssa (MBR)"
 
 #: pkg/storaged/content-views.jsx:524
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr ""
-"Yhteensopiva modernien järjestelmien ja kovalevyjen kanssa > 2TB (GPT)"
+msgstr "Yhteensopiva modernien järjestelmien ja kovalevyjen kanssa > 2TB (GPT)"
 
 #: pkg/kdump/kdump-view.jsx:162
 msgid "Compress crash dumps to save space"
 msgstr "Tiivistä crash dump säästääksesi tilaa"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Pakkaus"
 
@@ -1631,9 +1631,9 @@ msgid "Connecting to the machine"
 msgstr "Yhdistetään koneeseen"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Yhteys"
@@ -1783,9 +1783,9 @@ msgstr ""
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Luo"
 
@@ -1963,7 +1963,7 @@ msgstr ""
 msgid "Custom encryption options"
 msgstr "Mukautetut salausvalinnat"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Mukautetut liitosvalinnat"
 
@@ -2008,8 +2008,8 @@ msgstr "Kojelauta"
 msgid "Data Used"
 msgstr "Dataa käytetty"
 
-#: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Deaktivoi"
@@ -2042,17 +2042,17 @@ msgstr "Viive"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Poista"
@@ -2105,7 +2105,7 @@ msgstr "RAID-laitteen poistaminen tuhoaa kaiken sillä olevan datan."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "VDO-laitteen poistaminen tuhoaa kaiken sillä olevan datan."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "Kontin poistaminen tuhoaa kaiken sillä olevan datan."
 
@@ -2148,12 +2148,12 @@ msgstr ""
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:745
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Yksityiskohdat"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2242,9 +2242,9 @@ msgstr "Levy on OK"
 msgid "Disk passphrase"
 msgstr ""
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Levyt"
 
@@ -2517,9 +2517,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1476
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Virhe"
 
@@ -2623,7 +2623,7 @@ msgstr ""
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Ei voitu vaihtaa salasanaa"
 
@@ -2708,7 +2708,7 @@ msgstr "Suodata palveluja"
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Sormenjälki"
 
@@ -2753,10 +2753,9 @@ msgstr "Pakota salasanan vaihdos"
 msgid "Force remove passphrase in $0"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:147
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Alusta"
 
@@ -2832,11 +2831,11 @@ msgstr "Luodaan raporttia"
 msgid "Get new image"
 msgstr "Hae uusi levykuva"
 
-#: pkg/machines/components/diskAdd.jsx:186
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
 
@@ -2921,9 +2920,9 @@ msgstr "Hello time $hello_time"
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
 #: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Kone"
@@ -3156,9 +3155,9 @@ msgstr ""
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Asenna"
 
@@ -3221,8 +3220,8 @@ msgid "Interface Type"
 msgstr ""
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:737 pkg/networkmanager/firewall.jsx:925
-#: pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Liitännät"
 
@@ -3238,11 +3237,11 @@ msgstr "Sisäinen virhe"
 msgid "Invalid address $0"
 msgstr "Virheellinen osoite $0"
 
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Virheellinen päivämuoto"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Virheellinen päivämuoto ja aikamuoto"
 
@@ -3298,7 +3297,7 @@ msgstr "Virheellinen etuliite tai verkkopeite $0"
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Virheellinen aikamuoto"
 
@@ -3468,7 +3467,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66
@@ -3531,9 +3529,9 @@ msgstr "Saatavilla olevien päivitysten lataus epäonnistui"
 msgid "Loading available updates, please wait..."
 msgstr "Ladataan saatavilla olevat päivitykset, odota hetki..."
 
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Ladataan..."
 
@@ -3831,10 +3829,10 @@ msgid "Metadata Used"
 msgstr ""
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
-#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -3904,23 +3902,23 @@ msgstr "Lisää tietoja"
 msgid "More details"
 msgstr "Lisätietoja"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Liitosvalinnat"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Liitospiste"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Liitä käynnistyksen yhteydessä"
 
@@ -3940,7 +3938,7 @@ msgstr "Liitospiste ei voi olla tyhjä."
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr ""
 
@@ -3996,22 +3994,21 @@ msgstr "NTP-palvelin"
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Nimi"
 
@@ -4151,7 +4148,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Uutta salasanaa ei hyväksytty"
 
@@ -4273,9 +4270,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "Kuvausta ei annettu."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Levyjä ei ole saatavilla."
 
@@ -4407,8 +4404,8 @@ msgid "No volume groups created"
 msgstr "Taltioryhmiä ei ole luotu"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:734
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr ""
 
@@ -4508,7 +4505,7 @@ msgstr "Vanha salasana"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Vanhaa salasanaa ei hyväksytty"
 
@@ -4618,9 +4615,9 @@ msgstr "Muut laitteet"
 msgid "Other Options"
 msgstr "Muut valinnat"
 
-#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr ""
 
@@ -4700,10 +4697,10 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Tunnuslauseet eivät täsmää"
 
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "Salasana"
@@ -4805,8 +4802,8 @@ msgstr "Käyttö estetty"
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr ""
 
@@ -4850,9 +4847,9 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Vahvista kohteen $0 poistaminen"
@@ -4861,7 +4858,7 @@ msgstr "Vahvista kohteen $0 poistaminen"
 msgid "Please confirm forced deletion of $0"
 msgstr "Vahvista kohteen $0 pakotettu poistaminen"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Vahvista kohteen $0 pysäyttäminen"
 
@@ -4897,11 +4894,10 @@ msgstr ""
 msgid "Plug"
 msgstr ""
 
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr ""
 
@@ -5057,7 +5053,7 @@ msgstr ""
 msgid "Protocol"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Julkinen avain"
 
@@ -5137,7 +5133,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "RAID-laite"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "RAID-laite $0"
 
@@ -5304,9 +5300,9 @@ msgstr ""
 msgid "Removals:"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Poista"
 
@@ -5487,8 +5483,8 @@ msgstr ""
 
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Käynnistä uudelleen"
 
@@ -5529,8 +5525,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/users/index.html:94
@@ -5651,10 +5646,11 @@ msgstr "Lauantai"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Tallenna"
 
@@ -5707,8 +5703,8 @@ msgstr "Valitse"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:66
@@ -5729,8 +5725,8 @@ msgstr "Lähetetään"
 msgid "Serial Console"
 msgstr ""
 
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Palvelin"
 
@@ -5904,15 +5900,14 @@ msgstr "Sammuta"
 
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/diskAdd.jsx:167
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Koko"
 
@@ -5989,10 +5984,10 @@ msgstr ""
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:504
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Lähde"
 
@@ -6000,10 +5995,10 @@ msgstr "Lähde"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr ""
 
@@ -6045,8 +6040,8 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Käynnistä"
 
@@ -6083,8 +6078,8 @@ msgid "Startup"
 msgstr ""
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
 #: pkg/systemd/init.js:285
 msgid "State"
@@ -6111,8 +6106,8 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Pysäytä"
@@ -6353,8 +6348,8 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr ""
 
@@ -6476,8 +6471,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -6509,8 +6504,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1016
@@ -6519,8 +6513,7 @@ msgid ""
 msgstr ""
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/sosreport/index.html:51
@@ -6654,8 +6647,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:58
@@ -6960,18 +6952,17 @@ msgstr "Tuned ei ole käynnissä"
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Tyyppi"
 
@@ -7073,10 +7064,11 @@ msgstr "Yksikkö"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/lib/machine-info.js:65 pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:139
 #: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
 #: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Tuntematon"
 
@@ -7290,7 +7282,7 @@ msgstr "Käyttäjätunnus"
 msgid "User Password"
 msgstr "Salasana"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Käyttäjätunnus"
@@ -7439,7 +7431,7 @@ msgid "Verifying"
 msgstr "Vahvistetaan"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Versio"
 
@@ -7447,8 +7439,8 @@ msgstr "Versio"
 msgid "Very securely erasing $target"
 msgstr "Poistetaan hyvin turvallisesti $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Virtuaalikoneet"
@@ -7466,11 +7458,10 @@ msgid "Virtualization Service is Available"
 msgstr "Virtualisointipalvelu ei ole saatavilla"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Taltio"
 
@@ -7661,8 +7652,12 @@ msgstr "[binääridata]"
 msgid "[no data]"
 msgstr "[ei dataa]"
 
-#: pkg/machines/components/networks/network.jsx:59
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr ""
@@ -7792,8 +7787,8 @@ msgstr ""
 msgid "idle"
 msgstr "jouten"
 
-#: pkg/machines/components/networks/network.jsx:59
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr ""
 
@@ -7829,9 +7824,9 @@ msgstr "verkko"
 msgid "nfs dump target isn't formated as server:path"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "ei"
@@ -7995,9 +7990,9 @@ msgid ""
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "kyllä"

--- a/po/fr.po
+++ b/po/fr.po
@@ -12,14 +12,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-03 06:24+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-05-28 11:53+0000\n"
 "Last-Translator: corina roe <croe@redhat.com>\n"
 "Language-Team: French\n"
 "Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
 
@@ -27,19 +27,15 @@ msgstr ""
 msgid " (shared with the OS)"
 msgstr "(partagé avec l’OS)"
 
-#: pkg/kubernetes/views/node-delete.html:8
-msgid " 1\"Do you want to delete the following Nodes?"
-msgstr " 1\"Désirez-vous supprimer les nœuds suivants ?"
-
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0 Périphérique de bloc"
 
-#: pkg/storaged/mdraid-details.jsx:193
+#: pkg/storaged/mdraid-details.jsx:192
 msgid "$0 Chunk Size"
 msgstr "$0 Taille de bloc"
 
-#: pkg/storaged/mdraid-details.jsx:191
+#: pkg/storaged/mdraid-details.jsx:190
 msgid "$0 Disks"
 msgstr "$0 Disques"
 
@@ -88,16 +84,16 @@ msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 données + $1 frais généraux utilisés de $2 ( $3 )"
 
 #: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:213
+#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 disque est manquant"
 msgstr[1] "$0 disques sont manquants"
 
 #: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:34
-#: pkg/playground/translate.js:37
+#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
@@ -138,10 +134,10 @@ msgstr ""
 "suivantes :"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:237
-#: pkg/storaged/mdraid-details.jsx:290 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:203
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 est en utilisation active"
 
@@ -181,27 +177,11 @@ msgstr[1] "$0 mis à jour"
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 utilisé de $1 ( $2 enregistré)"
 
-#: pkg/ovirt/components/vcpuModal.jsx:98
-msgid "$0 vCPU Details"
-msgstr "$0 vCPU Détails"
-
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "0 $ sera installé."
 
-#: pkg/kubernetes/scripts/nodes.js:871
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0% disponible"
-msgstr[1] "$0% disponible"
-
-#: pkg/kubernetes/scripts/nodes.js:873
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0% utilisé"
-msgstr[1] "$0% utilisé"
-
-#: pkg/storaged/vgroup-details.jsx:118
+#: pkg/storaged/vgroup-details.jsx:117
 msgid "$0, $1 free"
 msgstr "$0 , $1 disponible"
 
@@ -227,19 +207,11 @@ msgstr "$ {hip}: $ {hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "$ {size} $ {desc}"
 
-#: pkg/subscriptions/subscriptions-client.js:197
-msgid "'Organization' required to register."
-msgstr "«Organisation» nécessaire pour s’inscrire."
-
-#: pkg/subscriptions/subscriptions-client.js:201
-msgid "'Organization' required when using activation keys."
-msgstr "«Organisation» requis lors de l’utilisation des clés d’activation."
-
-#: pkg/networkmanager/firewall.jsx:547
+#: pkg/networkmanager/firewall.jsx:549
 msgid "(Optional)"
 msgstr "(facultatif)"
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:616
+#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(défaut)"
@@ -501,8 +473,8 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Une version compatible de Cockpit n’’est pas installée sur "
-"{{#strong}}{{host}}{{/strong}}."
+"Une version compatible de Cockpit n’’est pas installée sur {{#strong}}"
+"{{host}}{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:59
 msgid "A disk is needed."
@@ -533,12 +505,8 @@ msgstr "Surveillance ARP"
 msgid "ARP Ping"
 msgstr "ARP Ping"
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "AWS Elastic Block Store"
-
 #: pkg/shell/index.html:56 pkg/shell/index.html:82 pkg/shell/simple.html:42
-#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
+#: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "À propos de Cockpit"
 
@@ -546,19 +514,9 @@ msgstr "À propos de Cockpit"
 msgid "Access"
 msgstr "Accès"
 
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
-msgid "Access Modes"
-msgstr "Modes d’accès"
-
-#: pkg/kubernetes/views/project-modify.html:49
 #: node_modules/registry-image-widgets/views/imagestream-body.html:12
 msgid "Access Policy"
 msgstr "Politique d’accès"
-
-#: pkg/subscriptions/subscriptions-view.jsx:213
-msgid "Access denied"
-msgstr "Accès refusé"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -576,18 +534,13 @@ msgstr "Compte non disponible ou ne peut pas être modifié."
 msgid "Accounts"
 msgstr "Comptes"
 
-#: pkg/users/local.js:335 pkg/users/local.js:642
+#: pkg/users/local.js:339 pkg/users/local.js:646
 msgctxt "page-title"
 msgid "Accounts"
 msgstr "Comptes"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:183
-msgid "Action"
-msgstr "action"
-
-#: pkg/machines/components/networks/network.jsx:147
-#: pkg/machines/components/storagePools/storagePool.jsx:167
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Activer"
@@ -595,10 +548,6 @@ msgstr "Activer"
 #: pkg/storaged/jobs-panel.jsx:68
 msgid "Activating $target"
 msgstr "Activation $target"
-
-#: pkg/subscriptions/subscriptions-register.jsx:168
-msgid "Activation Key"
-msgstr "Clé d’activation"
 
 #: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
 msgid "Active"
@@ -608,7 +557,7 @@ msgstr "actif"
 msgid "Active Backup"
 msgstr "Sauvegarde active"
 
-#: pkg/shell/index.html:59 pkg/shell/stub.html:49 pkg/shell/active-pages.js:95
+#: pkg/shell/index.html:59 pkg/shell/active-pages.js:95
 msgid "Active Pages"
 msgstr "Pages actives"
 
@@ -616,13 +565,9 @@ msgstr "Pages actives"
 msgid "Active since"
 msgstr "Actif depuis"
 
-#: pkg/networkmanager/firewall.jsx:922
+#: pkg/networkmanager/firewall.jsx:924
 msgid "Active zones"
 msgstr "Zones actives"
-
-#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
-msgid "Actual"
-msgstr "Réel"
 
 #: pkg/networkmanager/interfaces.js:1980
 msgid "Adaptive load balancing"
@@ -632,16 +577,11 @@ msgstr "Équilibrage de charge adaptatif"
 msgid "Adaptive transmit load balancing"
 msgstr "Equilibrage adaptatif de la charge d’émission"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/add-role-dialog.html:8
-#: pkg/kubernetes/views/add-user-dialog.html:27
-#: pkg/kubernetes/views/node-add.html:50
-#: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:534
-#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/vgroup-details.jsx:63
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Ajouter"
 
@@ -661,11 +601,7 @@ msgstr "Ajouter un lien"
 msgid "Add Bridge"
 msgstr "Ajouter un pont"
 
-#: pkg/kubernetes/views/node-add.html:3
-msgid "Add Cluster Node"
-msgstr "Ajouter une nœud de cluster"
-
-#: pkg/machines/components/diskAdd.jsx:356
+#: pkg/machines/components/diskAdd.jsx:360
 msgid "Add Disk"
 msgstr "Ajouter un disque"
 
@@ -673,55 +609,20 @@ msgstr "Ajouter un disque"
 msgid "Add Disks"
 msgstr "Ajouter des disques"
 
-#: pkg/kubernetes/views/add-group-dialog.html:3
-msgid "Add Group"
-msgstr "Ajouter un groupe"
-
 #: pkg/storaged/crypto-keyslots.jsx:200
 msgid "Add Key"
 msgstr "Ajouter une clé"
-
-#: pkg/kubernetes/views/nodes-page.html:34
-msgid "Add Kubernetes Node"
-msgstr "Ajouter un nœud Kubernetes"
 
 #: pkg/lib/machine-add.html:4
 msgid "Add Machine to Dashboard"
 msgstr "Ajouter une machine au tableau de bord"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:4
-#: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/group-panel.html:29
-#: pkg/kubernetes/views/project-body.html:108
-#: pkg/kubernetes/views/user-group-add.html:3
-msgid "Add Member"
-msgstr "Ajouter un membre"
-
-#: pkg/kubernetes/views/user-body.html:67
-#: pkg/kubernetes/views/user-panel.html:76
-msgid "Add Membership"
-msgstr "Ajouter un membre"
-
-#: pkg/kubernetes/views/auth-form.html:11
-#: pkg/kubernetes/views/auth-form.html:20
-msgid "Add New Cluster"
-msgstr "Ajouter un nouveau cluster"
-
-#: pkg/kubernetes/views/auth-form.html:67
-#: pkg/kubernetes/views/auth-form.html:76
-msgid "Add New User"
-msgstr "Ajouter un nouvel utilisateur"
-
 #: pkg/networkmanager/firewall.jsx:457
 msgid "Add Ports"
 msgstr "Ajouter des ports"
 
-#: pkg/kubernetes/views/add-role-dialog.html:3
-msgid "Add Role"
-msgstr "Ajouter un rôle"
-
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:872
-#: pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
+#: pkg/networkmanager/firewall.jsx:886
 msgid "Add Services"
 msgstr "Ajouter services"
 
@@ -733,17 +634,12 @@ msgstr "Ajouter du stockage"
 msgid "Add Team"
 msgstr "Ajouter une équipe"
 
-#: pkg/kubernetes/views/add-user-dialog.html:3
-#: pkg/kubernetes/views/project-listing.html:83
-msgid "Add User"
-msgstr "Ajouter un utilisateur"
-
 #: pkg/networkmanager/index.html:113
 msgid "Add VLAN"
 msgstr "Ajouter un VLAN"
 
-#: pkg/networkmanager/firewall.jsx:698 pkg/networkmanager/firewall.jsx:878
-#: pkg/networkmanager/firewall.jsx:889
+#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
+#: pkg/networkmanager/firewall.jsx:891
 msgid "Add Zone"
 msgstr "Ajouter une zone"
 
@@ -754,10 +650,6 @@ msgstr "Ajouter un portail iSCSI"
 #: pkg/shell/index.html:172 pkg/users/index.html:414
 msgid "Add key"
 msgstr "Ajouter une clé"
-
-#: pkg/kubernetes/views/user-add-membership.html:3
-msgid "Add membership"
-msgstr "Ajouter un membre"
 
 #: pkg/networkmanager/firewall.jsx:458
 msgid "Add ports to the following zones:"
@@ -771,7 +663,7 @@ msgstr "Ajouter une clé publique"
 msgid "Add services to following zones:"
 msgstr "Ajouter des services aux zones suivantes :"
 
-#: pkg/networkmanager/firewall.jsx:774
+#: pkg/networkmanager/firewall.jsx:776
 msgid "Add zone"
 msgstr "Ajouter une zone"
 
@@ -803,7 +695,7 @@ msgstr "DNS supplémentaire $val"
 msgid "Additional DNS Search Domains $val"
 msgstr "Domaines de recherche DNS supplémentaires $val"
 
-#: pkg/docker/index.html:307
+#: pkg/docker/index.html:309
 msgid "Additional Storage"
 msgstr "Stockage supplémentaire"
 
@@ -815,14 +707,11 @@ msgstr "Adresse supplémentaire $val"
 msgid "Additional packages:"
 msgstr "Paquets supplémentaires :"
 
-#: pkg/kubernetes/views/auth-form.html:29
-#: pkg/kubernetes/views/dashboard-page.html:157
-#: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
+#: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:77 pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:107
+#: pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adresse"
 
@@ -839,44 +728,18 @@ msgid "Address is not a valid URL"
 msgstr "L’adresse ne correspond pas à une URL valide"
 
 #: pkg/machines/components/desktopConsole.jsx:153
-#: pkg/ovirt/components/VmOverviewColumn.jsx:53
 msgid "Address:"
 msgstr "Adresse :"
 
-#: pkg/kubernetes/views/details-page.html:37
 #: pkg/networkmanager/interfaces.js:3309
 msgid "Addresses"
 msgstr "Adresses"
-
-#: pkg/kubernetes/views/service-modify.html:25
-msgid "Adjust"
-msgstr "Régler"
-
-#: pkg/kubernetes/views/pv-modify.html:3
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "Ajuster le volume persistant « {{item.metadata.name}} »"
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html:3
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "Ajuster le contrôleur de réplication {{item.metadata.name}}"
-
-#: pkg/kubernetes/views/route-modify.html:3
-msgid "Adjust Route"
-msgstr "Ajuster l’itinéraire"
-
-#: pkg/kubernetes/views/service-modify.html:3
-msgid "Adjust Service"
-msgstr "Ajuster le service"
-
-#: pkg/kubernetes/views/project-body.html:56
-msgid "Admin"
-msgstr "Admin"
 
 #: org.cockpit-project.cockpit-bridge.policy.in.h:1
 msgid "Administration with Cockpit Web Console"
 msgstr "Administration Console de gestion de Cockpit"
 
-#: pkg/realmd/operation.js:336
+#: pkg/realmd/operation.js:335
 msgid "Administrator Password"
 msgstr "Mot de passe administrateur"
 
@@ -916,14 +779,6 @@ msgstr "Tout"
 msgid "All In One"
 msgstr "Tout en un"
 
-#: pkg/kubernetes/views/filter-project.html:4
-msgid "All Projects"
-msgstr "Tous les projets"
-
-#: pkg/kubernetes/views/details-page.html:6
-msgid "All Types"
-msgstr "Tous les types"
-
 #: pkg/docker/storage.jsx:381
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
@@ -932,36 +787,15 @@ msgstr ""
 "Toutes les données sur les disques sélectionnés seront effacées et les "
 "disques seront ajoutés au pool de stockage."
 
-#: pkg/kubernetes/views/dashboard-page.html:112
-msgid "All healthy"
-msgstr "Tout fonctionne bien"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:74
-msgid "All images"
-msgstr "Toutes les images"
-
-#: pkg/kubernetes/views/dashboard-page.html:69
-msgid "All in use"
-msgstr "Tout en cours d’utilisation"
-
-#: pkg/kubernetes/views/dashboard-page.html:37
-msgid "All running"
-msgstr "Le tout est en cours d’exécution"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:36
-msgid "All running virtual machines will be turned off."
-msgstr ""
-"Toutes les machines virtuelles en cours d’exécution seront désactivées."
-
-#: pkg/networkmanager/firewall.jsx:749
+#: pkg/networkmanager/firewall.jsx:751
 msgid "Allowed Addresses"
 msgstr "Adresses autorisées"
 
-#: pkg/networkmanager/firewall.jsx:935
+#: pkg/networkmanager/firewall.jsx:937
 msgid "Allowed Services"
 msgstr "Services autorisés"
 
-#: pkg/docker/index.html:548 pkg/docker/util.js:108
+#: pkg/docker/index.html:550 pkg/docker/util.js:108
 msgid "Always"
 msgstr "Toujours"
 
@@ -969,19 +803,11 @@ msgstr "Toujours"
 msgid "Always attach"
 msgstr "Toujours attacher"
 
-#: pkg/kubernetes/views/node-body.html:57
-#: pkg/kubernetes/views/route-body.html:27
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Annotations"
 
-#: pkg/kubernetes/scripts/projects.js:1044
-msgid "Anonymous: Allow all unauthenticated users to pull images"
-msgstr ""
-"Anonyme : autoriser tous les utilisateurs non authentifiés à tirer des "
-"images"
-
-#: pkg/systemd/terminal.jsx:94
+#: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr "Apparence :"
 
@@ -994,11 +820,10 @@ msgstr "Applications"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235
-#: pkg/ovirt/components/vcpuModal.jsx:104 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Appliquer"
 
@@ -1027,7 +852,6 @@ msgid "Applying updates failed"
 msgstr "L’application des mises à jour a échoué"
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
-#: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Architecture"
 msgstr "Architecture"
 
@@ -1039,8 +863,8 @@ msgstr "Balise de ressource"
 msgid "At least $0 disks are needed."
 msgstr "Au moins $0 disques sont nécessaires."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Un disque au moins est nécessaire."
 
@@ -1056,9 +880,8 @@ msgstr "Journal d’audit"
 msgid "Authenticating"
 msgstr "Authentification"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
 #: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Authentification"
 
@@ -1086,7 +909,7 @@ msgstr ""
 msgid "Authentication required"
 msgstr "Authentification requise"
 
-#: pkg/docker/index.html:700
+#: pkg/docker/index.html:702
 #: node_modules/registry-image-widgets/views/image-body.html:12
 #: pkg/docker/containers-view.jsx:413
 msgid "Author"
@@ -1099,7 +922,7 @@ msgstr "Clés SSH publiques autorisées"
 #: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
 #: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
 #: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:339
+#: pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automatique"
 
@@ -1119,10 +942,6 @@ msgstr "Démarrage automatique"
 msgid "Automatic Updates"
 msgstr "Mises à jour automatiques"
 
-#: pkg/ovirt/components/OVirtTab.jsx:81
-msgid "Automatically selected host"
-msgstr "Hôte sélectionné automatiquement"
-
 #: pkg/machines/components/libvirtSlate.jsx:90
 msgid "Automatically start libvirt on boot"
 msgstr "Lancement automatique de libvirt au démarrage"
@@ -1135,9 +954,9 @@ msgstr "Utiliser automatiquement NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Utiliser automatiquement des serveurs NTP spécifiques"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:155
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "Démarrage automatique"
 
@@ -1158,10 +977,6 @@ msgstr "Cibles disponibles sur $0"
 #: pkg/dashboard/index.html:163
 msgid "Avatar"
 msgstr "Avatar"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azur"
 
 #: pkg/systemd/hwinfo.jsx:92
 msgid "BIOS"
@@ -1190,18 +1005,6 @@ msgstr "Mauvaises données transmises pour le mécanisme passwd1"
 #: pkg/networkmanager/index.html:333
 msgid "Balancer"
 msgstr "Équilibreur de charge"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-msgid "Base Template"
-msgstr "Modèle de base"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Base template"
-msgstr "Modèle de base"
-
-#: pkg/ovirt/components/OVirtTab.jsx:106 pkg/ovirt/components/OVirtTab.jsx:113
-msgid "Base template:"
-msgstr "Modèle de base :"
 
 #: pkg/systemd/init.js:729
 msgid "Before"
@@ -1244,12 +1047,8 @@ msgstr "Liaison"
 msgid "Bond Settings"
 msgstr "Paramètres de liaison"
 
-#: pkg/kubernetes/views/node-body.html:17
-msgid "Boot ID"
-msgstr "ID de démarrage"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:312
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:153
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:164
 msgid "Boot Order"
 msgstr "Ordre d’amorçage"
 
@@ -1308,10 +1107,8 @@ msgstr "Bus"
 msgid "Bus Expansion Chassis"
 msgstr "Châssis d’extension de bus"
 
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:270
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:603
-#: pkg/kubernetes/scripts/nodes.js:711 pkg/kubernetes/scripts/nodes.js:818
-#: pkg/systemd/hwinfo.jsx:108
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:272
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
 msgid "CPU"
 msgstr "CPU"
 
@@ -1328,28 +1125,20 @@ msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Statut du processeur"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:154
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:165
 msgid "CPU Type"
 msgstr "Type de CPU"
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "Utilisation du processeur : $0 %"
-
-#: pkg/docker/index.html:469 pkg/docker/index.html:641
+#: pkg/docker/index.html:471 pkg/docker/index.html:643
 msgid "CPU priority"
 msgstr "Priorité en CPU"
 
-#: pkg/docker/index.html:217
+#: pkg/docker/index.html:218
 msgid "CPU usage:"
 msgstr "Utilisation CPU :"
 
-#: pkg/ovirt/provider.js:256
-msgid "CREATE VM action failed"
-msgstr "Échec de l’action CREATE VM"
-
-#: pkg/machines/components/diskAdd.jsx:235
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr "Cache"
 
@@ -1369,79 +1158,44 @@ msgstr "Impossible de supprimer si déverrouillé"
 msgid "Can't load image"
 msgstr "Impossible de charger l’image"
 
-#: pkg/dashboard/index.html:175 pkg/docker/index.html:563
-#: pkg/docker/index.html:597 pkg/docker/index.html:661
-#: pkg/docker/index.html:715 pkg/docker/index.html:755
-#: pkg/docker/index.html:784 pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/add-role-dialog.html:7
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/image-delete.html:7
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/user-group-add.html:29
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
-#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:477 pkg/networkmanager/index.html:501
-#: pkg/networkmanager/index.html:525 pkg/networkmanager/index.html:549
-#: pkg/networkmanager/index.html:573 pkg/networkmanager/index.html:597
-#: pkg/networkmanager/index.html:621 pkg/networkmanager/index.html:645
-#: pkg/networkmanager/index.html:669 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:81 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/systemd/index.html:332
+#: pkg/dashboard/index.html:175 pkg/docker/index.html:565
+#: pkg/docker/index.html:599 pkg/docker/index.html:663
+#: pkg/docker/index.html:717 pkg/docker/index.html:757
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
+#: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
+#: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
+#: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:654
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:531
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:485
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:558 pkg/networkmanager/firewall.jsx:626
-#: pkg/networkmanager/firewall.jsx:769
-#: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Annuler"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:415
 msgid "Cannot connect to an unknown machine"
 msgstr "Impossible de se connecter à une machine inconnue"
-
-#: src/ws/cockpitcertificate.c:483
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "Impossible de déchiffrer la clé privée codée PEM"
 
 #: src/base1/cockpit.js:4031
 msgid "Cannot forward login credentials"
@@ -1451,8 +1205,6 @@ msgstr "Impossible de transférer les identifiants de connexion"
 msgid "Cannot schedule event in the past"
 msgstr "Impossible de planifier un événement dans le passé"
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
 #: pkg/machines/components/vmDisksTab.jsx:70
 msgid "Capacity"
 msgstr "Capacité"
@@ -1461,18 +1213,7 @@ msgstr "Capacité"
 msgid "Carrier"
 msgstr "Opérateur"
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Point de montage du système de fichiers Ceph"
-
-#: pkg/kubernetes/views/volume-body.html:97
-msgid "Ceph Monitors"
-msgstr "Moniteurs Ceph"
-
-#: pkg/docker/index.html:662 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
-#: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:333
+#: pkg/docker/index.html:664 pkg/systemd/index.html:333
 #: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
 #: pkg/storaged/iscsi-panel.jsx:181
 msgid "Change"
@@ -1498,31 +1239,19 @@ msgstr "Modifier le profil"
 msgid "Change System Time"
 msgstr "Modifier l’heure du système"
 
-#: pkg/kubernetes/views/user-modify.html:3
-msgid "Change User"
-msgstr "Modifier l’utilisateur"
-
 #: pkg/storaged/iscsi-panel.jsx:176
 msgid "Change iSCSI Initiator Name"
 msgstr "Modifier le nom de l’initiateur iSCSI"
-
-#: pkg/kubernetes/views/imagestream-modify.html:4
-msgid "Change image stream"
-msgstr "Modifier le flux d’image"
 
 #: pkg/storaged/crypto-keyslots.jsx:247
 msgid "Change passphrase"
 msgstr "Modifier la phrase de passe"
 
-#: pkg/kubernetes/views/project-modify.html:10
-msgid "Change project"
-msgstr "Modifier le projet"
-
-#: pkg/docker/index.html:228
+#: pkg/docker/index.html:229
 msgid "Change resource limits"
 msgstr "Modifier les limites de ressources"
 
-#: pkg/docker/index.html:612
+#: pkg/docker/index.html:614
 msgid "Change resources limits"
 msgstr "Modifier les limites de ressources"
 
@@ -1530,10 +1259,10 @@ msgstr "Modifier les limites de ressources"
 msgid "Change the settings"
 msgstr "Modifier les paramètres"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr ""
 "Ces modifications prendront effet après la prochaine extinction de la VM"
@@ -1582,25 +1311,13 @@ msgstr "Vérification des mises à jour…"
 msgid "Checking installed software"
 msgstr "Vérification des logiciels installés"
 
-#: pkg/shell/index.html:117 pkg/shell/simple.html:85 pkg/shell/stub.html:100
+#: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "Choisissez la langue à utiliser dans l’application"
 
 #: pkg/storaged/mdraids-panel.jsx:57
 msgid "Chunk Size"
 msgstr "Taille de bloc"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinder"
-
-#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
-msgid "Claim"
-msgstr "Requête"
-
-#: pkg/kubernetes/views/pvc-body.html:4
-msgid "Claim Name"
-msgstr "Nom de la requête"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Class"
@@ -1625,42 +1342,26 @@ msgstr ""
 "En cliquant sur \"Launch Remote Viewer\" (lancer l’afficheur à distance), "
 "vous téléchargerez un fichier .vv et le lancerez $0 ."
 
-#: pkg/kubernetes/views/auth-form.html:88
-msgid "Client Certificate"
-msgstr "Certificat client"
-
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr "Logiciel client"
 
-#: pkg/docker/index.html:736 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/systemd/index.html:278
-#: pkg/systemd/services.html:363 pkg/systemd/services.html:381
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:108 pkg/sosreport/index.js:45
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
 #: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Fermer"
 
 #: pkg/shell/active-pages.js:103
 msgid "Close Selected Pages"
 msgstr "Fermer les pages sélectionnées"
-
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
-#: pkg/ovirt/components/App.jsx:107
-msgid "Cluster"
-msgstr "Cluster"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:128
-msgid "Cluster Templates"
-msgstr "Modèles de cluster"
-
-#: pkg/ovirt/components/ClusterVms.jsx:174
-msgid "Cluster Virtual Machines"
-msgstr "Machines virtuelles de cluster"
 
 #: src/ws/login.js:346
 msgid "Cockpit authentication is configured incorrectly."
@@ -1703,7 +1404,7 @@ msgstr ""
 "via le terminal. De même, si une erreur se produit dans le terminal, elle "
 "s’affiche dans l’interface du journal Cockpit."
 
-#: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
+#: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr ""
 "Cockpit est une interface d’administration de serveur Linux interactive."
@@ -1741,10 +1442,10 @@ msgstr "Cockpit n’a pas pu contacter {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit n’a pas pu se connecter à {{#strong}}{{host}}{{/ strong}}. "
 "{{#can_sync}} Vous pouvez essayer de {{#sync_link}} synchroniser les "
@@ -1764,8 +1465,8 @@ msgid ""
 msgstr ""
 "Cockpit n’a pas pu se connecter à {{#strong}}{{host}}{{/ strong}}. Pour "
 "utiliser cette machine avec cockpit, vous devrez activer l’une des méthodes "
-"d’authentification suivantes dans la configuration de sshd sur "
-"{{#strong}}{{host}}{{/ strong}} :"
+"d’authentification suivantes dans la configuration de sshd sur {{#strong}}"
+"{{host}}{{/ strong}} :"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1792,13 +1493,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Utilisation combinée de $0 noyau CPU"
 msgstr[1] "Utilisation combinée de $0 noyaux CPU"
 
-#: pkg/networkmanager/firewall.jsx:527
+#: pkg/networkmanager/firewall.jsx:529
 msgid "Comma-separated ports, ranges, and aliases are accepted"
-msgstr ""
-"Plusieurs ports, pages et alias séparés par des virgules sont acceptés"
+msgstr "Plusieurs ports, pages et alias séparés par des virgules sont acceptés"
 
-#: pkg/docker/index.html:269 pkg/docker/index.html:445
-#: pkg/docker/index.html:706 pkg/systemd/services.html:427
+#: pkg/docker/index.html:271 pkg/docker/index.html:447
+#: pkg/docker/index.html:708 pkg/systemd/services.html:427
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1809,7 +1509,7 @@ msgstr "Commander"
 msgid "Command can't be empty"
 msgstr "La commande ne peut pas être vide"
 
-#: pkg/docker/index.html:163
+#: pkg/docker/index.html:164
 msgid "Command:"
 msgstr "Commande :"
 
@@ -1817,12 +1517,12 @@ msgstr "Commande :"
 msgid "Comment"
 msgstr "Commentaire"
 
-#: pkg/docker/index.html:137 pkg/docker/index.html:716
+#: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
 msgstr "Enregistrer"
 
-#: pkg/docker/index.html:676
+#: pkg/docker/index.html:678
 msgid "Commit Image"
 msgstr "Enregistrer l’image"
 
@@ -1846,8 +1546,8 @@ msgstr "Compatible avec les systèmes modernes et les disques durs> 2 To (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Compresser les vidages sur incident pour économiser de l’espace"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Compression"
 
@@ -1863,21 +1563,9 @@ msgstr "Condition $0 = $1 n’a pas été remplie"
 msgid "Condition failed"
 msgstr "Condition non remplie"
 
-#: pkg/kubernetes/views/node-add.html:24
-msgid "Configuration"
-msgstr "Configuration"
-
 #: pkg/networkmanager/interfaces.js:2725
 msgid "Configure"
 msgstr "Configurer"
-
-#: pkg/kubernetes/views/node-add.html:42
-msgid "Configure Flannel networking"
-msgstr "Configurer le réseau Flannel"
-
-#: pkg/kubernetes/views/node-add.html:32
-msgid "Configure Kubelet and Proxy"
-msgstr "Configurer Kubelet et Proxy"
 
 #: pkg/docker/storage.jsx:331
 msgid "Configure storage..."
@@ -1900,21 +1588,13 @@ msgstr "Confirmer"
 msgid "Confirm New Password"
 msgstr "Confirmer le nouveau mot de passe"
 
-#: pkg/ovirt/components/OVirtTab.jsx:65
-msgid "Confirm migration"
-msgstr "Confirmer la migration"
-
-#: pkg/ovirt/components/VdsmView.jsx:95
-msgid "Confirm reload:"
-msgstr "Confirmer le rechargement :"
+#: pkg/machines/components/networks/networkDelete.jsx:95
+msgid "Confirm deletion of the Virtual Network"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Confirm removal with passphrase"
 msgstr "Confirmer la suppression avec la phrase de passe"
-
-#: pkg/ovirt/components/VdsmView.jsx:108
-msgid "Confirm save:"
-msgstr "Confirmer l’enregistrement :"
 
 #: pkg/systemd/init.js:728
 msgid "Conflicted By"
@@ -1924,8 +1604,6 @@ msgstr "Conflit avec"
 msgid "Conflicts"
 msgstr "Conflits"
 
-#: pkg/kubernetes/views/auth-form.html:130
-#: pkg/kubernetes/views/auth-rejected-cert.html:33
 #: pkg/lib/machine-unknown-hostkey.html:22
 msgid "Connect"
 msgstr "Connecter"
@@ -1938,10 +1616,6 @@ msgstr "Connecter automatiquement"
 msgid "Connect to"
 msgstr "Se connecter à"
 
-#: pkg/ovirt/components/InstallationDialog.jsx:102
-msgid "Connect to oVirt Engine"
-msgstr "Se connectez à oVirt Engine"
-
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "Connect with any $0 viewer application."
 msgstr "Connectez-vous avec n’importe quel $0 application spectateur."
@@ -1951,7 +1625,7 @@ msgid "Connect with any SPICE or VNC viewer application."
 msgstr ""
 "Connectez-vous avec n’importe quelle application SPICE ou au VNC Viewer."
 
-#: pkg/machines/components/vnc.jsx:107
+#: pkg/machines/components/vnc.jsx:106
 msgid "Connecting"
 msgstr "Connexion en cours"
 
@@ -1974,33 +1648,21 @@ msgstr "Connexion au démon SETroubleshoot…"
 msgid "Connecting to Virtualization Service"
 msgstr "Connexion au service de virtualisation"
 
-#: pkg/shell/indexes.js:411
+#: pkg/shell/indexes.js:410
 msgid "Connecting to the machine"
 msgstr "Connexion à la machine"
 
-#: pkg/kubernetes/index.html:104 pkg/kubernetes/registry.html:71
-msgid "Connecting..."
-msgstr "Connexion en cours…"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:573
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Connexion"
 
-#: pkg/kubernetes/views/auth-dialog.html:4 pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:406
 msgid "Connection Error"
 msgstr "Erreur de connexion"
-
-#: pkg/kubernetes/scripts/connection.js:512
-msgid "Connection Error: $0"
-msgstr "Erreur de connexion : $0"
-
-#: pkg/kubernetes/views/auth-dialog.html:3
-msgid "Connection Settings"
-msgstr "Paramètres de connexion"
 
 #: src/base1/cockpit.js:4027
 msgid "Connection has timed out."
@@ -2022,34 +1684,23 @@ msgstr "Type de console"
 msgid "Consoles"
 msgstr "Consoles"
 
-#: pkg/realmd/operation.js:274
+#: pkg/realmd/operation.js:273
 msgid "Contacted domain"
 msgstr "Domaine contacté"
 
-#: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
-#: pkg/kubernetes/views/container-page-inline.html:2
-#: pkg/kubernetes/views/container-panel.html:4
-#: pkg/kubernetes/views/image-page.html:23
+#: pkg/docker/console.html:4
 #: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Conteneur"
 
-#: pkg/users/local.js:748
+#: pkg/users/local.js:752
 msgid "Container Administrator"
 msgstr "Administrateur de conteneur"
 
-#: pkg/kubernetes/views/container-body.html:10
-msgid "Container ID"
-msgstr "ID du conteneur"
-
-#: pkg/docker/index.html:438 pkg/docker/index.html:618
-#: pkg/docker/index.html:682
+#: pkg/docker/index.html:440 pkg/docker/index.html:620
+#: pkg/docker/index.html:684
 msgid "Container Name"
 msgstr "Nom du conteneur"
-
-#: pkg/kubernetes/views/node-body.html:21
-msgid "Container Runtime Version"
-msgstr "Version du runtime du conteneur"
 
 #: pkg/docker/util.js:506
 msgid ""
@@ -2062,15 +1713,12 @@ msgstr ""
 msgid "Container is currently running."
 msgstr "Le conteneur est en cours d’exécution."
 
-#: pkg/docker/index.html:141
+#: pkg/docker/index.html:133
 msgid "Container:"
 msgstr "Conteneur :"
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:287
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
-#: pkg/kubernetes/views/dashboard-page.html:158
-#: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:375
+#: pkg/docker/index.html:23 pkg/docker/index.html:289
+#: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "Conteneurs"
 
@@ -2084,12 +1732,12 @@ msgid "Content"
 msgstr "Contenu"
 
 #: src/base1/test-locale.js:42 src/base1/test-locale.js:53
-#: pkg/playground/translate.js:22
+#: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Contrôle"
 
 #: src/base1/test-locale.js:43 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:25
+#: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
 msgstr "Contrôle"
@@ -2103,7 +1751,6 @@ msgid "Copy"
 msgstr "Copier"
 
 #: pkg/machines/components/vcpuModal.jsx:209
-#: pkg/ovirt/components/vcpuModal.jsx:67
 msgid "Cores per socket"
 msgstr "Cores par socket"
 
@@ -2114,18 +1761,6 @@ msgstr "Impossible d’ajouter tous les disques"
 #: pkg/lib/machine-change-port.html:4
 msgid "Could not contact {{host}}"
 msgstr "Impossible de contacter {{host}}"
-
-#: pkg/kubernetes/views/dashboard-page.html:142
-msgid "Could not list services"
-msgstr "Impossible de répertorier les services"
-
-#: src/ws/cockpitcertificate.c:531
-msgid "Could not parse PEM-encoded certificate"
-msgstr "Impossible d’analyser le certificat codé PEM"
-
-#: src/ws/cockpitcertificate.c:498
-msgid "Could not parse PEM-encoded private key"
-msgstr "Impossible d’analyser la clé privée codée PEM"
 
 #: pkg/docker/storage.jsx:468
 msgid "Could not reset the storage pool"
@@ -2139,30 +1774,13 @@ msgstr "Impossible de modifier les groupes d’utilisateurs"
 msgid "Couldn't change user password"
 msgstr "Impossible de modifier le mot de passe utilisateur"
 
-#: pkg/kubernetes/index.html:105 pkg/kubernetes/registry.html:72
-msgid "Couldn't connect to server"
-msgstr "Impossible de se connecter au serveur"
-
-#: pkg/shell/indexes.js:414
+#: pkg/shell/indexes.js:413
 msgid "Couldn't connect to the machine"
 msgstr "Impossible de se connecter à la machine"
 
 #: src/bridge/cockpitdbussetup.c:544
 msgid "Couldn't create new users"
 msgstr "Impossible de créer de nouveaux utilisateurs"
-
-#: pkg/kubernetes/scripts/connection.js:510
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:957
-msgid "Couldn't find running API server"
-msgstr "Impossible de trouver le serveur d’API en cours d’exécution"
-
-#: pkg/subscriptions/subscriptions-view.jsx:218
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"Impossible d’obtenir le statut d’abonnement au système. Veuillez vous "
-"assurer que le gestionnaire d’abonnement est installé."
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -2184,14 +1802,12 @@ msgstr "Emplacement de vidage"
 msgid "Crash system"
 msgstr "Système de crash"
 
-#: pkg/kubernetes/views/add-group-dialog.html:19
-#: pkg/kubernetes/views/project-modify.html:72 pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:657
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:488
-#: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/users/index.html:199
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Créer"
 
@@ -2199,17 +1815,13 @@ msgstr "Créer"
 msgid "Create Logical Volume"
 msgstr "Créer un volume logique"
 
-#: pkg/machines/components/diskAdd.jsx:487
+#: pkg/machines/components/diskAdd.jsx:515
 msgid "Create New"
 msgstr "Créer Nouveau"
 
 #: pkg/users/index.html:52 pkg/users/index.html:163
 msgid "Create New Account"
 msgstr "Créer un nouveau compte"
-
-#: pkg/ovirt/components/App.jsx:162
-msgid "Create New VM"
-msgstr "Créer Nouvelle VM"
 
 #: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
 msgid "Create Partition"
@@ -2235,7 +1847,7 @@ msgstr "Créer Rapport"
 msgid "Create Snapshot"
 msgstr "Créer Instantané"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:522
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
 msgid "Create Storage Pool"
 msgstr "Création du pool de stockage"
 
@@ -2255,8 +1867,7 @@ msgstr "Créer des timers"
 msgid "Create VDO Device"
 msgstr "Créer Périphérique VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:690
-#: pkg/ovirt/components/ClusterTemplates.jsx:81
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
 msgid "Create VM"
 msgstr "Créer VM"
 
@@ -2268,14 +1879,6 @@ msgstr "Créer Groupe de volumes"
 msgid "Create diagnostic report"
 msgstr "Créer un rapport de diagnostic"
 
-#: pkg/kubernetes/scripts/images.js:643
-msgid "Create empty image stream"
-msgstr "Créer un flux d’images vide"
-
-#: pkg/kubernetes/views/imagestream-modify.html:3
-msgid "Create image stream"
-msgstr "Créer un flux d’images"
-
 #: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
 #: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
 msgid "Create it"
@@ -2285,16 +1888,12 @@ msgstr "Créez-le"
 msgid "Create new Logical Volume"
 msgstr "Créer un nouveau volume logique"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/kubernetes/views/replicationcontroller-body.html:7
-#: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:129
-#: pkg/docker/containers-view.jsx:412 pkg/docker/containers-view.jsx:683
+#: pkg/docker/containers-view.jsx:129 pkg/docker/containers-view.jsx:412
+#: pkg/docker/containers-view.jsx:683
 msgid "Created"
 msgstr "Créé"
 
-#: pkg/docker/index.html:152
+#: pkg/docker/index.html:153
 msgid "Created:"
 msgstr "Créé :"
 
@@ -2354,7 +1953,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Création d’un groupe de volumes $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:559
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
 msgid "Creation of VM $0 failed"
 msgstr "La création de la VM $0 a échoué"
 
@@ -2362,7 +1961,7 @@ msgstr "La création de la VM $0 a échoué"
 msgid "Critical and above"
 msgstr "Critique et au-dessus"
 
-#: pkg/machines/components/vnc.jsx:110
+#: pkg/machines/components/vnc.jsx:109
 msgid "Ctrl+Alt+Del"
 msgstr "Ctrl+Alt+Del"
 
@@ -2382,23 +1981,19 @@ msgstr "Boot actuel"
 msgid "Custom"
 msgstr "Personnalisé"
 
-#: pkg/networkmanager/firewall.jsx:521
+#: pkg/networkmanager/firewall.jsx:523
 msgid "Custom Ports"
 msgstr "Ports personnalisés"
-
-#: pkg/subscriptions/subscriptions-register.jsx:103
-msgid "Custom URL"
-msgstr "URL personnalisée"
 
 #: pkg/storaged/format-dialog.jsx:118
 msgid "Custom encryption options"
 msgstr "Options de chiffrement personnalisées"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Options de montage personnalisées"
 
-#: pkg/networkmanager/firewall.jsx:716
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Custom zones"
 msgstr "Zones personnalisées"
 
@@ -2418,10 +2013,6 @@ msgstr "DNS"
 #: pkg/networkmanager/interfaces.js:2656
 msgid "DNS $val"
 msgstr "DNS $val"
-
-#: pkg/kubernetes/views/pod-body.html:14
-msgid "DNS Policy"
-msgstr "Stratégie DNS"
 
 #: pkg/networkmanager/interfaces.js:3320
 msgid "DNS Search Domains"
@@ -2443,8 +2034,8 @@ msgstr "Tableau de bord"
 msgid "Data Used"
 msgstr "Données utilisées"
 
-#: pkg/machines/components/networks/network.jsx:143
-#: pkg/machines/components/storagePools/storagePool.jsx:163
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Désactiver"
@@ -2465,10 +2056,9 @@ msgstr "Débogage et au-dessus"
 msgid "Deduplication"
 msgstr "Déduplication"
 
-#: pkg/docker/index.html:357 pkg/docker/index.html:361
+#: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: node_modules/registry-image-widgets/views/image-config.html:10
 #: pkg/storaged/format-dialog.jsx:68
-#: pkg/subscriptions/subscriptions-register.jsx:102
 msgid "Default"
 msgstr "Par défaut"
 
@@ -2476,37 +2066,26 @@ msgstr "Par défaut"
 msgid "Delay"
 msgstr "Retard"
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:246
-#: pkg/kubernetes/views/image-delete.html:8
-#: pkg/kubernetes/views/imagestream-delete.html:8
-#: pkg/kubernetes/views/item-delete.html:11
-#: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/project-delete.html:9
-#: pkg/kubernetes/views/pv-delete.html:11
-#: pkg/kubernetes/views/pvc-delete.html:15
-#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/machines/components/networks/networkDelete.jsx:86
+#: pkg/machines/components/networks/networkDelete.jsx:103
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:300 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:214 pkg/storaged/vgroup-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Supprimer"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1179
+#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Supprimer $0"
-
-#: pkg/playground/translate.html:189
-msgid "Delete '{{ name }}'"
-msgstr "Supprimer « {{nom}} »"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
 msgid "Delete Content"
@@ -2516,25 +2095,10 @@ msgstr "Supprimer le contenu"
 msgid "Delete Files"
 msgstr "Supprimer les fichiers"
 
-#: pkg/kubernetes/views/node-delete.html:4
-msgid "Delete Node"
-msgstr "Supprimer le nœud"
-
-#: pkg/kubernetes/views/pv-delete.html:3
-msgid "Delete Persistent Volume"
-msgstr "Supprimer le volume persistant"
-
-#: pkg/kubernetes/views/pvc-delete.html:3
-msgid "Delete Persistent Volume Claim"
-msgstr "Supprimer la requête de volume persistant"
-
-#: pkg/kubernetes/views/project-delete.html:3
-msgid "Delete Project"
-msgstr "Supprimer le projet"
-
-#: pkg/kubernetes/views/nodes-page.html:3
-msgid "Delete Selected"
-msgstr "Supprimer la sélection"
+#: pkg/machines/components/networks/networkDelete.jsx:92
+#, fuzzy
+msgid "Delete Network $0"
+msgstr "Supprimer $0"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
 msgid "Delete Storage Pool $0"
@@ -2544,17 +2108,9 @@ msgstr "Supprimer le pool de stockage $0"
 msgid "Delete associated storage files:"
 msgstr "Supprimer les fichiers de stockage associés :"
 
-#: pkg/kubernetes/views/imagestream-delete.html:3
-msgid "Delete image stream"
-msgstr "Supprimer le flux d’images"
-
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
 msgid "Delete the Volumes inside this Pool"
 msgstr "Supprimer les volumes de ce pool"
-
-#: pkg/kubernetes/views/item-delete.html:3
-msgid "Delete {{ item.kind }}"
-msgstr "Supprimer {{item.kind}}"
 
 #: pkg/storaged/jobs-panel.jsx:53 pkg/storaged/jobs-panel.jsx:67
 msgid "Deleting $target"
@@ -2568,15 +2124,7 @@ msgstr ""
 "La suppression de <b>$0</b> interrompra la connexion au serveur et rendra "
 "l’interface utilisateur d’administration indisponible."
 
-#: pkg/kubernetes/views/item-delete.html:7
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-"Supprimer un Pod va tuer tous les conteneurs associés. Les pods peuvent être "
-"automatiquement créés à nouveau dans certains cas."
-
-#: pkg/storaged/mdraid-details.jsx:301
+#: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
 msgstr ""
 "La suppression d’un périphérique RAID effacera toutes les données qu’il "
@@ -2586,7 +2134,7 @@ msgstr ""
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Supprimer un appareil VDO effacera toutes les données qu’il contient."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "Supprimer un conteneur effacera toutes les données qu’il contient."
 
@@ -2601,7 +2149,7 @@ msgid "Deleting a partition will delete all data in it."
 msgstr ""
 "Supprimer une partition supprimera toutes les données qui s’y trouvent."
 
-#: pkg/storaged/vgroup-details.jsx:213
+#: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
 msgstr ""
 "La suppression d’un groupe de volumes effacera toutes les données qu’il "
@@ -2619,44 +2167,11 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Suppression du groupe de volumes $target"
 
-#: pkg/kubernetes/views/dashboard-page.html:131
-#: pkg/kubernetes/views/deploy.html:62
-msgid "Deploy"
-msgstr "Déployer"
-
-#: pkg/kubernetes/views/deploy.html:3
-msgid "Deploy Application"
-msgstr "Déployer l’application"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:22
-msgid "Deployment Causes"
-msgstr "Causes du déploiement"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:12
-#: pkg/kubernetes/views/deploymentconfig-panel.html:8
-msgid "Deployment Config"
-msgstr "Configuration du déploiement"
-
-#: pkg/kubernetes/views/details-page.html:98
-#: pkg/kubernetes/scripts/details.js:220
-msgid "Deployment Configs"
-msgstr "Configurations de déploiement"
-
-#: pkg/kubernetes/views/project-listing.html:15
-#: pkg/kubernetes/views/project-listing.html:54
-#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:413
+#: pkg/systemd/services.html:413
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:725
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
 msgid "Description"
 msgstr "La description"
-
-#: pkg/ovirt/components/OVirtTab.jsx:146
-#: pkg/ovirt/components/VmOverviewColumn.jsx:52
-msgid "Description:"
-msgstr "Description :"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2666,16 +2181,15 @@ msgstr "Bureau"
 msgid "Detachable"
 msgstr "Détachable"
 
-#: pkg/kubernetes/index.html:67 pkg/shell/index.html:229
-#: pkg/docker/containers-view.jsx:336 pkg/docker/containers-view.jsx:504
-#: pkg/docker/containers-view.jsx:514 pkg/docker/containers-view.jsx:642
-#: pkg/networkmanager/firewall.jsx:94 pkg/packagekit/updates.jsx:383
-#: pkg/subscriptions/subscriptions-view.jsx:232 pkg/systemd/host.js:745
+#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
+#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Détails"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2697,7 +2211,6 @@ msgstr "Rapports de diagnostic"
 msgid "Digest"
 msgstr "Digest"
 
-#: pkg/kubernetes/views/volume-body.html:28
 #: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
@@ -2728,8 +2241,8 @@ msgstr "Désactivé"
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:108
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:604
+#: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
+#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
 msgid "Disconnected"
 msgstr "Déconnecté"
 
@@ -2737,7 +2250,6 @@ msgstr "Déconnecté"
 msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr "Déconnecté de la console série. Cliquez sur le bouton Reconnecter."
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:836
 #: pkg/storaged/vdos-panel.jsx:55
 msgid "Disk"
 msgstr "Disque"
@@ -2750,15 +2262,11 @@ msgstr "Échec du détachement du disque $0 de la VM $1"
 msgid "Disk I/O"
 msgstr "E / S disque"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Utilisation du disque : $0 %"
-
-#: pkg/machines/components/diskAdd.jsx:461
+#: pkg/machines/components/diskAdd.jsx:489
 msgid "Disk failed to be attached"
 msgstr "Le disque n’a pas pu être attaché"
 
-#: pkg/machines/components/diskAdd.jsx:443
+#: pkg/machines/components/diskAdd.jsx:468
 msgid "Disk failed to be created"
 msgstr "Le disque n’a pas pu être créé"
 
@@ -2770,9 +2278,9 @@ msgstr "Le disque est OK"
 msgid "Disk passphrase"
 msgstr "Phrase de passe du disque"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Disques"
 
@@ -2781,61 +2289,9 @@ msgid "Disks cannot be removed from $0 VMs"
 msgstr "Les disques n'ont pu être retirés de $0 VMs"
 
 #: pkg/shell/index.html:52 pkg/shell/index.html:114 pkg/shell/simple.html:38
-#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
+#: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Langue d’affichage"
-
-#: pkg/kubernetes/views/project-modify.html:31
-msgid "Display name"
-msgstr "Afficher un nom"
-
-#: pkg/kubernetes/views/add-role-dialog.html:5
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "Voulez-vous ajouter le rôle « {{fields.displayRole}} » ?"
-
-#: pkg/kubernetes/views/imagestream-delete.html:5
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"Voulez-vous supprimer le flux d’image « {{stream.metadata.namespace}} / "
-"{{stream.metadata.name}} » ?"
-
-#: pkg/kubernetes/views/pv-delete.html:6
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr ""
-"Voulez-vous supprimer le volume persistant « {{item.metadata.name}} » ?"
-
-#: pkg/kubernetes/views/pvc-delete.html:6
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-"Voulez-vous supprimer la requête de volume persistant « {{item.metadata."
-"name}}’ »"
-
-#: pkg/kubernetes/views/item-delete.html:6
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "Voulez-vous supprimer le {{item.kind}} « {{item.metadata.name}} » ?"
-
-#: pkg/kubernetes/views/node-delete.html:7
-msgid "Do you want to delete this Node?"
-msgstr "Voulez-vous supprimer ce nœud ?"
-
-#: pkg/kubernetes/views/image-delete.html:5
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"Voulez-vous supprimer l’image intitulée « {{stream.metadata.namespace}} / "
-"{{stream.metadata.name}} : {{tag.tag}} » ?"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:5
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
-msgstr ""
-"Voulez-vous supprimer le rôle « {{fields.displayRole}} » du membre {{fields."
-"member.metadata.name}} ?"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2850,15 +2306,15 @@ msgid "Docking Station"
 msgstr "Station d’accueil"
 
 #: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
-#: pkg/realmd/operation.js:123
+#: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Domaine"
 
-#: pkg/realmd/operation.js:192
+#: pkg/realmd/operation.js:191
 msgid "Domain $0 could not be contacted"
 msgstr "Le domaine $0 n’a pas pu être contacté"
 
-#: pkg/realmd/operation.js:279
+#: pkg/realmd/operation.js:278
 msgid "Domain $0 is not supported"
 msgstr "Le domaine $0 n’est pas pris en charge"
 
@@ -2883,15 +2339,11 @@ msgstr "Ne pas répéter"
 msgid "Don't overwrite existing data"
 msgstr "Ne pas écraser les données existantes"
 
-#: pkg/kubernetes/scripts/images.js:633
-msgid "Don't pull images automatically"
-msgstr "Ne pas tirer les images automatiquement"
-
 #: pkg/sosreport/index.html:63
 msgid "Done!"
 msgstr "Terminé !"
 
-#: pkg/docker/index.html:598
+#: pkg/docker/index.html:600
 msgid "Download"
 msgstr "Télécharger"
 
@@ -2928,11 +2380,7 @@ msgctxt "storage"
 msgid "Drive"
 msgstr "Lecteur"
 
-#: pkg/kubernetes/views/volume-body.html:128
-msgid "Driver"
-msgstr "Pilote"
-
-#: pkg/storaged/drives-panel.jsx:119
+#: pkg/storaged/drives-panel.jsx:120
 msgid "Drives"
 msgstr "Lecteur"
 
@@ -2961,10 +2409,6 @@ msgstr "Modifier le serveur de clés Tang"
 msgid "Edit image stream"
 msgstr "Modifier le flux d’images"
 
-#: pkg/ovirt/components/VdsmView.jsx:125
-msgid "Edit the vdsm.conf"
-msgstr "Modifier le fichier vdsm.conf"
-
 #: pkg/storaged/crypto-keyslots.jsx:535
 msgid "Editing a key requires a free slot"
 msgstr "La modification d’une clé nécessite un emplacement libre"
@@ -2978,25 +2422,21 @@ msgid "Embedded PC"
 msgstr "PC intégré"
 
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:13
+#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Vide"
 
 #: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:19
+#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Vide"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Répertoire vide"
 
 #: pkg/storaged/jobs-panel.jsx:75
 msgid "Emptying $target"
 msgstr "$target en cours de vidage"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:151
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:162
 msgid "Emulated Machine"
 msgstr "Machine émulée"
 
@@ -3059,23 +2499,6 @@ msgstr "Chiffrement"
 msgid "Encryption Options"
 msgstr "Options de chiffrement"
 
-#: pkg/kubernetes/views/pv-modify.html:93
-msgid "Endpoint"
-msgstr "Point d’accès"
-
-#: pkg/kubernetes/views/volume-body.html:40
-msgid "Endpoint Name"
-msgstr "Nom du point d’accès"
-
-#: pkg/kubernetes/views/service-page.html:14
-#: pkg/kubernetes/views/service-panel.html:9
-msgid "Endpoints"
-msgstr "Points d’accès"
-
-#: pkg/subscriptions/subscriptions-view.jsx:39
-msgid "Ends"
-msgstr "Se termine"
-
 #: pkg/selinux/setroubleshoot-view.jsx:299
 msgid "Enforce policy:"
 msgstr "Appliquer la stratégie :"
@@ -3088,10 +2511,6 @@ msgstr "Mises à jour des améliorations disponibles"
 msgid "Enter IP address or host name"
 msgstr "Saisir l’adresse IP ou le nom d’hôte"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:74
-msgid "Enter New VM name"
-msgstr "Saisir le nom de la nouvelle machine virtuelle"
-
 #: pkg/lib/machine-change-auth.html:57
 msgid ""
 "Entering a different password here means you will need to retype it every "
@@ -3100,7 +2519,7 @@ msgstr ""
 "Saisir un mot de passe différent signifie que vous devrez le ressaisir à "
 "chaque fois que vous vous reconnectez à cette machine"
 
-#: pkg/networkmanager/firewall.jsx:752
+#: pkg/networkmanager/firewall.jsx:754
 msgid "Entire subnet"
 msgstr "Ensemble du sous-réseau"
 
@@ -3112,7 +2531,7 @@ msgstr "Entrée"
 msgid "Entrypoint"
 msgstr "Point d’accès"
 
-#: pkg/docker/index.html:526 pkg/kubernetes/views/container-body.html:26
+#: pkg/docker/index.html:528
 #: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Environnement"
@@ -3134,19 +2553,15 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1472
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Erreur"
 
 #: pkg/systemd/logs.html:59
 msgid "Error and above"
 msgstr "Erreur et au-dessus"
-
-#: pkg/kubernetes/scripts/connection.js:646
-msgid "Error getting certificate details: $0"
-msgstr "Erreur lors de l’obtention des détails du certificat : $0"
 
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
@@ -3168,10 +2583,6 @@ msgstr "Erreur lors de la suppression de l’alerte : $0"
 msgid "Error while setting SELinux mode: '$0'"
 msgstr "Erreur lors du réglage du mode SELinux: $0"
 
-#: pkg/kubernetes/scripts/connection.js:85
-msgid "Error writing kubectl config"
-msgstr "Erreur lors de l’écriture de la configuration de kubectl"
-
 #: pkg/networkmanager/index.html:658
 msgid "Ethernet MAC"
 msgstr "Ethernet MAC"
@@ -3188,23 +2599,23 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Tout"
 
-#: pkg/networkmanager/firewall.jsx:534
+#: pkg/networkmanager/firewall.jsx:536
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "Exemple : 22,ssh,8080,5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:542
+#: pkg/networkmanager/firewall.jsx:544
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "Exemple : 88,2019,nfs,rsync"
 
-#: pkg/users/local.js:473 pkg/users/local.js:1417
+#: pkg/users/local.js:477 pkg/users/local.js:1421
 msgid "Excellent password"
 msgstr "Excellent mot de passe"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:222
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
 msgid "Existing Disk Image"
 msgstr "Image disque existante"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 msgid "Existing disk image on host's file system"
 msgstr "Image disque existante sur le système de fichiers de l’hôte"
 
@@ -3216,7 +2627,7 @@ msgstr "Sortie $ExitCode"
 msgid "Expansion Chassis"
 msgstr "Châssis d’extension"
 
-#: pkg/docker/index.html:508
+#: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "Exposer les ports conteneurs"
 
@@ -3228,14 +2639,6 @@ msgstr "Partition étendue"
 msgid "FAILED"
 msgstr "ÉCHOUÉ"
 
-#: pkg/ovirt/provider.js:130
-msgid "FORCEOFF action failed: $0"
-msgstr "L’action FORCEOFF a échoué : $0"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:47
-msgid "FQDN"
-msgstr "FQDN"
-
 #: pkg/networkmanager/interfaces.js:842
 msgid "Failed"
 msgstr "Échoué"
@@ -3245,14 +2648,19 @@ msgid "Failed to add machine: $0"
 msgstr "Échec de l’ajout de la machine : $0"
 
 #: pkg/networkmanager/firewall.jsx:237
+#, fuzzy
+msgid "Failed to add port"
+msgstr "N'a pas pu ajouter de zone"
+
+#: pkg/networkmanager/firewall.jsx:237
 msgid "Failed to add service"
 msgstr "N'a pas pu ajouter le service"
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:679
 msgid "Failed to add zone"
 msgstr "N'a pas pu ajouter de zone"
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Échec de la modification du mot de passe"
 
@@ -3276,11 +2684,15 @@ msgstr "Échec de la modification de la machine : $0"
 msgid "Failed to enable tuned"
 msgstr "Échec de l’activation de tuned"
 
+#: pkg/machines/components/vmnetworktab.jsx:55
+msgid "Failed to fetch the IP addresses of the interfaces present in $0"
+msgstr ""
+
 #: pkg/users/index.html:393
 msgid "Failed to load authorized keys."
 msgstr "Échec du chargement des clés autorisées."
 
-#: pkg/networkmanager/firewall.jsx:589
+#: pkg/networkmanager/firewall.jsx:591
 msgid "Failed to remove service"
 msgstr "N'a pas pu supprimer le service"
 
@@ -3299,10 +2711,6 @@ msgstr "Échec du changement de profil"
 #: pkg/machines/components/vcpuModal.jsx:193
 msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr "On ne doit pas activer un nombre de CPU supérieur au nombre maximum."
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "Fibre Channel"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:92
 #: pkg/machines/components/vmDiskColumns.jsx:42
@@ -3325,22 +2733,11 @@ msgstr "Montage du système de fichiers"
 msgid "Filesystem Name"
 msgstr "Nom du système de fichiers"
 
-#: pkg/kubernetes/views/pv-modify.html:181
-#: pkg/kubernetes/views/volume-body.html:6
-#: pkg/kubernetes/views/volume-body.html:16
-#: pkg/kubernetes/views/volume-body.html:62
-#: pkg/kubernetes/views/volume-body.html:83
-#: pkg/kubernetes/views/volume-body.html:91
-#: pkg/kubernetes/views/volume-body.html:120
-#: pkg/kubernetes/views/volume-body.html:132
-msgid "Filesystem Type"
-msgstr "Type de système de fichiers"
-
 #: pkg/storaged/fsys-panel.jsx:103
 msgid "Filesystems"
 msgstr "Systèmes de fichiers"
 
-#: pkg/networkmanager/firewall.jsx:490
+#: pkg/networkmanager/firewall.jsx:491
 msgid "Filter Services"
 msgstr "Services de filtrage"
 
@@ -3348,30 +2745,18 @@ msgstr "Services de filtrage"
 msgid "Filter by name or description..."
 msgstr "Filtrer par nom ou description…"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Empreinte digitale"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:913 pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
 msgid "Firewall"
 msgstr "Pare-feu"
 
-#: pkg/networkmanager/firewall.jsx:861
+#: pkg/networkmanager/firewall.jsx:863
 msgid "Firewall is not available"
 msgstr "Le pare-feu n’est pas disponible"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/views/volume-body.html:125
-msgid "Flocker Dataset Name"
-msgstr "Nom du jeu de données Flocker"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:35
 msgid "Follows docker repo"
@@ -3405,10 +2790,9 @@ msgstr "Forcer la modification de mot de passe"
 msgid "Force remove passphrase in $0"
 msgstr "Suppression de la phrase de passe forcée dans $0"
 
-#: pkg/machines/components/diskAdd.jsx:167
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:258
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formater"
 
@@ -3471,11 +2855,7 @@ msgstr "De"
 msgid "Full Name"
 msgstr "Nom complet"
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "Disque persistant GCE"
-
-#: pkg/docker/index.html:183
+#: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "Gateway :"
 
@@ -3492,25 +2872,13 @@ msgstr "Générer un rapport"
 msgid "Get new image"
 msgstr "Obtenir une nouvelle image"
 
-#: pkg/machines/components/diskAdd.jsx:162
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Référentiel Git"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster FS"
-
-#: pkg/kubernetes/scripts/volumes.js:877
-msgid "GlusterFS"
-msgstr "GlusterFS"
 
 #: pkg/systemd/logs.js:199
 msgid "Go to"
@@ -3526,13 +2894,6 @@ msgstr "Aller à l’application"
 msgid "Go to now"
 msgstr "Aller à maintenant"
 
-#: pkg/kubernetes/views/project-body.html:3
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Grant additional push or admin access to specific members below."
-msgstr ""
-"Accordez un accès push ou admin supplémentaire à des membres spécifiques ci-"
-"dessous."
-
 #: pkg/machines/components/consoles.jsx:51
 msgid "Graphics Console (VNC)"
 msgstr "Console graphique (VNC)"
@@ -3540,20 +2901,6 @@ msgstr "Console graphique (VNC)"
 #: pkg/machines/components/consoles.jsx:60
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Console graphique dans la visionneuse de bureau"
-
-#: pkg/kubernetes/views/group-page.html:21
-#: pkg/kubernetes/views/group-panel.html:12
-msgid "Group Members"
-msgstr "Les membres du groupe"
-
-#: pkg/kubernetes/views/user-add-membership.html:9
-msgid "Group or Project"
-msgstr "Groupe ou projet"
-
-#: pkg/kubernetes/views/project-listing.html:48
-#: pkg/kubernetes/views/user-delete.html:14
-msgid "Groups"
-msgstr "Groupes"
 
 #: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
 #: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
@@ -3576,15 +2923,6 @@ msgstr "Augmenter la taille logique de $0"
 #: pkg/storaged/vdo-details.jsx:130
 msgid "Grow to take all space"
 msgstr "Augmenter en vue de prendre tout l’espace"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "HA"
-msgstr "HA"
-
-#: pkg/ovirt/components/OVirtTab.jsx:128
-msgid "HA:"
-msgstr "HA :"
 
 #: pkg/networkmanager/index.html:252
 msgid "Hair Pin mode"
@@ -3619,19 +2957,14 @@ msgstr "Informations sur le matériel"
 msgid "Hello time $hello_time"
 msgstr "Bonjour $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Hide Performance Options"
 msgstr "Masquer les options de performance"
 
-#: pkg/kubernetes/views/details-page.html:73
-#: pkg/kubernetes/views/route-body.html:9
-#: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:150
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47
-#: pkg/ovirt/components/App.jsx:103 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:334
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Hôte"
 
@@ -3640,29 +2973,21 @@ msgid "Host Device"
 msgstr "Périphérique hôte"
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:155
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
 msgid "Host Name"
 msgstr "Nom d’hôte"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:869
-msgid "Host Path"
-msgstr "Chemin d’hôte"
 
 #: src/base1/cockpit.js:4023
 msgid "Host key is incorrect"
 msgstr "La clé de l’hôte est incorrecte"
 
-#: pkg/realmd/operation.js:602
+#: pkg/realmd/operation.js:601
 msgid "Host name should not be changed in a domain"
 msgstr "Le nom de l’hôte ne devrait pas être changé dans un domaine"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:161
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
 msgid "Host should not be empty"
 msgstr "Le nom d’hôte n’est peut-être pas vide"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:75
-msgid "Host to Maintenance"
-msgstr "Hôte à la maintenance"
 
 #: pkg/systemd/services.html:499
 msgid "Hour : Minute"
@@ -3680,24 +3005,20 @@ msgstr "Heures"
 msgid "I/O Wait"
 msgstr "I / O Attente"
 
-#: pkg/kubernetes/views/node-body.html:10
-#: pkg/kubernetes/views/service-body.html:9
-msgid "IP"
-msgstr "IP"
-
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
+#: pkg/machines/components/vmnetworktab.jsx:133
 msgid "IP Address"
 msgstr "Adresse IP"
 
-#: pkg/docker/index.html:175
+#: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "Adresse IP :"
 
-#: pkg/docker/index.html:179
+#: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "Longueur du préfixe IP :"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "IP Range"
 msgstr "Gamme d'adresses IP"
 
@@ -3729,10 +3050,6 @@ msgstr "Adresse IPv6"
 msgid "IPv6 Settings"
 msgstr "Paramètres IPv6"
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:873
-msgid "ISCSI"
-msgstr "ISCSI"
-
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
@@ -3741,7 +3058,7 @@ msgstr "Id"
 msgid "Id $id"
 msgstr "Id $id"
 
-#: pkg/docker/index.html:148
+#: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "Id :"
 
@@ -3749,17 +3066,6 @@ msgstr "Id :"
 #: node_modules/registry-image-widgets/views/image-listing.html:7
 msgid "Identifier"
 msgstr "Identifiant"
-
-#: pkg/kubernetes/views/user-page.html:22
-#: pkg/kubernetes/views/user-panel.html:18
-msgid "Identities"
-msgstr "Identités"
-
-#: pkg/kubernetes/views/add-user-dialog.html:17
-#: pkg/kubernetes/views/project-listing.html:91
-#: pkg/kubernetes/views/user-modify.html:17
-msgid "Identity"
-msgstr "Identité"
 
 #: pkg/storaged/crypto-keyslots.jsx:325
 msgid "If tang-show-keys is not available, run the following:"
@@ -3769,9 +3075,7 @@ msgstr "Si tang-show-keys n’est pas disponible, exécutez ce qui suit :"
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: pkg/docker/index.html:268 pkg/docker/index.html:431
-#: pkg/kubernetes/views/container-body.html:6
-#: pkg/kubernetes/views/image-page.html:15
+#: pkg/docker/index.html:270 pkg/docker/index.html:433
 #: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
@@ -3781,33 +3085,13 @@ msgstr "Image"
 msgid "Image $0"
 msgstr "Image $0"
 
-#: pkg/users/local.js:749
+#: pkg/users/local.js:753
 msgid "Image Builder"
 msgstr "Image Builder"
 
-#: pkg/kubernetes/views/container-body.html:8
-msgid "Image ID"
-msgstr "ID de l’image"
-
-#: pkg/kubernetes/views/volume-body.html:58
-msgid "Image Name"
-msgstr "Nom de l’image"
-
-#: pkg/kubernetes/registry.html:23
-msgid "Image Registry"
-msgstr "Registre d’images"
-
-#: pkg/docker/index.html:578
+#: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Recherche d’image"
-
-#: pkg/kubernetes/views/imagestream-page.html:16
-msgid "Image Stream"
-msgstr "Flux d’images"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:135
-msgid "Image commands"
-msgstr "Commandes d’image"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:41
 msgid "Image count"
@@ -3817,14 +3101,10 @@ msgstr "Nombre d’images"
 msgid "Image stream"
 msgstr "Flux d’images"
 
-#: pkg/docker/index.html:156
+#: pkg/docker/index.html:157
 msgid "Image:"
 msgstr "Image :"
 
-#: pkg/kubernetes/index.html:81 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
-#: pkg/kubernetes/views/registry-dashboard-page.html:19
 #: pkg/docker/containers-view.jsx:711
 msgid "Images"
 msgstr "Images"
@@ -3838,10 +3118,6 @@ msgstr "Images"
 msgid "Images and running containers"
 msgstr "Images et conteneurs en cours"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:17
-msgid "Images by project"
-msgstr "Images par projet"
-
 #: node_modules/registry-image-widgets/views/imagestream-body.html:15
 #: node_modules/registry-image-widgets/views/imagestream-body.html:16
 msgid "Images may be pulled by anonymous users"
@@ -3851,8 +3127,7 @@ msgstr "Les images peuvent être extraites par des utilisateurs anonymes"
 #: node_modules/registry-image-widgets/views/imagestream-body.html:21
 msgid "Images may be pulled by any authenticated user or group"
 msgstr ""
-"Les images peuvent être extraites par un utilisateur ou un groupe "
-"authentifié"
+"Les images peuvent être extraites par un utilisateur ou un groupe authentifié"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:25
 #: node_modules/registry-image-widgets/views/imagestream-body.html:26
@@ -3861,11 +3136,7 @@ msgstr ""
 "Les images peuvent uniquement être extraites par des utilisateurs ou des "
 "groupes spécifiques"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:54
-msgid "Images pushed recently"
-msgstr "Images poussées récemment"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:637
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
 msgstr "Démarrer immédiatement la VM"
 
@@ -3873,7 +3144,7 @@ msgstr "Démarrer immédiatement la VM"
 msgid "In Sync"
 msgstr "En sync"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:171
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3881,28 +3152,13 @@ msgstr ""
 "Dans la plupart des configurations, macvtap ne fonctionne pas pour les "
 "communications en réseau entre hôte et invité."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:81
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-"Pour commencer à pousser les images dans le registre, utilisez les commandes "
-"ci-dessous."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:6
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr ""
-"Afin de commencer à pousser les images dans le registre, vous devez créer un "
-"projet."
-
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Pour synchroniser les utilisateurs, vous devez vous connecter à "
-"{{#strong}}{{host}}{{/strong}}."
+"Pour synchroniser les utilisateurs, vous devez vous connecter à {{#strong}}"
+"{{host}}{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
 #: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
@@ -3913,7 +3169,7 @@ msgstr "Inactif"
 msgid "Inactive volume"
 msgstr "Volume inactif"
 
-#: pkg/networkmanager/firewall.jsx:730
+#: pkg/networkmanager/firewall.jsx:732
 msgid "Included services"
 msgstr "services inclus"
 
@@ -3938,17 +3194,17 @@ msgstr ""
 msgid "Initializing..."
 msgstr "Initialisation…"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:177
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
 msgid "Initiator"
 msgstr "Initiateur"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:188
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
 msgid "Initiator IQN should not be empty"
 msgstr "L'initiateur IQN ne doit pas rester vide"
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Installer"
 
@@ -3976,25 +3232,21 @@ msgstr "Installer la prise en charge de VDO"
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "Installez setroubleshoot-server pour dépanner les événements SELinux."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:226
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
 msgid "Installation Source"
 msgstr "Source d’installation"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:212
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
 msgid "Installation Source Type"
 msgstr "Type de source d’installation"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:113
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
 msgid "Installation Source should not be empty"
 msgstr "La source d’installation ne doit pas être vide"
 
 #: pkg/packagekit/updates.jsx:59
 msgid "Installed"
 msgstr "installée"
-
-#: pkg/subscriptions/subscriptions-view.jsx:245
-msgid "Installed products"
-msgstr "Produits installés"
 
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:51
@@ -4009,17 +3261,13 @@ msgstr "Installation de $0"
 msgid "Instantiate"
 msgstr "Instancier"
 
-#: pkg/kubernetes/views/pv-modify.html:170
-#: pkg/kubernetes/views/volume-body.html:81
-msgid "Interface"
-msgstr "Interface"
-
 #: pkg/machines/components/nicEdit.jsx:123
 msgid "Interface Type"
 msgstr "Type d’interface"
 
-#: pkg/networkmanager/index.html:108 pkg/networkmanager/firewall.jsx:735
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Interfaces"
 
@@ -4035,15 +3283,11 @@ msgstr "Erreur interne"
 msgid "Invalid address $0"
 msgstr "Adresse non valide $0"
 
-#: pkg/subscriptions/subscriptions-client.js:195
-msgid "Invalid credentials"
-msgstr "Identifiants invalides"
-
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Format de date non valide"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Format de date non valide et format d’heure non valide"
 
@@ -4051,7 +3295,7 @@ msgstr "Format de date non valide et format d’heure non valide"
 msgid "Invalid date format."
 msgstr "Format de date incorrect"
 
-#: pkg/users/local.js:1237
+#: pkg/users/local.js:1241
 msgid "Invalid expiration date"
 msgstr "Date d’expiration non valide"
 
@@ -4059,7 +3303,7 @@ msgstr "Date d’expiration non valide"
 msgid "Invalid file permissions"
 msgstr "Les autorisations de fichier ne sont pas valides"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
 msgid "Invalid filename"
 msgstr "Nom de fichier non valide"
 
@@ -4071,7 +3315,7 @@ msgstr "Clé non valide"
 msgid "Invalid metric $0"
 msgstr "Métrique non valide $0"
 
-#: pkg/users/local.js:1313
+#: pkg/users/local.js:1317
 msgid "Invalid number of days"
 msgstr "Nombre de jours non valide"
 
@@ -4099,7 +3343,7 @@ msgstr "Préfixe ou masque de réseau non valide $0"
 msgid "Invalid range"
 msgstr "Plage invalide"
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Format d’heure non valide"
 
@@ -4108,7 +3352,6 @@ msgid "Invalid time zone"
 msgstr "Fuseau horaire non valide"
 
 #: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
-#: pkg/subscriptions/subscriptions-client.js:193
 msgid "Invalid username or password"
 msgstr "Nom d’utilisateur ou mot de passe non valide"
 
@@ -4128,19 +3371,19 @@ msgstr "Réseau isolé"
 msgid "Jobs"
 msgstr "Jobs"
 
-#: pkg/realmd/operation.js:117
+#: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "Joindre"
 
-#: pkg/realmd/operation.js:597
+#: pkg/realmd/operation.js:596
 msgid "Join Domain"
 msgstr "Joindre un domaine"
 
-#: pkg/realmd/operation.js:116
+#: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "Rejoignez un domaine"
 
-#: pkg/realmd/operation.js:506
+#: pkg/realmd/operation.js:505
 msgid "Joining this domain is not supported"
 msgstr "Rejoindre ce domaine n’est pas pris en charge"
 
@@ -4187,18 +3430,9 @@ msgstr "Noyau"
 msgid "Kernel Dump"
 msgstr "Kernel Dump"
 
-#: pkg/kubernetes/views/node-body.html:19
-msgid "Kernel Version"
-msgstr "Version du noyau"
-
-#: pkg/kubernetes/views/volume-body.html:67
-msgid "Key Ring Path"
-msgstr "Key Ring Path"
-
 #: pkg/storaged/crypto-keyslots.jsx:563
 msgid "Key slots with unknown types can not be edited here"
-msgstr ""
-"Les emplacements de clé de type inconnu ne peuvent pas être édités ici"
+msgstr "Les emplacements de clé de type inconnu ne peuvent pas être édités ici"
 
 #: pkg/storaged/crypto-keyslots.jsx:202
 msgid "Key source"
@@ -4221,23 +3455,10 @@ msgid "Keyserver removal may prevent unlocking $0."
 msgstr ""
 "La suppression du serveur de clés peut empêcher le déverrouillage de $0."
 
-#: pkg/kubernetes/views/node-body.html:23
-msgid "Kubelet Version"
-msgstr "Version Kubelet"
-
-#: pkg/kubernetes/index.html:23
-msgid "Kubernetes Cluster"
-msgstr "Cluster Kubernetes"
-
 #: pkg/networkmanager/index.html:377
 msgid "LACP Key"
 msgstr "Clé LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: pkg/kubernetes/views/replicationcontroller-body.html:17
-#: pkg/kubernetes/views/route-body.html:22
-#: pkg/kubernetes/views/service-body.html:26
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Étiquettes"
@@ -4254,17 +3475,9 @@ msgstr "Dernières 24 heures"
 msgid "Last 7 days"
 msgstr "Les 7 derniers jours"
 
-#: pkg/kubernetes/views/node-body.html:49
-msgid "Last Heartbeat"
-msgstr "Dernière pulsation"
-
 #: pkg/users/index.html:100
 msgid "Last Login"
 msgstr "Dernière connexion"
-
-#: pkg/kubernetes/views/node-body.html:51
-msgid "Last Status Change"
-msgstr "Dernière modification de statut"
 
 #: pkg/systemd/init.js:284
 msgid "Last Trigger"
@@ -4277,11 +3490,6 @@ msgstr "Dernière mise à jour"
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
 msgstr "Dernière vérification : il y a $0"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
-#: pkg/kubernetes/views/details-page.html:107
-msgid "Latest Version"
-msgstr "Dernière version"
 
 #: pkg/machines/components/desktopConsole.jsx:128
 msgid "Launch Remote Viewer"
@@ -4306,14 +3514,13 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Laissez vide pour vous connecter à cette machine en tant qu’utilisateur "
 "actuellement connecté user{{#default_user}} ({{default_user}}){{/"
 "default_user}}.. Si vous saisissez un nom d’utilisateur différent, cet "
 "utilisateur sera toujours utilisé pour se connecter à cette machine."
 
-#: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
+#: pkg/shell/index.html:90 pkg/shell/simple.html:66
 msgid "Licensed under:"
 msgstr "Licencié sous :"
 
@@ -4337,7 +3544,7 @@ msgstr "Délai de chute de lien"
 msgid "Link local"
 msgstr "Lien local"
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:499
 msgid "Link to another container"
 msgstr "Lien vers un autre conteneur"
 
@@ -4345,11 +3552,11 @@ msgstr "Lien vers un autre conteneur"
 msgid "Link up delay"
 msgstr "Délai d’activation de lien"
 
-#: pkg/docker/index.html:493
+#: pkg/docker/index.html:495
 msgid "Links"
 msgstr "Liens"
 
-#: pkg/docker/index.html:195
+#: pkg/docker/index.html:196
 msgid "Links:"
 msgstr "Liens :"
 
@@ -4374,13 +3581,9 @@ msgid "Loading available updates, please wait..."
 msgstr ""
 "Le chargement des mises à jour disponibles est en cours, veuillez patienter…"
 
-#: pkg/ovirt/components/VdsmView.jsx:34
-msgid "Loading data ..."
-msgstr "Chargement des données…"
-
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Chargement…"
 
@@ -4396,7 +3599,7 @@ msgstr "Disques locaux"
 msgid "Local Filesystem"
 msgstr "Système de fichiers local"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:218
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
 msgid "Local Install Media"
 msgstr "Média d’installation local"
 
@@ -4416,7 +3619,7 @@ msgstr "Verrouillage"
 msgid "Lock Account"
 msgstr "Verrouiller le compte"
 
-#: pkg/users/local.js:879 pkg/users/local.js:1218
+#: pkg/users/local.js:883 pkg/users/local.js:1222
 msgid "Lock account on $0"
 msgstr "Verrouiller le compte sur $0"
 
@@ -4428,7 +3631,7 @@ msgstr "Verrouillage de $target"
 msgid "Log In"
 msgstr "Connexion"
 
-#: pkg/shell/index.html:70 pkg/shell/simple.html:46 pkg/shell/stub.html:53
+#: pkg/shell/index.html:70 pkg/shell/simple.html:46
 msgid "Log Out"
 msgstr "Déconnexion"
 
@@ -4444,19 +3647,11 @@ msgstr "Connectez-vous à {{host}}"
 msgid "Log in with your server user account."
 msgstr "Connectez-vous avec votre compte d’utilisateur du serveur."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:116
-msgid "Log into OpenShift command line tools:"
-msgstr "Connectez-vous aux outils de ligne de commande OpenShift :"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:101
-msgid "Log into the registry:"
-msgstr "Connectez-vous au registre :"
-
 #: pkg/systemd/index.html:65
 msgid "Log messages"
 msgstr "Enregistrer les messages"
 
-#: pkg/users/local.js:961
+#: pkg/users/local.js:965
 msgid "Logged In"
 msgstr "Connecté"
 
@@ -4467,12 +3662,6 @@ msgstr "Logique"
 #: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
 msgid "Logical Size"
 msgstr "Taille logique"
-
-#: pkg/kubernetes/views/pv-modify.html:159
-#: pkg/kubernetes/views/volume-body.html:79
-#: pkg/kubernetes/views/volume-body.html:118
-msgid "Logical Unit Number"
-msgstr "Numéro d’unité logique"
 
 #: pkg/storaged/utils.js:197
 msgid "Logical Volume"
@@ -4486,10 +3675,6 @@ msgstr "Volume logique (instantané)"
 msgid "Logical Volume of $0"
 msgstr "Volume logique de $0"
 
-#: pkg/subscriptions/subscriptions-register.jsx:144
-msgid "Login"
-msgstr "S’identifier"
-
 #: src/ws/login.js:300
 msgid "Login Again"
 msgstr "Se connecter à nouveau"
@@ -4502,10 +3687,6 @@ msgstr "Format de connexion"
 msgid "Login Password"
 msgstr "Mot de passe"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:96
-msgid "Login commands"
-msgstr "Commandes de connexion"
-
 #: src/base1/cockpit.js:4015
 msgid "Login failed"
 msgstr "Échec de la connexion"
@@ -4514,18 +3695,11 @@ msgstr "Échec de la connexion"
 msgid "Login has escalated admin privileges"
 msgstr "La connexion a escaladé les privilèges administrateur"
 
-#: pkg/subscriptions/subscriptions-client.js:199
-msgid "Login/password or activation key required to register."
-msgstr ""
-"Identifiant / mot de passe ou clé d’activation nécessaire pour vous inscrire."
-""
-
 #: src/ws/login.js:301
 msgid "Logout Successful"
 msgstr "Déconnexion réussie"
 
-#: pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82
 msgid "Logs"
 msgstr "Journaux"
 
@@ -4545,17 +3719,13 @@ msgstr "Lunch Box"
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:102
+#: pkg/machines/components/vmnetworktab.jsx:132
 msgid "MAC Address"
 msgstr "Adresse Mac"
 
-#: pkg/docker/index.html:187
+#: pkg/docker/index.html:188
 msgid "MAC Address:"
 msgstr "Adresse Mac :"
-
-#: pkg/ovirt/provider.js:283
-msgid "MIGRATE action failed"
-msgstr "L’action MIGRATE a échoué"
 
 #: pkg/networkmanager/interfaces.js:1985
 msgid "MII (Recommended)"
@@ -4577,7 +3747,7 @@ msgstr "Mac"
 msgid "Mac Address"
 msgstr "Adresse MAC"
 
-#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:95
+#: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "ID machine"
 
@@ -4596,10 +3766,6 @@ msgstr "Châssis principal du serveur"
 #: pkg/storaged/crypto-keyslots.jsx:319
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Assurez-vous que le hachage de la clé du serveur Tang corresponde :"
-
-#: pkg/kubernetes/scripts/dashboard.js:457
-msgid "Manifest"
-msgstr "Manifeste"
 
 #: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
 msgid "Manual"
@@ -4657,16 +3823,6 @@ msgstr ""
 "Nombre maximum de CPU virtuels alloués pour l’OS invité; doit être compris "
 "entre 1 et $0."
 
-#: pkg/kubernetes/views/volume-body.html:34
-msgid "Medium"
-msgstr "Moyen"
-
-#: pkg/kubernetes/views/project-listing.html:92
-#: pkg/kubernetes/views/user-body.html:4
-#: pkg/kubernetes/views/user-panel.html:27
-msgid "Member of"
-msgstr "Membre de"
-
 #: pkg/storaged/content-views.jsx:345
 msgid "Member of RAID Device"
 msgstr "Membre de RAID Device"
@@ -4675,26 +3831,11 @@ msgstr "Membre de RAID Device"
 msgid "Member of RAID Device $0"
 msgstr "Membre de RAID Device $0"
 
-#: pkg/kubernetes/views/project-listing.html:16
-#: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/index.html:266 pkg/networkmanager/interfaces.js:2986
-msgid "Members"
-msgstr "Membres"
-
-#: pkg/kubernetes/views/project-page.html:29
-#: pkg/kubernetes/views/user-page.html:25
-#: pkg/kubernetes/views/user-panel.html:11
-msgid "Membership"
-msgstr "Appartenance"
-
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:271
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:608
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:827
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:304
+#: pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
 #: pkg/machines/components/vmOverviewTab.jsx:74
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Memory"
 msgstr "Mémoire"
 
@@ -4707,38 +3848,32 @@ msgstr "Mémoire"
 msgid "Memory & Swap"
 msgstr "Mémoire & Swap"
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Utilisation de la mémoire : $0 %"
-
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
 msgid "Memory could not be saved"
 msgstr "La mémoire n'a pas pu être sauvegardée"
 
-#: pkg/docker/index.html:452 pkg/docker/index.html:624
+#: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "Limite de mémoire"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#, fuzzy
+msgid "Memory must not be 0"
+msgstr "La mémoire n'a pas pu être sauvegardée"
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
 msgstr "La taille de la mémoire est entre 128 Mio et l'allocation maximale"
 
-#: pkg/docker/index.html:210
+#: pkg/docker/index.html:211
 msgid "Memory usage:"
 msgstr "Utilisation de la mémoire :"
-
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
-msgid "Message"
-msgstr "Message"
 
 #: pkg/systemd/shutdown.js:79
 msgid "Message to logged in users"
 msgstr "Message aux utilisateurs connectés"
 
-#: pkg/kubernetes/views/image-page.html:29
-#: pkg/kubernetes/views/imagestream-page.html:30
 #: node_modules/registry-image-widgets/views/image-panel.html:15
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
@@ -4748,17 +3883,13 @@ msgstr "Méta-données"
 msgid "Metadata Used"
 msgstr "Méta-données utilisées"
 
-#: pkg/docker/index.html:466 pkg/docker/index.html:638
-#: pkg/machines/components/diskAdd.jsx:159
-#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/docker/index.html:468 pkg/docker/index.html:640
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
-
-#: pkg/ovirt/components/OVirtTab.jsx:70
-msgid "Migrate To:"
-msgstr "Migrer vers :"
 
 #: pkg/lib/machine-info.js:98
 msgid "Mini PC"
@@ -4788,13 +3919,9 @@ msgstr "Mode"
 msgid "Model"
 msgstr "Modèle"
 
-#: pkg/machines/components/vmnetworktab.jsx:93
+#: pkg/machines/components/vmnetworktab.jsx:123
 msgid "Model type"
 msgstr "Type de modèle"
-
-#: pkg/kubernetes/views/user-modify.html:27
-msgid "Modify"
-msgstr "Modifier"
 
 #: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:45
 #: pkg/storaged/jobs-panel.jsx:52
@@ -4817,11 +3944,7 @@ msgstr "Intervalle de surveillance"
 msgid "Monitoring Targets"
 msgstr "Objectifs de surveillance"
 
-#: pkg/kubernetes/views/volume-body.html:54
-msgid "Monitors"
-msgstr "Moniteurs"
-
-#: pkg/realmd/operation.js:530
+#: pkg/realmd/operation.js:529
 msgid "More"
 msgstr "Plus"
 
@@ -4834,31 +3957,27 @@ msgstr "Plus d’information"
 msgid "More details"
 msgstr "Plus de détails"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Monter"
 
-#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
-msgid "Mount Location"
-msgstr "Emplacement de montage"
-
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Options de montage"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Point de montage"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Monter au démarrage"
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:521
 msgid "Mount container volumes"
 msgstr "Monter les volumes de conteneur"
 
@@ -4874,7 +3993,7 @@ msgstr "Le point de montage ne peut pas être vide."
 msgid "Mount point must start with \"/\"."
 msgstr "Le point de montage doit commencer par \"/\"."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Monter en lecture seule"
 
@@ -4898,11 +4017,7 @@ msgstr "Châssis multi-système"
 msgid "NAT to $0"
 msgstr "NAT vers $0"
 
-#: pkg/kubernetes/scripts/volumes.js:865
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:140
 msgid "NFS Mount"
 msgstr "Point de montage NFS"
 
@@ -4914,7 +4029,7 @@ msgstr "Points de montage NFS"
 msgid "NFS Support not installed"
 msgstr "Prise en charge NFS non installée"
 
-#: pkg/machines/components/vmnetworktab.jsx:67
+#: pkg/machines/components/vmnetworktab.jsx:97
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "Échec du changement d’état du NIC $0 de la VM $1"
 
@@ -4926,54 +4041,29 @@ msgstr "NSNA Ping"
 msgid "NTP Server"
 msgstr "Serveur NTP"
 
-#: pkg/docker/index.html:267 pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/containers-listing.html:11
-#: pkg/kubernetes/views/dashboard-page.html:156
-#: pkg/kubernetes/views/dashboard-page.html:198
-#: pkg/kubernetes/views/details-page.html:34
-#: pkg/kubernetes/views/details-page.html:70
-#: pkg/kubernetes/views/details-page.html:103
-#: pkg/kubernetes/views/details-page.html:137
-#: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/service-modify.html:9
-#: pkg/kubernetes/views/user-modify.html:9
-#: pkg/kubernetes/views/volume-body.html:31
-#: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:119
+#: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
 #: pkg/networkmanager/index.html:319
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:181
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Nom"
 
@@ -5005,7 +4095,7 @@ msgstr "Le nom ne peut pas contenir le caractère « $0 »."
 msgid "Name cannot contain whitespace."
 msgstr "Le nom ne peut pas contenir d’espace."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:82
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
 msgid "Name should not be empty"
 msgstr "Le nom ne doit pas être vide"
@@ -5013,26 +4103,6 @@ msgstr "Le nom ne doit pas être vide"
 #: pkg/machines/components/networks/networkOverviewTab.jsx:36
 msgid "Name: "
 msgstr "Nom :"
-
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
-#: pkg/kubernetes/views/details-page.html:36
-#: pkg/kubernetes/views/details-page.html:72
-#: pkg/kubernetes/views/details-page.html:105
-#: pkg/kubernetes/views/details-page.html:139
-#: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
-#: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
-#: pkg/kubernetes/views/service-body.html:5
-#: pkg/kubernetes/views/volumes-page.html:59
-msgid "Namespace"
-msgstr "Espace de noms"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "L’espace de noms ne peut pas être vide."
 
 #: pkg/systemd/host.js:1348
 msgid "Need at least one NTP server"
@@ -5043,19 +4113,18 @@ msgid "Netmask"
 msgstr "Masque réseau"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:613
 msgid "Network"
 msgstr "Réseau"
 
-#: pkg/machines/components/networks/network.jsx:117
+#: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
 msgstr "Échec de l’activation du réseau $0"
 
-#: pkg/machines/components/networks/network.jsx:129
+#: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
 msgstr "Échec de la désactivation du réseau $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
 msgid "Network Boot (PXE)"
 msgstr "Démarrage réseau (PXE)"
 
@@ -5067,7 +4136,7 @@ msgstr "Système de fichiers par réseau (NFS)"
 msgid "Network Interfaces"
 msgstr "Interfaces réseau"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:177
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Network Selection does not support PXE."
 msgstr "Le réseau sélectionné ne prend pas en charge le PXE."
 
@@ -5077,8 +4146,7 @@ msgstr "Trafic réseau"
 
 #: pkg/networkmanager/index.html:52
 msgid "Network devices and graphs require NetworkManager."
-msgstr ""
-"Les périphériques réseau et les graphiques nécessitent NetworkManager."
+msgstr "Les périphériques réseau et les graphiques nécessitent NetworkManager."
 
 #: pkg/machines/components/nicEdit.jsx:232
 msgid "Network interface settings could not be saved"
@@ -5089,7 +4157,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager n’est pas en cours d’exécution."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:914
 msgid "Networking"
 msgstr "Réseau"
 
@@ -5107,21 +4175,17 @@ msgstr "Journaux réseau"
 msgid "Networks"
 msgstr "Réseaux"
 
-#: pkg/users/local.js:963
+#: pkg/users/local.js:967
 msgid "Never"
 msgstr "Jamais"
 
-#: pkg/users/index.html:297 pkg/users/local.js:868
+#: pkg/users/index.html:297 pkg/users/local.js:872
 msgid "Never expire password"
 msgstr "Ne jamais faire expirer le mot de passe"
 
-#: pkg/users/index.html:258 pkg/users/local.js:876
+#: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "Ne jamais verrouiller le compte"
-
-#: pkg/kubernetes/views/project-listing.html:46
-msgid "New Group"
-msgstr "Nouveau groupe"
 
 #: pkg/storaged/nfs-details.jsx:140
 msgid "New NFS Mount"
@@ -5131,32 +4195,17 @@ msgstr "Nouveau point de montage NFS"
 msgid "New Password"
 msgstr "Nouveau mot de passe"
 
-#: pkg/kubernetes/views/project-listing.html:7
-msgid "New Project"
-msgstr "Nouveau projet"
-
 #: pkg/machines/components/diskAdd.jsx:132
 msgid "New Volume Name"
 msgstr "Nouveau nom de volume"
-
-#: pkg/kubernetes/views/images-page.html:11
-#: pkg/kubernetes/views/registry-dashboard-page.html:86
-msgid "New image stream"
-msgstr "Nouveau flux d’images"
 
 #: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
 msgid "New passphrase"
 msgstr "Nouvelle phrase de passe"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Le nouveau mot de passe n’a pas été accepté"
-
-#: pkg/kubernetes/views/project-modify.html:4
-#: pkg/kubernetes/views/registry-dashboard-page.html:9
-#: pkg/kubernetes/views/registry-dashboard-page.html:48
-msgid "New project"
-msgstr "Nouveau projet"
 
 #: pkg/realmd/operation.html:82 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
@@ -5170,9 +4219,8 @@ msgstr "Prochaine exécution"
 msgid "Nice"
 msgstr "Priorité"
 
-#: pkg/docker/index.html:542 pkg/docker/index.html:546 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/kubernetes/scripts/volumes.js:998
-#: pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
 msgid "No"
 msgstr "Non"
 
@@ -5196,35 +4244,18 @@ msgstr "Aucun résultat correspondant n’a été trouvé"
 msgid "No NFS mounts set up"
 msgstr "Aucun point de montage NFS configuré"
 
-#: src/ws/cockpitcertificate.c:522
-msgid "No PEM-encoded certificate found"
-msgstr "Aucun certificat codé PEM trouvé"
-
-#: src/ws/cockpitcertificate.c:488
-msgid "No PEM-encoded private key found"
-msgstr "Aucune clé privée codée PEM trouvée"
-
-#: pkg/kubernetes/views/pv-claim.html:39
-msgid "No Pods are using this claim"
-msgstr "Aucun pod n’utilise cette requête"
-
 #: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "No SELinux alerts."
 msgstr "Pas d’alertes SELinux."
 
-#: pkg/machines/components/diskAdd.jsx:193
-#: pkg/machines/components/diskAdd.jsx:205
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:216
 msgid "No Storage Pools available"
 msgstr "Aucun pool de stockage disponible"
 
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr "Aucun volume de stockage n’a été défini pour ce pool de stockage"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:29
-#: pkg/ovirt/components/ClusterVms.jsx:36
-msgid "No VM found in oVirt."
-msgstr "Aucune VM trouvée dans oVirt."
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
@@ -5235,11 +4266,7 @@ msgstr ""
 msgid "No Virtual Networks"
 msgstr "Aucun réseau virtuel"
 
-#: pkg/kubernetes/views/pvc-body.html:10
-msgid "No Volume Bound"
-msgstr "Aucune limite de volume"
-
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/networkmanager/firewall.jsx:926
 msgid "No active zones"
 msgstr "Aucune zone active"
 
@@ -5291,7 +4318,7 @@ msgstr "Aucun conteneur"
 msgid "No containers that match the current filter"
 msgstr "Aucun conteneur correspondant au filtre actuel"
 
-#: pkg/networkmanager/firewall.jsx:727
+#: pkg/networkmanager/firewall.jsx:729
 msgid "No description available"
 msgstr "Aucune description disponible"
 
@@ -5299,9 +4326,9 @@ msgstr "Aucune description disponible"
 msgid "No description provided."
 msgstr "Aucune description fournie."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Aucun disque disponible."
 
@@ -5309,7 +4336,7 @@ msgstr "Aucun disque disponible."
 msgid "No disks defined for this VM"
 msgstr "Aucun disque défini pour cette machine virtuelle"
 
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:121
 msgid "No drives attached"
 msgstr "Aucun lecteur relié"
 
@@ -5320,10 +4347,6 @@ msgstr "Pas d’emplacements libres pour les clés"
 #: pkg/storaged/content-views.jsx:700
 msgid "No free space"
 msgstr "Pas d’espace libre"
-
-#: pkg/kubernetes/views/project-listing.html:74
-msgid "No groups are present."
-msgstr "Aucun groupe n’est présent."
 
 #: pkg/systemd/index.html:29
 msgid "No host keys found."
@@ -5341,10 +4364,6 @@ msgstr "Aucun flux d’image n’est présent."
 msgid "No images"
 msgstr "Pas d’images"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:80
-msgid "No images pushed"
-msgstr "Aucune image poussée"
-
 #: pkg/docker/containers-view.jsx:707
 msgid "No images that match the current filter"
 msgstr "Aucune image correspondant au filtre actuel"
@@ -5352,10 +4371,6 @@ msgstr "Aucune image correspondant au filtre actuel"
 #: pkg/apps/utils.jsx:96
 msgid "No installation package found for this application."
 msgstr "Aucun paquet d’installation n’a été trouvé pour cette application."
-
-#: pkg/subscriptions/subscriptions-view.jsx:246
-msgid "No installed products on the system."
-msgstr "Aucun produit installé sur le système."
 
 #: pkg/storaged/crypto-keyslots.jsx:520
 msgid "No keys added"
@@ -5379,14 +4394,7 @@ msgstr ""
 "commande du noyau (par exemple dans /etc/default/grub) pour réserver de la "
 "mémoire au démarrage. Exemple : crashkernel = 512M"
 
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr ""
-"Aucun fichier de métadonnées n’a été sélectionné. Veuillez sélectionner un "
-"fichier de méta-données Kubernetes."
-
-#: pkg/machines/components/vmnetworktab.jsx:40
+#: pkg/machines/components/vmnetworktab.jsx:70
 msgid "No network interfaces defined for this VM"
 msgstr "Aucune interface réseau définie pour cette machine virtuelle"
 
@@ -5398,15 +4406,7 @@ msgstr "Aucun réseau n’est défini sur cet hôte"
 msgid "No networks available"
 msgstr "Aucun réseau disponible"
 
-#: pkg/kubernetes/views/dashboard-page.html:117
-msgid "No nodes in cluster"
-msgstr "Aucun nœud dans le cluster"
-
-#: pkg/ovirt/components/App.jsx:61
-msgid "No oVirt connection"
-msgstr "Pas de connexion oVirt"
-
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:939
 msgid "No open ports"
 msgstr "Pas de ports ouverts"
 
@@ -5414,27 +4414,7 @@ msgstr "Pas de ports ouverts"
 msgid "No partitioning"
 msgstr "Pas de partitionnement"
 
-#: pkg/kubernetes/views/dashboard-page.html:40
-msgid "No pods deployed"
-msgstr "Aucun pod déployé"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:6
-msgid "No pods replicated"
-msgstr "Aucun pod répliqué"
-
-#: pkg/kubernetes/views/node-capacity.html:11
-msgid "No pods scheduled"
-msgstr "Aucun pod programmé"
-
-#: pkg/kubernetes/views/service-endpoint.html:10
-msgid "No pods selected"
-msgstr "Aucun pod sélectionné"
-
-#: pkg/kubernetes/views/project-listing.html:37
-msgid "No projects are present."
-msgstr "Aucun projet n’est présent."
-
-#: pkg/users/local.js:449
+#: pkg/users/local.js:453
 msgid "No real name specified"
 msgstr "Aucun nom réel n’est renseigné"
 
@@ -5474,48 +4454,17 @@ msgstr "Aucun tag n’est présent"
 msgid "No updates pending"
 msgstr "Aucune mise à jour en attente"
 
-#: pkg/users/local.js:444
+#: pkg/users/local.js:448
 msgid "No user name specified"
 msgstr "Aucun nom d’utilisateur n’est renseigné"
-
-#: pkg/kubernetes/views/project-listing.html:112
-msgid "No users are present."
-msgstr "Aucun utilisateur n’est présent"
 
 #: pkg/storaged/vgroups-panel.jsx:114
 msgid "No volume groups created"
 msgstr "Aucun groupe de volumes créé"
 
-#: pkg/kubernetes/views/volumes-page.html:44
-msgid "No volumes are present."
-msgstr "Aucun volume n’est présent."
-
-#: pkg/kubernetes/views/dashboard-page.html:73
-msgid "No volumes in use"
-msgstr "Aucun volume en cours d’utilisation"
-
-#: pkg/kubernetes/views/containers-listing.html:15
-#: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
-#: pkg/kubernetes/views/topology-page.html:38
-msgid "Node"
-msgstr "Nœud"
-
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
-#: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
-msgid "Nodes"
-msgstr "Nœuds"
-
-#: pkg/kubernetes/views/topology-page.html:39
-msgid "Nodes are the machines that run your containers."
-msgstr "Les nœuds sont les machines qui exécutent vos conteneurs."
-
-#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
-#: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:732
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Aucun"
 
@@ -5523,23 +4472,13 @@ msgstr "Aucun"
 msgid "None (Isolated Network)"
 msgstr "Aucune (réseau isolé)"
 
-#: pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
-#: pkg/kubernetes/scripts/nodes.js:319
+#: pkg/playground/translate.html:29
 msgid "Not Ready"
 msgstr "Pas prêt"
-
-#: pkg/kubernetes/scripts/details.js:496 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "Nombre de répliques non valide"
 
 #: pkg/lib/credentials.js:255
 msgid "Not a valid private key"
 msgstr "Clé privée non valide"
-
-#: pkg/kubernetes/scripts/details.js:547
-msgid "Not a valid value for Host"
-msgstr "Valeur non valide pour l’hôte"
 
 #: pkg/docker/index.html:57
 msgid "Not authorized to access Docker on this system"
@@ -5557,11 +4496,6 @@ msgstr "Indisponible"
 msgid "Not connected"
 msgstr "Pas connecté"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
-#: pkg/kubernetes/views/details-page.html:122
-msgid "Not deployed"
-msgstr "Non déployé"
-
 #: pkg/storaged/lvol-tabs.jsx:369
 msgid "Not enough space to grow."
 msgstr "Espace insuffisant"
@@ -5578,7 +4512,7 @@ msgstr "Non monté"
 msgid "Not permitted to perform this action."
 msgstr "Non autorisé à effectuer cette action."
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Not running"
 msgstr "Pas en cours d’exécution"
 
@@ -5602,32 +4536,9 @@ msgstr "Notebook"
 msgid "Notice and above"
 msgstr "Notification et au-dessus"
 
-#: pkg/ovirt/components/vcpuModal.jsx:55
-msgid "Number of virtual CPUs that gonna be used."
-msgstr "Nombre de CPU qui seront utilisées."
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
-#: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
-msgid "OK"
-msgstr "OK"
-
-#: pkg/kubernetes/views/node-body.html:13
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "OS"
-msgstr "OS"
-
-#: pkg/ovirt/components/OVirtTab.jsx:148
-msgid "OS Type:"
-msgstr "OS Type :"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:274
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
 msgid "OS Vendor"
 msgstr "Fournisseur d’OS"
-
-#: pkg/kubernetes/views/nodes-page.html:19
-msgid "OS Versions"
-msgstr "Versions OS"
 
 #: pkg/selinux/setroubleshoot-view.jsx:394
 msgid "Occurred $0"
@@ -5653,7 +4564,7 @@ msgstr "Ancien mot de passe"
 msgid "Old passphrase"
 msgstr "Ancienne phrase de passe"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Ancien mot de passe non accepté"
 
@@ -5665,7 +4576,7 @@ msgstr "Sur"
 msgid "On Build"
 msgstr "On Build"
 
-#: pkg/docker/index.html:547 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/init.js:731
 msgid "On Failure"
 msgstr "En cas d’échec"
 
@@ -5687,7 +4598,7 @@ msgstr ""
 "Une fois que Cockpit est installé, l’activer avec \"systemctl enable --now "
 "cockpit.socket\"."
 
-#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:338
+#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
 msgstr "Mot de passe à usage unique"
 
@@ -5717,7 +4628,7 @@ msgstr ""
 msgid "Only editable when the guest is shut off"
 msgstr "Modifiable uniquement quand l'invité est fermé"
 
-#: pkg/shell/index.html:43 pkg/shell/simple.html:29 pkg/shell/stub.html:33
+#: pkg/shell/index.html:43 pkg/shell/simple.html:29
 msgid "Ooops!"
 msgstr "Zut !"
 
@@ -5725,8 +4636,8 @@ msgstr "Zut !"
 msgid "Open"
 msgstr "Ouvrir"
 
-#: pkg/kubernetes/views/nodes-page.html:42 pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+#: pkg/systemd/index.html:98
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
 msgid "Operating System"
 msgstr "Système d’exploitation"
 
@@ -5734,27 +4645,24 @@ msgstr "Système d’exploitation"
 msgid "Operation '$operation' on $target"
 msgstr "Opération « $operation » sur $target"
 
+#: pkg/machines/components/storagePools/storagePool.jsx:175
+#: pkg/machines/components/storagePools/storagePool.jsx:180
+#, fuzzy
+msgid "Operation is in progress"
+msgstr "Connexion oVirt en cours"
+
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Lecteur optique"
 
-#: pkg/ovirt/components/OVirtTab.jsx:157
-msgid "Optimized for:"
-msgstr "Optimisé pour :"
-
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:134
-#: pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
 msgid "Options"
 msgstr "Options"
 
 #: src/ws/login.html:125
 msgid "Or use a bundled browser"
 msgstr "Ou utilisez un navigateur groupé"
-
-#: pkg/subscriptions/subscriptions-register.jsx:180
-msgid "Organization"
-msgstr "Organisation"
 
 #: pkg/lib/machine-info.js:64
 msgid "Other"
@@ -5773,11 +4681,9 @@ msgstr "Autres périphériques"
 msgid "Other Options"
 msgstr "Autres options"
 
-#: pkg/docker/index.html:297 pkg/kubernetes/index.html:43
-#: pkg/kubernetes/registry.html:43
-#: pkg/machines/components/networks/network.jsx:71
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Aperçu"
 
@@ -5788,10 +4694,6 @@ msgstr "Remplacer les données existantes par des zéros"
 #: pkg/systemd/hwinfo.jsx:249
 msgid "PCI"
 msgstr "PCI"
-
-#: pkg/kubernetes/views/volume-body.html:4
-msgid "PD Name"
-msgstr "Nom du PD"
 
 #: pkg/packagekit/updates.jsx:501
 msgid "Package information"
@@ -5825,8 +4727,7 @@ msgstr "Fait partie de"
 msgid "Part of "
 msgstr "Partie de"
 
-#: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:141
 msgid "Partition"
 msgstr "Partition"
 
@@ -5863,13 +4764,11 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Les phrases de passe ne correspondent pas"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
 #: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
-#: pkg/subscriptions/subscriptions-register.jsx:89
-#: pkg/subscriptions/subscriptions-register.jsx:156
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -5885,7 +4784,7 @@ msgstr "Le mot de passe n’est pas acceptable"
 msgid "Password is too weak"
 msgstr "Le mot de passe est trop faible"
 
-#: pkg/users/local.js:870
+#: pkg/users/local.js:874
 msgid "Password must be changed"
 msgstr "Le mot de passe doit être changé"
 
@@ -5908,11 +4807,7 @@ msgstr "Coller"
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Collez le contenu de votre clé publique SSH ici"
 
-#: pkg/kubernetes/views/pv-modify.html:126
-#: pkg/kubernetes/views/volume-body.html:37
-#: pkg/kubernetes/views/volume-body.html:49
-#: pkg/kubernetes/views/volume-body.html:101 pkg/systemd/services.html:126
-#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
 msgid "Path"
 msgstr "Chemin"
 
@@ -5928,7 +4823,7 @@ msgstr "Coût du chemin $path_cost"
 msgid "Path on Server"
 msgstr "Chemin sur le serveur"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:129
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
 msgid "Path on host's filesystem"
 msgstr "Chemin d’accès sur le système de fichiers de l’hôte"
 
@@ -5940,7 +4835,7 @@ msgstr "Le chemin sur le serveur ne peut pas être vide."
 msgid "Path on server must start with \"/\"."
 msgstr "Le chemin sur le serveur doit commencer par \"/\"."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:154
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
 msgid "Path to ISO file on host's file system"
 msgstr "Chemin d’accès au fichier ISO sur le système de fichiers de l’hôte"
 
@@ -5955,10 +4850,6 @@ msgstr "Chemins"
 #: pkg/machines/components/vm/vmActions.jsx:77
 msgid "Pause"
 msgstr "Suspendre"
-
-#: pkg/kubernetes/views/volumes-page.html:53
-msgid "Pending Volume Claims"
-msgstr "Requêtes de volume en attente"
 
 #: pkg/systemd/index.html:152
 msgid "Performance Profile"
@@ -5980,18 +4871,10 @@ msgstr "Permission refusée"
 msgid "Persistence"
 msgstr "Persistance"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr "Persistant"
-
-#: pkg/kubernetes/views/volumes-page.html:14
-msgid "Persistent Volumes"
-msgstr "Volumes persistants"
-
-#: pkg/kubernetes/views/pod-body.html:16
-msgid "Phase"
-msgstr "Phase"
 
 #: pkg/storaged/vdo-details.jsx:277
 msgid "Physical"
@@ -6005,11 +4888,11 @@ msgstr "Périphérique de disque physique"
 msgid "Physical Volume"
 msgstr "Volume physique"
 
-#: pkg/storaged/vgroup-details.jsx:134
+#: pkg/storaged/vgroup-details.jsx:133
 msgid "Physical Volumes"
 msgstr "Volumes physiques"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:210
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
 msgid "Physical disk device on host"
 msgstr "Périphérique de disque physique sur l'hôte"
 
@@ -6033,10 +4916,10 @@ msgstr "Clible de ping"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:210
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Veuillez confirmer la suppression de $0"
 
@@ -6044,115 +4927,23 @@ msgstr "Veuillez confirmer la suppression de $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Veuillez confirmer la suppression forcée de $0"
 
-#: pkg/storaged/mdraid-details.jsx:244 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Veuillez confirmer l’arrêt de $0"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:34
-msgid "Please confirm, the host shall be switched to maintenance mode."
-msgstr "Veuillez confirmer, l’hôte doit passer en mode de maintenance."
-
-#: pkg/kubernetes/scripts/dashboard.js:439
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Veuillez créer un autre espace de nom pour $0 \"$1\""
-
-#: pkg/machines/components/diskAdd.jsx:425
+#: pkg/machines/components/diskAdd.jsx:447
 msgid "Please enter new volume name"
 msgstr "Veuillez saisir un nouveau nom de volume"
 
-#: pkg/machines/components/diskAdd.jsx:428
+#: pkg/machines/components/diskAdd.jsx:450
 msgid "Please enter new volume size"
 msgstr "Veuillez saisir une nouvelle taille de volume"
 
-#: pkg/networkmanager/firewall.jsx:862
+#: pkg/networkmanager/firewall.jsx:864
 msgid "Please install the $0 package"
 msgstr "Veuillez installer le paquet $0"
 
-#: pkg/kubernetes/scripts/volumes.js:582
-msgid "Please provide a GlusterFS volume name"
-msgstr "Veuillez indiquer un nom de volume GlusterFS"
-
-#: pkg/kubernetes/scripts/connection.js:550
-msgid "Please provide a username"
-msgstr "Veuillez fournir un nom d’utilisateur"
-
-#: pkg/kubernetes/scripts/volumes.js:640
-msgid "Please provide a valid NFS server"
-msgstr "Veuillez fournir un serveur NFS valide"
-
-#: pkg/kubernetes/scripts/connection.js:535
-msgid "Please provide a valid address"
-msgstr "Veuillez fournir une adresse valide"
-
-#: pkg/kubernetes/scripts/volumes.js:810
-msgid "Please provide a valid filesystem type"
-msgstr "Veuillez fournir un type de système de fichiers valide"
-
-#: pkg/kubernetes/scripts/volumes.js:818
-msgid "Please provide a valid interface"
-msgstr "Veuillez fournir une interface valide"
-
-#: pkg/kubernetes/scripts/volumes.js:802
-msgid "Please provide a valid logical unit number"
-msgstr "Veuillez fournir un numéro d’unité logique valide"
-
-#: pkg/kubernetes/scripts/volumes.js:483
-msgid "Please provide a valid name"
-msgstr "Veuillez fournir un nom valide"
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Veuillez fournir un espace de noms valide."
-
-#: pkg/kubernetes/scripts/volumes.js:648 pkg/kubernetes/scripts/volumes.js:703
-msgid "Please provide a valid path"
-msgstr "Veuillez fournir un chemin valide"
-
-#: pkg/kubernetes/scripts/volumes.js:794
-msgid "Please provide a valid qualified name"
-msgstr "Veuillez fournir un nom qualifié valide"
-
-#: pkg/kubernetes/scripts/volumes.js:491
-msgid "Please provide a valid storage capacity."
-msgstr "Veuillez indiquer une capacité de stockage valide"
-
-#: pkg/kubernetes/scripts/volumes.js:786
-msgid "Please provide a valid target"
-msgstr "Veuillez fournir une cible valide"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:83
-msgid ""
-"Please provide fully qualified domain name and port of the oVirt engine."
-msgstr "Veuillez fournir le nom de domaine complet et le port d’oVirt Engine."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:137
-msgid ""
-"Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-"port (443 by default)"
-msgstr ""
-"Veuillez indiquer le nom de domaine complet (FQDN) et le port valides "
-"d’oVirt Engine (443 par défaut)"
-
-#: pkg/ovirt/components/ConsoleClientResources.jsx:32
-msgid ""
-"Please refer to oVirt's $0 for more information about Remote Viewer setup."
-msgstr ""
-"Veuillez vous référer à oVirt $0 pour plus d’informations sur la "
-"configuration de l’afficheur à distance."
-
-#: pkg/kubernetes/scripts/volumes.js:475
-msgid "Please select a valid access mode"
-msgstr "Veuillez sélectionner un mode d’accès valide"
-
-#: pkg/kubernetes/scripts/volumes.js:573
-msgid "Please select a valid endpoint"
-msgstr "Veuillez sélectionner un point de terminaison valide"
-
-#: pkg/kubernetes/scripts/volumes.js:499
-msgid "Please select a valid policy option."
-msgstr "Veuillez sélectionner une option de politique valide."
-
-#: pkg/users/local.js:1232
+#: pkg/users/local.js:1236
 msgid "Please specify an expiration date"
 msgstr "Veuillez spécifier une date d’expiration"
 
@@ -6168,77 +4959,16 @@ msgstr "Veuillez démarrer la machine virtuelle pour accéder à sa console."
 msgid "Please try another term"
 msgstr "Veuillez essayer un autre terme"
 
-#: pkg/kubernetes/scripts/nodes.js:401
-msgid "Please type an address"
-msgstr "Veuillez saisir une adresse"
-
-#: pkg/ovirt/components/ClusterVms.jsx:37
-msgid "Please wait till VMs list is loaded from the server."
-msgstr ""
-"Veuillez attendre que la liste des machines virtuelles soit chargée depuis "
-"le serveur."
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:30
-msgid "Please wait till list of templates is loaded from the server."
-msgstr ""
-"Veuillez attendre que la liste des modèles soit chargée depuis le serveur."
-
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Plug"
 msgstr "Connecteur"
 
-#: pkg/kubernetes/views/containers-listing.html:12
-#: pkg/kubernetes/views/pod-page.html:12
-#: pkg/kubernetes/views/topology-page.html:14
-msgid "Pod"
-msgstr "Pod"
-
-#: pkg/kubernetes/views/pod-body.html:20
-msgid "Pod Address"
-msgstr "Adresse Pod"
-
-#: pkg/kubernetes/views/service-endpoint.html:4
-#: pkg/kubernetes/views/service-endpoint.html:9
-msgid "Pod Endpoints"
-msgstr "Points d’accès Pod"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:4
-msgid "Pod Replicated"
-msgstr "Pod répliqué"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:11
-#: pkg/kubernetes/views/service-endpoint.html:15
-msgid "Pod Selector"
-msgstr "Sélecteur de Pod"
-
-#: pkg/kubernetes/views/dashboard-page.html:18
-#: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/pv-claim.html:37
-#: pkg/kubernetes/views/replicationcontroller-page.html:17
-#: pkg/kubernetes/views/replicationcontroller-panel.html:12
-#: pkg/kubernetes/scripts/details.js:227
-msgid "Pods"
-msgstr "Pods"
-
-#: pkg/kubernetes/views/topology-page.html:15
-msgid ""
-"Pods contain one or more containers that run together on a node, containing "
-"your application code."
-msgstr ""
-"Les pods contiennent un ou plusieurs conteneurs qui s’exécutent ensemble sur "
-"un nœud, contenant le code de votre application."
-
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Pool"
-
-#: pkg/kubernetes/views/volume-body.html:60
-msgid "Pool Name"
-msgstr "Nom du pool"
 
 #: pkg/storaged/utils.js:191
 msgid "Pool for Thin Logical Volumes"
@@ -6252,16 +4982,11 @@ msgstr "Pool pour les volumes dynamiques"
 msgid "Pool for thinly provisioned volumes"
 msgstr "Pool pour les volumes à provisionnement dynamique"
 
-#: pkg/kubernetes/views/imagestream-modify.html:45
-msgid "Populate"
-msgstr "Remplissage"
-
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:78
-#: pkg/ovirt/components/InstallationDialog.jsx:65
+#: pkg/machines/components/vmnetworktab.jsx:108
 #: pkg/storaged/iscsi-panel.jsx:127
 msgid "Port"
 msgstr "Port"
@@ -6274,15 +4999,14 @@ msgstr "Le numéro de port et son type ne correspondent pas"
 msgid "Portable"
 msgstr "Portable"
 
-#: pkg/docker/index.html:504 pkg/kubernetes/views/container-body.html:12
-#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:213
+#: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
 #: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
 msgid "Ports"
 msgstr "Ports"
 
-#: pkg/docker/index.html:191
+#: pkg/docker/index.html:192
 msgid "Ports:"
 msgstr "Ports :"
 
@@ -6291,7 +5015,6 @@ msgid "Power Options"
 msgstr "Options d’alimentation"
 
 #: pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Preferred number of sockets to expose to the guest."
 msgstr "Nombre choisi de sockets à exposer à l’invité."
 
@@ -6310,10 +5033,6 @@ msgstr "Longueur du préfixe ou masque de réseau"
 #: pkg/networkmanager/interfaces.js:826
 msgid "Preparing"
 msgstr "Préparation en cours"
-
-#: pkg/ovirt/rephraseUI.js:25
-msgid "Preparing for Maintenance"
-msgstr "Préparation à la maintenance"
 
 #: pkg/networkmanager/interfaces.js:3631
 msgid "Preserve"
@@ -6352,12 +5071,6 @@ msgstr "Priorité $priority"
 msgid "Private"
 msgstr "Privé"
 
-#: pkg/kubernetes/scripts/projects.js:1042
-msgid "Private: Allow only specific users or groups to pull images"
-msgstr ""
-"Privé : autoriser uniquement des utilisateurs ou des groupes spécifiques à "
-"extraire des images"
-
 #: pkg/shell/index.html:39
 msgid "Privileged"
 msgstr "Privilégié"
@@ -6383,67 +5096,9 @@ msgstr "Processus"
 msgid "Product"
 msgstr "Produit"
 
-#: pkg/subscriptions/subscriptions-view.jsx:34
-msgid "Product ID"
-msgstr "ID de produit"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product name"
-msgstr "Nom du produit"
-
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
-#: pkg/kubernetes/views/details-page.html:35
-#: pkg/kubernetes/views/details-page.html:71
-#: pkg/kubernetes/views/details-page.html:104
-#: pkg/kubernetes/views/details-page.html:138
-#: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/pod-body.html:4
-#: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/route-body.html:4
-#: pkg/kubernetes/views/service-body.html:4
-#: pkg/kubernetes/views/volumes-page.html:58
-msgid "Project"
-msgstr "Projet"
-
-#: pkg/kubernetes/views/project-body.html:20
-msgid "Project Members"
-msgstr "Les membres du projet"
-
-#: pkg/kubernetes/views/project-body.html:3
-msgid "Project access policy allows anonymous users to pull images."
-msgstr ""
-"La stratégie d’accès au projet permet aux utilisateurs anonymes d’extraire "
-"des images."
-
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Project access policy allows any authenticated user to pull images."
-msgstr ""
-"La stratégie d’accès au projet permet à tout utilisateur authentifié "
-"d’extraire des images."
-
-#: pkg/kubernetes/views/project-body.html:13
-msgid "Project access policy only allows specific members to access images."
-msgstr ""
-"La stratégie d’accès au projet autorise uniquement des membres spécifiques à "
-"accéder aux images."
-
-#: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
+#: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
 msgstr "Site du projet"
-
-#: pkg/kubernetes/views/filter-project.html:5
-msgid "Project:"
-msgstr "Projet :"
-
-#: pkg/kubernetes/index.html:88 pkg/kubernetes/registry.html:55
-#: pkg/kubernetes/views/group-delete.html:10
-#: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
-msgid "Projects"
-msgstr "Projets"
 
 #: pkg/users/local.js:91
 msgid "Prompting via passwd timed out"
@@ -6467,15 +5122,7 @@ msgstr "Recharger Propagation jusqu’à"
 msgid "Protocol"
 msgstr "Protocole"
 
-#: pkg/subscriptions/subscriptions-register.jsx:129
-msgid "Proxy"
-msgstr "Proxy"
-
-#: pkg/kubernetes/views/node-body.html:25
-msgid "Proxy Version"
-msgstr "Version proxy"
-
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Clé publique"
 
@@ -6483,25 +5130,9 @@ msgstr "Clé publique"
 msgid "Public pulling repo"
 msgstr "Référentiel Extraction Public"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:152
-msgid "Pull an image:"
-msgstr "Extraire une image :"
-
-#: pkg/kubernetes/views/imagestream-modify.html:66
-msgid "Pull from"
-msgstr "Extraire de"
-
-#: pkg/kubernetes/scripts/images.js:635
-msgid "Pull specific tags from another image repository"
-msgstr "Extraire des tags spécifiques d’un autre référentiel d’images"
-
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Objectif"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:141
-msgid "Push an image:"
-msgstr "Pousser image :"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:31
 msgid "QEMU/KVM System connection"
@@ -6511,16 +5142,11 @@ msgstr "QEMU/KVM Connexion système"
 msgid "QEMU/KVM User connection"
 msgstr "QEMU/KVM Connexion utilisateur"
 
-#: pkg/kubernetes/views/pv-modify.html:148
-#: pkg/kubernetes/views/volume-body.html:77
-msgid "Qualified Name"
-msgstr "Nom qualifié"
-
-#: pkg/storaged/mdraid-details.jsx:186
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
 msgstr "RAID ( $0 )"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 0"
 msgstr "RAID 0"
 
@@ -6528,7 +5154,7 @@ msgstr "RAID 0"
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (Bande)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 1"
 msgstr "RAID 1"
 
@@ -6536,7 +5162,7 @@ msgstr "RAID 1"
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (Miroir)"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 10"
 msgstr "RAID 10"
 
@@ -6544,7 +5170,7 @@ msgstr "RAID 10"
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (Bande de miroirs)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 4"
 msgstr "RAID 4"
 
@@ -6552,7 +5178,7 @@ msgstr "RAID 4"
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (Parité dédiée)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 5"
 msgstr "RAID 5"
 
@@ -6560,7 +5186,7 @@ msgstr "RAID 5"
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (Parité répartie)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 6"
 msgstr "RAID 6"
 
@@ -6576,7 +5202,7 @@ msgstr "Châssis RAID"
 msgid "RAID Device"
 msgstr "Périphérique RAID"
 
-#: pkg/storaged/mdraid-details.jsx:316 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "Périphérique RAID $0"
 
@@ -6592,27 +5218,15 @@ msgstr "Niveau de RAID"
 msgid "RAID Member"
 msgstr "Membre RAID"
 
-#: pkg/ovirt/provider.js:179
-msgid "REBOOT action failed"
-msgstr "L’action REBOOT a échoué"
-
-#: pkg/ovirt/provider.js:164
-msgid "REBOOT_VM action failed: %s0"
-msgstr "L’action REBOOT_VM a échoué : %0"
-
 #: pkg/lib/machine-info.js:86
 msgid "Rack Mount Chassis"
 msgstr "Châssis de montage en rack"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Rados Block Device"
 
 #: pkg/networkmanager/interfaces.js:3632
 msgid "Random"
 msgstr "Random"
 
-#: pkg/networkmanager/firewall.jsx:757
+#: pkg/networkmanager/firewall.jsx:759
 msgid "Range"
 msgstr "Gamme"
 
@@ -6624,42 +5238,15 @@ msgstr "La plage doit être strictement ordonnée."
 msgid "Raw to a device"
 msgstr "Raw à un appareil"
 
-#: pkg/kubernetes/views/pv-modify.html:195
-#: pkg/kubernetes/views/volume-body.html:10
-#: pkg/kubernetes/views/volume-body.html:20
-#: pkg/kubernetes/views/volume-body.html:44
-#: pkg/kubernetes/views/volume-body.html:51
-#: pkg/kubernetes/views/volume-body.html:71
-#: pkg/kubernetes/views/volume-body.html:85
-#: pkg/kubernetes/views/volume-body.html:93
-#: pkg/kubernetes/views/volume-body.html:110
-#: pkg/kubernetes/views/volume-body.html:122
-#: pkg/kubernetes/views/volume-body.html:136
-#: pkg/kubernetes/views/volume-body.html:143
-msgid "Read Only"
-msgstr "Lecture seulement"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "Lecture et Écriture à partir d’un seul nœud"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "Lecture et Écriture à partir de plusieurs nœuds"
-
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr "En savoir plus…"
 
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "Lecture uniquement à partir de plusieurs nœuds"
-
-#: pkg/docker/index.html:363
+#: pkg/docker/index.html:365
 msgid "ReadOnly"
 msgstr "Lecture seulement"
 
-#: pkg/docker/index.html:362
+#: pkg/docker/index.html:364
 msgid "ReadWrite"
 msgstr "LectureÉcriture"
 
@@ -6675,13 +5262,11 @@ msgstr "Lecture en cours…"
 msgid "Readonly"
 msgstr "LectureUniquement"
 
-#: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
-#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/playground/translate.html:19
 msgid "Ready"
 msgstr "Prêt"
 
-#: pkg/playground/translate.html:24 pkg/playground/translate.html:184
+#: pkg/playground/translate.html:24
 msgctxt "verb"
 msgid "Ready"
 msgstr "Prêt"
@@ -6702,10 +5287,6 @@ msgstr ""
 msgid "Real host name must be 64 characters or less"
 msgstr "Le nom d’hôte réel doit comporter 64 caractères ou moins"
 
-#: pkg/kubernetes/views/node-body.html:45
-msgid "Reason"
-msgstr "Raison"
-
 #: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
 msgid "Reboot"
 msgstr "Redémarrer"
@@ -6720,16 +5301,11 @@ msgstr "Réception"
 msgid "Recent"
 msgstr "Récent"
 
-#: pkg/kubernetes/views/pv-body.html:6 pkg/kubernetes/views/pv-modify.html:56
-msgid "Reclaim Policy"
-msgstr "Politique de récupération"
-
 #: pkg/storaged/format-dialog.jsx:248
 msgid "Recommended default"
 msgstr "Valeur par défaut recommandée"
 
-#: pkg/kubernetes/index.html:108 pkg/kubernetes/registry.html:75
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138 pkg/shell/stub.html:180
+#: pkg/shell/index.html:386 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Reconnecter"
@@ -6741,10 +5317,6 @@ msgstr "Recouvrement"
 #: pkg/storaged/jobs-panel.jsx:65
 msgid "Recovering RAID Device $target"
 msgstr "Recouvrement du périphérique RAID $target"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "Recycler"
 
 #: pkg/docker/storage.jsx:389
 msgid "Reformat and add disks"
@@ -6766,36 +5338,10 @@ msgstr "Connexion refusée. Hostkey ne correspond pas"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Connexion refusée. Hostkey est inconnu"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:159
-msgid "Register"
-msgstr "Enregistrer"
-
-#: pkg/kubernetes/views/volumes-page.html:12
-msgid "Register New Volume"
-msgstr "Enregistrer un nouveau volume"
-
-#: pkg/kubernetes/views/pv-modify.html:4
-msgid "Register Persistent Volume"
-msgstr "Enregistrer le volume persistant"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:108
-msgid "Register oVirt"
-msgstr "Inscription oVirt"
-
-#: pkg/subscriptions/main.js:73
-msgid "Register system"
-msgstr "Enregistrer le système"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:128
-msgid "Registering oVirt to Cockpit"
-msgstr "Enregistrement d’oVirt dans Cockpit"
-
 #: pkg/packagekit/updates.jsx:777
 msgid "Register…"
 msgstr "Enregistrement…"
 
-#: pkg/ovirt/components/App.jsx:62 pkg/ovirt/components/VdsmView.jsx:100
 #: pkg/systemd/init.js:546
 msgid "Reload"
 msgstr "Recharger"
@@ -6804,7 +5350,7 @@ msgstr "Recharger"
 msgid "Reload Propagated From"
 msgstr "Recharger Propagation à partir de"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:202
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
 msgid "Remote URL"
 msgstr "URL distante"
 
@@ -6816,10 +5362,6 @@ msgstr "À distance sur NFS"
 msgid "Remote over SSH"
 msgstr "À distance sur SSH"
 
-#: pkg/kubernetes/views/imagestream-modify.html:89
-msgid "Remote registry is insecure"
-msgstr "L’enregistrement à distance n’est pas sécurisé"
-
 #: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
 msgctxt "storage"
 msgid "Removable Drive"
@@ -6829,13 +5371,9 @@ msgstr "Lecteur amovible"
 msgid "Removals:"
 msgstr "Suppressions :"
 
-#: pkg/kubernetes/views/group-delete.html:21
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-delete.html:25
-#: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Retirer"
 
@@ -6847,37 +5385,13 @@ msgstr "Supprimer $0"
 msgid "Remove $0?"
 msgstr "Supprimer $0"
 
-#: pkg/kubernetes/views/group-delete.html:3
-msgid "Remove Group"
-msgstr "Supprimer le groupe"
-
-#: pkg/kubernetes/views/user-group-remove.html:3
-msgid "Remove Member"
-msgstr "Supprimer le membre"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:3
-msgid "Remove Role"
-msgstr "Supprimer le rôle"
-
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove Tang keyserver"
 msgstr "Supprimer le serveur de clés Tang"
 
-#: pkg/kubernetes/views/user-delete.html:3
-msgid "Remove User"
-msgstr "Supprimer l’utilisateur"
-
 #: pkg/storaged/vdo-details.jsx:116
 msgid "Remove device"
 msgstr "Supprimer le périphérique"
-
-#: pkg/kubernetes/views/image-delete.html:3
-msgid "Remove image tag"
-msgstr "Supprimer le tag d’image"
-
-#: pkg/kubernetes/views/user-remove-membership.html:3
-msgid "Remove membership"
-msgstr "Révoquez l’appartenance"
 
 #: pkg/storaged/crypto-keyslots.jsx:387
 msgid "Remove passphrase"
@@ -6887,11 +5401,11 @@ msgstr "Modifier la phrase de passe"
 msgid "Remove passphrase in $0?"
 msgstr "Souhaitez-vous forcer la suppression de la phrase de passe dans $0 ?"
 
-#: pkg/networkmanager/firewall.jsx:629
+#: pkg/networkmanager/firewall.jsx:631
 msgid "Remove service"
 msgstr "Supprimer un service"
 
-#: pkg/networkmanager/firewall.jsx:608
+#: pkg/networkmanager/firewall.jsx:610
 msgid "Remove service from zones"
 msgstr "Supprimer un service des zones"
 
@@ -6919,8 +5433,8 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Suppression du volume physique de $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:187
-#: pkg/storaged/vgroup-details.jsx:235
+#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:234
 msgid "Rename"
 msgstr "Renommer"
 
@@ -6928,7 +5442,7 @@ msgstr "Renommer"
 msgid "Rename Logical Volume"
 msgstr "Renommer le volume logique"
 
-#: pkg/storaged/vgroup-details.jsx:179
+#: pkg/storaged/vgroup-details.jsx:178
 msgid "Rename Volume Group"
 msgstr "Renommer le groupe de volumes"
 
@@ -6965,32 +5479,6 @@ msgstr "Répéter chaque année"
 msgid "Repeat passphrase"
 msgstr "Répéter la phrase de passe"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
-#: pkg/kubernetes/views/details-page.html:141
-#: pkg/kubernetes/views/replicationcontroller-body.html:9
-#: pkg/kubernetes/views/replicationcontroller-modify.html:8
-msgid "Replicas"
-msgstr "Replicas"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/replicationcontroller-panel.html:10
-#: pkg/kubernetes/views/topology-page.html:22
-msgid "Replication Controller"
-msgstr "Contrôleur de réplication"
-
-#: pkg/kubernetes/views/details-page.html:132
-#: pkg/kubernetes/scripts/details.js:224
-msgid "Replication Controllers"
-msgstr "Contrôleurs de réplication"
-
-#: pkg/kubernetes/views/topology-page.html:23
-msgid ""
-"Replication controllers dynamically create instances of pods from templates, "
-"and remove pods when necessary."
-msgstr ""
-"Les contrôleurs de réplication créent dynamiquement des instances de pods à "
-"partir de modèles et suppriment des pods si nécessaire."
-
 #: pkg/systemd/logs.js:512
 msgid "Report"
 msgstr "Signaler"
@@ -7008,28 +5496,16 @@ msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr ""
 "La signalisation n’a pas abouti. Essayez d’exécuter `reporter-ureport -d"
 
-#: pkg/docker/index.html:688
+#: pkg/docker/index.html:690
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Référentiel"
 
-#: pkg/kubernetes/views/volume-body.html:24
-msgid "Repository URL"
-msgstr "URL du référentiel"
-
-#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
-msgid "Requested"
-msgstr "Demandé"
-
-#: pkg/kubernetes/views/pv-claim.html:13
-msgid "Requests"
-msgstr "Requêtes"
-
-#: pkg/users/local.js:1296
+#: pkg/users/local.js:1300
 msgid "Require password change every $0 days"
 msgstr "Exiger un changement de mot de passe tous les $0 jours"
 
-#: pkg/users/local.js:872
+#: pkg/users/local.js:876
 msgid "Require password change on $0"
 msgstr "Exiger un changement de mot de passe sur $0"
 
@@ -7040,10 +5516,6 @@ msgstr "Requis par"
 #: pkg/systemd/init.js:717
 msgid "Requires"
 msgstr "Nécessite"
-
-#: pkg/kubernetes/views/auth-form.html:54
-msgid "Requires Authentication"
-msgstr "Nécessite une authentification"
 
 #: pkg/systemd/init.js:718
 msgid "Requisite"
@@ -7057,7 +5529,7 @@ msgstr "Requis par"
 msgid "Reserved memory"
 msgstr "Mémoire réservée"
 
-#: pkg/docker/index.html:301 pkg/users/index.html:333
+#: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:105
 msgid "Reset"
 msgstr "Réinitialiser"
@@ -7087,26 +5559,22 @@ msgstr ""
 "Il faut déverrouiller le disque pour pouvoir redimensionner un système de "
 "fichier chiffré. Veuillez fournir une phrase de passe courante."
 
-#: pkg/docker/index.html:135 pkg/systemd/index.html:134
+#: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Redémarrer"
-
-#: pkg/kubernetes/views/container-body.html:20
-msgid "Restart Count"
-msgstr "Redémarrer Comptage"
 
 #: pkg/packagekit/updates.jsx:498
 msgid "Restart Now"
 msgstr "Redémarrer maintenant"
 
-#: pkg/docker/index.html:537 pkg/kubernetes/views/pod-body.html:10
+#: pkg/docker/index.html:539
 msgid "Restart Policy"
 msgstr "Redémarrer la stratégie"
 
-#: pkg/docker/index.html:171
+#: pkg/docker/index.html:172
 msgid "Restart Policy:"
 msgstr "Redémarrer la stratégie :"
 
@@ -7126,52 +5594,27 @@ msgstr "Restauration de la connexion"
 msgid "Resume"
 msgstr "Reprendre"
 
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "Conserver"
-
-#: pkg/docker/index.html:553
+#: pkg/docker/index.html:555
 msgid "Retries:"
 msgstr "Tentatives :"
-
-#: pkg/subscriptions/subscriptions-view.jsx:210
-msgid "Retrieving subscription status..."
-msgstr "Récupération du statut de l’abonnement…"
 
 #: src/ws/login.html:57
 msgid "Reuse my password for privileged tasks"
 msgstr "Réutiliser mon mot de passe pour les tâches privilégiées"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Réutiliser mon mot de passe pour les tâches privilégiées et me connecter à "
 "d’autres machines"
 
-#: pkg/kubernetes/views/volume-body.html:26
-msgid "Revision"
-msgstr "Révision"
-
-#: pkg/kubernetes/views/user-add-membership.html:28
-#: pkg/kubernetes/views/user-body.html:5
-#: pkg/kubernetes/views/user-panel.html:28
-msgid "Role"
-msgstr "Rôle"
-
-#: pkg/kubernetes/views/add-member-role-dialog.html:39
-#: pkg/kubernetes/views/project-body.html:21 pkg/users/index.html:94
+#: pkg/users/index.html:94
 msgid "Roles"
 msgstr "Les rôles"
 
 #: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
 msgid "Round Robin"
 msgstr "Round Robin"
-
-#: pkg/kubernetes/views/route-page.html:14
-#: pkg/kubernetes/views/route-panel.html:9
-msgid "Route"
-msgstr "Route"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:98
 msgid "Route to $0"
@@ -7181,22 +5624,16 @@ msgstr "Routage vers $0"
 msgid "Routed Network"
 msgstr "Réseau routé"
 
-#: pkg/kubernetes/views/details-page.html:65
-#: pkg/kubernetes/scripts/details.js:216 pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3325
 msgid "Routes"
 msgstr "Routes"
 
-#: pkg/docker/index.html:244 pkg/docker/index.html:564
+#: pkg/docker/index.html:253 pkg/docker/index.html:566
 #: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
-#: pkg/ovirt/components/ClusterVms.jsx:92
 msgid "Run"
 msgstr "Exécuter"
 
-#: pkg/ovirt/components/ClusterVms.jsx:97
-msgid "Run Here"
-msgstr "Exécuter ici"
-
-#: pkg/docker/index.html:425
+#: pkg/docker/index.html:427
 msgid "Run Image"
 msgstr "Exécuter l’image"
 
@@ -7205,7 +5642,7 @@ msgid "Run as"
 msgstr "Exécutez en tant que"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:128
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
 msgstr "Démarrer quand l’hôte est amorcé"
 
@@ -7213,17 +5650,13 @@ msgstr "Démarrer quand l’hôte est amorcé"
 msgid "Runner"
 msgstr "Runner"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Running"
 msgstr "En cours"
 
 #: pkg/systemd/services.html:123
 msgid "Running Since"
 msgstr "En fonctionnement depuis"
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:54
-msgid "Running Since:"
-msgstr "En cours d’exécution depuis :"
 
 #: pkg/selinux/setroubleshoot-view.jsx:364
 msgid "SELinux Access Control Errors"
@@ -7249,14 +5682,6 @@ msgstr "SELinux est désactivé sur le système."
 msgid "SELinux system status is unknown."
 msgstr "L’état du système SELinux est inconnu."
 
-#: pkg/ovirt/provider.js:440
-msgid "SET VCPU SETTINGS action failed"
-msgstr "L’action SET VCPU SETTINGS a échoué"
-
-#: pkg/ovirt/provider.js:111 pkg/ovirt/provider.js:145
-msgid "SHUTDOWN action failed"
-msgstr "L’action SHUTDOWN a échoué"
-
 #: pkg/storaged/jobs-panel.jsx:35
 msgid "SMART self-test of $target"
 msgstr "SMART auto-test de $target"
@@ -7277,14 +5702,6 @@ msgstr "Port SPICE :"
 msgid "SPICE TLS Port:"
 msgstr "Port SPICE TLS :"
 
-#: pkg/ovirt/provider.js:225
-msgid "START action failed"
-msgstr "L’action START a échoué"
-
-#: pkg/ovirt/provider.js:203
-msgid "START_VM action failed: %s0"
-msgstr "L’action START_VM a échoué : %0"
-
 #: pkg/networkmanager/index.html:228
 msgid "STP Forward delay"
 msgstr "Délai de réacheminement STP"
@@ -7301,10 +5718,6 @@ msgstr "Âge maximal de message STP"
 msgid "STP Priority"
 msgstr "Priorité STP"
 
-#: pkg/ovirt/provider.js:303
-msgid "SUSPEND action failed"
-msgstr "L’action SUSPEND a échoué"
-
 #: pkg/systemd/services.html:240
 msgid "Saturday"
 msgstr "Samedi"
@@ -7313,10 +5726,10 @@ msgstr "Samedi"
 msgid "Saturdays"
 msgstr "Samedis"
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/ovirt/components/VdsmView.jsx:114 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
 #: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "sauvegarder"
@@ -7343,14 +5756,6 @@ msgstr ""
 "Pour enregistrer une nouvelle phrase de passe, il faut déverrouiller le "
 "disque. Veuillez fournir une phrase de passe courante."
 
-#: pkg/kubernetes/views/node-capacity.html:9
-msgid "Scheduled Pods"
-msgstr "Pods planifiés"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "Planification désactivée"
-
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
 msgstr "PC scellé"
@@ -7359,24 +5764,6 @@ msgstr "PC scellé"
 #: pkg/systemd/init.js:1076
 msgid "Seconds"
 msgstr "Secondes"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Secret"
-
-#: pkg/kubernetes/views/volume-body.html:106
-msgid "Secret File"
-msgstr "Fichier secret"
-
-#: pkg/kubernetes/views/volume-body.html:141
-msgid "Secret Name"
-msgstr "Nom secret"
-
-#: pkg/kubernetes/views/volume-body.html:69
-#: pkg/kubernetes/views/volume-body.html:108
-#: pkg/kubernetes/views/volume-body.html:134
-msgid "Secret Volume"
-msgstr "Volume secret"
 
 #: pkg/systemd/index.html:106
 msgid "Secure Shell Keys"
@@ -7394,33 +5781,14 @@ msgstr "Sécurité"
 msgid "Security Updates Available"
 msgstr "Mises à jour de sécurité disponibles"
 
-#: pkg/shell/index.html:123 pkg/shell/simple.html:91 pkg/shell/stub.html:106
+#: pkg/shell/index.html:123 pkg/shell/simple.html:91
 msgid "Select"
 msgstr "Sélectionner"
 
-#: pkg/kubernetes/views/file-button.html:4
-msgid "Select Manifest File..."
-msgstr "Sélectionnez le fichier manifeste…"
-
-#: pkg/kubernetes/scripts/projects.js:899
-#: pkg/kubernetes/scripts/projects.js:1205
-#: pkg/kubernetes/scripts/projects.js:1335
-msgid "Select Member"
-msgstr "Choisir un membre"
-
-#: pkg/kubernetes/scripts/projects.js:901
-#: pkg/kubernetes/scripts/projects.js:1208
-msgid "Select Role"
-msgstr "Sélectionner un rôle"
-
-#: pkg/kubernetes/views/topology-page.html:7
-msgid "Select an object to see more details."
-msgstr "Sélectionnez un objet pour voir plus de détails."
-
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 "Sélectionnez les utilisateurs que vous souhaitez synchroniser avec "
 "{{#strong}}{{host}}{{/strong}}"
@@ -7429,7 +5797,7 @@ msgstr ""
 msgid "Send Non-Maskable Interrupt"
 msgstr "Envoyer une interruption non masquable"
 
-#: pkg/machines/components/vnc.jsx:109
+#: pkg/machines/components/vnc.jsx:108
 msgid "Send key"
 msgstr "Envoi de la clé"
 
@@ -7443,11 +5811,8 @@ msgstr "Envoi"
 msgid "Serial Console"
 msgstr "Console série"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:116 pkg/storaged/nfs-details.jsx:315
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:65
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Serveur"
 
@@ -7455,7 +5820,7 @@ msgstr "Serveur"
 msgid "Server Address"
 msgstr "Adresse du serveur"
 
-#: pkg/users/local.js:746 pkg/users/local.js:747
+#: pkg/users/local.js:750 pkg/users/local.js:751
 msgid "Server Administrator"
 msgstr "Administrateur de serveur"
 
@@ -7479,16 +5844,10 @@ msgstr "Le serveur a fermé la connexion."
 msgid "Servers"
 msgstr "Les serveurs"
 
-#: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/service-panel.html:8
-#: pkg/kubernetes/views/topology-page.html:30 pkg/systemd/logs.html:66
-#: pkg/networkmanager/firewall.jsx:936 pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Service"
-
-#: pkg/kubernetes/views/pod-body.html:12
-msgid "Service Account"
-msgstr "Compte de service"
 
 #: pkg/systemd/services.html:337
 msgid "Service Logs"
@@ -7518,28 +5877,14 @@ msgstr "Le service s’arrête"
 msgid "Service name"
 msgstr "Nom du service"
 
-#: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
-#: pkg/systemd/services.html:330 pkg/kubernetes/scripts/details.js:213
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
 #: pkg/networkmanager/firewall.jsx:483
 msgid "Services"
 msgstr "Prestations de service"
 
-#: pkg/kubernetes/views/topology-page.html:31
-msgid ""
-"Services group pods and provide a common DNS name and an optional, load-"
-"balanced IP address to access them."
-msgstr ""
-"Les services regroupe les pods et fournissent un nom DNS commun et une "
-"adresse IP facultative équilibrée pour y accéder."
-
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Session"
-
-#: pkg/kubernetes/views/service-body.html:20
-msgid "Session Affinity"
-msgstr "Affinité de session"
 
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
@@ -7557,7 +5902,7 @@ msgstr "Définir le mot"
 msgid "Set Time"
 msgstr "Régler l’heure"
 
-#: pkg/docker/index.html:530
+#: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Définir les variables d’environnement du conteneur"
 
@@ -7592,28 +5937,15 @@ msgstr "Gravité"
 msgid "Severity:"
 msgstr "Gravité :"
 
-#: pkg/kubernetes/views/volume-body.html:139
-msgid "Share Name"
-msgstr "Nom de partage (Share)"
-
 #: pkg/networkmanager/interfaces.js:1959
 msgid "Shared"
 msgstr "Shared"
-
-#: pkg/kubernetes/scripts/projects.js:1043
-msgid "Shared: Allow any authenticated user to pull images"
-msgstr "Shared : permet à tout utilisateur authentifié d’extraire des images"
-
-#: pkg/kubernetes/views/container-page-inline.html:14
-#: pkg/kubernetes/views/container-panel.html:9
-msgid "Shell"
-msgstr "Interpréteur de commande"
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr "Maj+Inser"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Show Performance Options"
 msgstr "Afficher les options de performance"
 
@@ -7621,61 +5953,15 @@ msgstr "Afficher les options de performance"
 msgid "Show all"
 msgstr "Tout afficher"
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:122
 msgid "Show all $0 drives"
 msgstr "Afficher tous les lecteurs $0 "
-
-#: pkg/kubernetes/views/container-page.html:4
-msgid "Show all Containers"
-msgstr "Afficher tous les conteneurs"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:8
-msgid "Show all Deployment Configs"
-msgstr "Afficher toutes les configurations de déploiement"
-
-#: pkg/kubernetes/views/node-page.html:8
-msgid "Show all Nodes"
-msgstr "Afficher tous les nœuds"
-
-#: pkg/kubernetes/views/pv-page.html:9
-msgid "Show all Persistent Volumes"
-msgstr "Afficher tous les volumes persistants"
-
-#: pkg/kubernetes/views/pod-container.html:4
-msgid "Show all Pod Containers"
-msgstr "Afficher tous les conteneurs Pod"
-
-#: pkg/kubernetes/views/pod-page.html:8
-msgid "Show all Pods"
-msgstr "Afficher tous les Pods"
-
-#: pkg/kubernetes/views/group-page.html:14
-#: pkg/kubernetes/views/project-page.html:23
-#: pkg/kubernetes/views/user-page.html:16
-msgid "Show all Projects"
-msgstr "Afficher tous les projets"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:10
-msgid "Show all Replication Controllers"
-msgstr "Afficher tous les contrôleurs de réplication"
-
-#: pkg/kubernetes/views/route-page.html:10
-msgid "Show all Routes"
-msgstr "Afficher tous les itinéraires"
-
-#: pkg/kubernetes/views/service-page.html:8
-msgid "Show all Services"
-msgstr "Afficher tous les services"
 
 #: pkg/docker/index.html:128
 msgid "Show all containers"
 msgstr "Afficher tous les conteneurs"
 
-#: pkg/kubernetes/views/imagestream-page.html:12
-msgid "Show all image streams"
-msgstr "Afficher tous les flux d’images"
-
-#: pkg/docker/index.html:254 pkg/kubernetes/views/image-page.html:10
+#: pkg/docker/index.html:249
 msgid "Show all images"
 msgstr "Afficher toutes les images"
 
@@ -7700,21 +5986,16 @@ msgstr "Réduire le volume"
 msgid "Shut Down"
 msgstr "Fermeture"
 
-#: pkg/kubernetes/views/container-body.html:18
-msgid "Since"
-msgstr "Depuis"
-
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:376
-#: pkg/machines/components/diskAdd.jsx:143
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Taille"
 
@@ -7738,11 +6019,6 @@ msgstr "La taille doit correspondre à un nombre"
 msgid "Size must be at least $0"
 msgstr "La taille doit être au moins $0"
 
-#: pkg/kubernetes/views/auth-form.html:43
-#: pkg/kubernetes/views/auth-rejected-cert.html:11
-msgid "Skip Certificate Verification"
-msgstr "Ignorer la vérification du certificat"
-
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Slot"
 msgstr "Emplacement"
@@ -7752,7 +6028,6 @@ msgid "Slot $0"
 msgstr "Emplacement $0"
 
 #: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Sockets"
 msgstr "Sockets"
 
@@ -7798,18 +6073,14 @@ msgstr ""
 "Un autre programme utilise actuellement le gestionnaire de paquets, veuillez "
 "patienter…"
 
-#: pkg/kubernetes/scripts/volumes.js:914
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "Désolé, je ne sais pas comment modifier ce volume"
-
-#: pkg/networkmanager/firewall.jsx:707
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Sorted from least trusted to most trusted"
 msgstr "Ordonner du moins au plus fiable"
 
-#: pkg/machines/components/diskAdd.jsx:476
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:103
+#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "La source"
 
@@ -7817,10 +6088,10 @@ msgstr "La source"
 msgid "Source Format"
 msgstr "Format de la source"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:217
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:244
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Chemin de la source "
 
@@ -7828,12 +6099,12 @@ msgstr "Chemin de la source "
 msgid "Source URL"
 msgstr "URL de la source"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:254
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
 msgid "Source path should not be empty"
 msgstr "Le chemin de la source ne doit pas être vide"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:108
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "La source devrait commencer par le protocole http, ftp ou nfs"
 
@@ -7861,9 +6132,9 @@ msgstr "Temps spécifique"
 msgid "Stable"
 msgstr "Stable"
 
-#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:320 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Démarrer"
 
@@ -7883,7 +6154,7 @@ msgstr "Démarrer le service"
 msgid "Start libvirt"
 msgstr "Lancer libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:291
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
 msgid "Start pool when host boots"
 msgstr "Démarrer le pool quand l’hôte est amorcé"
 
@@ -7895,59 +6166,29 @@ msgstr "Démarrage du périphérique RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Démarrage de swapspace $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Starts"
-msgstr "Démarre"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
 msgid "Startup"
 msgstr "Startup"
 
-#: pkg/kubernetes/views/container-body.html:16
-#: pkg/kubernetes/views/details-page.html:38
-#: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:127 pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/init.js:285
 msgid "State"
 msgstr "État"
 
-#: pkg/docker/index.html:167
+#: pkg/docker/index.html:168
 msgid "State:"
 msgstr "État :"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "Stateless"
-msgstr "Stateless"
-
-#: pkg/ovirt/components/OVirtTab.jsx:156
-msgid "Stateless:"
-msgstr "Stateless :"
 
 #: pkg/systemd/services.html:74 pkg/systemd/init.js:207
 msgid "Static"
 msgstr "Statique"
 
-#: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/volumes-page.html:21 pkg/systemd/services.html:121
-#: pkg/networkmanager/interfaces.js:2613
-#: pkg/subscriptions/subscriptions-view.jsx:37
+#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
 msgid "Status"
 msgstr "Statut"
-
-#: pkg/subscriptions/subscriptions-view.jsx:162
-msgid "Status: $0"
-msgstr "Statut : $0"
-
-#: pkg/subscriptions/subscriptions-view.jsx:157
-msgid "Status: System isn't registered"
-msgstr "Statut : le système n’est pas enregistré"
 
 #: pkg/lib/machine-info.js:99
 msgid "Stick PC"
@@ -7957,14 +6198,14 @@ msgstr "Stick PC"
 msgid "Sticky"
 msgstr "Sticky"
 
-#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Arrêter"
 
-#: pkg/storaged/mdraid-details.jsx:248
+#: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Arrêter le périphérique"
 
@@ -7996,8 +6237,8 @@ msgstr "Arrêt du périphérique RAID $target"
 msgid "Stopping swapspace $target"
 msgstr "Arrêt de l’espace d’échange $target"
 
-#: pkg/docker/index.html:288 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
+#: pkg/docker/index.html:290 pkg/storaged/index.html:23
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
 #: pkg/storaged/details.jsx:127
 msgid "Storage"
 msgstr "Stockage"
@@ -8006,11 +6247,11 @@ msgstr "Stockage"
 msgid "Storage Logs"
 msgstr "Journaux de stockage"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:137
+#: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr "Échec de l’activation du pool de stockage $0"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:149
+#: pkg/machines/components/storagePools/storagePool.jsx:153
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr "Échec de la désactivation du pool de stockage $0"
 
@@ -8018,7 +6259,7 @@ msgstr "Échec de la désactivation du pool de stockage $0"
 msgid "Storage Pool Name"
 msgstr "Nom du pool de stockage"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:437
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
 msgid "Storage Pool failed to be created"
 msgstr "Le pool de stockage n’a pas pu être créé"
 
@@ -8039,7 +6280,7 @@ msgstr "Les volumes de stockage n’ont pas pu être supprimés"
 msgid "Storage can not be managed on this system."
 msgstr "Le stockage ne peut pas être géré sur ce système."
 
-#: pkg/docker/index.html:302
+#: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Pool de stockage"
 
@@ -8059,10 +6300,6 @@ msgstr "Phrase de passe stockée"
 msgid "Stored passphrase"
 msgstr "Phrase de passe stockée"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:12
-msgid "Strategy"
-msgstr "Stratégie"
-
 #: pkg/lib/machine-info.js:82
 msgid "Sub Chassis"
 msgstr "Sous-châssis"
@@ -8070,10 +6307,6 @@ msgstr "Sous-châssis"
 #: pkg/lib/machine-info.js:77
 msgid "Sub Notebook"
 msgstr "Sub Notebook"
-
-#: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:177
-msgid "Subscriptions"
-msgstr "Abonnements"
 
 #: node_modules/registry-image-widgets/views/image-body.html:4
 msgid "Summary"
@@ -8091,10 +6324,6 @@ msgstr "Dimanches"
 msgid "Support is installed."
 msgstr "La prise en charge est installée."
 
-#: pkg/ovirt/components/VmActions.jsx:40
-msgid "Suspend"
-msgstr "Suspendre"
-
 #: pkg/storaged/content-views.jsx:157
 msgid "Swap"
 msgstr "Swap"
@@ -8108,10 +6337,6 @@ msgstr "Espace swap"
 msgid "Swap Used"
 msgstr "Swap utilisé"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:40
-msgid "Switch Host to Maintenance"
-msgstr "Passer l’hôte à la maintenance"
-
 #: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
 msgid "Switch off $0"
 msgstr "Éteindre $0"
@@ -8119,15 +6344,6 @@ msgstr "Éteindre $0"
 #: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
 msgid "Switch on $0"
 msgstr "Allumer $0"
-
-#: pkg/ovirt/provider.js:414
-msgid "Switching host to maintenance mode failed. Received error: "
-msgstr ""
-"La commutation de l’hôte en mode de maintenance a échoué. Erreur reçue :"
-
-#: pkg/ovirt/provider.js:408
-msgid "Switching host to maintenance mode in progress ..."
-msgstr "Passage de l’hôte au mode maintenance en cours…"
 
 #: pkg/networkmanager/interfaces.js:2491
 msgid ""
@@ -8152,10 +6368,6 @@ msgid ""
 msgstr ""
 "Activer <b>$0</b> interrompra la connexion au serveur et rendra l’interface "
 "utilisateur d’administration indisponible."
-
-#: pkg/kubernetes/scripts/images.js:634
-msgid "Sync all tags from a remote image repository"
-msgstr "Synchroniser toutes les balises d’un référentiel d’images distant"
 
 #: pkg/lib/machine-sync-users.html:75
 msgid "Synchronize"
@@ -8206,25 +6418,20 @@ msgstr "Le système est à jour"
 msgid "System is up to date"
 msgstr "Le système est à jour"
 
-#: pkg/docker/index.html:327 pkg/docker/index.html:331
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:329 pkg/docker/index.html:333
+#: pkg/networkmanager/firewall.jsx:938
 msgid "TCP"
 msgstr "TCP"
-
-#: pkg/kubernetes/views/route-body.html:12
-msgid "TLS Termination"
-msgstr "Résiliation TLS"
 
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
 msgstr "Tablette"
 
-#: pkg/docker/index.html:694
+#: pkg/docker/index.html:696
 #: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Balise"
 
-#: pkg/kubernetes/views/imagestream-modify.html:76
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
@@ -8236,25 +6443,16 @@ msgstr "Balises"
 msgid "Tang keyserver"
 msgstr "Serveur de clés Tang"
 
-#: pkg/kubernetes/views/pv-modify.html:137
 #: pkg/machines/components/vm/bootOrderModal.jsx:133
 msgid "Target"
 msgstr "Cible"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Chemin cible"
 
-#: pkg/kubernetes/views/volume-body.html:75
-msgid "Target Portal"
-msgstr "Portail cible"
-
-#: pkg/kubernetes/views/volume-body.html:114
-msgid "Target World Wide Names"
-msgstr "Ciblez des noms World Wide"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:133
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
 msgid "Target path should not be empty"
 msgstr "Le chemin cible ne doit pas rester vide"
 
@@ -8278,22 +6476,6 @@ msgstr "Paramètres du port de l’équipe"
 #: pkg/networkmanager/index.html:514
 msgid "Team Settings"
 msgstr "Paramètres de l’équipe"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:15
-#: pkg/kubernetes/views/deploymentconfig-panel.html:10
-#: pkg/kubernetes/views/replicationcontroller-page.html:20
-#: pkg/kubernetes/views/replicationcontroller-panel.html:14
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "Template"
-msgstr "Modèle"
-
-#: pkg/ovirt/components/App.jsx:111
-msgid "Templates"
-msgstr "Modèles"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:130
-msgid "Templates of $0 cluster"
-msgstr "Modèles de $0 cluster"
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
@@ -8329,11 +6511,11 @@ msgstr "Le pool de stockage Docker ne peut pas être géré sur ce système."
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "L’adresse IP ou le nom d’hôte ne peut pas contenir d’espace."
 
-#: pkg/storaged/mdraid-details.jsx:219
+#: pkg/storaged/mdraid-details.jsx:218
 msgid "The RAID Array is in a degraded state"
 msgstr "Le RAID Array est dans un état dégradé"
 
-#: pkg/storaged/mdraid-details.jsx:149
+#: pkg/storaged/mdraid-details.jsx:148
 msgid "The RAID device must be running in order to add spare disks."
 msgstr ""
 "Le périphérique RAID doit être en cours d’exécution pour pouvoir ajouter des "
@@ -8389,36 +6571,27 @@ msgstr ""
 "La machine virtuelle est suspendue par la gestion de l’alimentation de "
 "l’invité."
 
-#: pkg/users/local.js:1338
+#: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
 msgstr ""
 "Le compte « $0 » sera forcé de changer de mot de passe lors de la prochaine "
 "connexion"
 
-#: pkg/kubernetes/scripts/nodes.js:403
-msgid "The address contains invalid characters"
-msgstr "L’adresse contient des caractères non valides"
-
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "L’authenticité de l’hôte {{#strong}}{{host}}{{/strong}} ne peut pas être "
 "établie. Êtes-vous sûr de vouloir continuer à vous connecter ?"
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
-msgstr ""
-"Les informations collectées seront stockées localement sur le système."
+msgstr "Les informations collectées seront stockées localement sur le système."
 
 #: pkg/selinux/setroubleshoot-view.jsx:291
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr "L’état configuré est inconnu, il peut changer au démarrage suivant."
-
-#: pkg/kubernetes/views/container-page-inline.html:22
-msgid "The container '{{ target }}' does not exist."
-msgstr "Le conteneur « {{target}} » n’existe pas."
 
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
@@ -8427,12 +6600,6 @@ msgstr ""
 "La création de ce périphérique VDO n’est pas terminée et l’appareil ne peut "
 "pas être utilisé."
 
-#: pkg/subscriptions/subscriptions-view.jsx:214
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-"L’utilisateur actuel n’est pas autorisé à accéder au statut d’abonnement au "
-"système."
-
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
@@ -8440,11 +6607,7 @@ msgstr ""
 "L’utilisateur actuellement connecté n’est pas autorisé à voir les "
 "informations sur les clés."
 
-#: pkg/kubernetes/views/deploymentconfig-page.html:25
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "La configuration de déploiement « {{target}} » n’existe pas."
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:204
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
 msgid "The directory on the server being exported"
 msgstr "Le répertoire du serveur à exporter"
 
@@ -8457,8 +6620,7 @@ msgstr ""
 "système. Si vous continuez, vous les interromprez."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Le système de fichiers est utilisé par des sessions en cours. Si vous "
 "continuez, vous les interromprez."
@@ -8471,8 +6633,7 @@ msgstr ""
 "système. Si vous continuez, vous les interromprez."
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "Les conteneurs suivants dépendent de cette image et deviendront "
 "inutilisables."
@@ -8486,10 +6647,6 @@ msgstr ""
 "L’archive générée contient des données considérées comme sensibles et son "
 "contenu doit être examiné par l’organisation d’origine avant d’être transmis "
 "à un tiers."
-
-#: pkg/kubernetes/views/group-page.html:47
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "Le groupe « {{groupName}} » n’existe pas."
 
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
@@ -8519,31 +6676,16 @@ msgid "The last physical volume of a volume group cannot be removed."
 msgstr ""
 "Le dernier volume physique d’un groupe de volumes ne peut pas être supprimé."
 
-#: pkg/shell/indexes.js:408
+#: pkg/shell/indexes.js:407
 msgid "The machine is restarting"
 msgstr "La machine redémarre"
 
-#: pkg/kubernetes/scripts/details.js:498 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "Le nombre maximum de répliques est de 128"
+#: pkg/machines/components/networks/networkDelete.jsx:76
+#, fuzzy
+msgid "The network could not be deleted"
+msgstr "Le pool de stockage n’a pas pu être supprimé"
 
-#: pkg/kubernetes/scripts/nodes.js:411
-msgid "The name contains invalid characters"
-msgstr "Le nom contient des caractères invalides"
-
-#: pkg/kubernetes/views/node-page.html:23
-msgid "The node '{{ target }}' does not exist."
-msgstr "Le nœud « {{target}} » n’existe pas."
-
-#: pkg/kubernetes/views/node-alerts.html:7
-msgid "The node doesn't have enough disk space"
-msgstr "Le noeud n’a pas assez d’espace disque"
-
-#: pkg/kubernetes/views/node-alerts.html:11
-msgid "The node doesn't have enough free memory"
-msgstr "Le noeud n’a pas assez de mémoire disponible"
-
-#: pkg/users/local.js:439 pkg/users/local.js:1395
+#: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
 msgstr "Le mot de passe ne correspond pas"
 
@@ -8551,29 +6693,9 @@ msgstr "Le mot de passe ne correspond pas"
 msgid "The passwords do not match."
 msgstr "Le mot de passe ne correspond pas."
 
-#: pkg/kubernetes/views/pv-page.html:21
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "Le volume persistant « {{target}} » n’existe pas."
-
-#: pkg/kubernetes/views/pod-page.html:40
-msgid "The pod '{{ target }}' does not exist."
-msgstr "Le pod « {{target}} » n’existe pas."
-
 #: pkg/machines/components/diskAdd.jsx:80
 msgid "The pool is empty"
 msgstr "La pool est vide"
-
-#: pkg/kubernetes/views/project-page.html:34
-msgid "The project '{{ projName }}' does not exist."
-msgstr "Le projet « {{projName}} » n’existe pas."
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:30
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "Le contrôleur de réplication « {{target}} » n’existe pas."
-
-#: pkg/kubernetes/views/route-page.html:19
-msgid "The route '{{ target }}' does not exist."
-msgstr "La route « {{target}} » n’existe pas."
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
@@ -8582,12 +6704,6 @@ msgstr "Le scan de $time ( $type ) n’a trouvé aucune vulnérabilité."
 #: pkg/docker/containers-view.jsx:432
 msgid "The scan from $time ($type) was not successful."
 msgstr "Le scan de $time ( $type ) n’a pas réussi."
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-"Le fichier sélectionné n’est pas un manifeste d’application Kubernetes "
-"valide."
 
 #: src/ws/login.js:645
 msgid ""
@@ -8604,23 +6720,11 @@ msgstr ""
 "Le serveur a refusé d’authentifier en utilisant des méthodes prises en "
 "charge."
 
-#: pkg/kubernetes/views/auth-rejected-cert.html:2
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr "Le serveur utilise un certificat signé par une autorité inconnue."
-
-#: pkg/kubernetes/views/service-page.html:19
-msgid "The service '{{ target }}' does not exist."
-msgstr "Le service « {{target}} » n’existe pas."
-
 #: pkg/systemd/hwinfo.jsx:65
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 "L’utilisateur $0 n’est pas autorisé à changer les mitigations de sécurité "
 "pour le  CPU"
-
-#: pkg/kubernetes/views/user-page.html:29
-msgid "The user '{{ userName }}' does not exist."
-msgstr "L’utilisateur « {{userName}} » n’existe pas."
 
 #: pkg/systemd/init.js:922
 msgid "The user <b>$0</b> does not have permissions for creating timers"
@@ -8663,23 +6767,21 @@ msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
 "L’utilisateur <b>$0</b> n’est pas autorisé à modifier les paramètres réseau"
 
-#: pkg/realmd/operation.js:643
+#: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "L’utilisateur <b>$0</b> n’est pas autorisé à modifier les domaines"
 
 #: pkg/systemd/host.js:62
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr ""
-"L’utilisateur <b>$0</b> n’est pas autorisé à arrêter ou redémarrer ce "
-"serveur"
+"L’utilisateur <b>$0</b> n’est pas autorisé à arrêter ou redémarrer ce serveur"
 
 #: pkg/systemd/init.js:606 pkg/systemd/init.js:610
 msgid "The user <b>$0</b> is not permitted to start or stop services"
 msgstr ""
-"L’utilisateur <b>$0</b> n’est pas autorisé à démarrer ou arrêter les "
-"services"
+"L’utilisateur <b>$0</b> n’est pas autorisé à démarrer ou arrêter les services"
 
-#: pkg/users/local.js:549
+#: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
@@ -8689,8 +6791,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "La configuration du navigateur Web empêche l’exécution de Cockpit "
 "(inaccessible $0 )"
@@ -8716,8 +6817,8 @@ msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
 msgstr ""
-"Il n’y a pas assez d’espace libre ailleurs pour supprimer ce volume physique."
-" Il faut au moins $0 plus d’espace libre."
+"Il n’y a pas assez d’espace libre ailleurs pour supprimer ce volume "
+"physique. Il faut au moins $0 plus d’espace libre."
 
 #: pkg/storaged/utils.js:193
 msgid "Thin Logical Volume"
@@ -8731,15 +6832,7 @@ msgstr ""
 
 #: pkg/storaged/vdo-details.jsx:133
 msgid "This VDO device does not use all of its backing device."
-msgstr ""
-"Ce périphérique VDO n’utilise pas tout son périphérique de sauvegarde."
-
-#: pkg/kubernetes/views/pvc-delete.html:8
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-"Cette requête est en cours d’utilisation. La supprimer peut entraîner des "
-"problèmes avec le pod suivant :"
+msgstr "Ce périphérique VDO n’utilise pas tout son périphérique de sauvegarde."
 
 #: pkg/systemd/init.js:1371
 msgid ""
@@ -8798,14 +6891,6 @@ msgstr ""
 msgid "This field cannot be empty."
 msgstr "Ce champ ne peut pas être vide."
 
-#: pkg/ovirt/components/App.jsx:155
-msgid ""
-"This host is managed by a virtualization manager, so creation of new VMs "
-"from the host is not possible."
-msgstr ""
-"Cet hôte est géré par un gestionnaire de virtualisation, donc la création de "
-"nouvelles machines virtuelles à partir de l’hôte n’est pas possible."
-
 #: pkg/docker/containers-view.jsx:494
 msgid "This image does not exist."
 msgstr "Cette image n’existe pas."
@@ -8821,14 +6906,6 @@ msgstr "Cette machine a déjà été ajoutée."
 #: pkg/realmd/operation.html:80
 msgid "This may take a while"
 msgstr "Cela peut prendre un peu de temps"
-
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-"Cette option est réservée aux tests à un seul nœud - le stockage local ne "
-"fonctionnera pas dans un cluster à plusieurs nœuds"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
@@ -8868,7 +6945,7 @@ msgstr "Cette unité est une instance du modèle $0."
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Cette unité n’est pas conçue pour être activée explicitement."
 
-#: pkg/users/local.js:557
+#: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "Cet identifiant existe déjà"
 
@@ -8880,25 +6957,7 @@ msgstr ""
 "Cette version de cockpit-ws ne prend pas en charge la connexion à un hôte "
 "avec un autre utilisateur ou port"
 
-#: pkg/ovirt/components/OVirtTab.jsx:134
-msgid "This virtual machine is not managed by oVirt"
-msgstr "Cette machine virtuelle n’est pas gérée par oVirt"
-
-#: pkg/kubernetes/views/pv-delete.html:7
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
-msgstr ""
-"Ce volume a été revendiqué par {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Le supprimer va briser cette demande et "
-"peut entraîner des problèmes avec les pods qui en dépendent."
-
-#: pkg/kubernetes/views/pv-claim.html:23
-msgid "This volume has not been claimed"
-msgstr "Ce volume n’a pas été revendiqué"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:369
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
 msgid "This volume is already used by another VM."
 msgstr "Ce volume est déjà utilisé par une autre VM."
 
@@ -8929,7 +6988,6 @@ msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Cela testera la configuration de kdump en plantant le noyau."
 
 #: pkg/machines/components/vcpuModal.jsx:212
-#: pkg/ovirt/components/vcpuModal.jsx:70
 msgid "Threads per core"
 msgstr "Threads par noyaux"
 
@@ -8982,10 +7040,6 @@ msgstr ""
 "Pour essayer un port différent, vous devrez mettre à niveau cockpit-ws à une "
 "version plus récente."
 
-#: pkg/kubernetes/views/auth-form.html:116
-msgid "Token"
-msgstr "Jeton"
-
 #: pkg/lib/cockpit-components-file-autocomplete.jsx:148
 msgid "Too many files found"
 msgstr "Trop de fichiers trouvés"
@@ -8993,10 +7047,6 @@ msgstr "Trop de fichiers trouvés"
 #: src/base1/cockpit.js:4039
 msgid "Too much data"
 msgstr "Trop de données"
-
-#: pkg/kubernetes/index.html:61
-msgid "Topology"
-msgstr "Topologie"
 
 #: pkg/docker/storage.jsx:341
 msgid "Total"
@@ -9014,12 +7064,11 @@ msgstr "Tower"
 msgid "Triggered By"
 msgstr "Déclenché par"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:32 pkg/systemd/init.js:732
+#: pkg/systemd/init.js:732
 msgid "Triggers"
 msgstr "Déclencheurs"
 
-#: pkg/kubernetes/index.html:109 pkg/shell/index.html:387
-#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/shell/index.html:387 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Troubleshoot"
@@ -9028,13 +7077,9 @@ msgstr "Troubleshoot"
 msgid "Trust key"
 msgstr "Clé de confiance"
 
-#: pkg/networkmanager/firewall.jsx:703
+#: pkg/networkmanager/firewall.jsx:705
 msgid "Trust level"
 msgstr "Niveau de confiance"
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:21
-msgid "Trust this certificate for this connection"
-msgstr "Faites confiance à ce certificat pour cette connexion"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -9076,20 +7121,17 @@ msgstr "Tuned ne fonctionne pas"
 msgid "Tuned is off"
 msgstr "Tuned est désactivé"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:84
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Type"
 
@@ -9105,16 +7147,11 @@ msgstr "Tapez un mot de passe"
 msgid "Type to filter…"
 msgstr "Tapez pour filtrer…"
 
-#: pkg/kubernetes/views/details-page.html:7
-msgid "Type:"
-msgstr "Type :"
-
-#: pkg/docker/index.html:332 pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
-#: pkg/subscriptions/subscriptions-register.jsx:112
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
 msgid "URL"
 msgstr "URL"
 
@@ -9130,17 +7167,9 @@ msgstr "Les paramètres n’ont pas pu être appliés : $0"
 msgid "Unable to apply this solution automatically"
 msgstr "Cette solution n’a pas pu être appliquée automatiquement"
 
-#: pkg/subscriptions/subscriptions-view.jsx:217
-msgid "Unable to connect"
-msgstr "Incapable de se connecter"
-
 #: src/ws/login.js:649
 msgid "Unable to connect to that address"
 msgstr "Incapable de se connecter à cette adresse"
-
-#: pkg/kubernetes/scripts/dashboard.js:412
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "Incapable de décoder le manifeste d’application Kubernetes."
 
 #: pkg/users/local.js:58
 msgid "Unable to delete root account"
@@ -9158,10 +7187,6 @@ msgstr "Incapable d’obtenir l’alerte : $0"
 #: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Incapable d’atteindre le serveur"
-
-#: pkg/kubernetes/scripts/dashboard.js:400
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Incapable de lire le manifeste de l’application Kubernetes. Code $0 ."
 
 #: pkg/storaged/nfs-details.jsx:282
 msgid "Unable to remove mount"
@@ -9188,16 +7213,15 @@ msgid "Unable to unmount filesystem"
 msgstr "Incapable de démonter le système de fichiers"
 
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
-#: pkg/kubernetes/scripts/charts.js:110
 msgid "Unavailable"
 msgstr "Non disponible"
 
-#: pkg/docker/index.html:730 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1481
+#: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
+#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Erreur inattendue"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:132
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid "Unique name"
 msgstr "Nom unique"
 
@@ -9206,19 +7230,14 @@ msgstr "Nom unique"
 msgid "Unit"
 msgstr "Unité"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
-#: pkg/kubernetes/views/volumes-page.html:35
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:754 pkg/kubernetes/scripts/volumes.js:267
-#: pkg/lib/machine-info.js:65 pkg/networkmanager/interfaces.js:596
-#: pkg/networkmanager/interfaces.js:1067 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2534 pkg/storaged/fsys-tab.jsx:64
-#: pkg/storaged/swap-tab.jsx:57
+#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
+#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -9254,7 +7273,7 @@ msgstr "Nom de service inconnu"
 msgid "Unknown type"
 msgstr "Type inconnu"
 
-#: pkg/docker/index.html:549 pkg/docker/util.js:110
+#: pkg/docker/index.html:551 pkg/docker/util.js:110
 msgid "Unless Stopped"
 msgstr "Sauf si arrêté"
 
@@ -9303,7 +7322,7 @@ msgstr "Démonter $target"
 msgid "Unnamed"
 msgstr "Anonyme"
 
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Unplug"
 msgstr "Débrancher"
 
@@ -9319,14 +7338,6 @@ msgstr "Données non reconnues"
 #: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Les données non reconnues ne peuvent pas être plus petites ici."
-
-#: pkg/subscriptions/subscriptions-view.jsx:164
-msgid "Unregister"
-msgstr "Annuler l’inscription"
-
-#: pkg/subscriptions/subscriptions-view.jsx:170
-msgid "Unregistering system..."
-msgstr "Système de désenregistrement…"
 
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
@@ -9349,7 +7360,12 @@ msgstr "Hôte non sécurisé"
 msgid "Up since $0"
 msgstr "En cours depuis $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:316
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+#, fuzzy
+msgid "Up to $0 $1 available in the default location"
+msgstr "Jusqu'à $0 $1 disponibles sur l'hôte"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
 msgid "Up to $0 $1 available on the host"
 msgstr "Jusqu'à $0 $1 disponibles sur l'hôte"
 
@@ -9378,13 +7394,9 @@ msgstr ""
 msgid "Updates Available"
 msgstr "Mises à jour disponibles"
 
-#: pkg/packagekit/updates.jsx:52 pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/packagekit/updates.jsx:52
 msgid "Updating"
 msgstr "Mise à jour en cours"
-
-#: pkg/kubernetes/scripts/details.js:654
-msgid "Updating $0..."
-msgstr "Mise à jour de $0…"
 
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
@@ -9400,21 +7412,15 @@ msgstr[1] "Utilisation de $0 noyaux CPU"
 msgid "Use 512 Byte emulation"
 msgstr "Utiliser l’émulation 512 octets"
 
-#: pkg/machines/components/diskAdd.jsx:496
+#: pkg/machines/components/diskAdd.jsx:524
 msgid "Use Existing"
 msgstr "Utiliser l’existant"
 
-#: pkg/subscriptions/subscriptions-register.jsx:136
-msgid "Use proxy server"
-msgstr "Utiliser un serveur proxy"
-
 #: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
-msgstr ""
-"Utilisez les clés suivantes pour vous authentifier à d’autres systèmes"
+msgstr "Utilisez les clés suivantes pour vous authentifier à d’autres systèmes"
 
 #: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
-#: pkg/kubernetes/scripts/nodes.js:829 pkg/kubernetes/scripts/nodes.js:838
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
@@ -9426,18 +7432,13 @@ msgstr "Utilisé"
 msgid "Used by"
 msgstr "Utilisé par"
 
-#: pkg/docker/index.html:262
+#: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "Utilisé par les conteneurs"
 
-#: pkg/dashboard/index.html:144 pkg/kubernetes/views/auth-form.html:61
-#: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
-#: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/subscriptions/subscriptions-register.jsx:77 pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1584
 msgid "User"
 msgstr "Utilisateur"
 
@@ -9446,11 +7447,11 @@ msgstr "Utilisateur"
 msgid "User Name"
 msgstr "Nom d’utilisateur"
 
-#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:337
+#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:336
 msgid "User Password"
 msgstr "Mot de passe de l’utilisateur"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nom d’utilisateur"
@@ -9459,18 +7460,9 @@ msgstr "Nom d’utilisateur"
 msgid "User name cannot be empty"
 msgstr "Le nom d’utilisateur ne peut pas être vide"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:15
-msgid "User or Group"
-msgstr "Utilisateur ou groupe"
-
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
-#: pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
 msgid "Username"
 msgstr "Nom d’utilisateur"
-
-#: pkg/kubernetes/views/project-listing.html:85
-msgid "Users"
-msgstr "Utilisateurs"
 
 #: pkg/lib/machine-change-auth.html:44
 msgid "Using available credentials"
@@ -9509,14 +7501,6 @@ msgstr "Les sauvegardes VDO ne peuvent pas être plus petits"
 msgid "VDO support not installed"
 msgstr "Prise en charge VDO non installée"
 
-#: pkg/ovirt/components/App.jsx:115
-msgid "VDSM"
-msgstr "VDSM"
-
-#: pkg/ovirt/components/VdsmView.jsx:128
-msgid "VDSM Service Management"
-msgstr "VDSM Service Management"
-
 #: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
 #: pkg/networkmanager/interfaces.js:2906
 msgid "VLAN"
@@ -9546,7 +7530,7 @@ msgstr "Échec de l’arrêt forcé de la VM $0"
 msgid "VM $0 failed to get deleted"
 msgstr "Échec de la suppression de la VM $0"
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1317
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
 msgid "VM $0 failed to get installed"
 msgstr "Échec de l’installation de la VM $0"
 
@@ -9570,10 +7554,6 @@ msgstr "Échec de l’arrêt de la VM $0"
 msgid "VM $0 failed to start"
 msgstr "Échec du démarrage de la VM $0"
 
-#: pkg/ovirt/components/VmOverviewColumn.jsx:37
-msgid "VM icon"
-msgstr "Icône de machine virtuelle"
-
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
 msgstr "VNC"
@@ -9590,7 +7570,7 @@ msgstr "Port VNC :"
 msgid "VNC TLS Port:"
 msgstr "Port VNC TLS :"
 
-#: pkg/realmd/operation.js:165
+#: pkg/realmd/operation.js:164
 msgid "Validating address"
 msgstr "Validation de l’adresse"
 
@@ -9619,30 +7599,20 @@ msgstr "Vérifier la clé"
 msgid "Verifying"
 msgstr "Vérification"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:110 pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:381
-#: pkg/subscriptions/subscriptions-view.jsx:35 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Version"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Version num"
-msgstr "Num de version"
 
 #: pkg/storaged/jobs-panel.jsx:57
 msgid "Very securely erasing $target"
 msgstr "Effacement très sécurisé de $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Machines virtuelles"
-
-#: pkg/ovirt/components/ClusterVms.jsx:176
-msgid "Virtual Machines of $0 cluster"
-msgstr "Machines virtuelles de $0 cluster"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
@@ -9656,14 +7626,11 @@ msgstr "Le service de virtualisation (libvirt) n’est pas actif"
 msgid "Virtualization Service is Available"
 msgstr "Le service de virtualisation est disponible"
 
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
-#: pkg/kubernetes/views/pvc-body.html:6
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:359
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Volume"
 
@@ -9671,7 +7638,7 @@ msgstr "Volume"
 msgid "Volume Group"
 msgstr "Groupe de volumes"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:233
+#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Groupe de volumes $0"
 
@@ -9679,32 +7646,16 @@ msgstr "Groupe de volumes $0"
 msgid "Volume Groups"
 msgstr "Groupes de volumes"
 
-#: pkg/kubernetes/views/volume-body.html:14
-#: pkg/kubernetes/views/volume-body.html:89
-msgid "Volume ID"
-msgstr "ID de volume"
-
-#: pkg/kubernetes/views/pv-modify.html:115
-#: pkg/kubernetes/views/volume-body.html:42
-msgid "Volume Name"
-msgstr "Nom du volume"
-
-#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
-msgid "Volume Type"
-msgstr "Type de volume"
-
 #: pkg/storaged/lvol-tabs.jsx:410
 msgid "Volume size is $0. Content size is $1."
 msgstr "La taille du volume est $0. La taille du contenu est $1."
 
-#: pkg/docker/index.html:515 pkg/kubernetes/index.html:74
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:517
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volumes"
 
-#: pkg/docker/index.html:199
+#: pkg/docker/index.html:200
 msgid "Volumes:"
 msgstr "Volumes :"
 
@@ -9744,10 +7695,6 @@ msgstr "Recherches"
 msgid "Warning and above"
 msgstr "Avertissement et au-dessus"
 
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid "Warning:"
-msgstr "Attention :"
-
 #: cockpit.appdata.xml.in.h:1
 msgid "Web Console for Linux servers"
 msgstr "Console web pour serveurs Linux"
@@ -9764,23 +7711,15 @@ msgstr "Mercredis"
 msgid "Weeks"
 msgstr "Semaines"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:5
-msgid "Welcome to the Image Registry"
-msgstr "Bienvenue dans le registre d’images"
-
 #: pkg/storaged/crypto-keyslots.jsx:324
 msgid "What if tang-show-keys is not available?"
 msgstr "Que faire si les touches tang-show ne sont pas disponibles ?"
-
-#: pkg/kubernetes/views/volumes-page.html:61
-msgid "When"
-msgstr "Quand"
 
 #: pkg/systemd/terminal.jsx:101
 msgid "White"
 msgstr "Blanc"
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:488
 msgid "With terminal"
 msgstr "Avec terminal"
 
@@ -9800,7 +7739,7 @@ msgstr "Mauvais nom d’utilisateur ou mot de passe"
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:996 pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2593
 msgid "Yes"
 msgstr "Oui"
 
@@ -9821,22 +7760,9 @@ msgstr ""
 "le supprimer."
 
 #: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:871 pkg/networkmanager/firewall.jsx:877
+#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
 msgid "You are not authorized to modify the firewall."
 msgstr "Vous n’êtes pas autorisé à modifier le pare-feu."
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:3
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-"Vous pouvez ignorer la vérification du certificat, mais toutes les données "
-"que vous envoyez au serveur peuvent être interceptées par d’autres personnes."
-""
-
-#: pkg/kubernetes/views/dashboard-page.html:150
-msgid "You can deploy an application to your cluster."
-msgstr "Vous pouvez déployer une application sur votre cluster."
 
 #: pkg/users/index.html:390
 msgid ""
@@ -9854,7 +7780,7 @@ msgstr "Vous n’êtes pas autorisé à gérer le pool de stockage Docker."
 msgid "You must wait longer to change your password"
 msgstr "Vous devez encore attendre avant de changer votre mot de passe"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
 msgid ""
 "You need to select the most closely matching OS vendor and Operating System"
 msgstr ""
@@ -9869,14 +7795,6 @@ msgstr ""
 "Votre navigateur se déconnectera, mais cela n’affectera pas le processus de "
 "mise à jour, vous pourrez vous reconnecter dans quelques instants pour "
 "continuer à suivre la progression."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:112
-msgid ""
-"Your login credentials do not give you access to use the docker registry "
-"from the command line."
-msgstr ""
-"Vos identifiants ne vous permettent pas d’utiliser le registre docker à "
-"partir de la ligne de commande."
 
 #: pkg/packagekit/updates.jsx:865
 msgid ""
@@ -9894,11 +7812,11 @@ msgstr "Votre session a été interrompue."
 msgid "Your session has expired. Please log in again."
 msgstr "Votre session a expiré. Veuillez vous reconnecter"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Zone"
 msgstr "Zone"
 
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/networkmanager/firewall.jsx:938
 msgid "Zones"
 msgstr "Zones"
 
@@ -9914,8 +7832,12 @@ msgstr "[données binaires]"
 msgid "[no data]"
 msgstr "[pas de données]"
 
-#: pkg/machines/components/networks/network.jsx:58
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "actif"
@@ -9949,17 +7871,9 @@ msgstr "octets"
 msgid "cdrom"
 msgstr "CD ROM"
 
-#: pkg/ovirt/rephraseUI.js:35
-msgid "connecting"
-msgstr "connexion"
-
 #: pkg/machines/components/infoRecord.jsx:29
 msgid "control-label $0"
 msgstr "control-label $0"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "cores"
-msgstr "noyaux"
 
 #: pkg/machines/helpers.js:193
 msgid "crashed"
@@ -9978,7 +7892,6 @@ msgid "direct"
 msgstr "direct"
 
 #: pkg/machines/helpers.js:177 pkg/machines/helpers.js:180
-#: pkg/ovirt/components/OVirtTab.jsx:123
 msgid "disabled"
 msgstr "désactivé"
 
@@ -9986,7 +7899,7 @@ msgstr "désactivé"
 msgid "disk"
 msgstr "disque"
 
-#: pkg/machines/helpers.js:238 pkg/ovirt/rephraseUI.js:27
+#: pkg/machines/helpers.js:238
 msgid "down"
 msgstr "arrêté"
 
@@ -9994,26 +7907,17 @@ msgstr "arrêté"
 msgid "dying"
 msgstr "sur le point ce cesser toute activité"
 
-#: pkg/realmd/operation.js:299 pkg/realmd/operation.js:305
+#: pkg/realmd/operation.js:298 pkg/realmd/operation.js:304
 msgid "e.g. \"$0\""
 msgstr "par ex. \"$0\""
 
-#: pkg/kubernetes/scripts/images.js:639
-msgid "eg: my-image-stream"
-msgstr "ex : my-image-stream"
-
 #: pkg/machines/helpers.js:178 pkg/machines/helpers.js:181
-#: pkg/ovirt/components/OVirtTab.jsx:125
 msgid "enabled"
 msgstr "activée"
 
 #: pkg/packagekit/updates.jsx:267
 msgid "enhancement"
 msgstr "amélioration"
-
-#: pkg/ovirt/rephraseUI.js:28
-msgid "error"
-msgstr "erreur"
 
 #: pkg/machines/helpers.js:214
 msgid "ethernet"
@@ -10039,7 +7943,7 @@ msgstr "Périphérique hôte"
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:182
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
 msgid "iSCSI Initiator IQN"
 msgstr "iSCSI Initiator IQN"
 
@@ -10055,7 +7959,7 @@ msgstr "Cibles iSCSI"
 msgid "iSCSI direct Target"
 msgstr "Cible directe iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
 msgid "iSCSI target IQN"
 msgstr "Cible iSCSI IQN"
 
@@ -10063,22 +7967,10 @@ msgstr "Cible iSCSI IQN"
 msgid "idle"
 msgstr "inactif"
 
-#: pkg/machines/components/networks/network.jsx:58
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "inactif"
-
-#: pkg/ovirt/rephraseUI.js:29
-msgid "initializing"
-msgstr "initialisation"
-
-#: pkg/ovirt/rephraseUI.js:30
-msgid "installation failed"
-msgstr "l’installation a échoué"
-
-#: pkg/ovirt/rephraseUI.js:38
-msgid "installing OS"
-msgstr "l’installation du système"
 
 #: pkg/kdump/kdump-view.jsx:376
 msgid "invalid: multiple targets defined"
@@ -10087,10 +7979,6 @@ msgstr "invalide : plusieurs cibles définies"
 #: pkg/kdump/kdump-view.jsx:493
 msgid "kdump status"
 msgstr "statut kdump"
-
-#: pkg/ovirt/rephraseUI.js:39
-msgid "kdumping"
-msgstr "kdumping"
 
 #: pkg/docker/run.js:527
 msgid "key"
@@ -10104,10 +7992,6 @@ msgstr "logement de clé $0"
 msgid "locally in $0"
 msgstr "localement dans $0"
 
-#: pkg/ovirt/rephraseUI.js:31
-msgid "maintenance"
-msgstr "maintenance"
-
 #: pkg/machines/helpers.js:216
 msgid "mcast"
 msgstr "mcast"
@@ -10120,62 +8004,18 @@ msgstr "réseau"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "la cible nfs dump n’a pas été formatée sous la forme server : path"
 
-#: pkg/kubernetes/views/route-body.html:14
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:43
 msgid "no"
 msgstr "non"
 
-#: pkg/ovirt/rephraseUI.js:32
-msgid "non operational"
-msgstr "non opérationnel"
-
-#: pkg/ovirt/rephraseUI.js:33
-msgid "non responsive"
-msgstr "non réactif"
-
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
-#: pkg/kubernetes/views/route-body.html:24
-#: pkg/kubernetes/views/route-body.html:29
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "aucun"
-
-#: pkg/ovirt/provider.js:62
-msgid "oVirt"
-msgstr "oVirt"
-
-#: pkg/ovirt/components/HostStatus.jsx:37
-msgid "oVirt Host State:"
-msgstr "État hôte oVirt :"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:35
-msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr ""
-"Le script d’installation d’oVirt Provider a échoué en raison d’arguments "
-"manquants."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:36
-msgid ""
-"oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-"machines-ovirt.config, try as root."
-msgstr ""
-"Le script d’installation d’oVirt Provider a échoué : impossible d’écrire "
-"dans /etc/cockpit/machines-ovirt.config, essayez en tant que root."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:164
-msgid "oVirt installation script failed with following output: "
-msgstr "Le script d’installation d’oVirt a échoué avec la sortie suivante :"
-
-#: pkg/ovirt/components/App.jsx:51
-msgid "oVirt login in progress"
-msgstr "Connexion oVirt en cours"
 
 #: pkg/systemd/host.js:691
 msgid "of $0 CPU core"
@@ -10187,25 +8027,13 @@ msgstr[1] "de $0 noyaux CPU"
 msgid "paused"
 msgstr "mis en pause"
 
-#: pkg/ovirt/rephraseUI.js:34
-msgid "pending approval"
-msgstr "validation en attente"
-
-#: pkg/kubernetes/views/dashboard-page.html:83
-msgid "pending volume claims"
-msgstr "demandes de volume en attente"
-
-#: pkg/machines/components/diskAdd.jsx:174
+#: pkg/machines/components/diskAdd.jsx:154
 msgid "qcow2"
 msgstr "qcow2"
 
-#: pkg/machines/components/diskAdd.jsx:177
+#: pkg/machines/components/diskAdd.jsx:157
 msgid "raw"
 msgstr "raw"
-
-#: pkg/ovirt/rephraseUI.js:36
-msgid "reboot"
-msgstr "redémarrer"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -10227,7 +8055,7 @@ msgstr "recherche par nom, espace de noms ou description"
 msgid "security"
 msgstr "sécurité"
 
-#: pkg/docker/index.html:404
+#: pkg/docker/index.html:406
 msgid "select container"
 msgstr "sélectionnez le conteneur"
 
@@ -10235,7 +8063,7 @@ msgstr "sélectionnez le conteneur"
 msgid "server"
 msgstr "serveur"
 
-#: pkg/docker/index.html:483 pkg/docker/index.html:655
+#: pkg/docker/index.html:485 pkg/docker/index.html:657
 msgid "shares"
 msgstr "shares"
 
@@ -10254,10 +8082,6 @@ msgstr "éteindre"
 #: pkg/machines/helpers.js:191
 msgid "shutdown"
 msgstr "fermeture"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "sockets"
-msgstr "sockets"
 
 #: pkg/selinux/setroubleshoot-view.jsx:123
 msgid "solution details"
@@ -10279,10 +8103,6 @@ msgstr "le serveur ssh n’est pas vide"
 msgid "suspended (PM)"
 msgstr "suspendu (PM)"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "threads"
-msgstr "threads"
-
 #: pkg/docker/run.js:474
 msgid "to host path"
 msgstr "pour héberger le chemin"
@@ -10298,10 +8118,6 @@ msgstr "traduisible"
 #: pkg/machines/helpers.js:218
 msgid "udp"
 msgstr "UDP"
-
-#: pkg/ovirt/rephraseUI.js:37
-msgid "unassigned"
-msgstr "non attribué"
 
 #: pkg/lib/cockpit-components-select.jsx:28
 msgid "undefined"
@@ -10320,7 +8136,7 @@ msgstr "cible inconnue"
 msgid "unpartitioned space on $0"
 msgstr "espace non partitionné sur $0"
 
-#: pkg/machines/helpers.js:237 pkg/ovirt/rephraseUI.js:26
+#: pkg/machines/helpers.js:237
 msgid "up"
 msgstr "en cours"
 
@@ -10329,7 +8145,6 @@ msgid "user"
 msgstr "utilisateur"
 
 #: pkg/machines/components/vcpuModal.jsx:192
-#: pkg/ovirt/components/vcpuModal.jsx:54
 msgid "vCPU Count"
 msgstr "Nombre de vCPU"
 
@@ -10338,8 +8153,6 @@ msgid "vCPU Maximum"
 msgstr "vCPU Maximum"
 
 #: pkg/machines/components/vmOverviewTab.jsx:75
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "vCPUs"
 msgstr "vCPU"
 
@@ -10351,12 +8164,16 @@ msgstr "valeur"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/kubernetes/views/route-body.html:13
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+msgid ""
+"virt-install package needs to be installed on the system in order to create "
+"new VMs"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:42
 msgid "yes"
 msgstr "oui"
 
@@ -10367,3 +8184,1432 @@ msgid ""
 msgstr ""
 "{{condition.message}}. Horodatage : {{condition.lastTransitionTime}} Nombre "
 "d’erreurs : {{condition.generation}}"
+
+#~ msgid " 1\"Do you want to delete the following Nodes?"
+#~ msgstr " 1\"Désirez-vous supprimer les nœuds suivants ?"
+
+#~ msgid "$0 vCPU Details"
+#~ msgstr "$0 vCPU Détails"
+
+#~ msgid "$0% Free"
+#~ msgid_plural "$0% Free"
+#~ msgstr[0] "$0% disponible"
+#~ msgstr[1] "$0% disponible"
+
+#~ msgid "$0% Used"
+#~ msgid_plural "$0% Used"
+#~ msgstr[0] "$0% utilisé"
+#~ msgstr[1] "$0% utilisé"
+
+#~ msgid "'Organization' required to register."
+#~ msgstr "«Organisation» nécessaire pour s’inscrire."
+
+#~ msgid "'Organization' required when using activation keys."
+#~ msgstr "«Organisation» requis lors de l’utilisation des clés d’activation."
+
+#~ msgid "AWS Elastic Block Store"
+#~ msgstr "AWS Elastic Block Store"
+
+#~ msgid "Access Modes"
+#~ msgstr "Modes d’accès"
+
+#~ msgid "Access denied"
+#~ msgstr "Accès refusé"
+
+#~ msgid "Action"
+#~ msgstr "action"
+
+#~ msgid "Activation Key"
+#~ msgstr "Clé d’activation"
+
+#~ msgid "Actual"
+#~ msgstr "Réel"
+
+#~ msgid "Add Cluster Node"
+#~ msgstr "Ajouter une nœud de cluster"
+
+#~ msgid "Add Group"
+#~ msgstr "Ajouter un groupe"
+
+#~ msgid "Add Kubernetes Node"
+#~ msgstr "Ajouter un nœud Kubernetes"
+
+#~ msgid "Add Member"
+#~ msgstr "Ajouter un membre"
+
+#~ msgid "Add Membership"
+#~ msgstr "Ajouter un membre"
+
+#~ msgid "Add New Cluster"
+#~ msgstr "Ajouter un nouveau cluster"
+
+#~ msgid "Add New User"
+#~ msgstr "Ajouter un nouvel utilisateur"
+
+#~ msgid "Add Role"
+#~ msgstr "Ajouter un rôle"
+
+#~ msgid "Add User"
+#~ msgstr "Ajouter un utilisateur"
+
+#~ msgid "Add membership"
+#~ msgstr "Ajouter un membre"
+
+#~ msgid "Adjust"
+#~ msgstr "Régler"
+
+#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+#~ msgstr "Ajuster le volume persistant « {{item.metadata.name}} »"
+
+#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
+#~ msgstr "Ajuster le contrôleur de réplication {{item.metadata.name}}"
+
+#~ msgid "Adjust Route"
+#~ msgstr "Ajuster l’itinéraire"
+
+#~ msgid "Adjust Service"
+#~ msgstr "Ajuster le service"
+
+#~ msgid "Admin"
+#~ msgstr "Admin"
+
+#~ msgid "All Projects"
+#~ msgstr "Tous les projets"
+
+#~ msgid "All Types"
+#~ msgstr "Tous les types"
+
+#~ msgid "All healthy"
+#~ msgstr "Tout fonctionne bien"
+
+#~ msgid "All images"
+#~ msgstr "Toutes les images"
+
+#~ msgid "All in use"
+#~ msgstr "Tout en cours d’utilisation"
+
+#~ msgid "All running"
+#~ msgstr "Le tout est en cours d’exécution"
+
+#~ msgid "All running virtual machines will be turned off."
+#~ msgstr ""
+#~ "Toutes les machines virtuelles en cours d’exécution seront désactivées."
+
+#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
+#~ msgstr ""
+#~ "Anonyme : autoriser tous les utilisateurs non authentifiés à tirer des "
+#~ "images"
+
+#~ msgid "Automatically selected host"
+#~ msgstr "Hôte sélectionné automatiquement"
+
+#~ msgid "Azure"
+#~ msgstr "Azur"
+
+#~ msgid "Base Template"
+#~ msgstr "Modèle de base"
+
+#~ msgid "Base template"
+#~ msgstr "Modèle de base"
+
+#~ msgid "Base template:"
+#~ msgstr "Modèle de base :"
+
+#~ msgid "Boot ID"
+#~ msgstr "ID de démarrage"
+
+#~ msgid "CPU Utilization: $0%"
+#~ msgstr "Utilisation du processeur : $0 %"
+
+#~ msgid "CREATE VM action failed"
+#~ msgstr "Échec de l’action CREATE VM"
+
+#~ msgid "Cannot decrypt PEM-encoded private key"
+#~ msgstr "Impossible de déchiffrer la clé privée codée PEM"
+
+#~ msgid "Ceph Filesystem Mount"
+#~ msgstr "Point de montage du système de fichiers Ceph"
+
+#~ msgid "Ceph Monitors"
+#~ msgstr "Moniteurs Ceph"
+
+#~ msgid "Change User"
+#~ msgstr "Modifier l’utilisateur"
+
+#~ msgid "Change image stream"
+#~ msgstr "Modifier le flux d’image"
+
+#~ msgid "Change project"
+#~ msgstr "Modifier le projet"
+
+#~ msgid "Cinder"
+#~ msgstr "Cinder"
+
+#~ msgid "Claim"
+#~ msgstr "Requête"
+
+#~ msgid "Claim Name"
+#~ msgstr "Nom de la requête"
+
+#~ msgid "Client Certificate"
+#~ msgstr "Certificat client"
+
+#~ msgid "Cluster"
+#~ msgstr "Cluster"
+
+#~ msgid "Cluster Templates"
+#~ msgstr "Modèles de cluster"
+
+#~ msgid "Cluster Virtual Machines"
+#~ msgstr "Machines virtuelles de cluster"
+
+#~ msgid "Configuration"
+#~ msgstr "Configuration"
+
+#~ msgid "Configure Flannel networking"
+#~ msgstr "Configurer le réseau Flannel"
+
+#~ msgid "Configure Kubelet and Proxy"
+#~ msgstr "Configurer Kubelet et Proxy"
+
+#~ msgid "Confirm migration"
+#~ msgstr "Confirmer la migration"
+
+#~ msgid "Confirm reload:"
+#~ msgstr "Confirmer le rechargement :"
+
+#~ msgid "Confirm save:"
+#~ msgstr "Confirmer l’enregistrement :"
+
+#~ msgid "Connect to oVirt Engine"
+#~ msgstr "Se connectez à oVirt Engine"
+
+#~ msgid "Connecting..."
+#~ msgstr "Connexion en cours…"
+
+#~ msgid "Connection Error: $0"
+#~ msgstr "Erreur de connexion : $0"
+
+#~ msgid "Connection Settings"
+#~ msgstr "Paramètres de connexion"
+
+#~ msgid "Container ID"
+#~ msgstr "ID du conteneur"
+
+#~ msgid "Container Runtime Version"
+#~ msgstr "Version du runtime du conteneur"
+
+#~ msgid "Could not list services"
+#~ msgstr "Impossible de répertorier les services"
+
+#~ msgid "Could not parse PEM-encoded certificate"
+#~ msgstr "Impossible d’analyser le certificat codé PEM"
+
+#~ msgid "Could not parse PEM-encoded private key"
+#~ msgstr "Impossible d’analyser la clé privée codée PEM"
+
+#~ msgid "Couldn't connect to server"
+#~ msgstr "Impossible de se connecter au serveur"
+
+#~ msgid "Couldn't find running API server"
+#~ msgstr "Impossible de trouver le serveur d’API en cours d’exécution"
+
+#~ msgid ""
+#~ "Couldn't get system subscription status. Please ensure subscription-"
+#~ "manager is installed."
+#~ msgstr ""
+#~ "Impossible d’obtenir le statut d’abonnement au système. Veuillez vous "
+#~ "assurer que le gestionnaire d’abonnement est installé."
+
+#~ msgid "Create New VM"
+#~ msgstr "Créer Nouvelle VM"
+
+#~ msgid "Create empty image stream"
+#~ msgstr "Créer un flux d’images vide"
+
+#~ msgid "Create image stream"
+#~ msgstr "Créer un flux d’images"
+
+#~ msgid "Custom URL"
+#~ msgstr "URL personnalisée"
+
+#~ msgid "DNS Policy"
+#~ msgstr "Stratégie DNS"
+
+#~ msgid "Delete '{{ name }}'"
+#~ msgstr "Supprimer « {{nom}} »"
+
+#~ msgid "Delete Node"
+#~ msgstr "Supprimer le nœud"
+
+#~ msgid "Delete Persistent Volume"
+#~ msgstr "Supprimer le volume persistant"
+
+#~ msgid "Delete Persistent Volume Claim"
+#~ msgstr "Supprimer la requête de volume persistant"
+
+#~ msgid "Delete Project"
+#~ msgstr "Supprimer le projet"
+
+#~ msgid "Delete Selected"
+#~ msgstr "Supprimer la sélection"
+
+#~ msgid "Delete image stream"
+#~ msgstr "Supprimer le flux d’images"
+
+#~ msgid "Delete {{ item.kind }}"
+#~ msgstr "Supprimer {{item.kind}}"
+
+#~ msgid ""
+#~ "Deleting a Pod will kill all associated containers. Pods may be "
+#~ "automatically created again in some cases."
+#~ msgstr ""
+#~ "Supprimer un Pod va tuer tous les conteneurs associés. Les pods peuvent "
+#~ "être automatiquement créés à nouveau dans certains cas."
+
+#~ msgid "Deploy"
+#~ msgstr "Déployer"
+
+#~ msgid "Deploy Application"
+#~ msgstr "Déployer l’application"
+
+#~ msgid "Deployment Causes"
+#~ msgstr "Causes du déploiement"
+
+#~ msgid "Deployment Config"
+#~ msgstr "Configuration du déploiement"
+
+#~ msgid "Deployment Configs"
+#~ msgstr "Configurations de déploiement"
+
+#~ msgid "Description:"
+#~ msgstr "Description :"
+
+#~ msgid "Disk Utilization: $0%"
+#~ msgstr "Utilisation du disque : $0 %"
+
+#~ msgid "Display name"
+#~ msgstr "Afficher un nom"
+
+#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#~ msgstr "Voulez-vous ajouter le rôle « {{fields.displayRole}} » ?"
+
+#~ msgid ""
+#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}' image stream?"
+#~ msgstr ""
+#~ "Voulez-vous supprimer le flux d’image « {{stream.metadata.namespace}} / "
+#~ "{{stream.metadata.name}} » ?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+#~ msgstr ""
+#~ "Voulez-vous supprimer le volume persistant « {{item.metadata.name}} » ?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume Claim '{{item.metadata."
+#~ "name}}'?"
+#~ msgstr ""
+#~ "Voulez-vous supprimer la requête de volume persistant « {{item.metadata."
+#~ "name}}’ »"
+
+#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+#~ msgstr "Voulez-vous supprimer le {{item.kind}} « {{item.metadata.name}} » ?"
+
+#~ msgid "Do you want to delete this Node?"
+#~ msgstr "Voulez-vous supprimer ce nœud ?"
+
+#~ msgid ""
+#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+#~ msgstr ""
+#~ "Voulez-vous supprimer l’image intitulée « {{stream.metadata.namespace}} / "
+#~ "{{stream.metadata.name}} : {{tag.tag}} » ?"
+
+#~ msgid ""
+#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
+#~ "{{ fields.member.metadata.name }}?"
+#~ msgstr ""
+#~ "Voulez-vous supprimer le rôle « {{fields.displayRole}} » du membre "
+#~ "{{fields.member.metadata.name}} ?"
+
+#~ msgid "Don't pull images automatically"
+#~ msgstr "Ne pas tirer les images automatiquement"
+
+#~ msgid "Driver"
+#~ msgstr "Pilote"
+
+#~ msgid "Edit the vdsm.conf"
+#~ msgstr "Modifier le fichier vdsm.conf"
+
+#~ msgid "Empty Directory"
+#~ msgstr "Répertoire vide"
+
+#~ msgid "Endpoint"
+#~ msgstr "Point d’accès"
+
+#~ msgid "Endpoint Name"
+#~ msgstr "Nom du point d’accès"
+
+#~ msgid "Endpoints"
+#~ msgstr "Points d’accès"
+
+#~ msgid "Ends"
+#~ msgstr "Se termine"
+
+#~ msgid "Enter New VM name"
+#~ msgstr "Saisir le nom de la nouvelle machine virtuelle"
+
+#~ msgid "Error getting certificate details: $0"
+#~ msgstr "Erreur lors de l’obtention des détails du certificat : $0"
+
+#~ msgid "Error writing kubectl config"
+#~ msgstr "Erreur lors de l’écriture de la configuration de kubectl"
+
+#~ msgid "FORCEOFF action failed: $0"
+#~ msgstr "L’action FORCEOFF a échoué : $0"
+
+#~ msgid "FQDN"
+#~ msgstr "FQDN"
+
+#~ msgid "Fibre Channel"
+#~ msgstr "Fibre Channel"
+
+#~ msgid "Filesystem Type"
+#~ msgstr "Type de système de fichiers"
+
+#~ msgid "Flex"
+#~ msgstr "Flex"
+
+#~ msgid "Flocker"
+#~ msgstr "Flocker"
+
+#~ msgid "Flocker Dataset Name"
+#~ msgstr "Nom du jeu de données Flocker"
+
+#~ msgid "GCE Persistent Disk"
+#~ msgstr "Disque persistant GCE"
+
+#~ msgid "Git Repository"
+#~ msgstr "Référentiel Git"
+
+#~ msgid "Gluster FS"
+#~ msgstr "Gluster FS"
+
+#~ msgid "GlusterFS"
+#~ msgstr "GlusterFS"
+
+#~ msgid "Grant additional push or admin access to specific members below."
+#~ msgstr ""
+#~ "Accordez un accès push ou admin supplémentaire à des membres spécifiques "
+#~ "ci-dessous."
+
+#~ msgid "Group Members"
+#~ msgstr "Les membres du groupe"
+
+#~ msgid "Group or Project"
+#~ msgstr "Groupe ou projet"
+
+#~ msgid "Groups"
+#~ msgstr "Groupes"
+
+#~ msgid "HA"
+#~ msgstr "HA"
+
+#~ msgid "HA:"
+#~ msgstr "HA :"
+
+#~ msgid "Host Path"
+#~ msgstr "Chemin d’hôte"
+
+#~ msgid "Host to Maintenance"
+#~ msgstr "Hôte à la maintenance"
+
+#~ msgid "IP"
+#~ msgstr "IP"
+
+#~ msgid "ISCSI"
+#~ msgstr "ISCSI"
+
+#~ msgid "Identities"
+#~ msgstr "Identités"
+
+#~ msgid "Identity"
+#~ msgstr "Identité"
+
+#~ msgid "Image ID"
+#~ msgstr "ID de l’image"
+
+#~ msgid "Image Name"
+#~ msgstr "Nom de l’image"
+
+#~ msgid "Image Registry"
+#~ msgstr "Registre d’images"
+
+#~ msgid "Image Stream"
+#~ msgstr "Flux d’images"
+
+#~ msgid "Image commands"
+#~ msgstr "Commandes d’image"
+
+#~ msgid "Images by project"
+#~ msgstr "Images par projet"
+
+#~ msgid "Images pushed recently"
+#~ msgstr "Images poussées récemment"
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, use the commands below."
+#~ msgstr ""
+#~ "Pour commencer à pousser les images dans le registre, utilisez les "
+#~ "commandes ci-dessous."
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, you need to create a "
+#~ "project."
+#~ msgstr ""
+#~ "Afin de commencer à pousser les images dans le registre, vous devez créer "
+#~ "un projet."
+
+#~ msgid "Installed products"
+#~ msgstr "Produits installés"
+
+#~ msgid "Interface"
+#~ msgstr "Interface"
+
+#~ msgid "Invalid credentials"
+#~ msgstr "Identifiants invalides"
+
+#~ msgid "Kernel Version"
+#~ msgstr "Version du noyau"
+
+#~ msgid "Key Ring Path"
+#~ msgstr "Key Ring Path"
+
+#~ msgid "Kubelet Version"
+#~ msgstr "Version Kubelet"
+
+#~ msgid "Kubernetes Cluster"
+#~ msgstr "Cluster Kubernetes"
+
+#~ msgid "Last Heartbeat"
+#~ msgstr "Dernière pulsation"
+
+#~ msgid "Last Status Change"
+#~ msgstr "Dernière modification de statut"
+
+#~ msgid "Latest Version"
+#~ msgstr "Dernière version"
+
+#~ msgid "Loading data ..."
+#~ msgstr "Chargement des données…"
+
+#~ msgid "Log into OpenShift command line tools:"
+#~ msgstr "Connectez-vous aux outils de ligne de commande OpenShift :"
+
+#~ msgid "Log into the registry:"
+#~ msgstr "Connectez-vous au registre :"
+
+#~ msgid "Logical Unit Number"
+#~ msgstr "Numéro d’unité logique"
+
+#~ msgid "Login"
+#~ msgstr "S’identifier"
+
+#~ msgid "Login commands"
+#~ msgstr "Commandes de connexion"
+
+#~ msgid "Login/password or activation key required to register."
+#~ msgstr ""
+#~ "Identifiant / mot de passe ou clé d’activation nécessaire pour vous "
+#~ "inscrire."
+
+#~ msgid "MIGRATE action failed"
+#~ msgstr "L’action MIGRATE a échoué"
+
+#~ msgid "Manifest"
+#~ msgstr "Manifeste"
+
+#~ msgid "Medium"
+#~ msgstr "Moyen"
+
+#~ msgid "Member of"
+#~ msgstr "Membre de"
+
+#~ msgid "Members"
+#~ msgstr "Membres"
+
+#~ msgid "Membership"
+#~ msgstr "Appartenance"
+
+#~ msgid "Memory Utilization: $0%"
+#~ msgstr "Utilisation de la mémoire : $0 %"
+
+#~ msgid "Message"
+#~ msgstr "Message"
+
+#~ msgid "Migrate To:"
+#~ msgstr "Migrer vers :"
+
+#~ msgid "Modify"
+#~ msgstr "Modifier"
+
+#~ msgid "Monitors"
+#~ msgstr "Moniteurs"
+
+#~ msgid "Mount Location"
+#~ msgstr "Emplacement de montage"
+
+#~ msgid "NFS"
+#~ msgstr "NFS"
+
+#~ msgid "Namespace"
+#~ msgstr "Espace de noms"
+
+#~ msgid "Namespace cannot be empty."
+#~ msgstr "L’espace de noms ne peut pas être vide."
+
+#~ msgid "New Group"
+#~ msgstr "Nouveau groupe"
+
+#~ msgid "New Project"
+#~ msgstr "Nouveau projet"
+
+#~ msgid "New image stream"
+#~ msgstr "Nouveau flux d’images"
+
+#~ msgid "New project"
+#~ msgstr "Nouveau projet"
+
+#~ msgid "No PEM-encoded certificate found"
+#~ msgstr "Aucun certificat codé PEM trouvé"
+
+#~ msgid "No PEM-encoded private key found"
+#~ msgstr "Aucune clé privée codée PEM trouvée"
+
+#~ msgid "No Pods are using this claim"
+#~ msgstr "Aucun pod n’utilise cette requête"
+
+#~ msgid "No VM found in oVirt."
+#~ msgstr "Aucune VM trouvée dans oVirt."
+
+#~ msgid "No Volume Bound"
+#~ msgstr "Aucune limite de volume"
+
+#~ msgid "No groups are present."
+#~ msgstr "Aucun groupe n’est présent."
+
+#~ msgid "No images pushed"
+#~ msgstr "Aucune image poussée"
+
+#~ msgid "No installed products on the system."
+#~ msgstr "Aucun produit installé sur le système."
+
+#~ msgid ""
+#~ "No metadata file was selected. Please select a Kubernetes metadata file."
+#~ msgstr ""
+#~ "Aucun fichier de métadonnées n’a été sélectionné. Veuillez sélectionner "
+#~ "un fichier de méta-données Kubernetes."
+
+#~ msgid "No nodes in cluster"
+#~ msgstr "Aucun nœud dans le cluster"
+
+#~ msgid "No oVirt connection"
+#~ msgstr "Pas de connexion oVirt"
+
+#~ msgid "No pods deployed"
+#~ msgstr "Aucun pod déployé"
+
+#~ msgid "No pods replicated"
+#~ msgstr "Aucun pod répliqué"
+
+#~ msgid "No pods scheduled"
+#~ msgstr "Aucun pod programmé"
+
+#~ msgid "No pods selected"
+#~ msgstr "Aucun pod sélectionné"
+
+#~ msgid "No projects are present."
+#~ msgstr "Aucun projet n’est présent."
+
+#~ msgid "No users are present."
+#~ msgstr "Aucun utilisateur n’est présent"
+
+#~ msgid "No volumes are present."
+#~ msgstr "Aucun volume n’est présent."
+
+#~ msgid "No volumes in use"
+#~ msgstr "Aucun volume en cours d’utilisation"
+
+#~ msgid "Node"
+#~ msgstr "Nœud"
+
+#~ msgid "Nodes"
+#~ msgstr "Nœuds"
+
+#~ msgid "Nodes are the machines that run your containers."
+#~ msgstr "Les nœuds sont les machines qui exécutent vos conteneurs."
+
+#~ msgid "Not a valid number of replicas"
+#~ msgstr "Nombre de répliques non valide"
+
+#~ msgid "Not a valid value for Host"
+#~ msgstr "Valeur non valide pour l’hôte"
+
+#~ msgid "Not deployed"
+#~ msgstr "Non déployé"
+
+#~ msgid "Number of virtual CPUs that gonna be used."
+#~ msgstr "Nombre de CPU qui seront utilisées."
+
+#~ msgid "OK"
+#~ msgstr "OK"
+
+#~ msgid "OS"
+#~ msgstr "OS"
+
+#~ msgid "OS Type:"
+#~ msgstr "OS Type :"
+
+#~ msgid "OS Versions"
+#~ msgstr "Versions OS"
+
+#~ msgid "Optimized for:"
+#~ msgstr "Optimisé pour :"
+
+#~ msgid "Organization"
+#~ msgstr "Organisation"
+
+#~ msgid "PD Name"
+#~ msgstr "Nom du PD"
+
+#~ msgid "Pending Volume Claims"
+#~ msgstr "Requêtes de volume en attente"
+
+#~ msgid "Persistent Volumes"
+#~ msgstr "Volumes persistants"
+
+#~ msgid "Phase"
+#~ msgstr "Phase"
+
+#~ msgid "Please confirm, the host shall be switched to maintenance mode."
+#~ msgstr "Veuillez confirmer, l’hôte doit passer en mode de maintenance."
+
+#~ msgid "Please create another namespace for $0 \"$1\""
+#~ msgstr "Veuillez créer un autre espace de nom pour $0 \"$1\""
+
+#~ msgid "Please provide a GlusterFS volume name"
+#~ msgstr "Veuillez indiquer un nom de volume GlusterFS"
+
+#~ msgid "Please provide a username"
+#~ msgstr "Veuillez fournir un nom d’utilisateur"
+
+#~ msgid "Please provide a valid NFS server"
+#~ msgstr "Veuillez fournir un serveur NFS valide"
+
+#~ msgid "Please provide a valid address"
+#~ msgstr "Veuillez fournir une adresse valide"
+
+#~ msgid "Please provide a valid filesystem type"
+#~ msgstr "Veuillez fournir un type de système de fichiers valide"
+
+#~ msgid "Please provide a valid interface"
+#~ msgstr "Veuillez fournir une interface valide"
+
+#~ msgid "Please provide a valid logical unit number"
+#~ msgstr "Veuillez fournir un numéro d’unité logique valide"
+
+#~ msgid "Please provide a valid name"
+#~ msgstr "Veuillez fournir un nom valide"
+
+#~ msgid "Please provide a valid namespace."
+#~ msgstr "Veuillez fournir un espace de noms valide."
+
+#~ msgid "Please provide a valid path"
+#~ msgstr "Veuillez fournir un chemin valide"
+
+#~ msgid "Please provide a valid qualified name"
+#~ msgstr "Veuillez fournir un nom qualifié valide"
+
+#~ msgid "Please provide a valid storage capacity."
+#~ msgstr "Veuillez indiquer une capacité de stockage valide"
+
+#~ msgid "Please provide a valid target"
+#~ msgstr "Veuillez fournir une cible valide"
+
+#~ msgid ""
+#~ "Please provide fully qualified domain name and port of the oVirt engine."
+#~ msgstr ""
+#~ "Veuillez fournir le nom de domaine complet et le port d’oVirt Engine."
+
+#~ msgid ""
+#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
+#~ "port (443 by default)"
+#~ msgstr ""
+#~ "Veuillez indiquer le nom de domaine complet (FQDN) et le port valides "
+#~ "d’oVirt Engine (443 par défaut)"
+
+#~ msgid ""
+#~ "Please refer to oVirt's $0 for more information about Remote Viewer setup."
+#~ msgstr ""
+#~ "Veuillez vous référer à oVirt $0 pour plus d’informations sur la "
+#~ "configuration de l’afficheur à distance."
+
+#~ msgid "Please select a valid access mode"
+#~ msgstr "Veuillez sélectionner un mode d’accès valide"
+
+#~ msgid "Please select a valid endpoint"
+#~ msgstr "Veuillez sélectionner un point de terminaison valide"
+
+#~ msgid "Please select a valid policy option."
+#~ msgstr "Veuillez sélectionner une option de politique valide."
+
+#~ msgid "Please type an address"
+#~ msgstr "Veuillez saisir une adresse"
+
+#~ msgid "Please wait till VMs list is loaded from the server."
+#~ msgstr ""
+#~ "Veuillez attendre que la liste des machines virtuelles soit chargée "
+#~ "depuis le serveur."
+
+#~ msgid "Please wait till list of templates is loaded from the server."
+#~ msgstr ""
+#~ "Veuillez attendre que la liste des modèles soit chargée depuis le serveur."
+
+#~ msgid "Pod"
+#~ msgstr "Pod"
+
+#~ msgid "Pod Address"
+#~ msgstr "Adresse Pod"
+
+#~ msgid "Pod Endpoints"
+#~ msgstr "Points d’accès Pod"
+
+#~ msgid "Pod Replicated"
+#~ msgstr "Pod répliqué"
+
+#~ msgid "Pod Selector"
+#~ msgstr "Sélecteur de Pod"
+
+#~ msgid "Pods"
+#~ msgstr "Pods"
+
+#~ msgid ""
+#~ "Pods contain one or more containers that run together on a node, "
+#~ "containing your application code."
+#~ msgstr ""
+#~ "Les pods contiennent un ou plusieurs conteneurs qui s’exécutent ensemble "
+#~ "sur un nœud, contenant le code de votre application."
+
+#~ msgid "Pool Name"
+#~ msgstr "Nom du pool"
+
+#~ msgid "Populate"
+#~ msgstr "Remplissage"
+
+#~ msgid "Preparing for Maintenance"
+#~ msgstr "Préparation à la maintenance"
+
+#~ msgid "Private: Allow only specific users or groups to pull images"
+#~ msgstr ""
+#~ "Privé : autoriser uniquement des utilisateurs ou des groupes spécifiques "
+#~ "à extraire des images"
+
+#~ msgid "Product ID"
+#~ msgstr "ID de produit"
+
+#~ msgid "Product name"
+#~ msgstr "Nom du produit"
+
+#~ msgid "Project"
+#~ msgstr "Projet"
+
+#~ msgid "Project Members"
+#~ msgstr "Les membres du projet"
+
+#~ msgid "Project access policy allows anonymous users to pull images."
+#~ msgstr ""
+#~ "La stratégie d’accès au projet permet aux utilisateurs anonymes "
+#~ "d’extraire des images."
+
+#~ msgid "Project access policy allows any authenticated user to pull images."
+#~ msgstr ""
+#~ "La stratégie d’accès au projet permet à tout utilisateur authentifié "
+#~ "d’extraire des images."
+
+#~ msgid "Project access policy only allows specific members to access images."
+#~ msgstr ""
+#~ "La stratégie d’accès au projet autorise uniquement des membres "
+#~ "spécifiques à accéder aux images."
+
+#~ msgid "Project:"
+#~ msgstr "Projet :"
+
+#~ msgid "Projects"
+#~ msgstr "Projets"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "Proxy Version"
+#~ msgstr "Version proxy"
+
+#~ msgid "Pull an image:"
+#~ msgstr "Extraire une image :"
+
+#~ msgid "Pull from"
+#~ msgstr "Extraire de"
+
+#~ msgid "Pull specific tags from another image repository"
+#~ msgstr "Extraire des tags spécifiques d’un autre référentiel d’images"
+
+#~ msgid "Push an image:"
+#~ msgstr "Pousser image :"
+
+#~ msgid "Qualified Name"
+#~ msgstr "Nom qualifié"
+
+#~ msgid "REBOOT action failed"
+#~ msgstr "L’action REBOOT a échoué"
+
+#~ msgid "REBOOT_VM action failed: %s0"
+#~ msgstr "L’action REBOOT_VM a échoué : %0"
+
+#~ msgid "Rados Block Device"
+#~ msgstr "Rados Block Device"
+
+#~ msgid "Read Only"
+#~ msgstr "Lecture seulement"
+
+#~ msgid "Read and write from a single node"
+#~ msgstr "Lecture et Écriture à partir d’un seul nœud"
+
+#~ msgid "Read and write from multiple nodes"
+#~ msgstr "Lecture et Écriture à partir de plusieurs nœuds"
+
+#~ msgid "Read only from multiple nodes"
+#~ msgstr "Lecture uniquement à partir de plusieurs nœuds"
+
+#~ msgid "Reason"
+#~ msgstr "Raison"
+
+#~ msgid "Reclaim Policy"
+#~ msgstr "Politique de récupération"
+
+#~ msgid "Recycle"
+#~ msgstr "Recycler"
+
+#~ msgid "Register"
+#~ msgstr "Enregistrer"
+
+#~ msgid "Register New Volume"
+#~ msgstr "Enregistrer un nouveau volume"
+
+#~ msgid "Register Persistent Volume"
+#~ msgstr "Enregistrer le volume persistant"
+
+#~ msgid "Register oVirt"
+#~ msgstr "Inscription oVirt"
+
+#~ msgid "Register system"
+#~ msgstr "Enregistrer le système"
+
+#~ msgid "Registering oVirt to Cockpit"
+#~ msgstr "Enregistrement d’oVirt dans Cockpit"
+
+#~ msgid "Remote registry is insecure"
+#~ msgstr "L’enregistrement à distance n’est pas sécurisé"
+
+#~ msgid "Remove Group"
+#~ msgstr "Supprimer le groupe"
+
+#~ msgid "Remove Member"
+#~ msgstr "Supprimer le membre"
+
+#~ msgid "Remove Role"
+#~ msgstr "Supprimer le rôle"
+
+#~ msgid "Remove User"
+#~ msgstr "Supprimer l’utilisateur"
+
+#~ msgid "Remove image tag"
+#~ msgstr "Supprimer le tag d’image"
+
+#~ msgid "Remove membership"
+#~ msgstr "Révoquez l’appartenance"
+
+#~ msgid "Replicas"
+#~ msgstr "Replicas"
+
+#~ msgid "Replication Controller"
+#~ msgstr "Contrôleur de réplication"
+
+#~ msgid "Replication Controllers"
+#~ msgstr "Contrôleurs de réplication"
+
+#~ msgid ""
+#~ "Replication controllers dynamically create instances of pods from "
+#~ "templates, and remove pods when necessary."
+#~ msgstr ""
+#~ "Les contrôleurs de réplication créent dynamiquement des instances de pods "
+#~ "à partir de modèles et suppriment des pods si nécessaire."
+
+#~ msgid "Repository URL"
+#~ msgstr "URL du référentiel"
+
+#~ msgid "Requested"
+#~ msgstr "Demandé"
+
+#~ msgid "Requests"
+#~ msgstr "Requêtes"
+
+#~ msgid "Requires Authentication"
+#~ msgstr "Nécessite une authentification"
+
+#~ msgid "Restart Count"
+#~ msgstr "Redémarrer Comptage"
+
+#~ msgid "Retain"
+#~ msgstr "Conserver"
+
+#~ msgid "Retrieving subscription status..."
+#~ msgstr "Récupération du statut de l’abonnement…"
+
+#~ msgid "Revision"
+#~ msgstr "Révision"
+
+#~ msgid "Role"
+#~ msgstr "Rôle"
+
+#~ msgid "Route"
+#~ msgstr "Route"
+
+#~ msgid "Run Here"
+#~ msgstr "Exécuter ici"
+
+#~ msgid "Running Since:"
+#~ msgstr "En cours d’exécution depuis :"
+
+#~ msgid "SET VCPU SETTINGS action failed"
+#~ msgstr "L’action SET VCPU SETTINGS a échoué"
+
+#~ msgid "SHUTDOWN action failed"
+#~ msgstr "L’action SHUTDOWN a échoué"
+
+#~ msgid "START action failed"
+#~ msgstr "L’action START a échoué"
+
+#~ msgid "START_VM action failed: %s0"
+#~ msgstr "L’action START_VM a échoué : %0"
+
+#~ msgid "SUSPEND action failed"
+#~ msgstr "L’action SUSPEND a échoué"
+
+#~ msgid "Scheduled Pods"
+#~ msgstr "Pods planifiés"
+
+#~ msgid "Scheduling Disabled"
+#~ msgstr "Planification désactivée"
+
+#~ msgid "Secret"
+#~ msgstr "Secret"
+
+#~ msgid "Secret File"
+#~ msgstr "Fichier secret"
+
+#~ msgid "Secret Name"
+#~ msgstr "Nom secret"
+
+#~ msgid "Secret Volume"
+#~ msgstr "Volume secret"
+
+#~ msgid "Select Manifest File..."
+#~ msgstr "Sélectionnez le fichier manifeste…"
+
+#~ msgid "Select Member"
+#~ msgstr "Choisir un membre"
+
+#~ msgid "Select Role"
+#~ msgstr "Sélectionner un rôle"
+
+#~ msgid "Select an object to see more details."
+#~ msgstr "Sélectionnez un objet pour voir plus de détails."
+
+#~ msgid "Service Account"
+#~ msgstr "Compte de service"
+
+#~ msgid ""
+#~ "Services group pods and provide a common DNS name and an optional, load-"
+#~ "balanced IP address to access them."
+#~ msgstr ""
+#~ "Les services regroupe les pods et fournissent un nom DNS commun et une "
+#~ "adresse IP facultative équilibrée pour y accéder."
+
+#~ msgid "Session Affinity"
+#~ msgstr "Affinité de session"
+
+#~ msgid "Share Name"
+#~ msgstr "Nom de partage (Share)"
+
+#~ msgid "Shared: Allow any authenticated user to pull images"
+#~ msgstr ""
+#~ "Shared : permet à tout utilisateur authentifié d’extraire des images"
+
+#~ msgid "Shell"
+#~ msgstr "Interpréteur de commande"
+
+#~ msgid "Show all Containers"
+#~ msgstr "Afficher tous les conteneurs"
+
+#~ msgid "Show all Deployment Configs"
+#~ msgstr "Afficher toutes les configurations de déploiement"
+
+#~ msgid "Show all Nodes"
+#~ msgstr "Afficher tous les nœuds"
+
+#~ msgid "Show all Persistent Volumes"
+#~ msgstr "Afficher tous les volumes persistants"
+
+#~ msgid "Show all Pod Containers"
+#~ msgstr "Afficher tous les conteneurs Pod"
+
+#~ msgid "Show all Pods"
+#~ msgstr "Afficher tous les Pods"
+
+#~ msgid "Show all Projects"
+#~ msgstr "Afficher tous les projets"
+
+#~ msgid "Show all Replication Controllers"
+#~ msgstr "Afficher tous les contrôleurs de réplication"
+
+#~ msgid "Show all Routes"
+#~ msgstr "Afficher tous les itinéraires"
+
+#~ msgid "Show all Services"
+#~ msgstr "Afficher tous les services"
+
+#~ msgid "Show all image streams"
+#~ msgstr "Afficher tous les flux d’images"
+
+#~ msgid "Since"
+#~ msgstr "Depuis"
+
+#~ msgid "Skip Certificate Verification"
+#~ msgstr "Ignorer la vérification du certificat"
+
+#~ msgid "Sorry, I don't know how to modify this volume"
+#~ msgstr "Désolé, je ne sais pas comment modifier ce volume"
+
+#~ msgid "Starts"
+#~ msgstr "Démarre"
+
+#~ msgid "Stateless"
+#~ msgstr "Stateless"
+
+#~ msgid "Stateless:"
+#~ msgstr "Stateless :"
+
+#~ msgid "Status: $0"
+#~ msgstr "Statut : $0"
+
+#~ msgid "Status: System isn't registered"
+#~ msgstr "Statut : le système n’est pas enregistré"
+
+#~ msgid "Strategy"
+#~ msgstr "Stratégie"
+
+#~ msgid "Subscriptions"
+#~ msgstr "Abonnements"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspendre"
+
+#~ msgid "Switch Host to Maintenance"
+#~ msgstr "Passer l’hôte à la maintenance"
+
+#~ msgid "Switching host to maintenance mode failed. Received error: "
+#~ msgstr ""
+#~ "La commutation de l’hôte en mode de maintenance a échoué. Erreur reçue :"
+
+#~ msgid "Switching host to maintenance mode in progress ..."
+#~ msgstr "Passage de l’hôte au mode maintenance en cours…"
+
+#~ msgid "Sync all tags from a remote image repository"
+#~ msgstr "Synchroniser toutes les balises d’un référentiel d’images distant"
+
+#~ msgid "TLS Termination"
+#~ msgstr "Résiliation TLS"
+
+#~ msgid "Target Portal"
+#~ msgstr "Portail cible"
+
+#~ msgid "Target World Wide Names"
+#~ msgstr "Ciblez des noms World Wide"
+
+#~ msgid "Template"
+#~ msgstr "Modèle"
+
+#~ msgid "Templates"
+#~ msgstr "Modèles"
+
+#~ msgid "Templates of $0 cluster"
+#~ msgstr "Modèles de $0 cluster"
+
+#~ msgid "The address contains invalid characters"
+#~ msgstr "L’adresse contient des caractères non valides"
+
+#~ msgid "The container '{{ target }}' does not exist."
+#~ msgstr "Le conteneur « {{target}} » n’existe pas."
+
+#~ msgid "The current user isn't allowed to access system subscription status."
+#~ msgstr ""
+#~ "L’utilisateur actuel n’est pas autorisé à accéder au statut d’abonnement "
+#~ "au système."
+
+#~ msgid "The deployment config '{{ target }}' does not exist."
+#~ msgstr "La configuration de déploiement « {{target}} » n’existe pas."
+
+#~ msgid "The group '{{ groupName }}' does not exist."
+#~ msgstr "Le groupe « {{groupName}} » n’existe pas."
+
+#~ msgid "The maximum number of replicas is 128"
+#~ msgstr "Le nombre maximum de répliques est de 128"
+
+#~ msgid "The name contains invalid characters"
+#~ msgstr "Le nom contient des caractères invalides"
+
+#~ msgid "The node '{{ target }}' does not exist."
+#~ msgstr "Le nœud « {{target}} » n’existe pas."
+
+#~ msgid "The node doesn't have enough disk space"
+#~ msgstr "Le noeud n’a pas assez d’espace disque"
+
+#~ msgid "The node doesn't have enough free memory"
+#~ msgstr "Le noeud n’a pas assez de mémoire disponible"
+
+#~ msgid "The persistent volume '{{ target }}' does not exist."
+#~ msgstr "Le volume persistant « {{target}} » n’existe pas."
+
+#~ msgid "The pod '{{ target }}' does not exist."
+#~ msgstr "Le pod « {{target}} » n’existe pas."
+
+#~ msgid "The project '{{ projName }}' does not exist."
+#~ msgstr "Le projet « {{projName}} » n’existe pas."
+
+#~ msgid "The replication controller '{{ target }}' does not exist."
+#~ msgstr "Le contrôleur de réplication « {{target}} » n’existe pas."
+
+#~ msgid "The route '{{ target }}' does not exist."
+#~ msgstr "La route « {{target}} » n’existe pas."
+
+#~ msgid "The selected file is not a valid Kubernetes application manifest."
+#~ msgstr ""
+#~ "Le fichier sélectionné n’est pas un manifeste d’application Kubernetes "
+#~ "valide."
+
+#~ msgid "The server uses a certificate signed by an unknown authority."
+#~ msgstr "Le serveur utilise un certificat signé par une autorité inconnue."
+
+#~ msgid "The service '{{ target }}' does not exist."
+#~ msgstr "Le service « {{target}} » n’existe pas."
+
+#~ msgid "The user '{{ userName }}' does not exist."
+#~ msgstr "L’utilisateur « {{userName}} » n’existe pas."
+
+#~ msgid ""
+#~ "This claim is in use. Deleting it may cause issues with the following pod:"
+#~ msgstr ""
+#~ "Cette requête est en cours d’utilisation. La supprimer peut entraîner des "
+#~ "problèmes avec le pod suivant :"
+
+#~ msgid ""
+#~ "This host is managed by a virtualization manager, so creation of new VMs "
+#~ "from the host is not possible."
+#~ msgstr ""
+#~ "Cet hôte est géré par un gestionnaire de virtualisation, donc la création "
+#~ "de nouvelles machines virtuelles à partir de l’hôte n’est pas possible."
+
+#~ msgid ""
+#~ "This option is for single node testing only – local storage will not work "
+#~ "in a multi-node cluster"
+#~ msgstr ""
+#~ "Cette option est réservée aux tests à un seul nœud - le stockage local ne "
+#~ "fonctionnera pas dans un cluster à plusieurs nœuds"
+
+#~ msgid "This virtual machine is not managed by oVirt"
+#~ msgstr "Cette machine virtuelle n’est pas gérée par oVirt"
+
+#~ msgid ""
+#~ "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+#~ "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+#~ "may cause issues with any pods depending on it."
+#~ msgstr ""
+#~ "Ce volume a été revendiqué par {{ item.item.spec.claimRef.namespace }} / "
+#~ "{{ item.item.spec.claimRef.name }}. Le supprimer va briser cette demande "
+#~ "et peut entraîner des problèmes avec les pods qui en dépendent."
+
+#~ msgid "This volume has not been claimed"
+#~ msgstr "Ce volume n’a pas été revendiqué"
+
+#~ msgid "Token"
+#~ msgstr "Jeton"
+
+#~ msgid "Topology"
+#~ msgstr "Topologie"
+
+#~ msgid "Trust this certificate for this connection"
+#~ msgstr "Faites confiance à ce certificat pour cette connexion"
+
+#~ msgid "Type:"
+#~ msgstr "Type :"
+
+#~ msgid "Unable to connect"
+#~ msgstr "Incapable de se connecter"
+
+#~ msgid "Unable to decode Kubernetes application manifest."
+#~ msgstr "Incapable de décoder le manifeste d’application Kubernetes."
+
+#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
+#~ msgstr ""
+#~ "Incapable de lire le manifeste de l’application Kubernetes. Code $0 ."
+
+#~ msgid "Unregister"
+#~ msgstr "Annuler l’inscription"
+
+#~ msgid "Unregistering system..."
+#~ msgstr "Système de désenregistrement…"
+
+#~ msgid "Updating $0..."
+#~ msgstr "Mise à jour de $0…"
+
+#~ msgid "Use proxy server"
+#~ msgstr "Utiliser un serveur proxy"
+
+#~ msgid "User or Group"
+#~ msgstr "Utilisateur ou groupe"
+
+#~ msgid "Users"
+#~ msgstr "Utilisateurs"
+
+#~ msgid "VDSM"
+#~ msgstr "VDSM"
+
+#~ msgid "VDSM Service Management"
+#~ msgstr "VDSM Service Management"
+
+#~ msgid "VM icon"
+#~ msgstr "Icône de machine virtuelle"
+
+#~ msgid "Version num"
+#~ msgstr "Num de version"
+
+#~ msgid "Virtual Machines of $0 cluster"
+#~ msgstr "Machines virtuelles de $0 cluster"
+
+#~ msgid "Volume ID"
+#~ msgstr "ID de volume"
+
+#~ msgid "Volume Name"
+#~ msgstr "Nom du volume"
+
+#~ msgid "Volume Type"
+#~ msgstr "Type de volume"
+
+#~ msgid "Warning:"
+#~ msgstr "Attention :"
+
+#~ msgid "Welcome to the Image Registry"
+#~ msgstr "Bienvenue dans le registre d’images"
+
+#~ msgid "When"
+#~ msgstr "Quand"
+
+#~ msgid ""
+#~ "You can bypass the certificate check, but any data you send to the server "
+#~ "could be intercepted by others."
+#~ msgstr ""
+#~ "Vous pouvez ignorer la vérification du certificat, mais toutes les "
+#~ "données que vous envoyez au serveur peuvent être interceptées par "
+#~ "d’autres personnes."
+
+#~ msgid "You can deploy an application to your cluster."
+#~ msgstr "Vous pouvez déployer une application sur votre cluster."
+
+#~ msgid ""
+#~ "Your login credentials do not give you access to use the docker registry "
+#~ "from the command line."
+#~ msgstr ""
+#~ "Vos identifiants ne vous permettent pas d’utiliser le registre docker à "
+#~ "partir de la ligne de commande."
+
+#~ msgid "connecting"
+#~ msgstr "connexion"
+
+#~ msgid "cores"
+#~ msgstr "noyaux"
+
+#~ msgid "eg: my-image-stream"
+#~ msgstr "ex : my-image-stream"
+
+#~ msgid "error"
+#~ msgstr "erreur"
+
+#~ msgid "initializing"
+#~ msgstr "initialisation"
+
+#~ msgid "installation failed"
+#~ msgstr "l’installation a échoué"
+
+#~ msgid "installing OS"
+#~ msgstr "l’installation du système"
+
+#~ msgid "kdumping"
+#~ msgstr "kdumping"
+
+#~ msgid "maintenance"
+#~ msgstr "maintenance"
+
+#~ msgid "non operational"
+#~ msgstr "non opérationnel"
+
+#~ msgid "non responsive"
+#~ msgstr "non réactif"
+
+#~ msgid "oVirt"
+#~ msgstr "oVirt"
+
+#~ msgid "oVirt Host State:"
+#~ msgstr "État hôte oVirt :"
+
+#~ msgid "oVirt Provider installation script failed due to missing arguments."
+#~ msgstr ""
+#~ "Le script d’installation d’oVirt Provider a échoué en raison d’arguments "
+#~ "manquants."
+
+#~ msgid ""
+#~ "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
+#~ "machines-ovirt.config, try as root."
+#~ msgstr ""
+#~ "Le script d’installation d’oVirt Provider a échoué : impossible d’écrire "
+#~ "dans /etc/cockpit/machines-ovirt.config, essayez en tant que root."
+
+#~ msgid "oVirt installation script failed with following output: "
+#~ msgstr "Le script d’installation d’oVirt a échoué avec la sortie suivante :"
+
+#~ msgid "pending approval"
+#~ msgstr "validation en attente"
+
+#~ msgid "pending volume claims"
+#~ msgstr "demandes de volume en attente"
+
+#~ msgid "reboot"
+#~ msgstr "redémarrer"
+
+#~ msgid "sockets"
+#~ msgstr "sockets"
+
+#~ msgid "threads"
+#~ msgstr "threads"
+
+#~ msgid "unassigned"
+#~ msgstr "non attribué"

--- a/po/it.po
+++ b/po/it.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-12 12:39+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2018-12-17 04:52+0000\n"
 "Last-Translator: Giacomo Sanchietti <giacomo.sanchietti@gmail.com>\n"
 "Language-Team: Italian\n"
 "Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -23,28 +23,24 @@ msgstr ""
 msgid " (shared with the OS)"
 msgstr " (condiviso con il SO)"
 
-#: pkg/kubernetes/views/node-delete.html:8
-msgid " 1\"Do you want to delete the following Nodes?"
-msgstr " 1\"Eliminare i seguenti Nodi?"
-
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0 Dispositivo a blocchi"
 
-#: pkg/storaged/mdraid-details.jsx:193
+#: pkg/storaged/mdraid-details.jsx:192
 msgid "$0 Chunk Size"
 msgstr "$0 Dimensione del pezzo"
 
-#: pkg/storaged/mdraid-details.jsx:191
+#: pkg/storaged/mdraid-details.jsx:190
 msgid "$0 Disks"
 msgstr "$0 Dischi"
 
-#: pkg/storaged/content-views.jsx:338
+#: pkg/storaged/content-views.jsx:334
 msgctxt "storage-id-desc"
 msgid "$0 File System"
 msgstr "$0 File System"
 
-#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:113
+#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:105
 msgid "$0 Network"
 msgstr ""
 
@@ -54,7 +50,7 @@ msgid_plural "$0 Packages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/init.js:396 pkg/systemd/init.js:755
+#: pkg/systemd/init.js:395 pkg/systemd/init.js:749
 msgid "$0 Template"
 msgstr "$0 Template"
 
@@ -84,23 +80,23 @@ msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 dati + + $1 overhead utilizzato di $2 ($3)"
 
 #: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:213
+#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "Il $0 disco non esiste"
 msgstr[1] "Il $0 disco non esiste"
 
 #: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:34
-#: pkg/playground/translate.js:37
+#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "Il $0 disco non esiste"
 msgstr[1] "Il $0 disco non esiste"
 
-#: src/ws/login.js:326 src/ws/login.js:664
+#: src/ws/login.js:326 src/ws/login.js:667
 msgid "$0 error"
 msgstr "$0 errore"
 
@@ -132,11 +128,11 @@ msgstr ""
 "$0 è disponibile per la maggior parte dei sistemi operativi. Per "
 "installarlo, cercarlo nel software GNOME o eseguire quanto segue:"
 
-#: pkg/storaged/content-views.jsx:291 pkg/storaged/content-views.jsx:509
+#: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
 #: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
-#: pkg/storaged/mdraid-details.jsx:237 pkg/storaged/mdraid-details.jsx:290
 #: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
-#: pkg/storaged/vgroup-details.jsx:203 pkg/storaged/format-dialog.jsx:262
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 è in uso attivo"
 
@@ -176,27 +172,11 @@ msgstr[1] "$0 aggiornamenti"
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 usato di $1 ($2 salvato)"
 
-#: pkg/ovirt/components/vcpuModal.jsx:98
-msgid "$0 vCPU Details"
-msgstr "$0 dettagli vCPU"
-
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "$0 sarà installato."
 
-#: pkg/kubernetes/scripts/nodes.js:871
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0% Libero"
-msgstr[1] "$0% Libero"
-
-#: pkg/kubernetes/scripts/nodes.js:873
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0% Usato"
-msgstr[1] "$0% Usato"
-
-#: pkg/storaged/vgroup-details.jsx:118
+#: pkg/storaged/vgroup-details.jsx:117
 msgid "$0, $1 free"
 msgstr "$0# $1 libero"
 
@@ -206,7 +186,7 @@ msgid_plural "$1 security fixes"
 msgstr[0] "$1 fissaggio di sicurezza"
 msgstr[1] "$1 correzioni di sicurezza"
 
-#: pkg/networkmanager/interfaces.js:2749
+#: pkg/networkmanager/interfaces.js:2757
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -222,24 +202,16 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/subscriptions/subscriptions-client.js:197
-msgid "'Organization' required to register."
-msgstr "Organizzazione\" necessaria per la registrazione."
-
-#: pkg/subscriptions/subscriptions-client.js:201
-msgid "'Organization' required when using activation keys."
-msgstr ""
-"Organizzazione\" richiesta quando si utilizzano i tasti di attivazione."
-
-#: pkg/networkmanager/firewall.jsx:467
+#: pkg/networkmanager/firewall.jsx:549
 msgid "(Optional)"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:163
+#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
+#: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(predefinito)"
 
-#: pkg/storaged/crypto-tab.jsx:138
+#: pkg/storaged/crypto-tab.jsx:135
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -257,37 +229,37 @@ msgstr "--"
 msgid "1 MiB"
 msgstr "1 MiB"
 
-#: pkg/systemd/index.html:452 pkg/systemd/index.html:456
+#: pkg/systemd/index.html:444 pkg/systemd/index.html:448
 msgid "1 Minute"
 msgstr "1 minuto"
 
 #: pkg/dashboard/index.html:55 pkg/networkmanager/index.html:68
-#: pkg/networkmanager/index.html:409 pkg/systemd/index.html:191
+#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:183
 #: pkg/storaged/plot.jsx:85
 msgid "1 day"
 msgstr "1 giorno"
 
 #: pkg/dashboard/index.html:51 pkg/networkmanager/index.html:66
-#: pkg/networkmanager/index.html:407 pkg/systemd/index.html:187
+#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:179
 #: pkg/storaged/plot.jsx:79
 msgid "1 hour"
 msgstr "1 ora"
 
-#: pkg/systemd/host.js:1665
+#: pkg/systemd/host.js:1669
 msgid "1 min"
 msgstr "1 min"
 
 #: pkg/dashboard/index.html:57 pkg/networkmanager/index.html:69
-#: pkg/networkmanager/index.html:410 pkg/systemd/index.html:193
+#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:185
 #: pkg/storaged/plot.jsx:88
 msgid "1 week"
 msgstr "1 settimana"
 
-#: pkg/systemd/services.html:275
+#: pkg/systemd/services.html:273
 msgid "10th"
 msgstr "10°"
 
-#: pkg/systemd/services.html:276
+#: pkg/systemd/services.html:274
 msgid "11th"
 msgstr "11t°"
 
@@ -295,19 +267,19 @@ msgstr "11t°"
 msgid "128 KiB"
 msgstr "128 KiB"
 
-#: pkg/systemd/services.html:277
+#: pkg/systemd/services.html:275
 msgid "12th"
 msgstr "12°"
 
-#: pkg/systemd/services.html:278
+#: pkg/systemd/services.html:276
 msgid "13th"
 msgstr "13°"
 
-#: pkg/systemd/services.html:279
+#: pkg/systemd/services.html:277
 msgid "14th"
 msgstr "14°"
 
-#: pkg/systemd/services.html:280
+#: pkg/systemd/services.html:278
 msgid "15th"
 msgstr "15°"
 
@@ -315,23 +287,23 @@ msgstr "15°"
 msgid "16 KiB"
 msgstr "16 KiB"
 
-#: pkg/systemd/services.html:281
+#: pkg/systemd/services.html:279
 msgid "16th"
 msgstr "16°"
 
-#: pkg/systemd/services.html:282
+#: pkg/systemd/services.html:280
 msgid "17th"
 msgstr "17°"
 
-#: pkg/systemd/services.html:283
+#: pkg/systemd/services.html:281
 msgid "18th"
 msgstr "18°"
 
-#: pkg/systemd/services.html:284
+#: pkg/systemd/services.html:282
 msgid "19th"
 msgstr "19°"
 
-#: pkg/systemd/services.html:266
+#: pkg/systemd/services.html:264
 msgid "1st"
 msgstr "1°"
 
@@ -339,67 +311,67 @@ msgstr "1°"
 msgid "2 MiB"
 msgstr "2 MiB"
 
-#: pkg/systemd/host.js:1664
+#: pkg/systemd/host.js:1668
 msgid "2 min"
 msgstr "2 min"
 
-#: pkg/systemd/index.html:458
+#: pkg/systemd/index.html:450
 msgid "20 Minutes"
 msgstr "20 minuti"
 
-#: pkg/systemd/services.html:285
+#: pkg/systemd/services.html:283
 msgid "20th"
 msgstr "20"
 
-#: pkg/systemd/services.html:286
+#: pkg/systemd/services.html:284
 msgid "21st"
 msgstr "21"
 
-#: pkg/systemd/services.html:287
+#: pkg/systemd/services.html:285
 msgid "22nd"
 msgstr "22esimo"
 
-#: pkg/systemd/services.html:288
+#: pkg/systemd/services.html:286
 msgid "23rd"
 msgstr "ventitreesimo"
 
-#: pkg/systemd/services.html:289
+#: pkg/systemd/services.html:287
 msgid "24th"
 msgstr "ventiquattresimo"
 
-#: pkg/systemd/services.html:290
+#: pkg/systemd/services.html:288
 msgid "25th"
 msgstr "venticinquesimo"
 
-#: pkg/systemd/services.html:291
+#: pkg/systemd/services.html:289
 msgid "26th"
 msgstr "26°"
 
-#: pkg/systemd/services.html:292
+#: pkg/systemd/services.html:290
 msgid "27th"
 msgstr "27"
 
-#: pkg/systemd/services.html:293
+#: pkg/systemd/services.html:291
 msgid "28th"
 msgstr "ventottesimo"
 
-#: pkg/systemd/services.html:294
+#: pkg/systemd/services.html:292
 msgid "29th"
 msgstr "ventinovesimo"
 
-#: pkg/systemd/services.html:267
+#: pkg/systemd/services.html:265
 msgid "2nd"
 msgstr "2a"
 
-#: pkg/systemd/host.js:1663
+#: pkg/systemd/host.js:1667
 msgid "3 min"
 msgstr "3 min"
 
-#: pkg/systemd/services.html:295
+#: pkg/systemd/services.html:293
 msgid "30th"
 msgstr "30"
 
-#: pkg/systemd/services.html:296
+#: pkg/systemd/services.html:294
 msgid "31st"
 msgstr "31"
 
@@ -407,7 +379,7 @@ msgstr "31"
 msgid "32 KiB"
 msgstr "32 KiB"
 
-#: pkg/systemd/services.html:268
+#: pkg/systemd/services.html:266
 msgid "3rd"
 msgstr "Terzo"
 
@@ -415,28 +387,28 @@ msgstr "Terzo"
 msgid "4 KiB"
 msgstr "4 KiB"
 
-#: pkg/systemd/host.js:1662
+#: pkg/systemd/host.js:1666
 msgid "4 min"
 msgstr "4 min"
 
-#: pkg/systemd/index.html:459
+#: pkg/systemd/index.html:451
 msgid "40 Minutes"
 msgstr "40 minuti"
 
-#: pkg/systemd/services.html:269
+#: pkg/systemd/services.html:267
 msgid "4th"
 msgstr "4a"
 
-#: pkg/systemd/index.html:457
+#: pkg/systemd/index.html:449
 msgid "5 Minutes"
 msgstr "5 Minuti"
 
-#: pkg/systemd/host.js:1661
+#: pkg/systemd/host.js:1665
 msgid "5 min"
 msgstr "5 min"
 
 #: pkg/dashboard/index.html:49 pkg/networkmanager/index.html:65
-#: pkg/networkmanager/index.html:406 pkg/systemd/index.html:185
+#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:177
 #: pkg/storaged/plot.jsx:76
 msgid "5 minutes"
 msgstr "5 minuti"
@@ -445,17 +417,17 @@ msgstr "5 minuti"
 msgid "512 KiB"
 msgstr "512 KiB"
 
-#: pkg/systemd/services.html:270
+#: pkg/systemd/services.html:268
 msgid "5th"
 msgstr "Quinto"
 
 #: pkg/dashboard/index.html:53 pkg/networkmanager/index.html:67
-#: pkg/networkmanager/index.html:408 pkg/systemd/index.html:189
+#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:181
 #: pkg/storaged/plot.jsx:82
 msgid "6 hours"
 msgstr "6 ore"
 
-#: pkg/systemd/index.html:460
+#: pkg/systemd/index.html:452
 msgid "60 Minutes"
 msgstr "60 minuti"
 
@@ -463,11 +435,11 @@ msgstr "60 minuti"
 msgid "64 KiB"
 msgstr "64 KiB"
 
-#: pkg/systemd/services.html:271
+#: pkg/systemd/services.html:269
 msgid "6th"
 msgstr "6°"
 
-#: pkg/systemd/services.html:272
+#: pkg/systemd/services.html:270
 msgid "7th"
 msgstr "7°"
 
@@ -475,19 +447,19 @@ msgstr "7°"
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1975
+#: pkg/networkmanager/interfaces.js:1978
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:1992
+#: pkg/networkmanager/interfaces.js:1995
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
-#: pkg/systemd/services.html:273
+#: pkg/systemd/services.html:271
 msgid "8th"
 msgstr "ottavo"
 
-#: pkg/systemd/services.html:274
+#: pkg/systemd/services.html:272
 msgid "9th"
 msgstr "Nona"
 
@@ -496,8 +468,8 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Una versione compatibile di Cockpit non è installata su "
-"{{#strong}}{{host}}{{/strong}}."
+"Una versione compatibile di Cockpit non è installata su {{#strong}}{{host}}"
+"{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:59
 msgid "A disk is needed."
@@ -515,24 +487,20 @@ msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr ""
 "È necessario aggiungere un disco di riserva prima di poterlo rimuovere."
 
-#: pkg/networkmanager/interfaces.js:1983
+#: pkg/networkmanager/interfaces.js:1986
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2778
+#: pkg/networkmanager/interfaces.js:2786
 msgid "ARP Monitoring"
 msgstr "Monitoraggio ARP"
 
-#: pkg/networkmanager/interfaces.js:2004
+#: pkg/networkmanager/interfaces.js:2007
 msgid "ARP Ping"
 msgstr "ARP Ping"
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "AWS Elastic Block Store"
-
 #: pkg/shell/index.html:56 pkg/shell/index.html:82 pkg/shell/simple.html:42
-#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
+#: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Informazioni su Cockpit"
 
@@ -540,20 +508,9 @@ msgstr "Informazioni su Cockpit"
 msgid "Access"
 msgstr "Accesso"
 
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
-msgid "Access Modes"
-msgstr "Modalità di accesso"
-
-#: pkg/kubernetes/views/project-modify.html:49
 #: node_modules/registry-image-widgets/views/imagestream-body.html:12
 msgid "Access Policy"
 msgstr "Politica di accesso"
-
-# translation auto-copied from project libvirt, version 1.1.1, document libvirt
-#: pkg/subscriptions/subscriptions-view.jsx:213
-msgid "Access denied"
-msgstr "Accesso negato"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -571,19 +528,14 @@ msgstr "Account non disponibile o non modificabile."
 msgid "Accounts"
 msgstr "Account"
 
-#: pkg/users/local.js:335 pkg/users/local.js:642
+#: pkg/users/local.js:339 pkg/users/local.js:646
 msgctxt "page-title"
 msgid "Accounts"
 msgstr "Account"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:183
-msgid "Action"
-msgstr "Azione"
-
-#: pkg/machines/components/networks/network.jsx:147
-#: pkg/machines/components/storagePools/storagePool.jsx:167
-#: pkg/storaged/content-views.jsx:264
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
+#: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Attiva"
 
@@ -591,53 +543,45 @@ msgstr "Attiva"
 msgid "Activating $target"
 msgstr "Attivazione $target"
 
-#: pkg/subscriptions/subscriptions-register.jsx:168
-msgid "Activation Key"
-msgstr "Chiave di attivazione"
-
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/networkmanager/interfaces.js:835 pkg/networkmanager/interfaces.js:1998
+#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
 msgid "Active"
 msgstr "Attivo"
 
-#: pkg/networkmanager/interfaces.js:1972 pkg/networkmanager/interfaces.js:1989
+#: pkg/networkmanager/interfaces.js:1975 pkg/networkmanager/interfaces.js:1992
 msgid "Active Backup"
 msgstr "Backup attivo"
 
-#: pkg/shell/index.html:59 pkg/shell/stub.html:49 pkg/shell/active-pages.js:95
+#: pkg/shell/index.html:59 pkg/shell/active-pages.js:95
 msgid "Active Pages"
 msgstr "Pagine attive"
 
-#: pkg/storaged/dialog.jsx:1033 pkg/storaged/dialog.jsx:1037
+#: pkg/storaged/dialog.jsx:1043 pkg/storaged/dialog.jsx:1047
 msgid "Active since"
 msgstr "Attivo dal"
 
-#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
-msgid "Actual"
-msgstr "Attuale"
+#: pkg/networkmanager/firewall.jsx:924
+#, fuzzy
+msgid "Active zones"
+msgstr "Pagine attive"
 
-#: pkg/networkmanager/interfaces.js:1977
+#: pkg/networkmanager/interfaces.js:1980
 msgid "Adaptive load balancing"
 msgstr "Adaptive Load Balancing"
 
-#: pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1979
 msgid "Adaptive transmit load balancing"
 msgstr "Adaptive Transmit Load Balancing"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/add-role-dialog.html:8
-#: pkg/kubernetes/views/add-user-dialog.html:27
-#: pkg/kubernetes/views/node-add.html:50
-#: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:454
-#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/vgroup-details.jsx:63
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Aggiungi"
 
-#: pkg/networkmanager/interfaces.js:3095
+#: pkg/networkmanager/interfaces.js:3103
 msgid "Add $0"
 msgstr "Aggiungi $0"
 
@@ -645,19 +589,15 @@ msgstr "Aggiungi $0"
 msgid "Add Additional Storage"
 msgstr "Aggiungi memoria aggiuntiva"
 
-#: pkg/networkmanager/index.html:118
+#: pkg/networkmanager/index.html:110
 msgid "Add Bond"
 msgstr "Aggiungi bond"
 
-#: pkg/networkmanager/index.html:120
+#: pkg/networkmanager/index.html:112
 msgid "Add Bridge"
 msgstr "Aggiungi bridge"
 
-#: pkg/kubernetes/views/node-add.html:3
-msgid "Add Cluster Node"
-msgstr "Aggiungi nodo cluster"
-
-#: pkg/machines/components/diskAdd.jsx:279
+#: pkg/machines/components/diskAdd.jsx:360
 msgid "Add Disk"
 msgstr "Aggiungi disco"
 
@@ -665,55 +605,20 @@ msgstr "Aggiungi disco"
 msgid "Add Disks"
 msgstr "Aggiungere dischi"
 
-#: pkg/kubernetes/views/add-group-dialog.html:3
-msgid "Add Group"
-msgstr "Aggiungi gruppo"
-
 #: pkg/storaged/crypto-keyslots.jsx:200
 msgid "Add Key"
 msgstr "Aggiungi chiave"
-
-#: pkg/kubernetes/views/nodes-page.html:34
-msgid "Add Kubernetes Node"
-msgstr "Aggiungi Nodo Kubernetes"
 
 #: pkg/lib/machine-add.html:4
 msgid "Add Machine to Dashboard"
 msgstr "Aggiungi macchina alla dashboard"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:4
-#: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/group-panel.html:29
-#: pkg/kubernetes/views/project-body.html:108
-#: pkg/kubernetes/views/user-group-add.html:3
-msgid "Add Member"
-msgstr "Aggiungi membro"
-
-#: pkg/kubernetes/views/user-body.html:67
-#: pkg/kubernetes/views/user-panel.html:76
-msgid "Add Membership"
-msgstr "Aggiungete l'iscrizione"
-
-#: pkg/kubernetes/views/auth-form.html:11
-#: pkg/kubernetes/views/auth-form.html:20
-msgid "Add New Cluster"
-msgstr "Aggiungere un nuovo cluster"
-
-#: pkg/kubernetes/views/auth-form.html:67
-#: pkg/kubernetes/views/auth-form.html:76
-msgid "Add New User"
-msgstr "Aggiungi nuovo utente"
-
-#: pkg/networkmanager/firewall.jsx:392
+#: pkg/networkmanager/firewall.jsx:457
 msgid "Add Ports"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html:3
-msgid "Add Role"
-msgstr "Aggiungi ruolo"
-
-#: pkg/networkmanager/firewall.jsx:392 pkg/networkmanager/firewall.jsx:562
-#: pkg/networkmanager/firewall.jsx:568
+#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
+#: pkg/networkmanager/firewall.jsx:886
 msgid "Add Services"
 msgstr "Aggiungi servizi"
 
@@ -721,18 +626,19 @@ msgstr "Aggiungi servizi"
 msgid "Add Storage"
 msgstr "Aggiungi storage"
 
-#: pkg/networkmanager/index.html:119
+#: pkg/networkmanager/index.html:111
 msgid "Add Team"
 msgstr "Aggiungi team"
 
-#: pkg/kubernetes/views/add-user-dialog.html:3
-#: pkg/kubernetes/views/project-listing.html:83
-msgid "Add User"
-msgstr "Aggiungere Utente"
-
-#: pkg/networkmanager/index.html:121
+#: pkg/networkmanager/index.html:113
 msgid "Add VLAN"
 msgstr "Aggiungi VLAN"
+
+#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
+#: pkg/networkmanager/firewall.jsx:891
+#, fuzzy
+msgid "Add Zone"
+msgstr "Aggiungi bond"
 
 #: pkg/storaged/iscsi-panel.jsx:41
 msgid "Add iSCSI Portal"
@@ -742,15 +648,25 @@ msgstr "Aggiungi Portale iSCSI"
 msgid "Add key"
 msgstr "Aggiungi chiave"
 
-#: pkg/kubernetes/views/user-add-membership.html:3
-msgid "Add membership"
-msgstr "Aggiungete l'iscrizione"
+#: pkg/networkmanager/firewall.jsx:458
+#, fuzzy
+msgid "Add ports to the following zones:"
+msgstr " 1\"Eliminare i seguenti Nodi?"
 
 #: pkg/users/index.html:406
 msgid "Add public key"
 msgstr "Aggiungere la chiave pubblica"
 
-#: pkg/networkmanager/interfaces.js:3094
+#: pkg/networkmanager/firewall.jsx:458
+msgid "Add services to following zones:"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:776
+#, fuzzy
+msgid "Add zone"
+msgstr "Aggiungi bond"
+
+#: pkg/networkmanager/interfaces.js:3102
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -766,19 +682,24 @@ msgstr "Aggiunta di un tasto"
 msgid "Adding physical volume to $target"
 msgstr "Aggiunta di volume fisico a $target"
 
-#: pkg/networkmanager/interfaces.js:2648
+#: pkg/machines/components/vmDisksTab.jsx:78
+#, fuzzy
+msgid "Additional"
+msgstr "Memoria aggiuntiva"
+
+#: pkg/networkmanager/interfaces.js:2656
 msgid "Additional DNS $val"
 msgstr "DNS aggiuntivo $val"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/networkmanager/interfaces.js:2659
 msgid "Additional DNS Search Domains $val"
 msgstr "Domini di ricerca DNS aggiuntivi $val"
 
-#: pkg/docker/index.html:307
+#: pkg/docker/index.html:309
 msgid "Additional Storage"
 msgstr "Memoria aggiuntiva"
 
-#: pkg/networkmanager/interfaces.js:2643
+#: pkg/networkmanager/interfaces.js:2651
 msgid "Additional address $val"
 msgstr "Indirizzo aggiuntivo $val"
 
@@ -786,18 +707,15 @@ msgstr "Indirizzo aggiuntivo $val"
 msgid "Additional packages:"
 msgstr "Pacchetti aggiuntivi:"
 
-#: pkg/kubernetes/views/auth-form.html:29
-#: pkg/kubernetes/views/dashboard-page.html:157
-#: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
+#: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:77 pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:107
+#: pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Indirizzo"
 
-#: pkg/networkmanager/interfaces.js:2643
+#: pkg/networkmanager/interfaces.js:2651
 msgid "Address $val"
 msgstr "Indirizzo $val"
 
@@ -810,44 +728,18 @@ msgid "Address is not a valid URL"
 msgstr "L'indirizzo non è un URL valido"
 
 #: pkg/machines/components/desktopConsole.jsx:153
-#: pkg/ovirt/components/VmOverviewColumn.jsx:53
 msgid "Address:"
 msgstr "Indirizzo:"
 
-#: pkg/kubernetes/views/details-page.html:37
-#: pkg/networkmanager/interfaces.js:3290
+#: pkg/networkmanager/interfaces.js:3309
 msgid "Addresses"
 msgstr "Indirizzi"
-
-#: pkg/kubernetes/views/service-modify.html:25
-msgid "Adjust"
-msgstr "Regola"
-
-#: pkg/kubernetes/views/pv-modify.html:3
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "Regolare il volume persistente ' ' ' '"
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html:3
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "Regolare il controllore di replica {{ item.metadata.name }}"
-
-#: pkg/kubernetes/views/route-modify.html:3
-msgid "Adjust Route"
-msgstr "Regolare il percorso"
-
-#: pkg/kubernetes/views/service-modify.html:3
-msgid "Adjust Service"
-msgstr "Regolare il servizio"
-
-#: pkg/kubernetes/views/project-body.html:56
-msgid "Admin"
-msgstr "Admin"
 
 #: org.cockpit-project.cockpit-bridge.policy.in.h:1
 msgid "Administration with Cockpit Web Console"
 msgstr "Amministrazione con Cockpit Console Web"
 
-#: pkg/realmd/operation.js:336
+#: pkg/realmd/operation.js:335
 msgid "Administrator Password"
 msgstr "Password amministratore"
 
@@ -855,7 +747,7 @@ msgstr "Password amministratore"
 msgid "Advanced TCA"
 msgstr "TCA avanzato"
 
-#: pkg/systemd/services.html:457 pkg/systemd/init.js:736
+#: pkg/systemd/services.html:455 pkg/systemd/init.js:730
 msgid "After"
 msgstr "Dopo"
 
@@ -866,31 +758,22 @@ msgid ""
 "settings and the list of trusted CAs may change."
 msgstr ""
 
-#: pkg/systemd/services.html:448 pkg/systemd/services.html:452
-#: pkg/systemd/init.js:1079
+#: pkg/systemd/services.html:446 pkg/systemd/services.html:450
+#: pkg/systemd/init.js:1073
 msgid "After system boot"
 msgstr "Dopo l'avvio del sistema"
 
-#: pkg/systemd/logs.html:56
+#: pkg/systemd/logs.html:57
 msgid "Alert and above"
 msgstr "Allarme e oltre"
 
-#: pkg/systemd/services.html:67 pkg/systemd/services.html:71
-#: pkg/systemd/init.js:340 pkg/systemd/logs.js:212 pkg/systemd/logs.js:377
+#: pkg/systemd/services.html:71 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
 msgid "All"
 msgstr ""
 
 #: pkg/lib/machine-info.js:76
 msgid "All In One"
 msgstr "Tutto In Uno"
-
-#: pkg/kubernetes/views/filter-project.html:4
-msgid "All Projects"
-msgstr "Tutti i progetti"
-
-#: pkg/kubernetes/views/details-page.html:6
-msgid "All Types"
-msgstr "Tutti i tipi"
 
 #: pkg/docker/storage.jsx:381
 msgid ""
@@ -900,50 +783,28 @@ msgstr ""
 "Tutti i dati sui dischi selezionati verranno cancellati e i dischi verranno "
 "aggiunti al pool di archiviazione."
 
-#: pkg/kubernetes/views/dashboard-page.html:112
-msgid "All healthy"
-msgstr "Tutti sani"
+#: pkg/networkmanager/firewall.jsx:751
+#, fuzzy
+msgid "Allowed Addresses"
+msgstr "Indirizzo"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:74
-msgid "All images"
-msgstr "Tutte le immagini"
-
-#: pkg/kubernetes/views/dashboard-page.html:69
-msgid "All in use"
-msgstr "Tutto in uso"
-
-#: pkg/kubernetes/views/dashboard-page.html:37
-msgid "All running"
-msgstr "Tutti in esecuzione"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:36
-msgid "All running virtual machines will be turned off."
-msgstr "Tutte le macchine virtuali in esecuzione saranno disattivate."
-
-#: pkg/networkmanager/firewall.jsx:594
+#: pkg/networkmanager/firewall.jsx:937
 msgid "Allowed Services"
 msgstr "Servizi consentiti"
 
-#: pkg/docker/index.html:548 pkg/docker/util.js:108
+#: pkg/docker/index.html:550 pkg/docker/util.js:108
 msgid "Always"
 msgstr "Sempre"
 
-#: pkg/machines/components/diskAdd.jsx:115
+#: pkg/machines/components/diskAdd.jsx:116
 msgid "Always attach"
 msgstr ""
 
-#: pkg/kubernetes/views/node-body.html:57
-#: pkg/kubernetes/views/route-body.html:27
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Annotazioni"
 
-#: pkg/kubernetes/scripts/projects.js:1044
-msgid "Anonymous: Allow all unauthenticated users to pull images"
-msgstr ""
-"Anonimo: consente a tutti gli utenti non autenticati di scaricare immagini"
-
-#: pkg/systemd/terminal.jsx:94
+#: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr ""
 
@@ -952,15 +813,14 @@ msgstr ""
 msgid "Applications"
 msgstr "Applicazioni"
 
-#: pkg/networkmanager/index.html:486 pkg/networkmanager/index.html:510
-#: pkg/networkmanager/index.html:534 pkg/networkmanager/index.html:558
-#: pkg/networkmanager/index.html:582 pkg/networkmanager/index.html:606
-#: pkg/networkmanager/index.html:630 pkg/networkmanager/index.html:654
-#: pkg/networkmanager/index.html:678 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:247
-#: pkg/ovirt/components/vcpuModal.jsx:104 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:478 pkg/networkmanager/index.html:502
+#: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
+#: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
+#: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Applica"
 
@@ -989,7 +849,6 @@ msgid "Applying updates failed"
 msgstr "Applicazione degli aggiornamenti non riuscita"
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
-#: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Architecture"
 msgstr "Architettura"
 
@@ -1002,12 +861,12 @@ msgstr "Etichetta Asset"
 msgid "At least $0 disks are needed."
 msgstr "Sono necessari almeno dei $0 dischi."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "È necessario almeno un disco."
 
-#: pkg/systemd/services.html:453
+#: pkg/systemd/services.html:451
 msgid "At specific time"
 msgstr "In un momento specifico"
 
@@ -1015,13 +874,12 @@ msgstr "In un momento specifico"
 msgid "Audit log"
 msgstr "Log audit"
 
-#: pkg/networkmanager/interfaces.js:827
+#: pkg/networkmanager/interfaces.js:830
 msgid "Authenticating"
 msgstr "Autenticazione"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
 #: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Autenticazione"
 
@@ -1029,11 +887,11 @@ msgstr "Autenticazione"
 msgid "Authentication Failed"
 msgstr "Autenticazione fallita"
 
-#: src/ws/login.js:644
+#: src/ws/login.js:647
 msgid "Authentication Failed: Server closed connection"
 msgstr "Autenticazione fallita: il server ha terminato la connessione"
 
-#: src/ws/login.js:654
+#: src/ws/login.js:657
 msgid "Authentication failed"
 msgstr "Autenticazione fallita"
 
@@ -1049,7 +907,7 @@ msgstr ""
 msgid "Authentication required"
 msgstr "Autenticazione necessaria"
 
-#: pkg/docker/index.html:700
+#: pkg/docker/index.html:702
 #: node_modules/registry-image-widgets/views/image-body.html:12
 #: pkg/docker/containers-view.jsx:413
 msgid "Author"
@@ -1059,22 +917,22 @@ msgstr "Autore"
 msgid "Authorized Public SSH Keys"
 msgstr "Chiavi SSH pubbliche autorizzate"
 
-#: pkg/networkmanager/index.html:184 pkg/networkmanager/interfaces.js:1962
-#: pkg/networkmanager/interfaces.js:2751 pkg/networkmanager/interfaces.js:3298
-#: pkg/networkmanager/interfaces.js:3302 pkg/networkmanager/interfaces.js:3308
-#: pkg/realmd/operation.js:339
+#: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
+#: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
+#: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
+#: pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automatico"
 
-#: pkg/networkmanager/interfaces.js:1963
+#: pkg/networkmanager/interfaces.js:1966
 msgid "Automatic (DHCP only)"
 msgstr "Automatico (solo DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1953
+#: pkg/networkmanager/interfaces.js:1956
 msgid "Automatic (DHCP)"
 msgstr "Automatico (DHCP)"
 
-#: pkg/systemd/services.html:127 pkg/systemd/init.js:286
+#: pkg/systemd/services.html:125 pkg/systemd/init.js:286
 msgid "Automatic Startup"
 msgstr ""
 
@@ -1082,25 +940,21 @@ msgstr ""
 msgid "Automatic Updates"
 msgstr "Aggiornamenti automatici"
 
-#: pkg/ovirt/components/OVirtTab.jsx:81
-msgid "Automatically selected host"
-msgstr "Ospite selezionato automaticamente"
-
 #: pkg/machines/components/libvirtSlate.jsx:90
 msgid "Automatically start libvirt on boot"
 msgstr "Avvia automaticamente libvirt al boot"
 
-#: pkg/systemd/index.html:397
+#: pkg/systemd/index.html:389
 msgid "Automatically using NTP"
 msgstr "Automaticamente utilizzando NTP"
 
-#: pkg/systemd/index.html:398
+#: pkg/systemd/index.html:390
 msgid "Automatically using specific NTP servers"
 msgstr "Automaticamente utilizzando server NTP specifici"
 
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
 #: pkg/machines/components/networks/networkOverviewTab.jsx:86
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:59
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:140
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
 
@@ -1119,13 +973,9 @@ msgstr "Aggiornamenti disponibili"
 msgid "Available targets on $0"
 msgstr "Target disponibili su $0"
 
-#: pkg/dashboard/index.html:161
+#: pkg/dashboard/index.html:163
 msgid "Avatar"
 msgstr "Avatar"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
 
 #: pkg/systemd/hwinfo.jsx:92
 msgid "BIOS"
@@ -1151,27 +1001,15 @@ msgstr "Dispositivo di supporto"
 msgid "Bad data passed for passwd1 mechanism"
 msgstr "Dati errati passati per il meccanismo passwd1"
 
-#: pkg/networkmanager/index.html:341
+#: pkg/networkmanager/index.html:333
 msgid "Balancer"
 msgstr "Balancer"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-msgid "Base Template"
-msgstr "Modello di base"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Base template"
-msgstr "Modello di base"
-
-#: pkg/ovirt/components/OVirtTab.jsx:106 pkg/ovirt/components/OVirtTab.jsx:113
-msgid "Base template:"
-msgstr "Modello di base:"
-
-#: pkg/systemd/init.js:735
+#: pkg/systemd/init.js:729
 msgid "Before"
 msgstr "Prima"
 
-#: pkg/systemd/init.js:726
+#: pkg/systemd/init.js:720
 msgid "Binds To"
 msgstr "Si lega a"
 
@@ -1191,7 +1029,7 @@ msgstr "Involucro della lama"
 msgid "Block"
 msgstr "Blocco"
 
-#: pkg/storaged/content-views.jsx:653
+#: pkg/storaged/content-views.jsx:649
 msgid "Block device for filesystems"
 msgstr "Dispositivo di blocco per filesystem"
 
@@ -1199,59 +1037,55 @@ msgstr "Dispositivo di blocco per filesystem"
 msgid "Blocked"
 msgstr "Bloccato"
 
-#: pkg/networkmanager/interfaces.js:2507 pkg/networkmanager/interfaces.js:2519
-#: pkg/networkmanager/interfaces.js:2783
+#: pkg/networkmanager/interfaces.js:2510 pkg/networkmanager/interfaces.js:2522
+#: pkg/networkmanager/interfaces.js:2791
 msgid "Bond"
 msgstr "Bond"
 
-#: pkg/networkmanager/index.html:498
+#: pkg/networkmanager/index.html:490
 msgid "Bond Settings"
 msgstr "Impostazioni bond"
 
-#: pkg/kubernetes/views/node-body.html:17
-msgid "Boot ID"
-msgstr "ID boot"
-
-#: pkg/machines/components/vm/bootOrderModal.jsx:314
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:138
+#: pkg/machines/components/vm/bootOrderModal.jsx:312
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:164
 msgid "Boot Order"
 msgstr ""
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:210
+#: pkg/machines/components/vm/bootOrderModal.jsx:208
 msgid "Boot order settings could not be saved"
 msgstr ""
 
-#: pkg/systemd/init.js:731
+#: pkg/systemd/init.js:725
 msgid "Bound By"
 msgstr "Legato da"
 
 # translation auto-copied from project Anaconda, version master, document anaconda, author Gregorio
-#: pkg/networkmanager/interfaces.js:2513 pkg/networkmanager/interfaces.js:2525
-#: pkg/networkmanager/interfaces.js:2860
+#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
+#: pkg/networkmanager/interfaces.js:2868
 msgid "Bridge"
 msgstr "Bridge"
 
-#: pkg/networkmanager/index.html:594
+#: pkg/networkmanager/index.html:586
 msgid "Bridge Port Settings"
 msgstr "Impostazioni della porta del bridge"
 
-#: pkg/networkmanager/index.html:570
+#: pkg/networkmanager/index.html:562
 msgid "Bridge Settings"
 msgstr "Impostazioni del bridge"
 
-#: pkg/networkmanager/interfaces.js:2881
+#: pkg/networkmanager/interfaces.js:2889
 msgid "Bridge port"
 msgstr "Porta bridge"
 
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1977 pkg/networkmanager/interfaces.js:1994
 msgid "Broadcast"
 msgstr "Broadcast"
 
-#: pkg/networkmanager/interfaces.js:2796 pkg/networkmanager/interfaces.js:2830
+#: pkg/networkmanager/interfaces.js:2804 pkg/networkmanager/interfaces.js:2838
 msgid "Broken configuration"
 msgstr "Configurazione rotta"
 
-#: pkg/systemd/host.js:494
+#: pkg/systemd/host.js:498
 msgid "Bug Fix Updates Available"
 msgstr "Aggiornamenti Bug Fix disponibili"
 
@@ -1264,9 +1098,9 @@ msgstr "Bug:"
 msgid "Built"
 msgstr "Costruito"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:111
-#: pkg/machines/components/vm/bootOrderModal.jsx:134
-#: pkg/machines/components/vmDisksTab.jsx:71
+#: pkg/machines/components/vm/bootOrderModal.jsx:109
+#: pkg/machines/components/vm/bootOrderModal.jsx:132
+#: pkg/machines/components/vmDisksTab.jsx:72
 msgid "Bus"
 msgstr "Bus"
 
@@ -1274,10 +1108,8 @@ msgstr "Bus"
 msgid "Bus Expansion Chassis"
 msgstr "Telaio di espansione bus"
 
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:270
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:603
-#: pkg/kubernetes/scripts/nodes.js:711 pkg/kubernetes/scripts/nodes.js:818
-#: pkg/systemd/hwinfo.jsx:108
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:272
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
 msgid "CPU"
 msgstr "CPU"
 
@@ -1289,32 +1121,30 @@ msgstr ""
 msgid "CPU Security Toggles"
 msgstr ""
 
-#: pkg/systemd/host.js:1544
+#: pkg/systemd/host.js:1548
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Stato CPU"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:139
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:165
 msgid "CPU Type"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "Utilizzo CPU: $0%"
-
-#: pkg/docker/index.html:469 pkg/docker/index.html:641
+#: pkg/docker/index.html:471 pkg/docker/index.html:643
 msgid "CPU priority"
 msgstr "Priorità della CPU"
 
-#: pkg/docker/index.html:217
+#: pkg/docker/index.html:218
 msgid "CPU usage:"
 msgstr "Utilizzo CPU"
 
-#: pkg/ovirt/provider.js:256
-msgid "CREATE VM action failed"
-msgstr "Azione CREATE VM fallita"
+#: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
+#, fuzzy
+msgid "Cache"
+msgstr "Imbarcato"
 
-#: pkg/systemd/index.html:260 pkg/systemd/host.js:1675
+#: pkg/systemd/index.html:252 pkg/systemd/host.js:1679
 msgid "Cached"
 msgstr "Imbarcato"
 
@@ -1322,7 +1152,7 @@ msgstr "Imbarcato"
 msgid "Can&rsquo;t connect to Docker"
 msgstr "Non è possibile connettersi a Docker"
 
-#: pkg/storaged/content-views.jsx:321
+#: pkg/storaged/content-views.jsx:313
 msgid "Can't delete while unlocked"
 msgstr "Non può cancellare mentre è sbloccato"
 
@@ -1330,77 +1160,44 @@ msgstr "Non può cancellare mentre è sbloccato"
 msgid "Can't load image"
 msgstr "Can't load image"
 
-#: pkg/dashboard/index.html:173 pkg/docker/index.html:563
-#: pkg/docker/index.html:597 pkg/docker/index.html:661
-#: pkg/docker/index.html:715 pkg/docker/index.html:755
-#: pkg/docker/index.html:784 pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/add-role-dialog.html:7
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/image-delete.html:7
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/user-group-add.html:29
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
-#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:485 pkg/networkmanager/index.html:509
-#: pkg/networkmanager/index.html:533 pkg/networkmanager/index.html:557
-#: pkg/networkmanager/index.html:581 pkg/networkmanager/index.html:605
-#: pkg/networkmanager/index.html:629 pkg/networkmanager/index.html:653
-#: pkg/networkmanager/index.html:677 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:81 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/systemd/index.html:340
-#: pkg/systemd/index.html:427 pkg/systemd/index.html:479
-#: pkg/systemd/index.html:495 pkg/systemd/services.html:524
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:85
-#: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:496
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:451
-#: pkg/machines/components/nicEdit.jsx:281
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:344
+#: pkg/dashboard/index.html:175 pkg/docker/index.html:565
+#: pkg/docker/index.html:599 pkg/docker/index.html:663
+#: pkg/docker/index.html:717 pkg/docker/index.html:757
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
+#: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
+#: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
+#: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
+#: pkg/systemd/index.html:419 pkg/systemd/index.html:471
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
+#: pkg/machines/components/vm/bootOrderModal.jsx:327
+#: pkg/machines/components/vm/memoryModal.jsx:214
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:244
-#: pkg/machines/components/vm/bootOrderModal.jsx:329
-#: pkg/networkmanager/firewall.jsx:475
-#: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:383
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Annulla"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:415
 msgid "Cannot connect to an unknown machine"
 msgstr "Impossibile connettersi a una macchina sconosciuta"
-
-#: src/ws/cockpitcertificate.c:483
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "Impossibile decifrare la chiave privata codificata PEM"
 
 #: src/base1/cockpit.js:4031
 msgid "Cannot forward login credentials"
@@ -1410,38 +1207,25 @@ msgstr "Impossibile inoltrare le credenziali di accesso"
 msgid "Cannot schedule event in the past"
 msgstr "Non è possibile programmare eventi del passato"
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
-#: pkg/machines/components/vmDisksTab.jsx:69
+#: pkg/machines/components/vmDisksTab.jsx:70
 msgid "Capacity"
 msgstr "Capacità"
 
-#: pkg/networkmanager/interfaces.js:2582
+#: pkg/networkmanager/interfaces.js:2590
 msgid "Carrier"
 msgstr "Carrier"
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Montaggio su file system Ceph"
-
-#: pkg/kubernetes/views/volume-body.html:97
-msgid "Ceph Monitors"
-msgstr "Monitor Ceph"
-
-#: pkg/docker/index.html:662 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
-#: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:341
-#: pkg/systemd/index.html:428 pkg/users/index.html:277 pkg/users/index.html:316
+#: pkg/docker/index.html:664 pkg/systemd/index.html:333
+#: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
 #: pkg/storaged/iscsi-panel.jsx:181
 msgid "Change"
 msgstr "Cambia"
 
-#: pkg/systemd/index.html:297
+#: pkg/systemd/index.html:289
 msgid "Change Host Name"
 msgstr "Cambia nome host"
 
-#: pkg/shell/index.html:332
+#: pkg/shell/index.html:312
 msgid "Change Password"
 msgstr "Cambia password"
 
@@ -1453,50 +1237,38 @@ msgstr "Modifica del profilo perfomance"
 msgid "Change Profile"
 msgstr "Cambia profilo"
 
-#: pkg/systemd/index.html:366
+#: pkg/systemd/index.html:358
 msgid "Change System Time"
 msgstr "Modifica dell'ora di sistema"
-
-#: pkg/kubernetes/views/user-modify.html:3
-msgid "Change User"
-msgstr "Cambia utente"
 
 #: pkg/storaged/iscsi-panel.jsx:176
 msgid "Change iSCSI Initiator Name"
 msgstr "Cambiare il nome dell'iniziatore iSCSI"
 
-#: pkg/kubernetes/views/imagestream-modify.html:4
-msgid "Change image stream"
-msgstr "Cambia flusso di immagini"
-
 #: pkg/storaged/crypto-keyslots.jsx:247
 msgid "Change passphrase"
 msgstr "Cambiare la passphrase"
 
-#: pkg/kubernetes/views/project-modify.html:10
-msgid "Change project"
-msgstr "Cambia progetto"
-
-#: pkg/docker/index.html:228
+#: pkg/docker/index.html:229
 msgid "Change resource limits"
 msgstr "Modificare i limiti delle risorse"
 
-#: pkg/docker/index.html:612
+#: pkg/docker/index.html:614
 msgid "Change resources limits"
 msgstr "Modificare i limiti delle risorse"
 
-#: pkg/networkmanager/interfaces.js:3134
+#: pkg/networkmanager/interfaces.js:3153
 msgid "Change the settings"
 msgstr "Modificare le impostazioni"
 
-#: pkg/machines/components/nicEdit.jsx:257
-#: pkg/machines/components/vcpuModal.jsx:181
-#: pkg/machines/components/vm/bootOrderModal.jsx:285
+#: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Le modifiche avranno effetto dopo lo spegnimento della VM."
 
-#: pkg/networkmanager/interfaces.js:3133
+#: pkg/networkmanager/interfaces.js:3152
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1512,7 +1284,7 @@ msgstr "Controlla gli aggiornamenti"
 msgid "Checking $target"
 msgstr "Controllo $target"
 
-#: pkg/networkmanager/interfaces.js:831
+#: pkg/networkmanager/interfaces.js:834
 msgid "Checking IP"
 msgstr "Controllo dell'IP"
 
@@ -1532,7 +1304,7 @@ msgstr "Verifica di nuove applicazioni"
 msgid "Checking for public keys"
 msgstr "Controllo delle chiavi pubbliche"
 
-#: pkg/systemd/host.js:513
+#: pkg/systemd/host.js:517
 msgid "Checking for updates…"
 msgstr "Controllo degli aggiornamenti...."
 
@@ -1540,25 +1312,13 @@ msgstr "Controllo degli aggiornamenti...."
 msgid "Checking installed software"
 msgstr "Verifica del software installato"
 
-#: pkg/shell/index.html:117 pkg/shell/simple.html:85 pkg/shell/stub.html:100
+#: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "Scegliere la lingua da utilizzare nell'applicazione"
 
 #: pkg/storaged/mdraids-panel.jsx:57
 msgid "Chunk Size"
 msgstr "Dimensione chunk"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cenerentola"
-
-#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
-msgid "Claim"
-msgstr "Reclama"
-
-#: pkg/kubernetes/views/pvc-body.html:4
-msgid "Claim Name"
-msgstr "Nome del reclamo"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Class"
@@ -1568,11 +1328,11 @@ msgstr "Classe"
 msgid "Cleaning up for $target"
 msgstr "Pulizia per $target"
 
-#: pkg/systemd/services.html:196
+#: pkg/systemd/services.html:194
 msgid "Clear All Filters"
 msgstr ""
 
-#: pkg/systemd/host.js:730
+#: pkg/systemd/host.js:734
 msgid "Click to see system hardware information"
 msgstr "Fare clic per visualizzare le informazioni sull'hardware del sistema"
 
@@ -1583,42 +1343,26 @@ msgstr ""
 "Facendo clic su \"Avvia visualizzatore remoto\" si scarica un file .vv e si "
 "avvia $0."
 
-#: pkg/kubernetes/views/auth-form.html:88
-msgid "Client Certificate"
-msgstr "Certificato del client"
-
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:736 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:696 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:343 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/systemd/index.html:286
-#: pkg/systemd/services.html:365 pkg/systemd/services.html:383
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:126 pkg/storaged/dialog.jsx:383
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Chiudi"
 
 #: pkg/shell/active-pages.js:103
 msgid "Close Selected Pages"
 msgstr "Chiudere le pagine selezionate"
-
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
-#: pkg/ovirt/components/App.jsx:107
-msgid "Cluster"
-msgstr "Cluster"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:128
-msgid "Cluster Templates"
-msgstr "Modelli di cluster"
-
-#: pkg/ovirt/components/ClusterVms.jsx:174
-msgid "Cluster Virtual Machines"
-msgstr "Cluster Virtual Machines"
 
 #: src/ws/login.js:346
 msgid "Cockpit authentication is configured incorrectly."
@@ -1661,7 +1405,7 @@ msgstr ""
 "tramite il terminale. Allo stesso modo, se si verifica un errore nel "
 "terminale, può essere visto nell'interfaccia del diario di Cockpit."
 
-#: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
+#: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit è un'interfaccia amministrativa interattiva per server Linux."
 
@@ -1698,10 +1442,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit non è stato in grado di accedere a {{#strong}}{{host}}{{/strong}}. "
 "{{#can_sync}}Si consiglia di provare a {{#sync_link}}sincronizzare gli "
@@ -1723,8 +1467,8 @@ msgid ""
 msgstr ""
 "Cockpit non è riuscito ad accedere a {{#strong}}{{host}}{{/strong}}. Per "
 "utilizzare questa macchina con cockpit è necessario abilitare uno dei "
-"seguenti metodi di autenticazione nella configurazione di sshd su "
-"{{#strong}}{{host}}{{/strong}}:"
+"seguenti metodi di autenticazione nella configurazione di sshd su {{#strong}}"
+"{{host}}{{/strong}}:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1738,7 +1482,7 @@ msgstr ""
 "le password{{/sync_link}}.{{/can_sync}}"
 
 # titolo di scheda in dialogo di stampa
-#: pkg/dashboard/index.html:155 pkg/lib/machine-add.html:27
+#: pkg/dashboard/index.html:157 pkg/lib/machine-add.html:27
 msgid "Color"
 msgstr "Colore"
 
@@ -1752,12 +1496,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Utilizzo combinato di $0 core della CPU"
 msgstr[1] "Utilizzo combinato di $0 core della CPU"
 
-#: pkg/networkmanager/firewall.jsx:447
+#: pkg/networkmanager/firewall.jsx:529
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
-#: pkg/docker/index.html:269 pkg/docker/index.html:445
-#: pkg/docker/index.html:706 pkg/systemd/services.html:429
+#: pkg/docker/index.html:271 pkg/docker/index.html:447
+#: pkg/docker/index.html:708 pkg/systemd/services.html:427
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1768,20 +1512,20 @@ msgstr "Comando"
 msgid "Command can't be empty"
 msgstr "Il comando non può essere vuoto"
 
-#: pkg/docker/index.html:163
+#: pkg/docker/index.html:164
 msgid "Command:"
 msgstr "Comando:"
 
-#: pkg/shell/index.html:281
+#: pkg/shell/index.html:261
 msgid "Comment"
 msgstr "Commento"
 
-#: pkg/docker/index.html:137 pkg/docker/index.html:716
+#: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
 msgstr "Commit"
 
-#: pkg/docker/index.html:676
+#: pkg/docker/index.html:678
 msgid "Commit Image"
 msgstr "Commit immagine"
 
@@ -1793,11 +1537,11 @@ msgstr "La comunicazione con tuned non è riuscita"
 msgid "Compact PCI"
 msgstr "Compact PCI"
 
-#: pkg/storaged/content-views.jsx:526
+#: pkg/storaged/content-views.jsx:522
 msgid "Compatible with all systems and devices (MBR)"
 msgstr "Compatibile con tutti i sistemi e dispositivi (MBR)"
 
-#: pkg/storaged/content-views.jsx:528
+#: pkg/storaged/content-views.jsx:524
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
 msgstr "Compatibile con sistemi moderni e dischi rigidi > 2TB (GPT)"
 
@@ -1805,8 +1549,8 @@ msgstr "Compatibile con sistemi moderni e dischi rigidi > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Comprimere i crash dump per risparmiare spazio"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Compressione"
 
@@ -1814,45 +1558,33 @@ msgstr "Compressione"
 msgid "Computer OU"
 msgstr "OU del computer"
 
-#: pkg/systemd/init.js:698
+#: pkg/systemd/init.js:692
 msgid "Condition $0=$1 was not met"
 msgstr "Condizione $0=$1 non soddisfatta"
 
-#: pkg/systemd/services.html:145
+#: pkg/systemd/services.html:143
 msgid "Condition failed"
 msgstr "Condizione fallita"
 
-# translation auto-copied from project libreport, version master, document libreport
-#: pkg/kubernetes/views/node-add.html:24
-msgid "Configuration"
-msgstr "Configurazione"
-
-#: pkg/networkmanager/interfaces.js:2717
+#: pkg/networkmanager/interfaces.js:2725
 msgid "Configure"
 msgstr "Configura"
-
-#: pkg/kubernetes/views/node-add.html:42
-msgid "Configure Flannel networking"
-msgstr "Configurare la rete in flanella"
-
-#: pkg/kubernetes/views/node-add.html:32
-msgid "Configure Kubelet and Proxy"
-msgstr "Configura Kubelet e Proxy"
 
 #: pkg/docker/storage.jsx:331
 msgid "Configure storage..."
 msgstr "Configura storage....."
 
-#: pkg/networkmanager/interfaces.js:825
+#: pkg/networkmanager/interfaces.js:828
 msgid "Configuring"
 msgstr "Configurazione"
 
-#: pkg/networkmanager/interfaces.js:829
+#: pkg/networkmanager/interfaces.js:832
 msgid "Configuring IP"
 msgstr "Configurazione dell'IP"
 
 # translation auto-copied from project Katello, version 0.1v, document app, author fvalen
-#: pkg/shell/index.html:317 pkg/users/index.html:176
+#: pkg/shell/index.html:297 pkg/users/index.html:176
+#: pkg/storaged/format-dialog.jsx:303
 msgid "Confirm"
 msgstr "Conferma"
 
@@ -1860,41 +1592,27 @@ msgstr "Conferma"
 msgid "Confirm New Password"
 msgstr "Conferma nuova password"
 
-#: pkg/ovirt/components/OVirtTab.jsx:65
-msgid "Confirm migration"
-msgstr "Confermare la migrazione"
-
-#: pkg/storaged/format-dialog.jsx:305
-msgid "Confirm passphrase"
-msgstr "Conferma la passphrase"
-
-#: pkg/ovirt/components/VdsmView.jsx:95
-msgid "Confirm reload:"
-msgstr "Confermare la ricarica:"
+#: pkg/machines/components/networks/networkDelete.jsx:95
+msgid "Confirm deletion of the Virtual Network"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Confirm removal with passphrase"
 msgstr "Confermare la rimozione con la passphrase"
 
-#: pkg/ovirt/components/VdsmView.jsx:108
-msgid "Confirm save:"
-msgstr "Confermare il salvataggio:"
-
-#: pkg/systemd/init.js:734
+#: pkg/systemd/init.js:728
 msgid "Conflicted By"
 msgstr "Conflitto da"
 
-#: pkg/systemd/init.js:733
+#: pkg/systemd/init.js:727
 msgid "Conflicts"
 msgstr "Conflitti"
 
-#: pkg/kubernetes/views/auth-form.html:130
-#: pkg/kubernetes/views/auth-rejected-cert.html:33
 #: pkg/lib/machine-unknown-hostkey.html:22
 msgid "Connect"
 msgstr "Connetti"
 
-#: pkg/networkmanager/interfaces.js:2704
+#: pkg/networkmanager/interfaces.js:2712
 msgid "Connect automatically"
 msgstr "Connessione automatica"
 
@@ -1902,18 +1620,13 @@ msgstr "Connessione automatica"
 msgid "Connect to"
 msgstr "Collegati a"
 
-#: pkg/ovirt/components/InstallationDialog.jsx:102
-msgid "Connect to oVirt Engine"
-msgstr "Colega al motore oVirt"
-
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "Connect with any $0 viewer application."
 msgstr "Connettiti con qualsiasi applicazione di visualizzazione $0."
 
 #: pkg/machines/components/desktopConsole.jsx:185
 msgid "Connect with any SPICE or VNC viewer application."
-msgstr ""
-"Connessione con qualsiasi applicazione di visualizzazione SPICE o VNC."
+msgstr "Connessione con qualsiasi applicazione di visualizzazione SPICE o VNC."
 
 #: pkg/machines/components/vnc.jsx:106
 msgid "Connecting"
@@ -1937,44 +1650,32 @@ msgstr "Collegamento al demone SETroubleshoot....."
 msgid "Connecting to Virtualization Service"
 msgstr "Connessione al servizio di virtualizzazione"
 
-#: pkg/shell/indexes.js:411
+#: pkg/shell/indexes.js:410
 msgid "Connecting to the machine"
 msgstr "Collegamento alla macchina"
 
-#: pkg/kubernetes/index.html:104 pkg/kubernetes/registry.html:71
-msgid "Connecting..."
-msgstr "Connessione..."
-
 # ctx::sourcefile::Navigation Menu
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:279
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Connessione"
 
-#: pkg/kubernetes/views/auth-dialog.html:4 pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:406
 msgid "Connection Error"
 msgstr "Errore di connessione"
-
-#: pkg/kubernetes/scripts/connection.js:512
-msgid "Connection Error: $0"
-msgstr "Errore di connessione: $0"
-
-#: pkg/kubernetes/views/auth-dialog.html:3
-msgid "Connection Settings"
-msgstr "Impostazioni di connessione"
 
 #: src/base1/cockpit.js:4027
 msgid "Connection has timed out."
 msgstr "Il collegamento è scaduto."
 
-#: pkg/networkmanager/index.html:708
+#: pkg/networkmanager/index.html:700
 msgid "Connection will be lost"
 msgstr "La connessione andrà persa"
 
-#: pkg/systemd/init.js:732
+#: pkg/systemd/init.js:726
 msgid "Consists Of"
 msgstr "Consiste di"
 
@@ -1986,34 +1687,23 @@ msgstr "Tipo di console"
 msgid "Consoles"
 msgstr "Console"
 
-#: pkg/realmd/operation.js:274
+#: pkg/realmd/operation.js:273
 msgid "Contacted domain"
 msgstr ""
 
-#: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
-#: pkg/kubernetes/views/container-page-inline.html:2
-#: pkg/kubernetes/views/container-panel.html:4
-#: pkg/kubernetes/views/image-page.html:23
+#: pkg/docker/console.html:4
 #: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Container"
 
-#: pkg/users/local.js:748
+#: pkg/users/local.js:752
 msgid "Container Administrator"
 msgstr "Amministratore del contenitore"
 
-#: pkg/kubernetes/views/container-body.html:10
-msgid "Container ID"
-msgstr "ID container"
-
-#: pkg/docker/index.html:438 pkg/docker/index.html:618
-#: pkg/docker/index.html:682
+#: pkg/docker/index.html:440 pkg/docker/index.html:620
+#: pkg/docker/index.html:684
 msgid "Container Name"
 msgstr "Nome container"
-
-#: pkg/kubernetes/views/node-body.html:21
-msgid "Container Runtime Version"
-msgstr "Versione Runtime del contenitore"
 
 #: pkg/docker/util.js:506
 msgid ""
@@ -2026,15 +1716,12 @@ msgstr ""
 msgid "Container is currently running."
 msgstr "Il contenitore è attualmente in funzione."
 
-#: pkg/docker/index.html:141
+#: pkg/docker/index.html:133
 msgid "Container:"
 msgstr "Container:"
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:287
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
-#: pkg/kubernetes/views/dashboard-page.html:158
-#: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:375
+#: pkg/docker/index.html:23 pkg/docker/index.html:289
+#: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "Container"
 
@@ -2044,17 +1731,17 @@ msgid "Containers"
 msgstr "Container"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys, author fvalen
-#: pkg/storaged/content-views.jsx:561
+#: pkg/storaged/content-views.jsx:557
 msgid "Content"
 msgstr "Contenuto"
 
 #: src/base1/test-locale.js:42 src/base1/test-locale.js:53
-#: pkg/playground/translate.js:22
+#: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Controllo"
 
 #: src/base1/test-locale.js:43 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:25
+#: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
 msgstr "Controllo"
@@ -2067,8 +1754,7 @@ msgstr "Convertibile"
 msgid "Copy"
 msgstr ""
 
-#: pkg/machines/components/vcpuModal.jsx:216
-#: pkg/ovirt/components/vcpuModal.jsx:67
+#: pkg/machines/components/vcpuModal.jsx:209
 msgid "Cores per socket"
 msgstr "Core per socket"
 
@@ -2079,18 +1765,6 @@ msgstr "Impossibile aggiungere tutti i dischi"
 #: pkg/lib/machine-change-port.html:4
 msgid "Could not contact {{host}}"
 msgstr "Impossibile contattare {{host}}"
-
-#: pkg/kubernetes/views/dashboard-page.html:142
-msgid "Could not list services"
-msgstr "Impossibile elencare i servizi"
-
-#: src/ws/cockpitcertificate.c:531
-msgid "Could not parse PEM-encoded certificate"
-msgstr "Impossibile analizzare il certificato con codifica PEM"
-
-#: src/ws/cockpitcertificate.c:498
-msgid "Could not parse PEM-encoded private key"
-msgstr "Impossibile analizzare la chiave privata con codifica PEM"
 
 #: pkg/docker/storage.jsx:468
 msgid "Could not reset the storage pool"
@@ -2104,30 +1778,13 @@ msgstr "Non è stato possibile cambiare i gruppi di utenti"
 msgid "Couldn't change user password"
 msgstr "Impossibile cambiare la password utente"
 
-#: pkg/kubernetes/index.html:105 pkg/kubernetes/registry.html:72
-msgid "Couldn't connect to server"
-msgstr "Impossibile connettersi al server"
-
-#: pkg/shell/indexes.js:414
+#: pkg/shell/indexes.js:413
 msgid "Couldn't connect to the machine"
 msgstr "Non riusciva a connettersi alla macchina"
 
 #: src/bridge/cockpitdbussetup.c:544
 msgid "Couldn't create new users"
 msgstr "Non è stato possibile creare nuovi utenti"
-
-#: pkg/kubernetes/scripts/connection.js:510
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:957
-msgid "Couldn't find running API server"
-msgstr "Non sono riuscito a trovare un server API in esecuzione"
-
-#: pkg/subscriptions/subscriptions-view.jsx:218
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"Non è stato possibile ottenere lo stato di abbonamento al sistema. "
-"Assicurati che il gestore di abbonamento sia installato."
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -2149,22 +1806,20 @@ msgstr "Posizione della discarica di crash"
 msgid "Crash system"
 msgstr "Sistema Crash"
 
-#: pkg/kubernetes/views/add-group-dialog.html:19
-#: pkg/kubernetes/views/project-modify.html:72 pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:499
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:347
-#: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:117 pkg/storaged/content-views.jsx:693
-#: pkg/storaged/lvol-tabs.jsx:358 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/users/index.html:199
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Crea"
 
-#: pkg/storaged/content-views.jsx:643
+#: pkg/storaged/content-views.jsx:639
 msgid "Create Logical Volume"
 msgstr "Creare un volume logico"
 
-#: pkg/machines/components/diskAdd.jsx:407
+#: pkg/machines/components/diskAdd.jsx:515
 msgid "Create New"
 msgstr "Crea nuovo"
 
@@ -2172,19 +1827,15 @@ msgstr "Crea nuovo"
 msgid "Create New Account"
 msgstr "Crea un nuovo account"
 
-#: pkg/ovirt/components/App.jsx:162
-msgid "Create New VM"
-msgstr "Creare una nuova macchina virtuale"
-
-#: pkg/storaged/content-views.jsx:438 pkg/storaged/format-dialog.jsx:332
+#: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
 msgid "Create Partition"
 msgstr "Crea partizione"
 
-#: pkg/storaged/content-views.jsx:556
+#: pkg/storaged/content-views.jsx:552
 msgid "Create Partition Table"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:183
+#: pkg/storaged/format-dialog.jsx:184
 msgid "Create Partition on $0"
 msgstr ""
 
@@ -2196,23 +1847,23 @@ msgstr "Creare un dispositivo RAID"
 msgid "Create Report"
 msgstr "Crea report"
 
-#: pkg/storaged/lvol-tabs.jsx:344 pkg/storaged/lvol-tabs.jsx:393
+#: pkg/storaged/lvol-tabs.jsx:346 pkg/storaged/lvol-tabs.jsx:387
 msgid "Create Snapshot"
 msgstr "Crea snapshot"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:380
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
 msgid "Create Storage Pool"
 msgstr "Creare un pool di archiviazione"
 
-#: pkg/storaged/content-views.jsx:103 pkg/storaged/content-views.jsx:128
+#: pkg/storaged/content-views.jsx:109 pkg/storaged/content-views.jsx:134
 msgid "Create Thin Volume"
 msgstr "Creare un volume sottile"
 
-#: pkg/systemd/services.html:63
+#: pkg/systemd/services.html:64
 msgid "Create Timer"
 msgstr "Creare un timer"
 
-#: pkg/systemd/services.html:395
+#: pkg/systemd/services.html:393
 msgid "Create Timers"
 msgstr "Creazione di timer"
 
@@ -2220,8 +1871,7 @@ msgstr "Creazione di timer"
 msgid "Create VDO Device"
 msgstr "Creare un dispositivo VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:532
-#: pkg/ovirt/components/ClusterTemplates.jsx:81
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
 msgid "Create VM"
 msgstr "Creare VM"
 
@@ -2233,35 +1883,23 @@ msgstr "Crea gruppo di volumi"
 msgid "Create diagnostic report"
 msgstr "Crea un rapporto diagnostico"
 
-#: pkg/kubernetes/scripts/images.js:643
-msgid "Create empty image stream"
-msgstr "Creare un flusso di immagini vuoto"
-
-#: pkg/kubernetes/views/imagestream-modify.html:3
-msgid "Create image stream"
-msgstr "Crea flusso di immagini"
-
-#: pkg/networkmanager/interfaces.js:3803 pkg/networkmanager/interfaces.js:4002
-#: pkg/networkmanager/interfaces.js:4256 pkg/networkmanager/interfaces.js:4461
+#: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
+#: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
 msgid "Create it"
 msgstr "Crea"
 
-#: pkg/storaged/content-views.jsx:712
+#: pkg/storaged/content-views.jsx:708
 msgid "Create new Logical Volume"
 msgstr "Creare un nuovo volume logico"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys, author fvalen
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/kubernetes/views/replicationcontroller-body.html:7
-#: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:129
-#: pkg/docker/containers-view.jsx:412 pkg/docker/containers-view.jsx:683
+#: pkg/docker/containers-view.jsx:129 pkg/docker/containers-view.jsx:412
+#: pkg/docker/containers-view.jsx:683
 msgid "Created"
 msgstr "Creato"
 
 # ctx::sourcefile::/rhn/account/UserDetails
-#: pkg/docker/index.html:152
+#: pkg/docker/index.html:153
 msgid "Created:"
 msgstr "Creato:"
 
@@ -2285,7 +1923,7 @@ msgstr "Creazione della partizione $target"
 msgid "Creating snapshot of $target"
 msgstr "Creazione di un'istantanea di $target"
 
-#: pkg/networkmanager/interfaces.js:4460
+#: pkg/networkmanager/interfaces.js:4479
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2293,7 +1931,7 @@ msgstr ""
 "La creazione di questa VLAN interromperà la connessione al server e renderà "
 "l'interfaccia utente di amministrazione non disponibile."
 
-#: pkg/networkmanager/interfaces.js:3802
+#: pkg/networkmanager/interfaces.js:3821
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2301,7 +1939,7 @@ msgstr ""
 "La creazione di questo bond interromperà la connessione al server e renderà "
 "l'interfaccia utente di amministrazione non disponibile."
 
-#: pkg/networkmanager/interfaces.js:4255
+#: pkg/networkmanager/interfaces.js:4274
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2309,7 +1947,7 @@ msgstr ""
 "La creazione di questo bridge interromperà la connessione al server e "
 "renderà l'interfaccia utente di amministrazione non disponibile."
 
-#: pkg/networkmanager/interfaces.js:4001
+#: pkg/networkmanager/interfaces.js:4020
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2321,11 +1959,11 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Creazione di un gruppo di volumi $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:460
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
 msgid "Creation of VM $0 failed"
 msgstr ""
 
-#: pkg/systemd/logs.html:57
+#: pkg/systemd/logs.html:58
 msgid "Critical and above"
 msgstr "Critico e superiore"
 
@@ -2337,33 +1975,35 @@ msgstr "Ctrl+Alt+Del"
 msgid "Ctrl+Insert"
 msgstr ""
 
+#: pkg/machines/components/vm/memoryModal.jsx:130
+#, fuzzy
+msgid "Current Allocation"
+msgstr "Posizione di montaggio"
+
 #: pkg/systemd/logs.html:42
 msgid "Current boot"
 msgstr "Boot corrente"
 
-#: pkg/storaged/format-dialog.jsx:73
+#: pkg/storaged/format-dialog.jsx:69
 msgid "Custom"
 msgstr "Personalizzata"
 
-#: pkg/storaged/format-dialog.jsx:257
-msgid "Custom (Enter filesystem type)"
-msgstr "Personalizzato (Inserire il tipo di file system)"
-
-#: pkg/networkmanager/firewall.jsx:441
+#: pkg/networkmanager/firewall.jsx:523
 msgid "Custom Ports"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-register.jsx:103
-msgid "Custom URL"
-msgstr "URL personalizzata"
-
-#: pkg/storaged/format-dialog.jsx:130
+#: pkg/storaged/format-dialog.jsx:118
 msgid "Custom encryption options"
 msgstr "Opzioni di crittografia personalizzate"
 
-#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:95
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Opzioni di montaggio personalizzate"
+
+#: pkg/networkmanager/firewall.jsx:718
+#, fuzzy
+msgid "Custom zones"
+msgstr "Personalizzata"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:117
 #: pkg/machines/components/networks/networkOverviewTab.jsx:140
@@ -2374,23 +2014,19 @@ msgstr ""
 msgid "DISK IS FAILING"
 msgstr "DISCO SI STA GUASTANDO"
 
-#: pkg/networkmanager/interfaces.js:3297
+#: pkg/networkmanager/interfaces.js:3316
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2648
+#: pkg/networkmanager/interfaces.js:2656
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/kubernetes/views/pod-body.html:14
-msgid "DNS Policy"
-msgstr "Politica DNS"
-
-#: pkg/networkmanager/interfaces.js:3301
+#: pkg/networkmanager/interfaces.js:3320
 msgid "DNS Search Domains"
 msgstr "Domini di ricerca DNS"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/networkmanager/interfaces.js:2659
 msgid "DNS Search Domains $val"
 msgstr "Domini di ricerca DNS $val"
 
@@ -2402,17 +2038,17 @@ msgstr ""
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: pkg/storaged/lvol-tabs.jsx:442
+#: pkg/storaged/lvol-tabs.jsx:455
 msgid "Data Used"
 msgstr "Dati utilizzati"
 
-#: pkg/machines/components/networks/network.jsx:143
-#: pkg/machines/components/storagePools/storagePool.jsx:163
-#: pkg/storaged/content-views.jsx:262
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
+#: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Disattiva"
 
-#: pkg/networkmanager/interfaces.js:837
+#: pkg/networkmanager/interfaces.js:840
 msgid "Deactivating"
 msgstr "Disattivazione"
 
@@ -2420,7 +2056,7 @@ msgstr "Disattivazione"
 msgid "Deactivating $target"
 msgstr "Disattivazione $target"
 
-#: pkg/systemd/logs.html:62
+#: pkg/systemd/logs.html:63
 msgid "Debug and above"
 msgstr "Debug e superiore"
 
@@ -2428,48 +2064,36 @@ msgstr "Debug e superiore"
 msgid "Deduplication"
 msgstr "Deduplicazione"
 
-#: pkg/docker/index.html:357 pkg/docker/index.html:361
+#: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: node_modules/registry-image-widgets/views/image-config.html:10
-#: pkg/storaged/format-dialog.jsx:72
-#: pkg/subscriptions/subscriptions-register.jsx:102
+#: pkg/storaged/format-dialog.jsx:68
 msgid "Default"
 msgstr "Predefinito"
 
-#: pkg/systemd/index.html:446
+#: pkg/systemd/index.html:438
 msgid "Delay"
 msgstr "Ritardo"
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:246
-#: pkg/kubernetes/views/image-delete.html:8
-#: pkg/kubernetes/views/imagestream-delete.html:8
-#: pkg/kubernetes/views/item-delete.html:11
-#: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/project-delete.html:9
-#: pkg/kubernetes/views/pv-delete.html:11
-#: pkg/kubernetes/views/pvc-delete.html:15
-#: pkg/kubernetes/views/user-remove-membership.html:10
-#: pkg/networkmanager/index.html:441 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/docker/index.html:139 pkg/docker/index.html:251
+#: pkg/networkmanager/index.html:433 pkg/users/index.html:79
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
-#: pkg/storaged/content-views.jsx:301 pkg/storaged/content-views.jsx:322
-#: pkg/storaged/mdraid-details.jsx:300 pkg/storaged/mdraid-details.jsx:323
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/machines/components/networks/networkDelete.jsx:86
+#: pkg/machines/components/networks/networkDelete.jsx:103
+#: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:214 pkg/storaged/vgroup-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Cancella"
 
-#: pkg/networkmanager/interfaces.js:2432 pkg/users/local.js:1179
+#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Cancellare $0"
-
-#: pkg/playground/translate.html:189
-msgid "Delete '{{ name }}'"
-msgstr "Cancellare '{{ name }}' "
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
 msgid "Delete Content"
@@ -2479,25 +2103,10 @@ msgstr ""
 msgid "Delete Files"
 msgstr "Cancella file"
 
-#: pkg/kubernetes/views/node-delete.html:4
-msgid "Delete Node"
-msgstr "Elimina nodo"
-
-#: pkg/kubernetes/views/pv-delete.html:3
-msgid "Delete Persistent Volume"
-msgstr "Cancellare il volume persistente"
-
-#: pkg/kubernetes/views/pvc-delete.html:3
-msgid "Delete Persistent Volume Claim"
-msgstr "Eliminazione dell'indicazione del volume persistente"
-
-#: pkg/kubernetes/views/project-delete.html:3
-msgid "Delete Project"
-msgstr "Elimina progetto"
-
-#: pkg/kubernetes/views/nodes-page.html:3
-msgid "Delete Selected"
-msgstr "Cancella i selezionati"
+#: pkg/machines/components/networks/networkDelete.jsx:92
+#, fuzzy
+msgid "Delete Network $0"
+msgstr "Cancellare $0"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
 msgid "Delete Storage Pool $0"
@@ -2507,23 +2116,15 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr "Elimina i file di archiviazione associati:"
 
-#: pkg/kubernetes/views/imagestream-delete.html:3
-msgid "Delete image stream"
-msgstr "Elimina flusso di immagini"
-
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html:3
-msgid "Delete {{ item.kind }}"
-msgstr "Eliminazione {{ item.kind }}"
 
 #: pkg/storaged/jobs-panel.jsx:53 pkg/storaged/jobs-panel.jsx:67
 msgid "Deleting $target"
 msgstr "Eliminazione $target"
 
-#: pkg/networkmanager/interfaces.js:2431
+#: pkg/networkmanager/interfaces.js:2434
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2531,15 +2132,7 @@ msgstr ""
 "L'eliminazione di xcelection <b>$0</b>interromperà la connessione al server "
 "e renderà l'interfaccia utente di amministrazione non disponibile."
 
-#: pkg/kubernetes/views/item-delete.html:7
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-"L'eliminazione di un baccello uccide tutti i contenitori associati. In "
-"alcuni casi i baccelli possono essere creati automaticamente di nuovo."
-
-#: pkg/storaged/mdraid-details.jsx:301
+#: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
 msgstr ""
 "L'eliminazione di un dispositivo RAID cancellerà tutti i dati in esso "
@@ -2551,23 +2144,22 @@ msgstr ""
 "L'eliminazione di un dispositivo VDO cancellerà tutti i dati in esso "
 "contenuti."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 "L'eliminazione di un contenitore cancellerà tutti i dati in esso contenuti."
 
-#: pkg/storaged/content-views.jsx:281
+#: pkg/storaged/content-views.jsx:273
 msgid "Deleting a logical volume will delete all data in it."
 msgstr ""
 "L'eliminazione di un volume logico cancellerà tutti i dati in esso contenuti."
-""
 
-#: pkg/storaged/content-views.jsx:284
+#: pkg/storaged/content-views.jsx:276
 msgid "Deleting a partition will delete all data in it."
 msgstr ""
 "L'eliminazione di una partizione cancellerà tutti i dati in essa contenuti."
 
-#: pkg/storaged/vgroup-details.jsx:213
+#: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
 msgstr ""
 "L'eliminazione di un gruppo di volumi cancellerà tutti i dati in esso "
@@ -2583,43 +2175,11 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Eliminazione di un gruppo di volumi $target"
 
-#: pkg/kubernetes/views/dashboard-page.html:131
-#: pkg/kubernetes/views/deploy.html:62
-msgid "Deploy"
-msgstr "Dispiegare"
-
-#: pkg/kubernetes/views/deploy.html:3
-msgid "Deploy Application"
-msgstr "Distribuzione dell'applicazione"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:22
-msgid "Deployment Causes"
-msgstr "Cause di distribuzione"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:12
-#: pkg/kubernetes/views/deploymentconfig-panel.html:8
-msgid "Deployment Config"
-msgstr "Distribuzione Config"
-
-#: pkg/kubernetes/views/details-page.html:98
-#: pkg/kubernetes/scripts/details.js:220
-msgid "Deployment Configs"
-msgstr "Configurazioni di distribuzione"
-
-#: pkg/kubernetes/views/project-listing.html:15
-#: pkg/kubernetes/views/project-listing.html:54
-#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:415
+#: pkg/systemd/services.html:413
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
 msgid "Description"
 msgstr "Descrizione"
-
-#: pkg/ovirt/components/OVirtTab.jsx:146
-#: pkg/ovirt/components/VmOverviewColumn.jsx:52
-msgid "Description:"
-msgstr "Descrizione:"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2630,17 +2190,16 @@ msgid "Detachable"
 msgstr "Staccabile"
 
 # translation auto-copied from project libreport, version master, document libreport
-#: pkg/kubernetes/index.html:67 pkg/shell/index.html:249
-#: pkg/docker/containers-view.jsx:336 pkg/docker/containers-view.jsx:504
-#: pkg/docker/containers-view.jsx:514 pkg/docker/containers-view.jsx:642
-#: pkg/networkmanager/firewall.jsx:89 pkg/packagekit/updates.jsx:383
-#: pkg/subscriptions/subscriptions-view.jsx:232 pkg/systemd/host.js:741
+#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
+#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Dettagli"
 
+#: pkg/machines/components/vm/bootOrderModal.jsx:93
 #: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/vm/bootOrderModal.jsx:95
-#: pkg/machines/components/vmDiskSourceCell.jsx:38
+#: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
 msgstr "Device"
@@ -2649,7 +2208,7 @@ msgstr "Device"
 msgid "Device File"
 msgstr "File dispositivo"
 
-#: pkg/storaged/content-views.jsx:555 pkg/storaged/format-dialog.jsx:422
+#: pkg/storaged/content-views.jsx:551
 msgid "Device is read-only"
 msgstr "Il dispositivo è di sola lettura"
 
@@ -2661,7 +2220,6 @@ msgstr "Rapporti diagnostici"
 msgid "Digest"
 msgstr "Digest"
 
-#: pkg/kubernetes/views/volume-body.html:28
 #: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
@@ -2671,7 +2229,7 @@ msgstr "Directory"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "L'elenco non $0è scrivibile o non esiste."
 
-#: pkg/systemd/init.js:577
+#: pkg/systemd/init.js:571
 msgid "Disable"
 msgstr "Disabilita"
 
@@ -2683,7 +2241,7 @@ msgstr ""
 msgid "Disable tuned"
 msgstr "Disabilita sintonizzato"
 
-#: pkg/systemd/services.html:74 pkg/networkmanager/interfaces.js:1957
+#: pkg/systemd/services.html:73 pkg/networkmanager/interfaces.js:1960
 #: pkg/systemd/init.js:213
 msgid "Disabled"
 msgstr "Disabilitato"
@@ -2693,7 +2251,7 @@ msgid "Disconnect"
 msgstr "Disconnetti"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:604
+#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
 msgid "Disconnected"
 msgstr "Disconnesso"
 
@@ -2701,29 +2259,24 @@ msgstr "Disconnesso"
 msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr "Scollegato dalla console seriale. Fare clic sul pulsante Ricollega."
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:836
 #: pkg/storaged/vdos-panel.jsx:55
 msgid "Disk"
 msgstr "Disco"
 
-#: pkg/machines/components/diskRemove.jsx:31
+#: pkg/machines/components/diskRemove.jsx:32
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr ""
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:545
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:549
 msgid "Disk I/O"
 msgstr "I/O disco"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Utilizzo del disco: $0%"
-
-#: pkg/machines/components/diskAdd.jsx:381
+#: pkg/machines/components/diskAdd.jsx:489
 msgid "Disk failed to be attached"
 msgstr "Il disco non è stato collegato"
 
-#: pkg/machines/components/diskAdd.jsx:364
+#: pkg/machines/components/diskAdd.jsx:468
 msgid "Disk failed to be created"
 msgstr "Disco che non è stato creato"
 
@@ -2735,65 +2288,20 @@ msgstr "Il disco è OK"
 msgid "Disk passphrase"
 msgstr "Passphrase del disco"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Dischi"
 
+#: pkg/machines/components/diskRemove.jsx:57
+msgid "Disks cannot be removed from $0 VMs"
+msgstr ""
+
 #: pkg/shell/index.html:52 pkg/shell/index.html:114 pkg/shell/simple.html:38
-#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
+#: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Lingua di visualizzazione"
-
-#: pkg/kubernetes/views/project-modify.html:31
-msgid "Display name"
-msgstr "Nome visualizzato"
-
-#: pkg/kubernetes/views/add-role-dialog.html:5
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "Vuoi aggiungere il ruolo '{{ fields.displayRole }}' ?"
-
-#: pkg/kubernetes/views/imagestream-delete.html:5
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"Vuoi cancellare il flusso di{{stream.metadata.namespace}}{{stream.metadata."
-"name}}immagini ' / ' '?"
-
-#: pkg/kubernetes/views/pv-delete.html:6
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "Si desidera eliminare il volume persistente ' ' ' '?"
-
-#: pkg/kubernetes/views/pvc-delete.html:6
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr "Si desidera eliminare l'indicazione del volume persistente ' ' ' '?"
-
-#: pkg/kubernetes/views/item-delete.html:6
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "Vuoi cancellare il {{ item.kind }}' ' ' ' '?"
-
-#: pkg/kubernetes/views/node-delete.html:7
-msgid "Do you want to delete this Node?"
-msgstr "Vuoi cancellare questo Nodo?"
-
-#: pkg/kubernetes/views/image-delete.html:5
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"Vuoi rimuovere l'immagine etichettata come ' / : '{{stream.metadata."
-"namespace}}?"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:5
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
-msgstr ""
-"Vuoi rimuovere il ruolo '{{ fields.displayRole }}' da membro {{ fields."
-"member.metadata.name }}?"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2808,15 +2316,15 @@ msgid "Docking Station"
 msgstr "Docking Station"
 
 #: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
-#: pkg/realmd/operation.js:123
+#: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Dominio"
 
-#: pkg/realmd/operation.js:192
+#: pkg/realmd/operation.js:191
 msgid "Domain $0 could not be contacted"
 msgstr "Il dominio $0 non può essere contattato"
 
-#: pkg/realmd/operation.js:279
+#: pkg/realmd/operation.js:278
 msgid "Domain $0 is not supported"
 msgstr "Il dominio $0 non è supportato"
 
@@ -2832,24 +2340,20 @@ msgstr "Nome dell'amministratore di dominio"
 msgid "Domain Administrator Password"
 msgstr "Password dell'amministratore di dominio"
 
-#: pkg/systemd/services.html:485 pkg/systemd/services.html:489
-#: pkg/systemd/init.js:1262
+#: pkg/systemd/services.html:483 pkg/systemd/services.html:487
+#: pkg/systemd/init.js:1256
 msgid "Don't Repeat"
 msgstr "Non ripetere"
 
-#: pkg/storaged/content-views.jsx:520 pkg/storaged/format-dialog.jsx:283
+#: pkg/storaged/content-views.jsx:516 pkg/storaged/format-dialog.jsx:280
 msgid "Don't overwrite existing data"
 msgstr "Non sovrascrivere i dati esistenti"
-
-#: pkg/kubernetes/scripts/images.js:633
-msgid "Don't pull images automatically"
-msgstr "Non scaricare le immagini automaticamente"
 
 #: pkg/sosreport/index.html:63
 msgid "Done!"
 msgstr "Fatto!"
 
-#: pkg/docker/index.html:598
+#: pkg/docker/index.html:600
 msgid "Download"
 msgstr "Scarica"
 
@@ -2886,12 +2390,7 @@ msgctxt "storage"
 msgid "Drive"
 msgstr "Drive"
 
-# ctx::sourcefile::/systems/Search
-#: pkg/kubernetes/views/volume-body.html:128
-msgid "Driver"
-msgstr "Driver"
-
-#: pkg/storaged/drives-panel.jsx:119
+#: pkg/storaged/drives-panel.jsx:120
 msgid "Drives"
 msgstr "Drive"
 
@@ -2903,12 +2402,12 @@ msgstr "Duplica alias"
 msgid "Duplicate port"
 msgstr "Duplica porta"
 
-#: pkg/machines/components/nicEdit.jsx:266 pkg/storaged/crypto-tab.jsx:131
+#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
 #: pkg/storaged/nfs-details.jsx:306
 msgid "Edit"
 msgstr "Modifica"
 
-#: pkg/dashboard/index.html:128
+#: pkg/dashboard/index.html:130
 msgid "Edit Server"
 msgstr "Modifica server"
 
@@ -2919,10 +2418,6 @@ msgstr "Modifica Tang keyserver"
 #: node_modules/registry-image-widgets/views/imagestream-body.html:7
 msgid "Edit image stream"
 msgstr "Modifica flusso di immagini"
-
-#: pkg/ovirt/components/VdsmView.jsx:125
-msgid "Edit the vdsm.conf"
-msgstr "Modifica il file vdsm.conf"
 
 #: pkg/storaged/crypto-keyslots.jsx:535
 msgid "Editing a key requires a free slot"
@@ -2937,33 +2432,29 @@ msgid "Embedded PC"
 msgstr "PC integrato"
 
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:13
+#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Vuoto"
 
 #: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:19
+#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Vuoto"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Elenco vuoto"
 
 #: pkg/storaged/jobs-panel.jsx:75
 msgid "Emptying $target"
 msgstr "Svuotamento $target"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:136
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:162
 msgid "Emulated Machine"
 msgstr ""
 
-#: pkg/systemd/init.js:575
+#: pkg/systemd/init.js:569
 msgid "Enable"
 msgstr "Abilita"
 
-#: pkg/systemd/init.js:576
+#: pkg/systemd/init.js:570
 msgid "Enable Forcefully"
 msgstr "Abilita forzatamente"
 
@@ -2971,21 +2462,22 @@ msgstr "Abilita forzatamente"
 msgid "Enable Service"
 msgstr "Attivare il servizio"
 
-#: pkg/systemd/index.html:169
+#: pkg/systemd/index.html:161
 msgid "Enable stored metrics…"
 msgstr "Abilita metriche memorizzate...."
 
-#: pkg/systemd/services.html:73 pkg/systemd/init.js:210
+#: pkg/systemd/services.html:72 pkg/systemd/init.js:210
 msgid "Enabled"
 msgstr "Attivato"
+
+#: pkg/storaged/format-dialog.jsx:292
+#, fuzzy
+msgid "Encrypt data"
+msgstr "Dati crittografati"
 
 #: pkg/storaged/utils.js:273
 msgid "Encrypted $0"
 msgstr "Crittografato $0"
-
-#: pkg/storaged/format-dialog.jsx:250
-msgid "Encrypted EXT4 (LUKS)"
-msgstr "Crittografato EXT4 (LUKS)"
 
 #: pkg/storaged/utils.js:265
 msgid "Encrypted Logical Volume of $0"
@@ -2995,11 +2487,7 @@ msgstr "Volume logico criptato di $0"
 msgid "Encrypted Partition of $0"
 msgstr "Partizione criptata di $0"
 
-#: pkg/storaged/format-dialog.jsx:249
-msgid "Encrypted XFS (LUKS)"
-msgstr "XFS criptato (LUKS)"
-
-#: pkg/storaged/content-views.jsx:352
+#: pkg/storaged/content-views.jsx:348
 msgctxt "storage-id-desc"
 msgid "Encrypted data"
 msgstr "Dati crittografati"
@@ -3014,46 +2502,25 @@ msgstr ""
 "I volumi criptati devono essere sbloccati prima di poter essere "
 "ridimensionati."
 
-#: pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:147
 msgid "Encryption"
 msgstr "Cifratura"
 
-#: pkg/storaged/crypto-tab.jsx:102 pkg/storaged/format-dialog.jsx:120
+#: pkg/storaged/crypto-tab.jsx:102
 msgid "Encryption Options"
 msgstr "Opzioni di crittografia"
-
-#: pkg/kubernetes/views/pv-modify.html:93
-msgid "Endpoint"
-msgstr "Endpoint"
-
-#: pkg/kubernetes/views/volume-body.html:40
-msgid "Endpoint Name"
-msgstr "Nome del punto finale"
-
-#: pkg/kubernetes/views/service-page.html:14
-#: pkg/kubernetes/views/service-panel.html:9
-msgid "Endpoints"
-msgstr "Punti finali"
-
-#: pkg/subscriptions/subscriptions-view.jsx:39
-msgid "Ends"
-msgstr "Termina"
 
 #: pkg/selinux/setroubleshoot-view.jsx:299
 msgid "Enforce policy:"
 msgstr "Applicare la politica:"
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:500
 msgid "Enhancement Updates Available"
 msgstr "Aggiornamenti di miglioramento disponibili"
 
 #: pkg/lib/machine-dialogs.js:445
 msgid "Enter IP address or host name"
 msgstr "Inserire l'indirizzo IP o il nome host"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:74
-msgid "Enter New VM name"
-msgstr "Inserire il nome della nuova macchina virtuale"
 
 #: pkg/lib/machine-change-auth.html:57
 msgid ""
@@ -3063,7 +2530,11 @@ msgstr ""
 "L'inserimento di una password diversa significa che sarà necessario "
 "riscriverla ogni volta che ci si ricollega a questa macchina"
 
-#: pkg/systemd/logs.html:82
+#: pkg/networkmanager/firewall.jsx:754
+msgid "Entire subnet"
+msgstr ""
+
+#: pkg/systemd/logs.html:83
 msgid "Entry"
 msgstr "Voce"
 
@@ -3072,12 +2543,12 @@ msgid "Entrypoint"
 msgstr "Punto d'ingresso"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys, author fvalen
-#: pkg/docker/index.html:526 pkg/kubernetes/views/container-body.html:26
+#: pkg/docker/index.html:528
 #: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Ambiente"
 
-#: pkg/storaged/content-views.jsx:518 pkg/storaged/format-dialog.jsx:281
+#: pkg/storaged/content-views.jsx:514 pkg/storaged/format-dialog.jsx:278
 msgid "Erase"
 msgstr "Elimina"
 
@@ -3094,19 +2565,15 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:377 pkg/apps/utils.jsx:99
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1472
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Errore"
 
-#: pkg/systemd/logs.html:58
+#: pkg/systemd/logs.html:59
 msgid "Error and above"
 msgstr "Errore e superiore"
-
-#: pkg/kubernetes/scripts/connection.js:646
-msgid "Error getting certificate details: $0"
-msgstr "Errore nell'ottenere i dettagli del certificato: $0"
 
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
@@ -3128,43 +2595,39 @@ msgstr "Errore durante l'eliminazione dell'avviso: $0"
 msgid "Error while setting SELinux mode: '$0'"
 msgstr "Errore durante l'impostazione del modo SELinux: ' ' ' '"
 
-#: pkg/kubernetes/scripts/connection.js:85
-msgid "Error writing kubectl config"
-msgstr "Errore nella scrittura di kubectl config"
-
-#: pkg/networkmanager/index.html:666
+#: pkg/networkmanager/index.html:658
 msgid "Ethernet MAC"
 msgstr "Ethernet MAC"
 
-#: pkg/networkmanager/index.html:642
+#: pkg/networkmanager/index.html:634
 msgid "Ethernet MTU"
 msgstr "Ethernet MTU"
 
-#: pkg/networkmanager/interfaces.js:2003
+#: pkg/networkmanager/interfaces.js:2006
 msgid "Ethtool"
 msgstr "Ethtool"
 
-#: pkg/systemd/logs.html:54 pkg/docker/containers-view.jsx:108
+#: pkg/systemd/logs.html:55 pkg/docker/containers-view.jsx:108
 msgid "Everything"
 msgstr "Tutto"
 
-#: pkg/networkmanager/firewall.jsx:454
+#: pkg/networkmanager/firewall.jsx:536
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:462
+#: pkg/networkmanager/firewall.jsx:544
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
-#: pkg/users/local.js:473 pkg/users/local.js:1417
+#: pkg/users/local.js:477 pkg/users/local.js:1421
 msgid "Excellent password"
 msgstr "Password eccellente"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
 msgid "Existing Disk Image"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:215
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -3176,11 +2639,11 @@ msgstr "Codice di uscita $ExitCode"
 msgid "Expansion Chassis"
 msgstr "Telaio di espansione"
 
-#: pkg/docker/index.html:508
+#: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "Esporre le porte dei contenitori"
 
-#: pkg/storaged/content-views.jsx:458 pkg/storaged/format-dialog.jsx:254
+#: pkg/storaged/content-views.jsx:454 pkg/storaged/format-dialog.jsx:254
 msgid "Extended Partition"
 msgstr "Partizione estesa"
 
@@ -3188,15 +2651,7 @@ msgstr "Partizione estesa"
 msgid "FAILED"
 msgstr "FALLITO"
 
-#: pkg/ovirt/provider.js:130
-msgid "FORCEOFF action failed: $0"
-msgstr ""
-
-#: pkg/ovirt/components/InstallationDialog.jsx:47
-msgid "FQDN"
-msgstr "FQDN"
-
-#: pkg/networkmanager/interfaces.js:839
+#: pkg/networkmanager/interfaces.js:842
 msgid "Failed"
 msgstr "Non riuscito"
 
@@ -3204,7 +2659,22 @@ msgstr "Non riuscito"
 msgid "Failed to add machine: $0"
 msgstr "Non è riuscito ad aggiungere la macchina: $0"
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/networkmanager/firewall.jsx:237
+#, fuzzy
+msgid "Failed to add port"
+msgstr "Impossibile cambiare la password"
+
+#: pkg/networkmanager/firewall.jsx:237
+#, fuzzy
+msgid "Failed to add service"
+msgstr "Non è riuscito ad aggiungere la macchina: $0"
+
+#: pkg/networkmanager/firewall.jsx:679
+#, fuzzy
+msgid "Failed to add zone"
+msgstr "Non è riuscito ad aggiungere la macchina: $0"
+
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Impossibile cambiare la password"
 
@@ -3228,9 +2698,18 @@ msgstr "Impossibile modificare la macchina: $0"
 msgid "Failed to enable tuned"
 msgstr "Impossibile abilitare la sintonizzazione"
 
+#: pkg/machines/components/vmnetworktab.jsx:55
+msgid "Failed to fetch the IP addresses of the interfaces present in $0"
+msgstr ""
+
 #: pkg/users/index.html:393
 msgid "Failed to load authorized keys."
 msgstr "Impossibile caricare le chiavi autorizzate."
+
+#: pkg/networkmanager/firewall.jsx:591
+#, fuzzy
+msgid "Failed to remove service"
+msgstr "Impossibile raggiungere il server"
 
 #: pkg/docker/containers.js:60
 msgid "Failed to start Docker: $0"
@@ -3244,20 +2723,16 @@ msgstr "Non è riuscito a fermare il cannocchiale Docker: $0"
 msgid "Failed to switch profile"
 msgstr "Non è riuscito a commutare il profilo"
 
-#: pkg/machines/components/vcpuModal.jsx:196
+#: pkg/machines/components/vcpuModal.jsx:193
 msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr "Meno del numero massimo di CPU virtuali dovrebbe essere abilitato."
 
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "Canale in fibra ottica"
-
-#: pkg/machines/components/vm/bootOrderModal.jsx:94
-#: pkg/machines/components/vmDiskSourceCell.jsx:37
+#: pkg/machines/components/vm/bootOrderModal.jsx:92
+#: pkg/machines/components/vmDiskColumns.jsx:42
 msgid "File"
 msgstr "File"
 
-#: pkg/storaged/content-views.jsx:139
+#: pkg/storaged/content-views.jsx:145
 msgid "Filesystem"
 msgstr "File system"
 
@@ -3273,57 +2748,30 @@ msgstr "Montaggio del filesystem"
 msgid "Filesystem Name"
 msgstr "Nome del file system"
 
-#: pkg/kubernetes/views/pv-modify.html:181
-#: pkg/kubernetes/views/volume-body.html:6
-#: pkg/kubernetes/views/volume-body.html:16
-#: pkg/kubernetes/views/volume-body.html:62
-#: pkg/kubernetes/views/volume-body.html:83
-#: pkg/kubernetes/views/volume-body.html:91
-#: pkg/kubernetes/views/volume-body.html:120
-#: pkg/kubernetes/views/volume-body.html:132
-msgid "Filesystem Type"
-msgstr "Tipo di file system"
-
-#: pkg/storaged/format-dialog.jsx:293
-msgid "Filesystem type"
-msgstr "Tipo di file system"
-
 #: pkg/storaged/fsys-panel.jsx:103
 msgid "Filesystems"
 msgstr "Sistemi di file system"
 
-#: pkg/networkmanager/firewall.jsx:410
+#: pkg/networkmanager/firewall.jsx:491
 msgid "Filter Services"
 msgstr "Servizi di filtraggio"
 
-#: pkg/systemd/services.html:64
+#: pkg/systemd/services.html:68
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:289
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Firma digitale"
 
-#: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:96
-#: pkg/networkmanager/firewall.jsx:586 pkg/networkmanager/firewall.jsx:589
+#: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
+#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
 msgid "Firewall"
 msgstr "Firewall"
 
-#: pkg/networkmanager/firewall.jsx:551
+#: pkg/networkmanager/firewall.jsx:863
 msgid "Firewall is not available"
 msgstr "Firewall non è disponibile"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/views/volume-body.html:125
-msgid "Flocker Dataset Name"
-msgstr "Nome del set di dati Flocker"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:35
 msgid "Follows docker repo"
@@ -3357,31 +2805,32 @@ msgstr "Forzare la modifica della password"
 msgid "Force remove passphrase in $0"
 msgstr "Forza rimuovere la passphrase in $0"
 
-#: pkg/machines/components/diskAdd.jsx:166 pkg/storaged/content-views.jsx:534
-#: pkg/storaged/format-dialog.jsx:332 pkg/storaged/format-dialog.jsx:423
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formato"
 
-#: pkg/storaged/format-dialog.jsx:185
+#: pkg/storaged/format-dialog.jsx:186
 msgid "Format $0"
 msgstr "Formato $0"
 
-#: pkg/storaged/content-views.jsx:515
+#: pkg/storaged/content-views.jsx:511
 msgid "Format Disk $0"
 msgstr "Formato Disco $0"
 
-#: pkg/storaged/content-views.jsx:535
+#: pkg/storaged/content-views.jsx:531
 msgid "Formatting a disk will erase all data on it."
 msgstr ""
 "La formattazione di un disco cancellerà tutti i dati in esso contenuti."
 
-#: pkg/storaged/format-dialog.jsx:334
+#: pkg/storaged/format-dialog.jsx:325
 msgid "Formatting a storage device will erase all data on it."
 msgstr ""
 "La formattazione di un dispositivo di memorizzazione cancella tutti i dati "
 "in esso contenuti."
 
-#: pkg/networkmanager/interfaces.js:2853
+#: pkg/networkmanager/interfaces.js:2861
 msgid "Forward delay $forward_delay"
 msgstr "Ritardo in avanti $forward_ritardo"
 
@@ -3391,15 +2840,15 @@ msgstr ""
 
 # spazio su disco, quindi maschile
 #: pkg/docker/storage.jsx:325 pkg/docker/storage.jsx:348
-#: pkg/storaged/pvol-tabs.jsx:49
+#: pkg/storaged/pvol-tabs.jsx:44
 msgid "Free"
 msgstr "Libero"
 
-#: pkg/storaged/content-views.jsx:444
+#: pkg/storaged/content-views.jsx:440
 msgid "Free Space"
 msgstr "Spazio libero"
 
-#: pkg/storaged/lvol-tabs.jsx:377
+#: pkg/storaged/lvol-tabs.jsx:371
 msgid ""
 "Free up space in this group: Shrink or delete other logical volumes or add "
 "another physical volume."
@@ -3407,7 +2856,7 @@ msgstr ""
 "Recuperare spazio in questo gruppo: ridurre o eliminare volumi logici oppure "
 "aggiungere un altro volume fisico."
 
-#: pkg/systemd/services.html:241
+#: pkg/systemd/services.html:239
 msgid "Friday"
 msgstr "Venerdì"
 
@@ -3423,17 +2872,13 @@ msgstr "Da"
 msgid "Full Name"
 msgstr "Nome completo"
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "GCE Disco Persistente"
-
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:183
+#: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "Gateway:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2695 pkg/systemd/logs.js:481
+#: pkg/networkmanager/interfaces.js:2703 pkg/systemd/logs.js:486
 msgid "General"
 msgstr "Generale"
 
@@ -3445,23 +2890,13 @@ msgstr "Generazione di report"
 msgid "Get new image"
 msgstr "Ricevi una nuova immagine"
 
-#: pkg/machines/components/diskAdd.jsx:161
-#: pkg/machines/components/memorySelectRow.jsx:49
+#: pkg/machines/components/vm/memoryModal.jsx:153
+#: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Repository Git"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster FS"
-
-#: pkg/kubernetes/scripts/volumes.js:877
-msgid "GlusterFS"
-msgstr "GlusterFS"
 
 #: pkg/systemd/logs.js:199
 msgid "Go to"
@@ -3472,16 +2907,10 @@ msgid "Go to Application"
 msgstr "Vai all'applicazione"
 
 #: pkg/dashboard/index.html:46 pkg/networkmanager/index.html:63
-#: pkg/networkmanager/index.html:404 pkg/systemd/index.html:182
+#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:174
 #: pkg/storaged/plot.jsx:72
 msgid "Go to now"
 msgstr "Vai a ora"
-
-#: pkg/kubernetes/views/project-body.html:3
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Grant additional push or admin access to specific members below."
-msgstr ""
-"Concedi l'accesso aggiuntivo push o admin a specifici membri qui sotto."
 
 #: pkg/machines/components/consoles.jsx:51
 msgid "Graphics Console (VNC)"
@@ -3491,28 +2920,13 @@ msgstr "Console grafica (VNC)"
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Console grafica in Desktop Viewer"
 
-#: pkg/kubernetes/views/group-page.html:21
-#: pkg/kubernetes/views/group-panel.html:12
-msgid "Group Members"
-msgstr "Membri del gruppo"
-
-#: pkg/kubernetes/views/user-add-membership.html:9
-msgid "Group or Project"
-msgstr "Gruppo o progetto"
-
-# translation auto-copied from project libreport, version master, document libreport
-#: pkg/kubernetes/views/project-listing.html:48
-#: pkg/kubernetes/views/user-delete.html:14
-msgid "Groups"
-msgstr "Gruppi"
-
-#: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:404
-#: pkg/storaged/lvol-tabs.jsx:438 pkg/storaged/vdo-details.jsx:229
+#: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
+#: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
 #: pkg/storaged/vdo-details.jsx:298
 msgid "Grow"
 msgstr "Crescere"
 
-#: pkg/storaged/warning-tab.jsx:125
+#: pkg/storaged/lvol-tabs.jsx:417
 msgid "Grow Content"
 msgstr ""
 
@@ -3528,20 +2942,11 @@ msgstr "Estendere le dimensioni logiche di $0"
 msgid "Grow to take all space"
 msgstr "Crescere per prendere tutto lo spazio"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "HA"
-msgstr "HA"
-
-#: pkg/ovirt/components/OVirtTab.jsx:128
-msgid "HA:"
-msgstr "HA:"
-
-#: pkg/networkmanager/index.html:260
+#: pkg/networkmanager/index.html:252
 msgid "Hair Pin mode"
 msgstr "Capelli Modalità pin"
 
-#: pkg/networkmanager/interfaces.js:2879
+#: pkg/networkmanager/interfaces.js:2887
 msgid "Hairpin mode"
 msgstr "Modalità hairpin"
 
@@ -3566,89 +2971,81 @@ msgstr "Hardware"
 msgid "Hardware Information"
 msgstr "Informazioni hardware"
 
-#: pkg/networkmanager/interfaces.js:2855
+#: pkg/networkmanager/interfaces.js:2863
 msgid "Hello time $hello_time"
 msgstr "Ciao tempo $hello_time"
 
-#: pkg/kubernetes/views/details-page.html:73
-#: pkg/kubernetes/views/route-body.html:9
-#: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:145
+#: pkg/machines/components/diskAdd.jsx:238
+#, fuzzy
+msgid "Hide Performance Options"
+msgstr "Profilo di prestazione"
+
+#: pkg/machines/components/vm/bootOrderModal.jsx:97
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
-#: pkg/machines/components/vm/bootOrderModal.jsx:99
-#: pkg/machines/components/vmDiskSourceCell.jsx:42
-#: pkg/ovirt/components/App.jsx:103 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:334
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Host"
 
-#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:182
+#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:172
 msgid "Host Device"
 msgstr ""
 
-#: pkg/dashboard/index.html:135 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:150
+#: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
 msgid "Host Name"
 msgstr "Host Name"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:869
-msgid "Host Path"
-msgstr "Sentiero dell'ospite"
 
 #: src/base1/cockpit.js:4023
 msgid "Host key is incorrect"
 msgstr "La chiave host non è corretta"
 
-#: pkg/realmd/operation.js:602
+#: pkg/realmd/operation.js:601
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
 msgid "Host should not be empty"
 msgstr "L'host non deve essere vuoto"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:75
-msgid "Host to Maintenance"
-msgstr "Ospite a Manutenzione"
-
-#: pkg/systemd/services.html:501
+#: pkg/systemd/services.html:499
 msgid "Hour : Minute"
 msgstr "Ora : Minuto"
 
-#: pkg/systemd/init.js:1338 pkg/systemd/init.js:1367
+#: pkg/systemd/init.js:1332 pkg/systemd/init.js:1361
 msgid "Hour needs to be a number between 0-23"
 msgstr "L'ora deve essere un numero compreso tra 0-23"
 
-#: pkg/systemd/services.html:467
+#: pkg/systemd/services.html:465
 msgid "Hours"
 msgstr "Ore"
 
-#: pkg/systemd/index.html:246 pkg/systemd/host.js:1578
+#: pkg/systemd/index.html:238 pkg/systemd/host.js:1582
 msgid "I/O Wait"
 msgstr "Attesa I/O"
 
-#: pkg/kubernetes/views/node-body.html:10
-#: pkg/kubernetes/views/service-body.html:9
-msgid "IP"
-msgstr "IP"
-
-#: pkg/networkmanager/index.html:128 pkg/networkmanager/index.html:146
+#: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
+#: pkg/machines/components/vmnetworktab.jsx:133
 msgid "IP Address"
 msgstr "Indirizzo IP"
 
-#: pkg/docker/index.html:175
+#: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "Indirizzo IP:"
 
-#: pkg/docker/index.html:179
+#: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "Lunghezza prefisso IP:"
 
-#: pkg/networkmanager/index.html:474
+#: pkg/networkmanager/firewall.jsx:925
+msgid "IP Range"
+msgstr ""
+
+#: pkg/networkmanager/index.html:466
 msgid "IP Settings"
 msgstr "Impostazioni IP"
 
-#: pkg/networkmanager/interfaces.js:2904
+#: pkg/networkmanager/interfaces.js:2912
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3656,11 +3053,11 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3340
+#: pkg/networkmanager/interfaces.js:3359
 msgid "IPv4 Settings"
 msgstr "Impostazioni IPv4"
 
-#: pkg/networkmanager/interfaces.js:2905
+#: pkg/networkmanager/interfaces.js:2913
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3668,24 +3065,20 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3340
+#: pkg/networkmanager/interfaces.js:3359
 msgid "IPv6 Settings"
 msgstr "Impostazioni IPv6"
-
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:873
-msgid "ISCSI"
-msgstr "ISCSI"
 
 # translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
 
-#: pkg/networkmanager/interfaces.js:2896
+#: pkg/networkmanager/interfaces.js:2904
 msgid "Id $id"
 msgstr "Id $id"
 
-#: pkg/docker/index.html:148
+#: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "Id:"
 
@@ -3694,28 +3087,15 @@ msgstr "Id:"
 msgid "Identifier"
 msgstr "Identificazione"
 
-#: pkg/kubernetes/views/user-page.html:22
-#: pkg/kubernetes/views/user-panel.html:18
-msgid "Identities"
-msgstr "Identità"
-
-#: pkg/kubernetes/views/add-user-dialog.html:17
-#: pkg/kubernetes/views/project-listing.html:91
-#: pkg/kubernetes/views/user-modify.html:17
-msgid "Identity"
-msgstr "Identità"
-
 #: pkg/storaged/crypto-keyslots.jsx:325
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Se il tasto tang-show-key non è disponibile, eseguire quanto segue:"
 
-#: pkg/networkmanager/interfaces.js:1966 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1969 pkg/packagekit/updates.jsx:496
 msgid "Ignore"
 msgstr "Ignora"
 
-#: pkg/docker/index.html:268 pkg/docker/index.html:431
-#: pkg/kubernetes/views/container-body.html:6
-#: pkg/kubernetes/views/image-page.html:15
+#: pkg/docker/index.html:270 pkg/docker/index.html:433
 #: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
@@ -3725,33 +3105,13 @@ msgstr "Immagine"
 msgid "Image $0"
 msgstr "Immagine $0"
 
-#: pkg/users/local.js:749
+#: pkg/users/local.js:753
 msgid "Image Builder"
 msgstr "Costruttore di immagini"
 
-#: pkg/kubernetes/views/container-body.html:8
-msgid "Image ID"
-msgstr "ID immagine"
-
-#: pkg/kubernetes/views/volume-body.html:58
-msgid "Image Name"
-msgstr "Nome dell'immagine"
-
-#: pkg/kubernetes/registry.html:23
-msgid "Image Registry"
-msgstr "Registro immagini"
-
-#: pkg/docker/index.html:578
+#: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Ricerca immagini"
-
-#: pkg/kubernetes/views/imagestream-page.html:16
-msgid "Image Stream"
-msgstr "Flusso d'immagine"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:135
-msgid "Image commands"
-msgstr "Comandi immagine"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:41
 msgid "Image count"
@@ -3761,14 +3121,10 @@ msgstr "Conteggio immagini"
 msgid "Image stream"
 msgstr "Flusso di immagini"
 
-#: pkg/docker/index.html:156
+#: pkg/docker/index.html:157
 msgid "Image:"
 msgstr "Immagine:"
 
-#: pkg/kubernetes/index.html:81 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
-#: pkg/kubernetes/views/registry-dashboard-page.html:19
 #: pkg/docker/containers-view.jsx:711
 msgid "Images"
 msgstr "Immagini"
@@ -3781,10 +3137,6 @@ msgstr "Immagini"
 #: pkg/docker/containers-view.jsx:109
 msgid "Images and running containers"
 msgstr "Immagini e container in esecuzione"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:17
-msgid "Images by project"
-msgstr "Immagini per progetto"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:15
 #: node_modules/registry-image-widgets/views/imagestream-body.html:16
@@ -3802,11 +3154,7 @@ msgstr ""
 msgid "Images may only be pulled by specific users or groups"
 msgstr "Le immagini possono essere estratte solo da utenti o gruppi specifici"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:54
-msgid "Images pushed recently"
-msgstr "Immagini spinte di recente"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:367
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
 msgstr "Avviare immediatamente la VM"
 
@@ -3814,26 +3162,11 @@ msgstr "Avviare immediatamente la VM"
 msgid "In Sync"
 msgstr "In Sync"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:223
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
 msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:81
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-"Per iniziare a spingere le immagini nel registro di sistema, utilizzare i "
-"comandi seguenti."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:6
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr ""
-"Per iniziare a spingere le immagini nel registro di sistema, è necessario "
-"creare un progetto."
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
@@ -3844,14 +3177,19 @@ msgstr ""
 "strong}}."
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/networkmanager/interfaces.js:821 pkg/networkmanager/interfaces.js:1414
-#: pkg/networkmanager/interfaces.js:1421 pkg/networkmanager/interfaces.js:2598
+#: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
+#: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
 msgid "Inactive"
 msgstr "Inattiva"
 
-#: pkg/storaged/content-views.jsx:617
+#: pkg/storaged/content-views.jsx:613
 msgid "Inactive volume"
 msgstr "Volume inattivo"
+
+#: pkg/networkmanager/firewall.jsx:732
+#, fuzzy
+msgid "Included services"
+msgstr "Aggiungi servizi"
 
 #: pkg/lib/machine-invalid-hostkey.html:2
 msgid "Incorrect Host Key"
@@ -3861,22 +3199,31 @@ msgstr "Chiave host errata"
 msgid "Index Memory"
 msgstr "Memoria indice"
 
-#: pkg/systemd/logs.html:61
+#: pkg/systemd/logs.html:62
 msgid "Info and above"
 msgstr "Info e sopra"
 
 #: pkg/docker/storage.jsx:309
 msgid "Information about the Docker storage pool is not available."
-msgstr ""
-"Le informazioni sul pool di archiviazione Docker non sono disponibili."
+msgstr "Le informazioni sul pool di archiviazione Docker non sono disponibili."
 
 #: pkg/packagekit/updates.jsx:453
 msgid "Initializing..."
 msgstr "Inizializzazione....."
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#, fuzzy
+msgid "Initiator"
+msgstr "Istantanea"
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#, fuzzy
+msgid "Initiator IQN should not be empty"
+msgstr "Installazione La fonte non deve essere vuota"
+
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Installa"
 
@@ -3906,15 +3253,15 @@ msgstr ""
 "Installare setroubleshoot-server per la risoluzione dei problemi degli "
 "eventi SELinux."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:321
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
 msgid "Installation Source"
 msgstr "Fonte di installazione"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:307
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
 msgid "Installation Source Type"
 msgstr "Tipo di sorgente di installazione"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:412
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
 msgid "Installation Source should not be empty"
 msgstr "Installazione La fonte non deve essere vuota"
 
@@ -3922,10 +3269,6 @@ msgstr "Installazione La fonte non deve essere vuota"
 #: pkg/packagekit/updates.jsx:59
 msgid "Installed"
 msgstr "Installato"
-
-#: pkg/subscriptions/subscriptions-view.jsx:245
-msgid "Installed products"
-msgstr "Prodotti installati"
 
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:51
@@ -3936,24 +3279,21 @@ msgstr "Installazione in corso"
 msgid "Installing $0"
 msgstr "Installazione di $0"
 
-#: pkg/systemd/services.html:186
+#: pkg/systemd/services.html:184
 msgid "Instantiate"
 msgstr "Istantanea"
 
-#: pkg/kubernetes/views/pv-modify.html:170
-#: pkg/kubernetes/views/volume-body.html:81
-msgid "Interface"
-msgstr "Interfaccia"
-
-#: pkg/machines/components/nicEdit.jsx:125
+#: pkg/machines/components/nicEdit.jsx:123
 msgid "Interface Type"
 msgstr ""
 
-#: pkg/networkmanager/index.html:116
+#: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Interfaccia"
 
-#: src/ws/login.js:636
+#: src/ws/login.js:639
 msgid "Internal Error: Invalid challenge header"
 msgstr "Errore interno: intestazione di sfida non valida"
 
@@ -3965,23 +3305,19 @@ msgstr "Errore interno"
 msgid "Invalid address $0"
 msgstr "Indirizzo non valido $0"
 
-#: pkg/subscriptions/subscriptions-client.js:195
-msgid "Invalid credentials"
-msgstr "Credenziali non valide"
-
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Formato data non valido"
 
-#: pkg/systemd/host.js:1444 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Formato data non valido e formato ora non valido"
 
-#: pkg/systemd/init.js:1373
+#: pkg/systemd/init.js:1367
 msgid "Invalid date format."
 msgstr "Formato data non valido."
 
-#: pkg/users/local.js:1237
+#: pkg/users/local.js:1241
 msgid "Invalid expiration date"
 msgstr "Data di scadenza non valida"
 
@@ -3989,7 +3325,7 @@ msgstr "Data di scadenza non valida"
 msgid "Invalid file permissions"
 msgstr "Autorizzazioni file non valide"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:399
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
 msgid "Invalid filename"
 msgstr "Nome file non valido"
 
@@ -4001,11 +3337,11 @@ msgstr "Chiave non valida"
 msgid "Invalid metric $0"
 msgstr "Metrica non valida $0"
 
-#: pkg/users/local.js:1313
+#: pkg/users/local.js:1317
 msgid "Invalid number of days"
 msgstr "Numero di giorni non valido"
 
-#: pkg/systemd/init.js:1320
+#: pkg/systemd/init.js:1314
 msgid "Invalid number."
 msgstr "Numero non valido."
 
@@ -4013,7 +3349,7 @@ msgstr "Numero non valido."
 msgid "Invalid port"
 msgstr "Porta non valida"
 
-#: pkg/networkmanager/firewall.jsx:285
+#: pkg/networkmanager/firewall.jsx:335
 msgid "Invalid port number"
 msgstr ""
 
@@ -4025,20 +3361,19 @@ msgstr "Prefisso non valido $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "Prefisso o maschera di rete non validi $0"
 
-#: pkg/networkmanager/firewall.jsx:312
+#: pkg/networkmanager/firewall.jsx:362
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1446 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Formato ora non valido"
 
-#: pkg/systemd/index.html:382
+#: pkg/systemd/index.html:374
 msgid "Invalid time zone"
 msgstr "Fuso orario non valido"
 
 #: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
-#: pkg/subscriptions/subscriptions-client.js:193
 msgid "Invalid username or password"
 msgstr "Password o nome utente non validi"
 
@@ -4050,7 +3385,7 @@ msgstr "IoT Gateway"
 msgid "Is sshd running on a different port?"
 msgstr "La sshd è in esecuzione su un porto diverso?"
 
-#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:116
+#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:108
 msgid "Isolated Network"
 msgstr ""
 
@@ -4059,23 +3394,23 @@ msgid "Jobs"
 msgstr "Lavori"
 
 # ctx::sourcefile::Navigation Menu
-#: pkg/realmd/operation.js:117
+#: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "Unisci"
 
-#: pkg/realmd/operation.js:597
+#: pkg/realmd/operation.js:596
 msgid "Join Domain"
 msgstr "Unione al dominio"
 
-#: pkg/realmd/operation.js:116
+#: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "Join a un dominio"
 
-#: pkg/realmd/operation.js:506
+#: pkg/realmd/operation.js:505
 msgid "Joining this domain is not supported"
 msgstr "L'adesione a questo dominio non è supportata"
 
-#: pkg/systemd/init.js:742
+#: pkg/systemd/init.js:736
 msgid "Joins Namespace Of"
 msgstr "Iscrive Namespace Of"
 
@@ -4083,11 +3418,11 @@ msgstr "Iscrive Namespace Of"
 msgid "Journal"
 msgstr "Giornale"
 
-#: pkg/systemd/logs.js:402
+#: pkg/systemd/logs.js:407
 msgid "Journal entry"
 msgstr "Voce del diario"
 
-#: pkg/systemd/logs.js:433
+#: pkg/systemd/logs.js:438
 msgid "Journal entry not found"
 msgstr "Voce del diario non trovata"
 
@@ -4098,7 +3433,7 @@ msgstr ""
 "Servizio Kdump non installato. Assicurarsi che il pacchetto kexec-tools sia "
 "installato."
 
-#: pkg/networkmanager/index.html:716
+#: pkg/networkmanager/index.html:708
 msgid "Keep connection"
 msgstr "Mantenere la connessione"
 
@@ -4110,21 +3445,13 @@ msgstr "SSO basato su Kerberos"
 msgid "Kerberos Ticket"
 msgstr "Biglietto Kerberos"
 
-#: pkg/systemd/index.html:242 pkg/systemd/host.js:1579
+#: pkg/systemd/index.html:234 pkg/systemd/host.js:1583
 msgid "Kernel"
 msgstr "Kernel"
 
 #: pkg/kdump/index.html:23
 msgid "Kernel Dump"
 msgstr "Kernel Dump"
-
-#: pkg/kubernetes/views/node-body.html:19
-msgid "Kernel Version"
-msgstr "Versione del kernel"
-
-#: pkg/kubernetes/views/volume-body.html:67
-msgid "Key Ring Path"
-msgstr "Sentiero dell'anello portachiavi"
 
 #: pkg/storaged/crypto-keyslots.jsx:563
 msgid "Key slots with unknown types can not be edited here"
@@ -4151,23 +3478,10 @@ msgstr "Indirizzo Keyserver"
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "La rimozione di Keyserver può impedire lo sblocco$0."
 
-#: pkg/kubernetes/views/node-body.html:23
-msgid "Kubelet Version"
-msgstr "Versione Kubelet"
-
-#: pkg/kubernetes/index.html:23
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes Cluster"
-
-#: pkg/networkmanager/index.html:385
+#: pkg/networkmanager/index.html:377
 msgid "LACP Key"
 msgstr "Chiave LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: pkg/kubernetes/views/replicationcontroller-body.html:17
-#: pkg/kubernetes/views/route-body.html:22
-#: pkg/kubernetes/views/service-body.html:26
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Etichette"
@@ -4176,25 +3490,17 @@ msgstr "Etichette"
 msgid "Laptop"
 msgstr "Portatile"
 
-#: pkg/systemd/logs.html:43
+#: pkg/systemd/logs.html:44
 msgid "Last 24 hours"
 msgstr "Ultime 24 ore"
 
-#: pkg/systemd/logs.html:44
+#: pkg/systemd/logs.html:45
 msgid "Last 7 days"
 msgstr "Ultimi 7 giorni"
-
-#: pkg/kubernetes/views/node-body.html:49
-msgid "Last Heartbeat"
-msgstr "Ultimo battito cardiaco"
 
 #: pkg/users/index.html:100
 msgid "Last Login"
 msgstr "Ultimo accesso"
-
-#: pkg/kubernetes/views/node-body.html:51
-msgid "Last Status Change"
-msgstr "Ultimo cambiamento di stato"
 
 #: pkg/systemd/init.js:284
 msgid "Last Trigger"
@@ -4209,11 +3515,6 @@ msgstr "Ultimo aggiornato"
 msgid "Last checked: $0 ago"
 msgstr "Ultimo controllo: $0■fa"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
-#: pkg/kubernetes/views/details-page.html:107
-msgid "Latest Version"
-msgstr "Ultima versione"
-
 #: pkg/machines/components/desktopConsole.jsx:128
 msgid "Launch Remote Viewer"
 msgstr "Avviare il visualizzatore remoto"
@@ -4222,7 +3523,7 @@ msgstr "Avviare il visualizzatore remoto"
 msgid "Leave Domain"
 msgstr "Lascia dominio"
 
-#: pkg/dashboard/index.html:147
+#: pkg/dashboard/index.html:149
 msgid ""
 "Leave blank to connect to this machine as the currently logged in user. If "
 "you enter a different username, that user will always be used when "
@@ -4237,14 +3538,13 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Lasciare vuoto per connettersi a questa macchina come utente attualmente "
 "connesso{{#default_user}} ({{default_user}}){{/default_user}}. Se si "
 "inserisce un nome utente diverso, tale utente sarà sempre utilizzato per "
 "connettersi a questa macchina."
 
-#: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
+#: pkg/shell/index.html:90 pkg/shell/simple.html:66
 msgid "Licensed under:"
 msgstr "Concesso in licenza:"
 
@@ -4252,39 +3552,39 @@ msgstr "Concesso in licenza:"
 msgid "Light"
 msgstr ""
 
-#: pkg/networkmanager/index.html:302
+#: pkg/networkmanager/index.html:294
 msgid "Link Monitoring"
 msgstr "Monitoraggio dei collegamenti"
 
-#: pkg/networkmanager/index.html:346
+#: pkg/networkmanager/index.html:338
 msgid "Link Watch"
 msgstr "Orologio Link"
 
-#: pkg/networkmanager/index.html:319 pkg/networkmanager/index.html:363
+#: pkg/networkmanager/index.html:311 pkg/networkmanager/index.html:355
 msgid "Link down delay"
 msgstr "Ritardo caduta collegamento"
 
-#: pkg/networkmanager/interfaces.js:1954 pkg/networkmanager/interfaces.js:1964
+#: pkg/networkmanager/interfaces.js:1957 pkg/networkmanager/interfaces.js:1967
 msgid "Link local"
 msgstr "Collegamento locale"
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:499
 msgid "Link to another container"
 msgstr "Collegamento ad un altro contenitore"
 
-#: pkg/networkmanager/index.html:315 pkg/networkmanager/index.html:359
+#: pkg/networkmanager/index.html:307 pkg/networkmanager/index.html:351
 msgid "Link up delay"
 msgstr "Ritardo ripristino collegamento"
 
-#: pkg/docker/index.html:493
+#: pkg/docker/index.html:495
 msgid "Links"
 msgstr "Link"
 
-#: pkg/docker/index.html:195
+#: pkg/docker/index.html:196
 msgid "Links:"
 msgstr "Link:"
 
-#: pkg/networkmanager/interfaces.js:1990
+#: pkg/networkmanager/interfaces.js:1993
 msgid "Load Balancing"
 msgstr "Bilanciamento del carico"
 
@@ -4304,14 +3604,10 @@ msgstr "Caricamento degli aggiornamenti disponibili non riuscito"
 msgid "Loading available updates, please wait..."
 msgstr "Caricamento degli aggiornamenti disponibili, attendere....."
 
-#: pkg/ovirt/components/VdsmView.jsx:34
-msgid "Loading data ..."
-msgstr "Caricamento dati ...."
-
 # translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
-#: pkg/systemd/services.html:86 pkg/kdump/kdump-view.jsx:367
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
 #: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
-#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:312
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Caricamento in corso..."
 
@@ -4327,7 +3623,7 @@ msgstr "Dischi locali"
 msgid "Local Filesystem"
 msgstr "File system locale"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:313
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
 msgid "Local Install Media"
 msgstr ""
 
@@ -4340,7 +3636,7 @@ msgstr "Punto di montaggio locale"
 msgid "Location"
 msgstr "Posizione"
 
-#: pkg/storaged/content-views.jsx:246
+#: pkg/storaged/content-views.jsx:238
 msgid "Lock"
 msgstr "Blocca"
 
@@ -4348,7 +3644,7 @@ msgstr "Blocca"
 msgid "Lock Account"
 msgstr "Blocca account"
 
-#: pkg/users/local.js:879 pkg/users/local.js:1218
+#: pkg/users/local.js:883 pkg/users/local.js:1222
 msgid "Lock account on $0"
 msgstr "Blocca il tuo account su $0"
 
@@ -4356,11 +3652,11 @@ msgstr "Blocca il tuo account su $0"
 msgid "Locking $target"
 msgstr "Blocco $target"
 
-#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:85 src/ws/login.js:487
+#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:85 src/ws/login.js:490
 msgid "Log In"
 msgstr "Accedi"
 
-#: pkg/shell/index.html:70 pkg/shell/simple.html:46 pkg/shell/stub.html:53
+#: pkg/shell/index.html:70 pkg/shell/simple.html:46
 msgid "Log Out"
 msgstr "Esci"
 
@@ -4372,23 +3668,15 @@ msgstr "Effettua di nuovo il login"
 msgid "Log in to {{host}}"
 msgstr "Accedi a {{host}}"
 
-#: src/ws/login.js:512
+#: src/ws/login.js:515
 msgid "Log in with your server user account."
 msgstr "Accedi con il tuo account utente del server."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:116
-msgid "Log into OpenShift command line tools:"
-msgstr "Accedere agli strumenti della riga di comando di OpenShift:"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:101
-msgid "Log into the registry:"
-msgstr "Effettuare il login nel registro:"
 
 #: pkg/systemd/index.html:65
 msgid "Log messages"
 msgstr "Messaggi di log"
 
-#: pkg/users/local.js:961
+#: pkg/users/local.js:965
 msgid "Logged In"
 msgstr "Loggato"
 
@@ -4399,12 +3687,6 @@ msgstr "Logico"
 #: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
 msgid "Logical Size"
 msgstr "Dimensione logica"
-
-#: pkg/kubernetes/views/pv-modify.html:159
-#: pkg/kubernetes/views/volume-body.html:79
-#: pkg/kubernetes/views/volume-body.html:118
-msgid "Logical Unit Number"
-msgstr "Numero di unità logica"
 
 #: pkg/storaged/utils.js:197
 msgid "Logical Volume"
@@ -4418,10 +3700,6 @@ msgstr "Volume logico (istantanea)"
 msgid "Logical Volume of $0"
 msgstr "Volume logico di $0"
 
-#: pkg/subscriptions/subscriptions-register.jsx:144
-msgid "Login"
-msgstr "Accedi"
-
 #: src/ws/login.js:300
 msgid "Login Again"
 msgstr "Effettua di nuovo il login"
@@ -4434,10 +3712,6 @@ msgstr ""
 msgid "Login Password"
 msgstr "Password di login"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:96
-msgid "Login commands"
-msgstr "Comandi di accesso"
-
 #: src/base1/cockpit.js:4015
 msgid "Login failed"
 msgstr "Login fallito"
@@ -4446,21 +3720,15 @@ msgstr "Login fallito"
 msgid "Login has escalated admin privileges"
 msgstr "Il login ha aumentato i privilegi amministrativi"
 
-#: pkg/subscriptions/subscriptions-client.js:199
-msgid "Login/password or activation key required to register."
-msgstr ""
-"Login/password o chiave di attivazione richiesta per la registrazione."
-
 #: src/ws/login.js:301
 msgid "Logout Successful"
 msgstr "Logout di successo"
 
-#: pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:81
+#: pkg/systemd/logs.html:82
 msgid "Logs"
 msgstr "Log"
 
-#: pkg/dashboard/index.html:110
+#: pkg/dashboard/index.html:112
 msgid "Lost connection. Trying to reconnect"
 msgstr "Ho perso la connessione. Cerco di ricollegarmi a un'altra volta"
 
@@ -4473,47 +3741,43 @@ msgid "Lunch Box"
 msgstr "Scatola da pranzo"
 
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
-#: pkg/networkmanager/index.html:200 pkg/networkmanager/index.html:279
+#: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:271
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:102
+#: pkg/machines/components/vmnetworktab.jsx:132
 msgid "MAC Address"
 msgstr "Indirizzo MAC"
 
-#: pkg/docker/index.html:187
+#: pkg/docker/index.html:188
 msgid "MAC Address:"
 msgstr "Indirizzo MAC:"
 
-#: pkg/ovirt/provider.js:283
-msgid "MIGRATE action failed"
-msgstr "Azione MIGRATE fallita"
-
-#: pkg/networkmanager/interfaces.js:1982
+#: pkg/networkmanager/interfaces.js:1985
 msgid "MII (Recommended)"
 msgstr "MII (consigliato)"
 
-#: pkg/networkmanager/interfaces.js:2753
+#: pkg/networkmanager/interfaces.js:2761
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4526
+#: pkg/networkmanager/interfaces.js:4545
 msgid "MTU must be a positive number"
 msgstr "MTU deve essere un numero positivo"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:105
+#: pkg/machines/components/vm/bootOrderModal.jsx:103
 msgid "Mac"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:161
+#: pkg/machines/components/nicEdit.jsx:160
 msgid "Mac Address"
 msgstr "Indirizzo Mac"
 
-#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:95
+#: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "ID macchina"
 
-#: pkg/systemd/index.html:275
+#: pkg/systemd/index.html:267
 msgid "Machine SSH Key Fingerprints"
 msgstr "Impronte digitali dei tasti SSH a macchina"
 
@@ -4529,11 +3793,7 @@ msgstr "Telaio del server principale"
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Assicurarsi che l'hash chiave del server Tang corrisponda:"
 
-#: pkg/kubernetes/scripts/dashboard.js:457
-msgid "Manifest"
-msgstr "Manifesto"
-
-#: pkg/networkmanager/interfaces.js:1955 pkg/networkmanager/interfaces.js:1965
+#: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
 msgid "Manual"
 msgstr "Manuale"
 
@@ -4541,7 +3801,7 @@ msgstr "Manuale"
 msgid "Manual Connection"
 msgstr "Collegamento manuale"
 
-#: pkg/systemd/index.html:392 pkg/systemd/index.html:396
+#: pkg/systemd/index.html:384 pkg/systemd/index.html:388
 msgid "Manually"
 msgstr "Manualmente"
 
@@ -4553,27 +3813,37 @@ msgstr "Controllare manualmente con SSH: "
 msgid "Marking $target as faulty"
 msgstr "Marcatura $targetdifettosa"
 
-#: pkg/systemd/init.js:580
+#: pkg/systemd/init.js:574
 msgid "Mask"
 msgstr "Maschera"
 
-#: pkg/systemd/init.js:581
+#: pkg/systemd/init.js:575
 msgid "Mask Forcefully"
 msgstr "Maschera con forza"
 
-#: pkg/networkmanager/interfaces.js:2759
+#: pkg/networkmanager/interfaces.js:2767
 msgid "Master"
 msgstr "Maestro"
+
+#: pkg/machines/components/vm/memoryModal.jsx:165
+#, fuzzy
+msgid "Maximum Allocation"
+msgstr "Posizione della discarica di crash"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:96
 msgid "Maximum Transmission Unit"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2857
+#: pkg/machines/components/vm/memoryModal.jsx:99
+#, fuzzy
+msgid "Maximum memory could not be saved"
+msgstr "Non è stato possibile salvare le impostazioni del VCPU"
+
+#: pkg/networkmanager/interfaces.js:2865
 msgid "Maximum message age $max_age"
 msgstr "Età massima del messaggio $max_età"
 
-#: pkg/machines/components/vcpuModal.jsx:202
+#: pkg/machines/components/vcpuModal.jsx:199
 msgid ""
 "Maximum number of virtual CPUs allocated for the guest OS, which must be "
 "between 1 and $0"
@@ -4581,98 +3851,74 @@ msgstr ""
 "Numero massimo di CPU virtuali allocate per il sistema operativo guest, che "
 "deve essere compreso tra 1 e $0"
 
-#: pkg/kubernetes/views/volume-body.html:34
-msgid "Medium"
-msgstr "Media"
-
-#: pkg/kubernetes/views/project-listing.html:92
-#: pkg/kubernetes/views/user-body.html:4
-#: pkg/kubernetes/views/user-panel.html:27
-msgid "Member of"
-msgstr "Membro di"
-
-#: pkg/storaged/content-views.jsx:349
+#: pkg/storaged/content-views.jsx:345
 msgid "Member of RAID Device"
 msgstr "Membro del dispositivo RAID"
 
-#: pkg/storaged/content-views.jsx:345
+#: pkg/storaged/content-views.jsx:341
 msgid "Member of RAID Device $0"
 msgstr "Membro del dispositivo RAID $0"
 
-#: pkg/kubernetes/views/project-listing.html:16
-#: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/index.html:274 pkg/networkmanager/interfaces.js:2978
-msgid "Members"
-msgstr "Membri"
-
-# ctx::sourcefile::/systems/details/history/snapshots/Groups
-#: pkg/kubernetes/views/project-page.html:29
-#: pkg/kubernetes/views/user-page.html:25
-#: pkg/kubernetes/views/user-panel.html:11
-msgid "Membership"
-msgstr "Appartenenza"
-
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:271
-#: pkg/playground/translate.html:90 pkg/systemd/index.html:212
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:608
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:827
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:346
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:273
+#: pkg/playground/translate.html:90 pkg/systemd/index.html:204
+#: pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
 #: pkg/machines/components/vmOverviewTab.jsx:74
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Memory"
 msgstr "Memoria"
 
-#: pkg/systemd/host.js:1637
+#: pkg/systemd/host.js:1641
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Memoria"
 
-#: pkg/systemd/index.html:213
+#: pkg/systemd/index.html:205
 msgid "Memory & Swap"
 msgstr "Memoria & Scambio"
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Utilizzo memoria: $0%"
+#: pkg/machines/components/vm/memoryModal.jsx:103
+#: pkg/machines/components/vm/memoryModal.jsx:113
+#, fuzzy
+msgid "Memory could not be saved"
+msgstr "Non è stato possibile salvare le impostazioni del VCPU"
 
-#: pkg/docker/index.html:452 pkg/docker/index.html:624
+#: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "Limite memoria"
 
-#: pkg/docker/index.html:210
-msgid "Memory usage:"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#, fuzzy
+msgid "Memory must not be 0"
 msgstr "Utilizzo memoria:"
 
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
-msgid "Message"
-msgstr "Messaggio"
+#: pkg/machines/components/vm/memoryModal.jsx:158
+msgid "Memory size between 128 MiB and the maximum allocation"
+msgstr ""
+
+#: pkg/docker/index.html:211
+msgid "Memory usage:"
+msgstr "Utilizzo memoria:"
 
 #: pkg/systemd/shutdown.js:79
 msgid "Message to logged in users"
 msgstr "Messaggio agli utenti registrati"
 
-#: pkg/kubernetes/views/image-page.html:29
-#: pkg/kubernetes/views/imagestream-page.html:30
 #: node_modules/registry-image-widgets/views/image-panel.html:15
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
 msgstr "Metadati"
 
-#: pkg/storaged/lvol-tabs.jsx:445
+#: pkg/storaged/lvol-tabs.jsx:458
 msgid "Metadata Used"
 msgstr "Metadati utilizzati"
 
-#: pkg/docker/index.html:466 pkg/docker/index.html:638
-#: pkg/machines/components/diskAdd.jsx:158
-#: pkg/machines/components/memorySelectRow.jsx:46
+#: pkg/docker/index.html:468 pkg/docker/index.html:640
+#: pkg/machines/components/vm/memoryModal.jsx:150
+#: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
-
-#: pkg/ovirt/components/OVirtTab.jsx:70
-msgid "Migrate To:"
-msgstr "Migrare a:"
 
 #: pkg/lib/machine-info.js:98
 msgid "Mini PC"
@@ -4682,11 +3928,11 @@ msgstr "Mini PC"
 msgid "Mini Tower"
 msgstr "Mini Torre"
 
-#: pkg/systemd/init.js:1344 pkg/systemd/init.js:1353 pkg/systemd/init.js:1362
+#: pkg/systemd/init.js:1338 pkg/systemd/init.js:1347 pkg/systemd/init.js:1356
 msgid "Minute needs to be a number between 0-59"
 msgstr "Il minuto deve essere un numero compreso tra 0-59"
 
-#: pkg/systemd/services.html:466
+#: pkg/systemd/services.html:464
 msgid "Minutes"
 msgstr "Minuti"
 
@@ -4694,7 +3940,7 @@ msgstr "Minuti"
 msgid "Mitigations"
 msgstr ""
 
-#: pkg/networkmanager/index.html:292
+#: pkg/networkmanager/index.html:284
 msgid "Mode"
 msgstr "Modalità"
 
@@ -4702,20 +3948,16 @@ msgstr "Modalità"
 msgid "Model"
 msgstr "Modello"
 
-#: pkg/machines/components/vmnetworktab.jsx:93
+#: pkg/machines/components/vmnetworktab.jsx:123
 msgid "Model type"
 msgstr "Tipo di modello"
-
-#: pkg/kubernetes/views/user-modify.html:27
-msgid "Modify"
-msgstr "Modifica"
 
 #: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:45
 #: pkg/storaged/jobs-panel.jsx:52
 msgid "Modifying $target"
 msgstr "Modificare $target"
 
-#: pkg/systemd/services.html:237
+#: pkg/systemd/services.html:235
 msgid "Monday"
 msgstr "Lunedì"
 
@@ -4723,19 +3965,15 @@ msgstr "Lunedì"
 msgid "Mondays"
 msgstr ""
 
-#: pkg/networkmanager/index.html:307
+#: pkg/networkmanager/index.html:299
 msgid "Monitoring Interval"
 msgstr "Intervallo di monitoraggio"
 
-#: pkg/networkmanager/index.html:311
+#: pkg/networkmanager/index.html:303
 msgid "Monitoring Targets"
 msgstr "Obiettivi di monitoraggio"
 
-#: pkg/kubernetes/views/volume-body.html:54
-msgid "Monitors"
-msgstr "Monitor"
-
-#: pkg/realmd/operation.js:530
+#: pkg/realmd/operation.js:529
 msgid "More"
 msgstr "Di più"
 
@@ -4748,35 +3986,31 @@ msgstr "Per saperne di più"
 msgid "More details"
 msgstr "Maggiori dettagli"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:166
-#: pkg/storaged/fsys-tab.jsx:189 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Mount"
 
-#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
-msgid "Mount Location"
-msgstr "Posizione di montaggio"
-
-#: pkg/storaged/fsys-tab.jsx:174 pkg/storaged/nfs-details.jsx:172
-#: pkg/storaged/format-dialog.jsx:85
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Opzioni di montaggio"
 
-#: pkg/storaged/fsys-panel.jsx:109 pkg/storaged/fsys-tab.jsx:160
-#: pkg/storaged/nfs-details.jsx:318 pkg/storaged/nfs-panel.jsx:102
-#: pkg/storaged/format-dialog.jsx:75
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Punto di montaggio"
 
-#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:93
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Montaggio all'avvio"
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:521
 msgid "Mount container volumes"
 msgstr "Montare i volumi dei container"
 
-#: pkg/storaged/format-dialog.jsx:82
+#: pkg/storaged/format-dialog.jsx:78
 msgid "Mount point can not be empty"
 msgstr "Il punto di montaggio non può essere vuoto."
 
@@ -4788,15 +4022,15 @@ msgstr "Il punto di montaggio non può essere vuoto."
 msgid "Mount point must start with \"/\"."
 msgstr "Il punto di montaggio deve iniziare con \"/\"."
 
-#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:94
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Montaggio in sola lettura"
 
-#: pkg/storaged/fsys-tab.jsx:183
+#: pkg/storaged/fsys-tab.jsx:180
 msgid "Mounted At"
 msgstr "Montato a"
 
-#: pkg/storaged/format-dialog.jsx:68
+#: pkg/storaged/format-dialog.jsx:64
 msgid "Mounting"
 msgstr "Montaggio"
 
@@ -4808,15 +4042,11 @@ msgstr "Montaggio $target"
 msgid "Multi-system Chassis"
 msgstr "Telaio multisistema"
 
-#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:101
+#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:93
 msgid "NAT to $0"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:865
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:140
 msgid "NFS Mount"
 msgstr "Montaggio NFS"
 
@@ -4828,66 +4058,41 @@ msgstr "Supporti NFS"
 msgid "NFS Support not installed"
 msgstr "Supporto NFS non installato"
 
-#: pkg/machines/components/vmnetworktab.jsx:67
+#: pkg/machines/components/vmnetworktab.jsx:97
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2005
+#: pkg/networkmanager/interfaces.js:2008
 msgid "NSNA Ping"
 msgstr "NSNA Ping"
 
-#: pkg/systemd/host.js:1510
+#: pkg/systemd/host.js:1514
 msgid "NTP Server"
 msgstr "Server NTP"
 
-#: pkg/docker/index.html:267 pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/containers-listing.html:11
-#: pkg/kubernetes/views/dashboard-page.html:156
-#: pkg/kubernetes/views/dashboard-page.html:198
-#: pkg/kubernetes/views/details-page.html:34
-#: pkg/kubernetes/views/details-page.html:70
-#: pkg/kubernetes/views/details-page.html:103
-#: pkg/kubernetes/views/details-page.html:137
-#: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/service-modify.html:9
-#: pkg/kubernetes/views/user-modify.html:9
-#: pkg/kubernetes/views/volume-body.html:31
-#: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:127
-#: pkg/networkmanager/index.html:145 pkg/networkmanager/index.html:173
-#: pkg/networkmanager/index.html:217 pkg/networkmanager/index.html:270
-#: pkg/networkmanager/index.html:327
+#: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
+#: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
+#: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
+#: pkg/networkmanager/index.html:319
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
-#: pkg/machines/components/diskAdd.jsx:125
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:66
-#: pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:105 pkg/storaged/content-views.jsx:645
-#: pkg/storaged/fsys-panel.jsx:108 pkg/storaged/fsys-tab.jsx:72
-#: pkg/storaged/fsys-tab.jsx:153 pkg/storaged/iscsi-panel.jsx:127
-#: pkg/storaged/iscsi-panel.jsx:178 pkg/storaged/lvol-tabs.jsx:33
-#: pkg/storaged/lvol-tabs.jsx:346 pkg/storaged/lvol-tabs.jsx:396
-#: pkg/storaged/lvol-tabs.jsx:431 pkg/storaged/mdraids-panel.jsx:40
-#: pkg/storaged/part-tab.jsx:33 pkg/storaged/vdos-panel.jsx:48
-#: pkg/storaged/vgroup-details.jsx:181 pkg/storaged/vgroups-panel.jsx:55
-#: pkg/storaged/format-dialog.jsx:289 pkg/systemd/init.js:281
-#: pkg/systemd/hwinfo.jsx:79
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
+#: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
+#: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Nome"
 
@@ -4919,7 +4124,7 @@ msgstr "Il nome non può contenere il carattere '$0''."
 msgid "Name cannot contain whitespace."
 msgstr "Il nome non può contenere spazi bianchi."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:387
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
 msgid "Name should not be empty"
 msgstr "Il nome non deve essere vuoto"
@@ -4928,27 +4133,7 @@ msgstr "Il nome non deve essere vuoto"
 msgid "Name: "
 msgstr ""
 
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
-#: pkg/kubernetes/views/details-page.html:36
-#: pkg/kubernetes/views/details-page.html:72
-#: pkg/kubernetes/views/details-page.html:105
-#: pkg/kubernetes/views/details-page.html:139
-#: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
-#: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
-#: pkg/kubernetes/views/service-body.html:5
-#: pkg/kubernetes/views/volumes-page.html:59
-msgid "Namespace"
-msgstr "Namespace"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "Il namespace dei nomi non può essere vuoto."
-
-#: pkg/systemd/host.js:1344
+#: pkg/systemd/host.js:1348
 msgid "Need at least one NTP server"
 msgstr "Immettere almeno un server NTP"
 
@@ -4957,19 +4142,18 @@ msgid "Netmask"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:613
 msgid "Network"
 msgstr "Rete"
 
-#: pkg/machines/components/networks/network.jsx:117
+#: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/networks/network.jsx:129
+#: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:316
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
 msgid "Network Boot (PXE)"
 msgstr ""
 
@@ -4981,11 +4165,11 @@ msgstr "Sistema di file di rete"
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:230
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Network Selection does not support PXE."
 msgstr ""
 
-#: pkg/systemd/host.js:546
+#: pkg/systemd/host.js:550
 msgid "Network Traffic"
 msgstr "Traffico di rete"
 
@@ -4993,7 +4177,7 @@ msgstr "Traffico di rete"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "I dispositivi di rete e i grafici richiedono NetworkManager."
 
-#: pkg/machines/components/nicEdit.jsx:216
+#: pkg/machines/components/nicEdit.jsx:232
 msgid "Network interface settings could not be saved"
 msgstr ""
 
@@ -5001,17 +4185,17 @@ msgstr ""
 msgid "NetworkManager is not running."
 msgstr "NetworkManager non è in esecuzione."
 
-#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:393
-#: pkg/networkmanager/firewall.jsx:585
+#: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
+#: pkg/networkmanager/firewall.jsx:914
 msgid "Networking"
 msgstr "Rete"
 
-#: pkg/networkmanager/interfaces.js:1622 pkg/networkmanager/interfaces.js:2199
+#: pkg/networkmanager/interfaces.js:1625 pkg/networkmanager/interfaces.js:2207
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Rete"
 
-#: pkg/networkmanager/index.html:157
+#: pkg/networkmanager/index.html:149
 msgid "Networking Logs"
 msgstr "Log di rete"
 
@@ -5020,56 +4204,37 @@ msgstr "Log di rete"
 msgid "Networks"
 msgstr "Reti"
 
-#: pkg/users/local.js:963
+#: pkg/users/local.js:967
 msgid "Never"
 msgstr "Mai"
 
-#: pkg/users/index.html:297 pkg/users/local.js:868
+#: pkg/users/index.html:297 pkg/users/local.js:872
 msgid "Never expire password"
 msgstr "Non scadere mai la password"
 
-#: pkg/users/index.html:258 pkg/users/local.js:876
+#: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "Non chiudere mai il conto"
-
-#: pkg/kubernetes/views/project-listing.html:46
-msgid "New Group"
-msgstr "Nuovo gruppo"
 
 #: pkg/storaged/nfs-details.jsx:140
 msgid "New NFS Mount"
 msgstr "Nuovo supporto NFS"
 
-#: pkg/shell/index.html:309 pkg/users/index.html:218
+#: pkg/shell/index.html:289 pkg/users/index.html:218
 msgid "New Password"
 msgstr "Nuova password"
 
-#: pkg/kubernetes/views/project-listing.html:7
-msgid "New Project"
-msgstr "Nuovo progetto"
-
-#: pkg/machines/components/diskAdd.jsx:131
+#: pkg/machines/components/diskAdd.jsx:132
 msgid "New Volume Name"
 msgstr "Nuovo nome del volume"
-
-#: pkg/kubernetes/views/images-page.html:11
-#: pkg/kubernetes/views/registry-dashboard-page.html:86
-msgid "New image stream"
-msgstr "Nuovo flusso di immagini"
 
 #: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
 msgid "New passphrase"
 msgstr "Nuova passphrase"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Nuova password non è stata accettata"
-
-#: pkg/kubernetes/views/project-modify.html:4
-#: pkg/kubernetes/views/registry-dashboard-page.html:9
-#: pkg/kubernetes/views/registry-dashboard-page.html:48
-msgid "New project"
-msgstr "Nuovo progetto"
 
 #: pkg/realmd/operation.html:82 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
@@ -5079,29 +4244,28 @@ msgstr "Avanti"
 msgid "Next Run"
 msgstr "Prossima esecuzione"
 
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1581
+#: pkg/systemd/index.html:226 pkg/systemd/host.js:1585
 msgid "Nice"
 msgstr "Nice"
 
-#: pkg/docker/index.html:542 pkg/docker/index.html:546 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/kubernetes/scripts/volumes.js:998
-#: pkg/networkmanager/interfaces.js:2586
+#: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
 msgid "No"
 msgstr "No"
 
-#: pkg/systemd/index.html:462
+#: pkg/systemd/index.html:454
 msgid "No Delay"
 msgstr "Nessun ritardo"
 
-#: pkg/storaged/format-dialog.jsx:256
+#: pkg/storaged/format-dialog.jsx:252
 msgid "No Filesystem"
 msgstr "Nessun file system"
 
-#: pkg/storaged/content-views.jsx:719
+#: pkg/storaged/content-views.jsx:715
 msgid "No Logical Volumes"
 msgstr "Nessun volume logico"
 
-#: pkg/systemd/services.html:194
+#: pkg/systemd/services.html:192
 msgid "No Matching Results"
 msgstr ""
 
@@ -5109,38 +4273,33 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Nessun supporto NFS configurato"
 
-#: src/ws/cockpitcertificate.c:522
-msgid "No PEM-encoded certificate found"
-msgstr "Nessun certificato codificato PEM trovato"
-
-#: src/ws/cockpitcertificate.c:488
-msgid "No PEM-encoded private key found"
-msgstr "Nessuna chiave privata codificata PEM trovata"
-
-#: pkg/kubernetes/views/pv-claim.html:39
-msgid "No Pods are using this claim"
-msgstr "Nessun baccello sta usando questo claim"
-
 #: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "No SELinux alerts."
 msgstr "Nessun allarme SELinux."
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:70
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:216
+#, fuzzy
+msgid "No Storage Pools available"
+msgstr "Nome della piscina di stoccaggio"
+
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr "Nessun volume di stoccaggio definito per questo pool di stoccaggio"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:29
-#: pkg/ovirt/components/ClusterVms.jsx:36
-msgid "No VM found in oVirt."
-msgstr "Nessuna VM trovata in oVirt."
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
 msgstr "Nessuna VM è in esecuzione o definita su questo host"
 
-#: pkg/kubernetes/views/pvc-body.html:10
-msgid "No Volume Bound"
-msgstr "Nessun volume legato"
+#: pkg/machines/components/nicEdit.jsx:110
+#, fuzzy
+msgid "No Virtual Networks"
+msgstr "Nessuna rete virtuale"
+
+#: pkg/networkmanager/firewall.jsx:926
+#, fuzzy
+msgid "No active zones"
+msgstr "Volume inattivo"
 
 #: pkg/docker/storage.jsx:206
 msgid "No additional local storage found."
@@ -5154,7 +4313,7 @@ msgstr "Nessun alias specificato"
 msgid "No applications installed or available"
 msgstr "Nessuna applicazione installata o disponibile"
 
-#: pkg/sosreport/index.js:128
+#: pkg/sosreport/index.js:129
 msgid "No archive has been created."
 msgstr "Non è stato creato alcun archivio."
 
@@ -5162,11 +4321,11 @@ msgstr "Non è stato creato alcun archivio."
 msgid "No available slots"
 msgstr "Non ci sono slot disponibili"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:47
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:48
 msgid "No boot device found"
 msgstr "Nessun dispositivo di avvio trovato"
 
-#: pkg/networkmanager/interfaces.js:1416
+#: pkg/networkmanager/interfaces.js:1419
 msgid "No carrier"
 msgstr "Nessun vettore"
 
@@ -5190,21 +4349,26 @@ msgstr "Nessun contenitore"
 msgid "No containers that match the current filter"
 msgstr "Nessun contenitore che corrisponde al filtro corrente"
 
+#: pkg/networkmanager/firewall.jsx:729
+#, fuzzy
+msgid "No description available"
+msgstr "Nessuna descrizione fornita."
+
 #: pkg/apps/application.jsx:79
 msgid "No description provided."
 msgstr "Nessuna descrizione fornita."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Nessun disco disponibile"
 
-#: pkg/machines/components/vmDisksTab.jsx:82
+#: pkg/machines/components/vmDisksTab.jsx:85
 msgid "No disks defined for this VM"
 msgstr "Nessun disco definito per questa VM"
 
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:121
 msgid "No drives attached"
 msgstr "Nessuna unità collegata"
 
@@ -5212,13 +4376,9 @@ msgstr "Nessuna unità collegata"
 msgid "No free key slots"
 msgstr "Nessuna fessura per le chiavi libere"
 
-#: pkg/storaged/content-views.jsx:704
+#: pkg/storaged/content-views.jsx:700
 msgid "No free space"
 msgstr "Nessuno spazio libero disponibile"
-
-#: pkg/kubernetes/views/project-listing.html:74
-msgid "No groups are present."
-msgstr "Non sono presenti gruppi."
 
 #: pkg/systemd/index.html:29
 msgid "No host keys found."
@@ -5236,27 +4396,19 @@ msgstr "Non sono presenti flussi di immagini."
 msgid "No images"
 msgstr "Nessuna immagine"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:80
-msgid "No images pushed"
-msgstr "Nessuna immagine spinta"
-
 #: pkg/docker/containers-view.jsx:707
 msgid "No images that match the current filter"
 msgstr "Nessuna immagine che corrisponde al filtro corrente"
 
-#: pkg/apps/utils.jsx:95
+#: pkg/apps/utils.jsx:96
 msgid "No installation package found for this application."
 msgstr "Nessun pacchetto di installazione trovato per questa applicazione."
-
-#: pkg/subscriptions/subscriptions-view.jsx:246
-msgid "No installed products on the system."
-msgstr "Nessun prodotto installato sul sistema."
 
 #: pkg/storaged/crypto-keyslots.jsx:520
 msgid "No keys added"
 msgstr "Nessuna chiave aggiunta"
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:198
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:201
 msgid "No matching files found"
 msgstr "Nessun file corrispondente trovato"
 
@@ -5274,14 +4426,7 @@ msgstr ""
 "comando del kernel (p.e. in /etc/default/grub) per riservare memoria "
 "all'avvio. Esempio: crashkernel=512M"
 
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr ""
-"Non è stato selezionato alcun file di metadati. Selezionare un file di "
-"metadati Kubernetes."
-
-#: pkg/machines/components/vmnetworktab.jsx:40
+#: pkg/machines/components/vmnetworktab.jsx:70
 msgid "No network interfaces defined for this VM"
 msgstr "Nessuna interfaccia di rete definita per questa macchina virtuale"
 
@@ -5289,43 +4434,20 @@ msgstr "Nessuna interfaccia di rete definita per questa macchina virtuale"
 msgid "No network is defined on this host"
 msgstr ""
 
-#: pkg/kubernetes/views/dashboard-page.html:117
-msgid "No nodes in cluster"
-msgstr "Nessun nodo in cluster"
+#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:180
+#, fuzzy
+msgid "No networks available"
+msgstr "Non disponibile"
 
-#: pkg/ovirt/components/App.jsx:61
-msgid "No oVirt connection"
-msgstr "Nessuna connessione oVirt"
-
-#: pkg/networkmanager/firewall.jsx:596
+#: pkg/networkmanager/firewall.jsx:939
 msgid "No open ports"
 msgstr "Nessuna porta aperta"
 
-#: pkg/storaged/content-views.jsx:530
+#: pkg/storaged/content-views.jsx:526
 msgid "No partitioning"
 msgstr "Nessuna suddivisione"
 
-#: pkg/kubernetes/views/dashboard-page.html:40
-msgid "No pods deployed"
-msgstr "Nessun baccello dispiegato"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:6
-msgid "No pods replicated"
-msgstr "Nessun baccello replicato"
-
-#: pkg/kubernetes/views/node-capacity.html:11
-msgid "No pods scheduled"
-msgstr "Nessun baccello in programma"
-
-#: pkg/kubernetes/views/service-endpoint.html:10
-msgid "No pods selected"
-msgstr "Nessun baccello selezionato"
-
-#: pkg/kubernetes/views/project-listing.html:37
-msgid "No projects are present."
-msgstr "Non sono presenti progetti."
-
-#: pkg/users/local.js:449
+#: pkg/users/local.js:453
 msgid "No real name specified"
 msgstr "Nessun nome reale specificato"
 
@@ -5365,52 +4487,18 @@ msgstr "Non sono presenti tag."
 msgid "No updates pending"
 msgstr "Nessun aggiornamento in attesa"
 
-#: pkg/users/local.js:444
+#: pkg/users/local.js:448
 msgid "No user name specified"
 msgstr "Nessun nome utente specificato"
-
-#: pkg/kubernetes/views/project-listing.html:112
-msgid "No users are present."
-msgstr "Non ci sono utenti presenti."
-
-#: pkg/machines/components/nicEdit.jsx:111
-msgid "No virtual networks"
-msgstr "Nessuna rete virtuale"
 
 #: pkg/storaged/vgroups-panel.jsx:114
 msgid "No volume groups created"
 msgstr "Nessun gruppo di volumi creato"
 
-#: pkg/kubernetes/views/volumes-page.html:44
-msgid "No volumes are present."
-msgstr "Non sono presenti volumi."
-
-#: pkg/kubernetes/views/dashboard-page.html:73
-msgid "No volumes in use"
-msgstr "Nessun volume in uso"
-
-#: pkg/kubernetes/views/containers-listing.html:15
-#: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
-#: pkg/kubernetes/views/topology-page.html:38
-msgid "Node"
-msgstr "Nodo"
-
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
-#: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
-msgid "Nodes"
-msgstr "Nodi"
-
-#: pkg/kubernetes/views/topology-page.html:39
-msgid "Nodes are the machines that run your containers."
-msgstr "I nodi sono le macchine che gestiscono i vostri container."
-
 # FIXME: consultare bug 572158
-#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
-#: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Nessuno"
 
@@ -5418,33 +4506,23 @@ msgstr "Nessuno"
 msgid "None (Isolated Network)"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
-#: pkg/kubernetes/scripts/nodes.js:319
+#: pkg/playground/translate.html:29
 msgid "Not Ready"
 msgstr "Non pronto"
-
-#: pkg/kubernetes/scripts/details.js:496 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "Non un numero valido di repliche"
 
 #: pkg/lib/credentials.js:255
 msgid "Not a valid private key"
 msgstr "Non una chiave privata valida"
 
-#: pkg/kubernetes/scripts/details.js:547
-msgid "Not a valid value for Host"
-msgstr "Non è un valore valido per Host"
-
 #: pkg/docker/index.html:57
 msgid "Not authorized to access Docker on this system"
 msgstr "Non autorizzato ad accedere a Docker su questo sistema"
 
-#: pkg/systemd/logs.js:522
+#: pkg/systemd/logs.js:527
 msgid "Not authorized to upload-report"
 msgstr "Non autorizzato a caricare-report"
 
-#: pkg/networkmanager/interfaces.js:819
+#: pkg/networkmanager/interfaces.js:822
 msgid "Not available"
 msgstr "Non disponibile"
 
@@ -5452,12 +4530,7 @@ msgstr "Non disponibile"
 msgid "Not connected"
 msgstr "Non connesso"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
-#: pkg/kubernetes/views/details-page.html:122
-msgid "Not deployed"
-msgstr "Non utilizzato"
-
-#: pkg/storaged/lvol-tabs.jsx:375
+#: pkg/storaged/lvol-tabs.jsx:369
 msgid "Not enough space to grow."
 msgstr "Spazio non sufficiente"
 
@@ -5473,7 +4546,7 @@ msgstr "Non montato"
 msgid "Not permitted to perform this action."
 msgstr "Non è consentito eseguire questa azione."
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Not running"
 msgstr "Non in esecuzione"
 
@@ -5485,7 +4558,7 @@ msgstr "Non sincronizzato"
 msgid "Not yet synced"
 msgstr "Non ancora sincronizzato"
 
-#: pkg/systemd/services.html:359
+#: pkg/systemd/services.html:357
 msgid "Note"
 msgstr "Note"
 
@@ -5493,37 +4566,13 @@ msgstr "Note"
 msgid "Notebook"
 msgstr "Notebook"
 
-#: pkg/systemd/logs.html:60
+#: pkg/systemd/logs.html:61
 msgid "Notice and above"
 msgstr "Notice e oltre"
 
-#: pkg/ovirt/components/vcpuModal.jsx:55
-msgid "Number of virtual CPUs that gonna be used."
-msgstr "Numero di CPU virtuali che verranno utilizzate."
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
-#: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
-msgid "OK"
-msgstr "OK"
-
-# translation auto-copied from project Satellite6 Katello, version Sam-1.3.0, document katello, author fvalen
-#: pkg/kubernetes/views/node-body.html:13
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "OS"
-msgstr "OS"
-
-#: pkg/ovirt/components/OVirtTab.jsx:148
-msgid "OS Type:"
-msgstr "Tipo di OS:"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:327
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
 msgid "OS Vendor"
 msgstr "Fornitore di OS"
-
-#: pkg/kubernetes/views/nodes-page.html:19
-msgid "OS Versions"
-msgstr "Versioni OS"
 
 #: pkg/selinux/setroubleshoot-view.jsx:394
 msgid "Occurred $0"
@@ -5533,9 +4582,6 @@ msgstr "Si è verificato $0"
 msgid "Occurred between $0 and $1"
 msgstr "Si è verificato tra $0 e $1"
 
-#: pkg/networkmanager/index.html:105 pkg/playground/jquery-patterns.html:97
-#: pkg/playground/jquery-patterns.html:110 pkg/shell/index.html:241
-#: pkg/systemd/index.html:163 pkg/lib/cockpit-components-onoff.jsx:72
 #: pkg/lib/patterns.js:246
 msgid "Off"
 msgstr "Off"
@@ -5544,7 +4590,7 @@ msgstr "Off"
 msgid "Ok"
 msgstr "Ok"
 
-#: pkg/shell/index.html:301 pkg/users/index.html:215
+#: pkg/shell/index.html:281 pkg/users/index.html:215
 msgid "Old Password"
 msgstr "Vecchia password"
 
@@ -5552,13 +4598,10 @@ msgstr "Vecchia password"
 msgid "Old passphrase"
 msgstr "Vecchia passphrase"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Vecchia password non accettata"
 
-#: pkg/networkmanager/index.html:101 pkg/playground/jquery-patterns.html:93
-#: pkg/playground/jquery-patterns.html:106 pkg/shell/index.html:237
-#: pkg/systemd/index.html:159 pkg/lib/cockpit-components-onoff.jsx:73
 #: pkg/lib/patterns.js:246
 msgid "On"
 msgstr "On"
@@ -5567,7 +4610,7 @@ msgstr "On"
 msgid "On Build"
 msgstr "Su costruire"
 
-#: pkg/docker/index.html:547 pkg/systemd/init.js:737
+#: pkg/docker/index.html:549 pkg/systemd/init.js:731
 msgid "On Failure"
 msgstr "In caso di guasto"
 
@@ -5589,7 +4632,7 @@ msgstr ""
 "Una volta installato il Cockpit, abilitarlo con \"systemctl enable --ora "
 "cockpit.socket\"."
 
-#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:338
+#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
 msgstr "Password unica"
 
@@ -5603,15 +4646,19 @@ msgstr ""
 msgid "Only $0 of $1 are used."
 msgstr "$1Vengono utilizzati solo $0di δ."
 
-#: pkg/systemd/logs.html:55
+#: pkg/systemd/logs.html:56
 msgid "Only Emergency"
 msgstr "Solo emergenza"
 
-#: pkg/systemd/init.js:1294
+#: pkg/systemd/init.js:1288
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "Sono ammessi solo gli alfabeti, i numeri, : , _ , _ , . , , @ , -."
 
-#: pkg/shell/index.html:43 pkg/shell/simple.html:29 pkg/shell/stub.html:33
+#: pkg/machines/components/vm/memoryModal.jsx:196
+msgid "Only editable when the guest is shut off"
+msgstr ""
+
+#: pkg/shell/index.html:43 pkg/shell/simple.html:29
 msgid "Ooops!"
 msgstr "Ooops!"
 
@@ -5619,8 +4666,8 @@ msgstr "Ooops!"
 msgid "Open"
 msgstr ""
 
-#: pkg/kubernetes/views/nodes-page.html:42 pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:336
+#: pkg/systemd/index.html:98
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
 msgid "Operating System"
 msgstr "Sistema Operativo"
 
@@ -5628,18 +4675,19 @@ msgstr "Sistema Operativo"
 msgid "Operation '$operation' on $target"
 msgstr "Operazione ' ' ' ' su $target"
 
+#: pkg/machines/components/storagePools/storagePool.jsx:175
+#: pkg/machines/components/storagePools/storagePool.jsx:180
+#, fuzzy
+msgid "Operation is in progress"
+msgstr "oVirt login in corso"
+
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Unità ottica"
 
-#: pkg/ovirt/components/OVirtTab.jsx:157
-msgid "Optimized for:"
-msgstr "Ottimizzato per:"
-
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:137
-#: pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
 msgid "Options"
 msgstr "Opzioni"
 
@@ -5647,17 +4695,12 @@ msgstr "Opzioni"
 msgid "Or use a bundled browser"
 msgstr "Oppure utilizzare un browser in bundle"
 
-# translation auto-copied from project subscription-manager, version 1.9.X, document keys, author fvalen
-#: pkg/subscriptions/subscriptions-register.jsx:180
-msgid "Organization"
-msgstr "Organizzazione"
-
 # translation auto-copied from project control-center, version 3.8.6, document gnome-control-center-2.0
 #: pkg/lib/machine-info.js:64
 msgid "Other"
 msgstr "Altro"
 
-#: pkg/storaged/content-views.jsx:357
+#: pkg/storaged/content-views.jsx:353
 msgctxt "storage-id-desc"
 msgid "Other Data"
 msgstr "Altri dati"
@@ -5671,25 +4714,19 @@ msgid "Other Options"
 msgstr "Altre opzioni"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:297 pkg/kubernetes/index.html:43
-#: pkg/kubernetes/registry.html:43
-#: pkg/machines/components/networks/network.jsx:71
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Panoramica"
 
-#: pkg/storaged/content-views.jsx:521 pkg/storaged/format-dialog.jsx:284
+#: pkg/storaged/content-views.jsx:517 pkg/storaged/format-dialog.jsx:281
 msgid "Overwrite existing data with zeros"
 msgstr "Sovrascrivere i dati esistenti con zeri"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "PCI"
 msgstr "PCI"
-
-#: pkg/kubernetes/views/volume-body.html:4
-msgid "PD Name"
-msgstr "Nome PD"
 
 #: pkg/packagekit/updates.jsx:501
 msgid "Package information"
@@ -5707,24 +4744,23 @@ msgstr "PackageKit non è installato"
 msgid "PackageKit reported error code $0"
 msgstr "Codice di errore segnalato da PackageKit $0"
 
-#: pkg/networkmanager/index.html:164
+#: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "Padre"
 
-#: pkg/networkmanager/interfaces.js:2895
+#: pkg/networkmanager/interfaces.js:2903
 msgid "Parent $parent"
 msgstr "Genitore $parent"
 
-#: pkg/systemd/init.js:727
+#: pkg/systemd/init.js:721
 msgid "Part Of"
 msgstr "Parte di"
 
-#: pkg/networkmanager/interfaces.js:1462
+#: pkg/networkmanager/interfaces.js:1465
 msgid "Part of "
 msgstr "Parte di "
 
-#: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:135
+#: pkg/storaged/content-views.jsx:141
 msgid "Partition"
 msgstr "Partizione"
 
@@ -5732,23 +4768,23 @@ msgstr "Partizione"
 msgid "Partition of $0"
 msgstr "Partizione di $0"
 
-#: pkg/storaged/content-views.jsx:523
+#: pkg/storaged/content-views.jsx:519
 msgid "Partitioning"
 msgstr "Partizionamento"
 
-#: pkg/networkmanager/interfaces.js:1997
+#: pkg/networkmanager/interfaces.js:2000
 msgid "Passive"
 msgstr "Passivo"
 
 # translation auto-copied from project Anaconda, version master, document anaconda
-#: pkg/storaged/content-views.jsx:232 pkg/storaged/crypto-keyslots.jsx:206
-#: pkg/storaged/crypto-keyslots.jsx:552 pkg/storaged/format-dialog.jsx:298
+#: pkg/storaged/content-views.jsx:224 pkg/storaged/crypto-keyslots.jsx:206
+#: pkg/storaged/crypto-keyslots.jsx:552 pkg/storaged/format-dialog.jsx:296
 msgid "Passphrase"
 msgstr "Passphrase"
 
 #: pkg/storaged/crypto-keyslots.jsx:157 pkg/storaged/crypto-keyslots.jsx:212
 #: pkg/storaged/crypto-keyslots.jsx:250 pkg/storaged/crypto-keyslots.jsx:254
-#: pkg/storaged/format-dialog.jsx:301
+#: pkg/storaged/format-dialog.jsx:299
 msgid "Passphrase cannot be empty"
 msgstr "La frase non può essere vuota"
 
@@ -5757,17 +4793,15 @@ msgid "Passphrase removal may prevent unlocking $0."
 msgstr "La rimozione della passphrase può impedire lo sblocco $0."
 
 #: pkg/storaged/crypto-keyslots.jsx:219 pkg/storaged/crypto-keyslots.jsx:257
-#: pkg/storaged/format-dialog.jsx:308
+#: pkg/storaged/format-dialog.jsx:306
 msgid "Passphrases do not match"
 msgstr "Le passphrase non corrispondono"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
-#: pkg/shell/index.html:212 pkg/shell/index.html:251 pkg/shell/index.html:264
-#: pkg/users/index.html:118 pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
-#: pkg/subscriptions/subscriptions-register.jsx:89
-#: pkg/subscriptions/subscriptions-register.jsx:156
 msgid "Password"
 msgstr "Password"
 
@@ -5783,7 +4817,7 @@ msgstr "La password non è accettabile"
 msgid "Password is too weak"
 msgstr "La password è troppo debole"
 
-#: pkg/users/local.js:870
+#: pkg/users/local.js:874
 msgid "Password must be changed"
 msgstr "La password deve essere cambiata"
 
@@ -5806,19 +4840,15 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Incollare qui il contenuto del file della chiave SSH pubblica"
 
-#: pkg/kubernetes/views/pv-modify.html:126
-#: pkg/kubernetes/views/volume-body.html:37
-#: pkg/kubernetes/views/volume-body.html:49
-#: pkg/kubernetes/views/volume-body.html:101 pkg/systemd/services.html:128
-#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
 msgid "Path"
 msgstr "Percorso"
 
-#: pkg/networkmanager/index.html:256
+#: pkg/networkmanager/index.html:248
 msgid "Path cost"
 msgstr "Costo percorso"
 
-#: pkg/networkmanager/interfaces.js:2877
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Path cost $path_cost"
 msgstr "Costo della traiettoria $path_costo"
 
@@ -5826,7 +4856,7 @@ msgstr "Costo della traiettoria $path_costo"
 msgid "Path on Server"
 msgstr "Percorso su server"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:126
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
 msgid "Path on host's filesystem"
 msgstr "Percorso sul filesystem dell'host"
 
@@ -5838,11 +4868,11 @@ msgstr "Il percorso sul server non può essere vuoto."
 msgid "Path on server must start with \"/\"."
 msgstr "Il percorso sul server deve iniziare con \"/\"."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
 msgid "Path to ISO file on host's file system"
 msgstr "Percorso al file ISO sul file system dell'host"
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:258
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:261
 msgid "Path to file"
 msgstr "Percorso da file"
 
@@ -5854,10 +4884,6 @@ msgstr "Percorsi"
 msgid "Pause"
 msgstr ""
 
-#: pkg/kubernetes/views/volumes-page.html:53
-msgid "Pending Volume Claims"
-msgstr "Reclami sui volumi in sospeso"
-
 #: pkg/systemd/index.html:152
 msgid "Performance Profile"
 msgstr "Profilo di prestazione"
@@ -5866,45 +4892,45 @@ msgstr "Profilo di prestazione"
 msgid "Peripheral Chassis"
 msgstr "Telaio periferico"
 
-#: pkg/networkmanager/interfaces.js:3611
+#: pkg/networkmanager/interfaces.js:3630
 msgid "Permanent"
 msgstr "Salvata"
 
-#: src/ws/login.js:660
+#: src/ws/login.js:663
 msgid "Permission denied"
 msgstr "Permessi negati"
 
-#: pkg/machines/components/diskAdd.jsx:109
+#: pkg/machines/components/diskAdd.jsx:110
 msgid "Persistence"
 msgstr ""
 
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
 #: pkg/machines/components/networks/networkOverviewTab.jsx:83
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:56
 msgid "Persistent"
 msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html:14
-msgid "Persistent Volumes"
-msgstr "Volumi persistenti"
-
-#: pkg/kubernetes/views/pod-body.html:16
-msgid "Phase"
-msgstr "Fase"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
 #: pkg/storaged/vdo-details.jsx:277
 msgid "Physical"
 msgstr "Fisico"
 
-#: pkg/storaged/content-views.jsx:144 pkg/storaged/content-views.jsx:347
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+msgid "Physical Disk Device"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:150 pkg/storaged/content-views.jsx:343
 msgid "Physical Volume"
 msgstr "Volume fisico"
 
-#: pkg/storaged/vgroup-details.jsx:134
+#: pkg/storaged/vgroup-details.jsx:133
 msgid "Physical Volumes"
 msgstr "Volumi fisici"
 
-#: pkg/storaged/content-views.jsx:342
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+msgid "Physical disk device on host"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:338
 msgid "Physical volume of $0"
 msgstr "Volume fisico di $0"
 
@@ -5912,11 +4938,11 @@ msgstr "Volume fisico di $0"
 msgid "Physical volumes can not be resized here."
 msgstr "I volumi fisici non possono essere ridimensionati qui."
 
-#: pkg/networkmanager/index.html:351
+#: pkg/networkmanager/index.html:343
 msgid "Ping Interval"
 msgstr "Intervallo ping"
 
-#: pkg/networkmanager/index.html:355
+#: pkg/networkmanager/index.html:347
 msgid "Ping Target"
 msgstr "Target ping"
 
@@ -5924,10 +4950,10 @@ msgstr "Target ping"
 msgid "Pizza Box"
 msgstr "Scatola della pizza"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:297
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:210
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Si prega di confermare la cancellazione di $0"
 
@@ -5935,118 +4961,23 @@ msgstr "Si prega di confermare la cancellazione di $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Si prega di confermare la cancellazione forzata di $0"
 
-#: pkg/storaged/mdraid-details.jsx:244 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Si prega di confermare l'arresto di $0"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:34
-msgid "Please confirm, the host shall be switched to maintenance mode."
-msgstr ""
-"Si prega di confermare, l'host deve essere impostato sulla modalità di "
-"manutenzione."
-
-#: pkg/kubernetes/scripts/dashboard.js:439
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Si prega di creare un altro namespace per $0 \"$1\""
-
-#: pkg/machines/components/diskAdd.jsx:347
+#: pkg/machines/components/diskAdd.jsx:447
 msgid "Please enter new volume name"
 msgstr "Si prega di inserire il nuovo nome del volume"
 
-#: pkg/machines/components/diskAdd.jsx:350
+#: pkg/machines/components/diskAdd.jsx:450
 msgid "Please enter new volume size"
 msgstr "Si prega di inserire una nuova dimensione del volume"
 
-#: pkg/networkmanager/firewall.jsx:552
+#: pkg/networkmanager/firewall.jsx:864
 msgid "Please install the $0 package"
 msgstr "Si prega di installare il $0pacchetto"
 
-#: pkg/kubernetes/scripts/volumes.js:582
-msgid "Please provide a GlusterFS volume name"
-msgstr "Si prega di fornire un nome di volume GlusterFS"
-
-#: pkg/kubernetes/scripts/connection.js:550
-msgid "Please provide a username"
-msgstr "Si prega di fornire un nome utente"
-
-#: pkg/kubernetes/scripts/volumes.js:640
-msgid "Please provide a valid NFS server"
-msgstr "Si prega di fornire un server NFS valido"
-
-#: pkg/kubernetes/scripts/connection.js:535
-msgid "Please provide a valid address"
-msgstr "Si prega di fornire un indirizzo valido"
-
-#: pkg/kubernetes/scripts/volumes.js:810
-msgid "Please provide a valid filesystem type"
-msgstr "Si prega di fornire un tipo di filesystem valido"
-
-#: pkg/kubernetes/scripts/volumes.js:818
-msgid "Please provide a valid interface"
-msgstr "Si prega di fornire un'interfaccia valida"
-
-#: pkg/kubernetes/scripts/volumes.js:802
-msgid "Please provide a valid logical unit number"
-msgstr "Si prega di fornire un numero di unità logica valido"
-
-#: pkg/kubernetes/scripts/volumes.js:483
-msgid "Please provide a valid name"
-msgstr "Si prega di fornire un nome valido"
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Si prega di fornire un namespace valido."
-
-#: pkg/kubernetes/scripts/volumes.js:648 pkg/kubernetes/scripts/volumes.js:703
-msgid "Please provide a valid path"
-msgstr "Si prega di fornire un percorso valido"
-
-#: pkg/kubernetes/scripts/volumes.js:794
-msgid "Please provide a valid qualified name"
-msgstr "Si prega di fornire un nome qualificato valido"
-
-#: pkg/kubernetes/scripts/volumes.js:491
-msgid "Please provide a valid storage capacity."
-msgstr "Si prega di fornire una capacità di storage valida."
-
-#: pkg/kubernetes/scripts/volumes.js:786
-msgid "Please provide a valid target"
-msgstr "Si prega di fornire un obiettivo valido"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:83
-msgid ""
-"Please provide fully qualified domain name and port of the oVirt engine."
-msgstr ""
-"Si prega di fornire il nome di dominio completo e la porta del motore oVirt."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:137
-msgid ""
-"Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-"port (443 by default)"
-msgstr ""
-"Si prega di fornire un motore oVirt valido, un nome di dominio pienamente "
-"qualificato (FQDN) e una porta (443 di default)"
-
-#: pkg/ovirt/components/ConsoleClientResources.jsx:32
-msgid ""
-"Please refer to oVirt's $0 for more information about Remote Viewer setup."
-msgstr ""
-"Per $0ulteriori informazioni sulla configurazione del Remote Viewer, fare "
-"riferimento a oVirt."
-
-#: pkg/kubernetes/scripts/volumes.js:475
-msgid "Please select a valid access mode"
-msgstr "Selezionare una modalità di accesso valida"
-
-#: pkg/kubernetes/scripts/volumes.js:573
-msgid "Please select a valid endpoint"
-msgstr "Selezionare un punto finale valido"
-
-#: pkg/kubernetes/scripts/volumes.js:499
-msgid "Please select a valid policy option."
-msgstr "Selezionare un'opzione valida."
-
-#: pkg/users/local.js:1232
+#: pkg/users/local.js:1236
 msgid "Please specify an expiration date"
 msgstr "Si prega di specificare una data di scadenza"
 
@@ -6062,103 +4993,39 @@ msgstr "Avviare la macchina virtuale per accedere alla sua console."
 msgid "Please try another term"
 msgstr "Per favore, prova con un altro termine"
 
-#: pkg/kubernetes/scripts/nodes.js:401
-msgid "Please type an address"
-msgstr "Si prega di inserire un indirizzo"
-
-#: pkg/ovirt/components/ClusterVms.jsx:37
-msgid "Please wait till VMs list is loaded from the server."
-msgstr ""
-"Attendere che l'elenco delle macchine virtuali sia caricato dal server."
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:30
-msgid "Please wait till list of templates is loaded from the server."
-msgstr "Attendere che l'elenco dei modelli sia caricato dal server."
-
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Plug"
 msgstr "Spina"
 
-#: pkg/kubernetes/views/containers-listing.html:12
-#: pkg/kubernetes/views/pod-page.html:12
-#: pkg/kubernetes/views/topology-page.html:14
-msgid "Pod"
-msgstr "Baccello"
-
-#: pkg/kubernetes/views/pod-body.html:20
-msgid "Pod Address"
-msgstr "Indirizzo"
-
-#: pkg/kubernetes/views/service-endpoint.html:4
-#: pkg/kubernetes/views/service-endpoint.html:9
-msgid "Pod Endpoints"
-msgstr "Punti finali dei baccelli"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:4
-msgid "Pod Replicated"
-msgstr "Pod replicato"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:11
-#: pkg/kubernetes/views/service-endpoint.html:15
-msgid "Pod Selector"
-msgstr "Selettore di baccelli"
-
-#: pkg/kubernetes/views/dashboard-page.html:18
-#: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/pv-claim.html:37
-#: pkg/kubernetes/views/replicationcontroller-page.html:17
-#: pkg/kubernetes/views/replicationcontroller-panel.html:12
-#: pkg/kubernetes/scripts/details.js:227
-msgid "Pods"
-msgstr "Cialde"
-
-#: pkg/kubernetes/views/topology-page.html:15
-msgid ""
-"Pods contain one or more containers that run together on a node, containing "
-"your application code."
-msgstr ""
-"I baccelli contengono uno o più contenitori che girano insieme su un nodo, "
-"contenente il codice dell'applicazione."
-
+#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:187
-#: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskSourceCell.jsx:40
-#: pkg/storaged/content-views.jsx:127
+#: pkg/machines/components/vmDiskColumns.jsx:45
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Pool"
-
-#: pkg/kubernetes/views/volume-body.html:60
-msgid "Pool Name"
-msgstr "Nome pool"
 
 #: pkg/storaged/utils.js:191
 msgid "Pool for Thin Logical Volumes"
 msgstr "Piscina per volumi logici sottili"
 
-#: pkg/storaged/content-views.jsx:598
+#: pkg/storaged/content-views.jsx:594
 msgid "Pool for Thin Volumes"
 msgstr "Piscina per volumi sottili"
 
-#: pkg/storaged/content-views.jsx:655
+#: pkg/storaged/content-views.jsx:651
 msgid "Pool for thinly provisioned volumes"
 msgstr "Pool per i volumi scarsamente approvvigionati"
 
-#: pkg/kubernetes/views/imagestream-modify.html:45
-msgid "Populate"
-msgstr "Populate"
-
 #: pkg/lib/machine-change-port.html:23
-#: pkg/machines/components/vm/bootOrderModal.jsx:100
-#: pkg/machines/components/vm/bootOrderModal.jsx:112
-#: pkg/machines/components/vmDiskSourceCell.jsx:43
-#: pkg/machines/components/vmnetworktab.jsx:78
-#: pkg/ovirt/components/InstallationDialog.jsx:65
+#: pkg/machines/components/vm/bootOrderModal.jsx:98
+#: pkg/machines/components/vm/bootOrderModal.jsx:110
+#: pkg/machines/components/vmDiskColumns.jsx:48
+#: pkg/machines/components/vmnetworktab.jsx:108
 #: pkg/storaged/iscsi-panel.jsx:127
 msgid "Port"
 msgstr "Porta"
 
-#: pkg/networkmanager/firewall.jsx:289
+#: pkg/networkmanager/firewall.jsx:339
 msgid "Port number and type do not match"
 msgstr ""
 
@@ -6166,15 +5033,14 @@ msgstr ""
 msgid "Portable"
 msgstr "Portatile"
 
-#: pkg/docker/index.html:504 pkg/kubernetes/views/container-body.html:12
-#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:221
-#: pkg/networkmanager/index.html:331
+#: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
+#: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2978
+#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
 msgid "Ports"
 msgstr "Porte"
 
-#: pkg/docker/index.html:191
+#: pkg/docker/index.html:192
 msgid "Ports:"
 msgstr "Porte:"
 
@@ -6182,8 +5048,7 @@ msgstr "Porte:"
 msgid "Power Options"
 msgstr "Opzioni di alimentazione"
 
-#: pkg/machines/components/vcpuModal.jsx:213
-#: pkg/ovirt/components/vcpuModal.jsx:64
+#: pkg/machines/components/vcpuModal.jsx:206
 msgid "Preferred number of sockets to expose to the guest."
 msgstr "Numero preferito di prese da esporre all'ospite."
 
@@ -6191,48 +5056,49 @@ msgstr "Numero preferito di prese da esporre all'ospite."
 msgid "Prefix"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3287
+#: pkg/networkmanager/interfaces.js:3306
 msgid "Prefix length"
 msgstr "Lunghezza prefisso"
 
-#: pkg/networkmanager/interfaces.js:3287
+#: pkg/networkmanager/interfaces.js:3306
 msgid "Prefix length or Netmask"
 msgstr "Lunghezza prefisso o maschera di rete"
 
-#: pkg/networkmanager/interfaces.js:823
+#: pkg/networkmanager/interfaces.js:826
 msgid "Preparing"
 msgstr "Preparazione"
 
-#: pkg/ovirt/rephraseUI.js:25
-msgid "Preparing for Maintenance"
-msgstr "Preparazione per la manutenzione"
-
-#: pkg/networkmanager/interfaces.js:3612
+#: pkg/networkmanager/interfaces.js:3631
 msgid "Preserve"
 msgstr "Preserva"
 
-#: pkg/systemd/init.js:578
+#: pkg/systemd/init.js:572
 msgid "Preset"
 msgstr "Preset"
 
-#: pkg/systemd/init.js:579
+#: pkg/systemd/init.js:573
 msgid "Preset Forcefully"
 msgstr "Preselezionato Con forza"
 
-#: pkg/systemd/index.html:303
+#: pkg/systemd/index.html:295
 msgid "Pretty Host Name"
 msgstr "Nome dell'host grazioso"
 
-#: pkg/networkmanager/index.html:297
+#: pkg/systemd/logs.html:43
+#, fuzzy
+msgid "Previous boot"
+msgstr "riavvia"
+
+#: pkg/networkmanager/index.html:289
 msgid "Primary"
 msgstr "Primario"
 
-#: pkg/networkmanager/index.html:252 pkg/networkmanager/index.html:371
-#: pkg/networkmanager/index.html:381
+#: pkg/networkmanager/index.html:244 pkg/networkmanager/index.html:363
+#: pkg/networkmanager/index.html:373
 msgid "Priority"
 msgstr "Priorità"
 
-#: pkg/networkmanager/interfaces.js:2851 pkg/networkmanager/interfaces.js:2875
+#: pkg/networkmanager/interfaces.js:2859 pkg/networkmanager/interfaces.js:2883
 msgid "Priority $priority"
 msgstr "Priorità $priority"
 
@@ -6240,20 +5106,15 @@ msgstr "Priorità $priority"
 msgid "Private"
 msgstr ""
 
-#: pkg/kubernetes/scripts/projects.js:1042
-msgid "Private: Allow only specific users or groups to pull images"
-msgstr ""
-"Privato: Consentire solo a utenti o gruppi specifici di scaricare immagini"
-
 #: pkg/shell/index.html:39
 msgid "Privileged"
 msgstr "Privilegiato"
 
-#: pkg/systemd/logs.js:483
+#: pkg/systemd/logs.js:488
 msgid "Problem details"
 msgstr "Dettagli del problema"
 
-#: pkg/systemd/logs.js:482
+#: pkg/systemd/logs.js:487
 msgid "Problem info"
 msgstr "Informazioni sul problema"
 
@@ -6261,77 +5122,18 @@ msgstr "Informazioni sul problema"
 msgid "Problems"
 msgstr "Problemi"
 
-#: pkg/storaged/dialog.jsx:1033
+#: pkg/storaged/dialog.jsx:1043
 msgid "Process"
 msgstr "Processi"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:123
-#: pkg/machines/components/vm/bootOrderModal.jsx:129
+#: pkg/machines/components/vm/bootOrderModal.jsx:121
+#: pkg/machines/components/vm/bootOrderModal.jsx:127
 msgid "Product"
 msgstr ""
 
-# translation auto-copied from project RHEL Deployment Guide, version 6.2, document Product_Subscriptions_and_Entitlements, author fvalen
-#: pkg/subscriptions/subscriptions-view.jsx:34
-msgid "Product ID"
-msgstr "ID del prodotto"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product name"
-msgstr "Nome prodotto"
-
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
-#: pkg/kubernetes/views/details-page.html:35
-#: pkg/kubernetes/views/details-page.html:71
-#: pkg/kubernetes/views/details-page.html:104
-#: pkg/kubernetes/views/details-page.html:138
-#: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/pod-body.html:4
-#: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/route-body.html:4
-#: pkg/kubernetes/views/service-body.html:4
-#: pkg/kubernetes/views/volumes-page.html:58
-msgid "Project"
-msgstr "Progetto"
-
-#: pkg/kubernetes/views/project-body.html:20
-msgid "Project Members"
-msgstr "Membri del progetto"
-
-#: pkg/kubernetes/views/project-body.html:3
-msgid "Project access policy allows anonymous users to pull images."
-msgstr ""
-"La politica di accesso ai progetti consente agli utenti anonimi di scaricare "
-"immagini."
-
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Project access policy allows any authenticated user to pull images."
-msgstr ""
-"La politica di accesso al progetto consente a qualsiasi utente autenticato "
-"di estrarre immagini."
-
-#: pkg/kubernetes/views/project-body.html:13
-msgid "Project access policy only allows specific members to access images."
-msgstr ""
-"La politica di accesso ai progetti consente solo a membri specifici di "
-"accedere alle immagini."
-
-#: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
+#: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
 msgstr "Sito web del progetto"
-
-#: pkg/kubernetes/views/filter-project.html:5
-msgid "Project:"
-msgstr "Progetto:"
-
-#: pkg/kubernetes/index.html:88 pkg/kubernetes/registry.html:55
-#: pkg/kubernetes/views/group-delete.html:10
-#: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
-msgid "Projects"
-msgstr "Progetti"
 
 #: pkg/users/local.js:91
 msgid "Prompting via passwd timed out"
@@ -6345,25 +5147,17 @@ msgstr "Prompting via ssh-add timed out"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Prompting via ssh-keygen timed out"
 
-#: pkg/systemd/init.js:740
+#: pkg/systemd/init.js:734
 msgid "Propagates Reload To"
 msgstr "Propagati Ricarica su"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:96
-#: pkg/machines/components/vm/bootOrderModal.jsx:141
-#: pkg/machines/components/vmDiskSourceCell.jsx:39
+#: pkg/machines/components/vm/bootOrderModal.jsx:94
+#: pkg/machines/components/vm/bootOrderModal.jsx:139
+#: pkg/machines/components/vmDiskColumns.jsx:44
 msgid "Protocol"
 msgstr "Protocollo"
 
-#: pkg/subscriptions/subscriptions-register.jsx:129
-msgid "Proxy"
-msgstr "Proxy"
-
-#: pkg/kubernetes/views/node-body.html:25
-msgid "Proxy Version"
-msgstr "Versione proxy"
-
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:250
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Chiave pubblica"
 
@@ -6371,25 +5165,9 @@ msgstr "Chiave pubblica"
 msgid "Public pulling repo"
 msgstr "Pronti contro termine di ritiro pubblico"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:152
-msgid "Pull an image:"
-msgstr "Scarica un'immagine:"
-
-#: pkg/kubernetes/views/imagestream-modify.html:66
-msgid "Pull from"
-msgstr "Tirare da"
-
-#: pkg/kubernetes/scripts/images.js:635
-msgid "Pull specific tags from another image repository"
-msgstr "Tirare tag specifici da un altro repository di immagini"
-
-#: pkg/storaged/content-views.jsx:649
+#: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Scopo"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:141
-msgid "Push an image:"
-msgstr "Premere un'immagine:"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:31
 msgid "QEMU/KVM System connection"
@@ -6399,16 +5177,11 @@ msgstr "QEMU/KVM Collegamento di sistema"
 msgid "QEMU/KVM User connection"
 msgstr "QEMU/KVM Connessione utente"
 
-#: pkg/kubernetes/views/pv-modify.html:148
-#: pkg/kubernetes/views/volume-body.html:77
-msgid "Qualified Name"
-msgstr "Nome qualificato"
-
-#: pkg/storaged/mdraid-details.jsx:186
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 0"
 msgstr "RAID 0"
 
@@ -6416,7 +5189,7 @@ msgstr "RAID 0"
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (Stripe)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 1"
 msgstr "RAID 1"
 
@@ -6424,7 +5197,7 @@ msgstr "RAID 1"
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (Mirror)"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 10"
 msgstr "RAID 10"
 
@@ -6432,7 +5205,7 @@ msgstr "RAID 10"
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (Stripe di Mirror)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 4"
 msgstr "RAID 4"
 
@@ -6440,7 +5213,7 @@ msgstr "RAID 4"
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (Dedicated Parity)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 5"
 msgstr "RAID 5"
 
@@ -6448,7 +5221,7 @@ msgstr "RAID 5"
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (Distributed Parity)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 6"
 msgstr "RAID 6"
 
@@ -6461,11 +5234,11 @@ msgid "RAID Chassis"
 msgstr "Telaio RAID"
 
 # translation auto-copied from project Blivet, version master, document blivet
-#: pkg/storaged/pvol-tabs.jsx:67
+#: pkg/storaged/pvol-tabs.jsx:59
 msgid "RAID Device"
 msgstr "Dispositivo RAID"
 
-#: pkg/storaged/mdraid-details.jsx:316 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "Dispositivo RAID $0"
 
@@ -6477,31 +5250,24 @@ msgstr "Dispositivi RAID"
 msgid "RAID Level"
 msgstr "Livello RAID"
 
-#: pkg/storaged/content-views.jsx:147
+#: pkg/storaged/content-views.jsx:153
 msgid "RAID Member"
 msgstr "Membro RAID"
-
-#: pkg/ovirt/provider.js:179
-msgid "REBOOT action failed"
-msgstr "RIBOT azione fallita"
-
-#: pkg/ovirt/provider.js:164
-msgid "REBOOT_VM action failed: %s0"
-msgstr ""
 
 #: pkg/lib/machine-info.js:86
 msgid "Rack Mount Chassis"
 msgstr "Telaio a rack"
 
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Dispositivo di blocco radio"
-
-#: pkg/networkmanager/interfaces.js:3613
+#: pkg/networkmanager/interfaces.js:3632
 msgid "Random"
 msgstr "Casuale"
 
-#: pkg/networkmanager/firewall.jsx:320
+#: pkg/networkmanager/firewall.jsx:759
+#, fuzzy
+msgid "Range"
+msgstr "Cambia"
+
+#: pkg/networkmanager/firewall.jsx:370
 msgid "Range must be strictly ordered"
 msgstr ""
 
@@ -6509,46 +5275,19 @@ msgstr ""
 msgid "Raw to a device"
 msgstr "Crudo a un dispositivo"
 
-#: pkg/kubernetes/views/pv-modify.html:195
-#: pkg/kubernetes/views/volume-body.html:10
-#: pkg/kubernetes/views/volume-body.html:20
-#: pkg/kubernetes/views/volume-body.html:44
-#: pkg/kubernetes/views/volume-body.html:51
-#: pkg/kubernetes/views/volume-body.html:71
-#: pkg/kubernetes/views/volume-body.html:85
-#: pkg/kubernetes/views/volume-body.html:93
-#: pkg/kubernetes/views/volume-body.html:110
-#: pkg/kubernetes/views/volume-body.html:122
-#: pkg/kubernetes/views/volume-body.html:136
-#: pkg/kubernetes/views/volume-body.html:143
-msgid "Read Only"
-msgstr "Sola lettura"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "Leggere e scrivere da un singolo nodo"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "Leggere e scrivere da più nodi"
-
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "Leggere solo da più nodi"
-
-#: pkg/docker/index.html:363
+#: pkg/docker/index.html:365
 msgid "ReadOnly"
 msgstr "Solo lettura"
 
-#: pkg/docker/index.html:362
+#: pkg/docker/index.html:364
 msgid "ReadWrite"
 msgstr "Lettura scrittura"
 
-#: pkg/storaged/plot.jsx:265
+#: pkg/storaged/plot.jsx:310
 msgid "Reading"
 msgstr "Lettura"
 
@@ -6556,26 +5295,24 @@ msgstr "Lettura"
 msgid "Reading..."
 msgstr "Lettura....."
 
-#: pkg/machines/components/vmDisksTab.jsx:73
+#: pkg/machines/components/vmDisksTab.jsx:74
 msgid "Readonly"
 msgstr "Solo lettura"
 
-#: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
-#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/playground/translate.html:19
 msgid "Ready"
 msgstr "Ready"
 
-#: pkg/playground/translate.html:24 pkg/playground/translate.html:184
+#: pkg/playground/translate.html:24
 msgctxt "verb"
 msgid "Ready"
 msgstr "Pronto"
 
-#: pkg/systemd/index.html:312
+#: pkg/systemd/index.html:304
 msgid "Real Host Name"
 msgstr "Nome dell'host reale"
 
-#: pkg/systemd/host.js:1016
+#: pkg/systemd/host.js:1020
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
@@ -6583,22 +5320,17 @@ msgstr ""
 "Il nome host reale può contenere solo caratteri minuscoli, cifre, trattini e "
 "periodi (con sottodomini popolati)"
 
-#: pkg/systemd/host.js:1017
+#: pkg/systemd/host.js:1021
 msgid "Real host name must be 64 characters or less"
 msgstr "Il nome host reale deve essere di 64 caratteri o meno"
-
-# ctx::sourcefile::/rhn/systems/details/SoftwareCrashDetail.do
-#: pkg/kubernetes/views/node-body.html:45
-msgid "Reason"
-msgstr "Motivo"
 
 #: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
 msgid "Reboot"
 msgstr "Riavvia"
 
-#: pkg/networkmanager/index.html:88 pkg/networkmanager/index.html:130
-#: pkg/networkmanager/index.html:148 pkg/networkmanager/index.html:429
-#: pkg/networkmanager/index.html:457
+#: pkg/networkmanager/index.html:88 pkg/networkmanager/index.html:122
+#: pkg/networkmanager/index.html:140 pkg/networkmanager/index.html:421
+#: pkg/networkmanager/index.html:449
 msgid "Receiving"
 msgstr "Ricevuti"
 
@@ -6606,16 +5338,11 @@ msgstr "Ricevuti"
 msgid "Recent"
 msgstr "Recenti"
 
-#: pkg/kubernetes/views/pv-body.html:6 pkg/kubernetes/views/pv-modify.html:56
-msgid "Reclaim Policy"
-msgstr "Politica di Reclamo"
-
-#: pkg/storaged/format-dialog.jsx:247
+#: pkg/storaged/format-dialog.jsx:248
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/kubernetes/index.html:108 pkg/kubernetes/registry.html:75
-#: pkg/shell/index.html:406 pkg/shell/simple.html:138 pkg/shell/stub.html:180
+#: pkg/shell/index.html:386 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Ricollegare"
@@ -6628,10 +5355,6 @@ msgstr "Recupero"
 msgid "Recovering RAID Device $target"
 msgstr "Recupero del dispositivo RAID $target"
 
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "Riciclare"
-
 #: pkg/docker/storage.jsx:389
 msgid "Reformat and add disks"
 msgstr "Riformattare e aggiungere dischi"
@@ -6640,58 +5363,31 @@ msgstr "Riformattare e aggiungere dischi"
 msgid "Refreshing package information"
 msgstr "Informazioni sul pacchetto rinfrescante"
 
-#: src/ws/login.js:650
+#: src/ws/login.js:653
 msgid "Refusing to connect. Host is unknown"
 msgstr "Rifiuto di connettersi. L'host è sconosciuto"
 
-#: src/ws/login.js:652
+#: src/ws/login.js:655
 msgid "Refusing to connect. Hostkey does not match"
 msgstr "Rifiuto di connessione. Il tasto Hostkey non corrisponde"
 
-#: src/ws/login.js:648
+#: src/ws/login.js:651
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Rifiutarsi di connettersi. La chiave host è sconosciuta"
-
-# translation auto-copied from project subscription-manager, version 1.9.X, document keys
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:159
-msgid "Register"
-msgstr "Registra"
-
-#: pkg/kubernetes/views/volumes-page.html:12
-msgid "Register New Volume"
-msgstr "Registra nuovo volume"
-
-#: pkg/kubernetes/views/pv-modify.html:4
-msgid "Register Persistent Volume"
-msgstr "Registrare volume persistente"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:108
-msgid "Register oVirt"
-msgstr "Registrati su oVirt"
-
-#: pkg/subscriptions/main.js:73
-msgid "Register system"
-msgstr "Sistema di registro"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:128
-msgid "Registering oVirt to Cockpit"
-msgstr "Registrazione oVirt su Cockpit"
 
 #: pkg/packagekit/updates.jsx:777
 msgid "Register…"
 msgstr "Registrati...."
 
-#: pkg/ovirt/components/App.jsx:62 pkg/ovirt/components/VdsmView.jsx:100
-#: pkg/systemd/init.js:552
+#: pkg/systemd/init.js:546
 msgid "Reload"
 msgstr "Ricarica"
 
-#: pkg/systemd/init.js:741
+#: pkg/systemd/init.js:735
 msgid "Reload Propagated From"
 msgstr "Ricarica Propagato da"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
 msgid "Remote URL"
 msgstr "URL remoto"
 
@@ -6703,10 +5399,6 @@ msgstr "Remoto su NFS"
 msgid "Remote over SSH"
 msgstr "Remoto su SSH"
 
-#: pkg/kubernetes/views/imagestream-modify.html:89
-msgid "Remote registry is insecure"
-msgstr "Il registro remoto è insicuro"
-
 #: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
 msgctxt "storage"
 msgid "Removable Drive"
@@ -6716,17 +5408,13 @@ msgstr "Unità rimovibile"
 msgid "Removals:"
 msgstr "Traslochi:"
 
-#: pkg/kubernetes/views/group-delete.html:21
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-delete.html:25
-#: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Elimina Zona"
 
-#: pkg/networkmanager/interfaces.js:3047
+#: pkg/networkmanager/interfaces.js:3055
 msgid "Remove $0"
 msgstr "Rimuovere $0"
 
@@ -6734,37 +5422,13 @@ msgstr "Rimuovere $0"
 msgid "Remove $0?"
 msgstr "Rimuovere $0?"
 
-#: pkg/kubernetes/views/group-delete.html:3
-msgid "Remove Group"
-msgstr "Rimuovi gruppo"
-
-#: pkg/kubernetes/views/user-group-remove.html:3
-msgid "Remove Member"
-msgstr "Rimuovi membro"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:3
-msgid "Remove Role"
-msgstr "Rimuovi ruolo"
-
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove Tang keyserver"
 msgstr "Rimuovere Tang keyserver"
 
-#: pkg/kubernetes/views/user-delete.html:3
-msgid "Remove User"
-msgstr "Rimuovi utente"
-
 #: pkg/storaged/vdo-details.jsx:116
 msgid "Remove device"
 msgstr "Rimuovere il dispositivo"
-
-#: pkg/kubernetes/views/image-delete.html:3
-msgid "Remove image tag"
-msgstr "Rimuovi etichetta immagine"
-
-#: pkg/kubernetes/views/user-remove-membership.html:3
-msgid "Remove membership"
-msgstr "Rimuovere l'iscrizione"
 
 #: pkg/storaged/crypto-keyslots.jsx:387
 msgid "Remove passphrase"
@@ -6773,6 +5437,16 @@ msgstr "Rimuovere la passphrase"
 #: pkg/storaged/crypto-keyslots.jsx:354
 msgid "Remove passphrase in $0?"
 msgstr "Rimuovere la passphrase in $0?"
+
+#: pkg/networkmanager/firewall.jsx:631
+#, fuzzy
+msgid "Remove service"
+msgstr "Rimuovere il dispositivo"
+
+#: pkg/networkmanager/firewall.jsx:610
+#, fuzzy
+msgid "Remove service from zones"
+msgstr "Rimuovere il dispositivo"
 
 #: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
 msgid "Removing"
@@ -6786,7 +5460,7 @@ msgstr "Rimozione $0"
 msgid "Removing $target from RAID Device"
 msgstr "Rimozione $target dal dispositivo RAID"
 
-#: pkg/networkmanager/interfaces.js:3046
+#: pkg/networkmanager/interfaces.js:3054
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -6798,8 +5472,8 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Rimozione del volume fisico da $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:187
-#: pkg/storaged/vgroup-details.jsx:235
+#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:234
 msgid "Rename"
 msgstr "Rinomina"
 
@@ -6807,7 +5481,7 @@ msgstr "Rinomina"
 msgid "Rename Logical Volume"
 msgstr "Rinominare il volume logico"
 
-#: pkg/storaged/vgroup-details.jsx:179
+#: pkg/storaged/vgroup-details.jsx:178
 msgid "Rename Volume Group"
 msgstr "Rinomina gruppo di volumi"
 
@@ -6819,23 +5493,23 @@ msgstr "Rinominare $target"
 msgid "Repairing $target"
 msgstr "Riparazione $target"
 
-#: pkg/systemd/services.html:491
+#: pkg/systemd/services.html:489
 msgid "Repeat Daily"
 msgstr "Ripetere tutti i giorni"
 
-#: pkg/systemd/services.html:490
+#: pkg/systemd/services.html:488
 msgid "Repeat Hourly"
 msgstr "Ripetere ogni ora"
 
-#: pkg/systemd/services.html:493
+#: pkg/systemd/services.html:491
 msgid "Repeat Monthly"
 msgstr "Ripetere ogni mese"
 
-#: pkg/systemd/services.html:492
+#: pkg/systemd/services.html:490
 msgid "Repeat Weekly"
 msgstr "Ripetere ogni settimana"
 
-#: pkg/systemd/services.html:494
+#: pkg/systemd/services.html:492
 msgid "Repeat Yearly"
 msgstr "Ripetere ogni anno"
 
@@ -6844,94 +5518,51 @@ msgstr "Ripetere ogni anno"
 msgid "Repeat passphrase"
 msgstr "Ripetere la passphrase"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
-#: pkg/kubernetes/views/details-page.html:141
-#: pkg/kubernetes/views/replicationcontroller-body.html:9
-#: pkg/kubernetes/views/replicationcontroller-modify.html:8
-msgid "Replicas"
-msgstr "Repliche"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/replicationcontroller-panel.html:10
-#: pkg/kubernetes/views/topology-page.html:22
-msgid "Replication Controller"
-msgstr "Controller di replica"
-
-#: pkg/kubernetes/views/details-page.html:132
-#: pkg/kubernetes/scripts/details.js:224
-msgid "Replication Controllers"
-msgstr "Controller di replica"
-
-#: pkg/kubernetes/views/topology-page.html:23
-msgid ""
-"Replication controllers dynamically create instances of pods from templates, "
-"and remove pods when necessary."
-msgstr ""
-"I controller di replica creano dinamicamente istanze di pod dai modelli e "
-"rimuovono i pod quando necessario."
-
-#: pkg/systemd/logs.js:507
+#: pkg/systemd/logs.js:512
 msgid "Report"
 msgstr "Notifica"
 
-#: pkg/systemd/logs.js:502
+#: pkg/systemd/logs.js:507
 msgid "Reported"
 msgstr "Segnalato"
 
-#: pkg/systemd/logs.js:524
+#: pkg/systemd/logs.js:529
 msgid "Reporter 'reporter-ureport' not found."
 msgstr "Reporter \"reporter-ureport\" non trovato."
 
-#: pkg/systemd/logs.js:526
+#: pkg/systemd/logs.js:531
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr ""
 "La segnalazione non ha avuto successo. Prova a eseguire `reporter-ureport -d "
-""
 
 # translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
-#: pkg/docker/index.html:688
+#: pkg/docker/index.html:690
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Repository"
 
-#: pkg/kubernetes/views/volume-body.html:24
-msgid "Repository URL"
-msgstr "URL del repositorio"
-
-#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
-msgid "Requested"
-msgstr "Richiesto"
-
-#: pkg/kubernetes/views/pv-claim.html:13
-msgid "Requests"
-msgstr "Richieste"
-
-#: pkg/users/local.js:1296
+#: pkg/users/local.js:1300
 msgid "Require password change every $0 days"
 msgstr "Richiedere la modifica della password ogni $0giorno"
 
-#: pkg/users/local.js:872
+#: pkg/users/local.js:876
 msgid "Require password change on $0"
 msgstr "Richiedi la modifica della password su $0"
 
-#: pkg/systemd/init.js:728
+#: pkg/systemd/init.js:722
 msgid "Required By"
 msgstr "Richiesto da"
 
 # translation auto-copied from project CFSE, version sam-1.2, document app, author fvalen
-#: pkg/systemd/init.js:723
+#: pkg/systemd/init.js:717
 msgid "Requires"
 msgstr "Ha bisogno di"
 
-#: pkg/kubernetes/views/auth-form.html:54
-msgid "Requires Authentication"
-msgstr "Richiede l'autenticazione"
-
-#: pkg/systemd/init.js:724
+#: pkg/systemd/init.js:718
 msgid "Requisite"
 msgstr "Requisito"
 
-#: pkg/systemd/init.js:729
+#: pkg/systemd/init.js:723
 msgid "Requisite Of"
 msgstr "Requisito di"
 
@@ -6939,7 +5570,7 @@ msgstr "Requisito di"
 msgid "Reserved memory"
 msgstr "Memoria riservata"
 
-#: pkg/docker/index.html:301 pkg/users/index.html:333
+#: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:105
 msgid "Reset"
 msgstr "Azzera"
@@ -6968,26 +5599,22 @@ msgid ""
 msgstr ""
 
 # ctx::sourcefile::/rhn/admin/config/Restart.do
-#: pkg/docker/index.html:135 pkg/systemd/index.html:134
+#: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:551
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Riavvia"
-
-#: pkg/kubernetes/views/container-body.html:20
-msgid "Restart Count"
-msgstr "Riavvia il conteggio"
 
 #: pkg/packagekit/updates.jsx:498
 msgid "Restart Now"
 msgstr "Riavvia ora"
 
-#: pkg/docker/index.html:537 pkg/kubernetes/views/pod-body.html:10
+#: pkg/docker/index.html:539
 msgid "Restart Policy"
 msgstr "Politica di riavvio"
 
-#: pkg/docker/index.html:171
+#: pkg/docker/index.html:172
 msgid "Restart Policy:"
 msgstr "Politica di riavvio:"
 
@@ -7007,77 +5634,46 @@ msgstr "Ripristino della connessione"
 msgid "Resume"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "Conservare"
-
-#: pkg/docker/index.html:553
+#: pkg/docker/index.html:555
 msgid "Retries:"
 msgstr "Riprova:"
-
-#: pkg/subscriptions/subscriptions-view.jsx:210
-msgid "Retrieving subscription status..."
-msgstr "Richiamare lo stato dell'abbonamento....."
 
 #: src/ws/login.html:57
 msgid "Reuse my password for privileged tasks"
 msgstr "Riutilizza la mia password per attività privilegiate"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Riutilizza la mia password per attività privilegiate e per connettersi ad "
 "altre macchine"
 
-#: pkg/kubernetes/views/volume-body.html:26
-msgid "Revision"
-msgstr "Revisione"
-
-#: pkg/kubernetes/views/user-add-membership.html:28
-#: pkg/kubernetes/views/user-body.html:5
-#: pkg/kubernetes/views/user-panel.html:28
-msgid "Role"
-msgstr "Ruolo"
-
-#: pkg/kubernetes/views/add-member-role-dialog.html:39
-#: pkg/kubernetes/views/project-body.html:21 pkg/users/index.html:94
+#: pkg/users/index.html:94
 msgid "Roles"
 msgstr "Ruoli"
 
-#: pkg/networkmanager/interfaces.js:1971 pkg/networkmanager/interfaces.js:1988
+#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
 msgid "Round Robin"
 msgstr "Round robin"
 
-#: pkg/kubernetes/views/route-page.html:14
-#: pkg/kubernetes/views/route-panel.html:9
-msgid "Route"
-msgstr "Rotta"
-
-#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:106
+#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:98
 msgid "Route to $0"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:108
+#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:100
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:65
-#: pkg/kubernetes/scripts/details.js:216 pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3325
 msgid "Routes"
 msgstr "Rotte"
 
-#: pkg/docker/index.html:244 pkg/docker/index.html:564
-#: pkg/systemd/services.html:443 pkg/machines/components/vm/vmActions.jsx:91
-#: pkg/ovirt/components/ClusterVms.jsx:92
+#: pkg/docker/index.html:253 pkg/docker/index.html:566
+#: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
 msgid "Run"
 msgstr "Esegui"
 
-#: pkg/ovirt/components/ClusterVms.jsx:97
-msgid "Run Here"
-msgstr "Esegui qu"
-
-#: pkg/docker/index.html:425
+#: pkg/docker/index.html:427
 msgid "Run Image"
 msgstr "Esegui Immagine"
 
@@ -7086,25 +5682,21 @@ msgid "Run as"
 msgstr "Esegui come"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:119
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
 msgstr ""
 
-#: pkg/networkmanager/index.html:336
+#: pkg/networkmanager/index.html:328
 msgid "Runner"
 msgstr "Esecutore"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Running"
 msgstr "In esecuzione"
 
-#: pkg/systemd/services.html:125
+#: pkg/systemd/services.html:123
 msgid "Running Since"
 msgstr ""
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:54
-msgid "Running Since:"
-msgstr "Corsa da allora:"
 
 #: pkg/selinux/setroubleshoot-view.jsx:364
 msgid "SELinux Access Control Errors"
@@ -7130,14 +5722,6 @@ msgstr "SELinux è disabilitato sul sistema."
 msgid "SELinux system status is unknown."
 msgstr "Lo stato del sistema SELinux è sconosciuto."
 
-#: pkg/ovirt/provider.js:440
-msgid "SET VCPU SETTINGS action failed"
-msgstr "Azione SET_VCPU_SETTINGS fallita"
-
-#: pkg/ovirt/provider.js:111 pkg/ovirt/provider.js:145
-msgid "SHUTDOWN action failed"
-msgstr "Azione SHUTDOWN fallita"
-
 #: pkg/storaged/jobs-panel.jsx:35
 msgid "SMART self-test of $target"
 msgstr "Autotest SMART di $target"
@@ -7158,35 +5742,23 @@ msgstr "Porta SPICE:"
 msgid "SPICE TLS Port:"
 msgstr "SPICE TLS Port:"
 
-#: pkg/ovirt/provider.js:225
-msgid "START action failed"
-msgstr "Azione START fallita"
-
-#: pkg/ovirt/provider.js:203
-msgid "START_VM action failed: %s0"
-msgstr ""
-
-#: pkg/networkmanager/index.html:236
+#: pkg/networkmanager/index.html:228
 msgid "STP Forward delay"
 msgstr "STP Ritardo in avanti"
 
-#: pkg/networkmanager/index.html:240
+#: pkg/networkmanager/index.html:232
 msgid "STP Hello time"
 msgstr "STP Ciao tempo"
 
-#: pkg/networkmanager/index.html:244
+#: pkg/networkmanager/index.html:236
 msgid "STP Maximum message age"
 msgstr "STP Età massima del messaggio"
 
-#: pkg/networkmanager/index.html:232
+#: pkg/networkmanager/index.html:224
 msgid "STP Priority"
 msgstr "Priorità STP"
 
-#: pkg/ovirt/provider.js:303
-msgid "SUSPEND action failed"
-msgstr "Azione SUSPEND fallita"
-
-#: pkg/systemd/services.html:242
+#: pkg/systemd/services.html:240
 msgid "Saturday"
 msgstr "Sabato"
 
@@ -7194,9 +5766,10 @@ msgstr "Sabato"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:525 pkg/machines/components/nicEdit.jsx:284
-#: pkg/machines/components/vm/bootOrderModal.jsx:332
-#: pkg/ovirt/components/VdsmView.jsx:114 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/systemd/services.html:523
+#: pkg/machines/components/vm/bootOrderModal.jsx:330
+#: pkg/machines/components/vm/memoryModal.jsx:217
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
 #: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Salva"
@@ -7221,40 +5794,14 @@ msgstr ""
 "Per salvare una nuova passphrase è necessario sbloccare il disco. Fornire "
 "una passphrase attuale del disco."
 
-#: pkg/kubernetes/views/node-capacity.html:9
-msgid "Scheduled Pods"
-msgstr "Cialde in programma"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "Programmazione Disabili"
-
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
 msgstr "Caso PC sigillato"
 
-#: pkg/systemd/services.html:461 pkg/systemd/services.html:465
-#: pkg/systemd/init.js:1082
+#: pkg/systemd/services.html:459 pkg/systemd/services.html:463
+#: pkg/systemd/init.js:1076
 msgid "Seconds"
 msgstr "Secondi"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Segreto"
-
-#: pkg/kubernetes/views/volume-body.html:106
-msgid "Secret File"
-msgstr "Archivio segreto"
-
-#: pkg/kubernetes/views/volume-body.html:141
-msgid "Secret Name"
-msgstr "Nome segreto"
-
-#: pkg/kubernetes/views/volume-body.html:69
-#: pkg/kubernetes/views/volume-body.html:108
-#: pkg/kubernetes/views/volume-body.html:134
-msgid "Secret Volume"
-msgstr "Volume segreto"
 
 #: pkg/systemd/index.html:106
 msgid "Secure Shell Keys"
@@ -7268,40 +5815,21 @@ msgstr "Cancellazione sicura $target"
 msgid "Security"
 msgstr "Sicurezza"
 
-#: pkg/systemd/host.js:492
+#: pkg/systemd/host.js:496
 msgid "Security Updates Available"
 msgstr "Aggiornamenti di sicurezza disponibili"
 
-#: pkg/shell/index.html:123 pkg/shell/simple.html:91 pkg/shell/stub.html:106
+#: pkg/shell/index.html:123 pkg/shell/simple.html:91
 msgid "Select"
 msgstr "Seleziona"
 
-#: pkg/kubernetes/views/file-button.html:4
-msgid "Select Manifest File..."
-msgstr "Selezionare il file manifesto....."
-
-#: pkg/kubernetes/scripts/projects.js:899
-#: pkg/kubernetes/scripts/projects.js:1205
-#: pkg/kubernetes/scripts/projects.js:1335
-msgid "Select Member"
-msgstr "Selezionare il membro"
-
-#: pkg/kubernetes/scripts/projects.js:901
-#: pkg/kubernetes/scripts/projects.js:1208
-msgid "Select Role"
-msgstr "Seleziona ruolo"
-
-#: pkg/kubernetes/views/topology-page.html:7
-msgid "Select an object to see more details."
-msgstr "Selezionare un oggetto per vedere maggiori dettagli."
-
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Selezionare gli utenti con cui si desidera essere sincronizzati "
-"{{#strong}}{{host}}{{/strong}}"
+"Selezionare gli utenti con cui si desidera essere sincronizzati {{#strong}}"
+"{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
@@ -7311,9 +5839,9 @@ msgstr "Invia Interruzione non mascherabile"
 msgid "Send key"
 msgstr "Invia combinazione di tasti"
 
-#: pkg/networkmanager/index.html:82 pkg/networkmanager/index.html:129
-#: pkg/networkmanager/index.html:147 pkg/networkmanager/index.html:423
-#: pkg/networkmanager/index.html:456
+#: pkg/networkmanager/index.html:82 pkg/networkmanager/index.html:121
+#: pkg/networkmanager/index.html:139 pkg/networkmanager/index.html:415
+#: pkg/networkmanager/index.html:448
 msgid "Sending"
 msgstr "Invio"
 
@@ -7322,11 +5850,8 @@ msgid "Serial Console"
 msgstr "Console seriale"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys, author fvalen
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:116 pkg/storaged/nfs-details.jsx:315
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:65
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Server"
 
@@ -7334,7 +5859,7 @@ msgstr "Server"
 msgid "Server Address"
 msgstr "Indirizzo del server"
 
-#: pkg/users/local.js:746 pkg/users/local.js:747
+#: pkg/users/local.js:750 pkg/users/local.js:751
 msgid "Server Administrator"
 msgstr "Amministratore del server"
 
@@ -7354,22 +5879,16 @@ msgstr "Il server non può essere vuoto."
 msgid "Server has closed the connection."
 msgstr "Il server ha chiuso la connessione."
 
-#: pkg/dashboard/index.html:90
+#: pkg/dashboard/index.html:86
 msgid "Servers"
 msgstr "Server"
 
-#: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/service-panel.html:8
-#: pkg/kubernetes/views/topology-page.html:30 pkg/systemd/logs.html:65
-#: pkg/networkmanager/firewall.jsx:595 pkg/storaged/dialog.jsx:1037
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Servizio"
 
-#: pkg/kubernetes/views/pod-body.html:12
-msgid "Service Account"
-msgstr "Account di servizio"
-
-#: pkg/systemd/services.html:339
+#: pkg/systemd/services.html:337
 msgid "Service Logs"
 msgstr "Log servizi"
 
@@ -7393,39 +5912,25 @@ msgstr "Il servizio è interrotto"
 msgid "Service is stopping"
 msgstr "Il servizio si sta fermando"
 
-#: pkg/systemd/services.html:401
+#: pkg/systemd/services.html:399
 msgid "Service name"
 msgstr "Nome del servizio"
 
-#: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
-#: pkg/systemd/services.html:332 pkg/kubernetes/scripts/details.js:213
-#: pkg/networkmanager/firewall.jsx:403
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Services"
 msgstr "Servizi"
 
-#: pkg/kubernetes/views/topology-page.html:31
-msgid ""
-"Services group pods and provide a common DNS name and an optional, load-"
-"balanced IP address to access them."
-msgstr ""
-"I servizi raggruppano i pod e forniscono un nome DNS comune e un indirizzo "
-"IP load-balanced opzionale per accedervi."
-
-#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1033
+#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sessione"
 
-#: pkg/kubernetes/views/service-body.html:20
-msgid "Session Affinity"
-msgstr "Affinità della sessione"
-
 # ctx::sourcefile::/rhn/systems/details/virtualization/VirtualGuestsList.do
-#: pkg/dashboard/index.html:174 pkg/users/index.html:238
+#: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
 msgstr "Set"
 
-#: pkg/systemd/host.js:760
+#: pkg/systemd/host.js:764
 msgid "Set Host name"
 msgstr "Imposta nome host"
 
@@ -7433,15 +5938,15 @@ msgstr "Imposta nome host"
 msgid "Set Password"
 msgstr "Imposta password"
 
-#: pkg/systemd/index.html:386
+#: pkg/systemd/index.html:378
 msgid "Set Time"
 msgstr "Tempo impostato"
 
-#: pkg/docker/index.html:530
+#: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Impostare le variabili d'ambiente del container"
 
-#: pkg/networkmanager/index.html:191
+#: pkg/networkmanager/index.html:183
 msgid "Set to"
 msgstr "Impostare su"
 
@@ -7464,7 +5969,7 @@ msgid "Setting up loop device $target"
 msgstr "Impostazione del dispositivo di loop $target"
 
 # translation auto-copied from project Customer Portal Translations, version PCM_template, document template, author fvalen
-#: pkg/systemd/logs.html:47 pkg/packagekit/updates.jsx:382
+#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:382
 msgid "Severity"
 msgstr "Severità"
 
@@ -7472,80 +5977,34 @@ msgstr "Severità"
 msgid "Severity:"
 msgstr "Severità:"
 
-#: pkg/kubernetes/views/volume-body.html:139
-msgid "Share Name"
-msgstr "Condividi Nome"
-
-#: pkg/networkmanager/interfaces.js:1956
+#: pkg/networkmanager/interfaces.js:1959
 msgid "Shared"
 msgstr "Condivisa"
-
-#: pkg/kubernetes/scripts/projects.js:1043
-msgid "Shared: Allow any authenticated user to pull images"
-msgstr ""
-"Condivisa: consente a qualsiasi utente autenticato di estrarre immagini"
-
-# translation auto-copied from project Anaconda, version master, document anaconda
-#: pkg/kubernetes/views/container-page-inline.html:14
-#: pkg/kubernetes/views/container-panel.html:9
-msgid "Shell"
-msgstr "Shell"
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/kubernetes/views/container-page.html:4
-msgid "Show all Containers"
-msgstr "Mostra tutti i container"
+#: pkg/machines/components/diskAdd.jsx:238
+#, fuzzy
+msgid "Show Performance Options"
+msgstr "Opzioni di alimentazione"
 
-#: pkg/kubernetes/views/deploymentconfig-page.html:8
-msgid "Show all Deployment Configs"
-msgstr "Mostra tutte le configurazioni di deployment"
-
-#: pkg/kubernetes/views/node-page.html:8
-msgid "Show all Nodes"
-msgstr "Mostra tutti i nodi"
-
-#: pkg/kubernetes/views/pv-page.html:9
-msgid "Show all Persistent Volumes"
-msgstr "Mostra tutti i volumi persistenti"
-
-#: pkg/kubernetes/views/pod-container.html:4
-msgid "Show all Pod Containers"
-msgstr "Mostra tutti i containers pod"
-
-#: pkg/kubernetes/views/pod-page.html:8
-msgid "Show all Pods"
+#: pkg/storaged/overview.jsx:56
+#, fuzzy
+msgid "Show all"
 msgstr "Mostra tutti i pod"
 
-#: pkg/kubernetes/views/group-page.html:14
-#: pkg/kubernetes/views/project-page.html:23
-#: pkg/kubernetes/views/user-page.html:16
-msgid "Show all Projects"
-msgstr "Mostra tutti i progetti"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:10
-msgid "Show all Replication Controllers"
-msgstr "Mostra tutti i controller di replica"
-
-#: pkg/kubernetes/views/route-page.html:10
-msgid "Show all Routes"
-msgstr "Mostra tutti i percorsi"
-
-#: pkg/kubernetes/views/service-page.html:8
-msgid "Show all Services"
-msgstr "Mostra tutti i servizi"
+#: pkg/storaged/drives-panel.jsx:122
+#, fuzzy
+msgid "Show all $0 drives"
+msgstr "Mostra tutti i nodi"
 
 #: pkg/docker/index.html:128
 msgid "Show all containers"
 msgstr "Mostra tutti i container"
 
-#: pkg/kubernetes/views/imagestream-page.html:12
-msgid "Show all image streams"
-msgstr "Mostra tutti i flussi di immagini"
-
-#: pkg/docker/index.html:254 pkg/kubernetes/views/image-page.html:10
+#: pkg/docker/index.html:249
 msgid "Show all images"
 msgstr "Mostra tutte le immagini"
 
@@ -7553,7 +6012,7 @@ msgstr "Mostra tutte le immagini"
 msgid "Show fingerprints"
 msgstr "Mostra le impronte digitali"
 
-#: pkg/storaged/lvol-tabs.jsx:317 pkg/storaged/lvol-tabs.jsx:403
+#: pkg/storaged/lvol-tabs.jsx:317 pkg/storaged/lvol-tabs.jsx:398
 msgid "Shrink"
 msgstr "Riduci"
 
@@ -7561,7 +6020,7 @@ msgstr "Riduci"
 msgid "Shrink Logical Volume"
 msgstr "Restringimento del volume logico"
 
-#: pkg/storaged/warning-tab.jsx:123
+#: pkg/storaged/lvol-tabs.jsx:415
 msgid "Shrink Volume"
 msgstr ""
 
@@ -7571,47 +6030,38 @@ msgstr ""
 msgid "Shut Down"
 msgstr "Arresto"
 
-#: pkg/kubernetes/views/container-body.html:18
-msgid "Since"
-msgstr "Da"
-
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/diskAdd.jsx:142
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:66
-#: pkg/storaged/content-views.jsx:109 pkg/storaged/content-views.jsx:688
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
+#: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
 #: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
-#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:348
-#: pkg/storaged/lvol-tabs.jsx:399 pkg/storaged/lvol-tabs.jsx:434
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:274
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Dimensione"
 
-#: pkg/storaged/dialog.jsx:901
+#: pkg/storaged/dialog.jsx:911
 msgid "Size cannot be negative"
 msgstr "La dimensione non può essere negativa"
 
-#: pkg/storaged/dialog.jsx:899
+#: pkg/storaged/dialog.jsx:909
 msgid "Size cannot be zero"
 msgstr "La dimensione non può essere zero"
 
-#: pkg/storaged/dialog.jsx:903
+#: pkg/storaged/dialog.jsx:913
 msgid "Size is too large"
 msgstr "La dimensione è troppo grande"
 
-#: pkg/storaged/dialog.jsx:897
+#: pkg/storaged/dialog.jsx:907
 msgid "Size must be a number"
 msgstr "La dimensione deve essere un numero"
 
-#: pkg/storaged/dialog.jsx:905
+#: pkg/storaged/dialog.jsx:915
 msgid "Size must be at least $0"
 msgstr "La dimensione deve essere almeno $0"
-
-#: pkg/kubernetes/views/auth-form.html:43
-#: pkg/kubernetes/views/auth-rejected-cert.html:11
-msgid "Skip Certificate Verification"
-msgstr "Salta la verifica del certificato"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Slot"
@@ -7622,8 +6072,7 @@ msgid "Slot $0"
 msgstr "Slot $0"
 
 # translation auto-copied from project Satellite6 Katello, version Sam-1.3.0, document katello, author fvalen
-#: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:213
-#: pkg/ovirt/components/vcpuModal.jsx:64
+#: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
 msgid "Sockets"
 msgstr "Socket"
 
@@ -7666,20 +6115,26 @@ msgstr ""
 "Qualche altro programma sta attualmente utilizzando il gestore di pacchetti, "
 "si prega di attendere....."
 
-#: pkg/kubernetes/scripts/volumes.js:914
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "Mi dispiace, non so come modificare questo volume"
+#: pkg/networkmanager/firewall.jsx:709
+msgid "Sorted from least trusted to most trusted"
+msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:396
-#: pkg/machines/components/nicEdit.jsx:143
-#: pkg/machines/components/vmDisksTab.jsx:75
-#: pkg/machines/components/vmnetworktab.jsx:103
+#: pkg/machines/components/nicEdit.jsx:141
+#: pkg/machines/components/vmDisksTab.jsx:76
+#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Sorgente"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:177
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#, fuzzy
+msgid "Source Format"
+msgstr "Percorso della sorgente"
+
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Percorso della sorgente"
 
@@ -7687,11 +6142,12 @@ msgstr "Percorso della sorgente"
 msgid "Source URL"
 msgstr "URL di origine"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
 msgid "Source path should not be empty"
 msgstr "Il percorso della sorgente non deve essere vuoto"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:407
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "La sorgente dovrebbe iniziare con il protocollo http, ftp o nfs"
 
@@ -7699,11 +6155,11 @@ msgstr "La sorgente dovrebbe iniziare con il protocollo http, ftp o nfs"
 msgid "Space-saving Computer"
 msgstr "Computer salvaspazio"
 
-#: pkg/networkmanager/interfaces.js:2849
+#: pkg/networkmanager/interfaces.js:2857
 msgid "Spanning Tree Protocol"
 msgstr "Spanning Tree Protocol"
 
-#: pkg/networkmanager/index.html:226
+#: pkg/networkmanager/index.html:218
 msgid "Spanning Tree Protocol (STP)"
 msgstr "Protocollo dell'albero di scansione (STP)"
 
@@ -7711,17 +6167,17 @@ msgstr "Protocollo dell'albero di scansione (STP)"
 msgid "Spare"
 msgstr "Ricambio"
 
-#: pkg/systemd/index.html:463
+#: pkg/systemd/index.html:455
 msgid "Specific Time"
 msgstr "Tempo specifico"
 
-#: pkg/networkmanager/interfaces.js:3614
+#: pkg/networkmanager/interfaces.js:3633
 msgid "Stable"
 msgstr "Stabile"
 
-#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:320 pkg/storaged/swap-tab.jsx:78
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:547
+#: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Avvia"
 
@@ -7741,7 +6197,7 @@ msgstr "Avviare il servizio"
 msgid "Start libvirt"
 msgstr "Avvia libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:214
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
 msgid "Start pool when host boots"
 msgstr "Iniziare la piscina quando gli stivali host"
 
@@ -7753,78 +6209,47 @@ msgstr "Avvio del dispositivo RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Avvio dello spazio di swap $target"
 
-# translation auto-copied from project oVirt Engine jrs Branding, version JRS-5.5-branded, document querybuilder_messages
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Starts"
-msgstr "Inizia"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
 msgid "Startup"
 msgstr "Avvio"
 
-#: pkg/kubernetes/views/container-body.html:16
-#: pkg/kubernetes/views/details-page.html:38
-#: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:127 pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/init.js:285
 msgid "State"
 msgstr "Stato"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:167
+#: pkg/docker/index.html:168
 msgid "State:"
 msgstr "Stato:"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "Stateless"
-msgstr "Stateless"
-
-#: pkg/ovirt/components/OVirtTab.jsx:156
-msgid "Stateless:"
-msgstr "Stateless:"
-
-#: pkg/systemd/services.html:75 pkg/systemd/init.js:207
+#: pkg/systemd/services.html:74 pkg/systemd/init.js:207
 msgid "Static"
 msgstr "Statico"
 
-#: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/volumes-page.html:21 pkg/systemd/services.html:123
-#: pkg/networkmanager/interfaces.js:2605
-#: pkg/subscriptions/subscriptions-view.jsx:37
+#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
 msgid "Status"
 msgstr "Stato"
-
-#: pkg/subscriptions/subscriptions-view.jsx:162
-msgid "Status: $0"
-msgstr "Stato: $0"
-
-#: pkg/subscriptions/subscriptions-view.jsx:157
-msgid "Status: System isn't registered"
-msgstr "Stato: il sistema non è registrato"
 
 #: pkg/lib/machine-info.js:99
 msgid "Stick PC"
 msgstr "Stick PC"
 
-#: pkg/networkmanager/index.html:375
+#: pkg/networkmanager/index.html:367
 msgid "Sticky"
 msgstr "Sticky"
 
-#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
-#: pkg/systemd/init.js:548
+#: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
+#: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Ferma"
 
-#: pkg/storaged/mdraid-details.jsx:248
+#: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Ferma device"
 
@@ -7857,7 +6282,8 @@ msgid "Stopping swapspace $target"
 msgstr "Arresto dello spazio di swap $target"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:288 pkg/storaged/index.html:23
+#: pkg/docker/index.html:290 pkg/storaged/index.html:23
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
 #: pkg/storaged/details.jsx:127
 msgid "Storage"
 msgstr "Storage"
@@ -7866,11 +6292,11 @@ msgstr "Storage"
 msgid "Storage Logs"
 msgstr "Log storage"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:137
+#: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePool.jsx:149
+#: pkg/machines/components/storagePools/storagePool.jsx:153
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
@@ -7878,7 +6304,7 @@ msgstr ""
 msgid "Storage Pool Name"
 msgstr "Nome della piscina di stoccaggio"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:300
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
 msgid "Storage Pool failed to be created"
 msgstr "Non è stato creato un pool di storage che non è riuscito a creare"
 
@@ -7886,10 +6312,6 @@ msgstr "Non è stato creato un pool di storage che non è riuscito a creare"
 #: pkg/machines/components/storagePools/storagePoolList.jsx:48
 msgid "Storage Pools"
 msgstr "Pool di storage"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:354
-msgid "Storage Size"
-msgstr "Dimensione storage"
 
 #: pkg/machines/components/storagePools/storagePool.jsx:88
 msgid "Storage Volumes"
@@ -7899,11 +6321,11 @@ msgstr "Volumi di storage"
 msgid "Storage Volumes could not be deleted"
 msgstr ""
 
-#: pkg/storaged/devices.jsx:62
+#: pkg/storaged/devices.jsx:76
 msgid "Storage can not be managed on this system."
 msgstr ""
 
-#: pkg/docker/index.html:302
+#: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Pool di archiviazione"
 
@@ -7911,7 +6333,7 @@ msgstr "Pool di archiviazione"
 msgid "Store Metrics"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:315
+#: pkg/storaged/format-dialog.jsx:122
 msgid "Store passphrase"
 msgstr "Conservare la passphrase"
 
@@ -7919,13 +6341,9 @@ msgstr "Conservare la passphrase"
 msgid "Stored Passphrase"
 msgstr "Passphrase memorizzata"
 
-#: pkg/storaged/crypto-tab.jsx:129
+#: pkg/storaged/crypto-tab.jsx:126
 msgid "Stored passphrase"
 msgstr "Passphrase memorizzata"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:12
-msgid "Strategy"
-msgstr "Strategia"
 
 #: pkg/lib/machine-info.js:82
 msgid "Sub Chassis"
@@ -7935,16 +6353,11 @@ msgstr "Sub Chassis"
 msgid "Sub Notebook"
 msgstr "Sub Notebook"
 
-# translation auto-copied from project Customer Portal Translations, version management_page, document Management_Prototype.html, author fvalen
-#: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:177
-msgid "Subscriptions"
-msgstr "Sottoscrizioni"
-
 #: node_modules/registry-image-widgets/views/image-body.html:4
 msgid "Summary"
 msgstr "Sommario"
 
-#: pkg/systemd/services.html:243
+#: pkg/systemd/services.html:241
 msgid "Sunday"
 msgstr "Domenica"
 
@@ -7956,44 +6369,28 @@ msgstr ""
 msgid "Support is installed."
 msgstr "Il supporto è installato."
 
-#: pkg/ovirt/components/VmActions.jsx:40
-msgid "Suspend"
-msgstr "Sospendi"
-
-#: pkg/storaged/content-views.jsx:151
+#: pkg/storaged/content-views.jsx:157
 msgid "Swap"
 msgstr "Swap"
 
-#: pkg/storaged/content-views.jsx:355
+#: pkg/storaged/content-views.jsx:351
 msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "Spazio di swap"
 
-#: pkg/systemd/index.html:256 pkg/systemd/host.js:1688
+#: pkg/systemd/index.html:248 pkg/systemd/host.js:1692
 msgid "Swap Used"
 msgstr "Swap usato"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:40
-msgid "Switch Host to Maintenance"
-msgstr "Passa da l'host in modalità di manutenzione"
-
-#: pkg/networkmanager/interfaces.js:2489 pkg/networkmanager/interfaces.js:3031
+#: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
 msgid "Switch off $0"
 msgstr "Spegni $0"
 
-#: pkg/networkmanager/interfaces.js:2464 pkg/networkmanager/interfaces.js:3019
+#: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
 msgid "Switch on $0"
 msgstr "Accendi $0"
 
-#: pkg/ovirt/provider.js:414
-msgid "Switching host to maintenance mode failed. Received error: "
-msgstr "Cambio dell'host in modalità manutenzione fallita. Errore ricevuto: "
-
-#: pkg/ovirt/provider.js:408
-msgid "Switching host to maintenance mode in progress ..."
-msgstr "Cambio dell'host in modalità di manutenzione in corso ...."
-
-#: pkg/networkmanager/interfaces.js:2488
+#: pkg/networkmanager/interfaces.js:2491
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -8001,7 +6398,7 @@ msgstr ""
 "La disattivazione di ² interromperà la connessione al server e renderà "
 "l'interfaccia utente di amministrazione non disponibile."
 
-#: pkg/networkmanager/interfaces.js:3030
+#: pkg/networkmanager/interfaces.js:3038
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -8009,7 +6406,7 @@ msgstr ""
 "La disattivazione di <b>$0</b>questa opzione interromperà la connessione al "
 "server e renderà l'interfaccia utente di amministrazione non disponibile."
 
-#: pkg/networkmanager/interfaces.js:2463 pkg/networkmanager/interfaces.js:3018
+#: pkg/networkmanager/interfaces.js:2466 pkg/networkmanager/interfaces.js:3026
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -8017,15 +6414,11 @@ msgstr ""
 "L<b>$0</b>'attivazione di questa opzione interromperà la connessione al "
 "server e renderà l'interfaccia utente di amministrazione non disponibile."
 
-#: pkg/kubernetes/scripts/images.js:634
-msgid "Sync all tags from a remote image repository"
-msgstr "Sincronizzare tutti i tag da un archivio di immagini remoto"
-
 #: pkg/lib/machine-sync-users.html:75
 msgid "Synchronize"
 msgstr "Sincronizza"
 
-#: pkg/dashboard/index.html:172 pkg/lib/machine-sync-users.html:4
+#: pkg/dashboard/index.html:174 pkg/lib/machine-sync-users.html:4
 msgid "Synchronize users"
 msgstr "Sincronizzare gli utenti"
 
@@ -8051,7 +6444,7 @@ msgstr "Sistema"
 msgid "System Information"
 msgstr "Informazioni sul sistema"
 
-#: pkg/systemd/host.js:476
+#: pkg/systemd/host.js:480
 msgid "System Not Registered"
 msgstr "Sistema non registrato"
 
@@ -8063,7 +6456,7 @@ msgstr "Servizi di sistema"
 msgid "System Time"
 msgstr "Tempo di sistema"
 
-#: pkg/systemd/host.js:482
+#: pkg/systemd/host.js:486
 msgid "System Up To Date"
 msgstr "Sistema aggiornato"
 
@@ -8072,27 +6465,22 @@ msgstr "Sistema aggiornato"
 msgid "System is up to date"
 msgstr "Il sistema è aggiornato"
 
-#: pkg/docker/index.html:327 pkg/docker/index.html:331
-#: pkg/networkmanager/firewall.jsx:595
+#: pkg/docker/index.html:329 pkg/docker/index.html:333
+#: pkg/networkmanager/firewall.jsx:938
 msgid "TCP"
 msgstr "TCP"
-
-#: pkg/kubernetes/views/route-body.html:12
-msgid "TLS Termination"
-msgstr "Terminazione TLS"
 
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
 msgstr "Tavoletta"
 
 # translation auto-copied from project shotwell-core, version 0.14.1, document shotwell-core
-#: pkg/docker/index.html:694
+#: pkg/docker/index.html:696
 #: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Etichetta"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
-#: pkg/kubernetes/views/imagestream-modify.html:76
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
@@ -8104,25 +6492,16 @@ msgstr "Tag"
 msgid "Tang keyserver"
 msgstr "Tang keyserver"
 
-#: pkg/kubernetes/views/pv-modify.html:137
-#: pkg/machines/components/vm/bootOrderModal.jsx:135
+#: pkg/machines/components/vm/bootOrderModal.jsx:133
 msgid "Target"
 msgstr "Obiettivo"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:122
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Percorso di destinazione"
 
-#: pkg/kubernetes/views/volume-body.html:75
-msgid "Target Portal"
-msgstr "Portale di destinazione"
-
-#: pkg/kubernetes/views/volume-body.html:114
-msgid "Target World Wide Names"
-msgstr "Nomi di destinazione in tutto il mondo"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
 msgid "Target path should not be empty"
 msgstr "Il percorso di destinazione non deve essere vuoto"
 
@@ -8130,38 +6509,22 @@ msgstr "Il percorso di destinazione non deve essere vuoto"
 msgid "Targets"
 msgstr "Obiettivi"
 
-#: pkg/networkmanager/interfaces.js:2509 pkg/networkmanager/interfaces.js:2521
-#: pkg/networkmanager/interfaces.js:2806
+#: pkg/networkmanager/interfaces.js:2512 pkg/networkmanager/interfaces.js:2524
+#: pkg/networkmanager/interfaces.js:2814
 msgid "Team"
 msgstr "Team"
 
-#: pkg/networkmanager/interfaces.js:2834
+#: pkg/networkmanager/interfaces.js:2842
 msgid "Team Port"
 msgstr "Porta team"
 
-#: pkg/networkmanager/index.html:546
+#: pkg/networkmanager/index.html:538
 msgid "Team Port Settings"
 msgstr "Impostazioni della porta del team"
 
-#: pkg/networkmanager/index.html:522
+#: pkg/networkmanager/index.html:514
 msgid "Team Settings"
 msgstr "Impostazioni della squadra"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:15
-#: pkg/kubernetes/views/deploymentconfig-panel.html:10
-#: pkg/kubernetes/views/replicationcontroller-page.html:20
-#: pkg/kubernetes/views/replicationcontroller-panel.html:14
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "Template"
-msgstr "Modello"
-
-#: pkg/ovirt/components/App.jsx:111
-msgid "Templates"
-msgstr "Modelli"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:130
-msgid "Templates of $0 cluster"
-msgstr "Modelli di cluster $0"
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
@@ -8196,11 +6559,11 @@ msgstr ""
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "L'indirizzo IP o il nome host non può contenere spazi bianchi."
 
-#: pkg/storaged/mdraid-details.jsx:219
+#: pkg/storaged/mdraid-details.jsx:218
 msgid "The RAID Array is in a degraded state"
 msgstr "L'array RAID è in uno stato degradato"
 
-#: pkg/storaged/mdraid-details.jsx:149
+#: pkg/storaged/mdraid-details.jsx:148
 msgid "The RAID device must be running in order to add spare disks."
 msgstr ""
 "Il dispositivo RAID deve essere in funzione per poter aggiungere dischi di "
@@ -8251,20 +6614,16 @@ msgstr "La macchina virtuale è in funzione."
 msgid "The VM is suspended by guest power management."
 msgstr "La VM è sospesa dalla gestione dell'alimentazione degli ospiti."
 
-#: pkg/users/local.js:1338
+#: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
 msgstr ""
 "L'account '$0' ' ' sarà costretto a cambiare la propria password al prossimo "
 "login"
 
-#: pkg/kubernetes/scripts/nodes.js:403
-msgid "The address contains invalid characters"
-msgstr "L'indirizzo contiene caratteri non validi"
-
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "L'autenticità dell'host non {{#strong}}{{host}}{{/strong}} può essere "
 "stabilita. Sei sicuro di voler continuare a connetterti?"
@@ -8278,22 +6637,12 @@ msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 "Lo stato configurato è sconosciuto, potrebbe cambiare al prossimo avvio."
 
-#: pkg/kubernetes/views/container-page-inline.html:22
-msgid "The container '{{ target }}' does not exist."
-msgstr "Il contenitore '{{ target }}' non esiste."
-
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
 msgstr ""
 "La creazione di questo dispositivo VDO non è terminata e il dispositivo non "
 "può essere utilizzato."
-
-#: pkg/subscriptions/subscriptions-view.jsx:214
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-"L'utente corrente non è autorizzato a accedere allo stato della "
-"sottoscrizione di sistema."
 
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
@@ -8302,15 +6651,11 @@ msgstr ""
 "L'utente attualmente connesso non è autorizzato a vedere le informazioni "
 "sulle chiavi."
 
-#: pkg/kubernetes/views/deploymentconfig-page.html:25
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "La configurazione di distribuzione '{{ target }}'' non esiste."
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:190
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
 msgid "The directory on the server being exported"
 msgstr "La directory sul server da esportare"
 
-#: pkg/storaged/dialog.jsx:1002
+#: pkg/storaged/dialog.jsx:1012
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -8318,13 +6663,12 @@ msgstr ""
 "Il filesystem è in uso dalle sessioni di login e dai servizi di sistema. "
 "Procedendo si fermeranno."
 
-#: pkg/storaged/dialog.jsx:1004
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialog.jsx:1014
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Il filesystem è in uso per le sessioni di login. Procedendo si fermeranno."
 
-#: pkg/storaged/dialog.jsx:1006
+#: pkg/storaged/dialog.jsx:1016
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
@@ -8332,8 +6676,7 @@ msgstr ""
 "questi ultimi."
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "I seguenti contenitori dipendono da questa immagine e diventeranno "
 "inutilizzabili."
@@ -8347,10 +6690,6 @@ msgstr ""
 "L'archivio generato contiene dati considerati sensibili e il suo contenuto "
 "deve essere esaminato dall'organizzazione di origine prima di essere "
 "trasmesso a terzi."
-
-#: pkg/kubernetes/views/group-page.html:47
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "Il gruppo '{{ groupName }}' non esiste."
 
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
@@ -8379,31 +6718,16 @@ msgstr "L'ultima fessura per chiavi non può essere rimossa"
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "L'ultimo volume fisico di un gruppo di volumi non può essere rimosso."
 
-#: pkg/shell/indexes.js:408
+#: pkg/shell/indexes.js:407
 msgid "The machine is restarting"
 msgstr "La macchina si sta riavviando"
 
-#: pkg/kubernetes/scripts/details.js:498 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "Il numero massimo di repliche è 128"
+#: pkg/machines/components/networks/networkDelete.jsx:76
+#, fuzzy
+msgid "The network could not be deleted"
+msgstr "Il percorso di destinazione non deve essere vuoto"
 
-#: pkg/kubernetes/scripts/nodes.js:411
-msgid "The name contains invalid characters"
-msgstr "Il nome contiene caratteri non validi"
-
-#: pkg/kubernetes/views/node-page.html:23
-msgid "The node '{{ target }}' does not exist."
-msgstr "Il nodo '{{ target }}' ' non esiste."
-
-#: pkg/kubernetes/views/node-alerts.html:7
-msgid "The node doesn't have enough disk space"
-msgstr "Il nodo non ha abbastanza spazio su disco"
-
-#: pkg/kubernetes/views/node-alerts.html:11
-msgid "The node doesn't have enough free memory"
-msgstr "Il nodo non ha abbastanza memoria libera"
-
-#: pkg/users/local.js:439 pkg/users/local.js:1395
+#: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
 msgstr "Le password non corrispondono"
 
@@ -8411,29 +6735,9 @@ msgstr "Le password non corrispondono"
 msgid "The passwords do not match."
 msgstr "Le password non corrispondono."
 
-#: pkg/kubernetes/views/pv-page.html:21
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "Il volume persistente ''non esiste."
-
-#: pkg/kubernetes/views/pod-page.html:40
-msgid "The pod '{{ target }}' does not exist."
-msgstr "Il baccello ''non esiste."
-
-#: pkg/machines/components/diskAdd.jsx:79
+#: pkg/machines/components/diskAdd.jsx:80
 msgid "The pool is empty"
 msgstr "La piscina è vuota"
-
-#: pkg/kubernetes/views/project-page.html:34
-msgid "The project '{{ projName }}' does not exist."
-msgstr "Il progetto ''non esiste."
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:30
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "Il controller di replica ' ' ' '{{ target }}non esiste."
-
-#: pkg/kubernetes/views/route-page.html:19
-msgid "The route '{{ target }}' does not exist."
-msgstr "Il percorso ''non esiste."
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
@@ -8443,12 +6747,7 @@ msgstr "La scansione da $time ($type) non ha trovato vulnerabilità."
 msgid "The scan from $time ($type) was not successful."
 msgstr "La scansione da $time ($type) non ha avuto successo."
 
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-"Il file selezionato non è un manifesto valido di applicazione Kubernetes."
-
-#: src/ws/login.js:642
+#: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
 "no other supported authentication methods are available."
@@ -8463,23 +6762,11 @@ msgstr ""
 "Il server ha rifiutato di autenticarsi utilizzando qualsiasi metodo "
 "supportato."
 
-#: pkg/kubernetes/views/auth-rejected-cert.html:2
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr "Il server utilizza un certificato firmato da un'autorità sconosciuta."
-
-#: pkg/kubernetes/views/service-page.html:19
-msgid "The service '{{ target }}' does not exist."
-msgstr "Il servizio ''non esiste."
-
 #: pkg/systemd/hwinfo.jsx:65
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 
-#: pkg/kubernetes/views/user-page.html:29
-msgid "The user '{{ userName }}' does not exist."
-msgstr "L'utente ' ' ' '{{ userName }}non esiste."
-
-#: pkg/systemd/init.js:928
+#: pkg/systemd/init.js:922
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "L<b>$0</b>'utente non ha i permessi per la creazione di timer"
 
@@ -8487,11 +6774,11 @@ msgstr "L<b>$0</b>'utente non ha i permessi per la creazione di timer"
 msgid "The user <b>$0</b> is not permitted to change profiles"
 msgstr "L'utente non <b>$0</b>è autorizzato a modificare i profili"
 
-#: pkg/systemd/host.js:66
+#: pkg/systemd/host.js:70
 msgid "The user <b>$0</b> is not permitted to change the system time"
 msgstr "L'utente non <b>$0</b> è autorizzato a modificare l'orario di sistema"
 
-#: pkg/systemd/init.js:620
+#: pkg/systemd/init.js:614
 msgid "The user <b>$0</b> is not permitted to enable or disable services"
 msgstr ""
 "All'utente non <b>$0</b> è consentito abilitare o disabilitare i servizi"
@@ -8508,30 +6795,29 @@ msgstr "L'utente non <b>$0</b>è autorizzato a gestire l'archiviazione"
 msgid "The user <b>$0</b> is not permitted to modify accounts"
 msgstr "L'utente non <b>$0</b>è autorizzato a modificare gli account"
 
-#: pkg/systemd/host.js:50
+#: pkg/systemd/host.js:54
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
-msgstr ""
-"L'utente non <b>$0</b>è autorizzato a modificare i nomi degli hostname"
+msgstr "L'utente non <b>$0</b>è autorizzato a modificare i nomi degli hostname"
 
-#: pkg/networkmanager/interfaces.js:1513
+#: pkg/networkmanager/interfaces.js:1516
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
 "L'utente non <b>$0</b>è autorizzato a modificare le impostazioni di rete"
 
-#: pkg/realmd/operation.js:643
+#: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "L'utente non <b>$0</b>è autorizzato a modificare i regni"
 
-#: pkg/systemd/host.js:58
+#: pkg/systemd/host.js:62
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr "L'utente non <b>$0</b>è autorizzato a spegnere o riavviare il server"
 
-#: pkg/systemd/init.js:612 pkg/systemd/init.js:616
+#: pkg/systemd/init.js:606 pkg/systemd/init.js:610
 msgid "The user <b>$0</b> is not permitted to start or stop services"
 msgstr ""
 "L'utente non <b>$0</b>è autorizzato ad avviare o interrompere i servizi"
 
-#: pkg/users/local.js:549
+#: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
@@ -8539,10 +6825,9 @@ msgstr ""
 "Il nome utente può essere composto solo da lettere da a-z, cifre, punti, "
 "linee e sottolineature."
 
-#: src/ws/login.js:139 src/ws/login.js:162
+#: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "La configurazione del browser web impedisce l'esecuzione di Cockpit ($0 "
 "inaccessibile)"
@@ -8579,21 +6864,13 @@ msgstr "Volume logico sottile"
 msgid "This NFS mount is in use and only its options can be changed."
 msgstr ""
 "Questo supporto NFS è in uso e solo le sue opzioni possono essere modificate."
-""
 
 #: pkg/storaged/vdo-details.jsx:133
 msgid "This VDO device does not use all of its backing device."
 msgstr ""
 "Questo dispositivo VDO non utilizza tutti i suoi dispositivi di supporto."
 
-#: pkg/kubernetes/views/pvc-delete.html:8
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-"Questa indicazione è in uso. L'eliminazione potrebbe causare problemi con il "
-"seguente pod:"
-
-#: pkg/systemd/init.js:1377
+#: pkg/systemd/init.js:1371
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -8601,11 +6878,11 @@ msgstr ""
 "Questo giorno non esiste in tutti i mesi. Il<br> timer verrà eseguito solo "
 "nei mesi che hanno 31."
 
-#: pkg/networkmanager/interfaces.js:2616
+#: pkg/networkmanager/interfaces.js:2624
 msgid "This device cannot be managed here."
 msgstr "Questo dispositivo non può essere gestito qui."
 
-#: pkg/storaged/dialog.jsx:987
+#: pkg/storaged/dialog.jsx:997
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
@@ -8613,11 +6890,11 @@ msgstr ""
 "Questo dispositivo ha filesystem che sono attualmente in uso. Procedendo si "
 "smonta tutti i filesystem su di esso."
 
-#: pkg/storaged/dialog.jsx:966
+#: pkg/storaged/dialog.jsx:976
 msgid "This device is currently used for RAID devices."
 msgstr "Questo dispositivo è attualmente utilizzato per dispositivi RAID."
 
-#: pkg/storaged/dialog.jsx:995
+#: pkg/storaged/dialog.jsx:1005
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
@@ -8625,15 +6902,15 @@ msgstr ""
 "Questo dispositivo è attualmente utilizzato per i dispositivi RAID. "
 "Procedendo si rimuoverà dai suoi dispositivi RAID."
 
-#: pkg/storaged/dialog.jsx:970
+#: pkg/storaged/dialog.jsx:980
 msgid "This device is currently used for VDO devices."
 msgstr "Questo dispositivo è attualmente utilizzato per dispositivi VDO."
 
-#: pkg/storaged/dialog.jsx:962
+#: pkg/storaged/dialog.jsx:972
 msgid "This device is currently used for volume groups."
 msgstr "Questo dispositivo è attualmente utilizzato per gruppi di volumi."
 
-#: pkg/storaged/dialog.jsx:991
+#: pkg/storaged/dialog.jsx:1001
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -8647,23 +6924,15 @@ msgstr ""
 "Questo disco non può essere rimosso mentre il dispositivo è in fase di "
 "ripristino."
 
-#: pkg/systemd/init.js:1289 pkg/systemd/init.js:1303 pkg/systemd/init.js:1312
+#: pkg/systemd/init.js:1283 pkg/systemd/init.js:1297 pkg/systemd/init.js:1306
 msgid "This field cannot be empty."
 msgstr "Questo campo non può essere vuoto."
-
-#: pkg/ovirt/components/App.jsx:155
-msgid ""
-"This host is managed by a virtualization manager, so creation of new VMs "
-"from the host is not possible."
-msgstr ""
-"Questo host è gestito da un gestore di virtualizzazione, quindi non è "
-"possibile creare nuove macchine virtuali dall'host."
 
 #: pkg/docker/containers-view.jsx:494
 msgid "This image does not exist."
 msgstr "Questa immagine non esiste."
 
-#: pkg/storaged/warning-tab.jsx:116
+#: pkg/storaged/lvol-tabs.jsx:408
 msgid "This logical volume is not completely used by its content."
 msgstr ""
 
@@ -8674,14 +6943,6 @@ msgstr "Questa macchina è già stata aggiunta."
 #: pkg/realmd/operation.html:80
 msgid "This may take a while"
 msgstr "Attendere prego."
-
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-"Questa opzione è solo per il test di un singolo nodo - l'archiviazione "
-"locale non funziona in un cluster multi-nodo"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
@@ -8713,16 +6974,16 @@ msgstr ""
 "informazioni diagnostiche da questo sistema per l'uso con la diagnosi dei "
 "problemi con il sistema."
 
-#: pkg/systemd/init.js:691
+#: pkg/systemd/init.js:685
 msgid "This unit is an instance of the $0 template."
 msgstr "Questa unità è un'istanza del $0 modello."
 
-#: pkg/systemd/services.html:362
+#: pkg/systemd/services.html:360
 msgid "This unit is not designed to be enabled explicitly."
 msgstr ""
 "Questa unità non è stata progettata per essere abilitata esplicitamente."
 
-#: pkg/users/local.js:557
+#: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "Questo nome utente esiste già"
 
@@ -8734,31 +6995,16 @@ msgstr ""
 "Questa versione di cockpit-ws non supporta la connessione a un host con un "
 "utente alternativo o una porta"
 
-#: pkg/ovirt/components/OVirtTab.jsx:134
-msgid "This virtual machine is not managed by oVirt"
-msgstr "Questa macchina virtuale non è gestita da oVirt"
-
-#: pkg/kubernetes/views/pv-delete.html:7
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
+msgid "This volume is already used by another VM."
 msgstr ""
-"Questo volume è stato rivendicato da {{ item.item.spec.claimRef.namespace }} "
-"/ {{ item.item.spec.claimRef.name }}. Cancellandolo si rompe tale "
-"rivendicazione e può causare problemi con qualsiasi baccelli a seconda di "
-"esso."
-
-#: pkg/kubernetes/views/pv-claim.html:23
-msgid "This volume has not been claimed"
-msgstr "Questo volume non è stato rivendicato"
 
 #: pkg/storaged/lvol-tabs.jsx:186
 msgid "This volume needs to be activated before it can be resized."
 msgstr ""
 "Questo volume deve essere attivato prima di poter essere ridimensionato."
 
-#: src/ws/login.js:127
+#: src/ws/login.js:122
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr "Questo browser web è troppo vecchio per eseguire Cockpit (mancante$0)"
 
@@ -8778,15 +7024,13 @@ msgstr ""
 
 #: pkg/kdump/kdump-view.jsx:489
 msgid "This will test the kdump configuration by crashing the kernel."
-msgstr ""
-"Questo testerà la configurazione di kdump mandando in crash il kernel."
+msgstr "Questo testerà la configurazione di kdump mandando in crash il kernel."
 
-#: pkg/machines/components/vcpuModal.jsx:219
-#: pkg/ovirt/components/vcpuModal.jsx:70
+#: pkg/machines/components/vcpuModal.jsx:212
 msgid "Threads per core"
 msgstr "Threads per core"
 
-#: pkg/systemd/services.html:240
+#: pkg/systemd/services.html:238
 msgid "Thursday"
 msgstr "Giovedì"
 
@@ -8795,7 +7039,7 @@ msgid "Thursdays"
 msgstr ""
 
 # ctx::sourcefile::/rhn/account/LocalePreferences
-#: pkg/systemd/index.html:372
+#: pkg/systemd/index.html:364
 msgid "Time Zone"
 msgstr "Fuso Orario"
 
@@ -8803,7 +7047,7 @@ msgstr "Fuso Orario"
 msgid "Timers"
 msgstr "Timer"
 
-#: pkg/shell/index.html:325
+#: pkg/shell/index.html:305
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
@@ -8836,21 +7080,13 @@ msgstr ""
 "Per provare un porto diverso è necessario aggiornare le ganasce della cabina "
 "di pilotaggio ad una versione più recente."
 
-#: pkg/kubernetes/views/auth-form.html:116
-msgid "Token"
-msgstr "Token"
-
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:147
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:148
 msgid "Too many files found"
 msgstr "Troppi file trovati"
 
 #: src/base1/cockpit.js:4039
 msgid "Too much data"
 msgstr "Troppi dati"
-
-#: pkg/kubernetes/index.html:61
-msgid "Topology"
-msgstr "Topologia"
 
 #: pkg/docker/storage.jsx:341
 msgid "Total"
@@ -8864,16 +7100,15 @@ msgstr "Dimensione totale: $0"
 msgid "Tower"
 msgstr "Tower"
 
-#: pkg/systemd/init.js:739
+#: pkg/systemd/init.js:733
 msgid "Triggered By"
 msgstr "Attivato da"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:32 pkg/systemd/init.js:738
+#: pkg/systemd/init.js:732
 msgid "Triggers"
 msgstr "Trigger"
 
-#: pkg/kubernetes/index.html:109 pkg/shell/index.html:407
-#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/shell/index.html:387 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Risoluzione dei problemi"
@@ -8882,9 +7117,10 @@ msgstr "Risoluzione dei problemi"
 msgid "Trust key"
 msgstr "Chiave della fiducia"
 
-#: pkg/kubernetes/views/auth-rejected-cert.html:21
-msgid "Trust this certificate for this connection"
-msgstr "Fidarsi di questo certificato per questo collegamento"
+#: pkg/networkmanager/firewall.jsx:705
+#, fuzzy
+msgid "Trust level"
+msgstr "Chiave della fiducia"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -8902,7 +7138,7 @@ msgstr "Provare a riconnettersi"
 msgid "Trying to synchronize with {{Server}}"
 msgstr "Tenativo di sincronizzazione con {{Server}}"
 
-#: pkg/systemd/services.html:238
+#: pkg/systemd/services.html:236
 msgid "Tuesday"
 msgstr "Martedì"
 
@@ -8926,24 +7162,21 @@ msgstr "Tuned non è in esecuzione"
 msgid "Tuned is off"
 msgstr "Tuned è disattivato"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:285
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:96
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/vm/bootOrderModal.jsx:110
-#: pkg/machines/components/vm/bootOrderModal.jsx:121
-#: pkg/machines/components/vm/bootOrderModal.jsx:127
-#: pkg/machines/components/vm/bootOrderModal.jsx:133
-#: pkg/machines/components/vm/bootOrderModal.jsx:140
-#: pkg/machines/components/vm/bootOrderModal.jsx:146
-#: pkg/machines/components/vmnetworktab.jsx:84 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:38 pkg/storaged/format-dialog.jsx:286
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/machines/components/vm/bootOrderModal.jsx:119
+#: pkg/machines/components/vm/bootOrderModal.jsx:125
+#: pkg/machines/components/vm/bootOrderModal.jsx:131
+#: pkg/machines/components/vm/bootOrderModal.jsx:138
+#: pkg/machines/components/vm/bootOrderModal.jsx:144
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
 #: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Tipo"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:147
+#: pkg/machines/components/vm/bootOrderModal.jsx:145
 msgid "Type ID"
 msgstr ""
 
@@ -8955,16 +7188,11 @@ msgstr "Digitare una password"
 msgid "Type to filter…"
 msgstr "Tipo da filtrare...."
 
-#: pkg/kubernetes/views/details-page.html:7
-msgid "Type:"
-msgstr "Tipo:"
-
-#: pkg/docker/index.html:332 pkg/networkmanager/firewall.jsx:595
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:314
-#: pkg/subscriptions/subscriptions-register.jsx:112
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
 msgid "URL"
 msgstr "URL"
 
@@ -8981,17 +7209,9 @@ msgstr "Impossibile applicare le impostazioni: $0"
 msgid "Unable to apply this solution automatically"
 msgstr "Impossibile applicare automaticamente questa soluzione"
 
-#: pkg/subscriptions/subscriptions-view.jsx:217
-msgid "Unable to connect"
-msgstr "Impossibile collegarsi"
-
-#: src/ws/login.js:646
+#: src/ws/login.js:649
 msgid "Unable to connect to that address"
 msgstr "Impossibile connettersi a quell'indirizzo"
-
-#: pkg/kubernetes/scripts/dashboard.js:412
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "Incapace di decodificare il manifesto dell'applicazione Kubernetes."
 
 #: pkg/users/local.js:58
 msgid "Unable to delete root account"
@@ -9009,11 +7229,6 @@ msgstr "Incapace di stare all'erta: $0"
 #: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Impossibile raggiungere il server"
-
-#: pkg/kubernetes/scripts/dashboard.js:400
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr ""
-"Impossibile leggere il manifesto di applicazione Kubernetes. Codice $0."
 
 #: pkg/storaged/nfs-details.jsx:282
 msgid "Unable to remove mount"
@@ -9040,41 +7255,35 @@ msgid "Unable to unmount filesystem"
 msgstr "Impossibile smontare il filesystem"
 
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
-#: pkg/kubernetes/scripts/charts.js:110
 msgid "Unavailable"
 msgstr "Non disponibile"
 
-#: pkg/docker/index.html:730 pkg/networkmanager/index.html:690
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1481
+#: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
+#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Errore imprevisto"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:296
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid "Unique name"
 msgstr "Nome unico"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:136
-#: pkg/storaged/dialog.jsx:1037
+#: pkg/machines/components/vm/bootOrderModal.jsx:134
+#: pkg/storaged/dialog.jsx:1047
 msgid "Unit"
 msgstr "Unità"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
-#: pkg/kubernetes/views/volumes-page.html:35
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:754 pkg/kubernetes/scripts/volumes.js:267
-#: pkg/lib/machine-info.js:65 pkg/networkmanager/interfaces.js:593
-#: pkg/networkmanager/interfaces.js:1064 pkg/networkmanager/interfaces.js:2529
-#: pkg/networkmanager/interfaces.js:2531 pkg/storaged/fsys-tab.jsx:64
-#: pkg/storaged/swap-tab.jsx:58
+#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
+#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: pkg/networkmanager/interfaces.js:2515 pkg/networkmanager/interfaces.js:2527
+#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
 msgid "Unknown \"$0\""
 msgstr "Sconosciuto \" \" \" \" \""
 
@@ -9090,7 +7299,7 @@ msgstr "Applicazione sconosciuta"
 msgid "Unknown Host Key"
 msgstr "Chiave host sconosciuto"
 
-#: pkg/networkmanager/interfaces.js:2632
+#: pkg/networkmanager/interfaces.js:2640
 msgid "Unknown configuration"
 msgstr "Configurazione sconosciuta"
 
@@ -9098,7 +7307,7 @@ msgstr "Configurazione sconosciuta"
 msgid "Unknown host name"
 msgstr "Nome host sconosciuto"
 
-#: pkg/networkmanager/firewall.jsx:283
+#: pkg/networkmanager/firewall.jsx:333
 msgid "Unknown service name"
 msgstr ""
 
@@ -9106,24 +7315,24 @@ msgstr ""
 msgid "Unknown type"
 msgstr "Tipo sconosciuto"
 
-#: pkg/docker/index.html:549 pkg/docker/util.js:110
+#: pkg/docker/index.html:551 pkg/docker/util.js:110
 msgid "Unless Stopped"
 msgstr "A meno che non si sia fermato"
 
-#: pkg/storaged/content-views.jsx:230 pkg/storaged/content-views.jsx:235
-#: pkg/storaged/content-views.jsx:248
+#: pkg/storaged/content-views.jsx:222 pkg/storaged/content-views.jsx:227
+#: pkg/storaged/content-views.jsx:240
 msgid "Unlock"
 msgstr "Sblocca"
 
-#: pkg/shell/index.html:221 pkg/shell/index.html:273
+#: pkg/shell/index.html:212 pkg/shell/index.html:253
 msgid "Unlock Key"
 msgstr "Sbloccare la chiave"
 
-#: pkg/storaged/format-dialog.jsx:128
+#: pkg/storaged/format-dialog.jsx:116
 msgid "Unlock at boot"
 msgstr "Sbloccare all'avvio"
 
-#: pkg/storaged/format-dialog.jsx:129
+#: pkg/storaged/format-dialog.jsx:117
 msgid "Unlock read only"
 msgstr "Sblocca solo lettura"
 
@@ -9135,15 +7344,15 @@ msgstr "Sbloccaggio $target"
 msgid "Unlocking disk..."
 msgstr "Sblocco disco....."
 
-#: pkg/networkmanager/index.html:140
+#: pkg/networkmanager/index.html:132
 msgid "Unmanaged Interfaces"
 msgstr "Interfacce non gestite"
 
-#: pkg/systemd/init.js:582
+#: pkg/systemd/init.js:576
 msgid "Unmask"
 msgstr "Smascherare"
 
-#: pkg/storaged/fsys-tab.jsx:188 pkg/storaged/nfs-details.jsx:300
+#: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
 msgid "Unmount"
 msgstr "Smonta"
 
@@ -9155,15 +7364,15 @@ msgstr "Smontaggio $target"
 msgid "Unnamed"
 msgstr "Senza nome"
 
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Unplug"
 msgstr "Scollegare"
 
-#: pkg/storaged/content-views.jsx:153
+#: pkg/storaged/content-views.jsx:159
 msgid "Unrecognized Data"
 msgstr "Dati non riconosciuti"
 
-#: pkg/storaged/content-views.jsx:362
+#: pkg/storaged/content-views.jsx:358
 msgctxt "storage-id-desc"
 msgid "Unrecognized Data"
 msgstr "Dati non riconosciuti"
@@ -9171,14 +7380,6 @@ msgstr "Dati non riconosciuti"
 #: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
 msgid "Unrecognized data can not be made smaller here."
 msgstr "I dati non riconosciuti non possono essere ridotti qui."
-
-#: pkg/subscriptions/subscriptions-view.jsx:164
-msgid "Unregister"
-msgstr "Rimuovi-registrazione"
-
-#: pkg/subscriptions/subscriptions-view.jsx:170
-msgid "Unregistering system..."
-msgstr "Sistema di non registrazione....."
 
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
@@ -9189,7 +7390,7 @@ msgstr "Irrisolto"
 msgid "Unsupported setup mechanism"
 msgstr "Meccanismo di impostazione non supportato"
 
-#: pkg/storaged/content-views.jsx:617
+#: pkg/storaged/content-views.jsx:613
 msgid "Unsupported volume"
 msgstr "Volume non supportato"
 
@@ -9200,6 +7401,14 @@ msgstr "Ospite non fidato"
 #: pkg/docker/util.js:94
 msgid "Up since $0"
 msgstr "Avviato dal $0"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+msgid "Up to $0 $1 available in the default location"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
+msgid "Up to $0 $1 available on the host"
+msgstr ""
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
 #: pkg/lib/machine-change-port.html:41
@@ -9223,24 +7432,20 @@ msgid "Updated packages may require a restart to take effect."
 msgstr ""
 "I pacchetti aggiornati possono richiedere un riavvio per avere effetto."
 
-#: pkg/systemd/host.js:498
+#: pkg/systemd/host.js:502
 msgid "Updates Available"
 msgstr "Aggiornamenti disponibili"
 
-#: pkg/packagekit/updates.jsx:52 pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/packagekit/updates.jsx:52
 msgid "Updating"
 msgstr "Aggiornamento"
 
-#: pkg/kubernetes/scripts/details.js:654
-msgid "Updating $0..."
-msgstr "Aggiornamento $0...."
-
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
-#: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:35
+#: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Utilizzo"
 
-#: pkg/systemd/host.js:1609
+#: pkg/systemd/host.js:1613
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] "Utilizzo del core della $0CPU"
@@ -9250,44 +7455,34 @@ msgstr[1] "Utilizzo dei core della $0CPU"
 msgid "Use 512 Byte emulation"
 msgstr "Usa l'emulazione a 512 byte"
 
-#: pkg/machines/components/diskAdd.jsx:416
+#: pkg/machines/components/diskAdd.jsx:524
 msgid "Use Existing"
 msgstr "Usa esistente"
-
-#: pkg/subscriptions/subscriptions-register.jsx:136
-msgid "Use proxy server"
-msgstr "Usa server proxy"
 
 #: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Utilizzare i seguenti tasti per autenticarsi contro altri sistemi"
 
 # spazio su disco, quindi maschile
-#: pkg/systemd/index.html:264 pkg/docker/storage.jsx:340
-#: pkg/kubernetes/scripts/nodes.js:829 pkg/kubernetes/scripts/nodes.js:838
+#: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
-#: pkg/machines/components/vmDisksTab.jsx:67 pkg/storaged/fsys-tab.jsx:196
-#: pkg/storaged/swap-tab.jsx:83 pkg/systemd/host.js:1674
+#: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1678
 msgid "Used"
 msgstr "Usato"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:66
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 msgid "Used by"
 msgstr ""
 
-#: pkg/docker/index.html:262
+#: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "Usato da Contenitori"
 
-#: pkg/dashboard/index.html:142 pkg/kubernetes/views/auth-form.html:61
-#: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
-#: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
-#: pkg/playground/translate.html:105 pkg/systemd/index.html:238
-#: pkg/subscriptions/subscriptions-register.jsx:77 pkg/systemd/host.js:1580
+#: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
+#: pkg/playground/translate.html:105 pkg/systemd/index.html:230
+#: pkg/systemd/host.js:1584
 msgid "User"
 msgstr "Utente"
 
@@ -9296,11 +7491,11 @@ msgstr "Utente"
 msgid "User Name"
 msgstr "Nome utente"
 
-#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:337
+#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:336
 msgid "User Password"
 msgstr "Password utente"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nome utente"
@@ -9309,37 +7504,28 @@ msgstr "Nome utente"
 msgid "User name cannot be empty"
 msgstr "Il nome utente non può essere vuoto"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:15
-msgid "User or Group"
-msgstr "Utente o gruppo"
-
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
-#: pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
 msgid "Username"
 msgstr "Nome utente"
-
-#: pkg/kubernetes/views/project-listing.html:85
-msgid "Users"
-msgstr "Utenti"
 
 #: pkg/lib/machine-change-auth.html:44
 msgid "Using available credentials"
 msgstr "Utilizzo delle credenziali disponibili"
 
-#: pkg/machines/components/vcpuModal.jsx:162
+#: pkg/machines/components/vcpuModal.jsx:164
 msgid "VCPU settings could not be saved"
 msgstr "Non è stato possibile salvare le impostazioni del VCPU"
 
-#: pkg/storaged/content-views.jsx:149
+#: pkg/storaged/content-views.jsx:155
 msgid "VDO Backing"
 msgstr "Supporto VDO"
 
-#: pkg/storaged/content-views.jsx:360
+#: pkg/storaged/content-views.jsx:356
 msgctxt "storage-id-desc"
 msgid "VDO Backing"
 msgstr "Supporto VDO"
 
-#: pkg/storaged/pvol-tabs.jsx:91
+#: pkg/storaged/pvol-tabs.jsx:80
 msgid "VDO Device"
 msgstr "Dispositivo VDO"
 
@@ -9359,37 +7545,29 @@ msgstr "I dispositivi di supporto VDO non possono essere resi più piccoli"
 msgid "VDO support not installed"
 msgstr "Supporto VDO non installato"
 
-#: pkg/ovirt/components/App.jsx:115
-msgid "VDSM"
-msgstr "VDSM"
-
-#: pkg/ovirt/components/VdsmView.jsx:128
-msgid "VDSM Service Management"
-msgstr "Gestione dei servizi VDSM"
-
 # translation auto-copied from project Anaconda, version master, document anaconda, author Gregorio
-#: pkg/networkmanager/interfaces.js:2511 pkg/networkmanager/interfaces.js:2523
-#: pkg/networkmanager/interfaces.js:2898
+#: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
+#: pkg/networkmanager/interfaces.js:2906
 msgid "VLAN"
 msgstr "VLAN"
 
-#: pkg/networkmanager/index.html:169
+#: pkg/networkmanager/index.html:161
 msgid "VLAN Id"
 msgstr "ID VLAN"
 
-#: pkg/networkmanager/index.html:618
+#: pkg/networkmanager/index.html:610
 msgid "VLAN Settings"
 msgstr "Impostazioni VLAN"
 
-#: pkg/machines/hostvmslist.jsx:114
+#: pkg/machines/hostvmslist.jsx:116
 msgid "VM $0 failed to Reboot"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:120
+#: pkg/machines/hostvmslist.jsx:122
 msgid "VM $0 failed to force Reboot"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:144
+#: pkg/machines/hostvmslist.jsx:146
 msgid "VM $0 failed to force shutdown"
 msgstr ""
 
@@ -9397,33 +7575,29 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:108 pkg/machines/libvirt-common.js:1290
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
 msgid "VM $0 failed to get installed"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:132
+#: pkg/machines/hostvmslist.jsx:134
 msgid "VM $0 failed to pause"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:138
+#: pkg/machines/hostvmslist.jsx:140
 msgid "VM $0 failed to resume"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:150
+#: pkg/machines/hostvmslist.jsx:152
 msgid "VM $0 failed to send NMI"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:126
+#: pkg/machines/hostvmslist.jsx:128
 msgid "VM $0 failed to shutdown"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:102
+#: pkg/machines/hostvmslist.jsx:104
 msgid "VM $0 failed to start"
 msgstr ""
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:37
-msgid "VM icon"
-msgstr "Icona VM"
 
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
@@ -9441,7 +7615,7 @@ msgstr "Porta VNC:"
 msgid "VNC TLS Port:"
 msgstr "Porta VNC TLS:"
 
-#: pkg/realmd/operation.js:165
+#: pkg/realmd/operation.js:164
 msgid "Validating address"
 msgstr ""
 
@@ -9454,8 +7628,8 @@ msgid "Validating key"
 msgstr "Tasto di convalida"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
-#: pkg/machines/components/vm/bootOrderModal.jsx:122
-#: pkg/machines/components/vm/bootOrderModal.jsx:128 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/vm/bootOrderModal.jsx:120
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:249
 msgid "Vendor"
 msgstr "Rivenditore"
 
@@ -9472,32 +7646,22 @@ msgid "Verifying"
 msgstr "Verifica"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:110 pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:381
-#: pkg/subscriptions/subscriptions-view.jsx:35 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Versione"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Version num"
-msgstr "Version num"
 
 #: pkg/storaged/jobs-panel.jsx:57
 msgid "Very securely erasing $target"
 msgstr "Very securely erasing $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Server Virtuali"
 
-#: pkg/ovirt/components/ClusterVms.jsx:176
-msgid "Virtual Machines of $0 cluster"
-msgstr "Macchine virtuali del cluster $0"
-
-#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:171
+#: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
 msgstr ""
 
@@ -9510,21 +7674,19 @@ msgid "Virtualization Service is Available"
 msgstr "Il servizio di virtualizzazione è disponibile"
 
 # nome per a11y
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
-#: pkg/kubernetes/views/pvc-body.html:6
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
+#: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:88
-#: pkg/machines/components/vm/bootOrderModal.jsx:98
-#: pkg/machines/components/vmDiskSourceCell.jsx:41
-#: pkg/storaged/content-views.jsx:130
+#: pkg/machines/components/vmDiskColumns.jsx:46
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Volume"
 
-#: pkg/storaged/pvol-tabs.jsx:40
+#: pkg/storaged/pvol-tabs.jsx:35
 msgid "Volume Group"
 msgstr "Gruppo di volumi"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:233
+#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Gruppo di volumi $0"
 
@@ -9532,41 +7694,25 @@ msgstr "Gruppo di volumi $0"
 msgid "Volume Groups"
 msgstr "Gruppi di volume"
 
-#: pkg/kubernetes/views/volume-body.html:14
-#: pkg/kubernetes/views/volume-body.html:89
-msgid "Volume ID"
-msgstr "ID volume"
-
-#: pkg/kubernetes/views/pv-modify.html:115
-#: pkg/kubernetes/views/volume-body.html:42
-msgid "Volume Name"
-msgstr "Nome del volume"
-
-#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
-msgid "Volume Type"
-msgstr "Tipo di volume"
-
-#: pkg/storaged/warning-tab.jsx:118
+#: pkg/storaged/lvol-tabs.jsx:410
 msgid "Volume size is $0. Content size is $1."
 msgstr ""
 
-#: pkg/docker/index.html:515 pkg/kubernetes/index.html:74
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:517
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volumi"
 
-#: pkg/docker/index.html:199
+#: pkg/docker/index.html:200
 msgid "Volumes:"
 msgstr "Volumi:"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:142
+#: pkg/machines/components/vm/bootOrderModal.jsx:140
 msgid "WWPN"
 msgstr ""
 
 # translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
-#: pkg/networkmanager/interfaces.js:833
+#: pkg/networkmanager/interfaces.js:836
 msgid "Waiting"
 msgstr "In attesa"
 
@@ -9575,42 +7721,33 @@ msgstr "In attesa"
 msgid "Waiting for details..."
 msgstr "Aspettando i dettagli....."
 
-#: pkg/apps/utils.jsx:62
+#: pkg/apps/utils.jsx:63
 msgid "Waiting for other programs to finish using the package manager..."
 msgstr ""
 "In attesa che altri programmi finiscano di usare il gestore di pacchetti....."
-""
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:140
 #: pkg/lib/cockpit-components-install-dialog.jsx:175
 msgid "Waiting for other software management operations to finish"
 msgstr "In attesa che finiscano le altre operazioni di gestione del software"
 
-#: pkg/systemd/init.js:730
+#: pkg/systemd/init.js:724
 msgid "Wanted By"
 msgstr "Ricercato da"
 
-#: pkg/systemd/init.js:725
+#: pkg/systemd/init.js:719
 msgid "Wants"
 msgstr "Vuole"
 
-#: pkg/storaged/content-views.jsx:159
-msgid "Warning"
-msgstr ""
-
-#: pkg/systemd/logs.html:59
+#: pkg/systemd/logs.html:60
 msgid "Warning and above"
 msgstr "Avvertenza e oltre"
-
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid "Warning:"
-msgstr "Attenzione:"
 
 #: cockpit.appdata.xml.in.h:1
 msgid "Web Console for Linux servers"
 msgstr "Console Web per server Linux"
 
-#: pkg/systemd/services.html:239
+#: pkg/systemd/services.html:237
 msgid "Wednesday"
 msgstr "Mercoledì"
 
@@ -9618,27 +7755,19 @@ msgstr "Mercoledì"
 msgid "Wednesdays"
 msgstr ""
 
-#: pkg/systemd/services.html:468
+#: pkg/systemd/services.html:466
 msgid "Weeks"
 msgstr "Settimane"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:5
-msgid "Welcome to the Image Registry"
-msgstr "Benvenuti nel Registro delle immagini"
 
 #: pkg/storaged/crypto-keyslots.jsx:324
 msgid "What if tang-show-keys is not available?"
 msgstr "E se tang-show-keys non è disponibile?"
 
-#: pkg/kubernetes/views/volumes-page.html:61
-msgid "When"
-msgstr "Quando"
-
 #: pkg/systemd/terminal.jsx:101
 msgid "White"
 msgstr ""
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:488
 msgid "With terminal"
 msgstr "Con terminale"
 
@@ -9646,19 +7775,19 @@ msgstr "Con terminale"
 msgid "Write-mostly"
 msgstr "Scrittura-principalmente"
 
-#: pkg/storaged/plot.jsx:268
+#: pkg/storaged/plot.jsx:313
 msgid "Writing"
 msgstr "La scrittura"
 
-#: src/ws/login.js:656
+#: src/ws/login.js:659
 msgid "Wrong user name or password"
 msgstr "Nome utente o password sbagliata"
 
-#: pkg/networkmanager/interfaces.js:1973
+#: pkg/networkmanager/interfaces.js:1976
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:996 pkg/networkmanager/interfaces.js:2585
+#: pkg/networkmanager/interfaces.js:2593
 msgid "Yes"
 msgstr "Sì"
 
@@ -9677,21 +7806,10 @@ msgstr ""
 "Al momento siete connessi direttamente a questo server. Non potete "
 "cancellarlo."
 
-#: pkg/networkmanager/firewall.jsx:68 pkg/networkmanager/firewall.jsx:561
+#: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
+#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
 msgid "You are not authorized to modify the firewall."
 msgstr "Non sei autorizzato a modificare il firewall."
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:3
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-"È possibile aggirare il controllo del certificato, ma qualsiasi dato inviato "
-"al server potrebbe essere intercettato da altri."
-
-#: pkg/kubernetes/views/dashboard-page.html:150
-msgid "You can deploy an application to your cluster."
-msgstr "È possibile distribuire un'applicazione nel proprio cluster."
 
 #: pkg/users/index.html:390
 msgid ""
@@ -9709,6 +7827,11 @@ msgstr "Non hai il permesso di gestire il pool di archiviazione di Docker."
 msgid "You must wait longer to change your password"
 msgstr "Devi aspettare più a lungo per cambiare la tua password"
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
+msgid ""
+"You need to select the most closely matching OS vendor and Operating System"
+msgstr ""
+
 #: pkg/packagekit/updates.jsx:834
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
@@ -9717,14 +7840,6 @@ msgstr ""
 "Il tuo browser si scollegherà, ma questo non influisce sul processo di "
 "aggiornamento. È possibile riconnettersi in pochi istanti per continuare a "
 "guardare i progressi."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:112
-msgid ""
-"Your login credentials do not give you access to use the docker registry "
-"from the command line."
-msgstr ""
-"Le credenziali di accesso non danno accesso all'utilizzo del registro di "
-"bordo dalla riga di comando."
 
 #: pkg/packagekit/updates.jsx:865
 msgid ""
@@ -9742,6 +7857,16 @@ msgstr "La sua sessione e' terminata."
 msgid "Your session has expired. Please log in again."
 msgstr "La sessione è scaduta. Effettua di nuovo il login."
 
+# ctx::sourcefile::/rhn/account/LocalePreferences
+#: pkg/networkmanager/firewall.jsx:925
+#, fuzzy
+msgid "Zone"
+msgstr "Fuso Orario"
+
+#: pkg/networkmanager/firewall.jsx:938
+msgid "Zones"
+msgstr ""
+
 #: pkg/lib/journal.js:215
 msgid "[$0 bytes of binary data]"
 msgstr "[$0byte di dati binari]"
@@ -9754,8 +7879,12 @@ msgstr "[dati binari]"
 msgid "[no data]"
 msgstr "[nessun dato]"
 
-#: pkg/machines/components/networks/network.jsx:58
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "attivo"
@@ -9790,13 +7919,9 @@ msgstr "byte"
 msgid "cdrom"
 msgstr "cdrom"
 
-#: pkg/ovirt/rephraseUI.js:35
-msgid "connecting"
-msgstr "connessione in corso"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "cores"
-msgstr "core"
+#: pkg/machines/components/infoRecord.jsx:29
+msgid "control-label $0"
+msgstr ""
 
 #: pkg/machines/helpers.js:193
 msgid "crashed"
@@ -9815,7 +7940,6 @@ msgid "direct"
 msgstr "diretto"
 
 #: pkg/machines/helpers.js:177 pkg/machines/helpers.js:180
-#: pkg/ovirt/components/OVirtTab.jsx:123
 msgid "disabled"
 msgstr "disabilitato"
 
@@ -9823,7 +7947,7 @@ msgstr "disabilitato"
 msgid "disk"
 msgstr "disco"
 
-#: pkg/machines/helpers.js:238 pkg/ovirt/rephraseUI.js:27
+#: pkg/machines/helpers.js:238
 msgid "down"
 msgstr "giù"
 
@@ -9831,26 +7955,17 @@ msgstr "giù"
 msgid "dying"
 msgstr "morente"
 
-#: pkg/realmd/operation.js:299 pkg/realmd/operation.js:305
+#: pkg/realmd/operation.js:298 pkg/realmd/operation.js:304
 msgid "e.g. \"$0\""
 msgstr "es: \"$0\""
 
-#: pkg/kubernetes/scripts/images.js:639
-msgid "eg: my-image-stream"
-msgstr "es: my-image-stream"
-
 #: pkg/machines/helpers.js:178 pkg/machines/helpers.js:181
-#: pkg/ovirt/components/OVirtTab.jsx:125
 msgid "enabled"
 msgstr "abilitato"
 
 #: pkg/packagekit/updates.jsx:267
 msgid "enhancement"
 msgstr "miglioramento"
-
-#: pkg/ovirt/rephraseUI.js:28
-msgid "error"
-msgstr "errore"
 
 #: pkg/machines/helpers.js:214
 msgid "ethernet"
@@ -9860,7 +7975,7 @@ msgstr "ethernet"
 msgid "every day"
 msgstr "quotidianamente"
 
-#: pkg/systemd/host.js:882
+#: pkg/systemd/host.js:886
 msgid "failed to list ssh host keys: $0"
 msgstr "non ha elencato le chiavi host ssh: $0"
 
@@ -9876,6 +7991,11 @@ msgstr ""
 msgid "hostdev"
 msgstr "hostdev"
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#, fuzzy
+msgid "iSCSI Initiator IQN"
+msgstr "Cambiare il nome dell'iniziatore iSCSI"
+
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
 msgid "iSCSI Target"
 msgstr ""
@@ -9884,7 +8004,12 @@ msgstr ""
 msgid "iSCSI Targets"
 msgstr "target iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:190
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:83
+#, fuzzy
+msgid "iSCSI direct Target"
+msgstr "target iSCSI"
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -9892,22 +8017,10 @@ msgstr ""
 msgid "idle"
 msgstr "in attesa"
 
-#: pkg/machines/components/networks/network.jsx:58
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "Inattivo"
-
-#: pkg/ovirt/rephraseUI.js:29
-msgid "initializing"
-msgstr "inizializzazione"
-
-#: pkg/ovirt/rephraseUI.js:30
-msgid "installation failed"
-msgstr "installazione fallita"
-
-#: pkg/ovirt/rephraseUI.js:38
-msgid "installing OS"
-msgstr "installazione del sistema operativo"
 
 #: pkg/kdump/kdump-view.jsx:376
 msgid "invalid: multiple targets defined"
@@ -9916,10 +8029,6 @@ msgstr "non valido: sono stati definiti più obiettivi multipli"
 #: pkg/kdump/kdump-view.jsx:493
 msgid "kdump status"
 msgstr "stato kdump"
-
-#: pkg/ovirt/rephraseUI.js:39
-msgid "kdumping"
-msgstr "kdumping"
 
 #: pkg/docker/run.js:527
 msgid "key"
@@ -9933,10 +8042,6 @@ msgstr "fessura per chiavi $0"
 msgid "locally in $0"
 msgstr "localmente in $0"
 
-#: pkg/ovirt/rephraseUI.js:31
-msgid "maintenance"
-msgstr "mantenimento"
-
 #: pkg/machines/helpers.js:216
 msgid "mcast"
 msgstr "cast"
@@ -9949,63 +8054,20 @@ msgstr "rete"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs dump target non è formattato come server:path"
 
-#: pkg/kubernetes/views/route-body.html:14
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:60
-#: pkg/machines/components/vmDisksTab.jsx:99 pkg/machines/helpers.js:234
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:43
+#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "no"
 
-#: pkg/ovirt/rephraseUI.js:32
-msgid "non operational"
-msgstr "non operativo"
-
-#: pkg/ovirt/rephraseUI.js:33
-msgid "non responsive"
-msgstr "non risponde"
-
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
-#: pkg/kubernetes/views/route-body.html:24
-#: pkg/kubernetes/views/route-body.html:29
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "nessuno"
 
-#: pkg/ovirt/provider.js:62
-msgid "oVirt"
-msgstr "oVirt"
-
-#: pkg/ovirt/components/HostStatus.jsx:37
-msgid "oVirt Host State:"
-msgstr "Stato host oVirt:"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:35
-msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr "oVirt Provider non è riuscito a causa di argomenti mancanti."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:36
-msgid ""
-"oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-"machines-ovirt.config, try as root."
-msgstr ""
-"script di installazione oVirt Provider fallito: non è possibile scrivere su /"
-"etc/cockpit/machines-ovirt.config, provare come root."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:164
-msgid "oVirt installation script failed with following output: "
-msgstr ""
-"lo script di installazione di oVirt non è riuscito con il seguente output: "
-
-#: pkg/ovirt/components/App.jsx:51
-msgid "oVirt login in progress"
-msgstr "oVirt login in corso"
-
-#: pkg/systemd/host.js:687
+#: pkg/systemd/host.js:691
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] "di core della CPU $0"
@@ -10015,25 +8077,13 @@ msgstr[1] "di core della CPU $0"
 msgid "paused"
 msgstr "in pausa"
 
-#: pkg/ovirt/rephraseUI.js:34
-msgid "pending approval"
-msgstr "in attesa di approvazione"
-
-#: pkg/kubernetes/views/dashboard-page.html:83
-msgid "pending volume claims"
-msgstr "richieste di risarcimento in sospeso"
-
-#: pkg/machines/components/diskAdd.jsx:173
+#: pkg/machines/components/diskAdd.jsx:154
 msgid "qcow2"
 msgstr "qcow2"
 
-#: pkg/machines/components/diskAdd.jsx:176
+#: pkg/machines/components/diskAdd.jsx:157
 msgid "raw"
 msgstr "raw"
-
-#: pkg/ovirt/rephraseUI.js:36
-msgid "reboot"
-msgstr "riavvia"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -10055,7 +8105,7 @@ msgstr "ricerca per nome, spazio dei nomi o descrizione"
 msgid "security"
 msgstr "sicurezza"
 
-#: pkg/docker/index.html:404
+#: pkg/docker/index.html:406
 msgid "select container"
 msgstr "seleziona container"
 
@@ -10063,15 +8113,15 @@ msgstr "seleziona container"
 msgid "server"
 msgstr "server"
 
-#: pkg/docker/index.html:483 pkg/docker/index.html:655
+#: pkg/docker/index.html:485 pkg/docker/index.html:657
 msgid "shares"
 msgstr "condivisioni"
 
-#: pkg/machines/components/notification/inlineNotification.jsx:52
+#: pkg/lib/cockpit-components-inline-notification.jsx:60
 msgid "show less"
 msgstr "mostra meno"
 
-#: pkg/machines/components/notification/inlineNotification.jsx:50
+#: pkg/lib/cockpit-components-inline-notification.jsx:58
 msgid "show more"
 msgstr "mostra di più"
 
@@ -10082,10 +8132,6 @@ msgstr "spento"
 #: pkg/machines/helpers.js:191
 msgid "shutdown"
 msgstr "spegnimento"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "sockets"
-msgstr "raccordi"
 
 #: pkg/selinux/setroubleshoot-view.jsx:123
 msgid "solution details"
@@ -10107,10 +8153,6 @@ msgstr "il server ssh è vuoto"
 msgid "suspended (PM)"
 msgstr "sospesi (PM)"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "threads"
-msgstr "thread"
-
 #: pkg/docker/run.js:474
 msgid "to host path"
 msgstr "per ospitare il percorso"
@@ -10126,10 +8168,6 @@ msgstr "translatable"
 #: pkg/machines/helpers.js:218
 msgid "udp"
 msgstr "udp"
-
-#: pkg/ovirt/rephraseUI.js:37
-msgid "unassigned"
-msgstr "non assegnato"
 
 #: pkg/lib/cockpit-components-select.jsx:28
 msgid "undefined"
@@ -10148,7 +8186,7 @@ msgstr "obiettivo sconosciuto"
 msgid "unpartitioned space on $0"
 msgstr "spazio non ripartito su $0"
 
-#: pkg/machines/helpers.js:237 pkg/ovirt/rephraseUI.js:26
+#: pkg/machines/helpers.js:237
 msgid "up"
 msgstr "su"
 
@@ -10156,19 +8194,16 @@ msgstr "su"
 msgid "user"
 msgstr "utente"
 
-#: pkg/machines/components/vcpuModal.jsx:195
-#: pkg/ovirt/components/vcpuModal.jsx:54
+#: pkg/machines/components/vcpuModal.jsx:192
 msgid "vCPU Count"
 msgstr "conteggio vCPU"
 
-#: pkg/machines/components/vcpuModal.jsx:200
+#: pkg/machines/components/vcpuModal.jsx:197
 msgid "vCPU Maximum"
 msgstr "vCPU Massimo"
 
 # ctx::sourcefile::/rhn/systems/details/virtualization/VirtualGuestsList.do
 #: pkg/machines/components/vmOverviewTab.jsx:75
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "vCPUs"
 msgstr "vCPU"
 
@@ -10181,12 +8216,16 @@ msgstr "valore"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/kubernetes/views/route-body.html:13
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+msgid ""
+"virt-install package needs to be installed on the system in order to create "
+"new VMs"
+msgstr ""
+
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:60
-#: pkg/machines/components/vmDisksTab.jsx:99 pkg/machines/helpers.js:233
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:42
+#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "si"
 
@@ -10197,3 +8236,1430 @@ msgid ""
 msgstr ""
 "{{ condition.message }} Data e ora: {{ condition.lastTransitionTime }} "
 "Conteggio errori: {{ condition.generation }}"
+
+#~ msgid "$0 vCPU Details"
+#~ msgstr "$0 dettagli vCPU"
+
+#~ msgid "$0% Free"
+#~ msgid_plural "$0% Free"
+#~ msgstr[0] "$0% Libero"
+#~ msgstr[1] "$0% Libero"
+
+#~ msgid "$0% Used"
+#~ msgid_plural "$0% Used"
+#~ msgstr[0] "$0% Usato"
+#~ msgstr[1] "$0% Usato"
+
+#~ msgid "'Organization' required to register."
+#~ msgstr "Organizzazione\" necessaria per la registrazione."
+
+#~ msgid "'Organization' required when using activation keys."
+#~ msgstr ""
+#~ "Organizzazione\" richiesta quando si utilizzano i tasti di attivazione."
+
+#~ msgid "AWS Elastic Block Store"
+#~ msgstr "AWS Elastic Block Store"
+
+#~ msgid "Access Modes"
+#~ msgstr "Modalità di accesso"
+
+# translation auto-copied from project libvirt, version 1.1.1, document libvirt
+#~ msgid "Access denied"
+#~ msgstr "Accesso negato"
+
+#~ msgid "Action"
+#~ msgstr "Azione"
+
+#~ msgid "Activation Key"
+#~ msgstr "Chiave di attivazione"
+
+#~ msgid "Actual"
+#~ msgstr "Attuale"
+
+#~ msgid "Add Cluster Node"
+#~ msgstr "Aggiungi nodo cluster"
+
+#~ msgid "Add Group"
+#~ msgstr "Aggiungi gruppo"
+
+#~ msgid "Add Kubernetes Node"
+#~ msgstr "Aggiungi Nodo Kubernetes"
+
+#~ msgid "Add Member"
+#~ msgstr "Aggiungi membro"
+
+#~ msgid "Add Membership"
+#~ msgstr "Aggiungete l'iscrizione"
+
+#~ msgid "Add New Cluster"
+#~ msgstr "Aggiungere un nuovo cluster"
+
+#~ msgid "Add New User"
+#~ msgstr "Aggiungi nuovo utente"
+
+#~ msgid "Add Role"
+#~ msgstr "Aggiungi ruolo"
+
+#~ msgid "Add User"
+#~ msgstr "Aggiungere Utente"
+
+#~ msgid "Add membership"
+#~ msgstr "Aggiungete l'iscrizione"
+
+#~ msgid "Adjust"
+#~ msgstr "Regola"
+
+#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+#~ msgstr "Regolare il volume persistente ' ' ' '"
+
+#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
+#~ msgstr "Regolare il controllore di replica {{ item.metadata.name }}"
+
+#~ msgid "Adjust Route"
+#~ msgstr "Regolare il percorso"
+
+#~ msgid "Adjust Service"
+#~ msgstr "Regolare il servizio"
+
+#~ msgid "Admin"
+#~ msgstr "Admin"
+
+#~ msgid "All Projects"
+#~ msgstr "Tutti i progetti"
+
+#~ msgid "All Types"
+#~ msgstr "Tutti i tipi"
+
+#~ msgid "All healthy"
+#~ msgstr "Tutti sani"
+
+#~ msgid "All images"
+#~ msgstr "Tutte le immagini"
+
+#~ msgid "All in use"
+#~ msgstr "Tutto in uso"
+
+#~ msgid "All running"
+#~ msgstr "Tutti in esecuzione"
+
+#~ msgid "All running virtual machines will be turned off."
+#~ msgstr "Tutte le macchine virtuali in esecuzione saranno disattivate."
+
+#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
+#~ msgstr ""
+#~ "Anonimo: consente a tutti gli utenti non autenticati di scaricare immagini"
+
+#~ msgid "Automatically selected host"
+#~ msgstr "Ospite selezionato automaticamente"
+
+#~ msgid "Azure"
+#~ msgstr "Azure"
+
+#~ msgid "Base Template"
+#~ msgstr "Modello di base"
+
+#~ msgid "Base template"
+#~ msgstr "Modello di base"
+
+#~ msgid "Base template:"
+#~ msgstr "Modello di base:"
+
+#~ msgid "Boot ID"
+#~ msgstr "ID boot"
+
+#~ msgid "CPU Utilization: $0%"
+#~ msgstr "Utilizzo CPU: $0%"
+
+#~ msgid "CREATE VM action failed"
+#~ msgstr "Azione CREATE VM fallita"
+
+#~ msgid "Cannot decrypt PEM-encoded private key"
+#~ msgstr "Impossibile decifrare la chiave privata codificata PEM"
+
+#~ msgid "Ceph Filesystem Mount"
+#~ msgstr "Montaggio su file system Ceph"
+
+#~ msgid "Ceph Monitors"
+#~ msgstr "Monitor Ceph"
+
+#~ msgid "Change User"
+#~ msgstr "Cambia utente"
+
+#~ msgid "Change image stream"
+#~ msgstr "Cambia flusso di immagini"
+
+#~ msgid "Change project"
+#~ msgstr "Cambia progetto"
+
+#~ msgid "Cinder"
+#~ msgstr "Cenerentola"
+
+#~ msgid "Claim"
+#~ msgstr "Reclama"
+
+#~ msgid "Claim Name"
+#~ msgstr "Nome del reclamo"
+
+#~ msgid "Client Certificate"
+#~ msgstr "Certificato del client"
+
+#~ msgid "Cluster"
+#~ msgstr "Cluster"
+
+#~ msgid "Cluster Templates"
+#~ msgstr "Modelli di cluster"
+
+#~ msgid "Cluster Virtual Machines"
+#~ msgstr "Cluster Virtual Machines"
+
+# translation auto-copied from project libreport, version master, document libreport
+#~ msgid "Configuration"
+#~ msgstr "Configurazione"
+
+#~ msgid "Configure Flannel networking"
+#~ msgstr "Configurare la rete in flanella"
+
+#~ msgid "Configure Kubelet and Proxy"
+#~ msgstr "Configura Kubelet e Proxy"
+
+#~ msgid "Confirm migration"
+#~ msgstr "Confermare la migrazione"
+
+#~ msgid "Confirm passphrase"
+#~ msgstr "Conferma la passphrase"
+
+#~ msgid "Confirm reload:"
+#~ msgstr "Confermare la ricarica:"
+
+#~ msgid "Confirm save:"
+#~ msgstr "Confermare il salvataggio:"
+
+#~ msgid "Connect to oVirt Engine"
+#~ msgstr "Colega al motore oVirt"
+
+#~ msgid "Connecting..."
+#~ msgstr "Connessione..."
+
+#~ msgid "Connection Error: $0"
+#~ msgstr "Errore di connessione: $0"
+
+#~ msgid "Connection Settings"
+#~ msgstr "Impostazioni di connessione"
+
+#~ msgid "Container ID"
+#~ msgstr "ID container"
+
+#~ msgid "Container Runtime Version"
+#~ msgstr "Versione Runtime del contenitore"
+
+#~ msgid "Could not list services"
+#~ msgstr "Impossibile elencare i servizi"
+
+#~ msgid "Could not parse PEM-encoded certificate"
+#~ msgstr "Impossibile analizzare il certificato con codifica PEM"
+
+#~ msgid "Could not parse PEM-encoded private key"
+#~ msgstr "Impossibile analizzare la chiave privata con codifica PEM"
+
+#~ msgid "Couldn't connect to server"
+#~ msgstr "Impossibile connettersi al server"
+
+#~ msgid "Couldn't find running API server"
+#~ msgstr "Non sono riuscito a trovare un server API in esecuzione"
+
+#~ msgid ""
+#~ "Couldn't get system subscription status. Please ensure subscription-"
+#~ "manager is installed."
+#~ msgstr ""
+#~ "Non è stato possibile ottenere lo stato di abbonamento al sistema. "
+#~ "Assicurati che il gestore di abbonamento sia installato."
+
+#~ msgid "Create New VM"
+#~ msgstr "Creare una nuova macchina virtuale"
+
+#~ msgid "Create empty image stream"
+#~ msgstr "Creare un flusso di immagini vuoto"
+
+#~ msgid "Create image stream"
+#~ msgstr "Crea flusso di immagini"
+
+#~ msgid "Custom (Enter filesystem type)"
+#~ msgstr "Personalizzato (Inserire il tipo di file system)"
+
+#~ msgid "Custom URL"
+#~ msgstr "URL personalizzata"
+
+#~ msgid "DNS Policy"
+#~ msgstr "Politica DNS"
+
+#~ msgid "Delete '{{ name }}'"
+#~ msgstr "Cancellare '{{ name }}' "
+
+#~ msgid "Delete Node"
+#~ msgstr "Elimina nodo"
+
+#~ msgid "Delete Persistent Volume"
+#~ msgstr "Cancellare il volume persistente"
+
+#~ msgid "Delete Persistent Volume Claim"
+#~ msgstr "Eliminazione dell'indicazione del volume persistente"
+
+#~ msgid "Delete Project"
+#~ msgstr "Elimina progetto"
+
+#~ msgid "Delete Selected"
+#~ msgstr "Cancella i selezionati"
+
+#~ msgid "Delete image stream"
+#~ msgstr "Elimina flusso di immagini"
+
+#~ msgid "Delete {{ item.kind }}"
+#~ msgstr "Eliminazione {{ item.kind }}"
+
+#~ msgid ""
+#~ "Deleting a Pod will kill all associated containers. Pods may be "
+#~ "automatically created again in some cases."
+#~ msgstr ""
+#~ "L'eliminazione di un baccello uccide tutti i contenitori associati. In "
+#~ "alcuni casi i baccelli possono essere creati automaticamente di nuovo."
+
+#~ msgid "Deploy"
+#~ msgstr "Dispiegare"
+
+#~ msgid "Deploy Application"
+#~ msgstr "Distribuzione dell'applicazione"
+
+#~ msgid "Deployment Causes"
+#~ msgstr "Cause di distribuzione"
+
+#~ msgid "Deployment Config"
+#~ msgstr "Distribuzione Config"
+
+#~ msgid "Deployment Configs"
+#~ msgstr "Configurazioni di distribuzione"
+
+#~ msgid "Description:"
+#~ msgstr "Descrizione:"
+
+#~ msgid "Disk Utilization: $0%"
+#~ msgstr "Utilizzo del disco: $0%"
+
+#~ msgid "Display name"
+#~ msgstr "Nome visualizzato"
+
+#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#~ msgstr "Vuoi aggiungere il ruolo '{{ fields.displayRole }}' ?"
+
+#~ msgid ""
+#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}' image stream?"
+#~ msgstr ""
+#~ "Vuoi cancellare il flusso di{{stream.metadata.namespace}}{{stream."
+#~ "metadata.name}}immagini ' / ' '?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+#~ msgstr "Si desidera eliminare il volume persistente ' ' ' '?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume Claim '{{item.metadata."
+#~ "name}}'?"
+#~ msgstr "Si desidera eliminare l'indicazione del volume persistente ' ' ' '?"
+
+#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+#~ msgstr "Vuoi cancellare il {{ item.kind }}' ' ' ' '?"
+
+#~ msgid "Do you want to delete this Node?"
+#~ msgstr "Vuoi cancellare questo Nodo?"
+
+#~ msgid ""
+#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+#~ msgstr ""
+#~ "Vuoi rimuovere l'immagine etichettata come ' / : '{{stream.metadata."
+#~ "namespace}}?"
+
+#~ msgid ""
+#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
+#~ "{{ fields.member.metadata.name }}?"
+#~ msgstr ""
+#~ "Vuoi rimuovere il ruolo '{{ fields.displayRole }}' da membro {{ fields."
+#~ "member.metadata.name }}?"
+
+#~ msgid "Don't pull images automatically"
+#~ msgstr "Non scaricare le immagini automaticamente"
+
+# ctx::sourcefile::/systems/Search
+#~ msgid "Driver"
+#~ msgstr "Driver"
+
+#~ msgid "Edit the vdsm.conf"
+#~ msgstr "Modifica il file vdsm.conf"
+
+#~ msgid "Empty Directory"
+#~ msgstr "Elenco vuoto"
+
+#~ msgid "Encrypted EXT4 (LUKS)"
+#~ msgstr "Crittografato EXT4 (LUKS)"
+
+#~ msgid "Encrypted XFS (LUKS)"
+#~ msgstr "XFS criptato (LUKS)"
+
+#~ msgid "Endpoint"
+#~ msgstr "Endpoint"
+
+#~ msgid "Endpoint Name"
+#~ msgstr "Nome del punto finale"
+
+#~ msgid "Endpoints"
+#~ msgstr "Punti finali"
+
+#~ msgid "Ends"
+#~ msgstr "Termina"
+
+#~ msgid "Enter New VM name"
+#~ msgstr "Inserire il nome della nuova macchina virtuale"
+
+#~ msgid "Error getting certificate details: $0"
+#~ msgstr "Errore nell'ottenere i dettagli del certificato: $0"
+
+#~ msgid "Error writing kubectl config"
+#~ msgstr "Errore nella scrittura di kubectl config"
+
+#~ msgid "FQDN"
+#~ msgstr "FQDN"
+
+#~ msgid "Fibre Channel"
+#~ msgstr "Canale in fibra ottica"
+
+#~ msgid "Filesystem Type"
+#~ msgstr "Tipo di file system"
+
+#~ msgid "Filesystem type"
+#~ msgstr "Tipo di file system"
+
+#~ msgid "Flex"
+#~ msgstr "Flex"
+
+#~ msgid "Flocker"
+#~ msgstr "Flocker"
+
+#~ msgid "Flocker Dataset Name"
+#~ msgstr "Nome del set di dati Flocker"
+
+#~ msgid "GCE Persistent Disk"
+#~ msgstr "GCE Disco Persistente"
+
+#~ msgid "Git Repository"
+#~ msgstr "Repository Git"
+
+#~ msgid "Gluster FS"
+#~ msgstr "Gluster FS"
+
+#~ msgid "GlusterFS"
+#~ msgstr "GlusterFS"
+
+#~ msgid "Grant additional push or admin access to specific members below."
+#~ msgstr ""
+#~ "Concedi l'accesso aggiuntivo push o admin a specifici membri qui sotto."
+
+#~ msgid "Group Members"
+#~ msgstr "Membri del gruppo"
+
+#~ msgid "Group or Project"
+#~ msgstr "Gruppo o progetto"
+
+# translation auto-copied from project libreport, version master, document libreport
+#~ msgid "Groups"
+#~ msgstr "Gruppi"
+
+#~ msgid "HA"
+#~ msgstr "HA"
+
+#~ msgid "HA:"
+#~ msgstr "HA:"
+
+#~ msgid "Host Path"
+#~ msgstr "Sentiero dell'ospite"
+
+#~ msgid "Host to Maintenance"
+#~ msgstr "Ospite a Manutenzione"
+
+#~ msgid "IP"
+#~ msgstr "IP"
+
+#~ msgid "ISCSI"
+#~ msgstr "ISCSI"
+
+#~ msgid "Identities"
+#~ msgstr "Identità"
+
+#~ msgid "Identity"
+#~ msgstr "Identità"
+
+#~ msgid "Image ID"
+#~ msgstr "ID immagine"
+
+#~ msgid "Image Name"
+#~ msgstr "Nome dell'immagine"
+
+#~ msgid "Image Registry"
+#~ msgstr "Registro immagini"
+
+#~ msgid "Image Stream"
+#~ msgstr "Flusso d'immagine"
+
+#~ msgid "Image commands"
+#~ msgstr "Comandi immagine"
+
+#~ msgid "Images by project"
+#~ msgstr "Immagini per progetto"
+
+#~ msgid "Images pushed recently"
+#~ msgstr "Immagini spinte di recente"
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, use the commands below."
+#~ msgstr ""
+#~ "Per iniziare a spingere le immagini nel registro di sistema, utilizzare i "
+#~ "comandi seguenti."
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, you need to create a "
+#~ "project."
+#~ msgstr ""
+#~ "Per iniziare a spingere le immagini nel registro di sistema, è necessario "
+#~ "creare un progetto."
+
+#~ msgid "Installed products"
+#~ msgstr "Prodotti installati"
+
+#~ msgid "Interface"
+#~ msgstr "Interfaccia"
+
+#~ msgid "Invalid credentials"
+#~ msgstr "Credenziali non valide"
+
+#~ msgid "Kernel Version"
+#~ msgstr "Versione del kernel"
+
+#~ msgid "Key Ring Path"
+#~ msgstr "Sentiero dell'anello portachiavi"
+
+#~ msgid "Kubelet Version"
+#~ msgstr "Versione Kubelet"
+
+#~ msgid "Kubernetes Cluster"
+#~ msgstr "Kubernetes Cluster"
+
+#~ msgid "Last Heartbeat"
+#~ msgstr "Ultimo battito cardiaco"
+
+#~ msgid "Last Status Change"
+#~ msgstr "Ultimo cambiamento di stato"
+
+#~ msgid "Latest Version"
+#~ msgstr "Ultima versione"
+
+#~ msgid "Loading data ..."
+#~ msgstr "Caricamento dati ...."
+
+#~ msgid "Log into OpenShift command line tools:"
+#~ msgstr "Accedere agli strumenti della riga di comando di OpenShift:"
+
+#~ msgid "Log into the registry:"
+#~ msgstr "Effettuare il login nel registro:"
+
+#~ msgid "Logical Unit Number"
+#~ msgstr "Numero di unità logica"
+
+#~ msgid "Login"
+#~ msgstr "Accedi"
+
+#~ msgid "Login commands"
+#~ msgstr "Comandi di accesso"
+
+#~ msgid "Login/password or activation key required to register."
+#~ msgstr ""
+#~ "Login/password o chiave di attivazione richiesta per la registrazione."
+
+#~ msgid "MIGRATE action failed"
+#~ msgstr "Azione MIGRATE fallita"
+
+#~ msgid "Manifest"
+#~ msgstr "Manifesto"
+
+#~ msgid "Medium"
+#~ msgstr "Media"
+
+#~ msgid "Member of"
+#~ msgstr "Membro di"
+
+#~ msgid "Members"
+#~ msgstr "Membri"
+
+# ctx::sourcefile::/systems/details/history/snapshots/Groups
+#~ msgid "Membership"
+#~ msgstr "Appartenenza"
+
+#~ msgid "Memory Utilization: $0%"
+#~ msgstr "Utilizzo memoria: $0%"
+
+#~ msgid "Message"
+#~ msgstr "Messaggio"
+
+#~ msgid "Migrate To:"
+#~ msgstr "Migrare a:"
+
+#~ msgid "Modify"
+#~ msgstr "Modifica"
+
+#~ msgid "Monitors"
+#~ msgstr "Monitor"
+
+#~ msgid "NFS"
+#~ msgstr "NFS"
+
+#~ msgid "Namespace"
+#~ msgstr "Namespace"
+
+#~ msgid "Namespace cannot be empty."
+#~ msgstr "Il namespace dei nomi non può essere vuoto."
+
+#~ msgid "New Group"
+#~ msgstr "Nuovo gruppo"
+
+#~ msgid "New Project"
+#~ msgstr "Nuovo progetto"
+
+#~ msgid "New image stream"
+#~ msgstr "Nuovo flusso di immagini"
+
+#~ msgid "New project"
+#~ msgstr "Nuovo progetto"
+
+#~ msgid "No PEM-encoded certificate found"
+#~ msgstr "Nessun certificato codificato PEM trovato"
+
+#~ msgid "No PEM-encoded private key found"
+#~ msgstr "Nessuna chiave privata codificata PEM trovata"
+
+#~ msgid "No Pods are using this claim"
+#~ msgstr "Nessun baccello sta usando questo claim"
+
+#~ msgid "No VM found in oVirt."
+#~ msgstr "Nessuna VM trovata in oVirt."
+
+#~ msgid "No Volume Bound"
+#~ msgstr "Nessun volume legato"
+
+#~ msgid "No groups are present."
+#~ msgstr "Non sono presenti gruppi."
+
+#~ msgid "No images pushed"
+#~ msgstr "Nessuna immagine spinta"
+
+#~ msgid "No installed products on the system."
+#~ msgstr "Nessun prodotto installato sul sistema."
+
+#~ msgid ""
+#~ "No metadata file was selected. Please select a Kubernetes metadata file."
+#~ msgstr ""
+#~ "Non è stato selezionato alcun file di metadati. Selezionare un file di "
+#~ "metadati Kubernetes."
+
+#~ msgid "No nodes in cluster"
+#~ msgstr "Nessun nodo in cluster"
+
+#~ msgid "No oVirt connection"
+#~ msgstr "Nessuna connessione oVirt"
+
+#~ msgid "No pods deployed"
+#~ msgstr "Nessun baccello dispiegato"
+
+#~ msgid "No pods replicated"
+#~ msgstr "Nessun baccello replicato"
+
+#~ msgid "No pods scheduled"
+#~ msgstr "Nessun baccello in programma"
+
+#~ msgid "No pods selected"
+#~ msgstr "Nessun baccello selezionato"
+
+#~ msgid "No projects are present."
+#~ msgstr "Non sono presenti progetti."
+
+#~ msgid "No users are present."
+#~ msgstr "Non ci sono utenti presenti."
+
+#~ msgid "No volumes are present."
+#~ msgstr "Non sono presenti volumi."
+
+#~ msgid "No volumes in use"
+#~ msgstr "Nessun volume in uso"
+
+#~ msgid "Node"
+#~ msgstr "Nodo"
+
+#~ msgid "Nodes"
+#~ msgstr "Nodi"
+
+#~ msgid "Nodes are the machines that run your containers."
+#~ msgstr "I nodi sono le macchine che gestiscono i vostri container."
+
+#~ msgid "Not a valid number of replicas"
+#~ msgstr "Non un numero valido di repliche"
+
+#~ msgid "Not a valid value for Host"
+#~ msgstr "Non è un valore valido per Host"
+
+#~ msgid "Not deployed"
+#~ msgstr "Non utilizzato"
+
+#~ msgid "Number of virtual CPUs that gonna be used."
+#~ msgstr "Numero di CPU virtuali che verranno utilizzate."
+
+#~ msgid "OK"
+#~ msgstr "OK"
+
+# translation auto-copied from project Satellite6 Katello, version Sam-1.3.0, document katello, author fvalen
+#~ msgid "OS"
+#~ msgstr "OS"
+
+#~ msgid "OS Type:"
+#~ msgstr "Tipo di OS:"
+
+#~ msgid "OS Versions"
+#~ msgstr "Versioni OS"
+
+#~ msgid "Optimized for:"
+#~ msgstr "Ottimizzato per:"
+
+# translation auto-copied from project subscription-manager, version 1.9.X, document keys, author fvalen
+#~ msgid "Organization"
+#~ msgstr "Organizzazione"
+
+#~ msgid "PD Name"
+#~ msgstr "Nome PD"
+
+#~ msgid "Pending Volume Claims"
+#~ msgstr "Reclami sui volumi in sospeso"
+
+#~ msgid "Persistent Volumes"
+#~ msgstr "Volumi persistenti"
+
+#~ msgid "Phase"
+#~ msgstr "Fase"
+
+#~ msgid "Please confirm, the host shall be switched to maintenance mode."
+#~ msgstr ""
+#~ "Si prega di confermare, l'host deve essere impostato sulla modalità di "
+#~ "manutenzione."
+
+#~ msgid "Please create another namespace for $0 \"$1\""
+#~ msgstr "Si prega di creare un altro namespace per $0 \"$1\""
+
+#~ msgid "Please provide a GlusterFS volume name"
+#~ msgstr "Si prega di fornire un nome di volume GlusterFS"
+
+#~ msgid "Please provide a username"
+#~ msgstr "Si prega di fornire un nome utente"
+
+#~ msgid "Please provide a valid NFS server"
+#~ msgstr "Si prega di fornire un server NFS valido"
+
+#~ msgid "Please provide a valid address"
+#~ msgstr "Si prega di fornire un indirizzo valido"
+
+#~ msgid "Please provide a valid filesystem type"
+#~ msgstr "Si prega di fornire un tipo di filesystem valido"
+
+#~ msgid "Please provide a valid interface"
+#~ msgstr "Si prega di fornire un'interfaccia valida"
+
+#~ msgid "Please provide a valid logical unit number"
+#~ msgstr "Si prega di fornire un numero di unità logica valido"
+
+#~ msgid "Please provide a valid name"
+#~ msgstr "Si prega di fornire un nome valido"
+
+#~ msgid "Please provide a valid namespace."
+#~ msgstr "Si prega di fornire un namespace valido."
+
+#~ msgid "Please provide a valid path"
+#~ msgstr "Si prega di fornire un percorso valido"
+
+#~ msgid "Please provide a valid qualified name"
+#~ msgstr "Si prega di fornire un nome qualificato valido"
+
+#~ msgid "Please provide a valid storage capacity."
+#~ msgstr "Si prega di fornire una capacità di storage valida."
+
+#~ msgid "Please provide a valid target"
+#~ msgstr "Si prega di fornire un obiettivo valido"
+
+#~ msgid ""
+#~ "Please provide fully qualified domain name and port of the oVirt engine."
+#~ msgstr ""
+#~ "Si prega di fornire il nome di dominio completo e la porta del motore "
+#~ "oVirt."
+
+#~ msgid ""
+#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
+#~ "port (443 by default)"
+#~ msgstr ""
+#~ "Si prega di fornire un motore oVirt valido, un nome di dominio pienamente "
+#~ "qualificato (FQDN) e una porta (443 di default)"
+
+#~ msgid ""
+#~ "Please refer to oVirt's $0 for more information about Remote Viewer setup."
+#~ msgstr ""
+#~ "Per $0ulteriori informazioni sulla configurazione del Remote Viewer, fare "
+#~ "riferimento a oVirt."
+
+#~ msgid "Please select a valid access mode"
+#~ msgstr "Selezionare una modalità di accesso valida"
+
+#~ msgid "Please select a valid endpoint"
+#~ msgstr "Selezionare un punto finale valido"
+
+#~ msgid "Please select a valid policy option."
+#~ msgstr "Selezionare un'opzione valida."
+
+#~ msgid "Please type an address"
+#~ msgstr "Si prega di inserire un indirizzo"
+
+#~ msgid "Please wait till VMs list is loaded from the server."
+#~ msgstr ""
+#~ "Attendere che l'elenco delle macchine virtuali sia caricato dal server."
+
+#~ msgid "Please wait till list of templates is loaded from the server."
+#~ msgstr "Attendere che l'elenco dei modelli sia caricato dal server."
+
+#~ msgid "Pod"
+#~ msgstr "Baccello"
+
+#~ msgid "Pod Endpoints"
+#~ msgstr "Punti finali dei baccelli"
+
+#~ msgid "Pod Replicated"
+#~ msgstr "Pod replicato"
+
+#~ msgid "Pod Selector"
+#~ msgstr "Selettore di baccelli"
+
+#~ msgid "Pods"
+#~ msgstr "Cialde"
+
+#~ msgid ""
+#~ "Pods contain one or more containers that run together on a node, "
+#~ "containing your application code."
+#~ msgstr ""
+#~ "I baccelli contengono uno o più contenitori che girano insieme su un "
+#~ "nodo, contenente il codice dell'applicazione."
+
+#~ msgid "Pool Name"
+#~ msgstr "Nome pool"
+
+#~ msgid "Populate"
+#~ msgstr "Populate"
+
+#~ msgid "Preparing for Maintenance"
+#~ msgstr "Preparazione per la manutenzione"
+
+#~ msgid "Private: Allow only specific users or groups to pull images"
+#~ msgstr ""
+#~ "Privato: Consentire solo a utenti o gruppi specifici di scaricare immagini"
+
+# translation auto-copied from project RHEL Deployment Guide, version 6.2, document Product_Subscriptions_and_Entitlements, author fvalen
+#~ msgid "Product ID"
+#~ msgstr "ID del prodotto"
+
+#~ msgid "Product name"
+#~ msgstr "Nome prodotto"
+
+#~ msgid "Project"
+#~ msgstr "Progetto"
+
+#~ msgid "Project Members"
+#~ msgstr "Membri del progetto"
+
+#~ msgid "Project access policy allows anonymous users to pull images."
+#~ msgstr ""
+#~ "La politica di accesso ai progetti consente agli utenti anonimi di "
+#~ "scaricare immagini."
+
+#~ msgid "Project access policy allows any authenticated user to pull images."
+#~ msgstr ""
+#~ "La politica di accesso al progetto consente a qualsiasi utente "
+#~ "autenticato di estrarre immagini."
+
+#~ msgid "Project access policy only allows specific members to access images."
+#~ msgstr ""
+#~ "La politica di accesso ai progetti consente solo a membri specifici di "
+#~ "accedere alle immagini."
+
+#~ msgid "Project:"
+#~ msgstr "Progetto:"
+
+#~ msgid "Projects"
+#~ msgstr "Progetti"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "Proxy Version"
+#~ msgstr "Versione proxy"
+
+#~ msgid "Pull an image:"
+#~ msgstr "Scarica un'immagine:"
+
+#~ msgid "Pull from"
+#~ msgstr "Tirare da"
+
+#~ msgid "Pull specific tags from another image repository"
+#~ msgstr "Tirare tag specifici da un altro repository di immagini"
+
+#~ msgid "Push an image:"
+#~ msgstr "Premere un'immagine:"
+
+#~ msgid "Qualified Name"
+#~ msgstr "Nome qualificato"
+
+#~ msgid "REBOOT action failed"
+#~ msgstr "RIBOT azione fallita"
+
+#~ msgid "Rados Block Device"
+#~ msgstr "Dispositivo di blocco radio"
+
+#~ msgid "Read Only"
+#~ msgstr "Sola lettura"
+
+#~ msgid "Read and write from a single node"
+#~ msgstr "Leggere e scrivere da un singolo nodo"
+
+#~ msgid "Read and write from multiple nodes"
+#~ msgstr "Leggere e scrivere da più nodi"
+
+#~ msgid "Read only from multiple nodes"
+#~ msgstr "Leggere solo da più nodi"
+
+# ctx::sourcefile::/rhn/systems/details/SoftwareCrashDetail.do
+#~ msgid "Reason"
+#~ msgstr "Motivo"
+
+#~ msgid "Reclaim Policy"
+#~ msgstr "Politica di Reclamo"
+
+#~ msgid "Recycle"
+#~ msgstr "Riciclare"
+
+# translation auto-copied from project subscription-manager, version 1.9.X, document keys
+#~ msgid "Register"
+#~ msgstr "Registra"
+
+#~ msgid "Register New Volume"
+#~ msgstr "Registra nuovo volume"
+
+#~ msgid "Register Persistent Volume"
+#~ msgstr "Registrare volume persistente"
+
+#~ msgid "Register oVirt"
+#~ msgstr "Registrati su oVirt"
+
+#~ msgid "Register system"
+#~ msgstr "Sistema di registro"
+
+#~ msgid "Registering oVirt to Cockpit"
+#~ msgstr "Registrazione oVirt su Cockpit"
+
+#~ msgid "Remote registry is insecure"
+#~ msgstr "Il registro remoto è insicuro"
+
+#~ msgid "Remove Group"
+#~ msgstr "Rimuovi gruppo"
+
+#~ msgid "Remove Member"
+#~ msgstr "Rimuovi membro"
+
+#~ msgid "Remove Role"
+#~ msgstr "Rimuovi ruolo"
+
+#~ msgid "Remove User"
+#~ msgstr "Rimuovi utente"
+
+#~ msgid "Remove image tag"
+#~ msgstr "Rimuovi etichetta immagine"
+
+#~ msgid "Remove membership"
+#~ msgstr "Rimuovere l'iscrizione"
+
+#~ msgid "Replicas"
+#~ msgstr "Repliche"
+
+#~ msgid "Replication Controller"
+#~ msgstr "Controller di replica"
+
+#~ msgid "Replication Controllers"
+#~ msgstr "Controller di replica"
+
+#~ msgid ""
+#~ "Replication controllers dynamically create instances of pods from "
+#~ "templates, and remove pods when necessary."
+#~ msgstr ""
+#~ "I controller di replica creano dinamicamente istanze di pod dai modelli e "
+#~ "rimuovono i pod quando necessario."
+
+#~ msgid "Repository URL"
+#~ msgstr "URL del repositorio"
+
+#~ msgid "Requested"
+#~ msgstr "Richiesto"
+
+#~ msgid "Requests"
+#~ msgstr "Richieste"
+
+#~ msgid "Requires Authentication"
+#~ msgstr "Richiede l'autenticazione"
+
+#~ msgid "Restart Count"
+#~ msgstr "Riavvia il conteggio"
+
+#~ msgid "Retain"
+#~ msgstr "Conservare"
+
+#~ msgid "Retrieving subscription status..."
+#~ msgstr "Richiamare lo stato dell'abbonamento....."
+
+#~ msgid "Revision"
+#~ msgstr "Revisione"
+
+#~ msgid "Role"
+#~ msgstr "Ruolo"
+
+#~ msgid "Route"
+#~ msgstr "Rotta"
+
+#~ msgid "Run Here"
+#~ msgstr "Esegui qu"
+
+#~ msgid "Running Since:"
+#~ msgstr "Corsa da allora:"
+
+#~ msgid "SET VCPU SETTINGS action failed"
+#~ msgstr "Azione SET_VCPU_SETTINGS fallita"
+
+#~ msgid "SHUTDOWN action failed"
+#~ msgstr "Azione SHUTDOWN fallita"
+
+#~ msgid "START action failed"
+#~ msgstr "Azione START fallita"
+
+#~ msgid "SUSPEND action failed"
+#~ msgstr "Azione SUSPEND fallita"
+
+#~ msgid "Scheduled Pods"
+#~ msgstr "Cialde in programma"
+
+#~ msgid "Scheduling Disabled"
+#~ msgstr "Programmazione Disabili"
+
+#~ msgid "Secret"
+#~ msgstr "Segreto"
+
+#~ msgid "Secret File"
+#~ msgstr "Archivio segreto"
+
+#~ msgid "Secret Name"
+#~ msgstr "Nome segreto"
+
+#~ msgid "Secret Volume"
+#~ msgstr "Volume segreto"
+
+#~ msgid "Select Manifest File..."
+#~ msgstr "Selezionare il file manifesto....."
+
+#~ msgid "Select Member"
+#~ msgstr "Selezionare il membro"
+
+#~ msgid "Select Role"
+#~ msgstr "Seleziona ruolo"
+
+#~ msgid "Select an object to see more details."
+#~ msgstr "Selezionare un oggetto per vedere maggiori dettagli."
+
+#~ msgid "Service Account"
+#~ msgstr "Account di servizio"
+
+#~ msgid ""
+#~ "Services group pods and provide a common DNS name and an optional, load-"
+#~ "balanced IP address to access them."
+#~ msgstr ""
+#~ "I servizi raggruppano i pod e forniscono un nome DNS comune e un "
+#~ "indirizzo IP load-balanced opzionale per accedervi."
+
+#~ msgid "Session Affinity"
+#~ msgstr "Affinità della sessione"
+
+#~ msgid "Share Name"
+#~ msgstr "Condividi Nome"
+
+#~ msgid "Shared: Allow any authenticated user to pull images"
+#~ msgstr ""
+#~ "Condivisa: consente a qualsiasi utente autenticato di estrarre immagini"
+
+# translation auto-copied from project Anaconda, version master, document anaconda
+#~ msgid "Shell"
+#~ msgstr "Shell"
+
+#~ msgid "Show all Containers"
+#~ msgstr "Mostra tutti i container"
+
+#~ msgid "Show all Deployment Configs"
+#~ msgstr "Mostra tutte le configurazioni di deployment"
+
+#~ msgid "Show all Persistent Volumes"
+#~ msgstr "Mostra tutti i volumi persistenti"
+
+#~ msgid "Show all Pod Containers"
+#~ msgstr "Mostra tutti i containers pod"
+
+#~ msgid "Show all Projects"
+#~ msgstr "Mostra tutti i progetti"
+
+#~ msgid "Show all Replication Controllers"
+#~ msgstr "Mostra tutti i controller di replica"
+
+#~ msgid "Show all Routes"
+#~ msgstr "Mostra tutti i percorsi"
+
+#~ msgid "Show all Services"
+#~ msgstr "Mostra tutti i servizi"
+
+#~ msgid "Show all image streams"
+#~ msgstr "Mostra tutti i flussi di immagini"
+
+#~ msgid "Since"
+#~ msgstr "Da"
+
+#~ msgid "Skip Certificate Verification"
+#~ msgstr "Salta la verifica del certificato"
+
+#~ msgid "Sorry, I don't know how to modify this volume"
+#~ msgstr "Mi dispiace, non so come modificare questo volume"
+
+# translation auto-copied from project oVirt Engine jrs Branding, version JRS-5.5-branded, document querybuilder_messages
+#~ msgid "Starts"
+#~ msgstr "Inizia"
+
+#~ msgid "Stateless"
+#~ msgstr "Stateless"
+
+#~ msgid "Stateless:"
+#~ msgstr "Stateless:"
+
+#~ msgid "Status: $0"
+#~ msgstr "Stato: $0"
+
+#~ msgid "Status: System isn't registered"
+#~ msgstr "Stato: il sistema non è registrato"
+
+#~ msgid "Storage Size"
+#~ msgstr "Dimensione storage"
+
+#~ msgid "Strategy"
+#~ msgstr "Strategia"
+
+# translation auto-copied from project Customer Portal Translations, version management_page, document Management_Prototype.html, author fvalen
+#~ msgid "Subscriptions"
+#~ msgstr "Sottoscrizioni"
+
+#~ msgid "Suspend"
+#~ msgstr "Sospendi"
+
+#~ msgid "Switch Host to Maintenance"
+#~ msgstr "Passa da l'host in modalità di manutenzione"
+
+#~ msgid "Switching host to maintenance mode failed. Received error: "
+#~ msgstr ""
+#~ "Cambio dell'host in modalità manutenzione fallita. Errore ricevuto: "
+
+#~ msgid "Switching host to maintenance mode in progress ..."
+#~ msgstr "Cambio dell'host in modalità di manutenzione in corso ...."
+
+#~ msgid "Sync all tags from a remote image repository"
+#~ msgstr "Sincronizzare tutti i tag da un archivio di immagini remoto"
+
+#~ msgid "TLS Termination"
+#~ msgstr "Terminazione TLS"
+
+#~ msgid "Target Portal"
+#~ msgstr "Portale di destinazione"
+
+#~ msgid "Target World Wide Names"
+#~ msgstr "Nomi di destinazione in tutto il mondo"
+
+#~ msgid "Template"
+#~ msgstr "Modello"
+
+#~ msgid "Templates"
+#~ msgstr "Modelli"
+
+#~ msgid "Templates of $0 cluster"
+#~ msgstr "Modelli di cluster $0"
+
+#~ msgid "The address contains invalid characters"
+#~ msgstr "L'indirizzo contiene caratteri non validi"
+
+#~ msgid "The container '{{ target }}' does not exist."
+#~ msgstr "Il contenitore '{{ target }}' non esiste."
+
+#~ msgid "The current user isn't allowed to access system subscription status."
+#~ msgstr ""
+#~ "L'utente corrente non è autorizzato a accedere allo stato della "
+#~ "sottoscrizione di sistema."
+
+#~ msgid "The deployment config '{{ target }}' does not exist."
+#~ msgstr "La configurazione di distribuzione '{{ target }}'' non esiste."
+
+#~ msgid "The group '{{ groupName }}' does not exist."
+#~ msgstr "Il gruppo '{{ groupName }}' non esiste."
+
+#~ msgid "The maximum number of replicas is 128"
+#~ msgstr "Il numero massimo di repliche è 128"
+
+#~ msgid "The name contains invalid characters"
+#~ msgstr "Il nome contiene caratteri non validi"
+
+#~ msgid "The node '{{ target }}' does not exist."
+#~ msgstr "Il nodo '{{ target }}' ' non esiste."
+
+#~ msgid "The node doesn't have enough disk space"
+#~ msgstr "Il nodo non ha abbastanza spazio su disco"
+
+#~ msgid "The node doesn't have enough free memory"
+#~ msgstr "Il nodo non ha abbastanza memoria libera"
+
+#~ msgid "The persistent volume '{{ target }}' does not exist."
+#~ msgstr "Il volume persistente ''non esiste."
+
+#~ msgid "The pod '{{ target }}' does not exist."
+#~ msgstr "Il baccello ''non esiste."
+
+#~ msgid "The project '{{ projName }}' does not exist."
+#~ msgstr "Il progetto ''non esiste."
+
+#~ msgid "The replication controller '{{ target }}' does not exist."
+#~ msgstr "Il controller di replica ' ' ' '{{ target }}non esiste."
+
+#~ msgid "The route '{{ target }}' does not exist."
+#~ msgstr "Il percorso ''non esiste."
+
+#~ msgid "The selected file is not a valid Kubernetes application manifest."
+#~ msgstr ""
+#~ "Il file selezionato non è un manifesto valido di applicazione Kubernetes."
+
+#~ msgid "The server uses a certificate signed by an unknown authority."
+#~ msgstr ""
+#~ "Il server utilizza un certificato firmato da un'autorità sconosciuta."
+
+#~ msgid "The service '{{ target }}' does not exist."
+#~ msgstr "Il servizio ''non esiste."
+
+#~ msgid "The user '{{ userName }}' does not exist."
+#~ msgstr "L'utente ' ' ' '{{ userName }}non esiste."
+
+#~ msgid ""
+#~ "This claim is in use. Deleting it may cause issues with the following pod:"
+#~ msgstr ""
+#~ "Questa indicazione è in uso. L'eliminazione potrebbe causare problemi con "
+#~ "il seguente pod:"
+
+#~ msgid ""
+#~ "This host is managed by a virtualization manager, so creation of new VMs "
+#~ "from the host is not possible."
+#~ msgstr ""
+#~ "Questo host è gestito da un gestore di virtualizzazione, quindi non è "
+#~ "possibile creare nuove macchine virtuali dall'host."
+
+#~ msgid ""
+#~ "This option is for single node testing only – local storage will not work "
+#~ "in a multi-node cluster"
+#~ msgstr ""
+#~ "Questa opzione è solo per il test di un singolo nodo - l'archiviazione "
+#~ "locale non funziona in un cluster multi-nodo"
+
+#~ msgid "This virtual machine is not managed by oVirt"
+#~ msgstr "Questa macchina virtuale non è gestita da oVirt"
+
+#~ msgid ""
+#~ "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+#~ "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+#~ "may cause issues with any pods depending on it."
+#~ msgstr ""
+#~ "Questo volume è stato rivendicato da {{ item.item.spec.claimRef."
+#~ "namespace }} / {{ item.item.spec.claimRef.name }}. Cancellandolo si rompe "
+#~ "tale rivendicazione e può causare problemi con qualsiasi baccelli a "
+#~ "seconda di esso."
+
+#~ msgid "This volume has not been claimed"
+#~ msgstr "Questo volume non è stato rivendicato"
+
+#~ msgid "Token"
+#~ msgstr "Token"
+
+#~ msgid "Topology"
+#~ msgstr "Topologia"
+
+#~ msgid "Trust this certificate for this connection"
+#~ msgstr "Fidarsi di questo certificato per questo collegamento"
+
+#~ msgid "Type:"
+#~ msgstr "Tipo:"
+
+#~ msgid "Unable to connect"
+#~ msgstr "Impossibile collegarsi"
+
+#~ msgid "Unable to decode Kubernetes application manifest."
+#~ msgstr "Incapace di decodificare il manifesto dell'applicazione Kubernetes."
+
+#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
+#~ msgstr ""
+#~ "Impossibile leggere il manifesto di applicazione Kubernetes. Codice $0."
+
+#~ msgid "Unregister"
+#~ msgstr "Rimuovi-registrazione"
+
+#~ msgid "Unregistering system..."
+#~ msgstr "Sistema di non registrazione....."
+
+#~ msgid "Updating $0..."
+#~ msgstr "Aggiornamento $0...."
+
+#~ msgid "Use proxy server"
+#~ msgstr "Usa server proxy"
+
+#~ msgid "User or Group"
+#~ msgstr "Utente o gruppo"
+
+#~ msgid "Users"
+#~ msgstr "Utenti"
+
+#~ msgid "VDSM"
+#~ msgstr "VDSM"
+
+#~ msgid "VDSM Service Management"
+#~ msgstr "Gestione dei servizi VDSM"
+
+#~ msgid "VM icon"
+#~ msgstr "Icona VM"
+
+#~ msgid "Version num"
+#~ msgstr "Version num"
+
+#~ msgid "Virtual Machines of $0 cluster"
+#~ msgstr "Macchine virtuali del cluster $0"
+
+#~ msgid "Volume ID"
+#~ msgstr "ID volume"
+
+#~ msgid "Volume Name"
+#~ msgstr "Nome del volume"
+
+#~ msgid "Volume Type"
+#~ msgstr "Tipo di volume"
+
+#~ msgid "Warning:"
+#~ msgstr "Attenzione:"
+
+#~ msgid "Welcome to the Image Registry"
+#~ msgstr "Benvenuti nel Registro delle immagini"
+
+#~ msgid "When"
+#~ msgstr "Quando"
+
+#~ msgid ""
+#~ "You can bypass the certificate check, but any data you send to the server "
+#~ "could be intercepted by others."
+#~ msgstr ""
+#~ "È possibile aggirare il controllo del certificato, ma qualsiasi dato "
+#~ "inviato al server potrebbe essere intercettato da altri."
+
+#~ msgid "You can deploy an application to your cluster."
+#~ msgstr "È possibile distribuire un'applicazione nel proprio cluster."
+
+#~ msgid ""
+#~ "Your login credentials do not give you access to use the docker registry "
+#~ "from the command line."
+#~ msgstr ""
+#~ "Le credenziali di accesso non danno accesso all'utilizzo del registro di "
+#~ "bordo dalla riga di comando."
+
+#~ msgid "connecting"
+#~ msgstr "connessione in corso"
+
+#~ msgid "cores"
+#~ msgstr "core"
+
+#~ msgid "eg: my-image-stream"
+#~ msgstr "es: my-image-stream"
+
+#~ msgid "error"
+#~ msgstr "errore"
+
+#~ msgid "initializing"
+#~ msgstr "inizializzazione"
+
+#~ msgid "installation failed"
+#~ msgstr "installazione fallita"
+
+#~ msgid "installing OS"
+#~ msgstr "installazione del sistema operativo"
+
+#~ msgid "kdumping"
+#~ msgstr "kdumping"
+
+#~ msgid "maintenance"
+#~ msgstr "mantenimento"
+
+#~ msgid "non operational"
+#~ msgstr "non operativo"
+
+#~ msgid "non responsive"
+#~ msgstr "non risponde"
+
+#~ msgid "oVirt"
+#~ msgstr "oVirt"
+
+#~ msgid "oVirt Host State:"
+#~ msgstr "Stato host oVirt:"
+
+#~ msgid "oVirt Provider installation script failed due to missing arguments."
+#~ msgstr "oVirt Provider non è riuscito a causa di argomenti mancanti."
+
+#~ msgid ""
+#~ "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
+#~ "machines-ovirt.config, try as root."
+#~ msgstr ""
+#~ "script di installazione oVirt Provider fallito: non è possibile scrivere "
+#~ "su /etc/cockpit/machines-ovirt.config, provare come root."
+
+#~ msgid "oVirt installation script failed with following output: "
+#~ msgstr ""
+#~ "lo script di installazione di oVirt non è riuscito con il seguente "
+#~ "output: "
+
+#~ msgid "pending approval"
+#~ msgstr "in attesa di approvazione"
+
+#~ msgid "pending volume claims"
+#~ msgstr "richieste di risarcimento in sospeso"
+
+#~ msgid "sockets"
+#~ msgstr "raccordi"
+
+#~ msgid "threads"
+#~ msgstr "thread"
+
+#~ msgid "unassigned"
+#~ msgstr "non assegnato"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-03 06:24+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-05-28 11:43+0000\n"
 "Last-Translator: Keiko Moriguchi <kemorigu@redhat.com>\n"
 "Language-Team: Japanese\n"
 "Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
@@ -22,19 +22,15 @@ msgstr ""
 msgid " (shared with the OS)"
 msgstr " (OS と共有)"
 
-#: pkg/kubernetes/views/node-delete.html:8
-msgid " 1\"Do you want to delete the following Nodes?"
-msgstr " 1\" 次のノードを削除しますか?"
-
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0 ブロックデバイス"
 
-#: pkg/storaged/mdraid-details.jsx:193
+#: pkg/storaged/mdraid-details.jsx:192
 msgid "$0 Chunk Size"
 msgstr "$0 チャンクサイズ"
 
-#: pkg/storaged/mdraid-details.jsx:191
+#: pkg/storaged/mdraid-details.jsx:190
 msgid "$0 Disks"
 msgstr "$0 ディスク"
 
@@ -79,15 +75,15 @@ msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 データ + $1 オーバーヘッドが $2 ($3) を使用しています"
 
 #: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:213
+#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 ディスクがありません"
 
 #: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:34
-#: pkg/playground/translate.js:37
+#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
@@ -121,13 +117,15 @@ msgstr "ここでは、$0 ファイルシステムのサイズを変更できま
 msgid ""
 "$0 is available for most operating systems. To install it, search for it in "
 "GNOME Software or run the following:"
-msgstr "$0 は、多数のオペレーティングシステムで利用できます。インストールするには、GNOME ソフトウェアで検索するか、以下を実行します:"
+msgstr ""
+"$0 は、多数のオペレーティングシステムで利用できます。インストールするには、"
+"GNOME ソフトウェアで検索するか、以下を実行します:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:237
-#: pkg/storaged/mdraid-details.jsx:290 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:203
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 は、アクティブに使用されています。"
 
@@ -165,25 +163,11 @@ msgstr[0] "$0 更新"
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 が $1  ($2 が保存) を使用しています"
 
-#: pkg/ovirt/components/vcpuModal.jsx:98
-msgid "$0 vCPU Details"
-msgstr "$0 vCPU の詳細"
-
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "$0 がインストールされます。"
 
-#: pkg/kubernetes/scripts/nodes.js:871
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0% 空き"
-
-#: pkg/kubernetes/scripts/nodes.js:873
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0% 使用済み"
-
-#: pkg/storaged/vgroup-details.jsx:118
+#: pkg/storaged/vgroup-details.jsx:117
 msgid "$0, $1 free"
 msgstr "$0, $1 空き"
 
@@ -208,19 +192,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/subscriptions/subscriptions-client.js:197
-msgid "'Organization' required to register."
-msgstr "'組織' を登録する必要があります。"
-
-#: pkg/subscriptions/subscriptions-client.js:201
-msgid "'Organization' required when using activation keys."
-msgstr "アクティベーションキーを使用する場合は '組織' が必要です。"
-
-#: pkg/networkmanager/firewall.jsx:547
+#: pkg/networkmanager/firewall.jsx:549
 msgid "(Optional)"
 msgstr "(オプション)"
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:616
+#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(デフォルト)"
@@ -480,7 +456,9 @@ msgstr "9 日"
 msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
-msgstr "Cockpit の互換バージョンが {{#strong}}{{host}}{{/strong}} にインストールされていません。"
+msgstr ""
+"Cockpit の互換バージョンが {{#strong}}{{host}}{{/strong}} にインストールされ"
+"ていません。"
 
 #: pkg/storaged/vdos-panel.jsx:59
 msgid "A disk is needed."
@@ -489,7 +467,9 @@ msgstr " 1 つのディスクが必要です。"
 #: src/ws/login.html:115
 msgid ""
 "A modern browser is required for security, reliability, and performance."
-msgstr "セキュリティー、信頼性、およびパフォーマンスに対して最新のブラウザーが必要です。"
+msgstr ""
+"セキュリティー、信頼性、およびパフォーマンスに対して最新のブラウザーが必要で"
+"す。"
 
 #: pkg/storaged/mdraid-details.jsx:119
 msgid "A spare disk needs to be added first before this disk can be removed."
@@ -507,12 +487,8 @@ msgstr "ARP 監視"
 msgid "ARP Ping"
 msgstr "ARP Ping"
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "AWS Elastic Block Store"
-
 #: pkg/shell/index.html:56 pkg/shell/index.html:82 pkg/shell/simple.html:42
-#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
+#: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Cockpit について"
 
@@ -520,19 +496,9 @@ msgstr "Cockpit について"
 msgid "Access"
 msgstr "アクセス"
 
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
-msgid "Access Modes"
-msgstr "アクセスモード"
-
-#: pkg/kubernetes/views/project-modify.html:49
 #: node_modules/registry-image-widgets/views/imagestream-body.html:12
 msgid "Access Policy"
 msgstr "アクセスポリシー"
-
-#: pkg/subscriptions/subscriptions-view.jsx:213
-msgid "Access denied"
-msgstr "アクセスは拒否されました"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -550,18 +516,13 @@ msgstr "アカウントが利用可能でないか、アカウントを編集で
 msgid "Accounts"
 msgstr "アカウント"
 
-#: pkg/users/local.js:335 pkg/users/local.js:642
+#: pkg/users/local.js:339 pkg/users/local.js:646
 msgctxt "page-title"
 msgid "Accounts"
 msgstr "アカウント"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:183
-msgid "Action"
-msgstr "アクション"
-
-#: pkg/machines/components/networks/network.jsx:147
-#: pkg/machines/components/storagePools/storagePool.jsx:167
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "有効化"
@@ -569,10 +530,6 @@ msgstr "有効化"
 #: pkg/storaged/jobs-panel.jsx:68
 msgid "Activating $target"
 msgstr "$target のアクティベート"
-
-#: pkg/subscriptions/subscriptions-register.jsx:168
-msgid "Activation Key"
-msgstr "アクティベーションキー"
 
 #: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
 msgid "Active"
@@ -582,7 +539,7 @@ msgstr "動作中"
 msgid "Active Backup"
 msgstr "アクティブなバックアップ"
 
-#: pkg/shell/index.html:59 pkg/shell/stub.html:49 pkg/shell/active-pages.js:95
+#: pkg/shell/index.html:59 pkg/shell/active-pages.js:95
 msgid "Active Pages"
 msgstr "アクティブページ"
 
@@ -590,13 +547,9 @@ msgstr "アクティブページ"
 msgid "Active since"
 msgstr "以降有効"
 
-#: pkg/networkmanager/firewall.jsx:922
+#: pkg/networkmanager/firewall.jsx:924
 msgid "Active zones"
 msgstr "アクティブゾーン"
-
-#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
-msgid "Actual"
-msgstr "実際"
 
 #: pkg/networkmanager/interfaces.js:1980
 msgid "Adaptive load balancing"
@@ -606,16 +559,11 @@ msgstr "適応ロードバランス"
 msgid "Adaptive transmit load balancing"
 msgstr "適応送信のロードバランス"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/add-role-dialog.html:8
-#: pkg/kubernetes/views/add-user-dialog.html:27
-#: pkg/kubernetes/views/node-add.html:50
-#: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:534
-#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/vgroup-details.jsx:63
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "追加する"
 
@@ -635,11 +583,7 @@ msgstr "ボンドの追加"
 msgid "Add Bridge"
 msgstr "ブリッジの追加"
 
-#: pkg/kubernetes/views/node-add.html:3
-msgid "Add Cluster Node"
-msgstr "クラスターノードの追加"
-
-#: pkg/machines/components/diskAdd.jsx:356
+#: pkg/machines/components/diskAdd.jsx:360
 msgid "Add Disk"
 msgstr "ディスクの追加"
 
@@ -647,55 +591,20 @@ msgstr "ディスクの追加"
 msgid "Add Disks"
 msgstr "ディスクの追加"
 
-#: pkg/kubernetes/views/add-group-dialog.html:3
-msgid "Add Group"
-msgstr "グループの追加"
-
 #: pkg/storaged/crypto-keyslots.jsx:200
 msgid "Add Key"
 msgstr "鍵の追加"
-
-#: pkg/kubernetes/views/nodes-page.html:34
-msgid "Add Kubernetes Node"
-msgstr "Kubernetes ノードの追加"
 
 #: pkg/lib/machine-add.html:4
 msgid "Add Machine to Dashboard"
 msgstr "ダッシュボードへのマシンの追加"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:4
-#: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/group-panel.html:29
-#: pkg/kubernetes/views/project-body.html:108
-#: pkg/kubernetes/views/user-group-add.html:3
-msgid "Add Member"
-msgstr "メンバーの追加"
-
-#: pkg/kubernetes/views/user-body.html:67
-#: pkg/kubernetes/views/user-panel.html:76
-msgid "Add Membership"
-msgstr "メンバーシップの追加"
-
-#: pkg/kubernetes/views/auth-form.html:11
-#: pkg/kubernetes/views/auth-form.html:20
-msgid "Add New Cluster"
-msgstr "新規クラスターの追加"
-
-#: pkg/kubernetes/views/auth-form.html:67
-#: pkg/kubernetes/views/auth-form.html:76
-msgid "Add New User"
-msgstr "新規ユーザーの追加"
-
 #: pkg/networkmanager/firewall.jsx:457
 msgid "Add Ports"
 msgstr "ポートの追加"
 
-#: pkg/kubernetes/views/add-role-dialog.html:3
-msgid "Add Role"
-msgstr "ロールの追加"
-
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:872
-#: pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
+#: pkg/networkmanager/firewall.jsx:886
 msgid "Add Services"
 msgstr "サービスの追加"
 
@@ -707,17 +616,12 @@ msgstr "ストレージの追加"
 msgid "Add Team"
 msgstr "チームの追加"
 
-#: pkg/kubernetes/views/add-user-dialog.html:3
-#: pkg/kubernetes/views/project-listing.html:83
-msgid "Add User"
-msgstr "ユーザーの追加"
-
 #: pkg/networkmanager/index.html:113
 msgid "Add VLAN"
 msgstr "VLAN の追加"
 
-#: pkg/networkmanager/firewall.jsx:698 pkg/networkmanager/firewall.jsx:878
-#: pkg/networkmanager/firewall.jsx:889
+#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
+#: pkg/networkmanager/firewall.jsx:891
 msgid "Add Zone"
 msgstr "ゾーンの追加"
 
@@ -728,10 +632,6 @@ msgstr "iSCSI ポータルの追加"
 #: pkg/shell/index.html:172 pkg/users/index.html:414
 msgid "Add key"
 msgstr "鍵の追加"
-
-#: pkg/kubernetes/views/user-add-membership.html:3
-msgid "Add membership"
-msgstr "メンバーシップの追加"
 
 #: pkg/networkmanager/firewall.jsx:458
 msgid "Add ports to the following zones:"
@@ -745,7 +645,7 @@ msgstr "公開鍵の追加"
 msgid "Add services to following zones:"
 msgstr "以下のゾーンにサービスを追加:"
 
-#: pkg/networkmanager/firewall.jsx:774
+#: pkg/networkmanager/firewall.jsx:776
 msgid "Add zone"
 msgstr "ゾーンの追加"
 
@@ -753,7 +653,9 @@ msgstr "ゾーンの追加"
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
-msgstr "<b>$0</b> を追加すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"<b>$0</b> を追加すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/users/authorized-keys.js:113
 msgid "Adding key"
@@ -775,7 +677,7 @@ msgstr "追加の DNS $val"
 msgid "Additional DNS Search Domains $val"
 msgstr "追加の DNS 検索ドメイン $val"
 
-#: pkg/docker/index.html:307
+#: pkg/docker/index.html:309
 msgid "Additional Storage"
 msgstr "追加のストレージ"
 
@@ -787,14 +689,11 @@ msgstr "追加のアドレス $val"
 msgid "Additional packages:"
 msgstr "追加のパッケージ:"
 
-#: pkg/kubernetes/views/auth-form.html:29
-#: pkg/kubernetes/views/dashboard-page.html:157
-#: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
+#: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:77 pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:107
+#: pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "アドレス:"
 
@@ -811,44 +710,18 @@ msgid "Address is not a valid URL"
 msgstr "アドレスは有効ではありません。"
 
 #: pkg/machines/components/desktopConsole.jsx:153
-#: pkg/ovirt/components/VmOverviewColumn.jsx:53
 msgid "Address:"
 msgstr "アドレス: "
 
-#: pkg/kubernetes/views/details-page.html:37
 #: pkg/networkmanager/interfaces.js:3309
 msgid "Addresses"
 msgstr "アドレス"
-
-#: pkg/kubernetes/views/service-modify.html:25
-msgid "Adjust"
-msgstr "調整"
-
-#: pkg/kubernetes/views/pv-modify.html:3
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "永続ボリューム '{{ item.metadata.name }}' の調整"
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html:3
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "レプリケーションコントローラー {{ item.metadata.name }} の調整"
-
-#: pkg/kubernetes/views/route-modify.html:3
-msgid "Adjust Route"
-msgstr "ルートの調整"
-
-#: pkg/kubernetes/views/service-modify.html:3
-msgid "Adjust Service"
-msgstr "サービスの調整"
-
-#: pkg/kubernetes/views/project-body.html:56
-msgid "Admin"
-msgstr "管理者"
 
 #: org.cockpit-project.cockpit-bridge.policy.in.h:1
 msgid "Administration with Cockpit Web Console"
 msgstr "Cockpit Web コンソールでの管理"
 
-#: pkg/realmd/operation.js:336
+#: pkg/realmd/operation.js:335
 msgid "Administrator Password"
 msgstr "管理者パスワード"
 
@@ -866,8 +739,9 @@ msgid ""
 "log into this machine. This may also affect other services as DNS resolution "
 "settings and the list of trusted CAs may change."
 msgstr ""
-"ドメインの終了後は、ローカル認証情報を持つユーザーだけが、このマシンにログインできます。DNS 解決設定および信頼される CA "
-"の一覧が変更する可能性があるため、他のサービスにも影響を及ぼす場合があります。"
+"ドメインの終了後は、ローカル認証情報を持つユーザーだけが、このマシンにログイ"
+"ンできます。DNS 解決設定および信頼される CA の一覧が変更する可能性があるた"
+"め、他のサービスにも影響を及ぼす場合があります。"
 
 #: pkg/systemd/services.html:446 pkg/systemd/services.html:450
 #: pkg/systemd/init.js:1073
@@ -886,49 +760,23 @@ msgstr "すべて"
 msgid "All In One"
 msgstr "一体型"
 
-#: pkg/kubernetes/views/filter-project.html:4
-msgid "All Projects"
-msgstr "すべてのプロジェクト"
-
-#: pkg/kubernetes/views/details-page.html:6
-msgid "All Types"
-msgstr "すべてのタイプ"
-
 #: pkg/docker/storage.jsx:381
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
-msgstr "選択されたディスク上のすべてのデータが削除され、ストレージプールにディスクが追加されます。"
+msgstr ""
+"選択されたディスク上のすべてのデータが削除され、ストレージプールにディスクが"
+"追加されます。"
 
-#: pkg/kubernetes/views/dashboard-page.html:112
-msgid "All healthy"
-msgstr "すべてが正常"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:74
-msgid "All images"
-msgstr "すべてのイメージ"
-
-#: pkg/kubernetes/views/dashboard-page.html:69
-msgid "All in use"
-msgstr "使用中のすべてのもの"
-
-#: pkg/kubernetes/views/dashboard-page.html:37
-msgid "All running"
-msgstr "実行中のすべてのもの"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:36
-msgid "All running virtual machines will be turned off."
-msgstr "全ての実行中のマシンはオフされます。"
-
-#: pkg/networkmanager/firewall.jsx:749
+#: pkg/networkmanager/firewall.jsx:751
 msgid "Allowed Addresses"
 msgstr "許可されたアドレス"
 
-#: pkg/networkmanager/firewall.jsx:935
+#: pkg/networkmanager/firewall.jsx:937
 msgid "Allowed Services"
 msgstr "許可されたサービス"
 
-#: pkg/docker/index.html:548 pkg/docker/util.js:108
+#: pkg/docker/index.html:550 pkg/docker/util.js:108
 msgid "Always"
 msgstr "常時"
 
@@ -936,17 +784,11 @@ msgstr "常時"
 msgid "Always attach"
 msgstr "常に割り当てる"
 
-#: pkg/kubernetes/views/node-body.html:57
-#: pkg/kubernetes/views/route-body.html:27
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "アノテーション"
 
-#: pkg/kubernetes/scripts/projects.js:1044
-msgid "Anonymous: Allow all unauthenticated users to pull images"
-msgstr "匿名: 認証されていないすべてのユーザーがイメージをプルできます"
-
-#: pkg/systemd/terminal.jsx:94
+#: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr "Appearance:"
 
@@ -959,11 +801,10 @@ msgstr "アプリケーション"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235
-#: pkg/ovirt/components/vcpuModal.jsx:104 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "適用"
 
@@ -992,7 +833,6 @@ msgid "Applying updates failed"
 msgstr "アップデートの適用に失敗しました"
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
-#: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Architecture"
 msgstr "アーキテクチャー"
 
@@ -1004,8 +844,8 @@ msgstr "アセットタグ"
 msgid "At least $0 disks are needed."
 msgstr "少なくとも $0 ディスクが必要です。"
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "少なくとも 1 つのディスクが必要です。"
 
@@ -1021,9 +861,8 @@ msgstr "監査ログ"
 msgid "Authenticating"
 msgstr "認証"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
 #: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "認証"
 
@@ -1049,7 +888,7 @@ msgstr "Cockpit Web コンソールでの特権タスクの実行には、認証
 msgid "Authentication required"
 msgstr "認証が必要です"
 
-#: pkg/docker/index.html:700
+#: pkg/docker/index.html:702
 #: node_modules/registry-image-widgets/views/image-body.html:12
 #: pkg/docker/containers-view.jsx:413
 msgid "Author"
@@ -1062,7 +901,7 @@ msgstr "承認された公開 SSH 鍵"
 #: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
 #: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
 #: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:339
+#: pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "自動"
 
@@ -1082,10 +921,6 @@ msgstr "自動起動"
 msgid "Automatic Updates"
 msgstr "自動アップデート"
 
-#: pkg/ovirt/components/OVirtTab.jsx:81
-msgid "Automatically selected host"
-msgstr "自動的に選択されたホスト"
-
 #: pkg/machines/components/libvirtSlate.jsx:90
 msgid "Automatically start libvirt on boot"
 msgstr "起動時に libvirt を自動開始"
@@ -1098,9 +933,9 @@ msgstr "NTP を自動的に使用"
 msgid "Automatically using specific NTP servers"
 msgstr "特定の NTP サーバーを自動的に使用"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:155
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "自動起動"
 
@@ -1121,10 +956,6 @@ msgstr "$0 で利用可能なターゲット"
 #: pkg/dashboard/index.html:163
 msgid "Avatar"
 msgstr "アバター"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
 
 #: pkg/systemd/hwinfo.jsx:92
 msgid "BIOS"
@@ -1153,18 +984,6 @@ msgstr "passwd1 メカニズムに間違ったデータが渡されました"
 #: pkg/networkmanager/index.html:333
 msgid "Balancer"
 msgstr "バランサー"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-msgid "Base Template"
-msgstr "ベーステンプレート"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Base template"
-msgstr "ベーステンプレート"
-
-#: pkg/ovirt/components/OVirtTab.jsx:106 pkg/ovirt/components/OVirtTab.jsx:113
-msgid "Base template:"
-msgstr "ベーステンプレート:"
 
 #: pkg/systemd/init.js:729
 msgid "Before"
@@ -1207,12 +1026,8 @@ msgstr "Bond"
 msgid "Bond Settings"
 msgstr "ボンド設定"
 
-#: pkg/kubernetes/views/node-body.html:17
-msgid "Boot ID"
-msgstr "ブート ID"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:312
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:153
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:164
 msgid "Boot Order"
 msgstr "ブート順序"
 
@@ -1271,10 +1086,8 @@ msgstr "バス"
 msgid "Bus Expansion Chassis"
 msgstr "バス拡張シャーシ"
 
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:270
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:603
-#: pkg/kubernetes/scripts/nodes.js:711 pkg/kubernetes/scripts/nodes.js:818
-#: pkg/systemd/hwinfo.jsx:108
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:272
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
 msgid "CPU"
 msgstr "CPU"
 
@@ -1291,28 +1104,20 @@ msgctxt "page-title"
 msgid "CPU Status"
 msgstr "CPU ステータス"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:154
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:165
 msgid "CPU Type"
 msgstr "CPU タイプ"
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "CPU 使用率: $0%"
-
-#: pkg/docker/index.html:469 pkg/docker/index.html:641
+#: pkg/docker/index.html:471 pkg/docker/index.html:643
 msgid "CPU priority"
 msgstr "CPU 優先度"
 
-#: pkg/docker/index.html:217
+#: pkg/docker/index.html:218
 msgid "CPU usage:"
 msgstr "CPU 使用率:"
 
-#: pkg/ovirt/provider.js:256
-msgid "CREATE VM action failed"
-msgstr "CREATE VM アクションに失敗しました"
-
-#: pkg/machines/components/diskAdd.jsx:235
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr "キャッシュ"
 
@@ -1332,79 +1137,44 @@ msgstr "ロック解除されている間は削除できません"
 msgid "Can't load image"
 msgstr "画像を読み込めません。"
 
-#: pkg/dashboard/index.html:175 pkg/docker/index.html:563
-#: pkg/docker/index.html:597 pkg/docker/index.html:661
-#: pkg/docker/index.html:715 pkg/docker/index.html:755
-#: pkg/docker/index.html:784 pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/add-role-dialog.html:7
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/image-delete.html:7
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/user-group-add.html:29
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
-#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:477 pkg/networkmanager/index.html:501
-#: pkg/networkmanager/index.html:525 pkg/networkmanager/index.html:549
-#: pkg/networkmanager/index.html:573 pkg/networkmanager/index.html:597
-#: pkg/networkmanager/index.html:621 pkg/networkmanager/index.html:645
-#: pkg/networkmanager/index.html:669 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:81 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/systemd/index.html:332
+#: pkg/dashboard/index.html:175 pkg/docker/index.html:565
+#: pkg/docker/index.html:599 pkg/docker/index.html:663
+#: pkg/docker/index.html:717 pkg/docker/index.html:757
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
+#: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
+#: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
+#: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:654
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:531
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:485
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:558 pkg/networkmanager/firewall.jsx:626
-#: pkg/networkmanager/firewall.jsx:769
-#: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "取り消し"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:415
 msgid "Cannot connect to an unknown machine"
 msgstr "不明なマシンには接続できません"
-
-#: src/ws/cockpitcertificate.c:483
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "PEM で暗号化された秘密鍵を復号できません"
 
 #: src/base1/cockpit.js:4031
 msgid "Cannot forward login credentials"
@@ -1414,8 +1184,6 @@ msgstr "ログイン資格情報を転送できません"
 msgid "Cannot schedule event in the past"
 msgstr "過去のイベントはスケジュールできません"
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
 #: pkg/machines/components/vmDisksTab.jsx:70
 msgid "Capacity"
 msgstr "容量"
@@ -1424,18 +1192,7 @@ msgstr "容量"
 msgid "Carrier"
 msgstr "キャリア"
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Ceph ファイルシステムマウント"
-
-#: pkg/kubernetes/views/volume-body.html:97
-msgid "Ceph Monitors"
-msgstr "Ceph モニター"
-
-#: pkg/docker/index.html:662 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
-#: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:333
+#: pkg/docker/index.html:664 pkg/systemd/index.html:333
 #: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
 #: pkg/storaged/iscsi-panel.jsx:181
 msgid "Change"
@@ -1461,31 +1218,19 @@ msgstr "プロファイルの変更"
 msgid "Change System Time"
 msgstr "システム時間の変更"
 
-#: pkg/kubernetes/views/user-modify.html:3
-msgid "Change User"
-msgstr "ユーザーの変更"
-
 #: pkg/storaged/iscsi-panel.jsx:176
 msgid "Change iSCSI Initiator Name"
 msgstr "iSCSI イニシエーター名の変更"
-
-#: pkg/kubernetes/views/imagestream-modify.html:4
-msgid "Change image stream"
-msgstr "イメージストリームの変更"
 
 #: pkg/storaged/crypto-keyslots.jsx:247
 msgid "Change passphrase"
 msgstr "パスフレーズの変更"
 
-#: pkg/kubernetes/views/project-modify.html:10
-msgid "Change project"
-msgstr "プロジェクトの変更"
-
-#: pkg/docker/index.html:228
+#: pkg/docker/index.html:229
 msgid "Change resource limits"
 msgstr "リソース制限の変更"
 
-#: pkg/docker/index.html:612
+#: pkg/docker/index.html:614
 msgid "Change resources limits"
 msgstr "リソース制限の変更"
 
@@ -1493,10 +1238,10 @@ msgstr "リソース制限の変更"
 msgid "Change the settings"
 msgstr "設定の変更"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "変更は、仮想マシンをシャットダウンすると反映されます。"
 
@@ -1504,7 +1249,9 @@ msgstr "変更は、仮想マシンをシャットダウンすると反映され
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "設定を変更すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"設定を変更すると、サーバーへの接続が切断され、管理 UI が利用できなくなりま"
+"す。"
 
 #: pkg/packagekit/updates.jsx:175
 msgid "Check for Updates"
@@ -1542,25 +1289,13 @@ msgstr "更新の確認…"
 msgid "Checking installed software"
 msgstr "インストールされたソフトウェアの確認"
 
-#: pkg/shell/index.html:117 pkg/shell/simple.html:85 pkg/shell/stub.html:100
+#: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "アプリケーションで使用する言語の選択"
 
 #: pkg/storaged/mdraids-panel.jsx:57
 msgid "Chunk Size"
 msgstr "チャンクサイズ"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinder"
-
-#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
-msgid "Claim"
-msgstr "クレーム"
-
-#: pkg/kubernetes/views/pvc-body.html:4
-msgid "Claim Name"
-msgstr "クレーム名"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Class"
@@ -1581,44 +1316,30 @@ msgstr "クリックしてシステムハードウェア情報を確認"
 #: pkg/machines/components/desktopConsole.jsx:41
 msgid ""
 "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
-msgstr "\"リモートビューアーの起動\" をクリックすると、.vv ファイルをダウンロードし、$0 を起動します。"
-
-#: pkg/kubernetes/views/auth-form.html:88
-msgid "Client Certificate"
-msgstr "クライアント証明書"
+msgstr ""
+"\"リモートビューアーの起動\" をクリックすると、.vv ファイルをダウンロード"
+"し、$0 を起動します。"
 
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr "クライアントソフトウェア"
 
-#: pkg/docker/index.html:736 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/systemd/index.html:278
-#: pkg/systemd/services.html:363 pkg/systemd/services.html:381
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:108 pkg/sosreport/index.js:45
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
 #: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "閉じる"
 
 #: pkg/shell/active-pages.js:103
 msgid "Close Selected Pages"
 msgstr "選択されたページを閉じる"
-
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
-#: pkg/ovirt/components/App.jsx:107
-msgid "Cluster"
-msgstr "クラスター"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:128
-msgid "Cluster Templates"
-msgstr "クラスターテンプレート"
-
-#: pkg/ovirt/components/ClusterVms.jsx:174
-msgid "Cluster Virtual Machines"
-msgstr "クラスター仮想マシン"
 
 #: src/ws/login.js:346
 msgid "Cockpit authentication is configured incorrectly."
@@ -1629,8 +1350,8 @@ msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
 msgstr ""
-"Cockpit は該当するホスト $0 に接続できませんでした。そのホストのポート $1 で ssh "
-"が実行されていることを確認するか、アドレスで別のポートを指定します。"
+"Cockpit は該当するホスト $0 に接続できませんでした。そのホストのポート $1 で "
+"ssh が実行されていることを確認するか、アドレスで別のポートを指定します。"
 
 #: src/base1/cockpit.js:4037
 msgid "Cockpit could not contact the given host."
@@ -1642,9 +1363,9 @@ msgid ""
 "Cockpit by pressing refresh in your browser. The javascript console contains "
 "details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
-"Cockpit で予期しない内部エラーが発生しました。<br/><br/>ブラウザーで更新を押して Cockpit "
-"の再起動を試行できます。javascript コンソールにはこのエラーに関する詳細が含まれます (ほとんどのブラウザーでは <b>Ctrl-Shift-"
-"J</b>)。"
+"Cockpit で予期しない内部エラーが発生しました。<br/><br/>ブラウザーで更新を押"
+"して Cockpit の再起動を試行できます。javascript コンソールにはこのエラーに関"
+"する詳細が含まれます (ほとんどのブラウザーでは <b>Ctrl-Shift-J</b>)。"
 
 #: cockpit.appdata.xml.in.h:2
 msgid ""
@@ -1654,11 +1375,12 @@ msgid ""
 "Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
 "journal interface."
 msgstr ""
-"Cockpit は、Web ブラウザーで Linux サーバーを簡単に管理できるサーバーマネージャーです。端末と Web "
-"ツールを区別せずに使用できます。Cockpit で起動されたサービスは端末で停止できます。同様に、端末でエラーが発生した場合は、そのエラーを "
-"Cockpit ジャーナルインターフェースで確認できます。"
+"Cockpit は、Web ブラウザーで Linux サーバーを簡単に管理できるサーバーマネー"
+"ジャーです。端末と Web ツールを区別せずに使用できます。Cockpit で起動された"
+"サービスは端末で停止できます。同様に、端末でエラーが発生した場合は、そのエ"
+"ラーを Cockpit ジャーナルインターフェースで確認できます。"
 
-#: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
+#: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit は対話型 Linux サーバー管理インターフェースです。"
 
@@ -1682,8 +1404,11 @@ msgid ""
 "same time. Just add them with a single click and your machines will look "
 "after its buddies."
 msgstr ""
-"Cockpit "
-"は経験が少ないシステム管理者に最適です。これらのシステム管理者はストレージの管理、ジャーナルの検査、サービスの起動および停止などの単純なタスクを簡単に実行できるようになります。また、複数のサーバーを同時に監視および管理できます。これらのサーバーはクリックするだけで追加できます。追加後に、ご使用のマシンは他のマシンを管理するようになります。"
+"Cockpit は経験が少ないシステム管理者に最適です。これらのシステム管理者はスト"
+"レージの管理、ジャーナルの検査、サービスの起動および停止などの単純なタスクを"
+"簡単に実行できるようになります。また、複数のサーバーを同時に監視および管理で"
+"きます。これらのサーバーはクリックするだけで追加できます。追加後に、ご使用の"
+"マシンは他のマシンを管理するようになります。"
 
 #: pkg/lib/machine-change-port.html:9
 msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
@@ -1691,15 +1416,15 @@ msgstr "Cockpit は {{#strong}}{{host}}{{/strong}} に接続できませんで�
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit は {{#strong}}{{host}}{{/strong}} "
-"にログインできませんでした。{{#can_sync}}{{#sync_link}}ユーザーの同期{{/sync_link}}を行ってください。{{/"
-"can_sync}}他の認証オプションとトラブルシューティングのサポートが必要な場合は、cockpit-ws "
-"を新しいバージョンにアップグレードしてください。"
+"Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。"
+"{{#can_sync}}{{#sync_link}}ユーザーの同期{{/sync_link}}を行ってください。{{/"
+"can_sync}}他の認証オプションとトラブルシューティングのサポートが必要な場合"
+"は、cockpit-ws を新しいバージョンにアップグレードしてください。"
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1711,8 +1436,9 @@ msgid ""
 "machine with cockpit you will need to enable one of the following "
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
-"Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。このマシンを Cockpit "
-"で使用するには、{{#strong}}{{host}}{{/strong}} 上の sshd 設定で次の認証方法のいずれかを有効にする必要があります。"
+"Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。このマ"
+"シンを Cockpit で使用するには、{{#strong}}{{host}}{{/strong}} 上の sshd 設定"
+"で次の認証方法のいずれかを有効にする必要があります。"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1720,9 +1446,9 @@ msgid ""
 "change your authentication credentials below. {{#can_sync}}You may prefer to "
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
-"Cockpit は {{#strong}}{{host}}{{/strong}} "
-"にログインできませんでした。認証情報は以下で変更できます。{{#can_sync}}{{#sync_link}}アカウントとパスワードの同期{{/"
-"sync_link}}を実行できます。{{/can_sync}}"
+"Cockpit は {{#strong}}{{host}}{{/strong}} にログインできませんでした。認証情"
+"報は以下で変更できます。{{#can_sync}}{{#sync_link}}アカウントとパスワードの同"
+"期{{/sync_link}}を実行できます。{{/can_sync}}"
 
 #: pkg/dashboard/index.html:157 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1737,12 +1463,12 @@ msgid "Combined usage of $0 CPU core"
 msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "$0 CPU コアの合計使用率"
 
-#: pkg/networkmanager/firewall.jsx:527
+#: pkg/networkmanager/firewall.jsx:529
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "コンマで区切られたポート、範囲、およびエイリアスは使用できます"
 
-#: pkg/docker/index.html:269 pkg/docker/index.html:445
-#: pkg/docker/index.html:706 pkg/systemd/services.html:427
+#: pkg/docker/index.html:271 pkg/docker/index.html:447
+#: pkg/docker/index.html:708 pkg/systemd/services.html:427
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1753,7 +1479,7 @@ msgstr "コマンド"
 msgid "Command can't be empty"
 msgstr "コマンドは空にすることができません"
 
-#: pkg/docker/index.html:163
+#: pkg/docker/index.html:164
 msgid "Command:"
 msgstr "コマンド:"
 
@@ -1761,12 +1487,12 @@ msgstr "コマンド:"
 msgid "Comment"
 msgstr "コメント"
 
-#: pkg/docker/index.html:137 pkg/docker/index.html:716
+#: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
 msgstr "コミット"
 
-#: pkg/docker/index.html:676
+#: pkg/docker/index.html:678
 msgid "Commit Image"
 msgstr "イメージのコミット"
 
@@ -1784,14 +1510,15 @@ msgstr "すべてのシステムおよびデバイスとの互換性あり (MBR)
 
 #: pkg/storaged/content-views.jsx:524
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "最新のシステムとの互換性があり、ハードディスクが 2TB よりも大きい (GPT)"
+msgstr ""
+"最新のシステムとの互換性があり、ハードディスクが 2TB よりも大きい (GPT)"
 
 #: pkg/kdump/kdump-view.jsx:162
 msgid "Compress crash dumps to save space"
 msgstr "クラッシュダンプを圧縮し容量を節約する"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "圧縮"
 
@@ -1807,21 +1534,9 @@ msgstr "条件 $0=$1 を満たしていませんでした。"
 msgid "Condition failed"
 msgstr "条件が満たされませんでした。"
 
-#: pkg/kubernetes/views/node-add.html:24
-msgid "Configuration"
-msgstr "設定"
-
 #: pkg/networkmanager/interfaces.js:2725
 msgid "Configure"
 msgstr "設定"
-
-#: pkg/kubernetes/views/node-add.html:42
-msgid "Configure Flannel networking"
-msgstr "Flannel ネットワーキングの設定"
-
-#: pkg/kubernetes/views/node-add.html:32
-msgid "Configure Kubelet and Proxy"
-msgstr "Kubelet およびプロキシの設定"
 
 #: pkg/docker/storage.jsx:331
 msgid "Configure storage..."
@@ -1844,21 +1559,13 @@ msgstr "確定します"
 msgid "Confirm New Password"
 msgstr "新規パスワードの確認"
 
-#: pkg/ovirt/components/OVirtTab.jsx:65
-msgid "Confirm migration"
-msgstr "移行の確定"
-
-#: pkg/ovirt/components/VdsmView.jsx:95
-msgid "Confirm reload:"
-msgstr "リロードの確認:"
+#: pkg/machines/components/networks/networkDelete.jsx:95
+msgid "Confirm deletion of the Virtual Network"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Confirm removal with passphrase"
 msgstr "パスフレーズで削除を確認"
-
-#: pkg/ovirt/components/VdsmView.jsx:108
-msgid "Confirm save:"
-msgstr "保存の確認:"
 
 #: pkg/systemd/init.js:728
 msgid "Conflicted By"
@@ -1868,8 +1575,6 @@ msgstr "競合する"
 msgid "Conflicts"
 msgstr "競合"
 
-#: pkg/kubernetes/views/auth-form.html:130
-#: pkg/kubernetes/views/auth-rejected-cert.html:33
 #: pkg/lib/machine-unknown-hostkey.html:22
 msgid "Connect"
 msgstr "接続"
@@ -1882,10 +1587,6 @@ msgstr "自動的に接続"
 msgid "Connect to"
 msgstr "接続先"
 
-#: pkg/ovirt/components/InstallationDialog.jsx:102
-msgid "Connect to oVirt Engine"
-msgstr "oVirt エンジンに接続"
-
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "Connect with any $0 viewer application."
 msgstr "$0 ビューアーアプリケーションに接続します。"
@@ -1894,7 +1595,7 @@ msgstr "$0 ビューアーアプリケーションに接続します。"
 msgid "Connect with any SPICE or VNC viewer application."
 msgstr "SPICE または VNC のビューアーアプリケーションに接続します。"
 
-#: pkg/machines/components/vnc.jsx:107
+#: pkg/machines/components/vnc.jsx:106
 msgid "Connecting"
 msgstr "接続中"
 
@@ -1915,33 +1616,21 @@ msgstr "SETroubleshoot デーモンへの接続中 ..."
 msgid "Connecting to Virtualization Service"
 msgstr "仮想化サービスへの接続"
 
-#: pkg/shell/indexes.js:411
+#: pkg/shell/indexes.js:410
 msgid "Connecting to the machine"
 msgstr "マシンへの接続"
 
-#: pkg/kubernetes/index.html:104 pkg/kubernetes/registry.html:71
-msgid "Connecting..."
-msgstr "接続中..."
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:573
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "接続"
 
-#: pkg/kubernetes/views/auth-dialog.html:4 pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:406
 msgid "Connection Error"
 msgstr "接続エラー"
-
-#: pkg/kubernetes/scripts/connection.js:512
-msgid "Connection Error: $0"
-msgstr "接続エラー: $0"
-
-#: pkg/kubernetes/views/auth-dialog.html:3
-msgid "Connection Settings"
-msgstr "接続設定"
 
 #: src/base1/cockpit.js:4027
 msgid "Connection has timed out."
@@ -1963,53 +1652,40 @@ msgstr "コンソールタイプ"
 msgid "Consoles"
 msgstr "コンソール"
 
-#: pkg/realmd/operation.js:274
+#: pkg/realmd/operation.js:273
 msgid "Contacted domain"
 msgstr "接続されたドメイン"
 
-#: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
-#: pkg/kubernetes/views/container-page-inline.html:2
-#: pkg/kubernetes/views/container-panel.html:4
-#: pkg/kubernetes/views/image-page.html:23
+#: pkg/docker/console.html:4
 #: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "コンテナー"
 
-#: pkg/users/local.js:748
+#: pkg/users/local.js:752
 msgid "Container Administrator"
 msgstr "コンテナー管理者"
 
-#: pkg/kubernetes/views/container-body.html:10
-msgid "Container ID"
-msgstr "コンテナー ID"
-
-#: pkg/docker/index.html:438 pkg/docker/index.html:618
-#: pkg/docker/index.html:682
+#: pkg/docker/index.html:440 pkg/docker/index.html:620
+#: pkg/docker/index.html:684
 msgid "Container Name"
 msgstr "コンテナー名"
-
-#: pkg/kubernetes/views/node-body.html:21
-msgid "Container Runtime Version"
-msgstr "コンテナーランタイムバージョン"
 
 #: pkg/docker/util.js:506
 msgid ""
 "Container is currently marked as not running, but regular stopping failed."
-msgstr "コンテナーは現在実行中でないと示されていますが、正常な停止に失敗しました。"
+msgstr ""
+"コンテナーは現在実行中でないと示されていますが、正常な停止に失敗しました。"
 
 #: pkg/docker/util.js:504
 msgid "Container is currently running."
 msgstr "コンテナーは現在実行中です。"
 
-#: pkg/docker/index.html:141
+#: pkg/docker/index.html:133
 msgid "Container:"
 msgstr "コンテナー:"
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:287
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
-#: pkg/kubernetes/views/dashboard-page.html:158
-#: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:375
+#: pkg/docker/index.html:23 pkg/docker/index.html:289
+#: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "コンテナー"
 
@@ -2023,12 +1699,12 @@ msgid "Content"
 msgstr "コンテンツ"
 
 #: src/base1/test-locale.js:42 src/base1/test-locale.js:53
-#: pkg/playground/translate.js:22
+#: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "コントロール"
 
 #: src/base1/test-locale.js:43 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:25
+#: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
 msgstr "コントロール"
@@ -2042,7 +1718,6 @@ msgid "Copy"
 msgstr "コピー"
 
 #: pkg/machines/components/vcpuModal.jsx:209
-#: pkg/ovirt/components/vcpuModal.jsx:67
 msgid "Cores per socket"
 msgstr "ソケットごとのコア"
 
@@ -2053,18 +1728,6 @@ msgstr "すべてのディスクを追加することはできませんでした
 #: pkg/lib/machine-change-port.html:4
 msgid "Could not contact {{host}}"
 msgstr "{{host}} に接続できませんでした"
-
-#: pkg/kubernetes/views/dashboard-page.html:142
-msgid "Could not list services"
-msgstr "サービスを一覧表示できませんでした"
-
-#: src/ws/cockpitcertificate.c:531
-msgid "Could not parse PEM-encoded certificate"
-msgstr "PEM でエンコードされた証明書を解析できませんでした"
-
-#: src/ws/cockpitcertificate.c:498
-msgid "Could not parse PEM-encoded private key"
-msgstr "PEM で暗号化された秘密鍵を解析できませんでした"
 
 #: pkg/docker/storage.jsx:468
 msgid "Could not reset the storage pool"
@@ -2078,29 +1741,13 @@ msgstr "ユーザーグループを変更できませんでした"
 msgid "Couldn't change user password"
 msgstr "ユーザーパスワードを変更できませんでした"
 
-#: pkg/kubernetes/index.html:105 pkg/kubernetes/registry.html:72
-msgid "Couldn't connect to server"
-msgstr "サーバーに接続できませんでした"
-
-#: pkg/shell/indexes.js:414
+#: pkg/shell/indexes.js:413
 msgid "Couldn't connect to the machine"
 msgstr "マシンに接続できませんでした"
 
 #: src/bridge/cockpitdbussetup.c:544
 msgid "Couldn't create new users"
 msgstr "新規ユーザーを作成できませんでした"
-
-#: pkg/kubernetes/scripts/connection.js:510
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:957
-msgid "Couldn't find running API server"
-msgstr "実行中の API サーバーを見つけることができませんでした"
-
-#: pkg/subscriptions/subscriptions-view.jsx:218
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"システムサブスクリプションステータスを取得できませんでした。subscription-manager がインストールされていることを確認してください。"
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -2122,14 +1769,12 @@ msgstr "クラッシュダンプの場所"
 msgid "Crash system"
 msgstr "クラッシュシステム"
 
-#: pkg/kubernetes/views/add-group-dialog.html:19
-#: pkg/kubernetes/views/project-modify.html:72 pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:657
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:488
-#: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/users/index.html:199
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "作成"
 
@@ -2137,17 +1782,13 @@ msgstr "作成"
 msgid "Create Logical Volume"
 msgstr "論理ボリュームの作成"
 
-#: pkg/machines/components/diskAdd.jsx:487
+#: pkg/machines/components/diskAdd.jsx:515
 msgid "Create New"
 msgstr "新規作成"
 
 #: pkg/users/index.html:52 pkg/users/index.html:163
 msgid "Create New Account"
 msgstr "新規アカウントの作成"
-
-#: pkg/ovirt/components/App.jsx:162
-msgid "Create New VM"
-msgstr "仮想マシンの新規作成"
 
 #: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
 msgid "Create Partition"
@@ -2173,7 +1814,7 @@ msgstr "レポートの作成"
 msgid "Create Snapshot"
 msgstr "スナップショットの作成"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:522
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
 msgid "Create Storage Pool"
 msgstr "ストレージプールの作成"
 
@@ -2193,8 +1834,7 @@ msgstr "タイマーの作成"
 msgid "Create VDO Device"
 msgstr "VDO デバイスの作成"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:690
-#: pkg/ovirt/components/ClusterTemplates.jsx:81
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
 msgid "Create VM"
 msgstr "仮想マシンの作成"
 
@@ -2206,14 +1846,6 @@ msgstr "ボリュームグループの作成"
 msgid "Create diagnostic report"
 msgstr "診断レポートの作成"
 
-#: pkg/kubernetes/scripts/images.js:643
-msgid "Create empty image stream"
-msgstr "空のイメージストリームの作成"
-
-#: pkg/kubernetes/views/imagestream-modify.html:3
-msgid "Create image stream"
-msgstr "イメージストリームの作成"
-
 #: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
 #: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
 msgid "Create it"
@@ -2223,16 +1855,12 @@ msgstr "作成"
 msgid "Create new Logical Volume"
 msgstr "新規論理ボリュームの作成"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/kubernetes/views/replicationcontroller-body.html:7
-#: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:129
-#: pkg/docker/containers-view.jsx:412 pkg/docker/containers-view.jsx:683
+#: pkg/docker/containers-view.jsx:129 pkg/docker/containers-view.jsx:412
+#: pkg/docker/containers-view.jsx:683
 msgid "Created"
 msgstr "作成済み"
 
-#: pkg/docker/index.html:152
+#: pkg/docker/index.html:153
 msgid "Created:"
 msgstr "作成済み:"
 
@@ -2260,31 +1888,39 @@ msgstr "$target のスナップショットの作成"
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "この VLAN を作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"この VLAN を作成すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/networkmanager/interfaces.js:3821
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "このボンドを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"このボンドを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/networkmanager/interfaces.js:4274
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "このブリッジを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"このブリッジを作成すると、サーバーへの接続が切断され、管理 UI が利用できなく"
+"なります。"
 
 #: pkg/networkmanager/interfaces.js:4020
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "このチームを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"このチームを作成すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/storaged/jobs-panel.jsx:71
 msgid "Creating volume group $target"
 msgstr "ボリュームグループ $target の作成"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:559
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
 msgid "Creation of VM $0 failed"
 msgstr "VM $0 の作成に失敗"
 
@@ -2292,7 +1928,7 @@ msgstr "VM $0 の作成に失敗"
 msgid "Critical and above"
 msgstr "重大以上のレベル"
 
-#: pkg/machines/components/vnc.jsx:110
+#: pkg/machines/components/vnc.jsx:109
 msgid "Ctrl+Alt+Del"
 msgstr "Ctrl+Alt+Del"
 
@@ -2312,23 +1948,19 @@ msgstr "現在の起動"
 msgid "Custom"
 msgstr "Custom"
 
-#: pkg/networkmanager/firewall.jsx:521
+#: pkg/networkmanager/firewall.jsx:523
 msgid "Custom Ports"
 msgstr "カスタムポート"
-
-#: pkg/subscriptions/subscriptions-register.jsx:103
-msgid "Custom URL"
-msgstr "カスタム URL"
 
 #: pkg/storaged/format-dialog.jsx:118
 msgid "Custom encryption options"
 msgstr "カスタムの暗号化オプション"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "カスタムのマウントオプション"
 
-#: pkg/networkmanager/firewall.jsx:716
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Custom zones"
 msgstr "カスタムゾーン"
 
@@ -2348,10 +1980,6 @@ msgstr "DNS"
 #: pkg/networkmanager/interfaces.js:2656
 msgid "DNS $val"
 msgstr "DNS $val"
-
-#: pkg/kubernetes/views/pod-body.html:14
-msgid "DNS Policy"
-msgstr "DNS ポリシー"
 
 #: pkg/networkmanager/interfaces.js:3320
 msgid "DNS Search Domains"
@@ -2373,8 +2001,8 @@ msgstr "ダッシュボード"
 msgid "Data Used"
 msgstr "使用済みデータ"
 
-#: pkg/machines/components/networks/network.jsx:143
-#: pkg/machines/components/storagePools/storagePool.jsx:163
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "解除"
@@ -2395,10 +2023,9 @@ msgstr "デバッグ以上のレベル"
 msgid "Deduplication"
 msgstr "重複"
 
-#: pkg/docker/index.html:357 pkg/docker/index.html:361
+#: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: node_modules/registry-image-widgets/views/image-config.html:10
 #: pkg/storaged/format-dialog.jsx:68
-#: pkg/subscriptions/subscriptions-register.jsx:102
 msgid "Default"
 msgstr "デフォルト"
 
@@ -2406,37 +2033,26 @@ msgstr "デフォルト"
 msgid "Delay"
 msgstr "遅延"
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:246
-#: pkg/kubernetes/views/image-delete.html:8
-#: pkg/kubernetes/views/imagestream-delete.html:8
-#: pkg/kubernetes/views/item-delete.html:11
-#: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/project-delete.html:9
-#: pkg/kubernetes/views/pv-delete.html:11
-#: pkg/kubernetes/views/pvc-delete.html:15
-#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/machines/components/networks/networkDelete.jsx:86
+#: pkg/machines/components/networks/networkDelete.jsx:103
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:300 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:214 pkg/storaged/vgroup-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "削除"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1179
+#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "$0 の削除"
-
-#: pkg/playground/translate.html:189
-msgid "Delete '{{ name }}'"
-msgstr "'{{ name }}' の削除"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
 msgid "Delete Content"
@@ -2446,25 +2062,10 @@ msgstr "コンテンツの削除"
 msgid "Delete Files"
 msgstr "ファイルの削除"
 
-#: pkg/kubernetes/views/node-delete.html:4
-msgid "Delete Node"
-msgstr "ノードの削除"
-
-#: pkg/kubernetes/views/pv-delete.html:3
-msgid "Delete Persistent Volume"
-msgstr "永続ボリュームの削除"
-
-#: pkg/kubernetes/views/pvc-delete.html:3
-msgid "Delete Persistent Volume Claim"
-msgstr "永続ボリュームクレームの削除"
-
-#: pkg/kubernetes/views/project-delete.html:3
-msgid "Delete Project"
-msgstr "プロジェクトの削除"
-
-#: pkg/kubernetes/views/nodes-page.html:3
-msgid "Delete Selected"
-msgstr "選択項目の削除"
+#: pkg/machines/components/networks/networkDelete.jsx:92
+#, fuzzy
+msgid "Delete Network $0"
+msgstr "$0 の削除"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
 msgid "Delete Storage Pool $0"
@@ -2474,17 +2075,9 @@ msgstr "ストレージプール $0 の削除"
 msgid "Delete associated storage files:"
 msgstr "関連するストレージファイルの削除:"
 
-#: pkg/kubernetes/views/imagestream-delete.html:3
-msgid "Delete image stream"
-msgstr "イメージストリームの削除"
-
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
 msgid "Delete the Volumes inside this Pool"
 msgstr "このプール内のボリュームを削除します"
-
-#: pkg/kubernetes/views/item-delete.html:3
-msgid "Delete {{ item.kind }}"
-msgstr "{{ item.kind }} の削除"
 
 #: pkg/storaged/jobs-panel.jsx:53 pkg/storaged/jobs-panel.jsx:67
 msgid "Deleting $target"
@@ -2494,86 +2087,56 @@ msgstr "$target の削除中"
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "<b>$0</b> を削除すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"<b>$0</b> を削除すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
-#: pkg/kubernetes/views/item-delete.html:7
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr "ポッドを削除すると、関連するすべてのコンテナーが終了します。ポッドは自動的に再び作成されることもあります。"
-
-#: pkg/storaged/mdraid-details.jsx:301
+#: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
-msgstr "RAID デバイスを削除すると、そのデバイス上のすべてのデータが削除されます。"
+msgstr ""
+"RAID デバイスを削除すると、そのデバイス上のすべてのデータが削除されます。"
 
 #: pkg/storaged/vdo-details.jsx:200
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "VDO デバイスを削除すると、そのデバイスのデータはすべて削除されます。"
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "コンテナーを削除すると、コンテナー内のすべてのデータが削除されます。"
 
 #: pkg/storaged/content-views.jsx:273
 msgid "Deleting a logical volume will delete all data in it."
-msgstr "論理ボリュームを削除すると、論理ボリューム内のすべてのデータが削除されます。"
+msgstr ""
+"論理ボリュームを削除すると、論理ボリューム内のすべてのデータが削除されます。"
 
 #: pkg/storaged/content-views.jsx:276
 msgid "Deleting a partition will delete all data in it."
-msgstr "パーティションを削除すると、パーティション内のすべてのデータが削除されます。"
+msgstr ""
+"パーティションを削除すると、パーティション内のすべてのデータが削除されます。"
 
-#: pkg/storaged/vgroup-details.jsx:213
+#: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
-msgstr "ボリュームグループを削除すると、ボリュームグループ上のすべてのデータが削除されます。"
+msgstr ""
+"ボリュームグループを削除すると、ボリュームグループ上のすべてのデータが削除さ"
+"れます。"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
-msgstr "停止状態のストレージプールの削除は、プールの定義を解除するだけです。コンテンツは削除されません。"
+msgstr ""
+"停止状態のストレージプールの削除は、プールの定義を解除するだけです。コンテン"
+"ツは削除されません。"
 
 #: pkg/storaged/jobs-panel.jsx:72
 msgid "Deleting volume group $target"
 msgstr "ボリュームグループ $target の削除"
 
-#: pkg/kubernetes/views/dashboard-page.html:131
-#: pkg/kubernetes/views/deploy.html:62
-msgid "Deploy"
-msgstr "デプロイ"
-
-#: pkg/kubernetes/views/deploy.html:3
-msgid "Deploy Application"
-msgstr "アプリケーションのデプロイ"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:22
-msgid "Deployment Causes"
-msgstr "デプロイメントの理由"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:12
-#: pkg/kubernetes/views/deploymentconfig-panel.html:8
-msgid "Deployment Config"
-msgstr "デプロイメント設定"
-
-#: pkg/kubernetes/views/details-page.html:98
-#: pkg/kubernetes/scripts/details.js:220
-msgid "Deployment Configs"
-msgstr "デプロイメント設定"
-
-#: pkg/kubernetes/views/project-listing.html:15
-#: pkg/kubernetes/views/project-listing.html:54
-#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:413
+#: pkg/systemd/services.html:413
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:725
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
 msgid "Description"
 msgstr "説明"
-
-#: pkg/ovirt/components/OVirtTab.jsx:146
-#: pkg/ovirt/components/VmOverviewColumn.jsx:52
-msgid "Description:"
-msgstr "詳細:"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2583,16 +2146,15 @@ msgstr "デスクトップ"
 msgid "Detachable"
 msgstr "割り当て解除可能"
 
-#: pkg/kubernetes/index.html:67 pkg/shell/index.html:229
-#: pkg/docker/containers-view.jsx:336 pkg/docker/containers-view.jsx:504
-#: pkg/docker/containers-view.jsx:514 pkg/docker/containers-view.jsx:642
-#: pkg/networkmanager/firewall.jsx:94 pkg/packagekit/updates.jsx:383
-#: pkg/subscriptions/subscriptions-view.jsx:232 pkg/systemd/host.js:745
+#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
+#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "詳細"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2614,7 +2176,6 @@ msgstr "診断レポート"
 msgid "Digest"
 msgstr "ダイジェスト"
 
-#: pkg/kubernetes/views/volume-body.html:28
 #: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
@@ -2645,16 +2206,16 @@ msgstr "無効"
 msgid "Disconnect"
 msgstr "切断"
 
-#: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:108
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:604
+#: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
+#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
 msgid "Disconnected"
 msgstr "切断されています"
 
 #: pkg/machines/components/serialConsole.jsx:137
 msgid "Disconnected from serial console. Click the Reconnect button."
-msgstr "シリアルコンソールから切断されました。「再接続」ボタンをクリックします。"
+msgstr ""
+"シリアルコンソールから切断されました。「再接続」ボタンをクリックします。"
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:836
 #: pkg/storaged/vdos-panel.jsx:55
 msgid "Disk"
 msgstr "ディスク"
@@ -2667,15 +2228,11 @@ msgstr "ディスク $0 は、VM $1 からの切断に失敗しました"
 msgid "Disk I/O"
 msgstr "ディスク I/O"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "ディスク使用率: $0%˙"
-
-#: pkg/machines/components/diskAdd.jsx:461
+#: pkg/machines/components/diskAdd.jsx:489
 msgid "Disk failed to be attached"
 msgstr "ディスクの割り当てに失敗しました"
 
-#: pkg/machines/components/diskAdd.jsx:443
+#: pkg/machines/components/diskAdd.jsx:468
 msgid "Disk failed to be created"
 msgstr "ディスクの作成に失敗しました"
 
@@ -2687,9 +2244,9 @@ msgstr "ディスクは OK です"
 msgid "Disk passphrase"
 msgstr "ディスクのパスフレーズ"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "ディスク"
 
@@ -2698,57 +2255,9 @@ msgid "Disks cannot be removed from $0 VMs"
 msgstr "$0 VM からディスクを削除できません"
 
 #: pkg/shell/index.html:52 pkg/shell/index.html:114 pkg/shell/simple.html:38
-#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
+#: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "言語の表示"
-
-#: pkg/kubernetes/views/project-modify.html:31
-msgid "Display name"
-msgstr "名前の表示"
-
-#: pkg/kubernetes/views/add-role-dialog.html:5
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "ロール '{{ fields.displayRole }}' を追加しますか?"
-
-#: pkg/kubernetes/views/imagestream-delete.html:5
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"'{{stream.metadata.namespace}}/{{stream.metadata.name}}' イメージストリームを削除しますか?"
-
-#: pkg/kubernetes/views/pv-delete.html:6
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "永続ボリューム '{{item.metadata.name}}' を削除しますか?"
-
-#: pkg/kubernetes/views/pvc-delete.html:6
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr "永続ボリュームクレーム '{{item.metadata.name}}' を削除しますか?"
-
-#: pkg/kubernetes/views/item-delete.html:6
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "{{ item.kind }} '{{item.metadata.name}}' を削除しますか?"
-
-#: pkg/kubernetes/views/node-delete.html:7
-msgid "Do you want to delete this Node?"
-msgstr "このノードを削除しますか?"
-
-#: pkg/kubernetes/views/image-delete.html:5
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"'{{stream.metadata.namespace}}/{{stream.metadata.name}}:{{tag.tag}}' "
-"というタグが付けられたイメージを削除しますか?"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:5
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
-msgstr ""
-"ロール '{{ fields.displayRole }}' をメンバー {{ fields.member.metadata.name }} "
-"から削除しますか?"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2756,22 +2265,23 @@ msgstr "Docker バージョン"
 
 #: pkg/docker/index.html:60
 msgid "Docker is not installed or activated on the system"
-msgstr "Docker はインストールされていないか、システムでアクティベートされていません"
+msgstr ""
+"Docker はインストールされていないか、システムでアクティベートされていません"
 
 #: pkg/lib/machine-info.js:75
 msgid "Docking Station"
 msgstr "ドッキングステーション"
 
 #: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
-#: pkg/realmd/operation.js:123
+#: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Domain"
 
-#: pkg/realmd/operation.js:192
+#: pkg/realmd/operation.js:191
 msgid "Domain $0 could not be contacted"
 msgstr "ドメイン $0 に接続できませんでした"
 
-#: pkg/realmd/operation.js:279
+#: pkg/realmd/operation.js:278
 msgid "Domain $0 is not supported"
 msgstr "ドメイン $0 はサポートされていません"
 
@@ -2796,15 +2306,11 @@ msgstr "繰り返さないでください"
 msgid "Don't overwrite existing data"
 msgstr "既存のデータを上書きしないでください"
 
-#: pkg/kubernetes/scripts/images.js:633
-msgid "Don't pull images automatically"
-msgstr "イメージを自動的にプルしないでください"
-
 #: pkg/sosreport/index.html:63
 msgid "Done!"
 msgstr "完了！"
 
-#: pkg/docker/index.html:598
+#: pkg/docker/index.html:600
 msgid "Download"
 msgstr "ダウンロード"
 
@@ -2841,11 +2347,7 @@ msgctxt "storage"
 msgid "Drive"
 msgstr "ドライブ"
 
-#: pkg/kubernetes/views/volume-body.html:128
-msgid "Driver"
-msgstr "ドライバー"
-
-#: pkg/storaged/drives-panel.jsx:119
+#: pkg/storaged/drives-panel.jsx:120
 msgid "Drives"
 msgstr "ドライブ"
 
@@ -2874,10 +2376,6 @@ msgstr "Tang キーサーバーの編集"
 msgid "Edit image stream"
 msgstr "イメージストリームの編集"
 
-#: pkg/ovirt/components/VdsmView.jsx:125
-msgid "Edit the vdsm.conf"
-msgstr "vdsm.conf を編集します"
-
 #: pkg/storaged/crypto-keyslots.jsx:535
 msgid "Editing a key requires a free slot"
 msgstr "キーの編集にはフリースロットが必要です"
@@ -2891,25 +2389,21 @@ msgid "Embedded PC"
 msgstr "組み込み PC"
 
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:13
+#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "空"
 
 #: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:19
+#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "空"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "空のディレクトリー"
 
 #: pkg/storaged/jobs-panel.jsx:75
 msgid "Emptying $target"
 msgstr "$target を空にしています"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:151
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:162
 msgid "Emulated Machine"
 msgstr "エミュレートされたマシン"
 
@@ -2960,7 +2454,8 @@ msgstr "ここでは、暗号化したボリュームのサイズを変更する
 
 #: pkg/storaged/lvol-tabs.jsx:143
 msgid "Encrypted volumes need to be unlocked before they can be resized."
-msgstr "暗号化したボリュームは、サイズを変更する前にロックを解除する必要があります。"
+msgstr ""
+"暗号化したボリュームは、サイズを変更する前にロックを解除する必要があります。"
 
 #: pkg/storaged/content-views.jsx:147
 msgid "Encryption"
@@ -2969,23 +2464,6 @@ msgstr "暗号化"
 #: pkg/storaged/crypto-tab.jsx:102
 msgid "Encryption Options"
 msgstr "暗号化オプション"
-
-#: pkg/kubernetes/views/pv-modify.html:93
-msgid "Endpoint"
-msgstr "エンドポイント"
-
-#: pkg/kubernetes/views/volume-body.html:40
-msgid "Endpoint Name"
-msgstr "エンドポイント名"
-
-#: pkg/kubernetes/views/service-page.html:14
-#: pkg/kubernetes/views/service-panel.html:9
-msgid "Endpoints"
-msgstr "エンドポイント"
-
-#: pkg/subscriptions/subscriptions-view.jsx:39
-msgid "Ends"
-msgstr "終了"
 
 #: pkg/selinux/setroubleshoot-view.jsx:299
 msgid "Enforce policy:"
@@ -2999,17 +2477,15 @@ msgstr "機能拡張の更新を利用できます"
 msgid "Enter IP address or host name"
 msgstr "IP アドレスまたはホスト名の入力"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:74
-msgid "Enter New VM name"
-msgstr "新規仮想マシン名を入力します"
-
 #: pkg/lib/machine-change-auth.html:57
 msgid ""
 "Entering a different password here means you will need to retype it every "
 "time you reconnect to this machine"
-msgstr "ここで別のパスワードを入力すると、このマシンに接続するときに毎回そのパスワードを再入力する必要があります"
+msgstr ""
+"ここで別のパスワードを入力すると、このマシンに接続するときに毎回そのパスワー"
+"ドを再入力する必要があります"
 
-#: pkg/networkmanager/firewall.jsx:752
+#: pkg/networkmanager/firewall.jsx:754
 msgid "Entire subnet"
 msgstr "サブネット全体"
 
@@ -3021,7 +2497,7 @@ msgstr "エントリー"
 msgid "Entrypoint"
 msgstr "Entrypoint"
 
-#: pkg/docker/index.html:526 pkg/kubernetes/views/container-body.html:26
+#: pkg/docker/index.html:528
 #: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "環境"
@@ -3043,19 +2519,15 @@ msgid "Errata:"
 msgstr "エラータ:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1472
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "エラー"
 
 #: pkg/systemd/logs.html:59
 msgid "Error and above"
 msgstr "エラー以上のレベル"
-
-#: pkg/kubernetes/scripts/connection.js:646
-msgid "Error getting certificate details: $0"
-msgstr "証明書の詳細の取得中にエラーが発生しました: $0"
 
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
@@ -3077,10 +2549,6 @@ msgstr "アラートの削除中にエラーが発生しました: $0"
 msgid "Error while setting SELinux mode: '$0'"
 msgstr "SELinux モードの設定中にエラーが発生しました: '$0'"
 
-#: pkg/kubernetes/scripts/connection.js:85
-msgid "Error writing kubectl config"
-msgstr "kubectl 設定の書き込み中にエラーが発生しました"
-
 #: pkg/networkmanager/index.html:658
 msgid "Ethernet MAC"
 msgstr "Ethernet MAC"
@@ -3097,23 +2565,23 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "すべて"
 
-#: pkg/networkmanager/firewall.jsx:534
+#: pkg/networkmanager/firewall.jsx:536
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "例: 22,ssh,8080,5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:542
+#: pkg/networkmanager/firewall.jsx:544
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "例: 88,2019,nfs,rsync"
 
-#: pkg/users/local.js:473 pkg/users/local.js:1417
+#: pkg/users/local.js:477 pkg/users/local.js:1421
 msgid "Excellent password"
 msgstr "優れたパスワード"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:222
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
 msgid "Existing Disk Image"
 msgstr "既存のディスクイメージ"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 msgid "Existing disk image on host's file system"
 msgstr "ホストファイルシステム上の既存のディスクイメージ"
 
@@ -3125,7 +2593,7 @@ msgstr "終了した $ExitCode"
 msgid "Expansion Chassis"
 msgstr "拡張シャーシ"
 
-#: pkg/docker/index.html:508
+#: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "コンテナーポートの公開"
 
@@ -3137,14 +2605,6 @@ msgstr "拡張パーティション"
 msgid "FAILED"
 msgstr "失敗"
 
-#: pkg/ovirt/provider.js:130
-msgid "FORCEOFF action failed: $0"
-msgstr "FORCEOFF の動作が失敗: $0"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:47
-msgid "FQDN"
-msgstr "FQDN"
-
 #: pkg/networkmanager/interfaces.js:842
 msgid "Failed"
 msgstr "失敗"
@@ -3154,14 +2614,19 @@ msgid "Failed to add machine: $0"
 msgstr "マシンの追加に失敗しました: $0"
 
 #: pkg/networkmanager/firewall.jsx:237
+#, fuzzy
+msgid "Failed to add port"
+msgstr "ゾーンの追加に失敗しました"
+
+#: pkg/networkmanager/firewall.jsx:237
 msgid "Failed to add service"
 msgstr "サービスの追加に失敗しました"
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:679
 msgid "Failed to add zone"
 msgstr "ゾーンの追加に失敗しました"
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "パスワードの変更に失敗しました"
 
@@ -3185,11 +2650,15 @@ msgstr "マシンの編集に失敗しました: $0"
 msgid "Failed to enable tuned"
 msgstr "tuned の有効化に失敗しました"
 
+#: pkg/machines/components/vmnetworktab.jsx:55
+msgid "Failed to fetch the IP addresses of the interfaces present in $0"
+msgstr ""
+
 #: pkg/users/index.html:393
 msgid "Failed to load authorized keys."
 msgstr "承認された鍵のロードに失敗しました。"
 
-#: pkg/networkmanager/firewall.jsx:589
+#: pkg/networkmanager/firewall.jsx:591
 msgid "Failed to remove service"
 msgstr "サービスの削除に失敗しました"
 
@@ -3208,10 +2677,6 @@ msgstr "プロファイルの切り替えに失敗しました"
 #: pkg/machines/components/vcpuModal.jsx:193
 msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr "仮想 CPU の最大数よりも少ない数を有効にするべきです。"
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "ファイバーチャネル"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:92
 #: pkg/machines/components/vmDiskColumns.jsx:42
@@ -3234,22 +2699,11 @@ msgstr "ファイルシステムのマウント"
 msgid "Filesystem Name"
 msgstr "ファイルシステム名"
 
-#: pkg/kubernetes/views/pv-modify.html:181
-#: pkg/kubernetes/views/volume-body.html:6
-#: pkg/kubernetes/views/volume-body.html:16
-#: pkg/kubernetes/views/volume-body.html:62
-#: pkg/kubernetes/views/volume-body.html:83
-#: pkg/kubernetes/views/volume-body.html:91
-#: pkg/kubernetes/views/volume-body.html:120
-#: pkg/kubernetes/views/volume-body.html:132
-msgid "Filesystem Type"
-msgstr "ファイルシステムタイプ"
-
 #: pkg/storaged/fsys-panel.jsx:103
 msgid "Filesystems"
 msgstr "ファイルシステム"
 
-#: pkg/networkmanager/firewall.jsx:490
+#: pkg/networkmanager/firewall.jsx:491
 msgid "Filter Services"
 msgstr "フィルターサービス"
 
@@ -3257,30 +2711,18 @@ msgstr "フィルターサービス"
 msgid "Filter by name or description..."
 msgstr "名前または説明による絞り込み..."
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "フィンガープリント"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:913 pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
 msgid "Firewall"
 msgstr "ファイアウォール"
 
-#: pkg/networkmanager/firewall.jsx:861
+#: pkg/networkmanager/firewall.jsx:863
 msgid "Firewall is not available"
 msgstr "ファイアウォールは利用できません"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/views/volume-body.html:125
-msgid "Flocker Dataset Name"
-msgstr "Flocker データセット名"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:35
 msgid "Follows docker repo"
@@ -3314,10 +2756,9 @@ msgstr "パスワード変更の強制"
 msgid "Force remove passphrase in $0"
 msgstr "$0 のパスフレーズの削除を強制します"
 
-#: pkg/machines/components/diskAdd.jsx:167
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:258
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "フォーマット"
 
@@ -3331,11 +2772,14 @@ msgstr "ディスク $0 のフォーマット"
 
 #: pkg/storaged/content-views.jsx:531
 msgid "Formatting a disk will erase all data on it."
-msgstr "ディスクをフォーマットすると、ディスク上のすべてのデータが削除されます。"
+msgstr ""
+"ディスクをフォーマットすると、ディスク上のすべてのデータが削除されます。"
 
 #: pkg/storaged/format-dialog.jsx:325
 msgid "Formatting a storage device will erase all data on it."
-msgstr "ストレージデバイスをフォーマットすると、そのデバイス上のすべてのデータが削除されます。"
+msgstr ""
+"ストレージデバイスをフォーマットすると、そのデバイス上のすべてのデータが削除"
+"されます。"
 
 #: pkg/networkmanager/interfaces.js:2861
 msgid "Forward delay $forward_delay"
@@ -3358,7 +2802,9 @@ msgstr "空き領域"
 msgid ""
 "Free up space in this group: Shrink or delete other logical volumes or add "
 "another physical volume."
-msgstr "このグループ内で領域を解放します: 他の論理ボリュームを縮小または削除するか、新たな物理ボリュームを追加してください。"
+msgstr ""
+"このグループ内で領域を解放します: 他の論理ボリュームを縮小または削除するか、"
+"新たな物理ボリュームを追加してください。"
 
 #: pkg/systemd/services.html:239
 msgid "Friday"
@@ -3376,11 +2822,7 @@ msgstr "から"
 msgid "Full Name"
 msgstr "フルネーム"
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "GCE 永続ディスク"
-
-#: pkg/docker/index.html:183
+#: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "ゲートウェイ:"
 
@@ -3397,25 +2839,13 @@ msgstr "レポートの生成"
 msgid "Get new image"
 msgstr "新規イメージの取得"
 
-#: pkg/machines/components/diskAdd.jsx:162
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Git リポジトリー"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster FS"
-
-#: pkg/kubernetes/scripts/volumes.js:877
-msgid "GlusterFS"
-msgstr "GlusterFS"
 
 #: pkg/systemd/logs.js:199
 msgid "Go to"
@@ -3431,11 +2861,6 @@ msgstr "アプリケーションへ移動"
 msgid "Go to now"
 msgstr "今すぐ移動"
 
-#: pkg/kubernetes/views/project-body.html:3
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Grant additional push or admin access to specific members below."
-msgstr "以下の特定のメンバーに追加のプッシュまたは管理アクセスを提供します。"
-
 #: pkg/machines/components/consoles.jsx:51
 msgid "Graphics Console (VNC)"
 msgstr "グラフィックコンソール (VNC)"
@@ -3443,20 +2868,6 @@ msgstr "グラフィックコンソール (VNC)"
 #: pkg/machines/components/consoles.jsx:60
 msgid "Graphics Console in Desktop Viewer"
 msgstr "デスクトップビューアーのグラフィックコンソール"
-
-#: pkg/kubernetes/views/group-page.html:21
-#: pkg/kubernetes/views/group-panel.html:12
-msgid "Group Members"
-msgstr "グループメンバー"
-
-#: pkg/kubernetes/views/user-add-membership.html:9
-msgid "Group or Project"
-msgstr "グループまたはプロジェクト"
-
-#: pkg/kubernetes/views/project-listing.html:48
-#: pkg/kubernetes/views/user-delete.html:14
-msgid "Groups"
-msgstr "グループ"
 
 #: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
 #: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
@@ -3479,15 +2890,6 @@ msgstr "$0 の論理サイズを増加"
 #: pkg/storaged/vdo-details.jsx:130
 msgid "Grow to take all space"
 msgstr "すべての領域を使用して増加"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "HA"
-msgstr "HA"
-
-#: pkg/ovirt/components/OVirtTab.jsx:128
-msgid "HA:"
-msgstr "HA:"
 
 #: pkg/networkmanager/index.html:252
 msgid "Hair Pin mode"
@@ -3522,19 +2924,14 @@ msgstr "ハードウェア情報"
 msgid "Hello time $hello_time"
 msgstr "Hello タイム $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Hide Performance Options"
 msgstr "パフォーマンスオプションを非表示にします"
 
-#: pkg/kubernetes/views/details-page.html:73
-#: pkg/kubernetes/views/route-body.html:9
-#: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:150
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47
-#: pkg/ovirt/components/App.jsx:103 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:334
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "ホスト"
 
@@ -3543,29 +2940,21 @@ msgid "Host Device"
 msgstr "ホストデバイス"
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:155
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
 msgid "Host Name"
 msgstr "ホスト名"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:869
-msgid "Host Path"
-msgstr "ホストパス"
 
 #: src/base1/cockpit.js:4023
 msgid "Host key is incorrect"
 msgstr "ホスト鍵が正しくありません"
 
-#: pkg/realmd/operation.js:602
+#: pkg/realmd/operation.js:601
 msgid "Host name should not be changed in a domain"
 msgstr "ドメインでホスト名は変更できません"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:161
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
 msgid "Host should not be empty"
 msgstr "ホストは空にできません"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:75
-msgid "Host to Maintenance"
-msgstr "メンテナンスするホスト"
 
 #: pkg/systemd/services.html:499
 msgid "Hour : Minute"
@@ -3583,24 +2972,20 @@ msgstr "時"
 msgid "I/O Wait"
 msgstr "I/O 待機"
 
-#: pkg/kubernetes/views/node-body.html:10
-#: pkg/kubernetes/views/service-body.html:9
-msgid "IP"
-msgstr "IP"
-
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
+#: pkg/machines/components/vmnetworktab.jsx:133
 msgid "IP Address"
 msgstr "IP アドレス"
 
-#: pkg/docker/index.html:175
+#: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "IP アドレス:"
 
-#: pkg/docker/index.html:179
+#: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "IP プレフィックスの長さ:"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "IP Range"
 msgstr "IP 範囲"
 
@@ -3632,10 +3017,6 @@ msgstr "IPv6 アドレス"
 msgid "IPv6 Settings"
 msgstr "IPv6 のセッティング"
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:873
-msgid "ISCSI"
-msgstr "ISCSI"
-
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "ID"
@@ -3644,7 +3025,7 @@ msgstr "ID"
 msgid "Id $id"
 msgstr "Id $id"
 
-#: pkg/docker/index.html:148
+#: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "Id:"
 
@@ -3652,17 +3033,6 @@ msgstr "Id:"
 #: node_modules/registry-image-widgets/views/image-listing.html:7
 msgid "Identifier"
 msgstr "識別子"
-
-#: pkg/kubernetes/views/user-page.html:22
-#: pkg/kubernetes/views/user-panel.html:18
-msgid "Identities"
-msgstr "ID"
-
-#: pkg/kubernetes/views/add-user-dialog.html:17
-#: pkg/kubernetes/views/project-listing.html:91
-#: pkg/kubernetes/views/user-modify.html:17
-msgid "Identity"
-msgstr "ID"
 
 #: pkg/storaged/crypto-keyslots.jsx:325
 msgid "If tang-show-keys is not available, run the following:"
@@ -3672,9 +3042,7 @@ msgstr "tang-show-keys を利用できない場合は、以下を実行します
 msgid "Ignore"
 msgstr "無視"
 
-#: pkg/docker/index.html:268 pkg/docker/index.html:431
-#: pkg/kubernetes/views/container-body.html:6
-#: pkg/kubernetes/views/image-page.html:15
+#: pkg/docker/index.html:270 pkg/docker/index.html:433
 #: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
@@ -3684,33 +3052,13 @@ msgstr "画像"
 msgid "Image $0"
 msgstr "イメージ $0"
 
-#: pkg/users/local.js:749
+#: pkg/users/local.js:753
 msgid "Image Builder"
 msgstr "イメージビルダー"
 
-#: pkg/kubernetes/views/container-body.html:8
-msgid "Image ID"
-msgstr "イメージ ID"
-
-#: pkg/kubernetes/views/volume-body.html:58
-msgid "Image Name"
-msgstr "イメージ名"
-
-#: pkg/kubernetes/registry.html:23
-msgid "Image Registry"
-msgstr "イメージレジストリー"
-
-#: pkg/docker/index.html:578
+#: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "イメージ検索"
-
-#: pkg/kubernetes/views/imagestream-page.html:16
-msgid "Image Stream"
-msgstr "イメージストリーム"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:135
-msgid "Image commands"
-msgstr "イメージコマンド"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:41
 msgid "Image count"
@@ -3720,14 +3068,10 @@ msgstr "イメージ数"
 msgid "Image stream"
 msgstr "イメージストリーム"
 
-#: pkg/docker/index.html:156
+#: pkg/docker/index.html:157
 msgid "Image:"
 msgstr "イメージ:"
 
-#: pkg/kubernetes/index.html:81 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
-#: pkg/kubernetes/views/registry-dashboard-page.html:19
 #: pkg/docker/containers-view.jsx:711
 msgid "Images"
 msgstr "イメージ"
@@ -3740,10 +3084,6 @@ msgstr "イメージ"
 #: pkg/docker/containers-view.jsx:109
 msgid "Images and running containers"
 msgstr "イメージおよび実行中のコンテナー"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:17
-msgid "Images by project"
-msgstr "プロジェクト別イメージ"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:15
 #: node_modules/registry-image-widgets/views/imagestream-body.html:16
@@ -3760,11 +3100,7 @@ msgstr "イメージは認証済みユーザーまたはグループがプルで
 msgid "Images may only be pulled by specific users or groups"
 msgstr "イメージは特定のユーザーまたはグループのみがプルできます"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:54
-msgid "Images pushed recently"
-msgstr "最近プッシュされたイメージ"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:637
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
 msgstr "仮想マシンをすぐに起動"
 
@@ -3772,28 +3108,21 @@ msgstr "仮想マシンをすぐに起動"
 msgid "In Sync"
 msgstr "同期"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:171
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
-msgstr "ほとんどの構成で、macvtap は、ホストからゲストへのネットワーク通信には正しく動作しません。"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:81
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr "レジストリーへのイメージのプッシュを開始するには、次のコマンドを使用します。"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:6
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr "レジストリーへのイメージのプッシュを開始するには、プロジェクトを作成する必要があります。"
+msgstr ""
+"ほとんどの構成で、macvtap は、ホストからゲストへのネットワーク通信には正しく"
+"動作しません。"
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
-msgstr "ユーザーを同期するには、{{#strong}}{{host}}{{/strong}} にログインする必要があります。"
+msgstr ""
+"ユーザーを同期するには、{{#strong}}{{host}}{{/strong}} にログインする必要があ"
+"ります。"
 
 #: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
 #: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
@@ -3804,7 +3133,7 @@ msgstr "停止"
 msgid "Inactive volume"
 msgstr "非アクティブなボリューム"
 
-#: pkg/networkmanager/firewall.jsx:730
+#: pkg/networkmanager/firewall.jsx:732
 msgid "Included services"
 msgstr "含まれているサービス"
 
@@ -3828,17 +3157,17 @@ msgstr "Docker ストレージプールに関する情報は利用できませ�
 msgid "Initializing..."
 msgstr "初期化中..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:177
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
 msgid "Initiator"
 msgstr "イニシエーター"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:188
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
 msgid "Initiator IQN should not be empty"
 msgstr "イニシエーター IQN は空にできません"
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "インストール"
 
@@ -3864,27 +3193,25 @@ msgstr "VDO サポートをインストール"
 
 #: pkg/selinux/setroubleshoot-view.jsx:379
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
-msgstr "setroubleshoot-server をインストールして SELinux イベントをトラブルシュートします。"
+msgstr ""
+"setroubleshoot-server をインストールして SELinux イベントをトラブルシュートし"
+"ます。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:226
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
 msgid "Installation Source"
 msgstr "インストールソース"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:212
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
 msgid "Installation Source Type"
 msgstr "インストールソースのタイプ"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:113
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
 msgid "Installation Source should not be empty"
 msgstr "インストールソースは空欄にできません"
 
 #: pkg/packagekit/updates.jsx:59
 msgid "Installed"
 msgstr "インストール済み"
-
-#: pkg/subscriptions/subscriptions-view.jsx:245
-msgid "Installed products"
-msgstr "インストールされた製品"
 
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:51
@@ -3899,17 +3226,13 @@ msgstr "$0 をインストール中"
 msgid "Instantiate"
 msgstr "インスタンス化"
 
-#: pkg/kubernetes/views/pv-modify.html:170
-#: pkg/kubernetes/views/volume-body.html:81
-msgid "Interface"
-msgstr "インターフェース"
-
 #: pkg/machines/components/nicEdit.jsx:123
 msgid "Interface Type"
 msgstr "インターフェース形式"
 
-#: pkg/networkmanager/index.html:108 pkg/networkmanager/firewall.jsx:735
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "インターフェース"
 
@@ -3925,15 +3248,11 @@ msgstr "内部エラー"
 msgid "Invalid address $0"
 msgstr "無効なアドレス $0"
 
-#: pkg/subscriptions/subscriptions-client.js:195
-msgid "Invalid credentials"
-msgstr "無効な資格情報"
-
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "無効な日付形式"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "無効な日付形式と無効な時間形式"
 
@@ -3941,7 +3260,7 @@ msgstr "無効な日付形式と無効な時間形式"
 msgid "Invalid date format."
 msgstr "無効な日付形式。"
 
-#: pkg/users/local.js:1237
+#: pkg/users/local.js:1241
 msgid "Invalid expiration date"
 msgstr "無効な有効期限"
 
@@ -3949,7 +3268,7 @@ msgstr "無効な有効期限"
 msgid "Invalid file permissions"
 msgstr "無効なファイルパーミッション"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
 msgid "Invalid filename"
 msgstr "無効なファイル名"
 
@@ -3961,7 +3280,7 @@ msgstr "無効な鍵"
 msgid "Invalid metric $0"
 msgstr "無効なメトリック $0"
 
-#: pkg/users/local.js:1313
+#: pkg/users/local.js:1317
 msgid "Invalid number of days"
 msgstr "無効な日数"
 
@@ -3989,7 +3308,7 @@ msgstr "無効なプレフィックスまたはネットマスク $0"
 msgid "Invalid range"
 msgstr "無効な範囲"
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "無効な時間形式"
 
@@ -3998,7 +3317,6 @@ msgid "Invalid time zone"
 msgstr "無効なタイムゾーン"
 
 #: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
-#: pkg/subscriptions/subscriptions-client.js:193
 msgid "Invalid username or password"
 msgstr "無効なユーザー名またはパスワード"
 
@@ -4018,19 +3336,19 @@ msgstr "隔離されたネットワーク"
 msgid "Jobs"
 msgstr "ジョブ"
 
-#: pkg/realmd/operation.js:117
+#: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "参加"
 
-#: pkg/realmd/operation.js:597
+#: pkg/realmd/operation.js:596
 msgid "Join Domain"
 msgstr "ドメイン参加"
 
-#: pkg/realmd/operation.js:116
+#: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "ドメインの参加"
 
-#: pkg/realmd/operation.js:506
+#: pkg/realmd/operation.js:505
 msgid "Joining this domain is not supported"
 msgstr "このドメインの参加はサポートされていません"
 
@@ -4053,7 +3371,9 @@ msgstr "ジャーナルエントリーが見つかりません"
 #: pkg/kdump/kdump-view.jsx:459
 msgid ""
 "Kdump service not installed. Please ensure package kexec-tools is installed."
-msgstr "Kdump サービスがインストールされていません。パッケージ kexec-tools がインストールされていることを確認してください。"
+msgstr ""
+"Kdump サービスがインストールされていません。パッケージ kexec-tools がインス"
+"トールされていることを確認してください。"
 
 #: pkg/networkmanager/index.html:708
 msgid "Keep connection"
@@ -4074,14 +3394,6 @@ msgstr "カーネル"
 #: pkg/kdump/index.html:23
 msgid "Kernel Dump"
 msgstr "カーネルダンプ"
-
-#: pkg/kubernetes/views/node-body.html:19
-msgid "Kernel Version"
-msgstr "Kernel バージョン"
-
-#: pkg/kubernetes/views/volume-body.html:67
-msgid "Key Ring Path"
-msgstr "キーリングパス"
 
 #: pkg/storaged/crypto-keyslots.jsx:563
 msgid "Key slots with unknown types can not be edited here"
@@ -4107,23 +3419,10 @@ msgstr "キーサーバーのアドレス"
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "キーサーバーの削除により、$0 のロック解除ができない可能性があります。"
 
-#: pkg/kubernetes/views/node-body.html:23
-msgid "Kubelet Version"
-msgstr "Kubelet バージョン"
-
-#: pkg/kubernetes/index.html:23
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes クラスター"
-
 #: pkg/networkmanager/index.html:377
 msgid "LACP Key"
 msgstr "LACP キー"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: pkg/kubernetes/views/replicationcontroller-body.html:17
-#: pkg/kubernetes/views/route-body.html:22
-#: pkg/kubernetes/views/service-body.html:26
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "ラベル"
@@ -4140,17 +3439,9 @@ msgstr "過去 24 時間"
 msgid "Last 7 days"
 msgstr "過去 7 日間"
 
-#: pkg/kubernetes/views/node-body.html:49
-msgid "Last Heartbeat"
-msgstr "最後のハートビート"
-
 #: pkg/users/index.html:100
 msgid "Last Login"
 msgstr "最終ログイン"
-
-#: pkg/kubernetes/views/node-body.html:51
-msgid "Last Status Change"
-msgstr "最終ステータス変更"
 
 #: pkg/systemd/init.js:284
 msgid "Last Trigger"
@@ -4163,11 +3454,6 @@ msgstr "最終更新日"
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
 msgstr "最終確認: $0 前"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
-#: pkg/kubernetes/views/details-page.html:107
-msgid "Latest Version"
-msgstr "最新バージョン"
 
 #: pkg/machines/components/desktopConsole.jsx:128
 msgid "Launch Remote Viewer"
@@ -4183,19 +3469,21 @@ msgid ""
 "you enter a different username, that user will always be used when "
 "connecting to this machine."
 msgstr ""
-"現在ログインしているユーザーとしてこのマシンに接続する場合は空白のままにします。異なるユーザー名を入力した場合は、このマシンへの接続時にそのユーザーが常に使用されます。"
+"現在ログインしているユーザーとしてこのマシンに接続する場合は空白のままにしま"
+"す。異なるユーザー名を入力した場合は、このマシンへの接続時にそのユーザーが常"
+"に使用されます。"
 
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
-"現在ログインしているユーザー {{#default_user}} ({{default_user}}){{/default_user}} "
-"としてこのマシンに接続する場合は空白のままにします。別のユーザー名を入力すると、このマシンへの接続時にそのユーザーが常に使用されます。"
+"現在ログインしているユーザー {{#default_user}} ({{default_user}}){{/"
+"default_user}} としてこのマシンに接続する場合は空白のままにします。別のユー"
+"ザー名を入力すると、このマシンへの接続時にそのユーザーが常に使用されます。"
 
-#: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
+#: pkg/shell/index.html:90 pkg/shell/simple.html:66
 msgid "Licensed under:"
 msgstr "ライセンス保持者:"
 
@@ -4219,7 +3507,7 @@ msgstr "リンクダウンの遅延"
 msgid "Link local"
 msgstr "ローカルリンク"
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:499
 msgid "Link to another container"
 msgstr "別のコンテナーへのリンク"
 
@@ -4227,11 +3515,11 @@ msgstr "別のコンテナーへのリンク"
 msgid "Link up delay"
 msgstr "リンクアップの遅延"
 
-#: pkg/docker/index.html:493
+#: pkg/docker/index.html:495
 msgid "Links"
 msgstr "リンク"
 
-#: pkg/docker/index.html:195
+#: pkg/docker/index.html:196
 msgid "Links:"
 msgstr "リンク:"
 
@@ -4255,13 +3543,9 @@ msgstr "利用可能なアップデートのロードに失敗しました"
 msgid "Loading available updates, please wait..."
 msgstr "利用可能なアップデートをロード中です。しばらくお待ちください..."
 
-#: pkg/ovirt/components/VdsmView.jsx:34
-msgid "Loading data ..."
-msgstr "データのロード中..."
-
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "読み込み中..."
 
@@ -4277,7 +3561,7 @@ msgstr "ローカルディスク"
 msgid "Local Filesystem"
 msgstr "ローカルファイルシステム"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:218
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
 msgid "Local Install Media"
 msgstr "ローカルインストールメディア"
 
@@ -4297,7 +3581,7 @@ msgstr "ロック"
 msgid "Lock Account"
 msgstr "アカウントのロック"
 
-#: pkg/users/local.js:879 pkg/users/local.js:1218
+#: pkg/users/local.js:883 pkg/users/local.js:1222
 msgid "Lock account on $0"
 msgstr "$0 のアカウントをロック"
 
@@ -4309,7 +3593,7 @@ msgstr "$target のロック中"
 msgid "Log In"
 msgstr "ログイン"
 
-#: pkg/shell/index.html:70 pkg/shell/simple.html:46 pkg/shell/stub.html:53
+#: pkg/shell/index.html:70 pkg/shell/simple.html:46
 msgid "Log Out"
 msgstr "ログアウト"
 
@@ -4325,19 +3609,11 @@ msgstr "{{host}} へのログイン"
 msgid "Log in with your server user account."
 msgstr "サーバーのユーザーアカウントでログインします。"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:116
-msgid "Log into OpenShift command line tools:"
-msgstr "OpenShift コマンドラインツールへのログイン:"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:101
-msgid "Log into the registry:"
-msgstr "レジストリーへのログイン:"
-
 #: pkg/systemd/index.html:65
 msgid "Log messages"
 msgstr "ログメッセージ"
 
-#: pkg/users/local.js:961
+#: pkg/users/local.js:965
 msgid "Logged In"
 msgstr "すでにログインしています"
 
@@ -4348,12 +3624,6 @@ msgstr "論理"
 #: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
 msgid "Logical Size"
 msgstr "論理サイズ"
-
-#: pkg/kubernetes/views/pv-modify.html:159
-#: pkg/kubernetes/views/volume-body.html:79
-#: pkg/kubernetes/views/volume-body.html:118
-msgid "Logical Unit Number"
-msgstr "論理ユニット番号"
 
 #: pkg/storaged/utils.js:197
 msgid "Logical Volume"
@@ -4367,10 +3637,6 @@ msgstr "論理ボリューム (スナップショット)"
 msgid "Logical Volume of $0"
 msgstr "$0 の論理ボリューム"
 
-#: pkg/subscriptions/subscriptions-register.jsx:144
-msgid "Login"
-msgstr "ログイン"
-
 #: src/ws/login.js:300
 msgid "Login Again"
 msgstr "再ログイン"
@@ -4383,10 +3649,6 @@ msgstr "ログインフォーマット"
 msgid "Login Password"
 msgstr "ログインパスワード"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:96
-msgid "Login commands"
-msgstr "ログインコマンド"
-
 #: src/base1/cockpit.js:4015
 msgid "Login failed"
 msgstr "ログインが失敗しました"
@@ -4395,16 +3657,11 @@ msgstr "ログインが失敗しました"
 msgid "Login has escalated admin privileges"
 msgstr "ログインで、管理者の権限をエスカレートさせました"
 
-#: pkg/subscriptions/subscriptions-client.js:199
-msgid "Login/password or activation key required to register."
-msgstr "ログイン/パスワードまたはアクティベーションキーを登録する必要があります。"
-
 #: src/ws/login.js:301
 msgid "Logout Successful"
 msgstr "ログアウトが正常に行われました"
 
-#: pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82
 msgid "Logs"
 msgstr "ログ"
 
@@ -4424,17 +3681,13 @@ msgstr "Lunch Box"
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:102
+#: pkg/machines/components/vmnetworktab.jsx:132
 msgid "MAC Address"
 msgstr "MAC アドレス"
 
-#: pkg/docker/index.html:187
+#: pkg/docker/index.html:188
 msgid "MAC Address:"
 msgstr "MAC アドレス:"
-
-#: pkg/ovirt/provider.js:283
-msgid "MIGRATE action failed"
-msgstr "MIGRATE アクションに失敗しました"
 
 #: pkg/networkmanager/interfaces.js:1985
 msgid "MII (Recommended)"
@@ -4456,7 +3709,7 @@ msgstr "Mac"
 msgid "Mac Address"
 msgstr "Mac アドレス"
 
-#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:95
+#: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "マシン ID"
 
@@ -4475,10 +3728,6 @@ msgstr "メインサーバーシャーシ"
 #: pkg/storaged/crypto-keyslots.jsx:319
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Tang サーバーのキーハッシュが一致することを確認します。"
-
-#: pkg/kubernetes/scripts/dashboard.js:457
-msgid "Manifest"
-msgstr "マニフェスト"
 
 #: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
 msgid "Manual"
@@ -4532,17 +3781,9 @@ msgstr "メッセージ最大期間 $max_age"
 msgid ""
 "Maximum number of virtual CPUs allocated for the guest OS, which must be "
 "between 1 and $0"
-msgstr "ゲスト OS に割り当てられる仮想 CPU の最大数で、これは 1 から $0 の間でなければなりません"
-
-#: pkg/kubernetes/views/volume-body.html:34
-msgid "Medium"
-msgstr "普通"
-
-#: pkg/kubernetes/views/project-listing.html:92
-#: pkg/kubernetes/views/user-body.html:4
-#: pkg/kubernetes/views/user-panel.html:27
-msgid "Member of"
-msgstr "メンバー"
+msgstr ""
+"ゲスト OS に割り当てられる仮想 CPU の最大数で、これは 1 から $0 の間でなけれ"
+"ばなりません"
 
 #: pkg/storaged/content-views.jsx:345
 msgid "Member of RAID Device"
@@ -4552,26 +3793,11 @@ msgstr "RAID デバイスのメンバー"
 msgid "Member of RAID Device $0"
 msgstr "RAID デバイス $0 のメンバー"
 
-#: pkg/kubernetes/views/project-listing.html:16
-#: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/index.html:266 pkg/networkmanager/interfaces.js:2986
-msgid "Members"
-msgstr "メンバー"
-
-#: pkg/kubernetes/views/project-page.html:29
-#: pkg/kubernetes/views/user-page.html:25
-#: pkg/kubernetes/views/user-panel.html:11
-msgid "Membership"
-msgstr "メンバーシップ"
-
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:271
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:608
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:827
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:304
+#: pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
 #: pkg/machines/components/vmOverviewTab.jsx:74
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Memory"
 msgstr "メモリ"
 
@@ -4584,38 +3810,32 @@ msgstr "メモリー"
 msgid "Memory & Swap"
 msgstr "メモリー & スワップ"
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "メモリー使用率: $0%"
-
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
 msgid "Memory could not be saved"
 msgstr "メモリーは保存できませんでした"
 
-#: pkg/docker/index.html:452 pkg/docker/index.html:624
+#: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "メモリー制限"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#, fuzzy
+msgid "Memory must not be 0"
+msgstr "メモリーは保存できませんでした"
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
 msgstr "メモリーサイズは、128 MiB から最大割り当ての間です"
 
-#: pkg/docker/index.html:210
+#: pkg/docker/index.html:211
 msgid "Memory usage:"
 msgstr "メモリー使用状況:"
-
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
-msgid "Message"
-msgstr "メッセージ"
 
 #: pkg/systemd/shutdown.js:79
 msgid "Message to logged in users"
 msgstr "ログインしているユーザーへのメッセージ"
 
-#: pkg/kubernetes/views/image-page.html:29
-#: pkg/kubernetes/views/imagestream-page.html:30
 #: node_modules/registry-image-widgets/views/image-panel.html:15
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
@@ -4625,17 +3845,13 @@ msgstr "メタデータ"
 msgid "Metadata Used"
 msgstr "使用済みメタデータ"
 
-#: pkg/docker/index.html:466 pkg/docker/index.html:638
-#: pkg/machines/components/diskAdd.jsx:159
-#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/docker/index.html:468 pkg/docker/index.html:640
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
-
-#: pkg/ovirt/components/OVirtTab.jsx:70
-msgid "Migrate To:"
-msgstr "移行先:"
 
 #: pkg/lib/machine-info.js:98
 msgid "Mini PC"
@@ -4665,13 +3881,9 @@ msgstr "モード"
 msgid "Model"
 msgstr "モデル"
 
-#: pkg/machines/components/vmnetworktab.jsx:93
+#: pkg/machines/components/vmnetworktab.jsx:123
 msgid "Model type"
 msgstr "モデルタイプ"
-
-#: pkg/kubernetes/views/user-modify.html:27
-msgid "Modify"
-msgstr "修正"
 
 #: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:45
 #: pkg/storaged/jobs-panel.jsx:52
@@ -4694,11 +3906,7 @@ msgstr "監視間隔"
 msgid "Monitoring Targets"
 msgstr "ターゲットの監視"
 
-#: pkg/kubernetes/views/volume-body.html:54
-msgid "Monitors"
-msgstr "監視"
-
-#: pkg/realmd/operation.js:530
+#: pkg/realmd/operation.js:529
 msgid "More"
 msgstr "詳細表示"
 
@@ -4711,31 +3919,27 @@ msgstr "詳細情報"
 msgid "More details"
 msgstr "詳細"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "マウント"
 
-#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
-msgid "Mount Location"
-msgstr "マウント場所"
-
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "マウントオプション"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "マウントポイント"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "起動時にマウント"
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:521
 msgid "Mount container volumes"
 msgstr "マウントコンテナーボリューム"
 
@@ -4751,7 +3955,7 @@ msgstr "マウントポイントは空欄にできません。"
 msgid "Mount point must start with \"/\"."
 msgstr "マウントポイントは \"/\" で開始してください。"
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "読み取り専用でマウント"
 
@@ -4775,11 +3979,7 @@ msgstr "マルチシステムシャーシ"
 msgid "NAT to $0"
 msgstr "$0 への NAT"
 
-#: pkg/kubernetes/scripts/volumes.js:865
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:140
 msgid "NFS Mount"
 msgstr "NFS マウント"
 
@@ -4791,7 +3991,7 @@ msgstr "NFS マウント"
 msgid "NFS Support not installed"
 msgstr "NFS サポートはインストールされていません"
 
-#: pkg/machines/components/vmnetworktab.jsx:67
+#: pkg/machines/components/vmnetworktab.jsx:97
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "VM $1 の NIC $0 は、状態の変更に失敗しました"
 
@@ -4803,54 +4003,29 @@ msgstr "NSNA Ping"
 msgid "NTP Server"
 msgstr "NTP サーバー"
 
-#: pkg/docker/index.html:267 pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/containers-listing.html:11
-#: pkg/kubernetes/views/dashboard-page.html:156
-#: pkg/kubernetes/views/dashboard-page.html:198
-#: pkg/kubernetes/views/details-page.html:34
-#: pkg/kubernetes/views/details-page.html:70
-#: pkg/kubernetes/views/details-page.html:103
-#: pkg/kubernetes/views/details-page.html:137
-#: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/service-modify.html:9
-#: pkg/kubernetes/views/user-modify.html:9
-#: pkg/kubernetes/views/volume-body.html:31
-#: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:119
+#: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
 #: pkg/networkmanager/index.html:319
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:181
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "名前"
 
@@ -4882,7 +4057,7 @@ msgstr "名前には文字 '$0' を含めることができません。"
 msgid "Name cannot contain whitespace."
 msgstr "名前にはスペースを含めることができません。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:82
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
 msgid "Name should not be empty"
 msgstr "名前は空欄にできません"
@@ -4890,26 +4065,6 @@ msgstr "名前は空欄にできません"
 #: pkg/machines/components/networks/networkOverviewTab.jsx:36
 msgid "Name: "
 msgstr "名前: "
-
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
-#: pkg/kubernetes/views/details-page.html:36
-#: pkg/kubernetes/views/details-page.html:72
-#: pkg/kubernetes/views/details-page.html:105
-#: pkg/kubernetes/views/details-page.html:139
-#: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
-#: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
-#: pkg/kubernetes/views/service-body.html:5
-#: pkg/kubernetes/views/volumes-page.html:59
-msgid "Namespace"
-msgstr "名前空間"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "名前空間は空欄にできません。"
 
 #: pkg/systemd/host.js:1348
 msgid "Need at least one NTP server"
@@ -4920,19 +4075,18 @@ msgid "Netmask"
 msgstr "ネットマスク"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:613
 msgid "Network"
 msgstr "ネットワーク"
 
-#: pkg/machines/components/networks/network.jsx:117
+#: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
 msgstr "ネットワーク $0 のアクティベートに失敗しました"
 
-#: pkg/machines/components/networks/network.jsx:129
+#: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
 msgstr "ネットワーク $0 の停止に失敗しました"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
 msgid "Network Boot (PXE)"
 msgstr "ネットワークブート (PXE)"
 
@@ -4944,7 +4098,7 @@ msgstr "ネットワークファイルシステム"
 msgid "Network Interfaces"
 msgstr "ネットワークインターフェース"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:177
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Network Selection does not support PXE."
 msgstr "ネットワーク選択では PXE がサポートされていません。"
 
@@ -4965,7 +4119,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager が実行していません。"
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:914
 msgid "Networking"
 msgstr "ネットワーキング"
 
@@ -4983,21 +4137,17 @@ msgstr "ネットワークログ"
 msgid "Networks"
 msgstr "ネットワーク"
 
-#: pkg/users/local.js:963
+#: pkg/users/local.js:967
 msgid "Never"
 msgstr "しない"
 
-#: pkg/users/index.html:297 pkg/users/local.js:868
+#: pkg/users/index.html:297 pkg/users/local.js:872
 msgid "Never expire password"
 msgstr "パスワードを失効しない"
 
-#: pkg/users/index.html:258 pkg/users/local.js:876
+#: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "アカウントをロックしない"
-
-#: pkg/kubernetes/views/project-listing.html:46
-msgid "New Group"
-msgstr "新規グループ"
 
 #: pkg/storaged/nfs-details.jsx:140
 msgid "New NFS Mount"
@@ -5007,32 +4157,17 @@ msgstr "NFS の新規マウント"
 msgid "New Password"
 msgstr "新規パスワード"
 
-#: pkg/kubernetes/views/project-listing.html:7
-msgid "New Project"
-msgstr "新規プロジェクト"
-
 #: pkg/machines/components/diskAdd.jsx:132
 msgid "New Volume Name"
 msgstr "新しいボリューム名"
-
-#: pkg/kubernetes/views/images-page.html:11
-#: pkg/kubernetes/views/registry-dashboard-page.html:86
-msgid "New image stream"
-msgstr "新規イメージストリーム"
 
 #: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
 msgid "New passphrase"
 msgstr "新しいパスフレーズ"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "新規パスワードは受け入れられませんでした"
-
-#: pkg/kubernetes/views/project-modify.html:4
-#: pkg/kubernetes/views/registry-dashboard-page.html:9
-#: pkg/kubernetes/views/registry-dashboard-page.html:48
-msgid "New project"
-msgstr "新規プロジェクト"
 
 #: pkg/realmd/operation.html:82 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
@@ -5046,9 +4181,8 @@ msgstr "次回の実行日時"
 msgid "Nice"
 msgstr "Nice値"
 
-#: pkg/docker/index.html:542 pkg/docker/index.html:546 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/kubernetes/scripts/volumes.js:998
-#: pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
 msgid "No"
 msgstr "いいえ"
 
@@ -5072,35 +4206,18 @@ msgstr "一致する結果はありません"
 msgid "No NFS mounts set up"
 msgstr "NFS マウントが設定されていません"
 
-#: src/ws/cockpitcertificate.c:522
-msgid "No PEM-encoded certificate found"
-msgstr "PEM でエンコードされた証明書が見つかりません"
-
-#: src/ws/cockpitcertificate.c:488
-msgid "No PEM-encoded private key found"
-msgstr "PEM でエンコードされた秘密鍵が見つかりません"
-
-#: pkg/kubernetes/views/pv-claim.html:39
-msgid "No Pods are using this claim"
-msgstr "このクレームを使用しているポッドがありません"
-
 #: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "No SELinux alerts."
 msgstr "SELinux アラートがありません。"
 
-#: pkg/machines/components/diskAdd.jsx:193
-#: pkg/machines/components/diskAdd.jsx:205
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:216
 msgid "No Storage Pools available"
 msgstr "利用可能なストレージプールはありません"
 
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr "このストレージプールにストレージボリュームが定義されていません"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:29
-#: pkg/ovirt/components/ClusterVms.jsx:36
-msgid "No VM found in oVirt."
-msgstr "oVirt で仮想マシンが見つかりませんでした。"
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
@@ -5110,11 +4227,7 @@ msgstr "仮想マシンがこのホストで実行されていないか、定義
 msgid "No Virtual Networks"
 msgstr "仮想ネットワークはありません"
 
-#: pkg/kubernetes/views/pvc-body.html:10
-msgid "No Volume Bound"
-msgstr "ボリュームがバインドされていません"
-
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/networkmanager/firewall.jsx:926
 msgid "No active zones"
 msgstr "アクティブゾーンはありません"
 
@@ -5166,7 +4279,7 @@ msgstr "コンテナーなし"
 msgid "No containers that match the current filter"
 msgstr "現在のフィルターに一致するコンテナーがありません"
 
-#: pkg/networkmanager/firewall.jsx:727
+#: pkg/networkmanager/firewall.jsx:729
 msgid "No description available"
 msgstr "利用可能な説明はありません"
 
@@ -5174,9 +4287,9 @@ msgstr "利用可能な説明はありません"
 msgid "No description provided."
 msgstr "説明が入力されていません。"
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "ディスクが利用できません。"
 
@@ -5184,7 +4297,7 @@ msgstr "ディスクが利用できません。"
 msgid "No disks defined for this VM"
 msgstr "この仮想マシンに対してディスクが定義されていません"
 
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:121
 msgid "No drives attached"
 msgstr "ドライブが割り当てられていません"
 
@@ -5195,10 +4308,6 @@ msgstr "フリーのキースロットはありません"
 #: pkg/storaged/content-views.jsx:700
 msgid "No free space"
 msgstr "空き領域なし"
-
-#: pkg/kubernetes/views/project-listing.html:74
-msgid "No groups are present."
-msgstr "グループが存在しません。"
 
 #: pkg/systemd/index.html:29
 msgid "No host keys found."
@@ -5216,10 +4325,6 @@ msgstr "イメージストリームが存在しません。"
 msgid "No images"
 msgstr "イメージなし"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:80
-msgid "No images pushed"
-msgstr "イメージがプッシュされていません"
-
 #: pkg/docker/containers-view.jsx:707
 msgid "No images that match the current filter"
 msgstr "現在のフィルターに一致するイメージがありません"
@@ -5227,10 +4332,6 @@ msgstr "現在のフィルターに一致するイメージがありません"
 #: pkg/apps/utils.jsx:96
 msgid "No installation package found for this application."
 msgstr "このアプリケーションのインストールパッケージが見つかりませんでした。"
-
-#: pkg/subscriptions/subscriptions-view.jsx:246
-msgid "No installed products on the system."
-msgstr "システムにインストールされた製品がありません。"
 
 #: pkg/storaged/crypto-keyslots.jsx:520
 msgid "No keys added"
@@ -5250,15 +4351,11 @@ msgid ""
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
 "crashkernel=512M"
 msgstr ""
-"メモリーが予約されていません。crashkernel オプションをカーネルコマンドラインに追加して (例: /etc/default/"
-"grub)、起動時にメモリーを予約します。例: crashkernel=512M"
+"メモリーが予約されていません。crashkernel オプションをカーネルコマンドライン"
+"に追加して (例: /etc/default/grub)、起動時にメモリーを予約します。例: "
+"crashkernel=512M"
 
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr "メタデータファイルが選択されていません。Kubernetes メタデータファイルを選択してください。"
-
-#: pkg/machines/components/vmnetworktab.jsx:40
+#: pkg/machines/components/vmnetworktab.jsx:70
 msgid "No network interfaces defined for this VM"
 msgstr "この仮想マシンにはネットワークインターフェースが定義されていません"
 
@@ -5270,15 +4367,7 @@ msgstr "このホストで定義されるネットワークはありません"
 msgid "No networks available"
 msgstr "利用可能なネットワークはありません"
 
-#: pkg/kubernetes/views/dashboard-page.html:117
-msgid "No nodes in cluster"
-msgstr "クラスター内にノードがありません"
-
-#: pkg/ovirt/components/App.jsx:61
-msgid "No oVirt connection"
-msgstr "oVirt 接続がありません"
-
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:939
 msgid "No open ports"
 msgstr "開いているポートはありません"
 
@@ -5286,27 +4375,7 @@ msgstr "開いているポートはありません"
 msgid "No partitioning"
 msgstr "パーティションなし"
 
-#: pkg/kubernetes/views/dashboard-page.html:40
-msgid "No pods deployed"
-msgstr "ポッドがデプロイされていません"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:6
-msgid "No pods replicated"
-msgstr "ポッドがレプリケートされていません"
-
-#: pkg/kubernetes/views/node-capacity.html:11
-msgid "No pods scheduled"
-msgstr "ポッドがスケジュールされていません"
-
-#: pkg/kubernetes/views/service-endpoint.html:10
-msgid "No pods selected"
-msgstr "ポッドが選択されていません"
-
-#: pkg/kubernetes/views/project-listing.html:37
-msgid "No projects are present."
-msgstr "プロジェクトが存在しません。"
-
-#: pkg/users/local.js:449
+#: pkg/users/local.js:453
 msgid "No real name specified"
 msgstr "実際の名前が指定されていません"
 
@@ -5346,48 +4415,17 @@ msgstr "タグが存在しません。"
 msgid "No updates pending"
 msgstr "保留中の更新がありません"
 
-#: pkg/users/local.js:444
+#: pkg/users/local.js:448
 msgid "No user name specified"
 msgstr "ユーザー名が指定されていません"
-
-#: pkg/kubernetes/views/project-listing.html:112
-msgid "No users are present."
-msgstr "ユーザーが存在しません。"
 
 #: pkg/storaged/vgroups-panel.jsx:114
 msgid "No volume groups created"
 msgstr "ボリュームグループが作成されていません"
 
-#: pkg/kubernetes/views/volumes-page.html:44
-msgid "No volumes are present."
-msgstr "ボリュームが存在しません。"
-
-#: pkg/kubernetes/views/dashboard-page.html:73
-msgid "No volumes in use"
-msgstr "使用中のボリュームがありません"
-
-#: pkg/kubernetes/views/containers-listing.html:15
-#: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
-#: pkg/kubernetes/views/topology-page.html:38
-msgid "Node"
-msgstr "ノード"
-
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
-#: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
-msgid "Nodes"
-msgstr "ノード"
-
-#: pkg/kubernetes/views/topology-page.html:39
-msgid "Nodes are the machines that run your containers."
-msgstr "ノードはコンテナーを実行するマシンです。"
-
-#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
-#: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:732
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "なし"
 
@@ -5395,23 +4433,13 @@ msgstr "なし"
 msgid "None (Isolated Network)"
 msgstr "なし (隔離されたネットワーク)"
 
-#: pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
-#: pkg/kubernetes/scripts/nodes.js:319
+#: pkg/playground/translate.html:29
 msgid "Not Ready"
 msgstr "準備ができていません"
-
-#: pkg/kubernetes/scripts/details.js:496 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "レプリカの有効な数ではありません"
 
 #: pkg/lib/credentials.js:255
 msgid "Not a valid private key"
 msgstr "有効な秘密鍵ではありません"
-
-#: pkg/kubernetes/scripts/details.js:547
-msgid "Not a valid value for Host"
-msgstr "ホストの有効な値ではありません"
 
 #: pkg/docker/index.html:57
 msgid "Not authorized to access Docker on this system"
@@ -5429,11 +4457,6 @@ msgstr "利用できません"
 msgid "Not connected"
 msgstr "接続していません"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
-#: pkg/kubernetes/views/details-page.html:122
-msgid "Not deployed"
-msgstr "デプロイされていません"
-
 #: pkg/storaged/lvol-tabs.jsx:369
 msgid "Not enough space to grow."
 msgstr "スペースが不足しています。"
@@ -5450,7 +4473,7 @@ msgstr "マウントされていません"
 msgid "Not permitted to perform this action."
 msgstr "このアクションを実行する権限がありません。"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Not running"
 msgstr "実行中ではありません"
 
@@ -5474,32 +4497,9 @@ msgstr "ノートブック"
 msgid "Notice and above"
 msgstr "注意以上のレベル"
 
-#: pkg/ovirt/components/vcpuModal.jsx:55
-msgid "Number of virtual CPUs that gonna be used."
-msgstr "使用予定の仮想 CPU の数。"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
-#: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
-msgid "OK"
-msgstr "OK"
-
-#: pkg/kubernetes/views/node-body.html:13
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "OS"
-msgstr "OS"
-
-#: pkg/ovirt/components/OVirtTab.jsx:148
-msgid "OS Type:"
-msgstr "OS タイプ:"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:274
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
 msgid "OS Vendor"
 msgstr "OS ベンダー"
-
-#: pkg/kubernetes/views/nodes-page.html:19
-msgid "OS Versions"
-msgstr "OS バージョン"
 
 #: pkg/selinux/setroubleshoot-view.jsx:394
 msgid "Occurred $0"
@@ -5525,7 +4525,7 @@ msgstr "古いパスワード"
 msgid "Old passphrase"
 msgstr "古いパスフレーズ"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "古いパスワードは受け入れられません"
 
@@ -5537,7 +4537,7 @@ msgstr "オン"
 msgid "On Build"
 msgstr "ビルド時"
 
-#: pkg/docker/index.html:547 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/init.js:731
 msgid "On Failure"
 msgstr "障害発生時"
 
@@ -5555,9 +4555,10 @@ msgid ""
 "Once Cockpit is installed, enable it with \"systemctl enable --now cockpit."
 "socket\"."
 msgstr ""
-"Cockpit がインストールされたら、\"systemctl enable --now cockpit.socket\" コマンドで有効にします。"
+"Cockpit がインストールされたら、\"systemctl enable --now cockpit.socket\" コ"
+"マンドで有効にします。"
 
-#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:338
+#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
 msgstr "ワンタイムパスワード"
 
@@ -5565,7 +4566,9 @@ msgstr "ワンタイムパスワード"
 msgid ""
 "One or more selected volumes are used by domains. Detach the disks first to "
 "allow volume deletion."
-msgstr "ひとつまたは複数の選択されたボリュームがドメインで使用されています。最初にディスクを切断し、ボリュームが削除できるようにします。"
+msgstr ""
+"ひとつまたは複数の選択されたボリュームがドメインで使用されています。最初に"
+"ディスクを切断し、ボリュームが削除できるようにします。"
 
 #: pkg/storaged/vdo-details.jsx:134
 msgid "Only $0 of $1 are used."
@@ -5583,7 +4586,7 @@ msgstr "アルファベット、数字、:、 _ 、.、@、- のみを使用で�
 msgid "Only editable when the guest is shut off"
 msgstr "ゲストがシャットオフされた場合のみ、編集可能です"
 
-#: pkg/shell/index.html:43 pkg/shell/simple.html:29 pkg/shell/stub.html:33
+#: pkg/shell/index.html:43 pkg/shell/simple.html:29
 msgid "Ooops!"
 msgstr "問題が発生しました"
 
@@ -5591,8 +4594,8 @@ msgstr "問題が発生しました"
 msgid "Open"
 msgstr "開く"
 
-#: pkg/kubernetes/views/nodes-page.html:42 pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+#: pkg/systemd/index.html:98
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
 msgid "Operating System"
 msgstr "オペレーティングシステム"
 
@@ -5600,27 +4603,24 @@ msgstr "オペレーティングシステム"
 msgid "Operation '$operation' on $target"
 msgstr "$target 上の操作 '$operation'"
 
+#: pkg/machines/components/storagePools/storagePool.jsx:175
+#: pkg/machines/components/storagePools/storagePool.jsx:180
+#, fuzzy
+msgid "Operation is in progress"
+msgstr "oVirt ログインの処理中"
+
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "光学ドライブ"
 
-#: pkg/ovirt/components/OVirtTab.jsx:157
-msgid "Optimized for:"
-msgstr "次に対して最適化:"
-
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:134
-#: pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
 msgid "Options"
 msgstr "オプション"
 
 #: src/ws/login.html:125
 msgid "Or use a bundled browser"
 msgstr "あるいは、バンドルされたブラウザーを使用します"
-
-#: pkg/subscriptions/subscriptions-register.jsx:180
-msgid "Organization"
-msgstr "部門"
 
 #: pkg/lib/machine-info.js:64
 msgid "Other"
@@ -5639,11 +4639,9 @@ msgstr "他のデバイス"
 msgid "Other Options"
 msgstr "他のオプション"
 
-#: pkg/docker/index.html:297 pkg/kubernetes/index.html:43
-#: pkg/kubernetes/registry.html:43
-#: pkg/machines/components/networks/network.jsx:71
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "概要"
 
@@ -5654,10 +4652,6 @@ msgstr "既存のデータをゼロで上書きする"
 #: pkg/systemd/hwinfo.jsx:249
 msgid "PCI"
 msgstr "PCI"
-
-#: pkg/kubernetes/views/volume-body.html:4
-msgid "PD Name"
-msgstr "PD 名"
 
 #: pkg/packagekit/updates.jsx:501
 msgid "Package information"
@@ -5691,8 +4685,7 @@ msgstr "一部"
 msgid "Part of "
 msgstr "一部"
 
-#: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:141
 msgid "Partition"
 msgstr "パーティション"
 
@@ -5728,13 +4721,11 @@ msgstr "パスフレーズの削除で、$0 のロック解除ができない可
 msgid "Passphrases do not match"
 msgstr "パスフレーズが一致しません"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
 #: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
-#: pkg/subscriptions/subscriptions-register.jsx:89
-#: pkg/subscriptions/subscriptions-register.jsx:156
 msgid "Password"
 msgstr "パスワード"
 
@@ -5750,7 +4741,7 @@ msgstr "パスワードは受け入れられません"
 msgid "Password is too weak"
 msgstr "パスワードが弱すぎます"
 
-#: pkg/users/local.js:870
+#: pkg/users/local.js:874
 msgid "Password must be changed"
 msgstr "パスワードを変更する必要があります"
 
@@ -5761,7 +4752,8 @@ msgstr "パスワードは受け入れられません"
 #: pkg/shell/index.html:155
 msgid ""
 "Password not usable for privileged tasks or to connect to other machines"
-msgstr "特権タスクの実行または他のマシンへの接続のためにパスワードを使用できません"
+msgstr ""
+"特権タスクの実行または他のマシンへの接続のためにパスワードを使用できません"
 
 #: pkg/lib/cockpit-components-context-menu.jsx:104
 msgid "Paste"
@@ -5771,11 +4763,7 @@ msgstr "貼り付け"
 msgid "Paste the contents of your public SSH key file here"
 msgstr "公開 SSH 鍵ファイルの内容をここに貼り付けます"
 
-#: pkg/kubernetes/views/pv-modify.html:126
-#: pkg/kubernetes/views/volume-body.html:37
-#: pkg/kubernetes/views/volume-body.html:49
-#: pkg/kubernetes/views/volume-body.html:101 pkg/systemd/services.html:126
-#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
 msgid "Path"
 msgstr "パス"
 
@@ -5791,7 +4779,7 @@ msgstr "パスコスト $path_cost"
 msgid "Path on Server"
 msgstr "サーバーのパス"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:129
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
 msgid "Path on host's filesystem"
 msgstr "ホストファイルシステム上のパス"
 
@@ -5803,7 +4791,7 @@ msgstr "サーバーのパスは空欄にはできません。"
 msgid "Path on server must start with \"/\"."
 msgstr "サーバーのパスは \"/\" で開始してください。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:154
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
 msgid "Path to ISO file on host's file system"
 msgstr "ホストファイルシステムの ISO ファイルのパス"
 
@@ -5818,10 +4806,6 @@ msgstr "パス"
 #: pkg/machines/components/vm/vmActions.jsx:77
 msgid "Pause"
 msgstr "一時停止"
-
-#: pkg/kubernetes/views/volumes-page.html:53
-msgid "Pending Volume Claims"
-msgstr "保留中のボリュームクレーム"
 
 #: pkg/systemd/index.html:152
 msgid "Performance Profile"
@@ -5843,18 +4827,10 @@ msgstr "パーミッションが拒否されました。"
 msgid "Persistence"
 msgstr "永続"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr "永続"
-
-#: pkg/kubernetes/views/volumes-page.html:14
-msgid "Persistent Volumes"
-msgstr "永続ボリューム"
-
-#: pkg/kubernetes/views/pod-body.html:16
-msgid "Phase"
-msgstr "フェーズ"
 
 #: pkg/storaged/vdo-details.jsx:277
 msgid "Physical"
@@ -5868,11 +4844,11 @@ msgstr "物理ディスクデバイス"
 msgid "Physical Volume"
 msgstr "物理ボリューム"
 
-#: pkg/storaged/vgroup-details.jsx:134
+#: pkg/storaged/vgroup-details.jsx:133
 msgid "Physical Volumes"
 msgstr "物理ボリューム"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:210
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
 msgid "Physical disk device on host"
 msgstr "ホスト上の物理ディスクデバイス"
 
@@ -5896,10 +4872,10 @@ msgstr "Ping ターゲット"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:210
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "$0 の削除を確定してください"
 
@@ -5907,111 +4883,23 @@ msgstr "$0 の削除を確定してください"
 msgid "Please confirm forced deletion of $0"
 msgstr "$0 の強制削除を確定してください"
 
-#: pkg/storaged/mdraid-details.jsx:244 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "$0 の停止を確認してください"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:34
-msgid "Please confirm, the host shall be switched to maintenance mode."
-msgstr "ホストがメンテナンスモードに切り替わっていることを確認してください。"
-
-#: pkg/kubernetes/scripts/dashboard.js:439
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "$0 \"$1\" の別の名前空間を作成してください"
-
-#: pkg/machines/components/diskAdd.jsx:425
+#: pkg/machines/components/diskAdd.jsx:447
 msgid "Please enter new volume name"
 msgstr "新しいボリューム名を入力してください"
 
-#: pkg/machines/components/diskAdd.jsx:428
+#: pkg/machines/components/diskAdd.jsx:450
 msgid "Please enter new volume size"
 msgstr "新しいボリュームサイズを入力してください"
 
-#: pkg/networkmanager/firewall.jsx:862
+#: pkg/networkmanager/firewall.jsx:864
 msgid "Please install the $0 package"
 msgstr "$0 パッケージをインストールしてください"
 
-#: pkg/kubernetes/scripts/volumes.js:582
-msgid "Please provide a GlusterFS volume name"
-msgstr "GlusterFS ボリューム名を提供してください"
-
-#: pkg/kubernetes/scripts/connection.js:550
-msgid "Please provide a username"
-msgstr "ユーザー名を提供してください"
-
-#: pkg/kubernetes/scripts/volumes.js:640
-msgid "Please provide a valid NFS server"
-msgstr "有効な NFS サーバーを提供してください"
-
-#: pkg/kubernetes/scripts/connection.js:535
-msgid "Please provide a valid address"
-msgstr "有効なアドレスを提供してください"
-
-#: pkg/kubernetes/scripts/volumes.js:810
-msgid "Please provide a valid filesystem type"
-msgstr "有効なファイルシステムタイプを提供してください"
-
-#: pkg/kubernetes/scripts/volumes.js:818
-msgid "Please provide a valid interface"
-msgstr "有効なインターフェースを提供してください"
-
-#: pkg/kubernetes/scripts/volumes.js:802
-msgid "Please provide a valid logical unit number"
-msgstr "有効な論理ユニット番号を提供してください"
-
-#: pkg/kubernetes/scripts/volumes.js:483
-msgid "Please provide a valid name"
-msgstr "有効な名前を提供してください"
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "有効な名前空間を提供してください"
-
-#: pkg/kubernetes/scripts/volumes.js:648 pkg/kubernetes/scripts/volumes.js:703
-msgid "Please provide a valid path"
-msgstr "有効なパスを提供してください"
-
-#: pkg/kubernetes/scripts/volumes.js:794
-msgid "Please provide a valid qualified name"
-msgstr "有効な修飾名を提供してください"
-
-#: pkg/kubernetes/scripts/volumes.js:491
-msgid "Please provide a valid storage capacity."
-msgstr "有効なストレージ容量を提供してください"
-
-#: pkg/kubernetes/scripts/volumes.js:786
-msgid "Please provide a valid target"
-msgstr "有効なターゲットを提供してください"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:83
-msgid ""
-"Please provide fully qualified domain name and port of the oVirt engine."
-msgstr "完全修飾ドメイン名と、oVirt エンジンのポートを提供してください。"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:137
-msgid ""
-"Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-"port (443 by default)"
-msgstr "有効な oVirt エンジンの完全修飾ドメイン名 (FQDN) と、ポート (デフォルトでは 443) を提供してください"
-
-#: pkg/ovirt/components/ConsoleClientResources.jsx:32
-msgid ""
-"Please refer to oVirt's $0 for more information about Remote Viewer setup."
-msgstr "リモートビューアーの設定の詳細は、oVirt の $0 を参照してください。"
-
-#: pkg/kubernetes/scripts/volumes.js:475
-msgid "Please select a valid access mode"
-msgstr "有効なアクセスモードを選択してください"
-
-#: pkg/kubernetes/scripts/volumes.js:573
-msgid "Please select a valid endpoint"
-msgstr "有効なエンドポイントを選択してください"
-
-#: pkg/kubernetes/scripts/volumes.js:499
-msgid "Please select a valid policy option."
-msgstr "有効なポリシーオプションを選択してください"
-
-#: pkg/users/local.js:1232
+#: pkg/users/local.js:1236
 msgid "Please specify an expiration date"
 msgstr "有効期限を指定してください"
 
@@ -6027,72 +4915,16 @@ msgstr "仮想マシンを起動して、コンソールにアクセスしてく
 msgid "Please try another term"
 msgstr "別の用語を試してください"
 
-#: pkg/kubernetes/scripts/nodes.js:401
-msgid "Please type an address"
-msgstr "アドレスを入力してください"
-
-#: pkg/ovirt/components/ClusterVms.jsx:37
-msgid "Please wait till VMs list is loaded from the server."
-msgstr "サーバーから仮想マシンの一覧がロードされるのをお待ちください。"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:30
-msgid "Please wait till list of templates is loaded from the server."
-msgstr "テンプレートの一覧がサーバーからロードされるのをお待ちください。"
-
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Plug"
 msgstr "プラグ"
 
-#: pkg/kubernetes/views/containers-listing.html:12
-#: pkg/kubernetes/views/pod-page.html:12
-#: pkg/kubernetes/views/topology-page.html:14
-msgid "Pod"
-msgstr "ポッド"
-
-#: pkg/kubernetes/views/pod-body.html:20
-msgid "Pod Address"
-msgstr "ポッドアドレス"
-
-#: pkg/kubernetes/views/service-endpoint.html:4
-#: pkg/kubernetes/views/service-endpoint.html:9
-msgid "Pod Endpoints"
-msgstr "ポッドエンドポイント"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:4
-msgid "Pod Replicated"
-msgstr "ポッドがレプリケートされました"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:11
-#: pkg/kubernetes/views/service-endpoint.html:15
-msgid "Pod Selector"
-msgstr "ポッドセレクター"
-
-#: pkg/kubernetes/views/dashboard-page.html:18
-#: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/pv-claim.html:37
-#: pkg/kubernetes/views/replicationcontroller-page.html:17
-#: pkg/kubernetes/views/replicationcontroller-panel.html:12
-#: pkg/kubernetes/scripts/details.js:227
-msgid "Pods"
-msgstr "ポッド"
-
-#: pkg/kubernetes/views/topology-page.html:15
-msgid ""
-"Pods contain one or more containers that run together on a node, containing "
-"your application code."
-msgstr "ポッドには、ノードで一緒に実行される 1 つ以上のコンテナーが含まれます (アプリケーションコードを含む)"
-
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "プール"
-
-#: pkg/kubernetes/views/volume-body.html:60
-msgid "Pool Name"
-msgstr "プール名"
 
 #: pkg/storaged/utils.js:191
 msgid "Pool for Thin Logical Volumes"
@@ -6106,16 +4938,11 @@ msgstr "シンボリューム用プール"
 msgid "Pool for thinly provisioned volumes"
 msgstr "シンプロビジョニングされたボリューム用プール"
 
-#: pkg/kubernetes/views/imagestream-modify.html:45
-msgid "Populate"
-msgstr "入力"
-
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:78
-#: pkg/ovirt/components/InstallationDialog.jsx:65
+#: pkg/machines/components/vmnetworktab.jsx:108
 #: pkg/storaged/iscsi-panel.jsx:127
 msgid "Port"
 msgstr "ポート"
@@ -6128,15 +4955,14 @@ msgstr "ポート番号とタイプが一致しません"
 msgid "Portable"
 msgstr "ポータブル"
 
-#: pkg/docker/index.html:504 pkg/kubernetes/views/container-body.html:12
-#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:213
+#: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
 #: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
 msgid "Ports"
 msgstr "ポート"
 
-#: pkg/docker/index.html:191
+#: pkg/docker/index.html:192
 msgid "Ports:"
 msgstr "ポート:"
 
@@ -6145,7 +4971,6 @@ msgid "Power Options"
 msgstr "電源オプション"
 
 #: pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Preferred number of sockets to expose to the guest."
 msgstr "ゲストへの公開用の推奨されるソケットの数。"
 
@@ -6164,10 +4989,6 @@ msgstr "プレフィックス長またはネットマスク"
 #: pkg/networkmanager/interfaces.js:826
 msgid "Preparing"
 msgstr "準備中"
-
-#: pkg/ovirt/rephraseUI.js:25
-msgid "Preparing for Maintenance"
-msgstr "メンテナンスの準備中"
 
 #: pkg/networkmanager/interfaces.js:3631
 msgid "Preserve"
@@ -6206,10 +5027,6 @@ msgstr "優先度 $priority"
 msgid "Private"
 msgstr "プライベート"
 
-#: pkg/kubernetes/scripts/projects.js:1042
-msgid "Private: Allow only specific users or groups to pull images"
-msgstr "プライベート: 特定のユーザーまたはグループのみがイメージをプルすることを許可する"
-
 #: pkg/shell/index.html:39
 msgid "Privileged"
 msgstr "権限"
@@ -6235,61 +5052,9 @@ msgstr "プロセス"
 msgid "Product"
 msgstr "製品"
 
-#: pkg/subscriptions/subscriptions-view.jsx:34
-msgid "Product ID"
-msgstr "製品 ID"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product name"
-msgstr "製品名"
-
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
-#: pkg/kubernetes/views/details-page.html:35
-#: pkg/kubernetes/views/details-page.html:71
-#: pkg/kubernetes/views/details-page.html:104
-#: pkg/kubernetes/views/details-page.html:138
-#: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/pod-body.html:4
-#: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/route-body.html:4
-#: pkg/kubernetes/views/service-body.html:4
-#: pkg/kubernetes/views/volumes-page.html:58
-msgid "Project"
-msgstr "プロジェクト"
-
-#: pkg/kubernetes/views/project-body.html:20
-msgid "Project Members"
-msgstr "プロジェクトメンバー"
-
-#: pkg/kubernetes/views/project-body.html:3
-msgid "Project access policy allows anonymous users to pull images."
-msgstr "プロジェクトアクセスポリシーにより、匿名ユーザーはイメージをプルすることができます。"
-
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Project access policy allows any authenticated user to pull images."
-msgstr "プロジェクトアクセスポリシーにより、認証されたユーザーはイメージをプルすることができます。"
-
-#: pkg/kubernetes/views/project-body.html:13
-msgid "Project access policy only allows specific members to access images."
-msgstr "プロジェクトアクセスポリシーにより、特定のメンバーのみがイメージにアクセスできます。"
-
-#: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
+#: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
 msgstr "プロジェクト Web サイト"
-
-#: pkg/kubernetes/views/filter-project.html:5
-msgid "Project:"
-msgstr "プロジェクト:"
-
-#: pkg/kubernetes/index.html:88 pkg/kubernetes/registry.html:55
-#: pkg/kubernetes/views/group-delete.html:10
-#: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
-msgid "Projects"
-msgstr "プロジェクト"
 
 #: pkg/users/local.js:91
 msgid "Prompting via passwd timed out"
@@ -6313,15 +5078,7 @@ msgstr "再読み込み先を伝搬"
 msgid "Protocol"
 msgstr "プロトコル"
 
-#: pkg/subscriptions/subscriptions-register.jsx:129
-msgid "Proxy"
-msgstr "プロキシ"
-
-#: pkg/kubernetes/views/node-body.html:25
-msgid "Proxy Version"
-msgstr "プロキシバージョン"
-
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "公開鍵"
 
@@ -6329,25 +5086,9 @@ msgstr "公開鍵"
 msgid "Public pulling repo"
 msgstr "パブリックのプルリポジトリ－"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:152
-msgid "Pull an image:"
-msgstr "イメージのプル:"
-
-#: pkg/kubernetes/views/imagestream-modify.html:66
-msgid "Pull from"
-msgstr "プル対象"
-
-#: pkg/kubernetes/scripts/images.js:635
-msgid "Pull specific tags from another image repository"
-msgstr "別のイメージリポジトリーから特定のタグをプルします"
-
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "目的"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:141
-msgid "Push an image:"
-msgstr "イメージのプッシュ:"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:31
 msgid "QEMU/KVM System connection"
@@ -6357,16 +5098,11 @@ msgstr "QEMU/KVM システム接続"
 msgid "QEMU/KVM User connection"
 msgstr "QEMU/KVM ユーザー接続"
 
-#: pkg/kubernetes/views/pv-modify.html:148
-#: pkg/kubernetes/views/volume-body.html:77
-msgid "Qualified Name"
-msgstr "修飾名"
-
-#: pkg/storaged/mdraid-details.jsx:186
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 0"
 msgstr "RAID 0"
 
@@ -6374,7 +5110,7 @@ msgstr "RAID 0"
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (ストライプ)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 1"
 msgstr "RAID 1"
 
@@ -6382,7 +5118,7 @@ msgstr "RAID 1"
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (ミラー)"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 10"
 msgstr "RAID 10"
 
@@ -6390,7 +5126,7 @@ msgstr "RAID 10"
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (ミラーのストライプ)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 4"
 msgstr "RAID 4"
 
@@ -6398,7 +5134,7 @@ msgstr "RAID 4"
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (専用パリティー)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 5"
 msgstr "RAID 5"
 
@@ -6406,7 +5142,7 @@ msgstr "RAID 5"
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (分散パリティー)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 6"
 msgstr "RAID 6"
 
@@ -6422,7 +5158,7 @@ msgstr "RAID シャーシ"
 msgid "RAID Device"
 msgstr "RAID デバイス"
 
-#: pkg/storaged/mdraid-details.jsx:316 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "RAID デバイス $0"
 
@@ -6438,27 +5174,15 @@ msgstr "RAID レベル"
 msgid "RAID Member"
 msgstr "RAID メンバー"
 
-#: pkg/ovirt/provider.js:179
-msgid "REBOOT action failed"
-msgstr "REBOOT アクションに失敗しました"
-
-#: pkg/ovirt/provider.js:164
-msgid "REBOOT_VM action failed: %s0"
-msgstr "REBOOT_VM の動作が失敗: %s0"
-
 #: pkg/lib/machine-info.js:86
 msgid "Rack Mount Chassis"
 msgstr "ラックマウントシャーシ"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Rados ブロックデバイス"
 
 #: pkg/networkmanager/interfaces.js:3632
 msgid "Random"
 msgstr "ランダム"
 
-#: pkg/networkmanager/firewall.jsx:757
+#: pkg/networkmanager/firewall.jsx:759
 msgid "Range"
 msgstr "範囲"
 
@@ -6470,42 +5194,15 @@ msgstr "範囲の順序は厳密でなければなりません"
 msgid "Raw to a device"
 msgstr "デバイスに対する Raw"
 
-#: pkg/kubernetes/views/pv-modify.html:195
-#: pkg/kubernetes/views/volume-body.html:10
-#: pkg/kubernetes/views/volume-body.html:20
-#: pkg/kubernetes/views/volume-body.html:44
-#: pkg/kubernetes/views/volume-body.html:51
-#: pkg/kubernetes/views/volume-body.html:71
-#: pkg/kubernetes/views/volume-body.html:85
-#: pkg/kubernetes/views/volume-body.html:93
-#: pkg/kubernetes/views/volume-body.html:110
-#: pkg/kubernetes/views/volume-body.html:122
-#: pkg/kubernetes/views/volume-body.html:136
-#: pkg/kubernetes/views/volume-body.html:143
-msgid "Read Only"
-msgstr "読み込み専用"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "単一ノードからの読み書き"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "複数のノードからの読み書き"
-
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr "さらに読む..."
 
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "複数のノードからの読み取り専用"
-
-#: pkg/docker/index.html:363
+#: pkg/docker/index.html:365
 msgid "ReadOnly"
 msgstr "読み取り専用"
 
-#: pkg/docker/index.html:362
+#: pkg/docker/index.html:364
 msgid "ReadWrite"
 msgstr "読み書き"
 
@@ -6521,13 +5218,11 @@ msgstr "読み取り中 ..."
 msgid "Readonly"
 msgstr "読み取り専用"
 
-#: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
-#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/playground/translate.html:19
 msgid "Ready"
 msgstr "準備ができています"
 
-#: pkg/playground/translate.html:24 pkg/playground/translate.html:184
+#: pkg/playground/translate.html:24
 msgctxt "verb"
 msgid "Ready"
 msgstr "準備ができています"
@@ -6540,15 +5235,13 @@ msgstr "実際のホスト名"
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
-msgstr "実際のホスト名には小文字、数字、ダッシュ、およびピリオドのみを使用できます (入力されたサブドメインを含む)。"
+msgstr ""
+"実際のホスト名には小文字、数字、ダッシュ、およびピリオドのみを使用できます "
+"(入力されたサブドメインを含む)。"
 
 #: pkg/systemd/host.js:1021
 msgid "Real host name must be 64 characters or less"
 msgstr "実際のホスト名は 64 文字以下である必要があります"
-
-#: pkg/kubernetes/views/node-body.html:45
-msgid "Reason"
-msgstr "理由"
 
 #: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
 msgid "Reboot"
@@ -6564,16 +5257,11 @@ msgstr "受信:"
 msgid "Recent"
 msgstr "最近開いたファイル"
 
-#: pkg/kubernetes/views/pv-body.html:6 pkg/kubernetes/views/pv-modify.html:56
-msgid "Reclaim Policy"
-msgstr "リクレームポリシー"
-
 #: pkg/storaged/format-dialog.jsx:248
 msgid "Recommended default"
 msgstr "推奨されるデフォルト"
 
-#: pkg/kubernetes/index.html:108 pkg/kubernetes/registry.html:75
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138 pkg/shell/stub.html:180
+#: pkg/shell/index.html:386 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "再接続"
@@ -6585,10 +5273,6 @@ msgstr "復旧"
 #: pkg/storaged/jobs-panel.jsx:65
 msgid "Recovering RAID Device $target"
 msgstr "RAID デバイス $target の復旧"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "リサイクル"
 
 #: pkg/docker/storage.jsx:389
 msgid "Reformat and add disks"
@@ -6610,36 +5294,10 @@ msgstr "接続を拒否しています。ホストキーが一致しません"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "接続を拒否しています。ホストキーが不明です"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:159
-msgid "Register"
-msgstr "登録"
-
-#: pkg/kubernetes/views/volumes-page.html:12
-msgid "Register New Volume"
-msgstr "新規ボリュームの登録"
-
-#: pkg/kubernetes/views/pv-modify.html:4
-msgid "Register Persistent Volume"
-msgstr "永続ボリュームの登録"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:108
-msgid "Register oVirt"
-msgstr "oVirt の登録"
-
-#: pkg/subscriptions/main.js:73
-msgid "Register system"
-msgstr "システムの登録"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:128
-msgid "Registering oVirt to Cockpit"
-msgstr "oVirt を Cockpit に登録中"
-
 #: pkg/packagekit/updates.jsx:777
 msgid "Register…"
 msgstr "登録中…"
 
-#: pkg/ovirt/components/App.jsx:62 pkg/ovirt/components/VdsmView.jsx:100
 #: pkg/systemd/init.js:546
 msgid "Reload"
 msgstr "再読み込み"
@@ -6648,7 +5306,7 @@ msgstr "再読み込み"
 msgid "Reload Propagated From"
 msgstr "伝搬元を再読み込み"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:202
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
 msgid "Remote URL"
 msgstr "リモート URL"
 
@@ -6660,10 +5318,6 @@ msgstr "NFS 経由のリモート"
 msgid "Remote over SSH"
 msgstr "SSH 経由のリモート"
 
-#: pkg/kubernetes/views/imagestream-modify.html:89
-msgid "Remote registry is insecure"
-msgstr "リモートレジストリーは安全ではありません"
-
 #: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
 msgctxt "storage"
 msgid "Removable Drive"
@@ -6673,13 +5327,9 @@ msgstr "リムーバブルドライブ"
 msgid "Removals:"
 msgstr "削除:"
 
-#: pkg/kubernetes/views/group-delete.html:21
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-delete.html:25
-#: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "削除"
 
@@ -6691,37 +5341,13 @@ msgstr "$0 の削除"
 msgid "Remove $0?"
 msgstr "$0 を削除しますか?"
 
-#: pkg/kubernetes/views/group-delete.html:3
-msgid "Remove Group"
-msgstr "グループの削除"
-
-#: pkg/kubernetes/views/user-group-remove.html:3
-msgid "Remove Member"
-msgstr "メンバーの削除"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:3
-msgid "Remove Role"
-msgstr "ロールの削除"
-
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove Tang keyserver"
 msgstr "Tang キーサーバーを削除"
 
-#: pkg/kubernetes/views/user-delete.html:3
-msgid "Remove User"
-msgstr "ユーザーの削除"
-
 #: pkg/storaged/vdo-details.jsx:116
 msgid "Remove device"
 msgstr "リモートデバイス"
-
-#: pkg/kubernetes/views/image-delete.html:3
-msgid "Remove image tag"
-msgstr "イメージタグの削除"
-
-#: pkg/kubernetes/views/user-remove-membership.html:3
-msgid "Remove membership"
-msgstr "メンバーシップの削除"
 
 #: pkg/storaged/crypto-keyslots.jsx:387
 msgid "Remove passphrase"
@@ -6731,11 +5357,11 @@ msgstr "パスフレーズを削除"
 msgid "Remove passphrase in $0?"
 msgstr "$0 のパスフレーズを削除しますか?"
 
-#: pkg/networkmanager/firewall.jsx:629
+#: pkg/networkmanager/firewall.jsx:631
 msgid "Remove service"
 msgstr "サービスの削除"
 
-#: pkg/networkmanager/firewall.jsx:608
+#: pkg/networkmanager/firewall.jsx:610
 msgid "Remove service from zones"
 msgstr "ゾーンからのサービスの削除"
 
@@ -6755,14 +5381,16 @@ msgstr "$target を RAID デバイスから削除"
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "<b>$0</b> を削除すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"<b>$0</b> を削除すると、サーバーへの接続が切断され、管理 UI が利用できなくな"
+"ります。"
 
 #: pkg/storaged/jobs-panel.jsx:74
 msgid "Removing physical volume from $target"
 msgstr "$target  から物理ボリュームを削除"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:187
-#: pkg/storaged/vgroup-details.jsx:235
+#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:234
 msgid "Rename"
 msgstr "名前変更"
 
@@ -6770,7 +5398,7 @@ msgstr "名前変更"
 msgid "Rename Logical Volume"
 msgstr "論理ボリュームの名前変更"
 
-#: pkg/storaged/vgroup-details.jsx:179
+#: pkg/storaged/vgroup-details.jsx:178
 msgid "Rename Volume Group"
 msgstr "ボリュームグループの名前変更"
 
@@ -6807,30 +5435,6 @@ msgstr "毎年繰り返す"
 msgid "Repeat passphrase"
 msgstr "パスフレーズの繰り返し"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
-#: pkg/kubernetes/views/details-page.html:141
-#: pkg/kubernetes/views/replicationcontroller-body.html:9
-#: pkg/kubernetes/views/replicationcontroller-modify.html:8
-msgid "Replicas"
-msgstr "レプリカ"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/replicationcontroller-panel.html:10
-#: pkg/kubernetes/views/topology-page.html:22
-msgid "Replication Controller"
-msgstr "レプリケーションコントローラー"
-
-#: pkg/kubernetes/views/details-page.html:132
-#: pkg/kubernetes/scripts/details.js:224
-msgid "Replication Controllers"
-msgstr "レプリケーションコントローラー"
-
-#: pkg/kubernetes/views/topology-page.html:23
-msgid ""
-"Replication controllers dynamically create instances of pods from templates, "
-"and remove pods when necessary."
-msgstr "レプリケーションコントローラーにより、テンプレートからポッドのインスタンスが動的に作成され、必要に応じてポッドが削除されます。"
-
 #: pkg/systemd/logs.js:512
 msgid "Report"
 msgstr "レポート"
@@ -6847,28 +5451,16 @@ msgstr "レポーターの 'reporter-ureport' が見つかりませんでした�
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr "レポートは成功しませんでした。次を試してください: `reporter-ureport -d"
 
-#: pkg/docker/index.html:688
+#: pkg/docker/index.html:690
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "リポジトリー"
 
-#: pkg/kubernetes/views/volume-body.html:24
-msgid "Repository URL"
-msgstr "リポジトリー URL"
-
-#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
-msgid "Requested"
-msgstr "要求者"
-
-#: pkg/kubernetes/views/pv-claim.html:13
-msgid "Requests"
-msgstr "要求"
-
-#: pkg/users/local.js:1296
+#: pkg/users/local.js:1300
 msgid "Require password change every $0 days"
 msgstr "$0 日ごとのパスワードの変更が必要"
 
-#: pkg/users/local.js:872
+#: pkg/users/local.js:876
 msgid "Require password change on $0"
 msgstr "$0 でパスワードの変更が必要"
 
@@ -6879,10 +5471,6 @@ msgstr "必要とされる"
 #: pkg/systemd/init.js:717
 msgid "Requires"
 msgstr "必要"
-
-#: pkg/kubernetes/views/auth-form.html:54
-msgid "Requires Authentication"
-msgstr "認証が必要"
 
 #: pkg/systemd/init.js:718
 msgid "Requisite"
@@ -6896,7 +5484,7 @@ msgstr "必須の"
 msgid "Reserved memory"
 msgstr "予約済みメモリー"
 
-#: pkg/docker/index.html:301 pkg/users/index.html:333
+#: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:105
 msgid "Reset"
 msgstr "リセット"
@@ -6909,7 +5497,9 @@ msgstr "ストレージプールのリセット"
 msgid ""
 "Resetting the storage pool will erase all containers and release disks in "
 "the pool."
-msgstr "ストレージプールをリセットすると、すべてのコンテナーが削除され、プール内のディスクが解放されます。"
+msgstr ""
+"ストレージプールをリセットすると、すべてのコンテナーが削除され、プール内の"
+"ディスクが解放されます。"
 
 #: pkg/storaged/jobs-panel.jsx:40 pkg/storaged/jobs-panel.jsx:46
 #: pkg/storaged/jobs-panel.jsx:78
@@ -6920,28 +5510,26 @@ msgstr "$target のサイズ変更"
 msgid ""
 "Resizing an encrypted filesystem requires unlocking the disk. Please provide "
 "a current disk passphrase."
-msgstr "暗号化されたファイルシステムのサイズ変更には、ディスクのロック解除が必要です。現在のディスクのパスフレーズを提供してください。"
+msgstr ""
+"暗号化されたファイルシステムのサイズ変更には、ディスクのロック解除が必要で"
+"す。現在のディスクのパスフレーズを提供してください。"
 
-#: pkg/docker/index.html:135 pkg/systemd/index.html:134
+#: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "再起動"
-
-#: pkg/kubernetes/views/container-body.html:20
-msgid "Restart Count"
-msgstr "再起動回数"
 
 #: pkg/packagekit/updates.jsx:498
 msgid "Restart Now"
 msgstr "すぐに再起動"
 
-#: pkg/docker/index.html:537 pkg/kubernetes/views/pod-body.html:10
+#: pkg/docker/index.html:539
 msgid "Restart Policy"
 msgstr "再起動ポリシー"
 
-#: pkg/docker/index.html:171
+#: pkg/docker/index.html:172
 msgid "Restart Policy:"
 msgstr "再起動ポリシー:"
 
@@ -6961,50 +5549,26 @@ msgstr "接続の復元"
 msgid "Resume"
 msgstr "再開"
 
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "保持"
-
-#: pkg/docker/index.html:553
+#: pkg/docker/index.html:555
 msgid "Retries:"
 msgstr "再試行回数:"
-
-#: pkg/subscriptions/subscriptions-view.jsx:210
-msgid "Retrieving subscription status..."
-msgstr "サブスクリプションステータスを再取得中 ..."
 
 #: src/ws/login.html:57
 msgid "Reuse my password for privileged tasks"
 msgstr "特権タスクにパスワードを再使用する"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
-msgstr "特権タスクの実行または他のマシンへの接続のためにパスワードを再使用します"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
+msgstr ""
+"特権タスクの実行または他のマシンへの接続のためにパスワードを再使用します"
 
-#: pkg/kubernetes/views/volume-body.html:26
-msgid "Revision"
-msgstr "リビジョン"
-
-#: pkg/kubernetes/views/user-add-membership.html:28
-#: pkg/kubernetes/views/user-body.html:5
-#: pkg/kubernetes/views/user-panel.html:28
-msgid "Role"
-msgstr "役職"
-
-#: pkg/kubernetes/views/add-member-role-dialog.html:39
-#: pkg/kubernetes/views/project-body.html:21 pkg/users/index.html:94
+#: pkg/users/index.html:94
 msgid "Roles"
 msgstr "ロール"
 
 #: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
 msgid "Round Robin"
 msgstr "ラウンドロビン"
-
-#: pkg/kubernetes/views/route-page.html:14
-#: pkg/kubernetes/views/route-panel.html:9
-msgid "Route"
-msgstr "ルート"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:98
 msgid "Route to $0"
@@ -7014,22 +5578,16 @@ msgstr "$0 へのルーティング"
 msgid "Routed Network"
 msgstr "ルーティングされたネットワーク"
 
-#: pkg/kubernetes/views/details-page.html:65
-#: pkg/kubernetes/scripts/details.js:216 pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3325
 msgid "Routes"
 msgstr "ルート"
 
-#: pkg/docker/index.html:244 pkg/docker/index.html:564
+#: pkg/docker/index.html:253 pkg/docker/index.html:566
 #: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
-#: pkg/ovirt/components/ClusterVms.jsx:92
 msgid "Run"
 msgstr "実行"
 
-#: pkg/ovirt/components/ClusterVms.jsx:97
-msgid "Run Here"
-msgstr "ここから実行"
-
-#: pkg/docker/index.html:425
+#: pkg/docker/index.html:427
 msgid "Run Image"
 msgstr "イメージの実行"
 
@@ -7038,7 +5596,7 @@ msgid "Run as"
 msgstr "次で実行"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:128
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
 msgstr "ホスト起動時に実行します"
 
@@ -7046,17 +5604,13 @@ msgstr "ホスト起動時に実行します"
 msgid "Runner"
 msgstr "ランナー"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Running"
 msgstr "実行中"
 
 #: pkg/systemd/services.html:123
 msgid "Running Since"
 msgstr "実行開始"
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:54
-msgid "Running Since:"
-msgstr "実行開始:"
 
 #: pkg/selinux/setroubleshoot-view.jsx:364
 msgid "SELinux Access Control Errors"
@@ -7082,14 +5636,6 @@ msgstr "SELinux はシステムで無効です"
 msgid "SELinux system status is unknown."
 msgstr "SELinux システムステータスが不明です。"
 
-#: pkg/ovirt/provider.js:440
-msgid "SET VCPU SETTINGS action failed"
-msgstr "SET VCPU SETTINGS アクションに失敗しました"
-
-#: pkg/ovirt/provider.js:111 pkg/ovirt/provider.js:145
-msgid "SHUTDOWN action failed"
-msgstr "SHUTDOWN アクションに失敗しました"
-
 #: pkg/storaged/jobs-panel.jsx:35
 msgid "SMART self-test of $target"
 msgstr "$target の SMART 自己テスト"
@@ -7110,14 +5656,6 @@ msgstr "SPICE ポート:"
 msgid "SPICE TLS Port:"
 msgstr "SPICE TLS ポート:"
 
-#: pkg/ovirt/provider.js:225
-msgid "START action failed"
-msgstr "START アクションに失敗しました"
-
-#: pkg/ovirt/provider.js:203
-msgid "START_VM action failed: %s0"
-msgstr "START_VM の動作が失敗: %s0"
-
 #: pkg/networkmanager/index.html:228
 msgid "STP Forward delay"
 msgstr "STP フォワード遅延"
@@ -7134,10 +5672,6 @@ msgstr "STP メッセージ最大期間"
 msgid "STP Priority"
 msgstr "STP 優先度"
 
-#: pkg/ovirt/provider.js:303
-msgid "SUSPEND action failed"
-msgstr "SUSPEND アクションに失敗しました"
-
 #: pkg/systemd/services.html:240
 msgid "Saturday"
 msgstr "土曜日"
@@ -7146,10 +5680,10 @@ msgstr "土曜日"
 msgid "Saturdays"
 msgstr "毎週土曜日"
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/ovirt/components/VdsmView.jsx:114 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
 #: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "保存"
@@ -7170,15 +5704,9 @@ msgstr "同一のデータブロックを 1 回だけ保存することで、空
 msgid ""
 "Saving a new passphrase requires unlocking the disk. Please provide a "
 "current disk passphrase."
-msgstr "新しいパスフレーズの保存には、ディスクのロック解除が必要です。現在のディスクのパスフレーズを提供してください。"
-
-#: pkg/kubernetes/views/node-capacity.html:9
-msgid "Scheduled Pods"
-msgstr "スケジュール済みポッド"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "スケジューリングの無効化"
+msgstr ""
+"新しいパスフレーズの保存には、ディスクのロック解除が必要です。現在のディスク"
+"のパスフレーズを提供してください。"
 
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
@@ -7188,24 +5716,6 @@ msgstr "シールドケース PC"
 #: pkg/systemd/init.js:1076
 msgid "Seconds"
 msgstr "秒"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "シークレット"
-
-#: pkg/kubernetes/views/volume-body.html:106
-msgid "Secret File"
-msgstr "シークレットファイル"
-
-#: pkg/kubernetes/views/volume-body.html:141
-msgid "Secret Name"
-msgstr "シークレット名"
-
-#: pkg/kubernetes/views/volume-body.html:69
-#: pkg/kubernetes/views/volume-body.html:108
-#: pkg/kubernetes/views/volume-body.html:134
-msgid "Secret Volume"
-msgstr "シークレットボリューム"
 
 #: pkg/systemd/index.html:106
 msgid "Secure Shell Keys"
@@ -7223,40 +5733,21 @@ msgstr "Security"
 msgid "Security Updates Available"
 msgstr "セキュリティーの更新を利用できます"
 
-#: pkg/shell/index.html:123 pkg/shell/simple.html:91 pkg/shell/stub.html:106
+#: pkg/shell/index.html:123 pkg/shell/simple.html:91
 msgid "Select"
 msgstr "選択"
 
-#: pkg/kubernetes/views/file-button.html:4
-msgid "Select Manifest File..."
-msgstr "マニフェストファイルの選択 ..."
-
-#: pkg/kubernetes/scripts/projects.js:899
-#: pkg/kubernetes/scripts/projects.js:1205
-#: pkg/kubernetes/scripts/projects.js:1335
-msgid "Select Member"
-msgstr "メンバーの選択"
-
-#: pkg/kubernetes/scripts/projects.js:901
-#: pkg/kubernetes/scripts/projects.js:1208
-msgid "Select Role"
-msgstr "ロールの選択"
-
-#: pkg/kubernetes/views/topology-page.html:7
-msgid "Select an object to see more details."
-msgstr "オブジェクトを選択して詳細を参照します。"
-
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr "{{#strong}}{{host}}{{/strong}} と同期するユーザーを選択します"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
 msgstr "マスク不可割り込みを送信します"
 
-#: pkg/machines/components/vnc.jsx:109
+#: pkg/machines/components/vnc.jsx:108
 msgid "Send key"
 msgstr "キーの送信"
 
@@ -7270,11 +5761,8 @@ msgstr "送信:"
 msgid "Serial Console"
 msgstr "シリアルコンソール"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:116 pkg/storaged/nfs-details.jsx:315
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:65
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "サーバー"
 
@@ -7282,7 +5770,7 @@ msgstr "サーバー"
 msgid "Server Address"
 msgstr "サーバーアドレス"
 
-#: pkg/users/local.js:746 pkg/users/local.js:747
+#: pkg/users/local.js:750 pkg/users/local.js:751
 msgid "Server Administrator"
 msgstr "サーバー管理者"
 
@@ -7306,16 +5794,10 @@ msgstr "サーバーの接続が終了しました。"
 msgid "Servers"
 msgstr "サーバー"
 
-#: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/service-panel.html:8
-#: pkg/kubernetes/views/topology-page.html:30 pkg/systemd/logs.html:66
-#: pkg/networkmanager/firewall.jsx:936 pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "サービス"
-
-#: pkg/kubernetes/views/pod-body.html:12
-msgid "Service Account"
-msgstr "サービスアカウント"
 
 #: pkg/systemd/services.html:337
 msgid "Service Logs"
@@ -7345,26 +5827,14 @@ msgstr "サービスが停止中です"
 msgid "Service name"
 msgstr "サービス名"
 
-#: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
-#: pkg/systemd/services.html:330 pkg/kubernetes/scripts/details.js:213
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
 #: pkg/networkmanager/firewall.jsx:483
 msgid "Services"
 msgstr "サービス"
 
-#: pkg/kubernetes/views/topology-page.html:31
-msgid ""
-"Services group pods and provide a common DNS name and an optional, load-"
-"balanced IP address to access them."
-msgstr "サービスはポッドをグループ化し、ポッドにアクセスするために共通の DNS 名とオプションのロードバランス IP アドレスを提供します。"
-
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "セッション"
-
-#: pkg/kubernetes/views/service-body.html:20
-msgid "Session Affinity"
-msgstr "セッションアフィニティー"
 
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
@@ -7382,7 +5852,7 @@ msgstr "パスワードの設定"
 msgid "Set Time"
 msgstr "時間の設定"
 
-#: pkg/docker/index.html:530
+#: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "コンテナー環境変数の設定"
 
@@ -7415,28 +5885,15 @@ msgstr "重大度"
 msgid "Severity:"
 msgstr "重要度:"
 
-#: pkg/kubernetes/views/volume-body.html:139
-msgid "Share Name"
-msgstr "共有名"
-
 #: pkg/networkmanager/interfaces.js:1959
 msgid "Shared"
 msgstr "共有"
-
-#: pkg/kubernetes/scripts/projects.js:1043
-msgid "Shared: Allow any authenticated user to pull images"
-msgstr "共有済み: 認証されたユーザーはイメージをプルできます"
-
-#: pkg/kubernetes/views/container-page-inline.html:14
-#: pkg/kubernetes/views/container-panel.html:9
-msgid "Shell"
-msgstr "シェル"
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr "Shift+Insert"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Show Performance Options"
 msgstr "パフォーマンスオプションを表示します"
 
@@ -7444,61 +5901,15 @@ msgstr "パフォーマンスオプションを表示します"
 msgid "Show all"
 msgstr "すべて表示"
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:122
 msgid "Show all $0 drives"
 msgstr "$0 ドライブをすべて表示"
-
-#: pkg/kubernetes/views/container-page.html:4
-msgid "Show all Containers"
-msgstr "すべてのコンテナーの表示"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:8
-msgid "Show all Deployment Configs"
-msgstr "すべてのデプロイメント設定の表示"
-
-#: pkg/kubernetes/views/node-page.html:8
-msgid "Show all Nodes"
-msgstr "すべてのノードの表示"
-
-#: pkg/kubernetes/views/pv-page.html:9
-msgid "Show all Persistent Volumes"
-msgstr "すべての永続ボリュームの表示"
-
-#: pkg/kubernetes/views/pod-container.html:4
-msgid "Show all Pod Containers"
-msgstr "すべてのポッドコンテナーの表示"
-
-#: pkg/kubernetes/views/pod-page.html:8
-msgid "Show all Pods"
-msgstr "すべてのポッドの表示"
-
-#: pkg/kubernetes/views/group-page.html:14
-#: pkg/kubernetes/views/project-page.html:23
-#: pkg/kubernetes/views/user-page.html:16
-msgid "Show all Projects"
-msgstr "すべてのプロジェクトの表示"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:10
-msgid "Show all Replication Controllers"
-msgstr "すべてのレプリケーションコントローラーの表示"
-
-#: pkg/kubernetes/views/route-page.html:10
-msgid "Show all Routes"
-msgstr "すべてのルートの表示"
-
-#: pkg/kubernetes/views/service-page.html:8
-msgid "Show all Services"
-msgstr "すべてのサービスの表示"
 
 #: pkg/docker/index.html:128
 msgid "Show all containers"
 msgstr "すべてのコンテナーの表示"
 
-#: pkg/kubernetes/views/imagestream-page.html:12
-msgid "Show all image streams"
-msgstr "すべてのイメージストリームの表示"
-
-#: pkg/docker/index.html:254 pkg/kubernetes/views/image-page.html:10
+#: pkg/docker/index.html:249
 msgid "Show all images"
 msgstr "すべてのイメージの表示"
 
@@ -7523,21 +5934,16 @@ msgstr "ボリュームの縮小"
 msgid "Shut Down"
 msgstr "シャットダウン"
 
-#: pkg/kubernetes/views/container-body.html:18
-msgid "Since"
-msgstr "以降"
-
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:376
-#: pkg/machines/components/diskAdd.jsx:143
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Size"
 
@@ -7561,11 +5967,6 @@ msgstr "サイズは数値である必要があります"
 msgid "Size must be at least $0"
 msgstr "サイズは $0 以上にする必要があります"
 
-#: pkg/kubernetes/views/auth-form.html:43
-#: pkg/kubernetes/views/auth-rejected-cert.html:11
-msgid "Skip Certificate Verification"
-msgstr "証明書検証の省略"
-
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Slot"
 msgstr "スロット"
@@ -7575,7 +5976,6 @@ msgid "Slot $0"
 msgstr "スロット $0"
 
 #: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Sockets"
 msgstr "ソケット"
 
@@ -7589,8 +5989,9 @@ msgid ""
 "mitigations have the side effect of reducing performance. Change these "
 "settings at your own risk."
 msgstr ""
-"ソフトウェアベースの回避策により、CPU "
-"セキュリティー問題を回避します。これらの緩和策にはパフォーマンスの低下という副次的な影響があります。リスクをご理解の上、これらの設定を変更してください。"
+"ソフトウェアベースの回避策により、CPU セキュリティー問題を回避します。これら"
+"の緩和策にはパフォーマンスの低下という副次的な影響があります。リスクをご理解"
+"の上、これらの設定を変更してください。"
 
 #: pkg/docker/storage.jsx:165
 msgid "Solid-State Disk"
@@ -7616,20 +6017,17 @@ msgstr "ソリューション"
 #: pkg/packagekit/updates.jsx:40
 msgid ""
 "Some other program is currently using the package manager, please wait..."
-msgstr "別のプログラムがパッケージマネージャーを使用中です。しばらくお待ちください..."
+msgstr ""
+"別のプログラムがパッケージマネージャーを使用中です。しばらくお待ちください..."
 
-#: pkg/kubernetes/scripts/volumes.js:914
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "申し訳ありませんが、このボリュームを変更する方法がわかりません"
-
-#: pkg/networkmanager/firewall.jsx:707
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Sorted from least trusted to most trusted"
 msgstr "信頼性が最も低い順から最も高い順による並べ替え"
 
-#: pkg/machines/components/diskAdd.jsx:476
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:103
+#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "ソース"
 
@@ -7637,10 +6035,10 @@ msgstr "ソース"
 msgid "Source Format"
 msgstr "ソースフォーマット"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:217
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:244
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "ソースパス"
 
@@ -7648,12 +6046,12 @@ msgstr "ソースパス"
 msgid "Source URL"
 msgstr "ソース URL"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:254
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
 msgid "Source path should not be empty"
 msgstr "ソースパスは空欄にできません"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:108
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "ソースは、http、ftp、または nfs プロトコルで開始する必要があります"
 
@@ -7681,9 +6079,9 @@ msgstr "特定の時間"
 msgid "Stable"
 msgstr "安定"
 
-#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:320 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "開始日"
 
@@ -7703,7 +6101,7 @@ msgstr "サービスの開始"
 msgid "Start libvirt"
 msgstr "libvirt の開始"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:291
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
 msgid "Start pool when host boots"
 msgstr "ホスト起動時にプールを開始します"
 
@@ -7715,59 +6113,29 @@ msgstr "RAID デバイス $target の起動"
 msgid "Starting swapspace $target"
 msgstr "スワップ領域 $target の起動"
 
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Starts"
-msgstr "開始"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
 msgid "Startup"
 msgstr "起動"
 
-#: pkg/kubernetes/views/container-body.html:16
-#: pkg/kubernetes/views/details-page.html:38
-#: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:127 pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/init.js:285
 msgid "State"
 msgstr "状態"
 
-#: pkg/docker/index.html:167
+#: pkg/docker/index.html:168
 msgid "State:"
 msgstr "状態:"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "Stateless"
-msgstr "ステートレス"
-
-#: pkg/ovirt/components/OVirtTab.jsx:156
-msgid "Stateless:"
-msgstr "ステートレス:"
 
 #: pkg/systemd/services.html:74 pkg/systemd/init.js:207
 msgid "Static"
 msgstr "静的"
 
-#: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/volumes-page.html:21 pkg/systemd/services.html:121
-#: pkg/networkmanager/interfaces.js:2613
-#: pkg/subscriptions/subscriptions-view.jsx:37
+#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
 msgid "Status"
 msgstr "状態"
-
-#: pkg/subscriptions/subscriptions-view.jsx:162
-msgid "Status: $0"
-msgstr "ステータス: $0"
-
-#: pkg/subscriptions/subscriptions-view.jsx:157
-msgid "Status: System isn't registered"
-msgstr "ステータス: システムが登録されていません"
 
 #: pkg/lib/machine-info.js:99
 msgid "Stick PC"
@@ -7777,14 +6145,14 @@ msgstr "スティッキー PC"
 msgid "Sticky"
 msgstr "スティッキー"
 
-#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "停止"
 
-#: pkg/storaged/mdraid-details.jsx:248
+#: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "デバイスの停止"
 
@@ -7816,8 +6184,8 @@ msgstr "RAID デバイス $target の停止"
 msgid "Stopping swapspace $target"
 msgstr "スワップ領域 $target の停止"
 
-#: pkg/docker/index.html:288 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
+#: pkg/docker/index.html:290 pkg/storaged/index.html:23
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
 #: pkg/storaged/details.jsx:127
 msgid "Storage"
 msgstr "ストレージ"
@@ -7826,11 +6194,11 @@ msgstr "ストレージ"
 msgid "Storage Logs"
 msgstr "ストレージログ"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:137
+#: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr "ストレージプール $0 は、アクティベートに失敗しました"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:149
+#: pkg/machines/components/storagePools/storagePool.jsx:153
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr "ストレージプール $0 は、停止に失敗しました"
 
@@ -7838,7 +6206,7 @@ msgstr "ストレージプール $0 は、停止に失敗しました"
 msgid "Storage Pool Name"
 msgstr "ストレージプール名"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:437
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
 msgid "Storage Pool failed to be created"
 msgstr "ストレージプールの作成に失敗しました"
 
@@ -7859,7 +6227,7 @@ msgstr "ストレージボリュームは削除できませんでした"
 msgid "Storage can not be managed on this system."
 msgstr "ストレージは、このシステムで管理できません。"
 
-#: pkg/docker/index.html:302
+#: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "ストレージプール"
 
@@ -7879,10 +6247,6 @@ msgstr "保存されたパスフレーズ"
 msgid "Stored passphrase"
 msgstr "保存されたパスフレーズ"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:12
-msgid "Strategy"
-msgstr "ストラテジー"
-
 #: pkg/lib/machine-info.js:82
 msgid "Sub Chassis"
 msgstr "サブシャーシ"
@@ -7890,10 +6254,6 @@ msgstr "サブシャーシ"
 #: pkg/lib/machine-info.js:77
 msgid "Sub Notebook"
 msgstr "サブノートブック"
-
-#: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:177
-msgid "Subscriptions"
-msgstr "サブスクリプション"
 
 #: node_modules/registry-image-widgets/views/image-body.html:4
 msgid "Summary"
@@ -7911,10 +6271,6 @@ msgstr "毎週日曜日"
 msgid "Support is installed."
 msgstr "サポートはインストールされました。"
 
-#: pkg/ovirt/components/VmActions.jsx:40
-msgid "Suspend"
-msgstr "一時停止"
-
 #: pkg/storaged/content-views.jsx:157
 msgid "Swap"
 msgstr "スワップ"
@@ -7928,10 +6284,6 @@ msgstr "スワップ領域"
 msgid "Swap Used"
 msgstr "使用済みスワップ"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:40
-msgid "Switch Host to Maintenance"
-msgstr "ホストをメンテナンスに切り替え"
-
 #: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
 msgid "Switch off $0"
 msgstr "$0 をオフにする"
@@ -7940,35 +6292,29 @@ msgstr "$0 をオフにする"
 msgid "Switch on $0"
 msgstr "$0 をオンにする"
 
-#: pkg/ovirt/provider.js:414
-msgid "Switching host to maintenance mode failed. Received error: "
-msgstr "ホストをメンテナンスモードに切り替えることができませんでした。受け取ったエラー: "
-
-#: pkg/ovirt/provider.js:408
-msgid "Switching host to maintenance mode in progress ..."
-msgstr "ホストをメンテナンスモードに切り替え中..."
-
 #: pkg/networkmanager/interfaces.js:2491
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
-msgstr "<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
+msgstr ""
+"<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなく"
+"なります。"
 
 #: pkg/networkmanager/interfaces.js:3038
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
-msgstr "<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなくなります。1"
+msgstr ""
+"<b>$0</b> をオフにすると、サーバーへの接続が切断され、管理 UI が利用できなく"
+"なります。1"
 
 #: pkg/networkmanager/interfaces.js:2466 pkg/networkmanager/interfaces.js:3026
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
-msgstr "<b>$0</b> をオンにすると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
-
-#: pkg/kubernetes/scripts/images.js:634
-msgid "Sync all tags from a remote image repository"
-msgstr "リモートイメージリポジトリーからすべてのタグを同期"
+msgstr ""
+"<b>$0</b> をオンにすると、サーバーへの接続が切断され、管理 UI が利用できなく"
+"なります。"
 
 #: pkg/lib/machine-sync-users.html:75
 msgid "Synchronize"
@@ -8019,25 +6365,20 @@ msgstr "システムは最新の状態です"
 msgid "System is up to date"
 msgstr "システムは最新の状態です"
 
-#: pkg/docker/index.html:327 pkg/docker/index.html:331
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:329 pkg/docker/index.html:333
+#: pkg/networkmanager/firewall.jsx:938
 msgid "TCP"
 msgstr "TCP"
-
-#: pkg/kubernetes/views/route-body.html:12
-msgid "TLS Termination"
-msgstr "TLS 終了"
 
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
 msgstr "タブレット"
 
-#: pkg/docker/index.html:694
+#: pkg/docker/index.html:696
 #: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "タグ"
 
-#: pkg/kubernetes/views/imagestream-modify.html:76
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
@@ -8049,25 +6390,16 @@ msgstr "タグ"
 msgid "Tang keyserver"
 msgstr "Tang キーサーバー"
 
-#: pkg/kubernetes/views/pv-modify.html:137
 #: pkg/machines/components/vm/bootOrderModal.jsx:133
 msgid "Target"
 msgstr "ターゲット"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "ターゲットパス"
 
-#: pkg/kubernetes/views/volume-body.html:75
-msgid "Target Portal"
-msgstr "ターゲットポータル"
-
-#: pkg/kubernetes/views/volume-body.html:114
-msgid "Target World Wide Names"
-msgstr "ターゲットワールドワイド名"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:133
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
 msgid "Target path should not be empty"
 msgstr "ターゲットパスは空欄にできません"
 
@@ -8091,22 +6423,6 @@ msgstr "チームポート設定"
 #: pkg/networkmanager/index.html:514
 msgid "Team Settings"
 msgstr "チーム設定"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:15
-#: pkg/kubernetes/views/deploymentconfig-panel.html:10
-#: pkg/kubernetes/views/replicationcontroller-page.html:20
-#: pkg/kubernetes/views/replicationcontroller-panel.html:14
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "Template"
-msgstr "テンプレート"
-
-#: pkg/ovirt/components/App.jsx:111
-msgid "Templates"
-msgstr "テンプレート"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:130
-msgid "Templates of $0 cluster"
-msgstr "$0 クラスターのテンプレート"
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
@@ -8140,13 +6456,14 @@ msgstr "Docker ストレージプールはこのシステムで管理できま�
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "IP アドレスまたはホスト名にはスペースを含めることができません。"
 
-#: pkg/storaged/mdraid-details.jsx:219
+#: pkg/storaged/mdraid-details.jsx:218
 msgid "The RAID Array is in a degraded state"
 msgstr "RAID アレイは劣化状態にあります"
 
-#: pkg/storaged/mdraid-details.jsx:149
+#: pkg/storaged/mdraid-details.jsx:148
 msgid "The RAID device must be running in order to add spare disks."
-msgstr "スペアディスクを追加する場合は、RAID デバイスが実行中である必要があります。"
+msgstr ""
+"スペアディスクを追加する場合は、RAID デバイスが実行中である必要があります。"
 
 #: pkg/storaged/mdraid-details.jsx:115
 msgid "The RAID device must be running in order to remove disks."
@@ -8175,7 +6492,9 @@ msgstr "仮想マシンがアイドル状態です。"
 
 #: pkg/machines/components/vm/stateIcon.jsx:43
 msgid "The VM is in process of dying (shut down or crash is not completed)."
-msgstr "仮想マシンが終了中の状態です (シャットダウンまたはクラッシュが完了していません)。"
+msgstr ""
+"仮想マシンが終了中の状態です (シャットダウンまたはクラッシュが完了していませ"
+"ん)。"
 
 #: pkg/machines/components/vm/stateIcon.jsx:37
 msgid "The VM is paused."
@@ -8193,19 +6512,17 @@ msgstr "仮想マシンが実行中です。"
 msgid "The VM is suspended by guest power management."
 msgstr "仮想マシンはゲストの電源管理によって一時停止されています。"
 
-#: pkg/users/local.js:1338
+#: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
 msgstr "アカウント '$0' が次回ログインする際に、パスワードの変更が求められます"
 
-#: pkg/kubernetes/scripts/nodes.js:403
-msgid "The address contains invalid characters"
-msgstr "アドレスに無効な文字が含まれています。"
-
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
-msgstr "ホスト {{#strong}}{{host}}{{/strong}} の認証を確立できません。本当に接続を維持しますか?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+"ホスト {{#strong}}{{host}}{{/strong}} の認証を確立できません。本当に接続を維"
+"持しますか?"
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
@@ -8215,29 +6532,18 @@ msgstr "収集された情報はシステムにローカルで保存されます
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr "設定された状態が不明です。状態は次回の起動時に変わることがあります。"
 
-#: pkg/kubernetes/views/container-page-inline.html:22
-msgid "The container '{{ target }}' does not exist."
-msgstr "コンテナー '{{ target }}' が存在しません。"
-
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
 msgstr "この VDO デバイスの作成は終了していないため、使用できません。"
 
-#: pkg/subscriptions/subscriptions-view.jsx:214
-msgid "The current user isn't allowed to access system subscription status."
-msgstr "現在のユーザーにはシステムサブスクリプションステータスへのアクセスが許可されていません。"
-
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
-msgstr "現在ログイン中のユーザーは、キーに関する情報を見ることを許可されていません。"
+msgstr ""
+"現在ログイン中のユーザーは、キーに関する情報を見ることを許可されていません。"
 
-#: pkg/kubernetes/views/deploymentconfig-page.html:25
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "デプロイメント設定 '{{ target }}' が存在しません。"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:204
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
 msgid "The directory on the server being exported"
 msgstr "サーバー上のディレクトリーをエクスポート中"
 
@@ -8245,21 +6551,25 @@ msgstr "サーバー上のディレクトリーをエクスポート中"
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
-msgstr "このファイルシステムは、ログインセッションおよびシステムサービスで使用中です。続行すると、これらを停止します。"
+msgstr ""
+"このファイルシステムは、ログインセッションおよびシステムサービスで使用中で"
+"す。続行すると、これらを停止します。"
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
-msgstr "このファイルシステムは、ログインセッションで使用中です。続行すると、これらを停止します。"
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
+msgstr ""
+"このファイルシステムは、ログインセッションで使用中です。続行すると、これらを"
+"停止します。"
 
 #: pkg/storaged/dialog.jsx:1016
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
-msgstr "このファイルシステムは、システムサービスで使用中です。続行すると、これらを停止します。"
+msgstr ""
+"このファイルシステムは、システムサービスで使用中です。続行すると、これらを停"
+"止します。"
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr "以下のコンテナーはこのイメージに依存しており、使用できなくなります。"
 
 #: pkg/sosreport/index.html:51
@@ -8267,11 +6577,9 @@ msgid ""
 "The generated archive contains data considered sensitive and its content "
 "should be reviewed by the originating organization before being passed to "
 "any third party."
-msgstr "生成されたアーカイブには、機密データと見なされるデータが含まれます。その内容はサードパーティーに渡す前に元の組織が確認する必要があります。"
-
-#: pkg/kubernetes/views/group-page.html:47
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "グループ '{{ groupName }}' は存在しません。"
+msgstr ""
+"生成されたアーカイブには、機密データと見なされるデータが含まれます。その内容"
+"はサードパーティーに渡す前に元の組織が確認する必要があります。"
 
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
@@ -8279,8 +6587,9 @@ msgid ""
 "in use. Unless this machine was recently replaced, it is likely that someone "
 "is trying to attack your connection to this machine."
 msgstr ""
-"{{#strong}}{{host}}{{/strong}} "
-"の鍵が、以前に使用された鍵と一致しません。このマシンが最近置き換えられたものでない限り、誰かがこのマシンへの接続を攻撃しようとしている可能性があります。"
+"{{#strong}}{{host}}{{/strong}} の鍵が、以前に使用された鍵と一致しません。この"
+"マシンが最近置き換えられたものでない限り、誰かがこのマシンへの接続を攻撃しよ"
+"うとしている可能性があります。"
 
 #: pkg/users/authorized-keys.js:124
 msgid "The key you provided was not valid."
@@ -8298,31 +6607,16 @@ msgstr "最後のキースロットは削除できません。"
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "ボリュームグループの最後の物理ボリュームは削除できません。"
 
-#: pkg/shell/indexes.js:408
+#: pkg/shell/indexes.js:407
 msgid "The machine is restarting"
 msgstr "マシンが再起動中です"
 
-#: pkg/kubernetes/scripts/details.js:498 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "レプリカの最大数は 128 です"
+#: pkg/machines/components/networks/networkDelete.jsx:76
+#, fuzzy
+msgid "The network could not be deleted"
+msgstr "ストレージプールを削除できませんでした"
 
-#: pkg/kubernetes/scripts/nodes.js:411
-msgid "The name contains invalid characters"
-msgstr "名前に無効な文字が含まれています"
-
-#: pkg/kubernetes/views/node-page.html:23
-msgid "The node '{{ target }}' does not exist."
-msgstr "ノード '{{ target }}' が存在しません。"
-
-#: pkg/kubernetes/views/node-alerts.html:7
-msgid "The node doesn't have enough disk space"
-msgstr "ノードに十分なディスク領域がありません"
-
-#: pkg/kubernetes/views/node-alerts.html:11
-msgid "The node doesn't have enough free memory"
-msgstr "ノードに十分な空きメモリーがありません"
-
-#: pkg/users/local.js:439 pkg/users/local.js:1395
+#: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
 msgstr "パスワードが一致しません"
 
@@ -8330,29 +6624,9 @@ msgstr "パスワードが一致しません"
 msgid "The passwords do not match."
 msgstr "パスワードが一致しません。"
 
-#: pkg/kubernetes/views/pv-page.html:21
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "永続ボリューム '{{ target }}' が存在しません。"
-
-#: pkg/kubernetes/views/pod-page.html:40
-msgid "The pod '{{ target }}' does not exist."
-msgstr "ポッド '{{ target }}' が存在しません。"
-
 #: pkg/machines/components/diskAdd.jsx:80
 msgid "The pool is empty"
 msgstr "プールが空です"
-
-#: pkg/kubernetes/views/project-page.html:34
-msgid "The project '{{ projName }}' does not exist."
-msgstr "プロジェクト '{{ projName }}' が存在しません。"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:30
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "レプリケーションコントローラー '{{ target }}' が存在しません。"
-
-#: pkg/kubernetes/views/route-page.html:19
-msgid "The route '{{ target }}' does not exist."
-msgstr "ルート '{{ target }}' が存在しません。"
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
@@ -8362,35 +6636,21 @@ msgstr "$time ($type) のスキャンでは、脆弱性は見つかりません�
 msgid "The scan from $time ($type) was not successful."
 msgstr "$time ($type) のスキャンは成功しませんでした。"
 
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "選択されたファイルは有効な Kubernetes アプリケーションマニフェストではありません。"
-
 #: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
 "no other supported authentication methods are available."
-msgstr "サーバーはパスワード認証を使用した '$0' の認証を拒否しました。サポートされた他の認証方法は利用できません。"
+msgstr ""
+"サーバーはパスワード認証を使用した '$0' の認証を拒否しました。サポートされた"
+"他の認証方法は利用できません。"
 
 #: src/base1/cockpit.js:4017
 msgid "The server refused to authenticate using any supported methods."
 msgstr "サーバーはサポートされた方法を使用した認証を拒否しました。"
 
-#: pkg/kubernetes/views/auth-rejected-cert.html:2
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr "サーバーは不明な認証局によって署名された証明書を使用します。"
-
-#: pkg/kubernetes/views/service-page.html:19
-msgid "The service '{{ target }}' does not exist."
-msgstr "サービス '{{ target }}' は存在しません。"
-
 #: pkg/systemd/hwinfo.jsx:65
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr "ユーザー $0 は、cpu セキュリティー緩和の変更を許可されていません"
-
-#: pkg/kubernetes/views/user-page.html:29
-msgid "The user '{{ userName }}' does not exist."
-msgstr "ユーザー '{{ userName }}' は存在しません。"
 
 #: pkg/systemd/init.js:922
 msgid "The user <b>$0</b> does not have permissions for creating timers"
@@ -8406,7 +6666,8 @@ msgstr "ユーザー <b>$0</b> は、システムの時間の変更を許可さ�
 
 #: pkg/systemd/init.js:614
 msgid "The user <b>$0</b> is not permitted to enable or disable services"
-msgstr "ユーザー <b>$0</b> は、サービスを有効または無効にすることを許可されていません"
+msgstr ""
+"ユーザー <b>$0</b> は、サービスを有効または無効にすることを許可されていません"
 
 #: pkg/dashboard/list.js:223
 msgid "The user <b>$0</b> is not permitted to manage servers"
@@ -8426,31 +6687,37 @@ msgstr "ユーザー <b>$0</b> はホスト名を変更することを許可さ�
 
 #: pkg/networkmanager/interfaces.js:1516
 msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr "ユーザー <b>$0</b> はネットワーク設定を変更することを許可されていません"
+msgstr ""
+"ユーザー <b>$0</b> はネットワーク設定を変更することを許可されていません"
 
-#: pkg/realmd/operation.js:643
+#: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "ユーザー <b>$0</b> はレルムを変更することを許可されていません"
 
 #: pkg/systemd/host.js:62
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
-msgstr "ユーザー <b>$0</b> は、このサーバーをシャットダウンまたは再起動することを許可されていません"
+msgstr ""
+"ユーザー <b>$0</b> は、このサーバーをシャットダウンまたは再起動することを許可"
+"されていません"
 
 #: pkg/systemd/init.js:606 pkg/systemd/init.js:610
 msgid "The user <b>$0</b> is not permitted to start or stop services"
-msgstr "ユーザー <b>$0</b> は、サービスを開始または停止することを許可されていません"
+msgstr ""
+"ユーザー <b>$0</b> は、サービスを開始または停止することを許可されていません"
 
-#: pkg/users/local.js:549
+#: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
-msgstr "ユーザー名は a〜z の文字、数字、ドット、ダッシュ、およびアンダースコアだけで構成されます。"
+msgstr ""
+"ユーザー名は a〜z の文字、数字、ドット、ダッシュ、およびアンダースコアだけで"
+"構成されます。"
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
-msgstr "Web ブラウザーの設定により、Cockpit の実行は防がれます (アクセスできない $0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
+msgstr ""
+"Web ブラウザーの設定により、Cockpit の実行は防がれます (アクセスできない $0)"
 
 #: pkg/shell/active-pages-dialog.jsx:58
 msgid "There are currently no active pages"
@@ -8460,7 +6727,9 @@ msgstr "現在アクティブなページはありません"
 msgid ""
 "There are devices with multiple paths on the system, but the multipath "
 "service is not running."
-msgstr "システムに複数のパスを持つデバイスがありますが、マルチパスサービスが実行されていません。"
+msgstr ""
+"システムに複数のパスを持つデバイスがありますが、マルチパスサービスが実行され"
+"ていません。"
 
 #: pkg/users/index.html:387
 msgid "There are no authorized public keys for this account."
@@ -8470,7 +6739,9 @@ msgstr "このアカウントに承認された公開鍵がありません。"
 msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
-msgstr "この物理ボリュームを削除するのに十分な空き領域がありません。少なくとも $0 の空き領域が必要です。"
+msgstr ""
+"この物理ボリュームを削除するのに十分な空き領域がありません。少なくとも $0 の"
+"空き領域が必要です。"
 
 #: pkg/storaged/utils.js:193
 msgid "Thin Logical Volume"
@@ -8484,16 +6755,13 @@ msgstr "この NFS マウントは使用中で、そのオプションだけを�
 msgid "This VDO device does not use all of its backing device."
 msgstr "この VDO デバイスは、そのバッキングデバイスをすべて使用していません。"
 
-#: pkg/kubernetes/views/pvc-delete.html:8
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr "このクレームは使用中です。クレームを削除すると、次のポッドで問題が発生することがあります。"
-
 #: pkg/systemd/init.js:1371
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
-msgstr "この日はすべての月で存在しません。<br> タイマーは 31 日がある月でのみ実行されます。"
+msgstr ""
+"この日はすべての月で存在しません。<br> タイマーは 31 日がある月でのみ実行され"
+"ます。"
 
 #: pkg/networkmanager/interfaces.js:2624
 msgid "This device cannot be managed here."
@@ -8503,7 +6771,9 @@ msgstr "このデバイスはここで管理できません。"
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
-msgstr "このデバイスには、現在使用中のファイルシステムがあります。続行すると、このデバイスのファイルシステムをすべてアンマウントします。"
+msgstr ""
+"このデバイスには、現在使用中のファイルシステムがあります。続行すると、このデ"
+"バイスのファイルシステムをすべてアンマウントします。"
 
 #: pkg/storaged/dialog.jsx:976
 msgid "This device is currently used for RAID devices."
@@ -8513,7 +6783,9 @@ msgstr "このデバイスは、現在 RAID デバイスに使用されていま
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
-msgstr "このデバイスは、現在 RAID デバイスに使用されています。続行すると、RAID デバイスからこのデバイスが削除されます。"
+msgstr ""
+"このデバイスは、現在 RAID デバイスに使用されています。続行すると、RAID デバイ"
+"スからこのデバイスが削除されます。"
 
 #: pkg/storaged/dialog.jsx:980
 msgid "This device is currently used for VDO devices."
@@ -8527,7 +6799,9 @@ msgstr "このデバイスは、現在ボリュームグループに使用され
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
-msgstr "このデバイスは現在ボリュームグループに使用されています。続行すると、そのボリュームグループからこのデバイスが削除されます。"
+msgstr ""
+"このデバイスは現在ボリュームグループに使用されています。続行すると、そのボ"
+"リュームグループからこのデバイスが削除されます。"
 
 #: pkg/storaged/mdraid-details.jsx:117
 msgid "This disk cannot be removed while the device is recovering."
@@ -8536,12 +6810,6 @@ msgstr "このディスクは、デバイスが復旧中に取り外すことが
 #: pkg/systemd/init.js:1283 pkg/systemd/init.js:1297 pkg/systemd/init.js:1306
 msgid "This field cannot be empty."
 msgstr "このフィールドは空にできません。"
-
-#: pkg/ovirt/components/App.jsx:155
-msgid ""
-"This host is managed by a virtualization manager, so creation of new VMs "
-"from the host is not possible."
-msgstr "このホストは仮想化マネージャーによって管理されているため、ホストからの新規の仮想マシンの作成は不可能です。"
 
 #: pkg/docker/containers-view.jsx:494
 msgid "This image does not exist."
@@ -8558,12 +6826,6 @@ msgstr "このマシンはすでに追加されています。"
 #: pkg/realmd/operation.html:80
 msgid "This may take a while"
 msgstr "これにはしばらく時間がかかることがあります"
-
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr "このオプションは単一ノードのテストにのみ使用できます – ローカルストレージはマルチノードクラスターで動作しません"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
@@ -8590,7 +6852,9 @@ msgstr "このシステムは推奨プロファイルを使用しています"
 msgid ""
 "This tool will collect system configuration and diagnostic information from "
 "this system for use with diagnosing problems with the system."
-msgstr "このツールは、システムの問題の診断で使用するためにシステムからシステム設定と診断情報を収集します。"
+msgstr ""
+"このツールは、システムの問題の診断で使用するためにシステムからシステム設定と"
+"診断情報を収集します。"
 
 #: pkg/systemd/init.js:685
 msgid "This unit is an instance of the $0 template."
@@ -8600,7 +6864,7 @@ msgstr "このユニットは $0 テンプレートのインスタンスです�
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "このユニットは明示的に有効にするよう設計されていません。"
 
-#: pkg/users/local.js:557
+#: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "このユーザー名はすでに存在します"
 
@@ -8608,33 +6872,18 @@ msgstr "このユーザー名はすでに存在します"
 msgid ""
 "This version of cockpit-ws does not support connecting to a host with an "
 "alternate user or port"
-msgstr "cockpit-ws のこのバージョンでは、別のユーザーまたはポートによるホストへの接続がサポートされません"
-
-#: pkg/ovirt/components/OVirtTab.jsx:134
-msgid "This virtual machine is not managed by oVirt"
-msgstr "この仮想マシンは、oVirt で管理されていません"
-
-#: pkg/kubernetes/views/pv-delete.html:7
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
 msgstr ""
-"このボリュームは {{ item.item.spec.claimRef.namespace }} / {{ item.item.spec."
-"claimRef.name }} "
-"によってクレームされました。このボリュームを削除すると、そのクレームが破損して、依存するすべてのポッドで問題が発生することがあります。"
+"cockpit-ws のこのバージョンでは、別のユーザーまたはポートによるホストへの接続"
+"がサポートされません"
 
-#: pkg/kubernetes/views/pv-claim.html:23
-msgid "This volume has not been claimed"
-msgstr "このボリュームはクレームされていません"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:369
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
 msgid "This volume is already used by another VM."
 msgstr "このボリュームは、別の VM によってすでに使用されています。"
 
 #: pkg/storaged/lvol-tabs.jsx:186
 msgid "This volume needs to be activated before it can be resized."
-msgstr "このボリュームは、サイズを変更する前にアクティベートする必要があります。"
+msgstr ""
+"このボリュームは、サイズを変更する前にアクティベートする必要があります。"
 
 #: src/ws/login.js:122
 msgid "This web browser is too old to run Cockpit (missing $0)"
@@ -8650,15 +6899,16 @@ msgid ""
 "Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
 msgstr ""
-"このため、kdump 設定は、カーネル (つまり、システム) "
-"をクラッシュすることによりテストされます。設定に応じて、再起動が自動的に行われず、処理にしばらく時間がかかることがあります。"
+"このため、kdump 設定は、カーネル (つまり、システム) をクラッシュすることによ"
+"りテストされます。設定に応じて、再起動が自動的に行われず、処理にしばらく時間"
+"がかかることがあります。"
 
 #: pkg/kdump/kdump-view.jsx:489
 msgid "This will test the kdump configuration by crashing the kernel."
-msgstr "このため、kdump 設定はカーネルをクラッシュすることによりテストされます。"
+msgstr ""
+"このため、kdump 設定はカーネルをクラッシュすることによりテストされます。"
 
 #: pkg/machines/components/vcpuModal.jsx:212
-#: pkg/ovirt/components/vcpuModal.jsx:70
 msgid "Threads per core"
 msgstr "コアあたりのスレッド"
 
@@ -8682,15 +6932,18 @@ msgstr "タイマー"
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
-msgstr "ヒント: 他のシステムに対して自動的に認証する場合は、鍵のパスワードをログインパスワードに一致させます。"
+msgstr ""
+"ヒント: 他のシステムに対して自動的に認証する場合は、鍵のパスワードをログイン"
+"パスワードに一致させます。"
 
 #: pkg/packagekit/updates.jsx:773
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
 msgstr ""
-"ソフトウェアアップデートを取得するには、このシステムを Red Hat に登録する必要があります。登録には、Red Hat "
-"カスタマーポータルまたはローカルのサブスクリプションサーバーを使用します。"
+"ソフトウェアアップデートを取得するには、このシステムを Red Hat に登録する必要"
+"があります。登録には、Red Hat カスタマーポータルまたはローカルのサブスクリプ"
+"ションサーバーを使用します。"
 
 #: node_modules/registry-image-widgets/views/image-pull.html:4
 msgid "To pull this image:"
@@ -8704,11 +6957,9 @@ msgstr "このイメージストリームにイメージをプッシュするに
 msgid ""
 "To try a different port you will need to upgrade cockpit-ws to a newer "
 "version."
-msgstr "別のポートを試すには、cockpit-ws を新しいバージョンにアップグレードする必要があります。"
-
-#: pkg/kubernetes/views/auth-form.html:116
-msgid "Token"
-msgstr "トークン"
+msgstr ""
+"別のポートを試すには、cockpit-ws を新しいバージョンにアップグレードする必要が"
+"あります。"
 
 #: pkg/lib/cockpit-components-file-autocomplete.jsx:148
 msgid "Too many files found"
@@ -8717,10 +6968,6 @@ msgstr "見つかったファイルが多すぎます"
 #: src/base1/cockpit.js:4039
 msgid "Too much data"
 msgstr "データが多すぎます"
-
-#: pkg/kubernetes/index.html:61
-msgid "Topology"
-msgstr "トポロジー"
 
 #: pkg/docker/storage.jsx:341
 msgid "Total"
@@ -8738,12 +6985,11 @@ msgstr "タワー"
 msgid "Triggered By"
 msgstr "トリガー元"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:32 pkg/systemd/init.js:732
+#: pkg/systemd/init.js:732
 msgid "Triggers"
 msgstr "トリガー"
 
-#: pkg/kubernetes/index.html:109 pkg/shell/index.html:387
-#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/shell/index.html:387 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "トラブルシュート"
@@ -8752,13 +6998,9 @@ msgstr "トラブルシュート"
 msgid "Trust key"
 msgstr "キーを信頼します"
 
-#: pkg/networkmanager/firewall.jsx:703
+#: pkg/networkmanager/firewall.jsx:705
 msgid "Trust level"
 msgstr "信頼レベル"
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:21
-msgid "Trust this certificate for this connection"
-msgstr "この接続に対してこの証明書を信頼します"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -8800,20 +7042,17 @@ msgstr "Tuned が実行中ではありません"
 msgid "Tuned is off"
 msgstr "Tuned がオフです"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:84
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "タイプ"
 
@@ -8829,16 +7068,11 @@ msgstr "パスワードを入力します"
 msgid "Type to filter…"
 msgstr "フィルターのために入力します…"
 
-#: pkg/kubernetes/views/details-page.html:7
-msgid "Type:"
-msgstr "種類:"
-
-#: pkg/docker/index.html:332 pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
-#: pkg/subscriptions/subscriptions-register.jsx:112
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
 msgid "URL"
 msgstr "URL"
 
@@ -8854,17 +7088,9 @@ msgstr "設定を適用できません: $0"
 msgid "Unable to apply this solution automatically"
 msgstr "このソリューションを自動的に適用できません"
 
-#: pkg/subscriptions/subscriptions-view.jsx:217
-msgid "Unable to connect"
-msgstr "接続できません"
-
 #: src/ws/login.js:649
 msgid "Unable to connect to that address"
 msgstr "そのアドレスに接続できません"
-
-#: pkg/kubernetes/scripts/dashboard.js:412
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "Kubernetes アプリケーションマニフェストをデコードできません。"
 
 #: pkg/users/local.js:58
 msgid "Unable to delete root account"
@@ -8882,10 +7108,6 @@ msgstr "アラートを取得できません: $0"
 #: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "サーバーに到達できません"
-
-#: pkg/kubernetes/scripts/dashboard.js:400
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Kubernetes アプリケーションマニフェストを読み取ることができません。コード $0。"
 
 #: pkg/storaged/nfs-details.jsx:282
 msgid "Unable to remove mount"
@@ -8912,16 +7134,15 @@ msgid "Unable to unmount filesystem"
 msgstr "ファイルシステムをアンマウントできません"
 
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
-#: pkg/kubernetes/scripts/charts.js:110
 msgid "Unavailable"
 msgstr "利用できません"
 
-#: pkg/docker/index.html:730 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1481
+#: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
+#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "予期しないエラー"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:132
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid "Unique name"
 msgstr "固有名"
 
@@ -8930,19 +7151,14 @@ msgstr "固有名"
 msgid "Unit"
 msgstr "単位"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
-#: pkg/kubernetes/views/volumes-page.html:35
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:754 pkg/kubernetes/scripts/volumes.js:267
-#: pkg/lib/machine-info.js:65 pkg/networkmanager/interfaces.js:596
-#: pkg/networkmanager/interfaces.js:1067 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2534 pkg/storaged/fsys-tab.jsx:64
-#: pkg/storaged/swap-tab.jsx:57
+#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
+#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "不明"
 
@@ -8978,7 +7194,7 @@ msgstr "不明なサービス名"
 msgid "Unknown type"
 msgstr "不明なタイプ"
 
-#: pkg/docker/index.html:549 pkg/docker/util.js:110
+#: pkg/docker/index.html:551 pkg/docker/util.js:110
 msgid "Unless Stopped"
 msgstr "停止されていない場合"
 
@@ -9027,7 +7243,7 @@ msgstr "$target のアンマウント中"
 msgid "Unnamed"
 msgstr "名前なし"
 
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Unplug"
 msgstr "アンプラグ"
 
@@ -9043,14 +7259,6 @@ msgstr "認識されないデータ"
 #: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
 msgid "Unrecognized data can not be made smaller here."
 msgstr "ここでは、認識されないデータを小さくすることはできません。"
-
-#: pkg/subscriptions/subscriptions-view.jsx:164
-msgid "Unregister"
-msgstr "登録解除"
-
-#: pkg/subscriptions/subscriptions-view.jsx:170
-msgid "Unregistering system..."
-msgstr "システムの登録解除中 ..."
 
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
@@ -9073,7 +7281,12 @@ msgstr "信用できないホスト"
 msgid "Up since $0"
 msgstr "$0 から稼働中"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:316
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+#, fuzzy
+msgid "Up to $0 $1 available in the default location"
+msgstr "このホストでは最大 $0 $1 まで使用できます"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
 msgid "Up to $0 $1 available on the host"
 msgstr "このホストでは最大 $0 $1 まで使用できます"
 
@@ -9101,13 +7314,9 @@ msgstr "パッケージの更新を反映するには、再起動が必要にな
 msgid "Updates Available"
 msgstr "更新を利用できます"
 
-#: pkg/packagekit/updates.jsx:52 pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/packagekit/updates.jsx:52
 msgid "Updating"
 msgstr "更新中"
-
-#: pkg/kubernetes/scripts/details.js:654
-msgid "Updating $0..."
-msgstr "$0 の更新中 ..."
 
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
@@ -9122,20 +7331,15 @@ msgstr[0] "$0 CPU コアの使用率"
 msgid "Use 512 Byte emulation"
 msgstr "512 バイトのエミュレーションを使用します。"
 
-#: pkg/machines/components/diskAdd.jsx:496
+#: pkg/machines/components/diskAdd.jsx:524
 msgid "Use Existing"
 msgstr "既存の使用"
-
-#: pkg/subscriptions/subscriptions-register.jsx:136
-msgid "Use proxy server"
-msgstr "プロキシサーバーの使用"
 
 #: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
 msgstr "他のシステムに対して認証する場合は次の鍵を使用します"
 
 #: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
-#: pkg/kubernetes/scripts/nodes.js:829 pkg/kubernetes/scripts/nodes.js:838
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
@@ -9147,18 +7351,13 @@ msgstr "Used"
 msgid "Used by"
 msgstr "使用中"
 
-#: pkg/docker/index.html:262
+#: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "コンテナーにより使用済み"
 
-#: pkg/dashboard/index.html:144 pkg/kubernetes/views/auth-form.html:61
-#: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
-#: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/subscriptions/subscriptions-register.jsx:77 pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1584
 msgid "User"
 msgstr "ユーザー"
 
@@ -9167,11 +7366,11 @@ msgstr "ユーザー"
 msgid "User Name"
 msgstr "ユーザー名"
 
-#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:337
+#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:336
 msgid "User Password"
 msgstr "ユーザーパスワード"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "ユーザー名"
@@ -9180,18 +7379,9 @@ msgstr "ユーザー名"
 msgid "User name cannot be empty"
 msgstr "ユーザー名は空にできません"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:15
-msgid "User or Group"
-msgstr "ユーザーまたはグループ"
-
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
-#: pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
 msgid "Username"
 msgstr "ユーザー名"
-
-#: pkg/kubernetes/views/project-listing.html:85
-msgid "Users"
-msgstr "ユーザー"
 
 #: pkg/lib/machine-change-auth.html:44
 msgid "Using available credentials"
@@ -9230,14 +7420,6 @@ msgstr "VDO バッキングデバイスを小さくすることはできませ�
 msgid "VDO support not installed"
 msgstr "VDO サポートはインストールされていません"
 
-#: pkg/ovirt/components/App.jsx:115
-msgid "VDSM"
-msgstr "VDSM"
-
-#: pkg/ovirt/components/VdsmView.jsx:128
-msgid "VDSM Service Management"
-msgstr "VDSM サービス管理"
-
 #: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
 #: pkg/networkmanager/interfaces.js:2906
 msgid "VLAN"
@@ -9267,7 +7449,7 @@ msgstr "VM $0 は、強制的にシャットダウンさせることに失敗し
 msgid "VM $0 failed to get deleted"
 msgstr "VM $0 の削除に失敗しました"
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1317
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
 msgid "VM $0 failed to get installed"
 msgstr "VM $0 のインストールに失敗しました"
 
@@ -9291,10 +7473,6 @@ msgstr "VM $0 はシャットダウンに失敗しました"
 msgid "VM $0 failed to start"
 msgstr "VM $0 は起動に失敗しました"
 
-#: pkg/ovirt/components/VmOverviewColumn.jsx:37
-msgid "VM icon"
-msgstr "仮想マシンのアイコン"
-
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
 msgstr "VNC"
@@ -9311,7 +7489,7 @@ msgstr "VNC ポート:"
 msgid "VNC TLS Port:"
 msgstr "VNC TLS ポート:"
 
-#: pkg/realmd/operation.js:165
+#: pkg/realmd/operation.js:164
 msgid "Validating address"
 msgstr "アドレスの検証"
 
@@ -9340,30 +7518,20 @@ msgstr "キーを検証します"
 msgid "Verifying"
 msgstr "検証中"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:110 pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:381
-#: pkg/subscriptions/subscriptions-view.jsx:35 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "バージョン"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Version num"
-msgstr "バージョン番号"
 
 #: pkg/storaged/jobs-panel.jsx:57
 msgid "Very securely erasing $target"
 msgstr "$target を非常に安全に削除"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "仮想マシン"
-
-#: pkg/ovirt/components/ClusterVms.jsx:176
-msgid "Virtual Machines of $0 cluster"
-msgstr "$0 クラスターの仮想マシン"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
@@ -9377,14 +7545,11 @@ msgstr "仮想化サービス (libvirt) は有効ではありません "
 msgid "Virtualization Service is Available"
 msgstr "仮想化サービスは利用可能です"
 
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
-#: pkg/kubernetes/views/pvc-body.html:6
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:359
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "音量"
 
@@ -9392,7 +7557,7 @@ msgstr "音量"
 msgid "Volume Group"
 msgstr "ボリュームグループ"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:233
+#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "ボリュームグループ $0"
 
@@ -9400,32 +7565,16 @@ msgstr "ボリュームグループ $0"
 msgid "Volume Groups"
 msgstr "ボリュームグループ"
 
-#: pkg/kubernetes/views/volume-body.html:14
-#: pkg/kubernetes/views/volume-body.html:89
-msgid "Volume ID"
-msgstr "ボリューム ID"
-
-#: pkg/kubernetes/views/pv-modify.html:115
-#: pkg/kubernetes/views/volume-body.html:42
-msgid "Volume Name"
-msgstr "ボリューム名"
-
-#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
-msgid "Volume Type"
-msgstr "ボリュームタイプ"
-
 #: pkg/storaged/lvol-tabs.jsx:410
 msgid "Volume size is $0. Content size is $1."
 msgstr "ボリュームサイズは $0 です。コンテンツサイズは $1 です。"
 
-#: pkg/docker/index.html:515 pkg/kubernetes/index.html:74
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:517
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "ボリューム"
 
-#: pkg/docker/index.html:199
+#: pkg/docker/index.html:200
 msgid "Volumes:"
 msgstr "ボリューム:"
 
@@ -9444,7 +7593,8 @@ msgstr "詳細を待機中 ..."
 
 #: pkg/apps/utils.jsx:63
 msgid "Waiting for other programs to finish using the package manager..."
-msgstr "パッケージマネージャーを使用して、その他のプログラムを終了するのを待機中..."
+msgstr ""
+"パッケージマネージャーを使用して、その他のプログラムを終了するのを待機中..."
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:140
 #: pkg/lib/cockpit-components-install-dialog.jsx:175
@@ -9463,10 +7613,6 @@ msgstr "望む"
 msgid "Warning and above"
 msgstr "警告以上のレベル"
 
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid "Warning:"
-msgstr "警告:"
-
 #: cockpit.appdata.xml.in.h:1
 msgid "Web Console for Linux servers"
 msgstr "Linux サーバー用 Web コンソール"
@@ -9483,23 +7629,15 @@ msgstr "毎週水曜日"
 msgid "Weeks"
 msgstr "週"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:5
-msgid "Welcome to the Image Registry"
-msgstr "イメージレジストリーへようこそ"
-
 #: pkg/storaged/crypto-keyslots.jsx:324
 msgid "What if tang-show-keys is not available?"
 msgstr "tang-show-keys を利用できない場合はどうしますか?"
-
-#: pkg/kubernetes/views/volumes-page.html:61
-msgid "When"
-msgstr "日付"
 
 #: pkg/systemd/terminal.jsx:101
 msgid "White"
 msgstr "白"
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:488
 msgid "With terminal"
 msgstr "端末の使用"
 
@@ -9519,7 +7657,7 @@ msgstr "ユーザー名またはパスワードが間違っています"
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:996 pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2593
 msgid "Yes"
 msgstr "はい"
 
@@ -9528,8 +7666,8 @@ msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
 msgstr ""
-"{{#strong}}{{host}}{{/strong}} "
-"に接続されていますが、ユーザーを同期するには、スーパーユーザー権限を持つユーザーが必要です。"
+"{{#strong}}{{host}}{{/strong}} に接続されていますが、ユーザーを同期するには、"
+"スーパーユーザー権限を持つユーザーが必要です。"
 
 #: pkg/dashboard/list.js:440
 msgid ""
@@ -9537,19 +7675,9 @@ msgid ""
 msgstr "現在このサーバーに直接接続されています。削除できません。"
 
 #: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:871 pkg/networkmanager/firewall.jsx:877
+#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
 msgid "You are not authorized to modify the firewall."
 msgstr "ファイアウォールを修正する権限がありません。"
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:3
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr "証明書チェックを省略できますが、サーバーに送信したデータは他者によって取得されることがあります。"
-
-#: pkg/kubernetes/views/dashboard-page.html:150
-msgid "You can deploy an application to your cluster."
-msgstr "アプリケーションをクラスターにデプロイできます。"
 
 #: pkg/users/index.html:390
 msgid ""
@@ -9565,22 +7693,20 @@ msgstr "Docker ストレージプールを管理するパーミッションが�
 msgid "You must wait longer to change your password"
 msgstr "パスワードを変更するにはより長い時間の経過が必要です。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
 msgid ""
 "You need to select the most closely matching OS vendor and Operating System"
-msgstr "最も合致する OS ベンダーおよびオペレーティングシステムを選択しなければなりません"
+msgstr ""
+"最も合致する OS ベンダーおよびオペレーティングシステムを選択しなければなりま"
+"せん"
 
 #: pkg/packagekit/updates.jsx:834
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
-msgstr "ブラウザーが切断されますが、更新プロセスへの影響はありません。すぐに再接続して進捗確認を継続できます。"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:112
-msgid ""
-"Your login credentials do not give you access to use the docker registry "
-"from the command line."
-msgstr "ログイン資格情報は、コマンドラインから docker レジストリーを使用するアクセスを提供しません。"
+msgstr ""
+"ブラウザーが切断されますが、更新プロセスへの影響はありません。すぐに再接続し"
+"て進捗確認を継続できます。"
 
 #: pkg/packagekit/updates.jsx:865
 msgid ""
@@ -9596,11 +7722,11 @@ msgstr "セッションが終了しました。"
 msgid "Your session has expired. Please log in again."
 msgstr "セッションの有効期限が切れました。再度ログインしてください。"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Zone"
 msgstr "ゾーン"
 
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/networkmanager/firewall.jsx:938
 msgid "Zones"
 msgstr "ゾーン"
 
@@ -9616,8 +7742,12 @@ msgstr "[バイナリーデータ]"
 msgid "[no data]"
 msgstr "[データなし]"
 
-#: pkg/machines/components/networks/network.jsx:58
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "アクティブ"
@@ -9651,17 +7781,9 @@ msgstr "バイト"
 msgid "cdrom"
 msgstr "cdrom"
 
-#: pkg/ovirt/rephraseUI.js:35
-msgid "connecting"
-msgstr "接続中"
-
 #: pkg/machines/components/infoRecord.jsx:29
 msgid "control-label $0"
 msgstr "control-label $0"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "cores"
-msgstr "コア"
 
 #: pkg/machines/helpers.js:193
 msgid "crashed"
@@ -9680,7 +7802,6 @@ msgid "direct"
 msgstr "ダイレクト"
 
 #: pkg/machines/helpers.js:177 pkg/machines/helpers.js:180
-#: pkg/ovirt/components/OVirtTab.jsx:123
 msgid "disabled"
 msgstr "無効"
 
@@ -9688,7 +7809,7 @@ msgstr "無効"
 msgid "disk"
 msgstr "ディスク"
 
-#: pkg/machines/helpers.js:238 pkg/ovirt/rephraseUI.js:27
+#: pkg/machines/helpers.js:238
 msgid "down"
 msgstr "下へ"
 
@@ -9696,26 +7817,17 @@ msgstr "下へ"
 msgid "dying"
 msgstr "終了中"
 
-#: pkg/realmd/operation.js:299 pkg/realmd/operation.js:305
+#: pkg/realmd/operation.js:298 pkg/realmd/operation.js:304
 msgid "e.g. \"$0\""
 msgstr "例: \"$0\""
 
-#: pkg/kubernetes/scripts/images.js:639
-msgid "eg: my-image-stream"
-msgstr "例: my-image-stream"
-
 #: pkg/machines/helpers.js:178 pkg/machines/helpers.js:181
-#: pkg/ovirt/components/OVirtTab.jsx:125
 msgid "enabled"
 msgstr "有効"
 
 #: pkg/packagekit/updates.jsx:267
 msgid "enhancement"
 msgstr "機能強化"
-
-#: pkg/ovirt/rephraseUI.js:28
-msgid "error"
-msgstr "エラー"
 
 #: pkg/machines/helpers.js:214
 msgid "ethernet"
@@ -9741,7 +7853,7 @@ msgstr "ホストデバイス"
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:182
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
 msgid "iSCSI Initiator IQN"
 msgstr "iSCSI イニシエーター IQN"
 
@@ -9757,7 +7869,7 @@ msgstr "iSCSI ターゲット"
 msgid "iSCSI direct Target"
 msgstr "iSCSI ダイレクトターゲット"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
 msgid "iSCSI target IQN"
 msgstr "iSCSI ターゲット IQN"
 
@@ -9765,22 +7877,10 @@ msgstr "iSCSI ターゲット IQN"
 msgid "idle"
 msgstr "アイドル"
 
-#: pkg/machines/components/networks/network.jsx:58
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "非アクティブ"
-
-#: pkg/ovirt/rephraseUI.js:29
-msgid "initializing"
-msgstr "初期化中"
-
-#: pkg/ovirt/rephraseUI.js:30
-msgid "installation failed"
-msgstr "インストールに失敗しました"
-
-#: pkg/ovirt/rephraseUI.js:38
-msgid "installing OS"
-msgstr "OS のインストール中"
 
 #: pkg/kdump/kdump-view.jsx:376
 msgid "invalid: multiple targets defined"
@@ -9789,10 +7889,6 @@ msgstr "無効: 複数のターゲットが定義されています"
 #: pkg/kdump/kdump-view.jsx:493
 msgid "kdump status"
 msgstr "kdump ステータス"
-
-#: pkg/ovirt/rephraseUI.js:39
-msgid "kdumping"
-msgstr "kdump 中"
 
 #: pkg/docker/run.js:527
 msgid "key"
@@ -9806,10 +7902,6 @@ msgstr "キースロット $0"
 msgid "locally in $0"
 msgstr "$0 (ローカル)"
 
-#: pkg/ovirt/rephraseUI.js:31
-msgid "maintenance"
-msgstr "メンテナンス"
-
 #: pkg/machines/helpers.js:216
 msgid "mcast"
 msgstr "mcast"
@@ -9822,60 +7914,18 @@ msgstr "ネットワーク"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs ダンプターゲットは server:path の形式になっていません"
 
-#: pkg/kubernetes/views/route-body.html:14
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:43
 msgid "no"
 msgstr "いいえ"
 
-#: pkg/ovirt/rephraseUI.js:32
-msgid "non operational"
-msgstr "稼動していません"
-
-#: pkg/ovirt/rephraseUI.js:33
-msgid "non responsive"
-msgstr "応答しません"
-
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
-#: pkg/kubernetes/views/route-body.html:24
-#: pkg/kubernetes/views/route-body.html:29
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "なし"
-
-#: pkg/ovirt/provider.js:62
-msgid "oVirt"
-msgstr "oVirt"
-
-#: pkg/ovirt/components/HostStatus.jsx:37
-msgid "oVirt Host State:"
-msgstr "oVirt ホストの状態:"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:35
-msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr "引数がないため、oVirt プロバイダーのインストールスクリプトに失敗しました。"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:36
-msgid ""
-"oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-"machines-ovirt.config, try as root."
-msgstr ""
-"oVirt プロバイダーのインストールスクリプトに失敗しました。/etc/cockpit/machines-ovirt.config "
-"に書き込めません。root で試行してください。"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:164
-msgid "oVirt installation script failed with following output: "
-msgstr "oVirt インストールスクリプトが失敗し、次が出力されます: "
-
-#: pkg/ovirt/components/App.jsx:51
-msgid "oVirt login in progress"
-msgstr "oVirt ログインの処理中"
 
 #: pkg/systemd/host.js:691
 msgid "of $0 CPU core"
@@ -9886,25 +7936,13 @@ msgstr[0] "$0 CPU コアの"
 msgid "paused"
 msgstr "一時停止"
 
-#: pkg/ovirt/rephraseUI.js:34
-msgid "pending approval"
-msgstr "保留中の承認"
-
-#: pkg/kubernetes/views/dashboard-page.html:83
-msgid "pending volume claims"
-msgstr "保留中のボリュームクレーム"
-
-#: pkg/machines/components/diskAdd.jsx:174
+#: pkg/machines/components/diskAdd.jsx:154
 msgid "qcow2"
 msgstr "qcow2"
 
-#: pkg/machines/components/diskAdd.jsx:177
+#: pkg/machines/components/diskAdd.jsx:157
 msgid "raw"
 msgstr "raw"
-
-#: pkg/ovirt/rephraseUI.js:36
-msgid "reboot"
-msgstr "再起動"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -9926,7 +7964,7 @@ msgstr "名前、名前空間、または説明別の検索"
 msgid "security"
 msgstr "セキュリティー"
 
-#: pkg/docker/index.html:404
+#: pkg/docker/index.html:406
 msgid "select container"
 msgstr "コンテナーの選択"
 
@@ -9934,7 +7972,7 @@ msgstr "コンテナーの選択"
 msgid "server"
 msgstr "サーバー"
 
-#: pkg/docker/index.html:483 pkg/docker/index.html:655
+#: pkg/docker/index.html:485 pkg/docker/index.html:657
 msgid "shares"
 msgstr "共有"
 
@@ -9953,10 +7991,6 @@ msgstr "シャットオフ"
 #: pkg/machines/helpers.js:191
 msgid "shutdown"
 msgstr "shutdown"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "sockets"
-msgstr "ソケット"
 
 #: pkg/selinux/setroubleshoot-view.jsx:123
 msgid "solution details"
@@ -9978,10 +8012,6 @@ msgstr "ssh サーバーが空です"
 msgid "suspended (PM)"
 msgstr "一時停止中 (PM)"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "threads"
-msgstr "スレッド"
-
 #: pkg/docker/run.js:474
 msgid "to host path"
 msgstr "ホストパスに対して"
@@ -9997,10 +8027,6 @@ msgstr "翻訳可能"
 #: pkg/machines/helpers.js:218
 msgid "udp"
 msgstr "udp"
-
-#: pkg/ovirt/rephraseUI.js:37
-msgid "unassigned"
-msgstr "未割り当て"
 
 #: pkg/lib/cockpit-components-select.jsx:28
 msgid "undefined"
@@ -10019,7 +8045,7 @@ msgstr "不明なターゲット"
 msgid "unpartitioned space on $0"
 msgstr "$0 の未パーティション領域"
 
-#: pkg/machines/helpers.js:237 pkg/ovirt/rephraseUI.js:26
+#: pkg/machines/helpers.js:237
 msgid "up"
 msgstr "上へ"
 
@@ -10028,7 +8054,6 @@ msgid "user"
 msgstr "ユーザー"
 
 #: pkg/machines/components/vcpuModal.jsx:192
-#: pkg/ovirt/components/vcpuModal.jsx:54
 msgid "vCPU Count"
 msgstr "vCPU 数"
 
@@ -10037,8 +8062,6 @@ msgid "vCPU Maximum"
 msgstr "vCPU 最大値"
 
 #: pkg/machines/components/vmOverviewTab.jsx:75
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "vCPUs"
 msgstr "vCPU"
 
@@ -10050,12 +8073,16 @@ msgstr "value"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/kubernetes/views/route-body.html:13
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+msgid ""
+"virt-install package needs to be installed on the system in order to create "
+"new VMs"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:42
 msgid "yes"
 msgstr "はい"
 
@@ -10064,5 +8091,1419 @@ msgid ""
 "{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
 "count: {{ condition.generation }}"
 msgstr ""
-"{{ condition.message }}。タイムスタンプ: {{ condition.lastTransitionTime }} エラー数: {{ "
-"condition.generation }}"
+"{{ condition.message }}。タイムスタンプ: {{ condition.lastTransitionTime }} "
+"エラー数: {{ condition.generation }}"
+
+#~ msgid " 1\"Do you want to delete the following Nodes?"
+#~ msgstr " 1\" 次のノードを削除しますか?"
+
+#~ msgid "$0 vCPU Details"
+#~ msgstr "$0 vCPU の詳細"
+
+#~ msgid "$0% Free"
+#~ msgid_plural "$0% Free"
+#~ msgstr[0] "$0% 空き"
+
+#~ msgid "$0% Used"
+#~ msgid_plural "$0% Used"
+#~ msgstr[0] "$0% 使用済み"
+
+#~ msgid "'Organization' required to register."
+#~ msgstr "'組織' を登録する必要があります。"
+
+#~ msgid "'Organization' required when using activation keys."
+#~ msgstr "アクティベーションキーを使用する場合は '組織' が必要です。"
+
+#~ msgid "AWS Elastic Block Store"
+#~ msgstr "AWS Elastic Block Store"
+
+#~ msgid "Access Modes"
+#~ msgstr "アクセスモード"
+
+#~ msgid "Access denied"
+#~ msgstr "アクセスは拒否されました"
+
+#~ msgid "Action"
+#~ msgstr "アクション"
+
+#~ msgid "Activation Key"
+#~ msgstr "アクティベーションキー"
+
+#~ msgid "Actual"
+#~ msgstr "実際"
+
+#~ msgid "Add Cluster Node"
+#~ msgstr "クラスターノードの追加"
+
+#~ msgid "Add Group"
+#~ msgstr "グループの追加"
+
+#~ msgid "Add Kubernetes Node"
+#~ msgstr "Kubernetes ノードの追加"
+
+#~ msgid "Add Member"
+#~ msgstr "メンバーの追加"
+
+#~ msgid "Add Membership"
+#~ msgstr "メンバーシップの追加"
+
+#~ msgid "Add New Cluster"
+#~ msgstr "新規クラスターの追加"
+
+#~ msgid "Add New User"
+#~ msgstr "新規ユーザーの追加"
+
+#~ msgid "Add Role"
+#~ msgstr "ロールの追加"
+
+#~ msgid "Add User"
+#~ msgstr "ユーザーの追加"
+
+#~ msgid "Add membership"
+#~ msgstr "メンバーシップの追加"
+
+#~ msgid "Adjust"
+#~ msgstr "調整"
+
+#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+#~ msgstr "永続ボリューム '{{ item.metadata.name }}' の調整"
+
+#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
+#~ msgstr "レプリケーションコントローラー {{ item.metadata.name }} の調整"
+
+#~ msgid "Adjust Route"
+#~ msgstr "ルートの調整"
+
+#~ msgid "Adjust Service"
+#~ msgstr "サービスの調整"
+
+#~ msgid "Admin"
+#~ msgstr "管理者"
+
+#~ msgid "All Projects"
+#~ msgstr "すべてのプロジェクト"
+
+#~ msgid "All Types"
+#~ msgstr "すべてのタイプ"
+
+#~ msgid "All healthy"
+#~ msgstr "すべてが正常"
+
+#~ msgid "All images"
+#~ msgstr "すべてのイメージ"
+
+#~ msgid "All in use"
+#~ msgstr "使用中のすべてのもの"
+
+#~ msgid "All running"
+#~ msgstr "実行中のすべてのもの"
+
+#~ msgid "All running virtual machines will be turned off."
+#~ msgstr "全ての実行中のマシンはオフされます。"
+
+#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
+#~ msgstr "匿名: 認証されていないすべてのユーザーがイメージをプルできます"
+
+#~ msgid "Automatically selected host"
+#~ msgstr "自動的に選択されたホスト"
+
+#~ msgid "Azure"
+#~ msgstr "Azure"
+
+#~ msgid "Base Template"
+#~ msgstr "ベーステンプレート"
+
+#~ msgid "Base template"
+#~ msgstr "ベーステンプレート"
+
+#~ msgid "Base template:"
+#~ msgstr "ベーステンプレート:"
+
+#~ msgid "Boot ID"
+#~ msgstr "ブート ID"
+
+#~ msgid "CPU Utilization: $0%"
+#~ msgstr "CPU 使用率: $0%"
+
+#~ msgid "CREATE VM action failed"
+#~ msgstr "CREATE VM アクションに失敗しました"
+
+#~ msgid "Cannot decrypt PEM-encoded private key"
+#~ msgstr "PEM で暗号化された秘密鍵を復号できません"
+
+#~ msgid "Ceph Filesystem Mount"
+#~ msgstr "Ceph ファイルシステムマウント"
+
+#~ msgid "Ceph Monitors"
+#~ msgstr "Ceph モニター"
+
+#~ msgid "Change User"
+#~ msgstr "ユーザーの変更"
+
+#~ msgid "Change image stream"
+#~ msgstr "イメージストリームの変更"
+
+#~ msgid "Change project"
+#~ msgstr "プロジェクトの変更"
+
+#~ msgid "Cinder"
+#~ msgstr "Cinder"
+
+#~ msgid "Claim"
+#~ msgstr "クレーム"
+
+#~ msgid "Claim Name"
+#~ msgstr "クレーム名"
+
+#~ msgid "Client Certificate"
+#~ msgstr "クライアント証明書"
+
+#~ msgid "Cluster"
+#~ msgstr "クラスター"
+
+#~ msgid "Cluster Templates"
+#~ msgstr "クラスターテンプレート"
+
+#~ msgid "Cluster Virtual Machines"
+#~ msgstr "クラスター仮想マシン"
+
+#~ msgid "Configuration"
+#~ msgstr "設定"
+
+#~ msgid "Configure Flannel networking"
+#~ msgstr "Flannel ネットワーキングの設定"
+
+#~ msgid "Configure Kubelet and Proxy"
+#~ msgstr "Kubelet およびプロキシの設定"
+
+#~ msgid "Confirm migration"
+#~ msgstr "移行の確定"
+
+#~ msgid "Confirm reload:"
+#~ msgstr "リロードの確認:"
+
+#~ msgid "Confirm save:"
+#~ msgstr "保存の確認:"
+
+#~ msgid "Connect to oVirt Engine"
+#~ msgstr "oVirt エンジンに接続"
+
+#~ msgid "Connecting..."
+#~ msgstr "接続中..."
+
+#~ msgid "Connection Error: $0"
+#~ msgstr "接続エラー: $0"
+
+#~ msgid "Connection Settings"
+#~ msgstr "接続設定"
+
+#~ msgid "Container ID"
+#~ msgstr "コンテナー ID"
+
+#~ msgid "Container Runtime Version"
+#~ msgstr "コンテナーランタイムバージョン"
+
+#~ msgid "Could not list services"
+#~ msgstr "サービスを一覧表示できませんでした"
+
+#~ msgid "Could not parse PEM-encoded certificate"
+#~ msgstr "PEM でエンコードされた証明書を解析できませんでした"
+
+#~ msgid "Could not parse PEM-encoded private key"
+#~ msgstr "PEM で暗号化された秘密鍵を解析できませんでした"
+
+#~ msgid "Couldn't connect to server"
+#~ msgstr "サーバーに接続できませんでした"
+
+#~ msgid "Couldn't find running API server"
+#~ msgstr "実行中の API サーバーを見つけることができませんでした"
+
+#~ msgid ""
+#~ "Couldn't get system subscription status. Please ensure subscription-"
+#~ "manager is installed."
+#~ msgstr ""
+#~ "システムサブスクリプションステータスを取得できませんでした。subscription-"
+#~ "manager がインストールされていることを確認してください。"
+
+#~ msgid "Create New VM"
+#~ msgstr "仮想マシンの新規作成"
+
+#~ msgid "Create empty image stream"
+#~ msgstr "空のイメージストリームの作成"
+
+#~ msgid "Create image stream"
+#~ msgstr "イメージストリームの作成"
+
+#~ msgid "Custom URL"
+#~ msgstr "カスタム URL"
+
+#~ msgid "DNS Policy"
+#~ msgstr "DNS ポリシー"
+
+#~ msgid "Delete '{{ name }}'"
+#~ msgstr "'{{ name }}' の削除"
+
+#~ msgid "Delete Node"
+#~ msgstr "ノードの削除"
+
+#~ msgid "Delete Persistent Volume"
+#~ msgstr "永続ボリュームの削除"
+
+#~ msgid "Delete Persistent Volume Claim"
+#~ msgstr "永続ボリュームクレームの削除"
+
+#~ msgid "Delete Project"
+#~ msgstr "プロジェクトの削除"
+
+#~ msgid "Delete Selected"
+#~ msgstr "選択項目の削除"
+
+#~ msgid "Delete image stream"
+#~ msgstr "イメージストリームの削除"
+
+#~ msgid "Delete {{ item.kind }}"
+#~ msgstr "{{ item.kind }} の削除"
+
+#~ msgid ""
+#~ "Deleting a Pod will kill all associated containers. Pods may be "
+#~ "automatically created again in some cases."
+#~ msgstr ""
+#~ "ポッドを削除すると、関連するすべてのコンテナーが終了します。ポッドは自動的"
+#~ "に再び作成されることもあります。"
+
+#~ msgid "Deploy"
+#~ msgstr "デプロイ"
+
+#~ msgid "Deploy Application"
+#~ msgstr "アプリケーションのデプロイ"
+
+#~ msgid "Deployment Causes"
+#~ msgstr "デプロイメントの理由"
+
+#~ msgid "Deployment Config"
+#~ msgstr "デプロイメント設定"
+
+#~ msgid "Deployment Configs"
+#~ msgstr "デプロイメント設定"
+
+#~ msgid "Description:"
+#~ msgstr "詳細:"
+
+#~ msgid "Disk Utilization: $0%"
+#~ msgstr "ディスク使用率: $0%˙"
+
+#~ msgid "Display name"
+#~ msgstr "名前の表示"
+
+#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#~ msgstr "ロール '{{ fields.displayRole }}' を追加しますか?"
+
+#~ msgid ""
+#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}' image stream?"
+#~ msgstr ""
+#~ "'{{stream.metadata.namespace}}/{{stream.metadata.name}}' イメージストリー"
+#~ "ムを削除しますか?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+#~ msgstr "永続ボリューム '{{item.metadata.name}}' を削除しますか?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume Claim '{{item.metadata."
+#~ "name}}'?"
+#~ msgstr "永続ボリュームクレーム '{{item.metadata.name}}' を削除しますか?"
+
+#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+#~ msgstr "{{ item.kind }} '{{item.metadata.name}}' を削除しますか?"
+
+#~ msgid "Do you want to delete this Node?"
+#~ msgstr "このノードを削除しますか?"
+
+#~ msgid ""
+#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+#~ msgstr ""
+#~ "'{{stream.metadata.namespace}}/{{stream.metadata.name}}:{{tag.tag}}' とい"
+#~ "うタグが付けられたイメージを削除しますか?"
+
+#~ msgid ""
+#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
+#~ "{{ fields.member.metadata.name }}?"
+#~ msgstr ""
+#~ "ロール '{{ fields.displayRole }}' をメンバー {{ fields.member.metadata."
+#~ "name }} から削除しますか?"
+
+#~ msgid "Don't pull images automatically"
+#~ msgstr "イメージを自動的にプルしないでください"
+
+#~ msgid "Driver"
+#~ msgstr "ドライバー"
+
+#~ msgid "Edit the vdsm.conf"
+#~ msgstr "vdsm.conf を編集します"
+
+#~ msgid "Empty Directory"
+#~ msgstr "空のディレクトリー"
+
+#~ msgid "Endpoint"
+#~ msgstr "エンドポイント"
+
+#~ msgid "Endpoint Name"
+#~ msgstr "エンドポイント名"
+
+#~ msgid "Endpoints"
+#~ msgstr "エンドポイント"
+
+#~ msgid "Ends"
+#~ msgstr "終了"
+
+#~ msgid "Enter New VM name"
+#~ msgstr "新規仮想マシン名を入力します"
+
+#~ msgid "Error getting certificate details: $0"
+#~ msgstr "証明書の詳細の取得中にエラーが発生しました: $0"
+
+#~ msgid "Error writing kubectl config"
+#~ msgstr "kubectl 設定の書き込み中にエラーが発生しました"
+
+#~ msgid "FORCEOFF action failed: $0"
+#~ msgstr "FORCEOFF の動作が失敗: $0"
+
+#~ msgid "FQDN"
+#~ msgstr "FQDN"
+
+#~ msgid "Fibre Channel"
+#~ msgstr "ファイバーチャネル"
+
+#~ msgid "Filesystem Type"
+#~ msgstr "ファイルシステムタイプ"
+
+#~ msgid "Flex"
+#~ msgstr "Flex"
+
+#~ msgid "Flocker"
+#~ msgstr "Flocker"
+
+#~ msgid "Flocker Dataset Name"
+#~ msgstr "Flocker データセット名"
+
+#~ msgid "GCE Persistent Disk"
+#~ msgstr "GCE 永続ディスク"
+
+#~ msgid "Git Repository"
+#~ msgstr "Git リポジトリー"
+
+#~ msgid "Gluster FS"
+#~ msgstr "Gluster FS"
+
+#~ msgid "GlusterFS"
+#~ msgstr "GlusterFS"
+
+#~ msgid "Grant additional push or admin access to specific members below."
+#~ msgstr ""
+#~ "以下の特定のメンバーに追加のプッシュまたは管理アクセスを提供します。"
+
+#~ msgid "Group Members"
+#~ msgstr "グループメンバー"
+
+#~ msgid "Group or Project"
+#~ msgstr "グループまたはプロジェクト"
+
+#~ msgid "Groups"
+#~ msgstr "グループ"
+
+#~ msgid "HA"
+#~ msgstr "HA"
+
+#~ msgid "HA:"
+#~ msgstr "HA:"
+
+#~ msgid "Host Path"
+#~ msgstr "ホストパス"
+
+#~ msgid "Host to Maintenance"
+#~ msgstr "メンテナンスするホスト"
+
+#~ msgid "IP"
+#~ msgstr "IP"
+
+#~ msgid "ISCSI"
+#~ msgstr "ISCSI"
+
+#~ msgid "Identities"
+#~ msgstr "ID"
+
+#~ msgid "Identity"
+#~ msgstr "ID"
+
+#~ msgid "Image ID"
+#~ msgstr "イメージ ID"
+
+#~ msgid "Image Name"
+#~ msgstr "イメージ名"
+
+#~ msgid "Image Registry"
+#~ msgstr "イメージレジストリー"
+
+#~ msgid "Image Stream"
+#~ msgstr "イメージストリーム"
+
+#~ msgid "Image commands"
+#~ msgstr "イメージコマンド"
+
+#~ msgid "Images by project"
+#~ msgstr "プロジェクト別イメージ"
+
+#~ msgid "Images pushed recently"
+#~ msgstr "最近プッシュされたイメージ"
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, use the commands below."
+#~ msgstr ""
+#~ "レジストリーへのイメージのプッシュを開始するには、次のコマンドを使用しま"
+#~ "す。"
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, you need to create a "
+#~ "project."
+#~ msgstr ""
+#~ "レジストリーへのイメージのプッシュを開始するには、プロジェクトを作成する必"
+#~ "要があります。"
+
+#~ msgid "Installed products"
+#~ msgstr "インストールされた製品"
+
+#~ msgid "Interface"
+#~ msgstr "インターフェース"
+
+#~ msgid "Invalid credentials"
+#~ msgstr "無効な資格情報"
+
+#~ msgid "Kernel Version"
+#~ msgstr "Kernel バージョン"
+
+#~ msgid "Key Ring Path"
+#~ msgstr "キーリングパス"
+
+#~ msgid "Kubelet Version"
+#~ msgstr "Kubelet バージョン"
+
+#~ msgid "Kubernetes Cluster"
+#~ msgstr "Kubernetes クラスター"
+
+#~ msgid "Last Heartbeat"
+#~ msgstr "最後のハートビート"
+
+#~ msgid "Last Status Change"
+#~ msgstr "最終ステータス変更"
+
+#~ msgid "Latest Version"
+#~ msgstr "最新バージョン"
+
+#~ msgid "Loading data ..."
+#~ msgstr "データのロード中..."
+
+#~ msgid "Log into OpenShift command line tools:"
+#~ msgstr "OpenShift コマンドラインツールへのログイン:"
+
+#~ msgid "Log into the registry:"
+#~ msgstr "レジストリーへのログイン:"
+
+#~ msgid "Logical Unit Number"
+#~ msgstr "論理ユニット番号"
+
+#~ msgid "Login"
+#~ msgstr "ログイン"
+
+#~ msgid "Login commands"
+#~ msgstr "ログインコマンド"
+
+#~ msgid "Login/password or activation key required to register."
+#~ msgstr ""
+#~ "ログイン/パスワードまたはアクティベーションキーを登録する必要があります。"
+
+#~ msgid "MIGRATE action failed"
+#~ msgstr "MIGRATE アクションに失敗しました"
+
+#~ msgid "Manifest"
+#~ msgstr "マニフェスト"
+
+#~ msgid "Medium"
+#~ msgstr "普通"
+
+#~ msgid "Member of"
+#~ msgstr "メンバー"
+
+#~ msgid "Members"
+#~ msgstr "メンバー"
+
+#~ msgid "Membership"
+#~ msgstr "メンバーシップ"
+
+#~ msgid "Memory Utilization: $0%"
+#~ msgstr "メモリー使用率: $0%"
+
+#~ msgid "Message"
+#~ msgstr "メッセージ"
+
+#~ msgid "Migrate To:"
+#~ msgstr "移行先:"
+
+#~ msgid "Modify"
+#~ msgstr "修正"
+
+#~ msgid "Monitors"
+#~ msgstr "監視"
+
+#~ msgid "Mount Location"
+#~ msgstr "マウント場所"
+
+#~ msgid "NFS"
+#~ msgstr "NFS"
+
+#~ msgid "Namespace"
+#~ msgstr "名前空間"
+
+#~ msgid "Namespace cannot be empty."
+#~ msgstr "名前空間は空欄にできません。"
+
+#~ msgid "New Group"
+#~ msgstr "新規グループ"
+
+#~ msgid "New Project"
+#~ msgstr "新規プロジェクト"
+
+#~ msgid "New image stream"
+#~ msgstr "新規イメージストリーム"
+
+#~ msgid "New project"
+#~ msgstr "新規プロジェクト"
+
+#~ msgid "No PEM-encoded certificate found"
+#~ msgstr "PEM でエンコードされた証明書が見つかりません"
+
+#~ msgid "No PEM-encoded private key found"
+#~ msgstr "PEM でエンコードされた秘密鍵が見つかりません"
+
+#~ msgid "No Pods are using this claim"
+#~ msgstr "このクレームを使用しているポッドがありません"
+
+#~ msgid "No VM found in oVirt."
+#~ msgstr "oVirt で仮想マシンが見つかりませんでした。"
+
+#~ msgid "No Volume Bound"
+#~ msgstr "ボリュームがバインドされていません"
+
+#~ msgid "No groups are present."
+#~ msgstr "グループが存在しません。"
+
+#~ msgid "No images pushed"
+#~ msgstr "イメージがプッシュされていません"
+
+#~ msgid "No installed products on the system."
+#~ msgstr "システムにインストールされた製品がありません。"
+
+#~ msgid ""
+#~ "No metadata file was selected. Please select a Kubernetes metadata file."
+#~ msgstr ""
+#~ "メタデータファイルが選択されていません。Kubernetes メタデータファイルを選"
+#~ "択してください。"
+
+#~ msgid "No nodes in cluster"
+#~ msgstr "クラスター内にノードがありません"
+
+#~ msgid "No oVirt connection"
+#~ msgstr "oVirt 接続がありません"
+
+#~ msgid "No pods deployed"
+#~ msgstr "ポッドがデプロイされていません"
+
+#~ msgid "No pods replicated"
+#~ msgstr "ポッドがレプリケートされていません"
+
+#~ msgid "No pods scheduled"
+#~ msgstr "ポッドがスケジュールされていません"
+
+#~ msgid "No pods selected"
+#~ msgstr "ポッドが選択されていません"
+
+#~ msgid "No projects are present."
+#~ msgstr "プロジェクトが存在しません。"
+
+#~ msgid "No users are present."
+#~ msgstr "ユーザーが存在しません。"
+
+#~ msgid "No volumes are present."
+#~ msgstr "ボリュームが存在しません。"
+
+#~ msgid "No volumes in use"
+#~ msgstr "使用中のボリュームがありません"
+
+#~ msgid "Node"
+#~ msgstr "ノード"
+
+#~ msgid "Nodes"
+#~ msgstr "ノード"
+
+#~ msgid "Nodes are the machines that run your containers."
+#~ msgstr "ノードはコンテナーを実行するマシンです。"
+
+#~ msgid "Not a valid number of replicas"
+#~ msgstr "レプリカの有効な数ではありません"
+
+#~ msgid "Not a valid value for Host"
+#~ msgstr "ホストの有効な値ではありません"
+
+#~ msgid "Not deployed"
+#~ msgstr "デプロイされていません"
+
+#~ msgid "Number of virtual CPUs that gonna be used."
+#~ msgstr "使用予定の仮想 CPU の数。"
+
+#~ msgid "OK"
+#~ msgstr "OK"
+
+#~ msgid "OS"
+#~ msgstr "OS"
+
+#~ msgid "OS Type:"
+#~ msgstr "OS タイプ:"
+
+#~ msgid "OS Versions"
+#~ msgstr "OS バージョン"
+
+#~ msgid "Optimized for:"
+#~ msgstr "次に対して最適化:"
+
+#~ msgid "Organization"
+#~ msgstr "部門"
+
+#~ msgid "PD Name"
+#~ msgstr "PD 名"
+
+#~ msgid "Pending Volume Claims"
+#~ msgstr "保留中のボリュームクレーム"
+
+#~ msgid "Persistent Volumes"
+#~ msgstr "永続ボリューム"
+
+#~ msgid "Phase"
+#~ msgstr "フェーズ"
+
+#~ msgid "Please confirm, the host shall be switched to maintenance mode."
+#~ msgstr ""
+#~ "ホストがメンテナンスモードに切り替わっていることを確認してください。"
+
+#~ msgid "Please create another namespace for $0 \"$1\""
+#~ msgstr "$0 \"$1\" の別の名前空間を作成してください"
+
+#~ msgid "Please provide a GlusterFS volume name"
+#~ msgstr "GlusterFS ボリューム名を提供してください"
+
+#~ msgid "Please provide a username"
+#~ msgstr "ユーザー名を提供してください"
+
+#~ msgid "Please provide a valid NFS server"
+#~ msgstr "有効な NFS サーバーを提供してください"
+
+#~ msgid "Please provide a valid address"
+#~ msgstr "有効なアドレスを提供してください"
+
+#~ msgid "Please provide a valid filesystem type"
+#~ msgstr "有効なファイルシステムタイプを提供してください"
+
+#~ msgid "Please provide a valid interface"
+#~ msgstr "有効なインターフェースを提供してください"
+
+#~ msgid "Please provide a valid logical unit number"
+#~ msgstr "有効な論理ユニット番号を提供してください"
+
+#~ msgid "Please provide a valid name"
+#~ msgstr "有効な名前を提供してください"
+
+#~ msgid "Please provide a valid namespace."
+#~ msgstr "有効な名前空間を提供してください"
+
+#~ msgid "Please provide a valid path"
+#~ msgstr "有効なパスを提供してください"
+
+#~ msgid "Please provide a valid qualified name"
+#~ msgstr "有効な修飾名を提供してください"
+
+#~ msgid "Please provide a valid storage capacity."
+#~ msgstr "有効なストレージ容量を提供してください"
+
+#~ msgid "Please provide a valid target"
+#~ msgstr "有効なターゲットを提供してください"
+
+#~ msgid ""
+#~ "Please provide fully qualified domain name and port of the oVirt engine."
+#~ msgstr "完全修飾ドメイン名と、oVirt エンジンのポートを提供してください。"
+
+#~ msgid ""
+#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
+#~ "port (443 by default)"
+#~ msgstr ""
+#~ "有効な oVirt エンジンの完全修飾ドメイン名 (FQDN) と、ポート (デフォルトで"
+#~ "は 443) を提供してください"
+
+#~ msgid ""
+#~ "Please refer to oVirt's $0 for more information about Remote Viewer setup."
+#~ msgstr "リモートビューアーの設定の詳細は、oVirt の $0 を参照してください。"
+
+#~ msgid "Please select a valid access mode"
+#~ msgstr "有効なアクセスモードを選択してください"
+
+#~ msgid "Please select a valid endpoint"
+#~ msgstr "有効なエンドポイントを選択してください"
+
+#~ msgid "Please select a valid policy option."
+#~ msgstr "有効なポリシーオプションを選択してください"
+
+#~ msgid "Please type an address"
+#~ msgstr "アドレスを入力してください"
+
+#~ msgid "Please wait till VMs list is loaded from the server."
+#~ msgstr "サーバーから仮想マシンの一覧がロードされるのをお待ちください。"
+
+#~ msgid "Please wait till list of templates is loaded from the server."
+#~ msgstr "テンプレートの一覧がサーバーからロードされるのをお待ちください。"
+
+#~ msgid "Pod"
+#~ msgstr "ポッド"
+
+#~ msgid "Pod Address"
+#~ msgstr "ポッドアドレス"
+
+#~ msgid "Pod Endpoints"
+#~ msgstr "ポッドエンドポイント"
+
+#~ msgid "Pod Replicated"
+#~ msgstr "ポッドがレプリケートされました"
+
+#~ msgid "Pod Selector"
+#~ msgstr "ポッドセレクター"
+
+#~ msgid "Pods"
+#~ msgstr "ポッド"
+
+#~ msgid ""
+#~ "Pods contain one or more containers that run together on a node, "
+#~ "containing your application code."
+#~ msgstr ""
+#~ "ポッドには、ノードで一緒に実行される 1 つ以上のコンテナーが含まれます (ア"
+#~ "プリケーションコードを含む)"
+
+#~ msgid "Pool Name"
+#~ msgstr "プール名"
+
+#~ msgid "Populate"
+#~ msgstr "入力"
+
+#~ msgid "Preparing for Maintenance"
+#~ msgstr "メンテナンスの準備中"
+
+#~ msgid "Private: Allow only specific users or groups to pull images"
+#~ msgstr ""
+#~ "プライベート: 特定のユーザーまたはグループのみがイメージをプルすることを許"
+#~ "可する"
+
+#~ msgid "Product ID"
+#~ msgstr "製品 ID"
+
+#~ msgid "Product name"
+#~ msgstr "製品名"
+
+#~ msgid "Project"
+#~ msgstr "プロジェクト"
+
+#~ msgid "Project Members"
+#~ msgstr "プロジェクトメンバー"
+
+#~ msgid "Project access policy allows anonymous users to pull images."
+#~ msgstr ""
+#~ "プロジェクトアクセスポリシーにより、匿名ユーザーはイメージをプルすることが"
+#~ "できます。"
+
+#~ msgid "Project access policy allows any authenticated user to pull images."
+#~ msgstr ""
+#~ "プロジェクトアクセスポリシーにより、認証されたユーザーはイメージをプルする"
+#~ "ことができます。"
+
+#~ msgid "Project access policy only allows specific members to access images."
+#~ msgstr ""
+#~ "プロジェクトアクセスポリシーにより、特定のメンバーのみがイメージにアクセス"
+#~ "できます。"
+
+#~ msgid "Project:"
+#~ msgstr "プロジェクト:"
+
+#~ msgid "Projects"
+#~ msgstr "プロジェクト"
+
+#~ msgid "Proxy"
+#~ msgstr "プロキシ"
+
+#~ msgid "Proxy Version"
+#~ msgstr "プロキシバージョン"
+
+#~ msgid "Pull an image:"
+#~ msgstr "イメージのプル:"
+
+#~ msgid "Pull from"
+#~ msgstr "プル対象"
+
+#~ msgid "Pull specific tags from another image repository"
+#~ msgstr "別のイメージリポジトリーから特定のタグをプルします"
+
+#~ msgid "Push an image:"
+#~ msgstr "イメージのプッシュ:"
+
+#~ msgid "Qualified Name"
+#~ msgstr "修飾名"
+
+#~ msgid "REBOOT action failed"
+#~ msgstr "REBOOT アクションに失敗しました"
+
+#~ msgid "REBOOT_VM action failed: %s0"
+#~ msgstr "REBOOT_VM の動作が失敗: %s0"
+
+#~ msgid "Rados Block Device"
+#~ msgstr "Rados ブロックデバイス"
+
+#~ msgid "Read Only"
+#~ msgstr "読み込み専用"
+
+#~ msgid "Read and write from a single node"
+#~ msgstr "単一ノードからの読み書き"
+
+#~ msgid "Read and write from multiple nodes"
+#~ msgstr "複数のノードからの読み書き"
+
+#~ msgid "Read only from multiple nodes"
+#~ msgstr "複数のノードからの読み取り専用"
+
+#~ msgid "Reason"
+#~ msgstr "理由"
+
+#~ msgid "Reclaim Policy"
+#~ msgstr "リクレームポリシー"
+
+#~ msgid "Recycle"
+#~ msgstr "リサイクル"
+
+#~ msgid "Register"
+#~ msgstr "登録"
+
+#~ msgid "Register New Volume"
+#~ msgstr "新規ボリュームの登録"
+
+#~ msgid "Register Persistent Volume"
+#~ msgstr "永続ボリュームの登録"
+
+#~ msgid "Register oVirt"
+#~ msgstr "oVirt の登録"
+
+#~ msgid "Register system"
+#~ msgstr "システムの登録"
+
+#~ msgid "Registering oVirt to Cockpit"
+#~ msgstr "oVirt を Cockpit に登録中"
+
+#~ msgid "Remote registry is insecure"
+#~ msgstr "リモートレジストリーは安全ではありません"
+
+#~ msgid "Remove Group"
+#~ msgstr "グループの削除"
+
+#~ msgid "Remove Member"
+#~ msgstr "メンバーの削除"
+
+#~ msgid "Remove Role"
+#~ msgstr "ロールの削除"
+
+#~ msgid "Remove User"
+#~ msgstr "ユーザーの削除"
+
+#~ msgid "Remove image tag"
+#~ msgstr "イメージタグの削除"
+
+#~ msgid "Remove membership"
+#~ msgstr "メンバーシップの削除"
+
+#~ msgid "Replicas"
+#~ msgstr "レプリカ"
+
+#~ msgid "Replication Controller"
+#~ msgstr "レプリケーションコントローラー"
+
+#~ msgid "Replication Controllers"
+#~ msgstr "レプリケーションコントローラー"
+
+#~ msgid ""
+#~ "Replication controllers dynamically create instances of pods from "
+#~ "templates, and remove pods when necessary."
+#~ msgstr ""
+#~ "レプリケーションコントローラーにより、テンプレートからポッドのインスタンス"
+#~ "が動的に作成され、必要に応じてポッドが削除されます。"
+
+#~ msgid "Repository URL"
+#~ msgstr "リポジトリー URL"
+
+#~ msgid "Requested"
+#~ msgstr "要求者"
+
+#~ msgid "Requests"
+#~ msgstr "要求"
+
+#~ msgid "Requires Authentication"
+#~ msgstr "認証が必要"
+
+#~ msgid "Restart Count"
+#~ msgstr "再起動回数"
+
+#~ msgid "Retain"
+#~ msgstr "保持"
+
+#~ msgid "Retrieving subscription status..."
+#~ msgstr "サブスクリプションステータスを再取得中 ..."
+
+#~ msgid "Revision"
+#~ msgstr "リビジョン"
+
+#~ msgid "Role"
+#~ msgstr "役職"
+
+#~ msgid "Route"
+#~ msgstr "ルート"
+
+#~ msgid "Run Here"
+#~ msgstr "ここから実行"
+
+#~ msgid "Running Since:"
+#~ msgstr "実行開始:"
+
+#~ msgid "SET VCPU SETTINGS action failed"
+#~ msgstr "SET VCPU SETTINGS アクションに失敗しました"
+
+#~ msgid "SHUTDOWN action failed"
+#~ msgstr "SHUTDOWN アクションに失敗しました"
+
+#~ msgid "START action failed"
+#~ msgstr "START アクションに失敗しました"
+
+#~ msgid "START_VM action failed: %s0"
+#~ msgstr "START_VM の動作が失敗: %s0"
+
+#~ msgid "SUSPEND action failed"
+#~ msgstr "SUSPEND アクションに失敗しました"
+
+#~ msgid "Scheduled Pods"
+#~ msgstr "スケジュール済みポッド"
+
+#~ msgid "Scheduling Disabled"
+#~ msgstr "スケジューリングの無効化"
+
+#~ msgid "Secret"
+#~ msgstr "シークレット"
+
+#~ msgid "Secret File"
+#~ msgstr "シークレットファイル"
+
+#~ msgid "Secret Name"
+#~ msgstr "シークレット名"
+
+#~ msgid "Secret Volume"
+#~ msgstr "シークレットボリューム"
+
+#~ msgid "Select Manifest File..."
+#~ msgstr "マニフェストファイルの選択 ..."
+
+#~ msgid "Select Member"
+#~ msgstr "メンバーの選択"
+
+#~ msgid "Select Role"
+#~ msgstr "ロールの選択"
+
+#~ msgid "Select an object to see more details."
+#~ msgstr "オブジェクトを選択して詳細を参照します。"
+
+#~ msgid "Service Account"
+#~ msgstr "サービスアカウント"
+
+#~ msgid ""
+#~ "Services group pods and provide a common DNS name and an optional, load-"
+#~ "balanced IP address to access them."
+#~ msgstr ""
+#~ "サービスはポッドをグループ化し、ポッドにアクセスするために共通の DNS 名と"
+#~ "オプションのロードバランス IP アドレスを提供します。"
+
+#~ msgid "Session Affinity"
+#~ msgstr "セッションアフィニティー"
+
+#~ msgid "Share Name"
+#~ msgstr "共有名"
+
+#~ msgid "Shared: Allow any authenticated user to pull images"
+#~ msgstr "共有済み: 認証されたユーザーはイメージをプルできます"
+
+#~ msgid "Shell"
+#~ msgstr "シェル"
+
+#~ msgid "Show all Containers"
+#~ msgstr "すべてのコンテナーの表示"
+
+#~ msgid "Show all Deployment Configs"
+#~ msgstr "すべてのデプロイメント設定の表示"
+
+#~ msgid "Show all Nodes"
+#~ msgstr "すべてのノードの表示"
+
+#~ msgid "Show all Persistent Volumes"
+#~ msgstr "すべての永続ボリュームの表示"
+
+#~ msgid "Show all Pod Containers"
+#~ msgstr "すべてのポッドコンテナーの表示"
+
+#~ msgid "Show all Pods"
+#~ msgstr "すべてのポッドの表示"
+
+#~ msgid "Show all Projects"
+#~ msgstr "すべてのプロジェクトの表示"
+
+#~ msgid "Show all Replication Controllers"
+#~ msgstr "すべてのレプリケーションコントローラーの表示"
+
+#~ msgid "Show all Routes"
+#~ msgstr "すべてのルートの表示"
+
+#~ msgid "Show all Services"
+#~ msgstr "すべてのサービスの表示"
+
+#~ msgid "Show all image streams"
+#~ msgstr "すべてのイメージストリームの表示"
+
+#~ msgid "Since"
+#~ msgstr "以降"
+
+#~ msgid "Skip Certificate Verification"
+#~ msgstr "証明書検証の省略"
+
+#~ msgid "Sorry, I don't know how to modify this volume"
+#~ msgstr "申し訳ありませんが、このボリュームを変更する方法がわかりません"
+
+#~ msgid "Starts"
+#~ msgstr "開始"
+
+#~ msgid "Stateless"
+#~ msgstr "ステートレス"
+
+#~ msgid "Stateless:"
+#~ msgstr "ステートレス:"
+
+#~ msgid "Status: $0"
+#~ msgstr "ステータス: $0"
+
+#~ msgid "Status: System isn't registered"
+#~ msgstr "ステータス: システムが登録されていません"
+
+#~ msgid "Strategy"
+#~ msgstr "ストラテジー"
+
+#~ msgid "Subscriptions"
+#~ msgstr "サブスクリプション"
+
+#~ msgid "Suspend"
+#~ msgstr "一時停止"
+
+#~ msgid "Switch Host to Maintenance"
+#~ msgstr "ホストをメンテナンスに切り替え"
+
+#~ msgid "Switching host to maintenance mode failed. Received error: "
+#~ msgstr ""
+#~ "ホストをメンテナンスモードに切り替えることができませんでした。受け取ったエ"
+#~ "ラー: "
+
+#~ msgid "Switching host to maintenance mode in progress ..."
+#~ msgstr "ホストをメンテナンスモードに切り替え中..."
+
+#~ msgid "Sync all tags from a remote image repository"
+#~ msgstr "リモートイメージリポジトリーからすべてのタグを同期"
+
+#~ msgid "TLS Termination"
+#~ msgstr "TLS 終了"
+
+#~ msgid "Target Portal"
+#~ msgstr "ターゲットポータル"
+
+#~ msgid "Target World Wide Names"
+#~ msgstr "ターゲットワールドワイド名"
+
+#~ msgid "Template"
+#~ msgstr "テンプレート"
+
+#~ msgid "Templates"
+#~ msgstr "テンプレート"
+
+#~ msgid "Templates of $0 cluster"
+#~ msgstr "$0 クラスターのテンプレート"
+
+#~ msgid "The address contains invalid characters"
+#~ msgstr "アドレスに無効な文字が含まれています。"
+
+#~ msgid "The container '{{ target }}' does not exist."
+#~ msgstr "コンテナー '{{ target }}' が存在しません。"
+
+#~ msgid "The current user isn't allowed to access system subscription status."
+#~ msgstr ""
+#~ "現在のユーザーにはシステムサブスクリプションステータスへのアクセスが許可さ"
+#~ "れていません。"
+
+#~ msgid "The deployment config '{{ target }}' does not exist."
+#~ msgstr "デプロイメント設定 '{{ target }}' が存在しません。"
+
+#~ msgid "The group '{{ groupName }}' does not exist."
+#~ msgstr "グループ '{{ groupName }}' は存在しません。"
+
+#~ msgid "The maximum number of replicas is 128"
+#~ msgstr "レプリカの最大数は 128 です"
+
+#~ msgid "The name contains invalid characters"
+#~ msgstr "名前に無効な文字が含まれています"
+
+#~ msgid "The node '{{ target }}' does not exist."
+#~ msgstr "ノード '{{ target }}' が存在しません。"
+
+#~ msgid "The node doesn't have enough disk space"
+#~ msgstr "ノードに十分なディスク領域がありません"
+
+#~ msgid "The node doesn't have enough free memory"
+#~ msgstr "ノードに十分な空きメモリーがありません"
+
+#~ msgid "The persistent volume '{{ target }}' does not exist."
+#~ msgstr "永続ボリューム '{{ target }}' が存在しません。"
+
+#~ msgid "The pod '{{ target }}' does not exist."
+#~ msgstr "ポッド '{{ target }}' が存在しません。"
+
+#~ msgid "The project '{{ projName }}' does not exist."
+#~ msgstr "プロジェクト '{{ projName }}' が存在しません。"
+
+#~ msgid "The replication controller '{{ target }}' does not exist."
+#~ msgstr "レプリケーションコントローラー '{{ target }}' が存在しません。"
+
+#~ msgid "The route '{{ target }}' does not exist."
+#~ msgstr "ルート '{{ target }}' が存在しません。"
+
+#~ msgid "The selected file is not a valid Kubernetes application manifest."
+#~ msgstr ""
+#~ "選択されたファイルは有効な Kubernetes アプリケーションマニフェストではあり"
+#~ "ません。"
+
+#~ msgid "The server uses a certificate signed by an unknown authority."
+#~ msgstr "サーバーは不明な認証局によって署名された証明書を使用します。"
+
+#~ msgid "The service '{{ target }}' does not exist."
+#~ msgstr "サービス '{{ target }}' は存在しません。"
+
+#~ msgid "The user '{{ userName }}' does not exist."
+#~ msgstr "ユーザー '{{ userName }}' は存在しません。"
+
+#~ msgid ""
+#~ "This claim is in use. Deleting it may cause issues with the following pod:"
+#~ msgstr ""
+#~ "このクレームは使用中です。クレームを削除すると、次のポッドで問題が発生する"
+#~ "ことがあります。"
+
+#~ msgid ""
+#~ "This host is managed by a virtualization manager, so creation of new VMs "
+#~ "from the host is not possible."
+#~ msgstr ""
+#~ "このホストは仮想化マネージャーによって管理されているため、ホストからの新規"
+#~ "の仮想マシンの作成は不可能です。"
+
+#~ msgid ""
+#~ "This option is for single node testing only – local storage will not work "
+#~ "in a multi-node cluster"
+#~ msgstr ""
+#~ "このオプションは単一ノードのテストにのみ使用できます – ローカルストレージ"
+#~ "はマルチノードクラスターで動作しません"
+
+#~ msgid "This virtual machine is not managed by oVirt"
+#~ msgstr "この仮想マシンは、oVirt で管理されていません"
+
+#~ msgid ""
+#~ "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+#~ "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+#~ "may cause issues with any pods depending on it."
+#~ msgstr ""
+#~ "このボリュームは {{ item.item.spec.claimRef.namespace }} / {{ item.item."
+#~ "spec.claimRef.name }} によってクレームされました。このボリュームを削除する"
+#~ "と、そのクレームが破損して、依存するすべてのポッドで問題が発生することがあ"
+#~ "ります。"
+
+#~ msgid "This volume has not been claimed"
+#~ msgstr "このボリュームはクレームされていません"
+
+#~ msgid "Token"
+#~ msgstr "トークン"
+
+#~ msgid "Topology"
+#~ msgstr "トポロジー"
+
+#~ msgid "Trust this certificate for this connection"
+#~ msgstr "この接続に対してこの証明書を信頼します"
+
+#~ msgid "Type:"
+#~ msgstr "種類:"
+
+#~ msgid "Unable to connect"
+#~ msgstr "接続できません"
+
+#~ msgid "Unable to decode Kubernetes application manifest."
+#~ msgstr "Kubernetes アプリケーションマニフェストをデコードできません。"
+
+#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
+#~ msgstr ""
+#~ "Kubernetes アプリケーションマニフェストを読み取ることができません。コード "
+#~ "$0。"
+
+#~ msgid "Unregister"
+#~ msgstr "登録解除"
+
+#~ msgid "Unregistering system..."
+#~ msgstr "システムの登録解除中 ..."
+
+#~ msgid "Updating $0..."
+#~ msgstr "$0 の更新中 ..."
+
+#~ msgid "Use proxy server"
+#~ msgstr "プロキシサーバーの使用"
+
+#~ msgid "User or Group"
+#~ msgstr "ユーザーまたはグループ"
+
+#~ msgid "Users"
+#~ msgstr "ユーザー"
+
+#~ msgid "VDSM"
+#~ msgstr "VDSM"
+
+#~ msgid "VDSM Service Management"
+#~ msgstr "VDSM サービス管理"
+
+#~ msgid "VM icon"
+#~ msgstr "仮想マシンのアイコン"
+
+#~ msgid "Version num"
+#~ msgstr "バージョン番号"
+
+#~ msgid "Virtual Machines of $0 cluster"
+#~ msgstr "$0 クラスターの仮想マシン"
+
+#~ msgid "Volume ID"
+#~ msgstr "ボリューム ID"
+
+#~ msgid "Volume Name"
+#~ msgstr "ボリューム名"
+
+#~ msgid "Volume Type"
+#~ msgstr "ボリュームタイプ"
+
+#~ msgid "Warning:"
+#~ msgstr "警告:"
+
+#~ msgid "Welcome to the Image Registry"
+#~ msgstr "イメージレジストリーへようこそ"
+
+#~ msgid "When"
+#~ msgstr "日付"
+
+#~ msgid ""
+#~ "You can bypass the certificate check, but any data you send to the server "
+#~ "could be intercepted by others."
+#~ msgstr ""
+#~ "証明書チェックを省略できますが、サーバーに送信したデータは他者によって取得"
+#~ "されることがあります。"
+
+#~ msgid "You can deploy an application to your cluster."
+#~ msgstr "アプリケーションをクラスターにデプロイできます。"
+
+#~ msgid ""
+#~ "Your login credentials do not give you access to use the docker registry "
+#~ "from the command line."
+#~ msgstr ""
+#~ "ログイン資格情報は、コマンドラインから docker レジストリーを使用するアクセ"
+#~ "スを提供しません。"
+
+#~ msgid "connecting"
+#~ msgstr "接続中"
+
+#~ msgid "cores"
+#~ msgstr "コア"
+
+#~ msgid "eg: my-image-stream"
+#~ msgstr "例: my-image-stream"
+
+#~ msgid "error"
+#~ msgstr "エラー"
+
+#~ msgid "initializing"
+#~ msgstr "初期化中"
+
+#~ msgid "installation failed"
+#~ msgstr "インストールに失敗しました"
+
+#~ msgid "installing OS"
+#~ msgstr "OS のインストール中"
+
+#~ msgid "kdumping"
+#~ msgstr "kdump 中"
+
+#~ msgid "maintenance"
+#~ msgstr "メンテナンス"
+
+#~ msgid "non operational"
+#~ msgstr "稼動していません"
+
+#~ msgid "non responsive"
+#~ msgstr "応答しません"
+
+#~ msgid "oVirt"
+#~ msgstr "oVirt"
+
+#~ msgid "oVirt Host State:"
+#~ msgstr "oVirt ホストの状態:"
+
+#~ msgid "oVirt Provider installation script failed due to missing arguments."
+#~ msgstr ""
+#~ "引数がないため、oVirt プロバイダーのインストールスクリプトに失敗しました。"
+
+#~ msgid ""
+#~ "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
+#~ "machines-ovirt.config, try as root."
+#~ msgstr ""
+#~ "oVirt プロバイダーのインストールスクリプトに失敗しました。/etc/cockpit/"
+#~ "machines-ovirt.config に書き込めません。root で試行してください。"
+
+#~ msgid "oVirt installation script failed with following output: "
+#~ msgstr "oVirt インストールスクリプトが失敗し、次が出力されます: "
+
+#~ msgid "pending approval"
+#~ msgstr "保留中の承認"
+
+#~ msgid "pending volume claims"
+#~ msgstr "保留中のボリュームクレーム"
+
+#~ msgid "reboot"
+#~ msgstr "再起動"
+
+#~ msgid "sockets"
+#~ msgstr "ソケット"
+
+#~ msgid "threads"
+#~ msgstr "スレッド"
+
+#~ msgid "unassigned"
+#~ msgstr "未割り当て"

--- a/po/ko.po
+++ b/po/ko.po
@@ -10,14 +10,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 04:52+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-07-01 06:01+0000\n"
 "Last-Translator: Eun-Ju Kim <eukim@redhat.com>\n"
 "Language-Team: Korean\n"
 "Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
@@ -120,13 +120,15 @@ msgstr "$0 파일 시스템의 크기를 조정할 수 없습니다."
 msgid ""
 "$0 is available for most operating systems. To install it, search for it in "
 "GNOME Software or run the following:"
-msgstr "$0 대부분의 운영 체제에서 사용할 수 있습니다. 설치하려면 GNOME 소프트웨어에서 검색하거나 다음을 실행하십시오."
+msgstr ""
+"$0 대부분의 운영 체제에서 사용할 수 있습니다. 설치하려면 GNOME 소프트웨어에"
+"서 검색하거나 다음을 실행하십시오."
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 은/는 현재 사용 중입니다. "
 
@@ -457,7 +459,9 @@ msgstr "9일 "
 msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
-msgstr "Cockpit 호환 버전이 {{#strong}}{{host}}{{/strong}} 에 설치되어 있지 않습니다. "
+msgstr ""
+"Cockpit 호환 버전이 {{#strong}}{{host}}{{/strong}} 에 설치되어 있지 않습니"
+"다. "
 
 #: pkg/storaged/vdos-panel.jsx:59
 msgid "A disk is needed."
@@ -518,8 +522,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "계정"
 
-#: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "활성화"
@@ -556,10 +560,10 @@ msgstr "적응형 로드 밸런싱"
 msgid "Adaptive transmit load balancing"
 msgstr "적응형 전송 로드 밸런싱"
 
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "추가"
@@ -650,7 +654,9 @@ msgstr "영역 추가 "
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
-msgstr "<b>$0</b>을/를 추가하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
+msgstr ""
+"<b>$0</b>을/를 추가하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩"
+"니다. "
 
 #: pkg/users/authorized-keys.js:113
 msgid "Adding key"
@@ -734,8 +740,9 @@ msgid ""
 "log into this machine. This may also affect other services as DNS resolution "
 "settings and the list of trusted CAs may change."
 msgstr ""
-"도메인 종료 후 로컬 인증 정보가 있는 사용자만 시스템에 로그인할 수 있습니다. 이 경우 DNS 확인 설정 및 신뢰할 수 있는 CA "
-"목록이 변경될 수 있으므로 다른 서비스에도 영향을 미칠 수 있습니다. "
+"도메인 종료 후 로컬 인증 정보가 있는 사용자만 시스템에 로그인할 수 있습니다. "
+"이 경우 DNS 확인 설정 및 신뢰할 수 있는 CA 목록이 변경될 수 있으므로 다른 서"
+"비스에도 영향을 미칠 수 있습니다. "
 
 #: pkg/systemd/services.html:446 pkg/systemd/services.html:450
 #: pkg/systemd/init.js:1073
@@ -758,7 +765,8 @@ msgstr "일체형 "
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
-msgstr "선택된 디스크의 모든 데이터가 삭제되며 디스크는 스토리지 풀에 추가됩니다. "
+msgstr ""
+"선택된 디스크의 모든 데이터가 삭제되며 디스크는 스토리지 풀에 추가됩니다. "
 
 #: pkg/networkmanager/firewall.jsx:751
 msgid "Allowed Addresses"
@@ -793,10 +801,10 @@ msgstr "애플리케이션 "
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "적용"
 
@@ -837,8 +845,8 @@ msgstr "자산 태그"
 msgid "At least $0 disks are needed."
 msgstr "최소 $0 개의 디스크가 필요합니다."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "최소 1개의 디스크가 필요합니다."
 
@@ -854,8 +862,8 @@ msgstr "감사 로그 "
 msgid "Authenticating"
 msgstr "인증 중입니다"
 
-#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
-#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "인증"
 
@@ -926,8 +934,8 @@ msgstr "자동으로 NTP 사용"
 msgid "Automatically using specific NTP servers"
 msgstr "특정 NTP 서버를 자동으로 사용"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "자동 시작"
@@ -1110,8 +1118,8 @@ msgstr "CPU 우선순위"
 msgid "CPU usage:"
 msgstr "CPU 사용량:"
 
-#: pkg/machines/components/diskAdd.jsx:246
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr "캐시 "
 
@@ -1134,35 +1142,35 @@ msgstr "이미지를 로드할 수 없습니다."
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:560
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:560 pkg/networkmanager/firewall.jsx:628
-#: pkg/networkmanager/firewall.jsx:771 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "취소"
 
@@ -1232,10 +1240,10 @@ msgstr "리소스 제한 변경"
 msgid "Change the settings"
 msgstr "설정 변경"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "VM 종료 후 변경사항이 적용됩니다. "
 
@@ -1314,15 +1322,16 @@ msgstr ""
 msgid "Client Software"
 msgstr "클라이언트 소프트웨어 "
 
-#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
-#: pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "닫기"
 
@@ -1362,7 +1371,8 @@ msgstr ""
 
 #: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
-msgstr "Cockpit은 대화형 Linux 서버 관리 인터페이스입니다.\n"
+msgstr ""
+"Cockpit은 대화형 Linux 서버 관리 인터페이스입니다.\n"
 "            "
 
 #: src/base1/cockpit.js:4035
@@ -1392,14 +1402,15 @@ msgstr "Cockpit은 {{#strong}}{{host}}{{/strong}}에 연결할 수 없습니다.
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit은 {{#strong}}{{host}}{{/strong}}에 로그인할 수 없습니다. {{#can_sync}} "
-"{{#sync_link}}사용자 동기화{{/sync_link}}를 수행하십시오.{{/can_sync}} 다른 인증 옵션 및 문제 해결에 "
-"대한 지원이 필요한 경우 cockpit-ws를 새 버전으로 업그레이드하십시오."
+"Cockpit은 {{#strong}}{{host}}{{/strong}}에 로그인할 수 없습니다. "
+"{{#can_sync}} {{#sync_link}}사용자 동기화{{/sync_link}}를 수행하십시오.{{/"
+"can_sync}} 다른 인증 옵션 및 문제 해결에 대한 지원이 필요한 경우 cockpit-ws"
+"를 새 버전으로 업그레이드하십시오."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1411,8 +1422,9 @@ msgid ""
 "machine with cockpit you will need to enable one of the following "
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
-"Cockpit은 {{#strong}}{{host}}{{/strong}}에 로그인할 수 없습니다. 이 시스템을 cockpit과 사용하려면 "
-"{{#strong}}{{host}}{{/strong}}의 sshd 설정에서 다음 인증 방법 중 하나를 사용해야 합니다:"
+"Cockpit은 {{#strong}}{{host}}{{/strong}}에 로그인할 수 없습니다. 이 시스템을 "
+"cockpit과 사용하려면 {{#strong}}{{host}}{{/strong}}의 sshd 설정에서 다음 인"
+"증 방법 중 하나를 사용해야 합니다:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1487,8 +1499,8 @@ msgstr "최신 시스템과 2TB 이상의 하드 디스크와 호환됩니다 (G
 msgid "Compress crash dumps to save space"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "압축"
 
@@ -1592,9 +1604,9 @@ msgstr "장치에 연결 중입니다"
 
 # ctx::sourcefile::Navigation Menu
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "연결"
@@ -1644,7 +1656,9 @@ msgstr "컨테이너 이름"
 #: pkg/docker/util.js:506
 msgid ""
 "Container is currently marked as not running, but regular stopping failed."
-msgstr "컨테이너는 현재 실행중이지 않은 것으로 보이지만, 정상적인 종료가 되지 않았습니다."
+msgstr ""
+"컨테이너는 현재 실행중이지 않은 것으로 보이지만, 정상적인 종료가 되지 않았습"
+"니다."
 
 #: pkg/docker/util.js:504
 msgid "Container is currently running."
@@ -1743,9 +1757,9 @@ msgstr "크래시 시스템 "
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "생성"
 
@@ -1860,25 +1874,30 @@ msgstr "$target 스냅샷 생성 중"
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "이 VLAN을 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
+msgstr ""
+"이 VLAN을 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
 
 #: pkg/networkmanager/interfaces.js:3821
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "이 본드를 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
+msgstr ""
+"이 본드를 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
 
 #: pkg/networkmanager/interfaces.js:4274
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "이 브릿지를 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
+msgstr ""
+"이 브릿지를 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니"
+"다. "
 
 #: pkg/networkmanager/interfaces.js:4020
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "이 팀을 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
+msgstr ""
+"이 팀을 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
 
 #: pkg/storaged/jobs-panel.jsx:71
 msgid "Creating volume group $target"
@@ -1920,7 +1939,7 @@ msgstr "사용자 지정 포트 "
 msgid "Custom encryption options"
 msgstr "사용자 지정 암호화 옵션 "
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "사용자 정의 마운트 옵션 "
 
@@ -1966,8 +1985,8 @@ msgstr "대시보드"
 msgid "Data Used"
 msgstr "사용된 데이터 "
 
-#: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "비활성화 "
@@ -2000,17 +2019,17 @@ msgstr "지연 "
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "삭제"
@@ -2051,7 +2070,9 @@ msgstr "$target 삭제 중 "
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
-msgstr "<b>$0</b>을/를 삭제하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
+msgstr ""
+"<b>$0</b>을/를 삭제하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩"
+"니다. "
 
 #: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
@@ -2061,7 +2082,7 @@ msgstr "RAID 장치를 제거하면 내부의 모든 데이터를 지우게 됩�
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "VDO 장치를 제거하면 장치 내부의 모든 데이터가 삭제됩니다. "
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "컨테이너를 삭제하시면, 내부의 모든 데이터도 함께 삭제됩니다. "
 
@@ -2105,12 +2126,12 @@ msgstr ""
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:745
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "상세 정보"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2200,9 +2221,9 @@ msgstr ""
 msgid "Disk passphrase"
 msgstr ""
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "디스크 "
 
@@ -2473,9 +2494,9 @@ msgid "Errata:"
 msgstr "에라타: "
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1476
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "오류"
 
@@ -2579,7 +2600,7 @@ msgstr "서비스 추가 실패 "
 msgid "Failed to add zone"
 msgstr "영역 추가 실패 "
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "암호 변경 실패 "
 
@@ -2666,7 +2687,7 @@ msgstr "필터 서비스 "
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "지문 "
 
@@ -2711,10 +2732,9 @@ msgstr ""
 msgid "Force remove passphrase in $0"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:147
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "포멧"
 
@@ -2791,11 +2811,11 @@ msgstr ""
 msgid "Get new image"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:186
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
 
@@ -2880,9 +2900,9 @@ msgstr "Hello 시간 $hello_time"
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
 #: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "호스트"
@@ -3066,7 +3086,9 @@ msgstr ""
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
-msgstr "대부분의 설정에서 macvtap는 호스트와 게스트 간 네트워크 통신에서 작동하지 않습니다."
+msgstr ""
+"대부분의 설정에서 macvtap는 호스트와 게스트 간 네트워크 통신에서 작동하지 않"
+"습니다."
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
@@ -3115,9 +3137,9 @@ msgstr ""
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "설치"
 
@@ -3180,8 +3202,8 @@ msgid "Interface Type"
 msgstr "인터페이스 유형"
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:737 pkg/networkmanager/firewall.jsx:925
-#: pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "인터페이스"
 
@@ -3197,11 +3219,11 @@ msgstr "내부 오류 "
 msgid "Invalid address $0"
 msgstr "잘못된 주소 $0"
 
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr ""
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr ""
 
@@ -3260,7 +3282,7 @@ msgstr "잘못된 포트"
 msgid "Invalid range"
 msgstr "잘못된 범위 "
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr ""
 
@@ -3427,7 +3449,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66
@@ -3491,9 +3512,9 @@ msgid "Loading available updates, please wait..."
 msgstr ""
 
 # translation auto-copied from project oVirt, version ovirt-3.5, document frontend/webadmin/modules/webadmin/src/main/resources/org/ovirt/engine/ui/frontend/org.ovirt.engine.ui.webadmin.ApplicationConstants
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "로딩..."
 
@@ -3794,10 +3815,10 @@ msgid "Metadata Used"
 msgstr ""
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
-#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -3867,23 +3888,23 @@ msgstr "자세한 정보 "
 msgid "More details"
 msgstr "더 자세히"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "마운트 "
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "마운트 옵션"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "마운트 포인트"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr ""
 
@@ -3903,7 +3924,7 @@ msgstr "마운트 지점을 비워둘 수 없습니다. "
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr ""
 
@@ -3959,22 +3980,21 @@ msgstr "NTP 서버 "
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "이름"
 
@@ -4114,7 +4134,7 @@ msgstr "새 볼륨 이름 "
 msgid "New passphrase"
 msgstr "새 암호문 "
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr ""
 
@@ -4238,9 +4258,9 @@ msgstr "사용 가능한 설명이 없음"
 msgid "No description provided."
 msgstr "설명이 없습니다."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "사용 가능한 디스크가 없습니다."
 
@@ -4373,8 +4393,8 @@ msgid "No volume groups created"
 msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:734
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "없음"
 
@@ -4474,7 +4494,7 @@ msgstr ""
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr ""
 
@@ -4585,9 +4605,9 @@ msgid "Other Options"
 msgstr "기타 옵션 "
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "개요"
 
@@ -4668,10 +4688,10 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr ""
 
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "암호"
@@ -4773,8 +4793,8 @@ msgstr "권한이 거부되었습니다"
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr ""
 
@@ -4819,9 +4839,9 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "$0 삭제를 확인해주세요"
@@ -4830,7 +4850,7 @@ msgstr "$0 삭제를 확인해주세요"
 msgid "Please confirm forced deletion of $0"
 msgstr "$0 강제 삭제를 확인해주세요"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr ""
 
@@ -4866,11 +4886,10 @@ msgstr ""
 msgid "Plug"
 msgstr ""
 
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "풀"
 
@@ -5027,7 +5046,7 @@ msgstr ""
 msgid "Protocol"
 msgstr "프로토콜"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "공개 키 "
 
@@ -5108,7 +5127,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "RAID 장치"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "RAID 장치 $0"
 
@@ -5275,9 +5294,9 @@ msgstr ""
 msgid "Removals:"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "제거 "
 
@@ -5461,8 +5480,8 @@ msgstr ""
 # ctx::sourcefile::/rhn/admin/config/Restart.do
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "재시작"
 
@@ -5504,8 +5523,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 # auto translated by TM merge from project: RHEV Administration Guide, version: 4.0, DocId: chap-Administering_and_Maintaining_the_Red_Hat_Enterprise_Virtualization_Environment
@@ -5627,10 +5645,11 @@ msgstr "토요일 "
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "저장"
 
@@ -5683,8 +5702,8 @@ msgstr "선택"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:66
@@ -5706,8 +5725,8 @@ msgid "Serial Console"
 msgstr ""
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "서버"
 
@@ -5885,15 +5904,14 @@ msgstr "종료"
 
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/diskAdd.jsx:167
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "크기"
 
@@ -5971,10 +5989,10 @@ msgstr ""
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:504
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "원본"
 
@@ -5982,10 +6000,10 @@ msgstr "원본"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "소스 경로 "
 
@@ -6027,8 +6045,8 @@ msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "시작"
 
@@ -6065,8 +6083,8 @@ msgid "Startup"
 msgstr ""
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
 #: pkg/systemd/init.js:285
 msgid "State"
@@ -6094,8 +6112,8 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr ""
@@ -6338,8 +6356,8 @@ msgstr ""
 msgid "Target"
 msgstr "대상"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "대상 경로"
 
@@ -6460,8 +6478,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
@@ -6493,8 +6511,7 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1016
@@ -6503,8 +6520,7 @@ msgid ""
 msgstr ""
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/sosreport/index.html:51
@@ -6635,8 +6651,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:58
@@ -6935,18 +6950,17 @@ msgstr ""
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "유형"
 
@@ -7049,10 +7063,11 @@ msgstr "단위"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/lib/machine-info.js:65 pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:139
 #: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
 #: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "알 수 없음"
 
@@ -7267,7 +7282,7 @@ msgstr "사용자 이름"
 msgid "User Password"
 msgstr "사용자 암호 "
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "사용자 이름 "
@@ -7417,7 +7432,7 @@ msgid "Verifying"
 msgstr "확인 중"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "버전"
 
@@ -7425,8 +7440,8 @@ msgstr "버전"
 msgid "Very securely erasing $target"
 msgstr ""
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "가상머신"
@@ -7444,11 +7459,10 @@ msgid "Virtualization Service is Available"
 msgstr "가상화 서비스를 사용할 수 있습니다 "
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "볼륨"
 
@@ -7634,8 +7648,12 @@ msgstr "[바이너리 데이터]"
 msgid "[no data]"
 msgstr "[데이터 없음]"
 
-#: pkg/machines/components/networks/network.jsx:59
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "active"
@@ -7767,8 +7785,8 @@ msgstr "iSCSI 대상 IQN"
 msgid "idle"
 msgstr "유휴상태"
 
-#: pkg/machines/components/networks/network.jsx:59
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "비활성"
 
@@ -7804,9 +7822,9 @@ msgstr "네트워크 "
 msgid "nfs dump target isn't formated as server:path"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "아니요"
@@ -7971,9 +7989,9 @@ msgid ""
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "예 "
@@ -7983,5 +8001,5 @@ msgid ""
 "{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
 "count: {{ condition.generation }}"
 msgstr ""
-"{{ condition.message }}. 타임스탬프: {{ condition.lastTransitionTime }} 오류 수: {{ "
-"condition.generation }}"
+"{{ condition.message }}. 타임스탬프: {{ condition.lastTransitionTime }} 오류 "
+"수: {{ condition.generation }}"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,14 +12,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 04:52+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-06-25 05:34+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Zanata 4.6.2\n"
@@ -140,10 +140,10 @@ msgstr ""
 "należy wyszukać w Menedżerze oprogramowania GNOME lub wykonać polecenie:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 jest obecnie używane"
 
@@ -546,8 +546,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Konta"
 
-#: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Aktywuj"
@@ -584,10 +584,10 @@ msgstr "Adaptacyjne równoważenie obciążenia"
 msgid "Adaptive transmit load balancing"
 msgstr "Adaptacyjne równoważenie obciążenia przesyłu"
 
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Dodaj"
@@ -827,10 +827,10 @@ msgstr "Aplikacje"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Zastosuj"
 
@@ -870,8 +870,8 @@ msgstr "Etykieta zasobu"
 msgid "At least $0 disks are needed."
 msgstr "Wymagane są co najmniej $0 dyski."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Wymagany jest co najmniej jeden dysk."
 
@@ -887,8 +887,8 @@ msgstr "Dziennik audytu"
 msgid "Authenticating"
 msgstr "Uwierzytelnianie"
 
-#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
-#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Uwierzytelnienie"
 
@@ -961,8 +961,8 @@ msgstr "Automatycznie za pomocą NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Automatycznie za pomocą podanych serwerów NTP"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "Automatyczne uruchamianie"
@@ -1144,8 +1144,8 @@ msgstr "Priorytet procesora"
 msgid "CPU usage:"
 msgstr "Użycie procesora:"
 
-#: pkg/machines/components/diskAdd.jsx:246
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr "Pamięć podręczna"
 
@@ -1168,35 +1168,35 @@ msgstr "Nie można wczytać obrazu"
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:560
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:560 pkg/networkmanager/firewall.jsx:628
-#: pkg/networkmanager/firewall.jsx:771 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -1266,10 +1266,10 @@ msgstr "Zmień ograniczenia zasobów"
 msgid "Change the settings"
 msgstr "Zmień ustawienia"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Zmiany zostaną uwzględnione po wyłączeniu maszyny wirtualnej"
 
@@ -1351,15 +1351,16 @@ msgstr ""
 msgid "Client Software"
 msgstr "Oprogramowanie klienta"
 
-#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
-#: pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Zamknij"
 
@@ -1445,15 +1446,15 @@ msgstr "Cockpit nie może skontaktować się z {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit nie może zalogować do {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}Można spróbować {{#sync_link}}synchronizować użytkowników{{/"
-"sync_link}}.{{/can_sync}} Zaktualizowanie cockpit-ws do nowszej wersji "
-"udostępni więcej opcji uwierzytelniania i pomocy w rozwiązywaniu problemów."
+"Cockpit nie może zalogować do {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"Można spróbować {{#sync_link}}synchronizować użytkowników{{/sync_link}}.{{/"
+"can_sync}} Zaktualizowanie cockpit-ws do nowszej wersji udostępni więcej "
+"opcji uwierzytelniania i pomocy w rozwiązywaniu problemów."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1477,8 +1478,8 @@ msgid ""
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
 "Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}. Poniżej "
-"można zmienić dane uwierzytelniające. {{#can_sync}}Można też "
-"{{#sync_link}}synchronizować konta i hasła{{/sync_link}}.{{/can_sync}}"
+"można zmienić dane uwierzytelniające. {{#can_sync}}Można też {{#sync_link}}"
+"synchronizować konta i hasła{{/sync_link}}.{{/can_sync}}"
 
 #: pkg/dashboard/index.html:157 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1548,8 +1549,8 @@ msgstr "Zgodne z nowoczesnymi systemami i dyskami twardymi > 2 TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Kompresowanie zrzutów awarii, aby oszczędzać miejsce"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Kompresja"
 
@@ -1654,9 +1655,9 @@ msgid "Connecting to the machine"
 msgstr "Łączenie z komputerem"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Połączenie"
@@ -1806,9 +1807,9 @@ msgstr "System awarii"
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Utwórz"
 
@@ -1990,7 +1991,7 @@ msgstr "Niestandardowe porty"
 msgid "Custom encryption options"
 msgstr "Niestandardowe opcje szyfrowania"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Niestandardowe opcje montowania"
 
@@ -2035,8 +2036,8 @@ msgstr "Panel kontrolny"
 msgid "Data Used"
 msgstr "Użyte dane"
 
-#: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Dezaktywuj"
@@ -2069,17 +2070,17 @@ msgstr "Opóźnienie"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Usuń"
@@ -2126,14 +2127,13 @@ msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
-msgstr ""
-"Usunięcie urządzenia RAID usunie wszystkie znajdujące się na nim dane."
+msgstr "Usunięcie urządzenia RAID usunie wszystkie znajdujące się na nim dane."
 
 #: pkg/storaged/vdo-details.jsx:200
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Usunięcie urządzenia VDO usunie wszystkie znajdujące się na nim dane."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "Usunięcie kontenera usunie wszystkie znajdujące się w nim dane."
 
@@ -2148,8 +2148,7 @@ msgstr "Usunięcie partycji usunie wszystkie znajdujące się na niej dane."
 
 #: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
-msgstr ""
-"Usunięcie grupy woluminów usunie wszystkie znajdujące się w niej dane."
+msgstr "Usunięcie grupy woluminów usunie wszystkie znajdujące się w niej dane."
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
 msgid ""
@@ -2180,12 +2179,12 @@ msgstr "Odłączalny"
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:745
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Szczegóły"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2275,9 +2274,9 @@ msgstr "Dysk jest OK"
 msgid "Disk passphrase"
 msgstr "Hasło dysku"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Dyski"
 
@@ -2548,9 +2547,9 @@ msgid "Errata:"
 msgstr "Poprawka:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1476
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Błąd"
 
@@ -2654,7 +2653,7 @@ msgstr "Dodanie usługi się nie powiodło"
 msgid "Failed to add zone"
 msgstr "Dodanie strefy się nie powiodło"
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Zmiana hasła się nie powiodła"
 
@@ -2740,7 +2739,7 @@ msgstr "Filtrowanie usług"
 msgid "Filter by name or description..."
 msgstr "Wyszukiwanie według nazwy lub opisu…"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Odcisk"
 
@@ -2785,10 +2784,9 @@ msgstr "Wymuszenie zmiany hasła"
 msgid "Force remove passphrase in $0"
 msgstr "Wymuś usunięcie hasła w $0"
 
-#: pkg/machines/components/diskAdd.jsx:147
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Sformatuj"
 
@@ -2868,11 +2866,11 @@ msgstr "Tworzenie raportu"
 msgid "Get new image"
 msgstr "Pobierz nowy obraz"
 
-#: pkg/machines/components/diskAdd.jsx:186
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
 
@@ -2957,9 +2955,9 @@ msgstr "Czas powitania $hello_time"
 msgid "Hide Performance Options"
 msgstr "Ukryj opcje wydajności"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
 #: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Gospodarz"
@@ -3152,8 +3150,8 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Aby synchronizować użytkowników, należy się zalogować "
-"w {{#strong}}{{host}}{{/strong}}."
+"Aby synchronizować użytkowników, należy się zalogować w {{#strong}}{{host}}"
+"{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
 #: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
@@ -3197,9 +3195,9 @@ msgstr "Inicjator"
 msgid "Initiator IQN should not be empty"
 msgstr "Inicjator IQN nie może być pusty"
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Zainstaluj"
 
@@ -3263,8 +3261,8 @@ msgid "Interface Type"
 msgstr "Typ interfejsu"
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:737 pkg/networkmanager/firewall.jsx:925
-#: pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Interfejsy"
 
@@ -3280,11 +3278,11 @@ msgstr "Wewnętrzny błąd"
 msgid "Invalid address $0"
 msgstr "Nieprawidłowy adres $0"
 
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Nieprawidłowy format daty"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Nieprawidłowy format daty i nieprawidłowy format czasu"
 
@@ -3340,7 +3338,7 @@ msgstr "Nieprawidłowy przedrostek lub maska sieci $0"
 msgid "Invalid range"
 msgstr "Nieprawidłowy zakres"
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Nieprawidłowy format czasu"
 
@@ -3429,8 +3427,7 @@ msgstr "Zrzut jądra"
 
 #: pkg/storaged/crypto-keyslots.jsx:563
 msgid "Key slots with unknown types can not be edited here"
-msgstr ""
-"Nie można modyfikować gniazd na klucze o nieznanym typie w tym miejscu"
+msgstr "Nie można modyfikować gniazd na klucze o nieznanym typie w tym miejscu"
 
 #: pkg/storaged/crypto-keyslots.jsx:202
 msgid "Key source"
@@ -3511,7 +3508,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Pozostawienie pustego pola spowoduje łączenie z tą maszyną jako obecnie "
 "zalogowany użytkownik {{#default_user}}({{default_user}}){{/default_user}}. "
@@ -3578,9 +3574,9 @@ msgstr "Wczytanie dostępnych aktualizacji się nie powiodło"
 msgid "Loading available updates, please wait..."
 msgstr "Wczytywanie dostępnych aktualizacji, proszę czekać…"
 
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Wczytywanie…"
 
@@ -3881,10 +3877,10 @@ msgid "Metadata Used"
 msgstr "Użyte metadane"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
-#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -3954,23 +3950,23 @@ msgstr "Więcej informacji"
 msgid "More details"
 msgstr "Więcej informacji"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Zamontuj"
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Opcje montowania"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Punkt montowania"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Montowanie podczas uruchamiania"
 
@@ -3990,7 +3986,7 @@ msgstr "Punkt montowania nie może być pusty."
 msgid "Mount point must start with \"/\"."
 msgstr "Punkt montowania musi zaczynać się od „/”."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Montowanie tylko do odczytu"
 
@@ -4046,22 +4042,21 @@ msgstr "Serwer NTP"
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Nazwa"
 
@@ -4201,7 +4196,7 @@ msgstr "Nazwa nowego woluminu"
 msgid "New passphrase"
 msgstr "Nowe hasło"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Nie przyjęto nowego hasła"
 
@@ -4327,9 +4322,9 @@ msgstr "Brak dostępnego opisu"
 msgid "No description provided."
 msgstr "Nie podano opisu."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Brak dostępnych dysków."
 
@@ -4434,8 +4429,7 @@ msgstr "Brak uruchomionych kontenerów pasujących do obecnego filtru"
 #: pkg/machines/components/storagePools/storagePoolList.jsx:50
 msgid "No storage pool is defined on this host"
 msgstr ""
-"Na tym gospodarzu nie określono żadnej puli urządzeń do przechowywania "
-"danych"
+"Na tym gospodarzu nie określono żadnej puli urządzeń do przechowywania danych"
 
 #: pkg/storaged/mdraids-panel.jsx:130
 msgid "No storage set up as RAID"
@@ -4466,8 +4460,8 @@ msgid "No volume groups created"
 msgstr "Nie utworzono grup woluminów"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:734
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Brak"
 
@@ -4567,7 +4561,7 @@ msgstr "Poprzednie hasło"
 msgid "Old passphrase"
 msgstr "Poprzednie hasło"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Nie przyjęto poprzedniego hasła"
 
@@ -4682,9 +4676,9 @@ msgstr "Inne urządzenia"
 msgid "Other Options"
 msgstr "Inne opcje"
 
-#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Przegląd"
 
@@ -4764,10 +4758,10 @@ msgstr "Usunięcie hasła może uniemożliwić odblokowanie $0."
 msgid "Passphrases do not match"
 msgstr "Hasła się nie zgadzają"
 
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "Hasło"
@@ -4871,8 +4865,8 @@ msgstr "Odmowa dostępu"
 msgid "Persistence"
 msgstr "Trwałość"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr "Trwałe"
 
@@ -4916,9 +4910,9 @@ msgstr "Cel pingu"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Proszę potwierdzić usunięcie $0"
@@ -4927,7 +4921,7 @@ msgstr "Proszę potwierdzić usunięcie $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Proszę potwierdzić wymuszenie usunięcia $0"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Proszę potwierdzić zatrzymanie $0"
 
@@ -4953,8 +4947,7 @@ msgstr "Proszę podać komputer, z którym się połączyć"
 
 #: pkg/machines/components/consoles.jsx:38
 msgid "Please start the virtual machine to access its console."
-msgstr ""
-"Proszę uruchomić maszynę wirtualną, aby uzyskać dostęp do jej konsoli."
+msgstr "Proszę uruchomić maszynę wirtualną, aby uzyskać dostęp do jej konsoli."
 
 #: pkg/docker/search.js:148
 msgid "Please try another term"
@@ -4964,11 +4957,10 @@ msgstr "Proszę spróbować innego terminu"
 msgid "Plug"
 msgstr "Podłącz"
 
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Pula"
 
@@ -5124,7 +5116,7 @@ msgstr "Wysyła ponowne wczytanie do"
 msgid "Protocol"
 msgstr "Protokół"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Klucz publiczny"
 
@@ -5204,7 +5196,7 @@ msgstr "Obudowa RAID"
 msgid "RAID Device"
 msgstr "Urządzenie RAID"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "Urządzenie RAID $0"
 
@@ -5373,9 +5365,9 @@ msgstr "Dysk wymienny"
 msgid "Removals:"
 msgstr "Usuwane:"
 
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Usuń"
 
@@ -5562,8 +5554,8 @@ msgstr ""
 
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Uruchom ponownie"
 
@@ -5604,8 +5596,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Użycie istniejącego hasła do zadań wymagających uprawnień"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Użycie istniejącego hasła do zadań wymagających uprawnień i łączenia "
 "z innymi komputerami"
@@ -5728,10 +5719,11 @@ msgstr "sobota"
 msgid "Saturdays"
 msgstr "soboty"
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Zapisz"
 
@@ -5787,11 +5779,10 @@ msgstr "Wybierz"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Proszę wybrać użytkowników do synchronizacji z {{#strong}}{{host}}{{/"
-"strong}}"
+"Proszę wybrać użytkowników do synchronizacji z {{#strong}}{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
@@ -5811,8 +5802,8 @@ msgstr "Wysyłanie"
 msgid "Serial Console"
 msgstr "Konsola szeregowa"
 
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Serwer"
 
@@ -5988,15 +5979,14 @@ msgstr "Wyłącz"
 
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/diskAdd.jsx:167
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Rozmiar"
 
@@ -6076,10 +6066,10 @@ msgstr "Inny program obecnie używa menedżera pakietów, proszę czekać…"
 msgid "Sorted from least trusted to most trusted"
 msgstr "Uporządkowane od najmniej do najbardziej zaufanych"
 
-#: pkg/machines/components/diskAdd.jsx:504
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Źródło"
 
@@ -6087,10 +6077,10 @@ msgstr "Źródło"
 msgid "Source Format"
 msgstr "Format źródłowy"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Ścieżka źródłowa"
 
@@ -6132,8 +6122,8 @@ msgid "Stable"
 msgstr "Stabilna"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Rozpocznij"
 
@@ -6170,8 +6160,8 @@ msgid "Startup"
 msgstr "Uruchamianie"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
 #: pkg/systemd/init.js:285
 msgid "State"
@@ -6198,8 +6188,8 @@ msgid "Sticky"
 msgstr "Lepkie"
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Zatrzymaj"
@@ -6448,8 +6438,8 @@ msgstr "Serwer kluczy Tang"
 msgid "Target"
 msgstr "Cel"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Ścieżka docelowa"
 
@@ -6576,8 +6566,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Nie można ustalić autentyczności komputera {{#strong}}{{host}}{{/strong}}. "
 "Na pewno kontynuować łączenie?"
@@ -6590,7 +6580,6 @@ msgstr "Zebrane informacje będą przechowywane lokalnie w systemie."
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 "Nieznany stan konfiguracji, może zostać zmieniony po następnych uruchomieniu."
-""
 
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
@@ -6619,8 +6608,7 @@ msgstr ""
 "Kontynuacja je zatrzyma."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "System plików jest używany przez sesje logowania. Kontynuacja je zatrzyma."
 
@@ -6631,8 +6619,7 @@ msgstr ""
 "System plików jest używany przez usługi systemowe. Kontynuacja je zatrzyma."
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "Poniższe kontenery zależą od tego obrazu i nie będzie już można ich używać."
 
@@ -6757,8 +6744,7 @@ msgstr ""
 
 #: pkg/networkmanager/interfaces.js:1516
 msgid "The user <b>$0</b> is not permitted to modify network settings"
-msgstr ""
-"Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie ustawień sieci"
+msgstr "Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie ustawień sieci"
 
 #: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
@@ -6785,8 +6771,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "Konfiguracja przeglądarki uniemożliwia działanie programu Cockpit ($0 jest "
 "niedostępne)"
@@ -7114,18 +7099,17 @@ msgstr "tuned nie jest uruchomione"
 msgid "Tuned is off"
 msgstr "tuned jest wyłączone"
 
-#: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Typ"
 
@@ -7227,10 +7211,11 @@ msgstr "Jednostka"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/lib/machine-info.js:65 pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:139
 #: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
 #: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Nieznane"
 
@@ -7443,7 +7428,7 @@ msgstr "Nazwa użytkownika"
 msgid "User Password"
 msgstr "Hasło użytkownika"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nazwa użytkownika"
@@ -7593,7 +7578,7 @@ msgid "Verifying"
 msgstr "Sprawdzanie poprawności"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Wersja"
 
@@ -7601,8 +7586,8 @@ msgstr "Wersja"
 msgid "Very securely erasing $target"
 msgstr "Bardzo bezpieczne usuwanie zawartości $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Maszyny wirtualne"
@@ -7620,11 +7605,10 @@ msgid "Virtualization Service is Available"
 msgstr "Usługa wirtualizacji jest dostępna"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Wolumin"
 
@@ -7822,8 +7806,12 @@ msgstr "[dane binarne]"
 msgid "[no data]"
 msgstr "[brak danych]"
 
-#: pkg/machines/components/networks/network.jsx:59
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "aktywne"
@@ -7953,8 +7941,8 @@ msgstr "IQN celu iSCSI"
 msgid "idle"
 msgstr "bezczynne"
 
-#: pkg/machines/components/networks/network.jsx:59
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "nieaktywne"
 
@@ -7990,9 +7978,9 @@ msgstr "sieć"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "cel zrzutu NFS nie jest sformatowany jako serwer:ścieżka"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "nie"
@@ -8157,9 +8145,9 @@ msgid ""
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "tak"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,14 +15,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-25 16:06+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-02-05 07:01+0000\n"
 "Last-Translator: Leonardo Bressan Motyczka <leomoty@gmail.com>\n"
 "Language-Team: Portuguese (Brazil)\n"
 "Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -30,19 +30,15 @@ msgstr ""
 msgid " (shared with the OS)"
 msgstr "(compartilhado com o SO)"
 
-#: pkg/kubernetes/views/node-delete.html:8
-msgid " 1\"Do you want to delete the following Nodes?"
-msgstr "1 \"Deseja excluir os seguintes nós?"
-
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0 Dispositivos de Bloco"
 
-#: pkg/storaged/mdraid-details.jsx:193
+#: pkg/storaged/mdraid-details.jsx:192
 msgid "$0 Chunk Size"
 msgstr "$0 Tamanho do Bloco"
 
-#: pkg/storaged/mdraid-details.jsx:191
+#: pkg/storaged/mdraid-details.jsx:190
 msgid "$0 Disks"
 msgstr "$0 Discos"
 
@@ -91,16 +87,16 @@ msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 dados + $1 sobrecarga usada de $2 ($3)"
 
 #: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:213
+#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 disco não encontrado"
 msgstr[1] "$0 discos não encontrados"
 
 #: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:34
-#: pkg/playground/translate.js:37
+#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
@@ -140,10 +136,10 @@ msgstr ""
 "lo, procure-o no GNOME Software ou execute o seguinte:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:237
-#: pkg/storaged/mdraid-details.jsx:290 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:203
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 está ativo e em uso"
 
@@ -183,27 +179,11 @@ msgstr[1] "$0 atualizações"
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 usados of $1 ($2 salvos)"
 
-#: pkg/ovirt/components/vcpuModal.jsx:98
-msgid "$0 vCPU Details"
-msgstr "$0 vCPU Detalhes"
-
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "$0 será instalado."
 
-#: pkg/kubernetes/scripts/nodes.js:871
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0% Livre"
-msgstr[1] "$0% Livres"
-
-#: pkg/kubernetes/scripts/nodes.js:873
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0% Usado"
-msgstr[1] "$0% Usados"
-
-#: pkg/storaged/vgroup-details.jsx:118
+#: pkg/storaged/vgroup-details.jsx:117
 msgid "$0, $1 free"
 msgstr "$0, $1 livre"
 
@@ -229,19 +209,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/subscriptions/subscriptions-client.js:197
-msgid "'Organization' required to register."
-msgstr "'Organização' necessária para se registar."
-
-#: pkg/subscriptions/subscriptions-client.js:201
-msgid "'Organization' required when using activation keys."
-msgstr "'Organização' necessária ao usar chaves de ativação."
-
-#: pkg/networkmanager/firewall.jsx:547
+#: pkg/networkmanager/firewall.jsx:549
 msgid "(Optional)"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:616
+#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(padrão)"
@@ -535,12 +507,8 @@ msgstr "ARP Monitoramento"
 msgid "ARP Ping"
 msgstr "ARP Ping"
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "AWS Loja de Blocos Elásticos"
-
 #: pkg/shell/index.html:56 pkg/shell/index.html:82 pkg/shell/simple.html:42
-#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
+#: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Sobre o Cockpit"
 
@@ -548,19 +516,9 @@ msgstr "Sobre o Cockpit"
 msgid "Access"
 msgstr "Acesso"
 
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
-msgid "Access Modes"
-msgstr "Modos de Acesso"
-
-#: pkg/kubernetes/views/project-modify.html:49
 #: node_modules/registry-image-widgets/views/imagestream-body.html:12
 msgid "Access Policy"
 msgstr "Política de Acesso"
-
-#: pkg/subscriptions/subscriptions-view.jsx:213
-msgid "Access denied"
-msgstr "Acesso negado"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -578,18 +536,13 @@ msgstr "Conta não disponível ou não pode ser editada."
 msgid "Accounts"
 msgstr "Contas"
 
-#: pkg/users/local.js:335 pkg/users/local.js:642
+#: pkg/users/local.js:339 pkg/users/local.js:646
 msgctxt "page-title"
 msgid "Accounts"
 msgstr "Contas"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:183
-msgid "Action"
-msgstr "Ação"
-
-#: pkg/machines/components/networks/network.jsx:147
-#: pkg/machines/components/storagePools/storagePool.jsx:167
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Ativar"
@@ -597,10 +550,6 @@ msgstr "Ativar"
 #: pkg/storaged/jobs-panel.jsx:68
 msgid "Activating $target"
 msgstr "Ativando $target"
-
-#: pkg/subscriptions/subscriptions-register.jsx:168
-msgid "Activation Key"
-msgstr "Chave de Ativação"
 
 #: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
 msgid "Active"
@@ -610,7 +559,7 @@ msgstr "Ativo"
 msgid "Active Backup"
 msgstr "Backup Ativo"
 
-#: pkg/shell/index.html:59 pkg/shell/stub.html:49 pkg/shell/active-pages.js:95
+#: pkg/shell/index.html:59 pkg/shell/active-pages.js:95
 msgid "Active Pages"
 msgstr "Páginas Ativas"
 
@@ -618,13 +567,9 @@ msgstr "Páginas Ativas"
 msgid "Active since"
 msgstr "Ativo desde"
 
-#: pkg/networkmanager/firewall.jsx:922
+#: pkg/networkmanager/firewall.jsx:924
 msgid "Active zones"
 msgstr ""
-
-#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
-msgid "Actual"
-msgstr "Atual"
 
 #: pkg/networkmanager/interfaces.js:1980
 msgid "Adaptive load balancing"
@@ -634,16 +579,11 @@ msgstr "Balanceamento de carga dinâmico"
 msgid "Adaptive transmit load balancing"
 msgstr "Transmissão dinâmica de balanceamento de carga"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/add-role-dialog.html:8
-#: pkg/kubernetes/views/add-user-dialog.html:27
-#: pkg/kubernetes/views/node-add.html:50
-#: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:534
-#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/vgroup-details.jsx:63
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Adicionar"
 
@@ -663,11 +603,7 @@ msgstr "Adicionar Vínculo"
 msgid "Add Bridge"
 msgstr "Adicionar Ponte"
 
-#: pkg/kubernetes/views/node-add.html:3
-msgid "Add Cluster Node"
-msgstr "Adicionar Nó de Cluster"
-
-#: pkg/machines/components/diskAdd.jsx:356
+#: pkg/machines/components/diskAdd.jsx:360
 msgid "Add Disk"
 msgstr "Adicionar disco"
 
@@ -675,55 +611,20 @@ msgstr "Adicionar disco"
 msgid "Add Disks"
 msgstr "Adicionar Discos"
 
-#: pkg/kubernetes/views/add-group-dialog.html:3
-msgid "Add Group"
-msgstr "Adicionar Grupo"
-
 #: pkg/storaged/crypto-keyslots.jsx:200
 msgid "Add Key"
 msgstr "Adicionar chave"
-
-#: pkg/kubernetes/views/nodes-page.html:34
-msgid "Add Kubernetes Node"
-msgstr "Adicionar Nó Kubernetes"
 
 #: pkg/lib/machine-add.html:4
 msgid "Add Machine to Dashboard"
 msgstr "Adicionar Máquina ao Painel"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:4
-#: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/group-panel.html:29
-#: pkg/kubernetes/views/project-body.html:108
-#: pkg/kubernetes/views/user-group-add.html:3
-msgid "Add Member"
-msgstr "Adicionar Membro"
-
-#: pkg/kubernetes/views/user-body.html:67
-#: pkg/kubernetes/views/user-panel.html:76
-msgid "Add Membership"
-msgstr "Adicionar Associação"
-
-#: pkg/kubernetes/views/auth-form.html:11
-#: pkg/kubernetes/views/auth-form.html:20
-msgid "Add New Cluster"
-msgstr "Adicionar Novo Cluster"
-
-#: pkg/kubernetes/views/auth-form.html:67
-#: pkg/kubernetes/views/auth-form.html:76
-msgid "Add New User"
-msgstr "Adicionar Novo Usuário"
-
 #: pkg/networkmanager/firewall.jsx:457
 msgid "Add Ports"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html:3
-msgid "Add Role"
-msgstr "Adicionar Função"
-
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:872
-#: pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
+#: pkg/networkmanager/firewall.jsx:886
 msgid "Add Services"
 msgstr "Adicionar serviços"
 
@@ -735,17 +636,12 @@ msgstr "Adicionar Armazenamento"
 msgid "Add Team"
 msgstr "Adicionar Equipe"
 
-#: pkg/kubernetes/views/add-user-dialog.html:3
-#: pkg/kubernetes/views/project-listing.html:83
-msgid "Add User"
-msgstr "Adicionar Usuário"
-
 #: pkg/networkmanager/index.html:113
 msgid "Add VLAN"
 msgstr "Adicionar VLAN"
 
-#: pkg/networkmanager/firewall.jsx:698 pkg/networkmanager/firewall.jsx:878
-#: pkg/networkmanager/firewall.jsx:889
+#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
+#: pkg/networkmanager/firewall.jsx:891
 msgid "Add Zone"
 msgstr ""
 
@@ -756,10 +652,6 @@ msgstr "Adicionar Portal iSCSI"
 #: pkg/shell/index.html:172 pkg/users/index.html:414
 msgid "Add key"
 msgstr "Adicionar chave"
-
-#: pkg/kubernetes/views/user-add-membership.html:3
-msgid "Add membership"
-msgstr "Adicionar associação"
 
 #: pkg/networkmanager/firewall.jsx:458
 msgid "Add ports to the following zones:"
@@ -773,7 +665,7 @@ msgstr "Adicionar chave pública"
 msgid "Add services to following zones:"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:774
+#: pkg/networkmanager/firewall.jsx:776
 msgid "Add zone"
 msgstr ""
 
@@ -805,7 +697,7 @@ msgstr "DNS Adicional $val"
 msgid "Additional DNS Search Domains $val"
 msgstr "Domínios de Pesquisa de DNS Adicionais $val"
 
-#: pkg/docker/index.html:307
+#: pkg/docker/index.html:309
 msgid "Additional Storage"
 msgstr "Armazenamento Adicional"
 
@@ -817,14 +709,11 @@ msgstr "Endereço adicional $val"
 msgid "Additional packages:"
 msgstr "Pacotes adicionais:"
 
-#: pkg/kubernetes/views/auth-form.html:29
-#: pkg/kubernetes/views/dashboard-page.html:157
-#: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
+#: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:77 pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:107
+#: pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Endereço"
 
@@ -841,44 +730,18 @@ msgid "Address is not a valid URL"
 msgstr "O endereço não é um URL válido"
 
 #: pkg/machines/components/desktopConsole.jsx:153
-#: pkg/ovirt/components/VmOverviewColumn.jsx:53
 msgid "Address:"
 msgstr "Endereço:"
 
-#: pkg/kubernetes/views/details-page.html:37
 #: pkg/networkmanager/interfaces.js:3309
 msgid "Addresses"
 msgstr "Endereços"
-
-#: pkg/kubernetes/views/service-modify.html:25
-msgid "Adjust"
-msgstr "Ajustar"
-
-#: pkg/kubernetes/views/pv-modify.html:3
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "Ajustar Volume Persistente '{{ item.metadata.name }}'"
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html:3
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "Ajustar o Controlador de Replicação {{ item.metadata.name }}"
-
-#: pkg/kubernetes/views/route-modify.html:3
-msgid "Adjust Route"
-msgstr "Ajustar Rota"
-
-#: pkg/kubernetes/views/service-modify.html:3
-msgid "Adjust Service"
-msgstr "Ajuste de serviço"
-
-#: pkg/kubernetes/views/project-body.html:56
-msgid "Admin"
-msgstr "Admin"
 
 #: org.cockpit-project.cockpit-bridge.policy.in.h:1
 msgid "Administration with Cockpit Web Console"
 msgstr ""
 
-#: pkg/realmd/operation.js:336
+#: pkg/realmd/operation.js:335
 msgid "Administrator Password"
 msgstr "Senha de Administrador"
 
@@ -914,14 +777,6 @@ msgstr "Todos"
 msgid "All In One"
 msgstr "Tudo em um"
 
-#: pkg/kubernetes/views/filter-project.html:4
-msgid "All Projects"
-msgstr "Todos os Projetos"
-
-#: pkg/kubernetes/views/details-page.html:6
-msgid "All Types"
-msgstr "Todos os Tipos"
-
 #: pkg/docker/storage.jsx:381
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
@@ -930,35 +785,15 @@ msgstr ""
 "Todos os dados em discos selecionados serão apagados e os discos serão "
 "adicionados ao pool de armazenamento."
 
-#: pkg/kubernetes/views/dashboard-page.html:112
-msgid "All healthy"
-msgstr "Tudo saudável"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:74
-msgid "All images"
-msgstr "Todas as imagens"
-
-#: pkg/kubernetes/views/dashboard-page.html:69
-msgid "All in use"
-msgstr "Tudo em uso"
-
-#: pkg/kubernetes/views/dashboard-page.html:37
-msgid "All running"
-msgstr "Tudo executando"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:36
-msgid "All running virtual machines will be turned off."
-msgstr "Todas as máquinas virtuais em execução serão desativadas."
-
-#: pkg/networkmanager/firewall.jsx:749
+#: pkg/networkmanager/firewall.jsx:751
 msgid "Allowed Addresses"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:935
+#: pkg/networkmanager/firewall.jsx:937
 msgid "Allowed Services"
 msgstr "Serviços Permitidos"
 
-#: pkg/docker/index.html:548 pkg/docker/util.js:108
+#: pkg/docker/index.html:550 pkg/docker/util.js:108
 msgid "Always"
 msgstr "Sempre"
 
@@ -966,18 +801,11 @@ msgstr "Sempre"
 msgid "Always attach"
 msgstr "Sempre anexar"
 
-#: pkg/kubernetes/views/node-body.html:57
-#: pkg/kubernetes/views/route-body.html:27
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Anotações"
 
-#: pkg/kubernetes/scripts/projects.js:1044
-msgid "Anonymous: Allow all unauthenticated users to pull images"
-msgstr ""
-"Anônimo: permitir que todos os usuários não autenticados baixem imagens"
-
-#: pkg/systemd/terminal.jsx:94
+#: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr ""
 
@@ -990,11 +818,10 @@ msgstr "Aplicações"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235
-#: pkg/ovirt/components/vcpuModal.jsx:104 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -1023,7 +850,6 @@ msgid "Applying updates failed"
 msgstr "A aplicação de atualizações falhou"
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
-#: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Architecture"
 msgstr "Arquitetura"
 
@@ -1035,8 +861,8 @@ msgstr "Tag do Recurso"
 msgid "At least $0 disks are needed."
 msgstr "Pelo menos $0 discos são necessários."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Pelo menos um disco é necessário."
 
@@ -1052,9 +878,8 @@ msgstr "Log de auditoria"
 msgid "Authenticating"
 msgstr "Autenticando"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
 #: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Autenticação"
 
@@ -1082,7 +907,7 @@ msgstr ""
 msgid "Authentication required"
 msgstr "Autenticação requerida"
 
-#: pkg/docker/index.html:700
+#: pkg/docker/index.html:702
 #: node_modules/registry-image-widgets/views/image-body.html:12
 #: pkg/docker/containers-view.jsx:413
 msgid "Author"
@@ -1095,7 +920,7 @@ msgstr "Chaves Públicas Autorizadas de SSH"
 #: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
 #: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
 #: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:339
+#: pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automático"
 
@@ -1115,10 +940,6 @@ msgstr ""
 msgid "Automatic Updates"
 msgstr "Atualizações automáticas"
 
-#: pkg/ovirt/components/OVirtTab.jsx:81
-msgid "Automatically selected host"
-msgstr "Host selecionado automaticamente"
-
 #: pkg/machines/components/libvirtSlate.jsx:90
 msgid "Automatically start libvirt on boot"
 msgstr "Iniciar automaticamente a libvirt na inicialização"
@@ -1131,9 +952,9 @@ msgstr "Usando automaticamente o NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Usando automaticamente servidores NTP específicos"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:155
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
 
@@ -1154,10 +975,6 @@ msgstr "Alvos disponíveis em $0"
 #: pkg/dashboard/index.html:163
 msgid "Avatar"
 msgstr "Avatar"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
 
 #: pkg/systemd/hwinfo.jsx:92
 msgid "BIOS"
@@ -1186,18 +1003,6 @@ msgstr "Dados corrompidos passaram por passwd1 mecanismo"
 #: pkg/networkmanager/index.html:333
 msgid "Balancer"
 msgstr "Balanceador"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-msgid "Base Template"
-msgstr "Modelo base"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Base template"
-msgstr "Modelo base"
-
-#: pkg/ovirt/components/OVirtTab.jsx:106 pkg/ovirt/components/OVirtTab.jsx:113
-msgid "Base template:"
-msgstr "Modelo base:"
 
 #: pkg/systemd/init.js:729
 msgid "Before"
@@ -1240,12 +1045,8 @@ msgstr "Bond"
 msgid "Bond Settings"
 msgstr "Configurações de Vínculo"
 
-#: pkg/kubernetes/views/node-body.html:17
-msgid "Boot ID"
-msgstr "ID de Boot"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:312
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:153
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:164
 msgid "Boot Order"
 msgstr ""
 
@@ -1304,10 +1105,8 @@ msgstr "Bus"
 msgid "Bus Expansion Chassis"
 msgstr "Chassi de Expansão de Barramento"
 
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:270
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:603
-#: pkg/kubernetes/scripts/nodes.js:711 pkg/kubernetes/scripts/nodes.js:818
-#: pkg/systemd/hwinfo.jsx:108
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:272
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
 msgid "CPU"
 msgstr "CPU"
 
@@ -1324,28 +1123,20 @@ msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Status da CPU"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:154
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:165
 msgid "CPU Type"
 msgstr "Tipo da CPU"
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "Utilização da CPU: $0%"
-
-#: pkg/docker/index.html:469 pkg/docker/index.html:641
+#: pkg/docker/index.html:471 pkg/docker/index.html:643
 msgid "CPU priority"
 msgstr "Prioridade de CPU"
 
-#: pkg/docker/index.html:217
+#: pkg/docker/index.html:218
 msgid "CPU usage:"
 msgstr "Uso da CPU:"
 
-#: pkg/ovirt/provider.js:256
-msgid "CREATE VM action failed"
-msgstr "A ação CRiar VM falhou"
-
-#: pkg/machines/components/diskAdd.jsx:235
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
@@ -1365,79 +1156,44 @@ msgstr "Não é possível excluir enquanto desbloqueado"
 msgid "Can't load image"
 msgstr "Não é possível carregar a imagem"
 
-#: pkg/dashboard/index.html:175 pkg/docker/index.html:563
-#: pkg/docker/index.html:597 pkg/docker/index.html:661
-#: pkg/docker/index.html:715 pkg/docker/index.html:755
-#: pkg/docker/index.html:784 pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/add-role-dialog.html:7
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/image-delete.html:7
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/user-group-add.html:29
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
-#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:477 pkg/networkmanager/index.html:501
-#: pkg/networkmanager/index.html:525 pkg/networkmanager/index.html:549
-#: pkg/networkmanager/index.html:573 pkg/networkmanager/index.html:597
-#: pkg/networkmanager/index.html:621 pkg/networkmanager/index.html:645
-#: pkg/networkmanager/index.html:669 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:81 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/systemd/index.html:332
+#: pkg/dashboard/index.html:175 pkg/docker/index.html:565
+#: pkg/docker/index.html:599 pkg/docker/index.html:663
+#: pkg/docker/index.html:717 pkg/docker/index.html:757
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
+#: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
+#: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
+#: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:85
-#: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:649
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:531
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:485
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:558 pkg/networkmanager/firewall.jsx:626
-#: pkg/networkmanager/firewall.jsx:769
-#: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:415
 msgid "Cannot connect to an unknown machine"
 msgstr "Não pode conectar a uma máquina desconhecida"
-
-#: src/ws/cockpitcertificate.c:483
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "Não é possível decifrar a chave privada codificado em PEM"
 
 #: src/base1/cockpit.js:4031
 msgid "Cannot forward login credentials"
@@ -1447,8 +1203,6 @@ msgstr "Não é possível prosseguir com as credenciais de login"
 msgid "Cannot schedule event in the past"
 msgstr "Não é possível agendar eventos no passado"
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
 #: pkg/machines/components/vmDisksTab.jsx:70
 msgid "Capacity"
 msgstr "Capacidade"
@@ -1457,18 +1211,7 @@ msgstr "Capacidade"
 msgid "Carrier"
 msgstr "Sinal"
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Sistema de Arquivos de Montagem Ceph"
-
-#: pkg/kubernetes/views/volume-body.html:97
-msgid "Ceph Monitors"
-msgstr "Monitores Ceph"
-
-#: pkg/docker/index.html:662 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
-#: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:333
+#: pkg/docker/index.html:664 pkg/systemd/index.html:333
 #: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
 #: pkg/storaged/iscsi-panel.jsx:181
 msgid "Change"
@@ -1494,31 +1237,19 @@ msgstr "Alterar o perfil"
 msgid "Change System Time"
 msgstr "Alterar Horário do Sistema"
 
-#: pkg/kubernetes/views/user-modify.html:3
-msgid "Change User"
-msgstr "Alterar Usuário"
-
 #: pkg/storaged/iscsi-panel.jsx:176
 msgid "Change iSCSI Initiator Name"
 msgstr "Alterar Nome do Iniciador iSCSI"
-
-#: pkg/kubernetes/views/imagestream-modify.html:4
-msgid "Change image stream"
-msgstr "Alterar stream de imagem"
 
 #: pkg/storaged/crypto-keyslots.jsx:247
 msgid "Change passphrase"
 msgstr "Alterar senha"
 
-#: pkg/kubernetes/views/project-modify.html:10
-msgid "Change project"
-msgstr "Alterar projeto"
-
-#: pkg/docker/index.html:228
+#: pkg/docker/index.html:229
 msgid "Change resource limits"
 msgstr "Alterar limites de recursos"
 
-#: pkg/docker/index.html:612
+#: pkg/docker/index.html:614
 msgid "Change resources limits"
 msgstr "Alterar limites de recursos"
 
@@ -1526,10 +1257,10 @@ msgstr "Alterar limites de recursos"
 msgid "Change the settings"
 msgstr "Alterar as configurações"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "As alterações entrarão em vigor após o desligamento da VM"
 
@@ -1577,25 +1308,13 @@ msgstr "Verificando atualizações ..."
 msgid "Checking installed software"
 msgstr "Verificando o software instalado"
 
-#: pkg/shell/index.html:117 pkg/shell/simple.html:85 pkg/shell/stub.html:100
+#: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "Escolha o idioma a ser usado no aplicativo"
 
 #: pkg/storaged/mdraids-panel.jsx:57
 msgid "Chunk Size"
 msgstr "Tamanho do Bloco"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinzas"
-
-#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
-msgid "Claim"
-msgstr "Reivindicar"
-
-#: pkg/kubernetes/views/pvc-body.html:4
-msgid "Claim Name"
-msgstr "Nome da reivindicação"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Class"
@@ -1620,42 +1339,26 @@ msgstr ""
 "Clicar em \"Iniciar Visualizador Remoto\" fará o download de um arquivo .vv "
 "e será iniciado $0."
 
-#: pkg/kubernetes/views/auth-form.html:88
-msgid "Client Certificate"
-msgstr "Certificado de Cliente"
-
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:736 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/systemd/index.html:278
-#: pkg/systemd/services.html:363 pkg/systemd/services.html:381
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:107 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:126 pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Fechar"
 
 #: pkg/shell/active-pages.js:103
 msgid "Close Selected Pages"
 msgstr "Fechar Páginas Selecionadas"
-
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
-#: pkg/ovirt/components/App.jsx:107
-msgid "Cluster"
-msgstr "Cluster"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:128
-msgid "Cluster Templates"
-msgstr "Modelos de Cluster"
-
-#: pkg/ovirt/components/ClusterVms.jsx:174
-msgid "Cluster Virtual Machines"
-msgstr "Máquinas Virtuais de Cluster"
 
 #: src/ws/login.js:346
 msgid "Cockpit authentication is configured incorrectly."
@@ -1698,10 +1401,9 @@ msgstr ""
 "finalizado pelo Terminal. Da mesma forma, se um erro ocorrer no terminal, "
 "este pode ser detectado via interface do Cockpit."
 
-#: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
+#: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
-msgstr ""
-"Cockpit é uma interface interativa de administração de servidor Linux."
+msgstr "Cockpit é uma interface interativa de administração de servidor Linux."
 
 #: src/base1/cockpit.js:4035
 msgid "Cockpit is not compatible with the software on the system."
@@ -1736,10 +1438,10 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 "O Cockpit não pôde fazer login no {{#strong}}{{host}}{{/strong}}. "
 "{{#can_sync}}Talvez você queira tentar {{#sync_link}}sincronizar usuários{{/"
@@ -1786,12 +1488,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Uso combinado de núcleo de CPU de $0"
 msgstr[1] "Uso combinado de núcleos de CPU de $0 CPU"
 
-#: pkg/networkmanager/firewall.jsx:527
+#: pkg/networkmanager/firewall.jsx:529
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
-#: pkg/docker/index.html:269 pkg/docker/index.html:445
-#: pkg/docker/index.html:706 pkg/systemd/services.html:427
+#: pkg/docker/index.html:271 pkg/docker/index.html:447
+#: pkg/docker/index.html:708 pkg/systemd/services.html:427
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1802,7 +1504,7 @@ msgstr "Comando"
 msgid "Command can't be empty"
 msgstr "O comando não pode estar vazio"
 
-#: pkg/docker/index.html:163
+#: pkg/docker/index.html:164
 msgid "Command:"
 msgstr "Comando:"
 
@@ -1810,12 +1512,12 @@ msgstr "Comando:"
 msgid "Comment"
 msgstr "Comentário"
 
-#: pkg/docker/index.html:137 pkg/docker/index.html:716
+#: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
 msgstr "Commit"
 
-#: pkg/docker/index.html:676
+#: pkg/docker/index.html:678
 msgid "Commit Image"
 msgstr "Imagem Commit "
 
@@ -1839,8 +1541,8 @@ msgstr "Compatível com sistema moderno e discos rígidos > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Comprimir despejos de travamento para economizar espaço"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Compressão"
 
@@ -1856,21 +1558,9 @@ msgstr "Condição $0=$1 não foi cumprida"
 msgid "Condition failed"
 msgstr "Condição falhou"
 
-#: pkg/kubernetes/views/node-add.html:24
-msgid "Configuration"
-msgstr "Configuração"
-
 #: pkg/networkmanager/interfaces.js:2725
 msgid "Configure"
 msgstr "Configurar"
-
-#: pkg/kubernetes/views/node-add.html:42
-msgid "Configure Flannel networking"
-msgstr "Configurar rede de Flanela"
-
-#: pkg/kubernetes/views/node-add.html:32
-msgid "Configure Kubelet and Proxy"
-msgstr "Configurar Kubelet e o Proxy"
 
 #: pkg/docker/storage.jsx:331
 msgid "Configure storage..."
@@ -1893,21 +1583,13 @@ msgstr "Confirmar"
 msgid "Confirm New Password"
 msgstr "Confirmar Nova Senha"
 
-#: pkg/ovirt/components/OVirtTab.jsx:65
-msgid "Confirm migration"
-msgstr "Confirme a migração"
-
-#: pkg/ovirt/components/VdsmView.jsx:95
-msgid "Confirm reload:"
-msgstr "Confirme o recarregamento:"
+#: pkg/machines/components/networks/networkDelete.jsx:95
+msgid "Confirm deletion of the Virtual Network"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Confirm removal with passphrase"
 msgstr "Confirme a remoção com a frase secreta"
-
-#: pkg/ovirt/components/VdsmView.jsx:108
-msgid "Confirm save:"
-msgstr "Confirme salve:"
 
 #: pkg/systemd/init.js:728
 msgid "Conflicted By"
@@ -1917,8 +1599,6 @@ msgstr "Conflito por"
 msgid "Conflicts"
 msgstr "Conflitos"
 
-#: pkg/kubernetes/views/auth-form.html:130
-#: pkg/kubernetes/views/auth-rejected-cert.html:33
 #: pkg/lib/machine-unknown-hostkey.html:22
 msgid "Connect"
 msgstr "Conectar"
@@ -1930,10 +1610,6 @@ msgstr "Conecte automaticamente"
 #: src/ws/login.html:74
 msgid "Connect to"
 msgstr "Conectar à"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:102
-msgid "Connect to oVirt Engine"
-msgstr "Conecte-se ao motor do ivirt"
 
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "Connect with any $0 viewer application."
@@ -1966,33 +1642,21 @@ msgstr "Conectando-se ao daemon SETroubleshoot..."
 msgid "Connecting to Virtualization Service"
 msgstr "Conectando-se ao serviço de virtualização"
 
-#: pkg/shell/indexes.js:411
+#: pkg/shell/indexes.js:410
 msgid "Connecting to the machine"
 msgstr "Conectando a máquina"
 
-#: pkg/kubernetes/index.html:104 pkg/kubernetes/registry.html:71
-msgid "Connecting..."
-msgstr "Conectando..."
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:568
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Conexão"
 
-#: pkg/kubernetes/views/auth-dialog.html:4 pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:406
 msgid "Connection Error"
 msgstr "Erro de Conexão"
-
-#: pkg/kubernetes/scripts/connection.js:512
-msgid "Connection Error: $0"
-msgstr "Erro de Conexão: $0"
-
-#: pkg/kubernetes/views/auth-dialog.html:3
-msgid "Connection Settings"
-msgstr "Configurações de Conexão"
 
 #: src/base1/cockpit.js:4027
 msgid "Connection has timed out."
@@ -2014,34 +1678,23 @@ msgstr "Tipo de console"
 msgid "Consoles"
 msgstr "Consoles"
 
-#: pkg/realmd/operation.js:274
+#: pkg/realmd/operation.js:273
 msgid "Contacted domain"
 msgstr ""
 
-#: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
-#: pkg/kubernetes/views/container-page-inline.html:2
-#: pkg/kubernetes/views/container-panel.html:4
-#: pkg/kubernetes/views/image-page.html:23
+#: pkg/docker/console.html:4
 #: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Container"
 
-#: pkg/users/local.js:748
+#: pkg/users/local.js:752
 msgid "Container Administrator"
 msgstr "Administrador de contêineres"
 
-#: pkg/kubernetes/views/container-body.html:10
-msgid "Container ID"
-msgstr "ID do Contêiner"
-
-#: pkg/docker/index.html:438 pkg/docker/index.html:618
-#: pkg/docker/index.html:682
+#: pkg/docker/index.html:440 pkg/docker/index.html:620
+#: pkg/docker/index.html:684
 msgid "Container Name"
 msgstr "Nome do Container"
-
-#: pkg/kubernetes/views/node-body.html:21
-msgid "Container Runtime Version"
-msgstr "Versão de Tempo de Execução do Contêiner"
 
 #: pkg/docker/util.js:506
 msgid ""
@@ -2053,15 +1706,12 @@ msgstr ""
 msgid "Container is currently running."
 msgstr "Container está em execução."
 
-#: pkg/docker/index.html:141
+#: pkg/docker/index.html:133
 msgid "Container:"
 msgstr "Contêiner:"
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:287
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
-#: pkg/kubernetes/views/dashboard-page.html:158
-#: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:375
+#: pkg/docker/index.html:23 pkg/docker/index.html:289
+#: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "Containers"
 
@@ -2075,12 +1725,12 @@ msgid "Content"
 msgstr "Conteúdo"
 
 #: src/base1/test-locale.js:42 src/base1/test-locale.js:53
-#: pkg/playground/translate.js:22
+#: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Controle"
 
 #: src/base1/test-locale.js:43 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:25
+#: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
 msgstr "Controle"
@@ -2094,7 +1744,6 @@ msgid "Copy"
 msgstr ""
 
 #: pkg/machines/components/vcpuModal.jsx:209
-#: pkg/ovirt/components/vcpuModal.jsx:67
 msgid "Cores per socket"
 msgstr "Núcleos por soquete"
 
@@ -2105,18 +1754,6 @@ msgstr "Não foi possível adicionar todos os discos"
 #: pkg/lib/machine-change-port.html:4
 msgid "Could not contact {{host}}"
 msgstr "Não foi possível contatar {{host}}"
-
-#: pkg/kubernetes/views/dashboard-page.html:142
-msgid "Could not list services"
-msgstr "Não foi possível listar serviços"
-
-#: src/ws/cockpitcertificate.c:531
-msgid "Could not parse PEM-encoded certificate"
-msgstr "Não foi possível analisar certificado PEM-codificado"
-
-#: src/ws/cockpitcertificate.c:498
-msgid "Could not parse PEM-encoded private key"
-msgstr "Não foi possível analisar chave privada codificado em PEM"
 
 #: pkg/docker/storage.jsx:468
 msgid "Could not reset the storage pool"
@@ -2130,30 +1767,13 @@ msgstr "Não foi possível alterar os grupos de usuários"
 msgid "Couldn't change user password"
 msgstr "Não foi possível alterar a senha do usuário"
 
-#: pkg/kubernetes/index.html:105 pkg/kubernetes/registry.html:72
-msgid "Couldn't connect to server"
-msgstr "Não foi possível conectar ao servidor"
-
-#: pkg/shell/indexes.js:414
+#: pkg/shell/indexes.js:413
 msgid "Couldn't connect to the machine"
 msgstr "Não pode conectar a máquina"
 
 #: src/bridge/cockpitdbussetup.c:544
 msgid "Couldn't create new users"
 msgstr "Não foi possível criar novos usuários"
-
-#: pkg/kubernetes/scripts/connection.js:510
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:957
-msgid "Couldn't find running API server"
-msgstr "Não foi possível localizar o servidor API em execução"
-
-#: pkg/subscriptions/subscriptions-view.jsx:218
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"Não foi possível obter o status de assinatura do sistema. Verifique se o "
-"gerenciador de assinaturas está instalado."
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -2175,14 +1795,12 @@ msgstr "Local de despejo de travamento"
 msgid "Crash system"
 msgstr "Sistema de travamento"
 
-#: pkg/kubernetes/views/add-group-dialog.html:19
-#: pkg/kubernetes/views/project-modify.html:72 pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:652
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:488
-#: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/users/index.html:199
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Criar"
 
@@ -2190,17 +1808,13 @@ msgstr "Criar"
 msgid "Create Logical Volume"
 msgstr "Criar Volume Lógico"
 
-#: pkg/machines/components/diskAdd.jsx:487
+#: pkg/machines/components/diskAdd.jsx:515
 msgid "Create New"
 msgstr "Criar novo"
 
 #: pkg/users/index.html:52 pkg/users/index.html:163
 msgid "Create New Account"
 msgstr "Criar Nova Conta"
-
-#: pkg/ovirt/components/App.jsx:162
-msgid "Create New VM"
-msgstr "Criar nova VM"
 
 #: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
 msgid "Create Partition"
@@ -2226,7 +1840,7 @@ msgstr "Criar relatório"
 msgid "Create Snapshot"
 msgstr "Criar Snapshot"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:522
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
 msgid "Create Storage Pool"
 msgstr "Criar pool de armazenamento"
 
@@ -2246,8 +1860,7 @@ msgstr "Criar Temporizadores"
 msgid "Create VDO Device"
 msgstr "Criar dispositivo VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:685
-#: pkg/ovirt/components/ClusterTemplates.jsx:81
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
 msgid "Create VM"
 msgstr "Criar VM"
 
@@ -2259,14 +1872,6 @@ msgstr "Criar Grupo de Volumes"
 msgid "Create diagnostic report"
 msgstr "Criar um relatório de diagnostico"
 
-#: pkg/kubernetes/scripts/images.js:643
-msgid "Create empty image stream"
-msgstr "Criar um stream de imagem vazio"
-
-#: pkg/kubernetes/views/imagestream-modify.html:3
-msgid "Create image stream"
-msgstr "Criar Stream de Imagem"
-
 #: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
 #: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
 msgid "Create it"
@@ -2276,16 +1881,12 @@ msgstr "Criá-lo"
 msgid "Create new Logical Volume"
 msgstr "Criar novo Volume Lógico"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/kubernetes/views/replicationcontroller-body.html:7
-#: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:129
-#: pkg/docker/containers-view.jsx:412 pkg/docker/containers-view.jsx:683
+#: pkg/docker/containers-view.jsx:129 pkg/docker/containers-view.jsx:412
+#: pkg/docker/containers-view.jsx:683
 msgid "Created"
 msgstr "Criado"
 
-#: pkg/docker/index.html:152
+#: pkg/docker/index.html:153
 msgid "Created:"
 msgstr "Criado:"
 
@@ -2345,7 +1946,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Criando grupo de volume $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:554
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
 msgid "Creation of VM $0 failed"
 msgstr ""
 
@@ -2373,23 +1974,19 @@ msgstr "Inicialização atual"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: pkg/networkmanager/firewall.jsx:521
+#: pkg/networkmanager/firewall.jsx:523
 msgid "Custom Ports"
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:103
-msgid "Custom URL"
-msgstr "URL Personalizada"
 
 #: pkg/storaged/format-dialog.jsx:118
 msgid "Custom encryption options"
 msgstr "Opções de criptografia personalizadas"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Opções de montagem personalizadas"
 
-#: pkg/networkmanager/firewall.jsx:716
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Custom zones"
 msgstr ""
 
@@ -2409,10 +2006,6 @@ msgstr "DNS"
 #: pkg/networkmanager/interfaces.js:2656
 msgid "DNS $val"
 msgstr "DNS $val"
-
-#: pkg/kubernetes/views/pod-body.html:14
-msgid "DNS Policy"
-msgstr "Política de DNS"
 
 #: pkg/networkmanager/interfaces.js:3320
 msgid "DNS Search Domains"
@@ -2434,8 +2027,8 @@ msgstr "Painel"
 msgid "Data Used"
 msgstr "Dados Usados"
 
-#: pkg/machines/components/networks/network.jsx:143
-#: pkg/machines/components/storagePools/storagePool.jsx:163
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Desativar"
@@ -2456,10 +2049,9 @@ msgstr "Depurar e acima"
 msgid "Deduplication"
 msgstr "Desduplicação"
 
-#: pkg/docker/index.html:357 pkg/docker/index.html:361
+#: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: node_modules/registry-image-widgets/views/image-config.html:10
 #: pkg/storaged/format-dialog.jsx:68
-#: pkg/subscriptions/subscriptions-register.jsx:102
 msgid "Default"
 msgstr "Padrão"
 
@@ -2467,37 +2059,26 @@ msgstr "Padrão"
 msgid "Delay"
 msgstr "Atraso"
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:246
-#: pkg/kubernetes/views/image-delete.html:8
-#: pkg/kubernetes/views/imagestream-delete.html:8
-#: pkg/kubernetes/views/item-delete.html:11
-#: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/project-delete.html:9
-#: pkg/kubernetes/views/pv-delete.html:11
-#: pkg/kubernetes/views/pvc-delete.html:15
-#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/machines/components/networks/networkDelete.jsx:86
+#: pkg/machines/components/networks/networkDelete.jsx:103
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:300 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:214 pkg/storaged/vgroup-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Excluir"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1179
+#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Deletar $0"
-
-#: pkg/playground/translate.html:189
-msgid "Delete '{{ name }}'"
-msgstr "Deletar '{{ name }}'"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
 msgid "Delete Content"
@@ -2507,25 +2088,10 @@ msgstr ""
 msgid "Delete Files"
 msgstr "Excluir Arquivos"
 
-#: pkg/kubernetes/views/node-delete.html:4
-msgid "Delete Node"
-msgstr "Deletar Nó"
-
-#: pkg/kubernetes/views/pv-delete.html:3
-msgid "Delete Persistent Volume"
-msgstr "Deletar Volume Persistente"
-
-#: pkg/kubernetes/views/pvc-delete.html:3
-msgid "Delete Persistent Volume Claim"
-msgstr "Deletar Declaração de Volume Persistente"
-
-#: pkg/kubernetes/views/project-delete.html:3
-msgid "Delete Project"
-msgstr "Deletar Projeto"
-
-#: pkg/kubernetes/views/nodes-page.html:3
-msgid "Delete Selected"
-msgstr "Deletar o Selecionado"
+#: pkg/machines/components/networks/networkDelete.jsx:92
+#, fuzzy
+msgid "Delete Network $0"
+msgstr "Deletar $0"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
 msgid "Delete Storage Pool $0"
@@ -2535,17 +2101,9 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr "Excluir arquivos de armazenamento associados:"
 
-#: pkg/kubernetes/views/imagestream-delete.html:3
-msgid "Delete image stream"
-msgstr "Deletar stream de imagem"
-
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html:3
-msgid "Delete {{ item.kind }}"
-msgstr "Excluir {{ item.kind }}"
 
 #: pkg/storaged/jobs-panel.jsx:53 pkg/storaged/jobs-panel.jsx:67
 msgid "Deleting $target"
@@ -2559,15 +2117,7 @@ msgstr ""
 "Excluindo <b>$0</b> a conexão com o servidor será encerrada, e tornará a "
 "administração da interface do usuário indisponível."
 
-#: pkg/kubernetes/views/item-delete.html:7
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-"Excluir um Pod irá matar todos os contêineres associados. Pods podem ser "
-"automaticamente criados novamente em alguns casos."
-
-#: pkg/storaged/mdraid-details.jsx:301
+#: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "A exclusão de um dispositivo RAID apagará todos os dados nele."
 
@@ -2575,7 +2125,7 @@ msgstr "A exclusão de um dispositivo RAID apagará todos os dados nele."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "A exclusão de um dispositivo VDO apagará todos os dados nele."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "A exclusão de um container irá apagar todos os dados nele."
 
@@ -2587,7 +2137,7 @@ msgstr "Excluindo um volume lógico irá excluir todos os dados nele."
 msgid "Deleting a partition will delete all data in it."
 msgstr "A exclusão de uma partição apaga todos os dados da mesma."
 
-#: pkg/storaged/vgroup-details.jsx:213
+#: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
 msgstr "A exclusão de um grupo de volumes apaga todos os dados do mesmo."
 
@@ -2601,44 +2151,11 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Excluindo grupo de volume $target"
 
-#: pkg/kubernetes/views/dashboard-page.html:131
-#: pkg/kubernetes/views/deploy.html:62
-msgid "Deploy"
-msgstr "Implantar"
-
-#: pkg/kubernetes/views/deploy.html:3
-msgid "Deploy Application"
-msgstr "Implantar aplicativo"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:22
-msgid "Deployment Causes"
-msgstr "Causas de Implantação"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:12
-#: pkg/kubernetes/views/deploymentconfig-panel.html:8
-msgid "Deployment Config"
-msgstr "Config de Implantação"
-
-#: pkg/kubernetes/views/details-page.html:98
-#: pkg/kubernetes/scripts/details.js:220
-msgid "Deployment Configs"
-msgstr "Configs de Implantação"
-
-#: pkg/kubernetes/views/project-listing.html:15
-#: pkg/kubernetes/views/project-listing.html:54
-#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:413
+#: pkg/systemd/services.html:413
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:725
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
 msgid "Description"
 msgstr "Descrição"
-
-#: pkg/ovirt/components/OVirtTab.jsx:146
-#: pkg/ovirt/components/VmOverviewColumn.jsx:52
-msgid "Description:"
-msgstr "Descrição:"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2648,16 +2165,15 @@ msgstr "Desktop"
 msgid "Detachable"
 msgstr "Destacável"
 
-#: pkg/kubernetes/index.html:67 pkg/shell/index.html:229
-#: pkg/docker/containers-view.jsx:336 pkg/docker/containers-view.jsx:504
-#: pkg/docker/containers-view.jsx:514 pkg/docker/containers-view.jsx:642
-#: pkg/networkmanager/firewall.jsx:94 pkg/packagekit/updates.jsx:383
-#: pkg/subscriptions/subscriptions-view.jsx:232 pkg/systemd/host.js:745
+#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
+#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Detalhes"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2679,7 +2195,6 @@ msgstr "Relatório de diagnostico"
 msgid "Digest"
 msgstr "Digerir"
 
-#: pkg/kubernetes/views/volume-body.html:28
 #: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
@@ -2711,7 +2226,7 @@ msgid "Disconnect"
 msgstr "Desconectar"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:604
+#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
 msgid "Disconnected"
 msgstr "Desconectado"
 
@@ -2719,7 +2234,6 @@ msgstr "Desconectado"
 msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr "Desconectado do console serial. Clique no botão Reconectar."
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:836
 #: pkg/storaged/vdos-panel.jsx:55
 msgid "Disk"
 msgstr "Disco"
@@ -2732,15 +2246,11 @@ msgstr ""
 msgid "Disk I/O"
 msgstr "Entrada e Saida de disco"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Utilização do disco: $0%"
-
-#: pkg/machines/components/diskAdd.jsx:461
+#: pkg/machines/components/diskAdd.jsx:489
 msgid "Disk failed to be attached"
 msgstr "Disco falhou ao ser anexado"
 
-#: pkg/machines/components/diskAdd.jsx:443
+#: pkg/machines/components/diskAdd.jsx:468
 msgid "Disk failed to be created"
 msgstr "Disco falhou ao ser criado"
 
@@ -2752,9 +2262,9 @@ msgstr "O Disco está OK"
 msgid "Disk passphrase"
 msgstr "Senha de disco"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Discos"
 
@@ -2763,59 +2273,9 @@ msgid "Disks cannot be removed from $0 VMs"
 msgstr ""
 
 #: pkg/shell/index.html:52 pkg/shell/index.html:114 pkg/shell/simple.html:38
-#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
+#: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Linguagem Exibida"
-
-#: pkg/kubernetes/views/project-modify.html:31
-msgid "Display name"
-msgstr "Nome exibido"
-
-#: pkg/kubernetes/views/add-role-dialog.html:5
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "Deseja adicionar a função '{{ fields.displayRole }}'?"
-
-#: pkg/kubernetes/views/imagestream-delete.html:5
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"Deseja deletar o stream de imagem '{{stream.metadata.namespace}}/{{stream."
-"metadata.name}}'?"
-
-#: pkg/kubernetes/views/pv-delete.html:6
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "Deseja deletar o Volume Persistente '{{item.metadata.name}}'?"
-
-#: pkg/kubernetes/views/pvc-delete.html:6
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-"Deseja excluir a declaração de volume persistente '{{item.metadata.name}}'?"
-
-#: pkg/kubernetes/views/item-delete.html:6
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "Deseja excluir o {{ item.kind }} '{{item.metadata.name}}'?"
-
-#: pkg/kubernetes/views/node-delete.html:7
-msgid "Do you want to delete this Node?"
-msgstr "Deseja excluir este Nó?"
-
-#: pkg/kubernetes/views/image-delete.html:5
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"Deseja remover a imagem marcada como '{{stream.metadata.namespace}}/{{stream."
-"metadata.name}}:{{tag.tag}}'?"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:5
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
-msgstr ""
-"Deseja remover a função '{{ fields.displayRole }}' from member {{ fields."
-"member.metadata.name }}?"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2830,15 +2290,15 @@ msgid "Docking Station"
 msgstr "Estação de ancoragem."
 
 #: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
-#: pkg/realmd/operation.js:123
+#: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Domínio"
 
-#: pkg/realmd/operation.js:192
+#: pkg/realmd/operation.js:191
 msgid "Domain $0 could not be contacted"
 msgstr "O Domínio $0 não pôde ser contatado"
 
-#: pkg/realmd/operation.js:279
+#: pkg/realmd/operation.js:278
 msgid "Domain $0 is not supported"
 msgstr "O Domínio $0 não é suportado"
 
@@ -2863,15 +2323,11 @@ msgstr "Não Repita"
 msgid "Don't overwrite existing data"
 msgstr "Não sobrescrever dados existentes"
 
-#: pkg/kubernetes/scripts/images.js:633
-msgid "Don't pull images automatically"
-msgstr "Não baixe imagens automaticamente"
-
 #: pkg/sosreport/index.html:63
 msgid "Done!"
 msgstr "Feito!"
 
-#: pkg/docker/index.html:598
+#: pkg/docker/index.html:600
 msgid "Download"
 msgstr "Baixar"
 
@@ -2908,11 +2364,7 @@ msgctxt "storage"
 msgid "Drive"
 msgstr "Drive"
 
-#: pkg/kubernetes/views/volume-body.html:128
-msgid "Driver"
-msgstr "Driver"
-
-#: pkg/storaged/drives-panel.jsx:119
+#: pkg/storaged/drives-panel.jsx:120
 msgid "Drives"
 msgstr "Unidades"
 
@@ -2941,10 +2393,6 @@ msgstr "Editar o servidor de chaves Tang"
 msgid "Edit image stream"
 msgstr "Editar stream de imagem"
 
-#: pkg/ovirt/components/VdsmView.jsx:125
-msgid "Edit the vdsm.conf"
-msgstr "Edite o vdsm.conf"
-
 #: pkg/storaged/crypto-keyslots.jsx:535
 msgid "Editing a key requires a free slot"
 msgstr "Editar uma chave requer um espaço livre"
@@ -2958,25 +2406,21 @@ msgid "Embedded PC"
 msgstr "Embedded PC"
 
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:13
+#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Vazio"
 
 #: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:19
+#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Vazio"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Diretório Vazio"
 
 #: pkg/storaged/jobs-panel.jsx:75
 msgid "Emptying $target"
 msgstr "Esvaziando $target"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:151
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:162
 msgid "Emulated Machine"
 msgstr ""
 
@@ -3039,23 +2483,6 @@ msgstr "Encriptação"
 msgid "Encryption Options"
 msgstr "Opções de Criptografia"
 
-#: pkg/kubernetes/views/pv-modify.html:93
-msgid "Endpoint"
-msgstr "Ponto final"
-
-#: pkg/kubernetes/views/volume-body.html:40
-msgid "Endpoint Name"
-msgstr "Nome do Ponto de extremidade"
-
-#: pkg/kubernetes/views/service-page.html:14
-#: pkg/kubernetes/views/service-panel.html:9
-msgid "Endpoints"
-msgstr "Pontos finais"
-
-#: pkg/subscriptions/subscriptions-view.jsx:39
-msgid "Ends"
-msgstr "Finais"
-
 #: pkg/selinux/setroubleshoot-view.jsx:299
 msgid "Enforce policy:"
 msgstr "Política de aplicação:"
@@ -3068,10 +2495,6 @@ msgstr "Atualizações de aprimoramento disponíveis"
 msgid "Enter IP address or host name"
 msgstr "Digite o endereço IP ou nome de host"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:74
-msgid "Enter New VM name"
-msgstr "Insira o novo nome da VM"
-
 #: pkg/lib/machine-change-auth.html:57
 msgid ""
 "Entering a different password here means you will need to retype it every "
@@ -3080,7 +2503,7 @@ msgstr ""
 "Introduzir uma senha diferente aqui significa que você precisará digitá-la "
 "cada vez que você se reconecta a esta máquina"
 
-#: pkg/networkmanager/firewall.jsx:752
+#: pkg/networkmanager/firewall.jsx:754
 msgid "Entire subnet"
 msgstr ""
 
@@ -3092,7 +2515,7 @@ msgstr "Entrada"
 msgid "Entrypoint"
 msgstr "Ponto de entrada"
 
-#: pkg/docker/index.html:526 pkg/kubernetes/views/container-body.html:26
+#: pkg/docker/index.html:528
 #: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Ambiente"
@@ -3114,19 +2537,15 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:99
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1472
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Erro"
 
 #: pkg/systemd/logs.html:59
 msgid "Error and above"
 msgstr "Erro e acima"
-
-#: pkg/kubernetes/scripts/connection.js:646
-msgid "Error getting certificate details: $0"
-msgstr "Erro ao obter detalhes do certificado: $0"
 
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
@@ -3148,10 +2567,6 @@ msgstr "Erro durante a exclusão alerta: $0"
 msgid "Error while setting SELinux mode: '$0'"
 msgstr "Erro ao definir o modo de SELinux: '$0'"
 
-#: pkg/kubernetes/scripts/connection.js:85
-msgid "Error writing kubectl config"
-msgstr "Erro ao escrever kubectl config"
-
 #: pkg/networkmanager/index.html:658
 msgid "Ethernet MAC"
 msgstr "Ethernet MAC"
@@ -3168,23 +2583,23 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Tudo"
 
-#: pkg/networkmanager/firewall.jsx:534
+#: pkg/networkmanager/firewall.jsx:536
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:542
+#: pkg/networkmanager/firewall.jsx:544
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
-#: pkg/users/local.js:473 pkg/users/local.js:1417
+#: pkg/users/local.js:477 pkg/users/local.js:1421
 msgid "Excellent password"
 msgstr "Senha excelente"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:222
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
 msgid "Existing Disk Image"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -3196,7 +2611,7 @@ msgstr "Encerrado $ExitCode"
 msgid "Expansion Chassis"
 msgstr "Chassi de Expansão"
 
-#: pkg/docker/index.html:508
+#: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "Expor portas de contêiner"
 
@@ -3208,14 +2623,6 @@ msgstr "Partição Extendida"
 msgid "FAILED"
 msgstr "FALHOU"
 
-#: pkg/ovirt/provider.js:130
-msgid "FORCEOFF action failed: $0"
-msgstr ""
-
-#: pkg/ovirt/components/InstallationDialog.jsx:47
-msgid "FQDN"
-msgstr "FQDN"
-
 #: pkg/networkmanager/interfaces.js:842
 msgid "Failed"
 msgstr "Falhou"
@@ -3225,14 +2632,19 @@ msgid "Failed to add machine: $0"
 msgstr "Falha ao adicionar a máquina: $0"
 
 #: pkg/networkmanager/firewall.jsx:237
+#, fuzzy
+msgid "Failed to add port"
+msgstr "Falha ao mudar senha"
+
+#: pkg/networkmanager/firewall.jsx:237
 msgid "Failed to add service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:679
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Falha ao mudar senha"
 
@@ -3256,11 +2668,15 @@ msgstr "Falha ao editar a máquina: $0"
 msgid "Failed to enable tuned"
 msgstr "Falha ao habilitar tuned"
 
+#: pkg/machines/components/vmnetworktab.jsx:55
+msgid "Failed to fetch the IP addresses of the interfaces present in $0"
+msgstr ""
+
 #: pkg/users/index.html:393
 msgid "Failed to load authorized keys."
 msgstr "Falha ao carregar as chaves autorizadas."
 
-#: pkg/networkmanager/firewall.jsx:589
+#: pkg/networkmanager/firewall.jsx:591
 msgid "Failed to remove service"
 msgstr ""
 
@@ -3279,10 +2695,6 @@ msgstr "Falha ao mudar de perfil"
 #: pkg/machines/components/vcpuModal.jsx:193
 msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr "Menos do que o número máximo de CPUs virtuais deve ser ativado."
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "Canal de Fibra"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:92
 #: pkg/machines/components/vmDiskColumns.jsx:42
@@ -3305,22 +2717,11 @@ msgstr "Montagem do Sistema de Arquivos"
 msgid "Filesystem Name"
 msgstr "Nome do Sistema de Arquivos"
 
-#: pkg/kubernetes/views/pv-modify.html:181
-#: pkg/kubernetes/views/volume-body.html:6
-#: pkg/kubernetes/views/volume-body.html:16
-#: pkg/kubernetes/views/volume-body.html:62
-#: pkg/kubernetes/views/volume-body.html:83
-#: pkg/kubernetes/views/volume-body.html:91
-#: pkg/kubernetes/views/volume-body.html:120
-#: pkg/kubernetes/views/volume-body.html:132
-msgid "Filesystem Type"
-msgstr "Tipo do Sistema de Arquivos"
-
 #: pkg/storaged/fsys-panel.jsx:103
 msgid "Filesystems"
 msgstr "Sistema de Arquivos"
 
-#: pkg/networkmanager/firewall.jsx:490
+#: pkg/networkmanager/firewall.jsx:491
 msgid "Filter Services"
 msgstr "Serviços de filtro"
 
@@ -3328,30 +2729,18 @@ msgstr "Serviços de filtro"
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Digital"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:913 pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
 msgid "Firewall"
 msgstr "Firewall"
 
-#: pkg/networkmanager/firewall.jsx:861
+#: pkg/networkmanager/firewall.jsx:863
 msgid "Firewall is not available"
 msgstr "Firewall não está disponível"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/views/volume-body.html:125
-msgid "Flocker Dataset Name"
-msgstr "Nome do Flocker Dataset"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:35
 msgid "Follows docker repo"
@@ -3385,10 +2774,9 @@ msgstr "Force troca de senha"
 msgid "Force remove passphrase in $0"
 msgstr "Forçar a remoção da senha em $0"
 
-#: pkg/machines/components/diskAdd.jsx:167
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:258
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formate"
 
@@ -3447,11 +2835,7 @@ msgstr "De"
 msgid "Full Name"
 msgstr "Nome Completo"
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "Disco Persistente GCE"
-
-#: pkg/docker/index.html:183
+#: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "Gateway:"
 
@@ -3468,25 +2852,13 @@ msgstr "Gerando relatório"
 msgid "Get new image"
 msgstr "Obter nova imagem"
 
-#: pkg/machines/components/diskAdd.jsx:162
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Repositório Git"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster FS"
-
-#: pkg/kubernetes/scripts/volumes.js:877
-msgid "GlusterFS"
-msgstr "GlusterFS"
 
 #: pkg/systemd/logs.js:199
 msgid "Go to"
@@ -3502,12 +2874,6 @@ msgstr "Vá para o aplicativo"
 msgid "Go to now"
 msgstr "Ir para agora"
 
-#: pkg/kubernetes/views/project-body.html:3
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Grant additional push or admin access to specific members below."
-msgstr ""
-"Conceder acesso adicional de envio ou admin a membros específicos abaixo."
-
 #: pkg/machines/components/consoles.jsx:51
 msgid "Graphics Console (VNC)"
 msgstr "Console de gráficos (VNC)"
@@ -3515,20 +2881,6 @@ msgstr "Console de gráficos (VNC)"
 #: pkg/machines/components/consoles.jsx:60
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Console gráfico no visualizador da área de trabalho"
-
-#: pkg/kubernetes/views/group-page.html:21
-#: pkg/kubernetes/views/group-panel.html:12
-msgid "Group Members"
-msgstr "Membros do Grupo"
-
-#: pkg/kubernetes/views/user-add-membership.html:9
-msgid "Group or Project"
-msgstr "Grupo ou Projeto"
-
-#: pkg/kubernetes/views/project-listing.html:48
-#: pkg/kubernetes/views/user-delete.html:14
-msgid "Groups"
-msgstr "Grupos"
 
 #: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
 #: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
@@ -3551,15 +2903,6 @@ msgstr "Crescer tamanho lógico de $0"
 #: pkg/storaged/vdo-details.jsx:130
 msgid "Grow to take all space"
 msgstr "Crescer para tomar todo o espaço"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "HA"
-msgstr "HA"
-
-#: pkg/ovirt/components/OVirtTab.jsx:128
-msgid "HA:"
-msgstr "HA:"
 
 #: pkg/networkmanager/index.html:252
 msgid "Hair Pin mode"
@@ -3594,19 +2937,14 @@ msgstr "Informação de Hardware"
 msgid "Hello time $hello_time"
 msgstr "Hello time $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:73
-#: pkg/kubernetes/views/route-body.html:9
-#: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:150
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47
-#: pkg/ovirt/components/App.jsx:103 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:334
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Máquina"
 
@@ -3615,29 +2953,21 @@ msgid "Host Device"
 msgstr ""
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:155
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
 msgid "Host Name"
 msgstr "Nome do host"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:869
-msgid "Host Path"
-msgstr "Campo de Host"
 
 #: src/base1/cockpit.js:4023
 msgid "Host key is incorrect"
 msgstr "Chave de Host incorreta"
 
-#: pkg/realmd/operation.js:602
+#: pkg/realmd/operation.js:601
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:161
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
 msgid "Host should not be empty"
 msgstr "Host não deve estar vazio"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:75
-msgid "Host to Maintenance"
-msgstr "Host para Manutenção"
 
 #: pkg/systemd/services.html:499
 msgid "Hour : Minute"
@@ -3655,24 +2985,20 @@ msgstr "Horas"
 msgid "I/O Wait"
 msgstr "E/S Espera"
 
-#: pkg/kubernetes/views/node-body.html:10
-#: pkg/kubernetes/views/service-body.html:9
-msgid "IP"
-msgstr "IP"
-
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
+#: pkg/machines/components/vmnetworktab.jsx:133
 msgid "IP Address"
 msgstr "Endereço IP"
 
-#: pkg/docker/index.html:175
+#: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "Endereço IP:"
 
-#: pkg/docker/index.html:179
+#: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "Comprimento do prefixo IP:"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "IP Range"
 msgstr ""
 
@@ -3704,10 +3030,6 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr "IPv6 Ajustes"
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:873
-msgid "ISCSI"
-msgstr "ISCSI"
-
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
@@ -3716,7 +3038,7 @@ msgstr "Id"
 msgid "Id $id"
 msgstr "Id $id"
 
-#: pkg/docker/index.html:148
+#: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "Id:"
 
@@ -3724,17 +3046,6 @@ msgstr "Id:"
 #: node_modules/registry-image-widgets/views/image-listing.html:7
 msgid "Identifier"
 msgstr "Identificador"
-
-#: pkg/kubernetes/views/user-page.html:22
-#: pkg/kubernetes/views/user-panel.html:18
-msgid "Identities"
-msgstr "Identidades"
-
-#: pkg/kubernetes/views/add-user-dialog.html:17
-#: pkg/kubernetes/views/project-listing.html:91
-#: pkg/kubernetes/views/user-modify.html:17
-msgid "Identity"
-msgstr "Ìdentidade"
 
 #: pkg/storaged/crypto-keyslots.jsx:325
 msgid "If tang-show-keys is not available, run the following:"
@@ -3744,9 +3055,7 @@ msgstr "Se tang-show-keys não estiver disponível, execute o seguinte:"
 msgid "Ignore"
 msgstr "Ignorar"
 
-#: pkg/docker/index.html:268 pkg/docker/index.html:431
-#: pkg/kubernetes/views/container-body.html:6
-#: pkg/kubernetes/views/image-page.html:15
+#: pkg/docker/index.html:270 pkg/docker/index.html:433
 #: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
@@ -3756,33 +3065,13 @@ msgstr "Imagem"
 msgid "Image $0"
 msgstr "Imagem $0"
 
-#: pkg/users/local.js:749
+#: pkg/users/local.js:753
 msgid "Image Builder"
 msgstr "Criador de Imagem de Disco"
 
-#: pkg/kubernetes/views/container-body.html:8
-msgid "Image ID"
-msgstr "ID da Imagem"
-
-#: pkg/kubernetes/views/volume-body.html:58
-msgid "Image Name"
-msgstr "Nome da Imagem"
-
-#: pkg/kubernetes/registry.html:23
-msgid "Image Registry"
-msgstr "Registro de Imagem"
-
-#: pkg/docker/index.html:578
+#: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Pesquisa de Imagem"
-
-#: pkg/kubernetes/views/imagestream-page.html:16
-msgid "Image Stream"
-msgstr "Stream de Imagem"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:135
-msgid "Image commands"
-msgstr "Comandos da Imagem"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:41
 msgid "Image count"
@@ -3792,14 +3081,10 @@ msgstr "Contagem de imagens"
 msgid "Image stream"
 msgstr "Fluxo de imagem"
 
-#: pkg/docker/index.html:156
+#: pkg/docker/index.html:157
 msgid "Image:"
 msgstr "Imagem:"
 
-#: pkg/kubernetes/index.html:81 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
-#: pkg/kubernetes/views/registry-dashboard-page.html:19
 #: pkg/docker/containers-view.jsx:711
 msgid "Images"
 msgstr "Imagens"
@@ -3812,10 +3097,6 @@ msgstr "Imagens"
 #: pkg/docker/containers-view.jsx:109
 msgid "Images and running containers"
 msgstr "Imagens e contêineres em execução"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:17
-msgid "Images by project"
-msgstr "Imagens do projeto"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:15
 #: node_modules/registry-image-widgets/views/imagestream-body.html:16
@@ -3833,11 +3114,7 @@ msgstr ""
 msgid "Images may only be pulled by specific users or groups"
 msgstr "As imagens só podem ser baixadas por usuários ou grupos específicos"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:54
-msgid "Images pushed recently"
-msgstr "Imagens enviadas recentemente"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:632
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
 msgstr "Imediatamente Iniciar VM"
 
@@ -3845,33 +3122,19 @@ msgstr "Imediatamente Iniciar VM"
 msgid "In Sync"
 msgstr "Em Sincronização"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:171
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
 msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:81
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-"A fim de começar a enviar imagens para o registro, use os comandos abaixo."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:6
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr ""
-"A fim de começar a enviar imagens para o registro, você precisa criar um "
-"projeto."
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Para sincronizar os usuários, você precisa fazer login em "
-"{{#strong}}{{host}}{{/strong}}."
+"Para sincronizar os usuários, você precisa fazer login em {{#strong}}{{host}}"
+"{{/strong}}."
 
 #: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
 #: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
@@ -3882,7 +3145,7 @@ msgstr "Inativo"
 msgid "Inactive volume"
 msgstr "Volume inativo"
 
-#: pkg/networkmanager/firewall.jsx:730
+#: pkg/networkmanager/firewall.jsx:732
 msgid "Included services"
 msgstr ""
 
@@ -3902,23 +3165,22 @@ msgstr "Info e acima"
 msgid "Information about the Docker storage pool is not available."
 msgstr ""
 "As informações sobre o pool de armazenamento do Docker não estão disponíveis."
-""
 
 #: pkg/packagekit/updates.jsx:453
 msgid "Initializing..."
 msgstr "Inicializando ..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:177
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:188
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Instale"
 
@@ -3946,27 +3208,22 @@ msgstr "Instale o suporte do VDO"
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr ""
 "Instale o setroubleshoot-server para solucionar problemas de eventos SELinux."
-""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:226
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
 msgid "Installation Source"
 msgstr "Fonte de Instalação"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:212
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
 msgid "Installation Source Type"
 msgstr "Tipo de Fonte de Instalação"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:113
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
 msgid "Installation Source should not be empty"
 msgstr "A fonte de instalação não deve estar vazia"
 
 #: pkg/packagekit/updates.jsx:59
 msgid "Installed"
 msgstr "Instalado"
-
-#: pkg/subscriptions/subscriptions-view.jsx:245
-msgid "Installed products"
-msgstr "Produtos instalados"
 
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:51
@@ -3981,17 +3238,13 @@ msgstr "Instalando $0"
 msgid "Instantiate"
 msgstr "Instanciar"
 
-#: pkg/kubernetes/views/pv-modify.html:170
-#: pkg/kubernetes/views/volume-body.html:81
-msgid "Interface"
-msgstr "Interface"
-
 #: pkg/machines/components/nicEdit.jsx:123
 msgid "Interface Type"
 msgstr ""
 
-#: pkg/networkmanager/index.html:108 pkg/networkmanager/firewall.jsx:735
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Interfaces"
 
@@ -4007,15 +3260,11 @@ msgstr "Erro interno"
 msgid "Invalid address $0"
 msgstr "Endereço inválido $0"
 
-#: pkg/subscriptions/subscriptions-client.js:195
-msgid "Invalid credentials"
-msgstr "Credenciais Inválidas"
-
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Formato de data inválido"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Formato de data inválido e formato de tempo inválido"
 
@@ -4023,7 +3272,7 @@ msgstr "Formato de data inválido e formato de tempo inválido"
 msgid "Invalid date format."
 msgstr "Formato de data inválido."
 
-#: pkg/users/local.js:1237
+#: pkg/users/local.js:1241
 msgid "Invalid expiration date"
 msgstr "Data de validade inválida"
 
@@ -4031,7 +3280,7 @@ msgstr "Data de validade inválida"
 msgid "Invalid file permissions"
 msgstr "Permissão de arquivos inválida"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
 msgid "Invalid filename"
 msgstr "Nome de arquivo inválido"
 
@@ -4043,7 +3292,7 @@ msgstr "Chave inválida"
 msgid "Invalid metric $0"
 msgstr "Métrica inválida $0"
 
-#: pkg/users/local.js:1313
+#: pkg/users/local.js:1317
 msgid "Invalid number of days"
 msgstr "Número inválido de dias"
 
@@ -4071,7 +3320,7 @@ msgstr "Prefixo ou máscara de rede inválidos $0"
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Formato de tempo inválido"
 
@@ -4080,7 +3329,6 @@ msgid "Invalid time zone"
 msgstr "Fuso Horário inválido"
 
 #: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
-#: pkg/subscriptions/subscriptions-client.js:193
 msgid "Invalid username or password"
 msgstr "Nome de usuário ou senha inválidos"
 
@@ -4100,19 +3348,19 @@ msgstr ""
 msgid "Jobs"
 msgstr "Trabalhos"
 
-#: pkg/realmd/operation.js:117
+#: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "Afiliar-se"
 
-#: pkg/realmd/operation.js:597
+#: pkg/realmd/operation.js:596
 msgid "Join Domain"
 msgstr "Associar-se ao domínio"
 
-#: pkg/realmd/operation.js:116
+#: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "Ingressar em um domínio"
 
-#: pkg/realmd/operation.js:506
+#: pkg/realmd/operation.js:505
 msgid "Joining this domain is not supported"
 msgstr "A adesão à este domínio não é suportada"
 
@@ -4159,14 +3407,6 @@ msgstr "Kernel"
 msgid "Kernel Dump"
 msgstr "Kernel Dump"
 
-#: pkg/kubernetes/views/node-body.html:19
-msgid "Kernel Version"
-msgstr "Versão do Kernel"
-
-#: pkg/kubernetes/views/volume-body.html:67
-msgid "Key Ring Path"
-msgstr "Trajeto Chave do Anel"
-
 #: pkg/storaged/crypto-keyslots.jsx:563
 msgid "Key slots with unknown types can not be edited here"
 msgstr "Slots chave com tipos desconhecidos não podem ser editados aqui"
@@ -4191,23 +3431,10 @@ msgstr "Endereço do servidor de chaves"
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "A remoção do Keyserver pode impedir o desbloqueio de $0."
 
-#: pkg/kubernetes/views/node-body.html:23
-msgid "Kubelet Version"
-msgstr "Versão Kubelet"
-
-#: pkg/kubernetes/index.html:23
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes Cluster"
-
 #: pkg/networkmanager/index.html:377
 msgid "LACP Key"
 msgstr "Chave LACP"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: pkg/kubernetes/views/replicationcontroller-body.html:17
-#: pkg/kubernetes/views/route-body.html:22
-#: pkg/kubernetes/views/service-body.html:26
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Rótulos"
@@ -4224,17 +3451,9 @@ msgstr "Últimas 24 horas"
 msgid "Last 7 days"
 msgstr "Últimos 7 dias"
 
-#: pkg/kubernetes/views/node-body.html:49
-msgid "Last Heartbeat"
-msgstr "Último Batimento Cardíaco"
-
 #: pkg/users/index.html:100
 msgid "Last Login"
 msgstr "Último Login"
-
-#: pkg/kubernetes/views/node-body.html:51
-msgid "Last Status Change"
-msgstr "Última Mudança de Status"
 
 #: pkg/systemd/init.js:284
 msgid "Last Trigger"
@@ -4247,11 +3466,6 @@ msgstr "Ultima Atualização"
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
 msgstr "Última verificação: $0 atrás"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
-#: pkg/kubernetes/views/details-page.html:107
-msgid "Latest Version"
-msgstr "Versão Mais Recente"
 
 #: pkg/machines/components/desktopConsole.jsx:128
 msgid "Launch Remote Viewer"
@@ -4276,14 +3490,13 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Deixe em branco para se conectar a esta máquina como a conexão atualmente "
 "efetuada como user{{#default_user}} ({{default_user}}){{/default_user}}. Se "
 "você inserir um nome de usuário diferente, esse usuário sempre será usado "
 "para conectar-se a esta máquina."
 
-#: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
+#: pkg/shell/index.html:90 pkg/shell/simple.html:66
 msgid "Licensed under:"
 msgstr "Licenciado em:"
 
@@ -4307,7 +3520,7 @@ msgstr "Link down atraso"
 msgid "Link local"
 msgstr "Link Local"
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:499
 msgid "Link to another container"
 msgstr "Link para outro contêiner"
 
@@ -4315,11 +3528,11 @@ msgstr "Link para outro contêiner"
 msgid "Link up delay"
 msgstr "Link up atraso"
 
-#: pkg/docker/index.html:493
+#: pkg/docker/index.html:495
 msgid "Links"
 msgstr "Links"
 
-#: pkg/docker/index.html:195
+#: pkg/docker/index.html:196
 msgid "Links:"
 msgstr "Links:"
 
@@ -4343,13 +3556,9 @@ msgstr "Falhou ao carregar as atualizações disponíveis "
 msgid "Loading available updates, please wait..."
 msgstr "Carregando as atualizações disponíveis, por favor aguarde ..."
 
-#: pkg/ovirt/components/VdsmView.jsx:34
-msgid "Loading data ..."
-msgstr "Carregando dados ..."
-
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Carregando..."
 
@@ -4365,7 +3574,7 @@ msgstr "Discos Locais"
 msgid "Local Filesystem"
 msgstr "Sistema de Arquivos Local"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:218
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
 msgid "Local Install Media"
 msgstr ""
 
@@ -4385,7 +3594,7 @@ msgstr "Travar"
 msgid "Lock Account"
 msgstr "Bloquear Conta"
 
-#: pkg/users/local.js:879 pkg/users/local.js:1218
+#: pkg/users/local.js:883 pkg/users/local.js:1222
 msgid "Lock account on $0"
 msgstr "Bloquear conta em $0"
 
@@ -4397,7 +3606,7 @@ msgstr "Bloqueando $target"
 msgid "Log In"
 msgstr "Entrar"
 
-#: pkg/shell/index.html:70 pkg/shell/simple.html:46 pkg/shell/stub.html:53
+#: pkg/shell/index.html:70 pkg/shell/simple.html:46
 msgid "Log Out"
 msgstr "Log Out"
 
@@ -4413,19 +3622,11 @@ msgstr "Logar em {{host}}"
 msgid "Log in with your server user account."
 msgstr "Faça o login com sua conta de usuário do servidor."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:116
-msgid "Log into OpenShift command line tools:"
-msgstr "Logar em OpenShift ferramentas de linha de comando:"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:101
-msgid "Log into the registry:"
-msgstr "Logar no registro:"
-
 #: pkg/systemd/index.html:65
 msgid "Log messages"
 msgstr "Mensagens de Log"
 
-#: pkg/users/local.js:961
+#: pkg/users/local.js:965
 msgid "Logged In"
 msgstr "Logado"
 
@@ -4436,12 +3637,6 @@ msgstr "Logical"
 #: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
 msgid "Logical Size"
 msgstr "Tamanho Lógico"
-
-#: pkg/kubernetes/views/pv-modify.html:159
-#: pkg/kubernetes/views/volume-body.html:79
-#: pkg/kubernetes/views/volume-body.html:118
-msgid "Logical Unit Number"
-msgstr "Número da Unidade Lógica"
 
 #: pkg/storaged/utils.js:197
 msgid "Logical Volume"
@@ -4455,10 +3650,6 @@ msgstr "Volume Lógico (Snapshot)"
 msgid "Logical Volume of $0"
 msgstr "Volume Lógico de $0"
 
-#: pkg/subscriptions/subscriptions-register.jsx:144
-msgid "Login"
-msgstr "Login"
-
 #: src/ws/login.js:300
 msgid "Login Again"
 msgstr "Logar Novamente"
@@ -4471,10 +3662,6 @@ msgstr ""
 msgid "Login Password"
 msgstr "Senha de Login"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:96
-msgid "Login commands"
-msgstr "Comandos de login"
-
 #: src/base1/cockpit.js:4015
 msgid "Login failed"
 msgstr "Falha ao logar"
@@ -4483,16 +3670,11 @@ msgstr "Falha ao logar"
 msgid "Login has escalated admin privileges"
 msgstr "O login proveu privilégios de administrador"
 
-#: pkg/subscriptions/subscriptions-client.js:199
-msgid "Login/password or activation key required to register."
-msgstr "Login/senha ou chave de ativação necessária para registrar."
-
 #: src/ws/login.js:301
 msgid "Logout Successful"
 msgstr "Login Bem Sucedido"
 
-#: pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82
 msgid "Logs"
 msgstr "Logs"
 
@@ -4512,17 +3694,13 @@ msgstr "Lunch Box"
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:102
+#: pkg/machines/components/vmnetworktab.jsx:132
 msgid "MAC Address"
 msgstr "MAC Address"
 
-#: pkg/docker/index.html:187
+#: pkg/docker/index.html:188
 msgid "MAC Address:"
 msgstr "Endereço MAC:"
-
-#: pkg/ovirt/provider.js:283
-msgid "MIGRATE action failed"
-msgstr "A ação MIGRATE falhou"
 
 #: pkg/networkmanager/interfaces.js:1985
 msgid "MII (Recommended)"
@@ -4544,7 +3722,7 @@ msgstr ""
 msgid "Mac Address"
 msgstr "Endereço MAC"
 
-#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:95
+#: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "ID de Máquina"
 
@@ -4563,10 +3741,6 @@ msgstr "Chassi do Servidor Principal"
 #: pkg/storaged/crypto-keyslots.jsx:319
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Certifique-se de que o hash da chave do servidor Tang corresponda:"
-
-#: pkg/kubernetes/scripts/dashboard.js:457
-msgid "Manifest"
-msgstr "Manifesto"
 
 #: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
 msgid "Manual"
@@ -4624,16 +3798,6 @@ msgstr ""
 "Número máximo de CPUs virtuais alocadas para o sistema operacional "
 "virtualizado, que deve estar entre 1 e $0"
 
-#: pkg/kubernetes/views/volume-body.html:34
-msgid "Medium"
-msgstr "Médio"
-
-#: pkg/kubernetes/views/project-listing.html:92
-#: pkg/kubernetes/views/user-body.html:4
-#: pkg/kubernetes/views/user-panel.html:27
-msgid "Member of"
-msgstr "Membro de"
-
 #: pkg/storaged/content-views.jsx:345
 msgid "Member of RAID Device"
 msgstr "Membro do Dispositivo RAID"
@@ -4642,26 +3806,11 @@ msgstr "Membro do Dispositivo RAID"
 msgid "Member of RAID Device $0"
 msgstr "Membro do Dispositivo RAID $0"
 
-#: pkg/kubernetes/views/project-listing.html:16
-#: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/index.html:266 pkg/networkmanager/interfaces.js:2986
-msgid "Members"
-msgstr "Membros"
-
-#: pkg/kubernetes/views/project-page.html:29
-#: pkg/kubernetes/views/user-page.html:25
-#: pkg/kubernetes/views/user-panel.html:11
-msgid "Membership"
-msgstr "Associação"
-
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:271
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:608
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:827
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:304
+#: pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
 #: pkg/machines/components/vmOverviewTab.jsx:74
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Memory"
 msgstr "Memória"
 
@@ -4674,38 +3823,32 @@ msgstr "Memória"
 msgid "Memory & Swap"
 msgstr "Memória e Troca"
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Utilização de Memória: $0%"
-
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
 msgid "Memory could not be saved"
 msgstr ""
 
-#: pkg/docker/index.html:452 pkg/docker/index.html:624
+#: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "Limite de Memória"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#, fuzzy
+msgid "Memory must not be 0"
+msgstr "Uso de memória:"
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
 msgstr ""
 
-#: pkg/docker/index.html:210
+#: pkg/docker/index.html:211
 msgid "Memory usage:"
 msgstr "Uso de memória:"
-
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
-msgid "Message"
-msgstr "Mensagem"
 
 #: pkg/systemd/shutdown.js:79
 msgid "Message to logged in users"
 msgstr "Mensagem para usuários logados"
 
-#: pkg/kubernetes/views/image-page.html:29
-#: pkg/kubernetes/views/imagestream-page.html:30
 #: node_modules/registry-image-widgets/views/image-panel.html:15
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
@@ -4715,17 +3858,13 @@ msgstr "Metadados"
 msgid "Metadata Used"
 msgstr "Metadados Usados"
 
-#: pkg/docker/index.html:466 pkg/docker/index.html:638
-#: pkg/machines/components/diskAdd.jsx:159
-#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/docker/index.html:468 pkg/docker/index.html:640
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
-
-#: pkg/ovirt/components/OVirtTab.jsx:70
-msgid "Migrate To:"
-msgstr "Migrar para:"
 
 #: pkg/lib/machine-info.js:98
 msgid "Mini PC"
@@ -4755,13 +3894,9 @@ msgstr "Modo"
 msgid "Model"
 msgstr "Modelo"
 
-#: pkg/machines/components/vmnetworktab.jsx:93
+#: pkg/machines/components/vmnetworktab.jsx:123
 msgid "Model type"
 msgstr "Tipo de modelo"
-
-#: pkg/kubernetes/views/user-modify.html:27
-msgid "Modify"
-msgstr "Modificar"
 
 #: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:45
 #: pkg/storaged/jobs-panel.jsx:52
@@ -4784,11 +3919,7 @@ msgstr "Monitorando Intervalo"
 msgid "Monitoring Targets"
 msgstr "Alvod e Monitoramento"
 
-#: pkg/kubernetes/views/volume-body.html:54
-msgid "Monitors"
-msgstr "Monitores"
-
-#: pkg/realmd/operation.js:530
+#: pkg/realmd/operation.js:529
 msgid "More"
 msgstr "Mais"
 
@@ -4801,31 +3932,27 @@ msgstr "Mais Informações"
 msgid "More details"
 msgstr "Mais detalhes"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Montar"
 
-#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
-msgid "Mount Location"
-msgstr "Montar Locação"
-
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Opções de Montagem"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Ponto de Montagem"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Monte na Inicialização"
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:521
 msgid "Mount container volumes"
 msgstr "Montar contêiners de volumes"
 
@@ -4841,7 +3968,7 @@ msgstr "O ponto de montagem não pode estar vazio"
 msgid "Mount point must start with \"/\"."
 msgstr "O ponto de montagem deve começar com \"/\"."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Monte só de leitura"
 
@@ -4865,11 +3992,7 @@ msgstr "Chassi Multi-sistema"
 msgid "NAT to $0"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:865
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:140
 msgid "NFS Mount"
 msgstr "Montagem NFS"
 
@@ -4881,7 +4004,7 @@ msgstr "NFS Mounts"
 msgid "NFS Support not installed"
 msgstr "Suporte ao NFS não instalado"
 
-#: pkg/machines/components/vmnetworktab.jsx:67
+#: pkg/machines/components/vmnetworktab.jsx:97
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
@@ -4893,54 +4016,29 @@ msgstr "NSNA Ping"
 msgid "NTP Server"
 msgstr "Servidor NTP"
 
-#: pkg/docker/index.html:267 pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/containers-listing.html:11
-#: pkg/kubernetes/views/dashboard-page.html:156
-#: pkg/kubernetes/views/dashboard-page.html:198
-#: pkg/kubernetes/views/details-page.html:34
-#: pkg/kubernetes/views/details-page.html:70
-#: pkg/kubernetes/views/details-page.html:103
-#: pkg/kubernetes/views/details-page.html:137
-#: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/service-modify.html:9
-#: pkg/kubernetes/views/user-modify.html:9
-#: pkg/kubernetes/views/volume-body.html:31
-#: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:119
+#: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
 #: pkg/networkmanager/index.html:319
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:181
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Nome"
 
@@ -4972,7 +4070,7 @@ msgstr "O nome não pode conter o caractere '$0'."
 msgid "Name cannot contain whitespace."
 msgstr "Nome não pode conter espaço em branco."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:82
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
 msgid "Name should not be empty"
 msgstr "O nome não deve estar vazio"
@@ -4980,26 +4078,6 @@ msgstr "O nome não deve estar vazio"
 #: pkg/machines/components/networks/networkOverviewTab.jsx:36
 msgid "Name: "
 msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
-#: pkg/kubernetes/views/details-page.html:36
-#: pkg/kubernetes/views/details-page.html:72
-#: pkg/kubernetes/views/details-page.html:105
-#: pkg/kubernetes/views/details-page.html:139
-#: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
-#: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
-#: pkg/kubernetes/views/service-body.html:5
-#: pkg/kubernetes/views/volumes-page.html:59
-msgid "Namespace"
-msgstr "Namespace"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "Namespace não pode estar vazio ."
 
 #: pkg/systemd/host.js:1348
 msgid "Need at least one NTP server"
@@ -5010,19 +4088,18 @@ msgid "Netmask"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:613
 msgid "Network"
 msgstr "Rede"
 
-#: pkg/machines/components/networks/network.jsx:117
+#: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/networks/network.jsx:129
+#: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
 msgid "Network Boot (PXE)"
 msgstr ""
 
@@ -5034,7 +4111,7 @@ msgstr "Sistema de arquivos de rede"
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:177
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Network Selection does not support PXE."
 msgstr ""
 
@@ -5055,7 +4132,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager não está rodando."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:914
 msgid "Networking"
 msgstr "Rede"
 
@@ -5073,21 +4150,17 @@ msgstr "Logs de rede"
 msgid "Networks"
 msgstr "Networks"
 
-#: pkg/users/local.js:963
+#: pkg/users/local.js:967
 msgid "Never"
 msgstr "Nunca"
 
-#: pkg/users/index.html:297 pkg/users/local.js:868
+#: pkg/users/index.html:297 pkg/users/local.js:872
 msgid "Never expire password"
 msgstr "Senha nunca expira"
 
-#: pkg/users/index.html:258 pkg/users/local.js:876
+#: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "Nunca bloquear conta"
-
-#: pkg/kubernetes/views/project-listing.html:46
-msgid "New Group"
-msgstr "Novo Grupo"
 
 #: pkg/storaged/nfs-details.jsx:140
 msgid "New NFS Mount"
@@ -5097,32 +4170,17 @@ msgstr "Nova montagem de volume NFS"
 msgid "New Password"
 msgstr "Nova Senha"
 
-#: pkg/kubernetes/views/project-listing.html:7
-msgid "New Project"
-msgstr "Novo Projeto"
-
 #: pkg/machines/components/diskAdd.jsx:132
 msgid "New Volume Name"
 msgstr "Novo nome do volume"
-
-#: pkg/kubernetes/views/images-page.html:11
-#: pkg/kubernetes/views/registry-dashboard-page.html:86
-msgid "New image stream"
-msgstr "Novo stream de imagem"
 
 #: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
 msgid "New passphrase"
 msgstr "Nova senha"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Nova senha não foi aceita"
-
-#: pkg/kubernetes/views/project-modify.html:4
-#: pkg/kubernetes/views/registry-dashboard-page.html:9
-#: pkg/kubernetes/views/registry-dashboard-page.html:48
-msgid "New project"
-msgstr "Novo projeto"
 
 #: pkg/realmd/operation.html:82 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
@@ -5136,9 +4194,8 @@ msgstr "Próxima Execução"
 msgid "Nice"
 msgstr "Bom"
 
-#: pkg/docker/index.html:542 pkg/docker/index.html:546 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/kubernetes/scripts/volumes.js:998
-#: pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
 msgid "No"
 msgstr "Não"
 
@@ -5162,24 +4219,12 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Nenhum volume NFS montado"
 
-#: src/ws/cockpitcertificate.c:522
-msgid "No PEM-encoded certificate found"
-msgstr "Nenhum certificado codificado em PEM encontrados"
-
-#: src/ws/cockpitcertificate.c:488
-msgid "No PEM-encoded private key found"
-msgstr "Nenhuma chave privada codificado em PEM encontrados"
-
-#: pkg/kubernetes/views/pv-claim.html:39
-msgid "No Pods are using this claim"
-msgstr "Sem Pods usando esta afirmação"
-
 #: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "No SELinux alerts."
 msgstr "Nenhum alerta SELinux."
 
-#: pkg/machines/components/diskAdd.jsx:193
-#: pkg/machines/components/diskAdd.jsx:205
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:216
 msgid "No Storage Pools available"
 msgstr ""
 
@@ -5187,11 +4232,6 @@ msgstr ""
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr ""
 "Nenhum volume de armazenamento definido para este pool de armazenamento"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:29
-#: pkg/ovirt/components/ClusterVms.jsx:36
-msgid "No VM found in oVirt."
-msgstr "Nenhuma VM encontrada no oVirt."
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
@@ -5201,11 +4241,7 @@ msgstr "Nenhuma VM está sendo executada ou definida neste host"
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html:10
-msgid "No Volume Bound"
-msgstr "Nenhuma Ligação de Volume"
-
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/networkmanager/firewall.jsx:926
 msgid "No active zones"
 msgstr ""
 
@@ -5221,7 +4257,7 @@ msgstr "Nenhum apelido especificado"
 msgid "No applications installed or available"
 msgstr "Nenhum aplicativo instalado ou disponível"
 
-#: pkg/sosreport/index.js:128
+#: pkg/sosreport/index.js:129
 msgid "No archive has been created."
 msgstr "Nenhum arquivo foi criado."
 
@@ -5257,7 +4293,7 @@ msgstr "Nenhum contêiner"
 msgid "No containers that match the current filter"
 msgstr "Nenhum contêiner que corresponda ao filtro atual"
 
-#: pkg/networkmanager/firewall.jsx:727
+#: pkg/networkmanager/firewall.jsx:729
 msgid "No description available"
 msgstr ""
 
@@ -5265,9 +4301,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "Nenhuma descrição fornecida."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Sem discos disponíveis."
 
@@ -5275,7 +4311,7 @@ msgstr "Sem discos disponíveis."
 msgid "No disks defined for this VM"
 msgstr "Nenhum disco definido para esta VM"
 
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:121
 msgid "No drives attached"
 msgstr "Não há unidades anexadas"
 
@@ -5286,10 +4322,6 @@ msgstr "Nenhum slot de chave livre"
 #: pkg/storaged/content-views.jsx:700
 msgid "No free space"
 msgstr "Não há espaço livre"
-
-#: pkg/kubernetes/views/project-listing.html:74
-msgid "No groups are present."
-msgstr "Nenhum grupo presente."
 
 #: pkg/systemd/index.html:29
 msgid "No host keys found."
@@ -5307,21 +4339,13 @@ msgstr "Nenhum stream de imagem está presente."
 msgid "No images"
 msgstr "Nenhuma imagem"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:80
-msgid "No images pushed"
-msgstr "Nenhuma imagem inserida"
-
 #: pkg/docker/containers-view.jsx:707
 msgid "No images that match the current filter"
 msgstr "Sem imagens que correspondam ao filtro atual"
 
-#: pkg/apps/utils.jsx:95
+#: pkg/apps/utils.jsx:96
 msgid "No installation package found for this application."
 msgstr "Nenhum pacote de instalação encontrado para este aplicativo."
-
-#: pkg/subscriptions/subscriptions-view.jsx:246
-msgid "No installed products on the system."
-msgstr "Não há produtos instalados no sistema."
 
 #: pkg/storaged/crypto-keyslots.jsx:520
 msgid "No keys added"
@@ -5345,14 +4369,7 @@ msgstr ""
 "comando do kernel (por exemplo, em  /etc/default/grub) para reservar memória "
 "no momento de inicialização. Exemplo: crashkernel=512M"
 
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr ""
-"Nenhum arquivo de metadados foi selecionado. Por favor, selecione um arquivo "
-"de metadados Kubernetes ."
-
-#: pkg/machines/components/vmnetworktab.jsx:40
+#: pkg/machines/components/vmnetworktab.jsx:70
 msgid "No network interfaces defined for this VM"
 msgstr "Nenhuma interface de rede definida para esta VM"
 
@@ -5364,15 +4381,7 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/kubernetes/views/dashboard-page.html:117
-msgid "No nodes in cluster"
-msgstr "Não há nós no cluster"
-
-#: pkg/ovirt/components/App.jsx:61
-msgid "No oVirt connection"
-msgstr "Sem conexão com oVirt"
-
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:939
 msgid "No open ports"
 msgstr "Sem portas abertas"
 
@@ -5380,27 +4389,7 @@ msgstr "Sem portas abertas"
 msgid "No partitioning"
 msgstr "Sem particionamento"
 
-#: pkg/kubernetes/views/dashboard-page.html:40
-msgid "No pods deployed"
-msgstr "Sem pods implantados"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:6
-msgid "No pods replicated"
-msgstr "Sem pods replicados"
-
-#: pkg/kubernetes/views/node-capacity.html:11
-msgid "No pods scheduled"
-msgstr "Sem pods agendados"
-
-#: pkg/kubernetes/views/service-endpoint.html:10
-msgid "No pods selected"
-msgstr "Sem pods selecionados"
-
-#: pkg/kubernetes/views/project-listing.html:37
-msgid "No projects are present."
-msgstr "Nenhum projeto presente."
-
-#: pkg/users/local.js:449
+#: pkg/users/local.js:453
 msgid "No real name specified"
 msgstr "Nenhum nome real especificado"
 
@@ -5440,48 +4429,17 @@ msgstr "Nenhuma tag está presente."
 msgid "No updates pending"
 msgstr "Nenhuma atualização pendente"
 
-#: pkg/users/local.js:444
+#: pkg/users/local.js:448
 msgid "No user name specified"
 msgstr "Nenhum nome de usuário foi especificado"
-
-#: pkg/kubernetes/views/project-listing.html:112
-msgid "No users are present."
-msgstr "Não há usuários presentes."
 
 #: pkg/storaged/vgroups-panel.jsx:114
 msgid "No volume groups created"
 msgstr "Nenhum grupo de volume criado"
 
-#: pkg/kubernetes/views/volumes-page.html:44
-msgid "No volumes are present."
-msgstr "Não há volumes presentes."
-
-#: pkg/kubernetes/views/dashboard-page.html:73
-msgid "No volumes in use"
-msgstr "Não há volumes em uso"
-
-#: pkg/kubernetes/views/containers-listing.html:15
-#: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
-#: pkg/kubernetes/views/topology-page.html:38
-msgid "Node"
-msgstr "Nó"
-
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
-#: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
-msgid "Nodes"
-msgstr "Nós"
-
-#: pkg/kubernetes/views/topology-page.html:39
-msgid "Nodes are the machines that run your containers."
-msgstr "Nós são as máquinas que executam seus contêineres."
-
-#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
-#: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:732
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Nenhum"
 
@@ -5489,23 +4447,13 @@ msgstr "Nenhum"
 msgid "None (Isolated Network)"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
-#: pkg/kubernetes/scripts/nodes.js:319
+#: pkg/playground/translate.html:29
 msgid "Not Ready"
 msgstr "Não está pronto"
-
-#: pkg/kubernetes/scripts/details.js:496 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "Não é um número válido de réplicas"
 
 #: pkg/lib/credentials.js:255
 msgid "Not a valid private key"
 msgstr "Chave privada não válida"
-
-#: pkg/kubernetes/scripts/details.js:547
-msgid "Not a valid value for Host"
-msgstr "Não é um valor válido para o Host"
 
 #: pkg/docker/index.html:57
 msgid "Not authorized to access Docker on this system"
@@ -5523,11 +4471,6 @@ msgstr "Indisponível"
 msgid "Not connected"
 msgstr "Não conectado"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
-#: pkg/kubernetes/views/details-page.html:122
-msgid "Not deployed"
-msgstr "Não Implantado"
-
 #: pkg/storaged/lvol-tabs.jsx:369
 msgid "Not enough space to grow."
 msgstr ""
@@ -5544,7 +4487,7 @@ msgstr "Não montado"
 msgid "Not permitted to perform this action."
 msgstr "Não é permitido executar esta ação."
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Not running"
 msgstr "Não está rodando"
 
@@ -5568,32 +4511,9 @@ msgstr "Notebook"
 msgid "Notice and above"
 msgstr "Observe e acima"
 
-#: pkg/ovirt/components/vcpuModal.jsx:55
-msgid "Number of virtual CPUs that gonna be used."
-msgstr "Número de CPUs virtuais que serão usadas."
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
-#: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
-msgid "OK"
-msgstr "OK"
-
-#: pkg/kubernetes/views/node-body.html:13
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "OS"
-msgstr "OS"
-
-#: pkg/ovirt/components/OVirtTab.jsx:148
-msgid "OS Type:"
-msgstr "Tipo de SO:"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:274
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
 msgid "OS Vendor"
 msgstr "Fornecedor de SO"
-
-#: pkg/kubernetes/views/nodes-page.html:19
-msgid "OS Versions"
-msgstr "Versões de OS"
 
 #: pkg/selinux/setroubleshoot-view.jsx:394
 msgid "Occurred $0"
@@ -5619,7 +4539,7 @@ msgstr "Senha Atual"
 msgid "Old passphrase"
 msgstr "Old passphrase"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Senha antiga não aceita"
 
@@ -5631,7 +4551,7 @@ msgstr "Ligado"
 msgid "On Build"
 msgstr "Em Desenvolvimento"
 
-#: pkg/docker/index.html:547 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/init.js:731
 msgid "On Failure"
 msgstr "Em Falha"
 
@@ -5653,7 +4573,7 @@ msgstr ""
 "Uma vez instalado o Cockpit, habilite-o com \"systemctl enable --now cockpit."
 "socket\"."
 
-#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:338
+#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
 msgstr "Uma senha do tempo"
 
@@ -5679,7 +4599,7 @@ msgstr "Apenas alfabetos, números,:, _,. , @,- são permitidos."
 msgid "Only editable when the guest is shut off"
 msgstr ""
 
-#: pkg/shell/index.html:43 pkg/shell/simple.html:29 pkg/shell/stub.html:33
+#: pkg/shell/index.html:43 pkg/shell/simple.html:29
 msgid "Ooops!"
 msgstr "Ooops!"
 
@@ -5687,8 +4607,8 @@ msgstr "Ooops!"
 msgid "Open"
 msgstr ""
 
-#: pkg/kubernetes/views/nodes-page.html:42 pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+#: pkg/systemd/index.html:98
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
 msgid "Operating System"
 msgstr "Sistema Operacional"
 
@@ -5696,27 +4616,24 @@ msgstr "Sistema Operacional"
 msgid "Operation '$operation' on $target"
 msgstr "Operação '$operation' em $target"
 
+#: pkg/machines/components/storagePools/storagePool.jsx:175
+#: pkg/machines/components/storagePools/storagePool.jsx:180
+#, fuzzy
+msgid "Operation is in progress"
+msgstr "login do theVirt em andamento"
+
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Optical Drive"
 
-#: pkg/ovirt/components/OVirtTab.jsx:157
-msgid "Optimized for:"
-msgstr "Otimizado para:"
-
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:134
-#: pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
 msgid "Options"
 msgstr "Opções"
 
 #: src/ws/login.html:125
 msgid "Or use a bundled browser"
 msgstr "Ou use um navegador incluído"
-
-#: pkg/subscriptions/subscriptions-register.jsx:180
-msgid "Organization"
-msgstr "Organização"
 
 #: pkg/lib/machine-info.js:64
 msgid "Other"
@@ -5735,11 +4652,9 @@ msgstr "Outros dispositivos"
 msgid "Other Options"
 msgstr "Outras Opções"
 
-#: pkg/docker/index.html:297 pkg/kubernetes/index.html:43
-#: pkg/kubernetes/registry.html:43
-#: pkg/machines/components/networks/network.jsx:71
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Visão geral"
 
@@ -5750,10 +4665,6 @@ msgstr "Sobrescrever dados existentes com zeros"
 #: pkg/systemd/hwinfo.jsx:249
 msgid "PCI"
 msgstr "PCI"
-
-#: pkg/kubernetes/views/volume-body.html:4
-msgid "PD Name"
-msgstr "Nome de PD"
 
 #: pkg/packagekit/updates.jsx:501
 msgid "Package information"
@@ -5787,8 +4698,7 @@ msgstr "Parte de"
 msgid "Part of "
 msgstr "Parte de"
 
-#: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:141
 msgid "Partition"
 msgstr "Partição"
 
@@ -5824,13 +4734,11 @@ msgstr "A remoção da senha pode impedir o desbloqueio de $0."
 msgid "Passphrases do not match"
 msgstr "As senhas não correspondem"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
 #: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
-#: pkg/subscriptions/subscriptions-register.jsx:89
-#: pkg/subscriptions/subscriptions-register.jsx:156
 msgid "Password"
 msgstr "Senha"
 
@@ -5846,7 +4754,7 @@ msgstr "Senha não é aceitavél"
 msgid "Password is too weak"
 msgstr "Senha é muito fraca"
 
-#: pkg/users/local.js:870
+#: pkg/users/local.js:874
 msgid "Password must be changed"
 msgstr "A senha deve ser alterada"
 
@@ -5869,11 +4777,7 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Cole o conteúdo do seu arquivo de chave pública SSH aqui"
 
-#: pkg/kubernetes/views/pv-modify.html:126
-#: pkg/kubernetes/views/volume-body.html:37
-#: pkg/kubernetes/views/volume-body.html:49
-#: pkg/kubernetes/views/volume-body.html:101 pkg/systemd/services.html:126
-#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
 msgid "Path"
 msgstr "Caminho"
 
@@ -5889,7 +4793,7 @@ msgstr "Path cost $path_cost"
 msgid "Path on Server"
 msgstr "Caminho no servidor"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:129
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
 msgid "Path on host's filesystem"
 msgstr "Caminho no sistema de arquivos do host"
 
@@ -5901,7 +4805,7 @@ msgstr "Caminho no servidor não pode estar vazio."
 msgid "Path on server must start with \"/\"."
 msgstr "Caminho no servidor deve começar com \"/\"."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:154
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
 msgid "Path to ISO file on host's file system"
 msgstr "Caminho para o arquivo ISO no sistema de arquivos do host"
 
@@ -5916,10 +4820,6 @@ msgstr "Caminhos"
 #: pkg/machines/components/vm/vmActions.jsx:77
 msgid "Pause"
 msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html:53
-msgid "Pending Volume Claims"
-msgstr "Declarações de Volume Pendentes"
 
 #: pkg/systemd/index.html:152
 msgid "Performance Profile"
@@ -5941,18 +4841,10 @@ msgstr "Permissão negada"
 msgid "Persistence"
 msgstr "Persistência"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr "Persistente"
-
-#: pkg/kubernetes/views/volumes-page.html:14
-msgid "Persistent Volumes"
-msgstr "Volumes Persistentes"
-
-#: pkg/kubernetes/views/pod-body.html:16
-msgid "Phase"
-msgstr "Fase"
 
 #: pkg/storaged/vdo-details.jsx:277
 msgid "Physical"
@@ -5966,11 +4858,11 @@ msgstr ""
 msgid "Physical Volume"
 msgstr "Volume Físico"
 
-#: pkg/storaged/vgroup-details.jsx:134
+#: pkg/storaged/vgroup-details.jsx:133
 msgid "Physical Volumes"
 msgstr "Volumes Físicos"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:210
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -5994,10 +4886,10 @@ msgstr "Alvo do Ping"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:210
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Por favor, confirme a remoção de $0"
 
@@ -6005,117 +4897,23 @@ msgstr "Por favor, confirme a remoção de $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Por favor, confirme a exclusão forçada de $0"
 
-#: pkg/storaged/mdraid-details.jsx:244 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Por favor confirme a parada de $0"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:34
-msgid "Please confirm, the host shall be switched to maintenance mode."
-msgstr "Por favor confirme, o host deve ser mudado para o modo de manutenção."
-
-#: pkg/kubernetes/scripts/dashboard.js:439
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Por favor, crie outro namespace para $0 \"$1\""
-
-#: pkg/machines/components/diskAdd.jsx:425
+#: pkg/machines/components/diskAdd.jsx:447
 msgid "Please enter new volume name"
 msgstr "Por favor insira o novo nome do volume"
 
-#: pkg/machines/components/diskAdd.jsx:428
+#: pkg/machines/components/diskAdd.jsx:450
 msgid "Please enter new volume size"
 msgstr "Por favor insira o novo tamanho do volume"
 
-#: pkg/networkmanager/firewall.jsx:862
+#: pkg/networkmanager/firewall.jsx:864
 msgid "Please install the $0 package"
 msgstr "Por favor, instale o pacote de $0"
 
-#: pkg/kubernetes/scripts/volumes.js:582
-msgid "Please provide a GlusterFS volume name"
-msgstr "Por favor, forneça um nome de volume GlusterFS"
-
-#: pkg/kubernetes/scripts/connection.js:550
-msgid "Please provide a username"
-msgstr "Por favor, forneça um nome de usuário"
-
-#: pkg/kubernetes/scripts/volumes.js:640
-msgid "Please provide a valid NFS server"
-msgstr "Por favor, forneça um servidor NFS válido"
-
-#: pkg/kubernetes/scripts/connection.js:535
-msgid "Please provide a valid address"
-msgstr "Por favor, forneça um endereço válido"
-
-#: pkg/kubernetes/scripts/volumes.js:810
-msgid "Please provide a valid filesystem type"
-msgstr "Por favor, forneça um tipo de sistema de arquivos válido"
-
-#: pkg/kubernetes/scripts/volumes.js:818
-msgid "Please provide a valid interface"
-msgstr "Por favor, forneça uma interface válida"
-
-#: pkg/kubernetes/scripts/volumes.js:802
-msgid "Please provide a valid logical unit number"
-msgstr "Por favor, forneça um número lógico válido de unidade"
-
-#: pkg/kubernetes/scripts/volumes.js:483
-msgid "Please provide a valid name"
-msgstr "Por favor, forneça um nome válido"
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Por favor, forneça um namespace válido."
-
-#: pkg/kubernetes/scripts/volumes.js:648 pkg/kubernetes/scripts/volumes.js:703
-msgid "Please provide a valid path"
-msgstr "Por favor, forneça um caminho válido"
-
-#: pkg/kubernetes/scripts/volumes.js:794
-msgid "Please provide a valid qualified name"
-msgstr "Por favor, forneça um nome qualificado válido"
-
-#: pkg/kubernetes/scripts/volumes.js:491
-msgid "Please provide a valid storage capacity."
-msgstr "Por favor, forneça uma capacidade de armazenamento válida."
-
-#: pkg/kubernetes/scripts/volumes.js:786
-msgid "Please provide a valid target"
-msgstr "Por favor, forneça um alvo válido"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:83
-msgid ""
-"Please provide fully qualified domain name and port of the oVirt engine."
-msgstr ""
-"Por favor, forneça o nome de domínio e a porta totalmente qualificados do "
-"motor da oVirt."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:137
-msgid ""
-"Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-"port (443 by default)"
-msgstr ""
-"Por favor, forneça o nome de domínio totalmente qualificado (FQDN) do motor "
-"oVirt e a porta (443 por padrão)"
-
-#: pkg/ovirt/components/ConsoleClientResources.jsx:32
-msgid ""
-"Please refer to oVirt's $0 for more information about Remote Viewer setup."
-msgstr ""
-"Por favor, consulte o $0 da oVirt para mais informações sobre a configuração "
-"do Visualizador Remoto."
-
-#: pkg/kubernetes/scripts/volumes.js:475
-msgid "Please select a valid access mode"
-msgstr "Por favor, selecione um modo de acesso válido"
-
-#: pkg/kubernetes/scripts/volumes.js:573
-msgid "Please select a valid endpoint"
-msgstr "Por favor, selecione um ponto de extremidade válido"
-
-#: pkg/kubernetes/scripts/volumes.js:499
-msgid "Please select a valid policy option."
-msgstr "Por favor, selecione uma opção de diretiva válida."
-
-#: pkg/users/local.js:1232
+#: pkg/users/local.js:1236
 msgid "Please specify an expiration date"
 msgstr "Por favor especifique uma data de expiração"
 
@@ -6131,75 +4929,16 @@ msgstr "Por favor, inicie a máquina virtual para acessar seu console."
 msgid "Please try another term"
 msgstr "Por favor, tente outro termo"
 
-#: pkg/kubernetes/scripts/nodes.js:401
-msgid "Please type an address"
-msgstr "Por favor, digite um endereço"
-
-#: pkg/ovirt/components/ClusterVms.jsx:37
-msgid "Please wait till VMs list is loaded from the server."
-msgstr "Por favor, aguarde até que a lista de VMs seja carregada do servidor."
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:30
-msgid "Please wait till list of templates is loaded from the server."
-msgstr ""
-"Por favor, aguarde até que a lista de modelos seja carregada do servidor."
-
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Plug"
 msgstr "Plug"
 
-#: pkg/kubernetes/views/containers-listing.html:12
-#: pkg/kubernetes/views/pod-page.html:12
-#: pkg/kubernetes/views/topology-page.html:14
-msgid "Pod"
-msgstr "Pod"
-
-#: pkg/kubernetes/views/pod-body.html:20
-msgid "Pod Address"
-msgstr "Endereço Pod"
-
-#: pkg/kubernetes/views/service-endpoint.html:4
-#: pkg/kubernetes/views/service-endpoint.html:9
-msgid "Pod Endpoints"
-msgstr "Extremidades Pod"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:4
-msgid "Pod Replicated"
-msgstr "Pod Replicado"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:11
-#: pkg/kubernetes/views/service-endpoint.html:15
-msgid "Pod Selector"
-msgstr "Seletor Pod"
-
-#: pkg/kubernetes/views/dashboard-page.html:18
-#: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/pv-claim.html:37
-#: pkg/kubernetes/views/replicationcontroller-page.html:17
-#: pkg/kubernetes/views/replicationcontroller-panel.html:12
-#: pkg/kubernetes/scripts/details.js:227
-msgid "Pods"
-msgstr "Pods"
-
-#: pkg/kubernetes/views/topology-page.html:15
-msgid ""
-"Pods contain one or more containers that run together on a node, containing "
-"your application code."
-msgstr ""
-"Pods contêm um ou mais conteiners que são executados juntos em um nó, que "
-"contém o código do aplicativo."
-
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Pool"
-
-#: pkg/kubernetes/views/volume-body.html:60
-msgid "Pool Name"
-msgstr "Nome do Pool"
 
 #: pkg/storaged/utils.js:191
 msgid "Pool for Thin Logical Volumes"
@@ -6213,16 +4952,11 @@ msgstr "Pool para Volumes Finos"
 msgid "Pool for thinly provisioned volumes"
 msgstr "Pool para volumes finamente provisionados"
 
-#: pkg/kubernetes/views/imagestream-modify.html:45
-msgid "Populate"
-msgstr "Preencher"
-
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:78
-#: pkg/ovirt/components/InstallationDialog.jsx:65
+#: pkg/machines/components/vmnetworktab.jsx:108
 #: pkg/storaged/iscsi-panel.jsx:127
 msgid "Port"
 msgstr "Porta"
@@ -6235,15 +4969,14 @@ msgstr ""
 msgid "Portable"
 msgstr "Portatil"
 
-#: pkg/docker/index.html:504 pkg/kubernetes/views/container-body.html:12
-#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:213
+#: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
 #: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
 msgid "Ports"
 msgstr "Portas"
 
-#: pkg/docker/index.html:191
+#: pkg/docker/index.html:192
 msgid "Ports:"
 msgstr "Portas:"
 
@@ -6252,7 +4985,6 @@ msgid "Power Options"
 msgstr "Opções de Energia"
 
 #: pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Preferred number of sockets to expose to the guest."
 msgstr "Número preferido de soquetes para expor ao convidado."
 
@@ -6271,10 +5003,6 @@ msgstr "Comprimento do prefixo ou máscara de rede"
 #: pkg/networkmanager/interfaces.js:826
 msgid "Preparing"
 msgstr "Preparando"
-
-#: pkg/ovirt/rephraseUI.js:25
-msgid "Preparing for Maintenance"
-msgstr "Preparando-se para manutenção"
 
 #: pkg/networkmanager/interfaces.js:3631
 msgid "Preserve"
@@ -6313,11 +5041,6 @@ msgstr "Prioridade $priority"
 msgid "Private"
 msgstr ""
 
-#: pkg/kubernetes/scripts/projects.js:1042
-msgid "Private: Allow only specific users or groups to pull images"
-msgstr ""
-"Privado: permite que apenas usuários específicos ou grupos puxem imagens"
-
 #: pkg/shell/index.html:39
 msgid "Privileged"
 msgstr "Privilegiado"
@@ -6343,67 +5066,9 @@ msgstr "Processo"
 msgid "Product"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:34
-msgid "Product ID"
-msgstr "ID do Produto"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product name"
-msgstr "Nome do produto"
-
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
-#: pkg/kubernetes/views/details-page.html:35
-#: pkg/kubernetes/views/details-page.html:71
-#: pkg/kubernetes/views/details-page.html:104
-#: pkg/kubernetes/views/details-page.html:138
-#: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/pod-body.html:4
-#: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/route-body.html:4
-#: pkg/kubernetes/views/service-body.html:4
-#: pkg/kubernetes/views/volumes-page.html:58
-msgid "Project"
-msgstr "Projeto"
-
-#: pkg/kubernetes/views/project-body.html:20
-msgid "Project Members"
-msgstr "Membros do Projeto"
-
-#: pkg/kubernetes/views/project-body.html:3
-msgid "Project access policy allows anonymous users to pull images."
-msgstr ""
-"A diretiva de acesso ao projeto permite que usuários anônimos baixem imagens."
-""
-
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Project access policy allows any authenticated user to pull images."
-msgstr ""
-"A diretiva de acesso a projetos permite que qualquer usuário autenticado "
-"puxe imagens."
-
-#: pkg/kubernetes/views/project-body.html:13
-msgid "Project access policy only allows specific members to access images."
-msgstr ""
-"A diretiva de acesso ao projeto só permite que membros específicos acessem "
-"imagens."
-
-#: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
+#: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
 msgstr "Site do projeto"
-
-#: pkg/kubernetes/views/filter-project.html:5
-msgid "Project:"
-msgstr "Projeto:"
-
-#: pkg/kubernetes/index.html:88 pkg/kubernetes/registry.html:55
-#: pkg/kubernetes/views/group-delete.html:10
-#: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
-msgid "Projects"
-msgstr "Projetos"
 
 #: pkg/users/local.js:91
 msgid "Prompting via passwd timed out"
@@ -6427,15 +5092,7 @@ msgstr "Propaga Recarregar para"
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: pkg/subscriptions/subscriptions-register.jsx:129
-msgid "Proxy"
-msgstr "Proxy"
-
-#: pkg/kubernetes/views/node-body.html:25
-msgid "Proxy Version"
-msgstr "Versão do Proxy"
-
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Chave Pública"
 
@@ -6443,25 +5100,9 @@ msgstr "Chave Pública"
 msgid "Public pulling repo"
 msgstr "Publico pulling repo"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:152
-msgid "Pull an image:"
-msgstr "Baixar uma imagem:"
-
-#: pkg/kubernetes/views/imagestream-modify.html:66
-msgid "Pull from"
-msgstr "Baixar de"
-
-#: pkg/kubernetes/scripts/images.js:635
-msgid "Pull specific tags from another image repository"
-msgstr "Resgatar tags específicas de outro repositório de imagem"
-
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Propósito"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:141
-msgid "Push an image:"
-msgstr "Enviar uma imagem:"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:31
 msgid "QEMU/KVM System connection"
@@ -6471,16 +5112,11 @@ msgstr "Conexão do sistema QEMU / KVM"
 msgid "QEMU/KVM User connection"
 msgstr "Conexão do usuário QEMU / KVM"
 
-#: pkg/kubernetes/views/pv-modify.html:148
-#: pkg/kubernetes/views/volume-body.html:77
-msgid "Qualified Name"
-msgstr "Nome Qualificado"
-
-#: pkg/storaged/mdraid-details.jsx:186
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 0"
 msgstr "RAID 0"
 
@@ -6488,7 +5124,7 @@ msgstr "RAID 0"
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (Distribuição)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 1"
 msgstr "RAID 1"
 
@@ -6496,7 +5132,7 @@ msgstr "RAID 1"
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (Espelhamento)"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 10"
 msgstr "RAID 10"
 
@@ -6504,7 +5140,7 @@ msgstr "RAID 10"
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (Distribuição de Espelhos)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 4"
 msgstr "RAID 4"
 
@@ -6512,7 +5148,7 @@ msgstr "RAID 4"
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (Paridade Dedicada)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 5"
 msgstr "RAID 5"
 
@@ -6520,7 +5156,7 @@ msgstr "RAID 5"
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (Paridade Distribuída)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 6"
 msgstr "RAID 6"
 
@@ -6536,7 +5172,7 @@ msgstr "RAID Chassis"
 msgid "RAID Device"
 msgstr "Dispositivo RAID"
 
-#: pkg/storaged/mdraid-details.jsx:316 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "Dispositivo RAID $0"
 
@@ -6552,27 +5188,15 @@ msgstr "Nível de RAID"
 msgid "RAID Member"
 msgstr "Membro RAID"
 
-#: pkg/ovirt/provider.js:179
-msgid "REBOOT action failed"
-msgstr "A ação REBOOT falhou"
-
-#: pkg/ovirt/provider.js:164
-msgid "REBOOT_VM action failed: %s0"
-msgstr ""
-
 #: pkg/lib/machine-info.js:86
 msgid "Rack Mount Chassis"
 msgstr "Rack Mount Chassis"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Dispositivo Rados Bloqueado"
 
 #: pkg/networkmanager/interfaces.js:3632
 msgid "Random"
 msgstr "Aleatório(a)"
 
-#: pkg/networkmanager/firewall.jsx:757
+#: pkg/networkmanager/firewall.jsx:759
 msgid "Range"
 msgstr ""
 
@@ -6584,42 +5208,15 @@ msgstr ""
 msgid "Raw to a device"
 msgstr "Raw para um dispositivo"
 
-#: pkg/kubernetes/views/pv-modify.html:195
-#: pkg/kubernetes/views/volume-body.html:10
-#: pkg/kubernetes/views/volume-body.html:20
-#: pkg/kubernetes/views/volume-body.html:44
-#: pkg/kubernetes/views/volume-body.html:51
-#: pkg/kubernetes/views/volume-body.html:71
-#: pkg/kubernetes/views/volume-body.html:85
-#: pkg/kubernetes/views/volume-body.html:93
-#: pkg/kubernetes/views/volume-body.html:110
-#: pkg/kubernetes/views/volume-body.html:122
-#: pkg/kubernetes/views/volume-body.html:136
-#: pkg/kubernetes/views/volume-body.html:143
-msgid "Read Only"
-msgstr "Somente leitura"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "Ler e gravar a partir de um único nó"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "Ler e gravar a partir de vários nós"
-
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "Somente leitura de vários nós"
-
-#: pkg/docker/index.html:363
+#: pkg/docker/index.html:365
 msgid "ReadOnly"
 msgstr "SomenteLeitura"
 
-#: pkg/docker/index.html:362
+#: pkg/docker/index.html:364
 msgid "ReadWrite"
 msgstr "LeituraEscrita"
 
@@ -6635,13 +5232,11 @@ msgstr "Lendo..."
 msgid "Readonly"
 msgstr "Apenasleitura"
 
-#: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
-#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/playground/translate.html:19
 msgid "Ready"
 msgstr "Pronto"
 
-#: pkg/playground/translate.html:24 pkg/playground/translate.html:184
+#: pkg/playground/translate.html:24
 msgctxt "verb"
 msgid "Ready"
 msgstr "Pronto"
@@ -6662,10 +5257,6 @@ msgstr ""
 msgid "Real host name must be 64 characters or less"
 msgstr "Nome de host real deve conter 64 caracteres ou menos"
 
-#: pkg/kubernetes/views/node-body.html:45
-msgid "Reason"
-msgstr "Razão"
-
 #: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
 msgid "Reboot"
 msgstr "Reiniciar"
@@ -6680,16 +5271,11 @@ msgstr "Recebendo"
 msgid "Recent"
 msgstr "Recente"
 
-#: pkg/kubernetes/views/pv-body.html:6 pkg/kubernetes/views/pv-modify.html:56
-msgid "Reclaim Policy"
-msgstr "Recuperar Política"
-
 #: pkg/storaged/format-dialog.jsx:248
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/kubernetes/index.html:108 pkg/kubernetes/registry.html:75
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138 pkg/shell/stub.html:180
+#: pkg/shell/index.html:386 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Reconectar"
@@ -6701,10 +5287,6 @@ msgstr "Recuperação"
 #: pkg/storaged/jobs-panel.jsx:65
 msgid "Recovering RAID Device $target"
 msgstr "Recuperando Dispositivo RAID $target"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "Reciclar"
 
 #: pkg/docker/storage.jsx:389
 msgid "Reformat and add disks"
@@ -6726,36 +5308,10 @@ msgstr "Recusando-se a se conectar. A chave não coincide"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Recusando-se a se conectar. A chave é desconhecida"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:159
-msgid "Register"
-msgstr "Registrar"
-
-#: pkg/kubernetes/views/volumes-page.html:12
-msgid "Register New Volume"
-msgstr "Registrar Novo Volume"
-
-#: pkg/kubernetes/views/pv-modify.html:4
-msgid "Register Persistent Volume"
-msgstr "Registrar Volume Persistente"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:108
-msgid "Register oVirt"
-msgstr "Registrar oVirt"
-
-#: pkg/subscriptions/main.js:73
-msgid "Register system"
-msgstr "Registrar sistema"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:128
-msgid "Registering oVirt to Cockpit"
-msgstr "Registrando oVirt no Cockpit"
-
 #: pkg/packagekit/updates.jsx:777
 msgid "Register…"
 msgstr "Registro…"
 
-#: pkg/ovirt/components/App.jsx:62 pkg/ovirt/components/VdsmView.jsx:100
 #: pkg/systemd/init.js:546
 msgid "Reload"
 msgstr "Recarregar"
@@ -6764,7 +5320,7 @@ msgstr "Recarregar"
 msgid "Reload Propagated From"
 msgstr "Recarregar propagado de"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:202
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
 msgid "Remote URL"
 msgstr "URL remoto"
 
@@ -6776,10 +5332,6 @@ msgstr "Remoto sobre NFS"
 msgid "Remote over SSH"
 msgstr "Remoto sobre SSH"
 
-#: pkg/kubernetes/views/imagestream-modify.html:89
-msgid "Remote registry is insecure"
-msgstr "Registro remoto é inseguro"
-
 #: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
 msgctxt "storage"
 msgid "Removable Drive"
@@ -6789,13 +5341,9 @@ msgstr "Removable Drive"
 msgid "Removals:"
 msgstr "Remoções:"
 
-#: pkg/kubernetes/views/group-delete.html:21
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-delete.html:25
-#: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Remover"
 
@@ -6807,37 +5355,13 @@ msgstr "Remover $0"
 msgid "Remove $0?"
 msgstr "Remover $0?"
 
-#: pkg/kubernetes/views/group-delete.html:3
-msgid "Remove Group"
-msgstr "Remover Grupo"
-
-#: pkg/kubernetes/views/user-group-remove.html:3
-msgid "Remove Member"
-msgstr "Remover Membro"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:3
-msgid "Remove Role"
-msgstr "Remover Função"
-
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove Tang keyserver"
 msgstr "Remover o servidor de chaves Tang"
 
-#: pkg/kubernetes/views/user-delete.html:3
-msgid "Remove User"
-msgstr "Remover Usuário"
-
 #: pkg/storaged/vdo-details.jsx:116
 msgid "Remove device"
 msgstr "Remover dispositivo"
-
-#: pkg/kubernetes/views/image-delete.html:3
-msgid "Remove image tag"
-msgstr "Remover tag de imagem"
-
-#: pkg/kubernetes/views/user-remove-membership.html:3
-msgid "Remove membership"
-msgstr "Remover associação"
 
 #: pkg/storaged/crypto-keyslots.jsx:387
 msgid "Remove passphrase"
@@ -6847,11 +5371,11 @@ msgstr "Remover senha"
 msgid "Remove passphrase in $0?"
 msgstr "Remover frase secreta em $0?"
 
-#: pkg/networkmanager/firewall.jsx:629
+#: pkg/networkmanager/firewall.jsx:631
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:608
+#: pkg/networkmanager/firewall.jsx:610
 msgid "Remove service from zones"
 msgstr ""
 
@@ -6879,8 +5403,8 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Removendo volume físico de $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:187
-#: pkg/storaged/vgroup-details.jsx:235
+#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:234
 msgid "Rename"
 msgstr "Renomear"
 
@@ -6888,7 +5412,7 @@ msgstr "Renomear"
 msgid "Rename Logical Volume"
 msgstr "Renomear Volume Lógico"
 
-#: pkg/storaged/vgroup-details.jsx:179
+#: pkg/storaged/vgroup-details.jsx:178
 msgid "Rename Volume Group"
 msgstr "Renomear Grupo de Volume"
 
@@ -6925,32 +5449,6 @@ msgstr "Repita Anualmente"
 msgid "Repeat passphrase"
 msgstr "Repita a frase secreta"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
-#: pkg/kubernetes/views/details-page.html:141
-#: pkg/kubernetes/views/replicationcontroller-body.html:9
-#: pkg/kubernetes/views/replicationcontroller-modify.html:8
-msgid "Replicas"
-msgstr "Réplicas"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/replicationcontroller-panel.html:10
-#: pkg/kubernetes/views/topology-page.html:22
-msgid "Replication Controller"
-msgstr "Controlador de Replicação"
-
-#: pkg/kubernetes/views/details-page.html:132
-#: pkg/kubernetes/scripts/details.js:224
-msgid "Replication Controllers"
-msgstr "Controladores de Replicação"
-
-#: pkg/kubernetes/views/topology-page.html:23
-msgid ""
-"Replication controllers dynamically create instances of pods from templates, "
-"and remove pods when necessary."
-msgstr ""
-"Os controladores de replicação criam dinamicamente instâncias modelos de "
-"pods e removem esses pods quando necessário."
-
 #: pkg/systemd/logs.js:512
 msgid "Report"
 msgstr "Relatório"
@@ -6965,31 +5463,18 @@ msgstr "Repórter 'reporter-ureport' não encontrado."
 
 #: pkg/systemd/logs.js:531
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
-msgstr ""
-"Os relatórios não tiveram sucesso. Tente executar `reporter-ureport -d"
+msgstr "Os relatórios não tiveram sucesso. Tente executar `reporter-ureport -d"
 
-#: pkg/docker/index.html:688
+#: pkg/docker/index.html:690
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Repositório"
 
-#: pkg/kubernetes/views/volume-body.html:24
-msgid "Repository URL"
-msgstr "URL do Repositório"
-
-#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
-msgid "Requested"
-msgstr "Requisitado"
-
-#: pkg/kubernetes/views/pv-claim.html:13
-msgid "Requests"
-msgstr "Requisições"
-
-#: pkg/users/local.js:1296
+#: pkg/users/local.js:1300
 msgid "Require password change every $0 days"
 msgstr "Requer mudança de senha a cada $0 dias"
 
-#: pkg/users/local.js:872
+#: pkg/users/local.js:876
 msgid "Require password change on $0"
 msgstr "Exigir alteração de senha em $0"
 
@@ -7000,10 +5485,6 @@ msgstr "Solicitado por"
 #: pkg/systemd/init.js:717
 msgid "Requires"
 msgstr "Requere"
-
-#: pkg/kubernetes/views/auth-form.html:54
-msgid "Requires Authentication"
-msgstr "Requer Autenticação"
 
 #: pkg/systemd/init.js:718
 msgid "Requisite"
@@ -7017,7 +5498,7 @@ msgstr "Requisitode"
 msgid "Reserved memory"
 msgstr "Memória reservada"
 
-#: pkg/docker/index.html:301 pkg/users/index.html:333
+#: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:105
 msgid "Reset"
 msgstr "Redefinir"
@@ -7045,26 +5526,22 @@ msgid ""
 "a current disk passphrase."
 msgstr ""
 
-#: pkg/docker/index.html:135 pkg/systemd/index.html:134
+#: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Reiniciar"
-
-#: pkg/kubernetes/views/container-body.html:20
-msgid "Restart Count"
-msgstr "Reiniciar Contagem"
 
 #: pkg/packagekit/updates.jsx:498
 msgid "Restart Now"
 msgstr "Reinicie agora"
 
-#: pkg/docker/index.html:537 pkg/kubernetes/views/pod-body.html:10
+#: pkg/docker/index.html:539
 msgid "Restart Policy"
 msgstr "Reinicie a Política"
 
-#: pkg/docker/index.html:171
+#: pkg/docker/index.html:172
 msgid "Restart Policy:"
 msgstr "Reinicie a Política:"
 
@@ -7084,52 +5561,27 @@ msgstr "Restaurando conexão"
 msgid "Resume"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "Manter"
-
-#: pkg/docker/index.html:553
+#: pkg/docker/index.html:555
 msgid "Retries:"
 msgstr "Tentativas:"
-
-#: pkg/subscriptions/subscriptions-view.jsx:210
-msgid "Retrieving subscription status..."
-msgstr "Recuperando o status da assinatura..."
 
 #: src/ws/login.html:57
 msgid "Reuse my password for privileged tasks"
 msgstr "Reutilize minha senha para tarefas privilegiadas"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Reutilizar minha senha para tarefas privilegiadas e conectar-se a outras "
 "máquinas"
 
-#: pkg/kubernetes/views/volume-body.html:26
-msgid "Revision"
-msgstr "Revisão"
-
-#: pkg/kubernetes/views/user-add-membership.html:28
-#: pkg/kubernetes/views/user-body.html:5
-#: pkg/kubernetes/views/user-panel.html:28
-msgid "Role"
-msgstr "Função"
-
-#: pkg/kubernetes/views/add-member-role-dialog.html:39
-#: pkg/kubernetes/views/project-body.html:21 pkg/users/index.html:94
+#: pkg/users/index.html:94
 msgid "Roles"
 msgstr "Papéis"
 
 #: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
 msgid "Round Robin"
 msgstr "Round Robin"
-
-#: pkg/kubernetes/views/route-page.html:14
-#: pkg/kubernetes/views/route-panel.html:9
-msgid "Route"
-msgstr "Rota"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:98
 msgid "Route to $0"
@@ -7139,22 +5591,16 @@ msgstr ""
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:65
-#: pkg/kubernetes/scripts/details.js:216 pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3325
 msgid "Routes"
 msgstr "Rotas"
 
-#: pkg/docker/index.html:244 pkg/docker/index.html:564
+#: pkg/docker/index.html:253 pkg/docker/index.html:566
 #: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
-#: pkg/ovirt/components/ClusterVms.jsx:92
 msgid "Run"
 msgstr "Executar"
 
-#: pkg/ovirt/components/ClusterVms.jsx:97
-msgid "Run Here"
-msgstr "Rodar aqui"
-
-#: pkg/docker/index.html:425
+#: pkg/docker/index.html:427
 msgid "Run Image"
 msgstr "Executar Imagem"
 
@@ -7163,7 +5609,7 @@ msgid "Run as"
 msgstr "Executar como"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:128
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
 msgstr ""
 
@@ -7171,17 +5617,13 @@ msgstr ""
 msgid "Runner"
 msgstr "Executor"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Running"
 msgstr "Executando"
 
 #: pkg/systemd/services.html:123
 msgid "Running Since"
 msgstr "Executando desde"
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:54
-msgid "Running Since:"
-msgstr "Correndo desde:"
 
 #: pkg/selinux/setroubleshoot-view.jsx:364
 msgid "SELinux Access Control Errors"
@@ -7207,14 +5649,6 @@ msgstr "SELinux está desativado no sistema."
 msgid "SELinux system status is unknown."
 msgstr "O status do sistema SELinux é desconhecido."
 
-#: pkg/ovirt/provider.js:440
-msgid "SET VCPU SETTINGS action failed"
-msgstr "A ação SET SETUP VCPU falhou"
-
-#: pkg/ovirt/provider.js:111 pkg/ovirt/provider.js:145
-msgid "SHUTDOWN action failed"
-msgstr "A ação SHUTDOWN falhou"
-
 #: pkg/storaged/jobs-panel.jsx:35
 msgid "SMART self-test of $target"
 msgstr "SMART auto-teste de $target"
@@ -7235,14 +5669,6 @@ msgstr "SPICE Porta:"
 msgid "SPICE TLS Port:"
 msgstr "SPICE TLS Porta:"
 
-#: pkg/ovirt/provider.js:225
-msgid "START action failed"
-msgstr "START Ação: falhou"
-
-#: pkg/ovirt/provider.js:203
-msgid "START_VM action failed: %s0"
-msgstr ""
-
 #: pkg/networkmanager/index.html:228
 msgid "STP Forward delay"
 msgstr "STP Atraso de Redirecionamento "
@@ -7259,10 +5685,6 @@ msgstr "STP Máxima permanência de mensagem"
 msgid "STP Priority"
 msgstr "STP Prioridade"
 
-#: pkg/ovirt/provider.js:303
-msgid "SUSPEND action failed"
-msgstr "SUSPEND Ação: falhou"
-
 #: pkg/systemd/services.html:240
 msgid "Saturday"
 msgstr "Sábado"
@@ -7271,10 +5693,10 @@ msgstr "Sábado"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/ovirt/components/VdsmView.jsx:114 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
 #: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Salvar"
@@ -7299,14 +5721,6 @@ msgstr ""
 "Salvar uma nova senha requer o desbloqueio do disco. Por favor, forneça uma "
 "senha de disco atual."
 
-#: pkg/kubernetes/views/node-capacity.html:9
-msgid "Scheduled Pods"
-msgstr "Pods Agendados"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "Agendamento Desativado"
-
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
 msgstr "PC com caixa vedada"
@@ -7315,24 +5729,6 @@ msgstr "PC com caixa vedada"
 #: pkg/systemd/init.js:1076
 msgid "Seconds"
 msgstr "Segundos"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Secreto"
-
-#: pkg/kubernetes/views/volume-body.html:106
-msgid "Secret File"
-msgstr "Arquivo Secreto"
-
-#: pkg/kubernetes/views/volume-body.html:141
-msgid "Secret Name"
-msgstr "Nome Secreto"
-
-#: pkg/kubernetes/views/volume-body.html:69
-#: pkg/kubernetes/views/volume-body.html:108
-#: pkg/kubernetes/views/volume-body.html:134
-msgid "Secret Volume"
-msgstr "Volume Secreto"
 
 #: pkg/systemd/index.html:106
 msgid "Secure Shell Keys"
@@ -7350,36 +5746,17 @@ msgstr "Segurança"
 msgid "Security Updates Available"
 msgstr "Atualizações de segurança disponíveis"
 
-#: pkg/shell/index.html:123 pkg/shell/simple.html:91 pkg/shell/stub.html:106
+#: pkg/shell/index.html:123 pkg/shell/simple.html:91
 msgid "Select"
 msgstr "Selecione"
 
-#: pkg/kubernetes/views/file-button.html:4
-msgid "Select Manifest File..."
-msgstr "Selecione Arquivo Manifest ..."
-
-#: pkg/kubernetes/scripts/projects.js:899
-#: pkg/kubernetes/scripts/projects.js:1205
-#: pkg/kubernetes/scripts/projects.js:1335
-msgid "Select Member"
-msgstr "Selecione o membro"
-
-#: pkg/kubernetes/scripts/projects.js:901
-#: pkg/kubernetes/scripts/projects.js:1208
-msgid "Select Role"
-msgstr "Selecionar Função"
-
-#: pkg/kubernetes/views/topology-page.html:7
-msgid "Select an object to see more details."
-msgstr "Selecione um objeto para ver mais detalhes."
-
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Selecione os usuários que você gostaria de ser sincronizado com "
-"{{#strong}}{{host}}{{/strong}}"
+"Selecione os usuários que você gostaria de ser sincronizado com {{#strong}}"
+"{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
@@ -7399,11 +5776,8 @@ msgstr "Enviando"
 msgid "Serial Console"
 msgstr "Console Serial"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:116 pkg/storaged/nfs-details.jsx:315
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:65
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Servidor"
 
@@ -7411,7 +5785,7 @@ msgstr "Servidor"
 msgid "Server Address"
 msgstr "Endereço do Servidor"
 
-#: pkg/users/local.js:746 pkg/users/local.js:747
+#: pkg/users/local.js:750 pkg/users/local.js:751
 msgid "Server Administrator"
 msgstr "Administrador do servidor"
 
@@ -7435,16 +5809,10 @@ msgstr "O servidor encerrou a conexão."
 msgid "Servers"
 msgstr "Servidores"
 
-#: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/service-panel.html:8
-#: pkg/kubernetes/views/topology-page.html:30 pkg/systemd/logs.html:66
-#: pkg/networkmanager/firewall.jsx:936 pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Serviço"
-
-#: pkg/kubernetes/views/pod-body.html:12
-msgid "Service Account"
-msgstr "Serviço de Conta"
 
 #: pkg/systemd/services.html:337
 msgid "Service Logs"
@@ -7474,28 +5842,14 @@ msgstr "Serviço está a parar"
 msgid "Service name"
 msgstr "Nome do serviço"
 
-#: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
-#: pkg/systemd/services.html:330 pkg/kubernetes/scripts/details.js:213
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
 #: pkg/networkmanager/firewall.jsx:483
 msgid "Services"
 msgstr "Serviços"
 
-#: pkg/kubernetes/views/topology-page.html:31
-msgid ""
-"Services group pods and provide a common DNS name and an optional, load-"
-"balanced IP address to access them."
-msgstr ""
-"Pods de grupo de serviços fornecem um nome DNS comum e um endereço IP "
-"opcional, balanceado por carga para acessá-los."
-
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sessão"
-
-#: pkg/kubernetes/views/service-body.html:20
-msgid "Session Affinity"
-msgstr "Afinidade de Sessão"
 
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
@@ -7513,7 +5867,7 @@ msgstr "Definir uma Senha"
 msgid "Set Time"
 msgstr "Definir Tempo"
 
-#: pkg/docker/index.html:530
+#: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Definir variáveis de ambiente de contêiner"
 
@@ -7548,29 +5902,15 @@ msgstr "Gravidade"
 msgid "Severity:"
 msgstr "Gravidade:"
 
-#: pkg/kubernetes/views/volume-body.html:139
-msgid "Share Name"
-msgstr "Compartilhar Nome"
-
 #: pkg/networkmanager/interfaces.js:1959
 msgid "Shared"
 msgstr "Compartilhado"
-
-#: pkg/kubernetes/scripts/projects.js:1043
-msgid "Shared: Allow any authenticated user to pull images"
-msgstr ""
-"Compartilhado: permitir que qualquer usuário autenticado baixe imagens"
-
-#: pkg/kubernetes/views/container-page-inline.html:14
-#: pkg/kubernetes/views/container-panel.html:9
-msgid "Shell"
-msgstr "Shell"
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Show Performance Options"
 msgstr ""
 
@@ -7578,61 +5918,15 @@ msgstr ""
 msgid "Show all"
 msgstr ""
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:122
 msgid "Show all $0 drives"
 msgstr ""
-
-#: pkg/kubernetes/views/container-page.html:4
-msgid "Show all Containers"
-msgstr "Exibir todos os Contêineres"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:8
-msgid "Show all Deployment Configs"
-msgstr "Exibir todas as Configs de Implantação"
-
-#: pkg/kubernetes/views/node-page.html:8
-msgid "Show all Nodes"
-msgstr "Exibir todos os Nós"
-
-#: pkg/kubernetes/views/pv-page.html:9
-msgid "Show all Persistent Volumes"
-msgstr "Exibir todos os Volumes Persistentes"
-
-#: pkg/kubernetes/views/pod-container.html:4
-msgid "Show all Pod Containers"
-msgstr "Exibir todos os Contêineres Pod"
-
-#: pkg/kubernetes/views/pod-page.html:8
-msgid "Show all Pods"
-msgstr "Exibir todos os Pods"
-
-#: pkg/kubernetes/views/group-page.html:14
-#: pkg/kubernetes/views/project-page.html:23
-#: pkg/kubernetes/views/user-page.html:16
-msgid "Show all Projects"
-msgstr "Exibir todos os Projetos"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:10
-msgid "Show all Replication Controllers"
-msgstr "Exibir todos os Controladores de Replicação"
-
-#: pkg/kubernetes/views/route-page.html:10
-msgid "Show all Routes"
-msgstr "Exibir todas as Rotas"
-
-#: pkg/kubernetes/views/service-page.html:8
-msgid "Show all Services"
-msgstr "Exibir todos os Serviços"
 
 #: pkg/docker/index.html:128
 msgid "Show all containers"
 msgstr "Exibir todos os contêineres"
 
-#: pkg/kubernetes/views/imagestream-page.html:12
-msgid "Show all image streams"
-msgstr "Exibir todos os streams de imagem"
-
-#: pkg/docker/index.html:254 pkg/kubernetes/views/image-page.html:10
+#: pkg/docker/index.html:249
 msgid "Show all images"
 msgstr "Exibir todas as imagens"
 
@@ -7657,21 +5951,16 @@ msgstr ""
 msgid "Shut Down"
 msgstr "Encerrar"
 
-#: pkg/kubernetes/views/container-body.html:18
-msgid "Since"
-msgstr "Desde"
-
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:376
-#: pkg/machines/components/diskAdd.jsx:143
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Tamanho"
 
@@ -7695,11 +5984,6 @@ msgstr "O tamanho deve ser um número"
 msgid "Size must be at least $0"
 msgstr "O tamanho deve ser pelo menos $0"
 
-#: pkg/kubernetes/views/auth-form.html:43
-#: pkg/kubernetes/views/auth-rejected-cert.html:11
-msgid "Skip Certificate Verification"
-msgstr "Ignorar Verificação de Certificado"
-
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Slot"
 msgstr "Slot"
@@ -7709,7 +5993,6 @@ msgid "Slot $0"
 msgstr "Slot $0"
 
 #: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Sockets"
 msgstr "Sockets"
 
@@ -7752,18 +6035,14 @@ msgstr ""
 "Algum outro programa está atualmente usando o gerenciador de pacotes, por "
 "favor aguarde ..."
 
-#: pkg/kubernetes/scripts/volumes.js:914
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "Desculpe, eu não sei como modificar este volume"
-
-#: pkg/networkmanager/firewall.jsx:707
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:476
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:103
+#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Fonte"
 
@@ -7771,10 +6050,10 @@ msgstr "Fonte"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:217
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:244
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Caminho da origem"
 
@@ -7782,12 +6061,12 @@ msgstr "Caminho da origem"
 msgid "Source URL"
 msgstr "URL Fonte"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:254
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
 msgid "Source path should not be empty"
 msgstr "O caminho da origem não deve estar vazio"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:108
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "A fonte deve começar com o protocolo http, ftp ou nfs"
 
@@ -7815,9 +6094,9 @@ msgstr "Tempo Específico"
 msgid "Stable"
 msgstr "Estável"
 
-#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:320 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Iniciar"
 
@@ -7837,7 +6116,7 @@ msgstr "Começar serviço"
 msgid "Start libvirt"
 msgstr "Iniciar libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:291
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
 msgid "Start pool when host boots"
 msgstr "Iniciar pool quando o host inicializa"
 
@@ -7849,59 +6128,29 @@ msgstr "Iniciando o Dispositivo RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Iniciando swapspace $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Starts"
-msgstr "Começa"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
 msgid "Startup"
 msgstr "Comece"
 
-#: pkg/kubernetes/views/container-body.html:16
-#: pkg/kubernetes/views/details-page.html:38
-#: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:127 pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/init.js:285
 msgid "State"
 msgstr "Estado"
 
-#: pkg/docker/index.html:167
+#: pkg/docker/index.html:168
 msgid "State:"
 msgstr "Estado:"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "Stateless"
-msgstr "Sem estado"
-
-#: pkg/ovirt/components/OVirtTab.jsx:156
-msgid "Stateless:"
-msgstr "Sem estado:"
 
 #: pkg/systemd/services.html:74 pkg/systemd/init.js:207
 msgid "Static"
 msgstr "Estático"
 
-#: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/volumes-page.html:21 pkg/systemd/services.html:121
-#: pkg/networkmanager/interfaces.js:2613
-#: pkg/subscriptions/subscriptions-view.jsx:37
+#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
 msgid "Status"
 msgstr "Estado"
-
-#: pkg/subscriptions/subscriptions-view.jsx:162
-msgid "Status: $0"
-msgstr "Status: $0"
-
-#: pkg/subscriptions/subscriptions-view.jsx:157
-msgid "Status: System isn't registered"
-msgstr "Status: O sistema não está registrado"
 
 #: pkg/lib/machine-info.js:99
 msgid "Stick PC"
@@ -7911,14 +6160,14 @@ msgstr "Stick PC"
 msgid "Sticky"
 msgstr "Sticky"
 
-#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Pare"
 
-#: pkg/storaged/mdraid-details.jsx:248
+#: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Parar dispositivo"
 
@@ -7950,8 +6199,8 @@ msgstr "Parando o Dispositivo RAID $target"
 msgid "Stopping swapspace $target"
 msgstr "Parando swapspace $target"
 
-#: pkg/docker/index.html:288 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
+#: pkg/docker/index.html:290 pkg/storaged/index.html:23
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
 #: pkg/storaged/details.jsx:127
 msgid "Storage"
 msgstr "Armazenamento"
@@ -7960,11 +6209,11 @@ msgstr "Armazenamento"
 msgid "Storage Logs"
 msgstr "Logs de Armazenamento"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:137
+#: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePool.jsx:149
+#: pkg/machines/components/storagePools/storagePool.jsx:153
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
@@ -7972,7 +6221,7 @@ msgstr ""
 msgid "Storage Pool Name"
 msgstr "Nome do pool de armazenamento"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:437
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
 msgid "Storage Pool failed to be created"
 msgstr "O pool de armazenamento não pôde ser criado"
 
@@ -7993,7 +6242,7 @@ msgstr ""
 msgid "Storage can not be managed on this system."
 msgstr "O armazenamento não pode ser gerenciado neste sistema."
 
-#: pkg/docker/index.html:302
+#: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Pool de Armazenamento"
 
@@ -8013,10 +6262,6 @@ msgstr "Frase-senha armazenada"
 msgid "Stored passphrase"
 msgstr "Senha armazenada"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:12
-msgid "Strategy"
-msgstr "Estratégia"
-
 #: pkg/lib/machine-info.js:82
 msgid "Sub Chassis"
 msgstr "Sub Chassis"
@@ -8024,10 +6269,6 @@ msgstr "Sub Chassis"
 #: pkg/lib/machine-info.js:77
 msgid "Sub Notebook"
 msgstr "Sub Notebook"
-
-#: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:177
-msgid "Subscriptions"
-msgstr "Assinaturas"
 
 #: node_modules/registry-image-widgets/views/image-body.html:4
 msgid "Summary"
@@ -8045,10 +6286,6 @@ msgstr ""
 msgid "Support is installed."
 msgstr "O suporte está instalado."
 
-#: pkg/ovirt/components/VmActions.jsx:40
-msgid "Suspend"
-msgstr "Suspender"
-
 #: pkg/storaged/content-views.jsx:157
 msgid "Swap"
 msgstr "Swap"
@@ -8062,10 +6299,6 @@ msgstr "Swap Espaço"
 msgid "Swap Used"
 msgstr "Swap Usado"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:40
-msgid "Switch Host to Maintenance"
-msgstr "Trocar de host para manutenção"
-
 #: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
 msgid "Switch off $0"
 msgstr "Desligar $0"
@@ -8073,14 +6306,6 @@ msgstr "Desligar $0"
 #: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
 msgid "Switch on $0"
 msgstr "Ligar $0"
-
-#: pkg/ovirt/provider.js:414
-msgid "Switching host to maintenance mode failed. Received error: "
-msgstr "A comutação do host para o modo de manutenção falhou. Erro recebido:"
-
-#: pkg/ovirt/provider.js:408
-msgid "Switching host to maintenance mode in progress ..."
-msgstr "Mudando o host para o modo de manutenção em andamento ..."
 
 #: pkg/networkmanager/interfaces.js:2491
 msgid ""
@@ -8105,10 +6330,6 @@ msgid ""
 msgstr ""
 "Ligando <b>$0</b> irá encerrar a conexão com o servidor e tornará a "
 "administração da interface do usuário indisponível."
-
-#: pkg/kubernetes/scripts/images.js:634
-msgid "Sync all tags from a remote image repository"
-msgstr "Sincronizar todas as tags de um repositório de imagens remotas"
 
 #: pkg/lib/machine-sync-users.html:75
 msgid "Synchronize"
@@ -8159,25 +6380,20 @@ msgstr "Sistema atualizado"
 msgid "System is up to date"
 msgstr "O sistema está atualizado"
 
-#: pkg/docker/index.html:327 pkg/docker/index.html:331
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:329 pkg/docker/index.html:333
+#: pkg/networkmanager/firewall.jsx:938
 msgid "TCP"
 msgstr "TCP"
-
-#: pkg/kubernetes/views/route-body.html:12
-msgid "TLS Termination"
-msgstr "Término de TLS"
 
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
 msgstr "Tablet"
 
-#: pkg/docker/index.html:694
+#: pkg/docker/index.html:696
 #: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Marca"
 
-#: pkg/kubernetes/views/imagestream-modify.html:76
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
@@ -8189,25 +6405,16 @@ msgstr "Tags"
 msgid "Tang keyserver"
 msgstr "Tang keyserver"
 
-#: pkg/kubernetes/views/pv-modify.html:137
 #: pkg/machines/components/vm/bootOrderModal.jsx:133
 msgid "Target"
 msgstr "Alvo"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Caminho de Destino"
 
-#: pkg/kubernetes/views/volume-body.html:75
-msgid "Target Portal"
-msgstr "Portal Alvo"
-
-#: pkg/kubernetes/views/volume-body.html:114
-msgid "Target World Wide Names"
-msgstr "Nomes de Alvos Mundiais"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:133
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
 msgid "Target path should not be empty"
 msgstr "O caminho de destino não deve estar vazio"
 
@@ -8231,22 +6438,6 @@ msgstr "Configurações da Porta da Equipe"
 #: pkg/networkmanager/index.html:514
 msgid "Team Settings"
 msgstr "Configurações da Equipe"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:15
-#: pkg/kubernetes/views/deploymentconfig-panel.html:10
-#: pkg/kubernetes/views/replicationcontroller-page.html:20
-#: pkg/kubernetes/views/replicationcontroller-panel.html:14
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "Template"
-msgstr "Modelo"
-
-#: pkg/ovirt/components/App.jsx:111
-msgid "Templates"
-msgstr "Templates"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:130
-msgid "Templates of $0 cluster"
-msgstr "Templates de $0 cluster"
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
@@ -8281,11 +6472,11 @@ msgstr ""
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "O enderço IP ou hostname não podem conter espações."
 
-#: pkg/storaged/mdraid-details.jsx:219
+#: pkg/storaged/mdraid-details.jsx:218
 msgid "The RAID Array is in a degraded state"
 msgstr "A matriz RAID está em um estado degradado"
 
-#: pkg/storaged/mdraid-details.jsx:149
+#: pkg/storaged/mdraid-details.jsx:148
 msgid "The RAID device must be running in order to add spare disks."
 msgstr ""
 "O dispositivo RAID deve estar em execução para adicionar discos "
@@ -8337,18 +6528,14 @@ msgstr "A VM está em execução."
 msgid "The VM is suspended by guest power management."
 msgstr "A VM é suspensa pela gerência de poder do convidado."
 
-#: pkg/users/local.js:1338
+#: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
 msgstr "A conta '$0' será forçado a mudar sua senha no próximo login"
 
-#: pkg/kubernetes/scripts/nodes.js:403
-msgid "The address contains invalid characters"
-msgstr "O endereço contém caracteres inválidos"
-
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "A autenticidade do host {{#strong}}{{host}}{{/strong}} não pode ser "
 "estabelecida. Tem certeza de que deseja continuar conectando?"
@@ -8362,22 +6549,12 @@ msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 "O estado configurado é desconhecido, pode mudar na próxima inicialização."
 
-#: pkg/kubernetes/views/container-page-inline.html:22
-msgid "The container '{{ target }}' does not exist."
-msgstr "O contêiner '{{ target }}' não existe."
-
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
 msgstr ""
 "A criação deste dispositivo VDO não foi concluída e o dispositivo não pode "
 "ser usado."
-
-#: pkg/subscriptions/subscriptions-view.jsx:214
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-"O usuário atual não tem permissão para acessar o status de assinatura do "
-"sistema."
 
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
@@ -8386,11 +6563,7 @@ msgstr ""
 "O usuário atualmente conectado não tem permissão para ver informações sobre "
 "chaves."
 
-#: pkg/kubernetes/views/deploymentconfig-page.html:25
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "O Deployment config '{{target}}' não existe."
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:204
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
 msgid "The directory on the server being exported"
 msgstr "O diretório no servidor que está sendo exportado"
 
@@ -8399,12 +6572,11 @@ msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
 msgstr ""
-"O sistema de arquivos está em uso por sessões de login e serviços do sistema."
-" O processo interromperá isso."
+"O sistema de arquivos está em uso por sessões de login e serviços do "
+"sistema. O processo interromperá isso."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "O sistema de arquivos está em uso por sessões de login. O processo "
 "interromperá isso."
@@ -8417,10 +6589,8 @@ msgstr ""
 "interromperá isso."
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
-msgstr ""
-"Os contêineres a seguir dependem dessa imagem e ficarão inutilizáveis."
+msgid "The following containers depend on this image and will become unusable."
+msgstr "Os contêineres a seguir dependem dessa imagem e ficarão inutilizáveis."
 
 #: pkg/sosreport/index.html:51
 msgid ""
@@ -8431,10 +6601,6 @@ msgstr ""
 "O arquivo gerado contém dados considerados confidenciais e seu conteúdo deve "
 "ser revisado pela organização de origem antes de ser passado para quaisquer "
 "terceiros."
-
-#: pkg/kubernetes/views/group-page.html:47
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "O grupo '{{ groupName }}' não existe."
 
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
@@ -8462,31 +6628,16 @@ msgstr "O último slot chave não pode ser removido"
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "O último volume físico de um grupo de volumes não pode ser removido."
 
-#: pkg/shell/indexes.js:408
+#: pkg/shell/indexes.js:407
 msgid "The machine is restarting"
 msgstr "A máquina esta reiniciando"
 
-#: pkg/kubernetes/scripts/details.js:498 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "O número máximo de réplicas é 128"
+#: pkg/machines/components/networks/networkDelete.jsx:76
+#, fuzzy
+msgid "The network could not be deleted"
+msgstr "O caminho de destino não deve estar vazio"
 
-#: pkg/kubernetes/scripts/nodes.js:411
-msgid "The name contains invalid characters"
-msgstr "O nome contém caracteres inválidos"
-
-#: pkg/kubernetes/views/node-page.html:23
-msgid "The node '{{ target }}' does not exist."
-msgstr "O nó '{{ target }}' não existe."
-
-#: pkg/kubernetes/views/node-alerts.html:7
-msgid "The node doesn't have enough disk space"
-msgstr "O nó não tem espaço em disco suficiente"
-
-#: pkg/kubernetes/views/node-alerts.html:11
-msgid "The node doesn't have enough free memory"
-msgstr "O nó não tem memória livre suficiente"
-
-#: pkg/users/local.js:439 pkg/users/local.js:1395
+#: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
 msgstr "As senhas não batem"
 
@@ -8494,29 +6645,9 @@ msgstr "As senhas não batem"
 msgid "The passwords do not match."
 msgstr "As senhas não batem."
 
-#: pkg/kubernetes/views/pv-page.html:21
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "O volume persistente '{{ target }}' não existe."
-
-#: pkg/kubernetes/views/pod-page.html:40
-msgid "The pod '{{ target }}' does not exist."
-msgstr "O pod '{{ target }}' não existe."
-
 #: pkg/machines/components/diskAdd.jsx:80
 msgid "The pool is empty"
 msgstr "A piscina está vazia"
-
-#: pkg/kubernetes/views/project-page.html:34
-msgid "The project '{{ projName }}' does not exist."
-msgstr "O projeto '{{ projName }}' não existe."
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:30
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "O controlador de replicação '{{ target }}' não existe."
-
-#: pkg/kubernetes/views/route-page.html:19
-msgid "The route '{{ target }}' does not exist."
-msgstr "A rota '{{ target }}' não existe."
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
@@ -8525,11 +6656,6 @@ msgstr "O scanner de  $time ($type) não detectou vulnerabilidades."
 #: pkg/docker/containers-view.jsx:432
 msgid "The scan from $time ($type) was not successful."
 msgstr "O scanner de $time ($type) não funcionou."
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr ""
-"O arquivo selecionado não é um manifesto do aplicativo Kubernetes válido."
 
 #: src/ws/login.js:645
 msgid ""
@@ -8544,22 +6670,9 @@ msgid "The server refused to authenticate using any supported methods."
 msgstr ""
 "O servidor se recusou a autenticar usando quaisquer métodos suportados."
 
-#: pkg/kubernetes/views/auth-rejected-cert.html:2
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr ""
-"O servidor usa um certificado assinado por uma autoridade desconhecida."
-
-#: pkg/kubernetes/views/service-page.html:19
-msgid "The service '{{ target }}' does not exist."
-msgstr "O serviço '{{ target }}' não existe."
-
 #: pkg/systemd/hwinfo.jsx:65
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
-
-#: pkg/kubernetes/views/user-page.html:29
-msgid "The user '{{ userName }}' does not exist."
-msgstr "O usuário '{{ userName }}' não existe."
 
 #: pkg/systemd/init.js:922
 msgid "The user <b>$0</b> does not have permissions for creating timers"
@@ -8596,10 +6709,9 @@ msgstr "O usuário <b>$0</b> não tem permissão para modificar os hostnames"
 #: pkg/networkmanager/interfaces.js:1516
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
-"O usuário <b>$0</b> não tem permissão para modificar as configurações de "
-"rede"
+"O usuário <b>$0</b> não tem permissão para modificar as configurações de rede"
 
-#: pkg/realmd/operation.js:643
+#: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "O usuário <b> $0 </b> não tem permissão para modificar reinos"
 
@@ -8611,7 +6723,7 @@ msgstr "Ao usuário <b>$0</b>não é permitido modificar serviços"
 msgid "The user <b>$0</b> is not permitted to start or stop services"
 msgstr "Ao usuário <b>$0</b> não é permitido iniciar ou parar serviços"
 
-#: pkg/users/local.js:549
+#: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
@@ -8621,8 +6733,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "A configuração do navegador da Web impede que o Cockpit seja executado "
 "(inacessível $0)"
@@ -8663,13 +6774,6 @@ msgstr ""
 #: pkg/storaged/vdo-details.jsx:133
 msgid "This VDO device does not use all of its backing device."
 msgstr "Este dispositivo VDO não usa todo o seu dispositivo de apoio."
-
-#: pkg/kubernetes/views/pvc-delete.html:8
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-"Esta afirmação está em uso. Excluí-lo pode causar problemas com o seguinte "
-"pod:"
 
 #: pkg/systemd/init.js:1371
 msgid ""
@@ -8728,14 +6832,6 @@ msgstr ""
 msgid "This field cannot be empty."
 msgstr "Este campo não pode estar vazio."
 
-#: pkg/ovirt/components/App.jsx:155
-msgid ""
-"This host is managed by a virtualization manager, so creation of new VMs "
-"from the host is not possible."
-msgstr ""
-"Esse host é gerenciado por um gerenciador de virtualização, portanto, a "
-"criação de novas VMs a partir do host não é possível."
-
 #: pkg/docker/containers-view.jsx:494
 msgid "This image does not exist."
 msgstr "Esta imagem não existe."
@@ -8751,14 +6847,6 @@ msgstr "Esta máquina já foi adicionada"
 #: pkg/realmd/operation.html:80
 msgid "This may take a while"
 msgstr "Isso pode demorar um pouco"
-
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-"Esta opção é apenas para testes de nó único – o armazenamento local não "
-"funcionará em um cluster de vários nós"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
@@ -8797,7 +6885,7 @@ msgstr "Esta unidade é uma instância do modelo $0."
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Esta unidade não foi projetada para ser habilitada explicitamente."
 
-#: pkg/users/local.js:557
+#: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "Este usuário já existe"
 
@@ -8809,25 +6897,7 @@ msgstr ""
 "Esta versão do cockpit-ws não suporta conectar a um host com um usuário ou "
 "porta alternativa"
 
-#: pkg/ovirt/components/OVirtTab.jsx:134
-msgid "This virtual machine is not managed by oVirt"
-msgstr "Esta máquina virtual não é gerenciada pelo oVirt"
-
-#: pkg/kubernetes/views/pv-delete.html:7
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
-msgstr ""
-"Este volume foi reivindicado por {{ item.item.spec.claimRef.namespace }} / "
-"{{ item.item.spec.claimRef.name }}. Excluí-lo vai parar essa reivindicação e "
-"pode causar problemas com quaisquer pods, dependendo dele."
-
-#: pkg/kubernetes/views/pv-claim.html:23
-msgid "This volume has not been claimed"
-msgstr "Este volume não foi reivindicado"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:369
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
 msgid "This volume is already used by another VM."
 msgstr ""
 
@@ -8858,7 +6928,6 @@ msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Isso testará a configuração do kdump, quebrando o kernel."
 
 #: pkg/machines/components/vcpuModal.jsx:212
-#: pkg/ovirt/components/vcpuModal.jsx:70
 msgid "Threads per core"
 msgstr "Tópicos por núcleo"
 
@@ -8911,10 +6980,6 @@ msgstr ""
 "Para tentar uma porta diferente, você precisará atualizar o cockpit-ws para "
 "uma versão mais recente."
 
-#: pkg/kubernetes/views/auth-form.html:116
-msgid "Token"
-msgstr "Token"
-
 #: pkg/lib/cockpit-components-file-autocomplete.jsx:148
 msgid "Too many files found"
 msgstr "Muitos arquivos encontrados"
@@ -8922,10 +6987,6 @@ msgstr "Muitos arquivos encontrados"
 #: src/base1/cockpit.js:4039
 msgid "Too much data"
 msgstr "Muitos dados"
-
-#: pkg/kubernetes/index.html:61
-msgid "Topology"
-msgstr "Topologia"
 
 #: pkg/docker/storage.jsx:341
 msgid "Total"
@@ -8943,12 +7004,11 @@ msgstr "Torre"
 msgid "Triggered By"
 msgstr "Disparado por"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:32 pkg/systemd/init.js:732
+#: pkg/systemd/init.js:732
 msgid "Triggers"
 msgstr "Triggers"
 
-#: pkg/kubernetes/index.html:109 pkg/shell/index.html:387
-#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/shell/index.html:387 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Solução de problemas"
@@ -8957,13 +7017,9 @@ msgstr "Solução de problemas"
 msgid "Trust key"
 msgstr "Chave de confiança"
 
-#: pkg/networkmanager/firewall.jsx:703
+#: pkg/networkmanager/firewall.jsx:705
 msgid "Trust level"
 msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:21
-msgid "Trust this certificate for this connection"
-msgstr "Confie neste certificado para esta conexão"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -9005,20 +7061,17 @@ msgstr "Tuned não está em execução"
 msgid "Tuned is off"
 msgstr "Tuned está fora"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:84
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Tipo"
 
@@ -9034,16 +7087,11 @@ msgstr "Digite uma senha"
 msgid "Type to filter…"
 msgstr "Tipo para filtrar..."
 
-#: pkg/kubernetes/views/details-page.html:7
-msgid "Type:"
-msgstr "Tipo:"
-
-#: pkg/docker/index.html:332 pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
-#: pkg/subscriptions/subscriptions-register.jsx:112
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
 msgid "URL"
 msgstr "URL"
 
@@ -9059,17 +7107,9 @@ msgstr "ão é possível aplicar as configurações: $0"
 msgid "Unable to apply this solution automatically"
 msgstr "Não é possível aplicar esta solução automaticamente"
 
-#: pkg/subscriptions/subscriptions-view.jsx:217
-msgid "Unable to connect"
-msgstr "Não é possível conectar"
-
 #: src/ws/login.js:649
 msgid "Unable to connect to that address"
 msgstr "Não é possível conectar a esse endereço"
-
-#: pkg/kubernetes/scripts/dashboard.js:412
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "Não é possível decodificar o manifesto do aplicativo Kubernetes."
 
 #: pkg/users/local.js:58
 msgid "Unable to delete root account"
@@ -9087,10 +7127,6 @@ msgstr "Não é possível obter alerta: $0"
 #: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Não é possível acessar o servidor"
-
-#: pkg/kubernetes/scripts/dashboard.js:400
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Não é possível ler o manifesto do aplicativo Kubernetes . Código $0."
 
 #: pkg/storaged/nfs-details.jsx:282
 msgid "Unable to remove mount"
@@ -9117,16 +7153,15 @@ msgid "Unable to unmount filesystem"
 msgstr "Não é possível desmontar o sistema de arquivos"
 
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
-#: pkg/kubernetes/scripts/charts.js:110
 msgid "Unavailable"
 msgstr "Indisponível"
 
-#: pkg/docker/index.html:730 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1481
+#: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
+#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Erro inesperado"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:132
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid "Unique name"
 msgstr "Nome único"
 
@@ -9135,19 +7170,14 @@ msgstr "Nome único"
 msgid "Unit"
 msgstr "Unidade"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
-#: pkg/kubernetes/views/volumes-page.html:35
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:754 pkg/kubernetes/scripts/volumes.js:267
-#: pkg/lib/machine-info.js:65 pkg/networkmanager/interfaces.js:596
-#: pkg/networkmanager/interfaces.js:1067 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2534 pkg/storaged/fsys-tab.jsx:64
-#: pkg/storaged/swap-tab.jsx:57
+#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
+#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -9183,7 +7213,7 @@ msgstr ""
 msgid "Unknown type"
 msgstr "Tipo desconhecido"
 
-#: pkg/docker/index.html:549 pkg/docker/util.js:110
+#: pkg/docker/index.html:551 pkg/docker/util.js:110
 msgid "Unless Stopped"
 msgstr "Parou-se"
 
@@ -9232,7 +7262,7 @@ msgstr "Desmontando $target"
 msgid "Unnamed"
 msgstr "Não nomeado"
 
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Unplug"
 msgstr "Desplugar"
 
@@ -9248,14 +7278,6 @@ msgstr "Dados não reconhecidos"
 #: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Dados não reconhecidos não podem ser reduzidos aqui."
-
-#: pkg/subscriptions/subscriptions-view.jsx:164
-msgid "Unregister"
-msgstr "Cancelar o registro"
-
-#: pkg/subscriptions/subscriptions-view.jsx:170
-msgid "Unregistering system..."
-msgstr "Cancelando o registro do sistema..."
 
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
@@ -9278,7 +7300,11 @@ msgstr "Host não confiável"
 msgid "Up since $0"
 msgstr "Ativo desde $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:316
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+msgid "Up to $0 $1 available in the default location"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -9307,13 +7333,9 @@ msgstr ""
 msgid "Updates Available"
 msgstr "Atualizações disponíveis"
 
-#: pkg/packagekit/updates.jsx:52 pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/packagekit/updates.jsx:52
 msgid "Updating"
 msgstr "Atualizando"
-
-#: pkg/kubernetes/scripts/details.js:654
-msgid "Updating $0..."
-msgstr "Atualizando $0..."
 
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
@@ -9329,20 +7351,15 @@ msgstr[1] "Uso de $0 núcleos da CPU"
 msgid "Use 512 Byte emulation"
 msgstr "Use a emulação de 512 bytes"
 
-#: pkg/machines/components/diskAdd.jsx:496
+#: pkg/machines/components/diskAdd.jsx:524
 msgid "Use Existing"
 msgstr "Usar existente"
-
-#: pkg/subscriptions/subscriptions-register.jsx:136
-msgid "Use proxy server"
-msgstr "Usar servidor proxy"
 
 #: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Use as seguintes chaves para autenticar contra outros sistemas"
 
 #: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
-#: pkg/kubernetes/scripts/nodes.js:829 pkg/kubernetes/scripts/nodes.js:838
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
@@ -9354,18 +7371,13 @@ msgstr "Usado"
 msgid "Used by"
 msgstr ""
 
-#: pkg/docker/index.html:262
+#: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "Usado pelos Contêineres"
 
-#: pkg/dashboard/index.html:144 pkg/kubernetes/views/auth-form.html:61
-#: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
-#: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/subscriptions/subscriptions-register.jsx:77 pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1584
 msgid "User"
 msgstr "Usuário"
 
@@ -9374,11 +7386,11 @@ msgstr "Usuário"
 msgid "User Name"
 msgstr "Nome de Usuário"
 
-#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:337
+#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:336
 msgid "User Password"
 msgstr "Senha de Usuário"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nome de usuário"
@@ -9387,18 +7399,9 @@ msgstr "Nome de usuário"
 msgid "User name cannot be empty"
 msgstr "O nome de usuário não pode estar vazio"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:15
-msgid "User or Group"
-msgstr "Usuário ou Grupo"
-
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
-#: pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
 msgid "Username"
 msgstr "Nome de Usuário"
-
-#: pkg/kubernetes/views/project-listing.html:85
-msgid "Users"
-msgstr "Usuários"
 
 #: pkg/lib/machine-change-auth.html:44
 msgid "Using available credentials"
@@ -9437,14 +7440,6 @@ msgstr "Dispositivos de suporte VDO não podem ser  menores"
 msgid "VDO support not installed"
 msgstr "Suporte a VDO não instalado"
 
-#: pkg/ovirt/components/App.jsx:115
-msgid "VDSM"
-msgstr "VDSM"
-
-#: pkg/ovirt/components/VdsmView.jsx:128
-msgid "VDSM Service Management"
-msgstr "VDSM Gerenciamento de Serviços"
-
 #: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
 #: pkg/networkmanager/interfaces.js:2906
 msgid "VLAN"
@@ -9474,7 +7469,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1317
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -9498,10 +7493,6 @@ msgstr ""
 msgid "VM $0 failed to start"
 msgstr ""
 
-#: pkg/ovirt/components/VmOverviewColumn.jsx:37
-msgid "VM icon"
-msgstr "VM icone"
-
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
 msgstr "VNC"
@@ -9518,7 +7509,7 @@ msgstr "VNC Porta:"
 msgid "VNC TLS Port:"
 msgstr "VNC TLS Porta:"
 
-#: pkg/realmd/operation.js:165
+#: pkg/realmd/operation.js:164
 msgid "Validating address"
 msgstr ""
 
@@ -9547,30 +7538,20 @@ msgstr "Verificar chave"
 msgid "Verifying"
 msgstr "Verificando"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:110 pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:381
-#: pkg/subscriptions/subscriptions-view.jsx:35 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Versão"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Version num"
-msgstr "Versão num"
 
 #: pkg/storaged/jobs-panel.jsx:57
 msgid "Very securely erasing $target"
 msgstr "Apagando com muita segurança $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Máquinas Virtuais"
-
-#: pkg/ovirt/components/ClusterVms.jsx:176
-msgid "Virtual Machines of $0 cluster"
-msgstr "Máquinas Virtuais de $0 cluster"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
@@ -9584,14 +7565,11 @@ msgstr "Serviço de virtualização (libvirt) não está ativo"
 msgid "Virtualization Service is Available"
 msgstr "Serviço de virtualização disponível"
 
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
-#: pkg/kubernetes/views/pvc-body.html:6
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:359
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Volume"
 
@@ -9599,7 +7577,7 @@ msgstr "Volume"
 msgid "Volume Group"
 msgstr "Grupo de volumes"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:233
+#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Grupo do Volume $0"
 
@@ -9607,32 +7585,16 @@ msgstr "Grupo do Volume $0"
 msgid "Volume Groups"
 msgstr "Grupos do Volume"
 
-#: pkg/kubernetes/views/volume-body.html:14
-#: pkg/kubernetes/views/volume-body.html:89
-msgid "Volume ID"
-msgstr "ID do Volume"
-
-#: pkg/kubernetes/views/pv-modify.html:115
-#: pkg/kubernetes/views/volume-body.html:42
-msgid "Volume Name"
-msgstr "Nome do Volume"
-
-#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
-msgid "Volume Type"
-msgstr "Tipo do Volume"
-
 #: pkg/storaged/lvol-tabs.jsx:410
 msgid "Volume size is $0. Content size is $1."
 msgstr ""
 
-#: pkg/docker/index.html:515 pkg/kubernetes/index.html:74
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:517
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volumes"
 
-#: pkg/docker/index.html:199
+#: pkg/docker/index.html:200
 msgid "Volumes:"
 msgstr "Volumes:"
 
@@ -9649,7 +7611,7 @@ msgstr "Aguardando"
 msgid "Waiting for details..."
 msgstr "Esperando por detalhes..."
 
-#: pkg/apps/utils.jsx:62
+#: pkg/apps/utils.jsx:63
 msgid "Waiting for other programs to finish using the package manager..."
 msgstr ""
 "Aguardando outros programas terminarem de usar o gerenciador de pacotes ..."
@@ -9671,10 +7633,6 @@ msgstr "Requer"
 msgid "Warning and above"
 msgstr "Aviso e acima"
 
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid "Warning:"
-msgstr "Aviso:"
-
 #: cockpit.appdata.xml.in.h:1
 msgid "Web Console for Linux servers"
 msgstr "Console da Web para servidores Linux"
@@ -9691,23 +7649,15 @@ msgstr ""
 msgid "Weeks"
 msgstr "Semanas"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:5
-msgid "Welcome to the Image Registry"
-msgstr "Bem vindo ao Registro de Imagem"
-
 #: pkg/storaged/crypto-keyslots.jsx:324
 msgid "What if tang-show-keys is not available?"
 msgstr "E se tang-show-keys não estiver disponível?"
-
-#: pkg/kubernetes/views/volumes-page.html:61
-msgid "When"
-msgstr "Quando"
 
 #: pkg/systemd/terminal.jsx:101
 msgid "White"
 msgstr ""
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:488
 msgid "With terminal"
 msgstr "Com o terminal"
 
@@ -9727,7 +7677,7 @@ msgstr "Nome de usuário ou senha incorretos"
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:996 pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2593
 msgid "Yes"
 msgstr "Sim"
 
@@ -9747,21 +7697,9 @@ msgstr ""
 "Você está conectado diretamente a este servidor. Você não pode excluí-lo."
 
 #: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:871 pkg/networkmanager/firewall.jsx:877
+#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
 msgid "You are not authorized to modify the firewall."
 msgstr "Você não está autorizado a modificar o firewall."
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:3
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-"Você pode ignorar a verificação do certificado, mas os dados que você enviar "
-"para o servidor podem ser interceptados por outros."
-
-#: pkg/kubernetes/views/dashboard-page.html:150
-msgid "You can deploy an application to your cluster."
-msgstr "Você pode implantar um aplicativo para o seu cluster."
 
 #: pkg/users/index.html:390
 msgid ""
@@ -9780,7 +7718,7 @@ msgstr ""
 msgid "You must wait longer to change your password"
 msgstr "Você deve esperar mais tempo para alterar sua senha"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
 msgid ""
 "You need to select the most closely matching OS vendor and Operating System"
 msgstr ""
@@ -9793,14 +7731,6 @@ msgstr ""
 "Seu navegador será desconectado, mas isso não afeta o processo de "
 "atualização. Você pode se reconectar em alguns instantes para continuar "
 "acompanhando o progresso."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:112
-msgid ""
-"Your login credentials do not give you access to use the docker registry "
-"from the command line."
-msgstr ""
-"As credenciais de login não lhe dão acesso para usar o registro de docker na "
-"linha de comando."
 
 #: pkg/packagekit/updates.jsx:865
 msgid ""
@@ -9818,11 +7748,11 @@ msgstr "Sua sessão foi encerrada."
 msgid "Your session has expired. Please log in again."
 msgstr "Sua sessão expirou. Por favor, faça o login novamente."
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/networkmanager/firewall.jsx:938
 msgid "Zones"
 msgstr ""
 
@@ -9838,8 +7768,12 @@ msgstr "[dados binários]"
 msgid "[no data]"
 msgstr "[sem dados]"
 
-#: pkg/machines/components/networks/network.jsx:58
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "ativo"
@@ -9873,17 +7807,9 @@ msgstr "bytes"
 msgid "cdrom"
 msgstr "cdrom"
 
-#: pkg/ovirt/rephraseUI.js:35
-msgid "connecting"
-msgstr "conectando"
-
 #: pkg/machines/components/infoRecord.jsx:29
 msgid "control-label $0"
 msgstr ""
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "cores"
-msgstr "cores"
 
 #: pkg/machines/helpers.js:193
 msgid "crashed"
@@ -9902,7 +7828,6 @@ msgid "direct"
 msgstr "direto"
 
 #: pkg/machines/helpers.js:177 pkg/machines/helpers.js:180
-#: pkg/ovirt/components/OVirtTab.jsx:123
 msgid "disabled"
 msgstr "desabilitado"
 
@@ -9910,7 +7835,7 @@ msgstr "desabilitado"
 msgid "disk"
 msgstr "disco"
 
-#: pkg/machines/helpers.js:238 pkg/ovirt/rephraseUI.js:27
+#: pkg/machines/helpers.js:238
 msgid "down"
 msgstr "down"
 
@@ -9918,26 +7843,17 @@ msgstr "down"
 msgid "dying"
 msgstr "morrendo"
 
-#: pkg/realmd/operation.js:299 pkg/realmd/operation.js:305
+#: pkg/realmd/operation.js:298 pkg/realmd/operation.js:304
 msgid "e.g. \"$0\""
 msgstr "e.g. \"$0\""
 
-#: pkg/kubernetes/scripts/images.js:639
-msgid "eg: my-image-stream"
-msgstr "eg: meu-stream-de-imagem"
-
 #: pkg/machines/helpers.js:178 pkg/machines/helpers.js:181
-#: pkg/ovirt/components/OVirtTab.jsx:125
 msgid "enabled"
 msgstr "habilitado"
 
 #: pkg/packagekit/updates.jsx:267
 msgid "enhancement"
 msgstr "Aprimoramento"
-
-#: pkg/ovirt/rephraseUI.js:28
-msgid "error"
-msgstr "erro"
 
 #: pkg/machines/helpers.js:214
 msgid "ethernet"
@@ -9963,7 +7879,7 @@ msgstr ""
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:182
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
@@ -9979,7 +7895,7 @@ msgstr "Alvos iSCSI"
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -9987,22 +7903,10 @@ msgstr ""
 msgid "idle"
 msgstr "ocioso"
 
-#: pkg/machines/components/networks/network.jsx:58
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "inativo"
-
-#: pkg/ovirt/rephraseUI.js:29
-msgid "initializing"
-msgstr "inicializando"
-
-#: pkg/ovirt/rephraseUI.js:30
-msgid "installation failed"
-msgstr "Instalação falhada"
-
-#: pkg/ovirt/rephraseUI.js:38
-msgid "installing OS"
-msgstr "instalando o sistema operacional"
 
 #: pkg/kdump/kdump-view.jsx:376
 msgid "invalid: multiple targets defined"
@@ -10011,10 +7915,6 @@ msgstr "inválido: vários destinos definidos"
 #: pkg/kdump/kdump-view.jsx:493
 msgid "kdump status"
 msgstr "status kdump"
-
-#: pkg/ovirt/rephraseUI.js:39
-msgid "kdumping"
-msgstr "kdumping"
 
 #: pkg/docker/run.js:527
 msgid "key"
@@ -10028,10 +7928,6 @@ msgstr "key slot $0"
 msgid "locally in $0"
 msgstr "localmente em $0"
 
-#: pkg/ovirt/rephraseUI.js:31
-msgid "maintenance"
-msgstr "manutenção"
-
 #: pkg/machines/helpers.js:216
 msgid "mcast"
 msgstr "mcast"
@@ -10044,62 +7940,18 @@ msgstr "rede"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "destino de despejo nfs não é formatado como servidor: caminho"
 
-#: pkg/kubernetes/views/route-body.html:14
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:43
 msgid "no"
 msgstr "não"
 
-#: pkg/ovirt/rephraseUI.js:32
-msgid "non operational"
-msgstr "não operacional"
-
-#: pkg/ovirt/rephraseUI.js:33
-msgid "non responsive"
-msgstr "não responsivo"
-
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
-#: pkg/kubernetes/views/route-body.html:24
-#: pkg/kubernetes/views/route-body.html:29
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "Nenhum"
-
-#: pkg/ovirt/provider.js:62
-msgid "oVirt"
-msgstr "oVirt"
-
-#: pkg/ovirt/components/HostStatus.jsx:37
-msgid "oVirt Host State:"
-msgstr "oVirt Host State:"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:35
-msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr ""
-"O script de instalação do Provedor oVirt falhou devido a argumentos ausentes."
-""
-
-#: pkg/ovirt/components/InstallationDialog.jsx:36
-msgid ""
-"oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-"machines-ovirt.config, try as root."
-msgstr ""
-"Falha no script de instalação do Provedor oVirt: Não é possível gravar em /"
-"etc/cockpit/machines-ovirt.config, tente como root."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:164
-msgid "oVirt installation script failed with following output: "
-msgstr "O script de instalação do ivirt falhou com a seguinte saída: "
-
-#: pkg/ovirt/components/App.jsx:51
-msgid "oVirt login in progress"
-msgstr "login do theVirt em andamento"
 
 #: pkg/systemd/host.js:691
 msgid "of $0 CPU core"
@@ -10111,25 +7963,13 @@ msgstr[1] "de $0 núcleos da CPU"
 msgid "paused"
 msgstr "pausado"
 
-#: pkg/ovirt/rephraseUI.js:34
-msgid "pending approval"
-msgstr "aprovação pendente"
-
-#: pkg/kubernetes/views/dashboard-page.html:83
-msgid "pending volume claims"
-msgstr "declarações de volume pendentes"
-
-#: pkg/machines/components/diskAdd.jsx:174
+#: pkg/machines/components/diskAdd.jsx:154
 msgid "qcow2"
 msgstr "qcow2"
 
-#: pkg/machines/components/diskAdd.jsx:177
+#: pkg/machines/components/diskAdd.jsx:157
 msgid "raw"
 msgstr "raw"
-
-#: pkg/ovirt/rephraseUI.js:36
-msgid "reboot"
-msgstr "reiniciar"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -10151,7 +7991,7 @@ msgstr "pesquisar por nome, tamanho do nome ou descrição"
 msgid "security"
 msgstr "segurança"
 
-#: pkg/docker/index.html:404
+#: pkg/docker/index.html:406
 msgid "select container"
 msgstr "selecionar contêiner"
 
@@ -10159,7 +7999,7 @@ msgstr "selecionar contêiner"
 msgid "server"
 msgstr "servidor"
 
-#: pkg/docker/index.html:483 pkg/docker/index.html:655
+#: pkg/docker/index.html:485 pkg/docker/index.html:657
 msgid "shares"
 msgstr "compartilhamentos"
 
@@ -10178,10 +8018,6 @@ msgstr "desligar"
 #: pkg/machines/helpers.js:191
 msgid "shutdown"
 msgstr "desligar"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "sockets"
-msgstr "sockets"
 
 #: pkg/selinux/setroubleshoot-view.jsx:123
 msgid "solution details"
@@ -10203,10 +8039,6 @@ msgstr "servidor ssh está vazio"
 msgid "suspended (PM)"
 msgstr "suspenso (PM)"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "threads"
-msgstr "threads"
-
 #: pkg/docker/run.js:474
 msgid "to host path"
 msgstr "para hospedar o caminho"
@@ -10222,10 +8054,6 @@ msgstr "traduzível"
 #: pkg/machines/helpers.js:218
 msgid "udp"
 msgstr "udp"
-
-#: pkg/ovirt/rephraseUI.js:37
-msgid "unassigned"
-msgstr "não assinado"
 
 #: pkg/lib/cockpit-components-select.jsx:28
 msgid "undefined"
@@ -10244,7 +8072,7 @@ msgstr "alvo desconhecido"
 msgid "unpartitioned space on $0"
 msgstr "espaço não particionado em $0"
 
-#: pkg/machines/helpers.js:237 pkg/ovirt/rephraseUI.js:26
+#: pkg/machines/helpers.js:237
 msgid "up"
 msgstr "up"
 
@@ -10253,7 +8081,6 @@ msgid "user"
 msgstr "usuário"
 
 #: pkg/machines/components/vcpuModal.jsx:192
-#: pkg/ovirt/components/vcpuModal.jsx:54
 msgid "vCPU Count"
 msgstr "quantidade de vCPU"
 
@@ -10262,8 +8089,6 @@ msgid "vCPU Maximum"
 msgstr "Máximo de vCPU"
 
 #: pkg/machines/components/vmOverviewTab.jsx:75
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "vCPUs"
 msgstr "vCPUs"
 
@@ -10275,12 +8100,16 @@ msgstr "valor"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/kubernetes/views/route-body.html:13
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+msgid ""
+"virt-install package needs to be installed on the system in order to create "
+"new VMs"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:42
 msgid "yes"
 msgstr "sim"
 
@@ -10291,3 +8120,1416 @@ msgid ""
 msgstr ""
 "{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
 "count: {{ condition.generation }}"
+
+#~ msgid " 1\"Do you want to delete the following Nodes?"
+#~ msgstr "1 \"Deseja excluir os seguintes nós?"
+
+#~ msgid "$0 vCPU Details"
+#~ msgstr "$0 vCPU Detalhes"
+
+#~ msgid "$0% Free"
+#~ msgid_plural "$0% Free"
+#~ msgstr[0] "$0% Livre"
+#~ msgstr[1] "$0% Livres"
+
+#~ msgid "$0% Used"
+#~ msgid_plural "$0% Used"
+#~ msgstr[0] "$0% Usado"
+#~ msgstr[1] "$0% Usados"
+
+#~ msgid "'Organization' required to register."
+#~ msgstr "'Organização' necessária para se registar."
+
+#~ msgid "'Organization' required when using activation keys."
+#~ msgstr "'Organização' necessária ao usar chaves de ativação."
+
+#~ msgid "AWS Elastic Block Store"
+#~ msgstr "AWS Loja de Blocos Elásticos"
+
+#~ msgid "Access Modes"
+#~ msgstr "Modos de Acesso"
+
+#~ msgid "Access denied"
+#~ msgstr "Acesso negado"
+
+#~ msgid "Action"
+#~ msgstr "Ação"
+
+#~ msgid "Activation Key"
+#~ msgstr "Chave de Ativação"
+
+#~ msgid "Actual"
+#~ msgstr "Atual"
+
+#~ msgid "Add Cluster Node"
+#~ msgstr "Adicionar Nó de Cluster"
+
+#~ msgid "Add Group"
+#~ msgstr "Adicionar Grupo"
+
+#~ msgid "Add Kubernetes Node"
+#~ msgstr "Adicionar Nó Kubernetes"
+
+#~ msgid "Add Member"
+#~ msgstr "Adicionar Membro"
+
+#~ msgid "Add Membership"
+#~ msgstr "Adicionar Associação"
+
+#~ msgid "Add New Cluster"
+#~ msgstr "Adicionar Novo Cluster"
+
+#~ msgid "Add New User"
+#~ msgstr "Adicionar Novo Usuário"
+
+#~ msgid "Add Role"
+#~ msgstr "Adicionar Função"
+
+#~ msgid "Add User"
+#~ msgstr "Adicionar Usuário"
+
+#~ msgid "Add membership"
+#~ msgstr "Adicionar associação"
+
+#~ msgid "Adjust"
+#~ msgstr "Ajustar"
+
+#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+#~ msgstr "Ajustar Volume Persistente '{{ item.metadata.name }}'"
+
+#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
+#~ msgstr "Ajustar o Controlador de Replicação {{ item.metadata.name }}"
+
+#~ msgid "Adjust Route"
+#~ msgstr "Ajustar Rota"
+
+#~ msgid "Adjust Service"
+#~ msgstr "Ajuste de serviço"
+
+#~ msgid "Admin"
+#~ msgstr "Admin"
+
+#~ msgid "All Projects"
+#~ msgstr "Todos os Projetos"
+
+#~ msgid "All Types"
+#~ msgstr "Todos os Tipos"
+
+#~ msgid "All healthy"
+#~ msgstr "Tudo saudável"
+
+#~ msgid "All images"
+#~ msgstr "Todas as imagens"
+
+#~ msgid "All in use"
+#~ msgstr "Tudo em uso"
+
+#~ msgid "All running"
+#~ msgstr "Tudo executando"
+
+#~ msgid "All running virtual machines will be turned off."
+#~ msgstr "Todas as máquinas virtuais em execução serão desativadas."
+
+#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
+#~ msgstr ""
+#~ "Anônimo: permitir que todos os usuários não autenticados baixem imagens"
+
+#~ msgid "Automatically selected host"
+#~ msgstr "Host selecionado automaticamente"
+
+#~ msgid "Azure"
+#~ msgstr "Azure"
+
+#~ msgid "Base Template"
+#~ msgstr "Modelo base"
+
+#~ msgid "Base template"
+#~ msgstr "Modelo base"
+
+#~ msgid "Base template:"
+#~ msgstr "Modelo base:"
+
+#~ msgid "Boot ID"
+#~ msgstr "ID de Boot"
+
+#~ msgid "CPU Utilization: $0%"
+#~ msgstr "Utilização da CPU: $0%"
+
+#~ msgid "CREATE VM action failed"
+#~ msgstr "A ação CRiar VM falhou"
+
+#~ msgid "Cannot decrypt PEM-encoded private key"
+#~ msgstr "Não é possível decifrar a chave privada codificado em PEM"
+
+#~ msgid "Ceph Filesystem Mount"
+#~ msgstr "Sistema de Arquivos de Montagem Ceph"
+
+#~ msgid "Ceph Monitors"
+#~ msgstr "Monitores Ceph"
+
+#~ msgid "Change User"
+#~ msgstr "Alterar Usuário"
+
+#~ msgid "Change image stream"
+#~ msgstr "Alterar stream de imagem"
+
+#~ msgid "Change project"
+#~ msgstr "Alterar projeto"
+
+#~ msgid "Cinder"
+#~ msgstr "Cinzas"
+
+#~ msgid "Claim"
+#~ msgstr "Reivindicar"
+
+#~ msgid "Claim Name"
+#~ msgstr "Nome da reivindicação"
+
+#~ msgid "Client Certificate"
+#~ msgstr "Certificado de Cliente"
+
+#~ msgid "Cluster"
+#~ msgstr "Cluster"
+
+#~ msgid "Cluster Templates"
+#~ msgstr "Modelos de Cluster"
+
+#~ msgid "Cluster Virtual Machines"
+#~ msgstr "Máquinas Virtuais de Cluster"
+
+#~ msgid "Configuration"
+#~ msgstr "Configuração"
+
+#~ msgid "Configure Flannel networking"
+#~ msgstr "Configurar rede de Flanela"
+
+#~ msgid "Configure Kubelet and Proxy"
+#~ msgstr "Configurar Kubelet e o Proxy"
+
+#~ msgid "Confirm migration"
+#~ msgstr "Confirme a migração"
+
+#~ msgid "Confirm reload:"
+#~ msgstr "Confirme o recarregamento:"
+
+#~ msgid "Confirm save:"
+#~ msgstr "Confirme salve:"
+
+#~ msgid "Connect to oVirt Engine"
+#~ msgstr "Conecte-se ao motor do ivirt"
+
+#~ msgid "Connecting..."
+#~ msgstr "Conectando..."
+
+#~ msgid "Connection Error: $0"
+#~ msgstr "Erro de Conexão: $0"
+
+#~ msgid "Connection Settings"
+#~ msgstr "Configurações de Conexão"
+
+#~ msgid "Container ID"
+#~ msgstr "ID do Contêiner"
+
+#~ msgid "Container Runtime Version"
+#~ msgstr "Versão de Tempo de Execução do Contêiner"
+
+#~ msgid "Could not list services"
+#~ msgstr "Não foi possível listar serviços"
+
+#~ msgid "Could not parse PEM-encoded certificate"
+#~ msgstr "Não foi possível analisar certificado PEM-codificado"
+
+#~ msgid "Could not parse PEM-encoded private key"
+#~ msgstr "Não foi possível analisar chave privada codificado em PEM"
+
+#~ msgid "Couldn't connect to server"
+#~ msgstr "Não foi possível conectar ao servidor"
+
+#~ msgid "Couldn't find running API server"
+#~ msgstr "Não foi possível localizar o servidor API em execução"
+
+#~ msgid ""
+#~ "Couldn't get system subscription status. Please ensure subscription-"
+#~ "manager is installed."
+#~ msgstr ""
+#~ "Não foi possível obter o status de assinatura do sistema. Verifique se o "
+#~ "gerenciador de assinaturas está instalado."
+
+#~ msgid "Create New VM"
+#~ msgstr "Criar nova VM"
+
+#~ msgid "Create empty image stream"
+#~ msgstr "Criar um stream de imagem vazio"
+
+#~ msgid "Create image stream"
+#~ msgstr "Criar Stream de Imagem"
+
+#~ msgid "Custom URL"
+#~ msgstr "URL Personalizada"
+
+#~ msgid "DNS Policy"
+#~ msgstr "Política de DNS"
+
+#~ msgid "Delete '{{ name }}'"
+#~ msgstr "Deletar '{{ name }}'"
+
+#~ msgid "Delete Node"
+#~ msgstr "Deletar Nó"
+
+#~ msgid "Delete Persistent Volume"
+#~ msgstr "Deletar Volume Persistente"
+
+#~ msgid "Delete Persistent Volume Claim"
+#~ msgstr "Deletar Declaração de Volume Persistente"
+
+#~ msgid "Delete Project"
+#~ msgstr "Deletar Projeto"
+
+#~ msgid "Delete Selected"
+#~ msgstr "Deletar o Selecionado"
+
+#~ msgid "Delete image stream"
+#~ msgstr "Deletar stream de imagem"
+
+#~ msgid "Delete {{ item.kind }}"
+#~ msgstr "Excluir {{ item.kind }}"
+
+#~ msgid ""
+#~ "Deleting a Pod will kill all associated containers. Pods may be "
+#~ "automatically created again in some cases."
+#~ msgstr ""
+#~ "Excluir um Pod irá matar todos os contêineres associados. Pods podem ser "
+#~ "automaticamente criados novamente em alguns casos."
+
+#~ msgid "Deploy"
+#~ msgstr "Implantar"
+
+#~ msgid "Deploy Application"
+#~ msgstr "Implantar aplicativo"
+
+#~ msgid "Deployment Causes"
+#~ msgstr "Causas de Implantação"
+
+#~ msgid "Deployment Config"
+#~ msgstr "Config de Implantação"
+
+#~ msgid "Deployment Configs"
+#~ msgstr "Configs de Implantação"
+
+#~ msgid "Description:"
+#~ msgstr "Descrição:"
+
+#~ msgid "Disk Utilization: $0%"
+#~ msgstr "Utilização do disco: $0%"
+
+#~ msgid "Display name"
+#~ msgstr "Nome exibido"
+
+#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#~ msgstr "Deseja adicionar a função '{{ fields.displayRole }}'?"
+
+#~ msgid ""
+#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}' image stream?"
+#~ msgstr ""
+#~ "Deseja deletar o stream de imagem '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}'?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+#~ msgstr "Deseja deletar o Volume Persistente '{{item.metadata.name}}'?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume Claim '{{item.metadata."
+#~ "name}}'?"
+#~ msgstr ""
+#~ "Deseja excluir a declaração de volume persistente '{{item.metadata."
+#~ "name}}'?"
+
+#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+#~ msgstr "Deseja excluir o {{ item.kind }} '{{item.metadata.name}}'?"
+
+#~ msgid "Do you want to delete this Node?"
+#~ msgstr "Deseja excluir este Nó?"
+
+#~ msgid ""
+#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+#~ msgstr ""
+#~ "Deseja remover a imagem marcada como '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+
+#~ msgid ""
+#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
+#~ "{{ fields.member.metadata.name }}?"
+#~ msgstr ""
+#~ "Deseja remover a função '{{ fields.displayRole }}' from member {{ fields."
+#~ "member.metadata.name }}?"
+
+#~ msgid "Don't pull images automatically"
+#~ msgstr "Não baixe imagens automaticamente"
+
+#~ msgid "Driver"
+#~ msgstr "Driver"
+
+#~ msgid "Edit the vdsm.conf"
+#~ msgstr "Edite o vdsm.conf"
+
+#~ msgid "Empty Directory"
+#~ msgstr "Diretório Vazio"
+
+#~ msgid "Endpoint"
+#~ msgstr "Ponto final"
+
+#~ msgid "Endpoint Name"
+#~ msgstr "Nome do Ponto de extremidade"
+
+#~ msgid "Endpoints"
+#~ msgstr "Pontos finais"
+
+#~ msgid "Ends"
+#~ msgstr "Finais"
+
+#~ msgid "Enter New VM name"
+#~ msgstr "Insira o novo nome da VM"
+
+#~ msgid "Error getting certificate details: $0"
+#~ msgstr "Erro ao obter detalhes do certificado: $0"
+
+#~ msgid "Error writing kubectl config"
+#~ msgstr "Erro ao escrever kubectl config"
+
+#~ msgid "FQDN"
+#~ msgstr "FQDN"
+
+#~ msgid "Fibre Channel"
+#~ msgstr "Canal de Fibra"
+
+#~ msgid "Filesystem Type"
+#~ msgstr "Tipo do Sistema de Arquivos"
+
+#~ msgid "Flex"
+#~ msgstr "Flex"
+
+#~ msgid "Flocker"
+#~ msgstr "Flocker"
+
+#~ msgid "Flocker Dataset Name"
+#~ msgstr "Nome do Flocker Dataset"
+
+#~ msgid "GCE Persistent Disk"
+#~ msgstr "Disco Persistente GCE"
+
+#~ msgid "Git Repository"
+#~ msgstr "Repositório Git"
+
+#~ msgid "Gluster FS"
+#~ msgstr "Gluster FS"
+
+#~ msgid "GlusterFS"
+#~ msgstr "GlusterFS"
+
+#~ msgid "Grant additional push or admin access to specific members below."
+#~ msgstr ""
+#~ "Conceder acesso adicional de envio ou admin a membros específicos abaixo."
+
+#~ msgid "Group Members"
+#~ msgstr "Membros do Grupo"
+
+#~ msgid "Group or Project"
+#~ msgstr "Grupo ou Projeto"
+
+#~ msgid "Groups"
+#~ msgstr "Grupos"
+
+#~ msgid "HA"
+#~ msgstr "HA"
+
+#~ msgid "HA:"
+#~ msgstr "HA:"
+
+#~ msgid "Host Path"
+#~ msgstr "Campo de Host"
+
+#~ msgid "Host to Maintenance"
+#~ msgstr "Host para Manutenção"
+
+#~ msgid "IP"
+#~ msgstr "IP"
+
+#~ msgid "ISCSI"
+#~ msgstr "ISCSI"
+
+#~ msgid "Identities"
+#~ msgstr "Identidades"
+
+#~ msgid "Identity"
+#~ msgstr "Ìdentidade"
+
+#~ msgid "Image ID"
+#~ msgstr "ID da Imagem"
+
+#~ msgid "Image Name"
+#~ msgstr "Nome da Imagem"
+
+#~ msgid "Image Registry"
+#~ msgstr "Registro de Imagem"
+
+#~ msgid "Image Stream"
+#~ msgstr "Stream de Imagem"
+
+#~ msgid "Image commands"
+#~ msgstr "Comandos da Imagem"
+
+#~ msgid "Images by project"
+#~ msgstr "Imagens do projeto"
+
+#~ msgid "Images pushed recently"
+#~ msgstr "Imagens enviadas recentemente"
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, use the commands below."
+#~ msgstr ""
+#~ "A fim de começar a enviar imagens para o registro, use os comandos abaixo."
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, you need to create a "
+#~ "project."
+#~ msgstr ""
+#~ "A fim de começar a enviar imagens para o registro, você precisa criar um "
+#~ "projeto."
+
+#~ msgid "Installed products"
+#~ msgstr "Produtos instalados"
+
+#~ msgid "Interface"
+#~ msgstr "Interface"
+
+#~ msgid "Invalid credentials"
+#~ msgstr "Credenciais Inválidas"
+
+#~ msgid "Kernel Version"
+#~ msgstr "Versão do Kernel"
+
+#~ msgid "Key Ring Path"
+#~ msgstr "Trajeto Chave do Anel"
+
+#~ msgid "Kubelet Version"
+#~ msgstr "Versão Kubelet"
+
+#~ msgid "Kubernetes Cluster"
+#~ msgstr "Kubernetes Cluster"
+
+#~ msgid "Last Heartbeat"
+#~ msgstr "Último Batimento Cardíaco"
+
+#~ msgid "Last Status Change"
+#~ msgstr "Última Mudança de Status"
+
+#~ msgid "Latest Version"
+#~ msgstr "Versão Mais Recente"
+
+#~ msgid "Loading data ..."
+#~ msgstr "Carregando dados ..."
+
+#~ msgid "Log into OpenShift command line tools:"
+#~ msgstr "Logar em OpenShift ferramentas de linha de comando:"
+
+#~ msgid "Log into the registry:"
+#~ msgstr "Logar no registro:"
+
+#~ msgid "Logical Unit Number"
+#~ msgstr "Número da Unidade Lógica"
+
+#~ msgid "Login"
+#~ msgstr "Login"
+
+#~ msgid "Login commands"
+#~ msgstr "Comandos de login"
+
+#~ msgid "Login/password or activation key required to register."
+#~ msgstr "Login/senha ou chave de ativação necessária para registrar."
+
+#~ msgid "MIGRATE action failed"
+#~ msgstr "A ação MIGRATE falhou"
+
+#~ msgid "Manifest"
+#~ msgstr "Manifesto"
+
+#~ msgid "Medium"
+#~ msgstr "Médio"
+
+#~ msgid "Member of"
+#~ msgstr "Membro de"
+
+#~ msgid "Members"
+#~ msgstr "Membros"
+
+#~ msgid "Membership"
+#~ msgstr "Associação"
+
+#~ msgid "Memory Utilization: $0%"
+#~ msgstr "Utilização de Memória: $0%"
+
+#~ msgid "Message"
+#~ msgstr "Mensagem"
+
+#~ msgid "Migrate To:"
+#~ msgstr "Migrar para:"
+
+#~ msgid "Modify"
+#~ msgstr "Modificar"
+
+#~ msgid "Monitors"
+#~ msgstr "Monitores"
+
+#~ msgid "Mount Location"
+#~ msgstr "Montar Locação"
+
+#~ msgid "NFS"
+#~ msgstr "NFS"
+
+#~ msgid "Namespace"
+#~ msgstr "Namespace"
+
+#~ msgid "Namespace cannot be empty."
+#~ msgstr "Namespace não pode estar vazio ."
+
+#~ msgid "New Group"
+#~ msgstr "Novo Grupo"
+
+#~ msgid "New Project"
+#~ msgstr "Novo Projeto"
+
+#~ msgid "New image stream"
+#~ msgstr "Novo stream de imagem"
+
+#~ msgid "New project"
+#~ msgstr "Novo projeto"
+
+#~ msgid "No PEM-encoded certificate found"
+#~ msgstr "Nenhum certificado codificado em PEM encontrados"
+
+#~ msgid "No PEM-encoded private key found"
+#~ msgstr "Nenhuma chave privada codificado em PEM encontrados"
+
+#~ msgid "No Pods are using this claim"
+#~ msgstr "Sem Pods usando esta afirmação"
+
+#~ msgid "No VM found in oVirt."
+#~ msgstr "Nenhuma VM encontrada no oVirt."
+
+#~ msgid "No Volume Bound"
+#~ msgstr "Nenhuma Ligação de Volume"
+
+#~ msgid "No groups are present."
+#~ msgstr "Nenhum grupo presente."
+
+#~ msgid "No images pushed"
+#~ msgstr "Nenhuma imagem inserida"
+
+#~ msgid "No installed products on the system."
+#~ msgstr "Não há produtos instalados no sistema."
+
+#~ msgid ""
+#~ "No metadata file was selected. Please select a Kubernetes metadata file."
+#~ msgstr ""
+#~ "Nenhum arquivo de metadados foi selecionado. Por favor, selecione um "
+#~ "arquivo de metadados Kubernetes ."
+
+#~ msgid "No nodes in cluster"
+#~ msgstr "Não há nós no cluster"
+
+#~ msgid "No oVirt connection"
+#~ msgstr "Sem conexão com oVirt"
+
+#~ msgid "No pods deployed"
+#~ msgstr "Sem pods implantados"
+
+#~ msgid "No pods replicated"
+#~ msgstr "Sem pods replicados"
+
+#~ msgid "No pods scheduled"
+#~ msgstr "Sem pods agendados"
+
+#~ msgid "No pods selected"
+#~ msgstr "Sem pods selecionados"
+
+#~ msgid "No projects are present."
+#~ msgstr "Nenhum projeto presente."
+
+#~ msgid "No users are present."
+#~ msgstr "Não há usuários presentes."
+
+#~ msgid "No volumes are present."
+#~ msgstr "Não há volumes presentes."
+
+#~ msgid "No volumes in use"
+#~ msgstr "Não há volumes em uso"
+
+#~ msgid "Node"
+#~ msgstr "Nó"
+
+#~ msgid "Nodes"
+#~ msgstr "Nós"
+
+#~ msgid "Nodes are the machines that run your containers."
+#~ msgstr "Nós são as máquinas que executam seus contêineres."
+
+#~ msgid "Not a valid number of replicas"
+#~ msgstr "Não é um número válido de réplicas"
+
+#~ msgid "Not a valid value for Host"
+#~ msgstr "Não é um valor válido para o Host"
+
+#~ msgid "Not deployed"
+#~ msgstr "Não Implantado"
+
+#~ msgid "Number of virtual CPUs that gonna be used."
+#~ msgstr "Número de CPUs virtuais que serão usadas."
+
+#~ msgid "OK"
+#~ msgstr "OK"
+
+#~ msgid "OS"
+#~ msgstr "OS"
+
+#~ msgid "OS Type:"
+#~ msgstr "Tipo de SO:"
+
+#~ msgid "OS Versions"
+#~ msgstr "Versões de OS"
+
+#~ msgid "Optimized for:"
+#~ msgstr "Otimizado para:"
+
+#~ msgid "Organization"
+#~ msgstr "Organização"
+
+#~ msgid "PD Name"
+#~ msgstr "Nome de PD"
+
+#~ msgid "Pending Volume Claims"
+#~ msgstr "Declarações de Volume Pendentes"
+
+#~ msgid "Persistent Volumes"
+#~ msgstr "Volumes Persistentes"
+
+#~ msgid "Phase"
+#~ msgstr "Fase"
+
+#~ msgid "Please confirm, the host shall be switched to maintenance mode."
+#~ msgstr ""
+#~ "Por favor confirme, o host deve ser mudado para o modo de manutenção."
+
+#~ msgid "Please create another namespace for $0 \"$1\""
+#~ msgstr "Por favor, crie outro namespace para $0 \"$1\""
+
+#~ msgid "Please provide a GlusterFS volume name"
+#~ msgstr "Por favor, forneça um nome de volume GlusterFS"
+
+#~ msgid "Please provide a username"
+#~ msgstr "Por favor, forneça um nome de usuário"
+
+#~ msgid "Please provide a valid NFS server"
+#~ msgstr "Por favor, forneça um servidor NFS válido"
+
+#~ msgid "Please provide a valid address"
+#~ msgstr "Por favor, forneça um endereço válido"
+
+#~ msgid "Please provide a valid filesystem type"
+#~ msgstr "Por favor, forneça um tipo de sistema de arquivos válido"
+
+#~ msgid "Please provide a valid interface"
+#~ msgstr "Por favor, forneça uma interface válida"
+
+#~ msgid "Please provide a valid logical unit number"
+#~ msgstr "Por favor, forneça um número lógico válido de unidade"
+
+#~ msgid "Please provide a valid name"
+#~ msgstr "Por favor, forneça um nome válido"
+
+#~ msgid "Please provide a valid namespace."
+#~ msgstr "Por favor, forneça um namespace válido."
+
+#~ msgid "Please provide a valid path"
+#~ msgstr "Por favor, forneça um caminho válido"
+
+#~ msgid "Please provide a valid qualified name"
+#~ msgstr "Por favor, forneça um nome qualificado válido"
+
+#~ msgid "Please provide a valid storage capacity."
+#~ msgstr "Por favor, forneça uma capacidade de armazenamento válida."
+
+#~ msgid "Please provide a valid target"
+#~ msgstr "Por favor, forneça um alvo válido"
+
+#~ msgid ""
+#~ "Please provide fully qualified domain name and port of the oVirt engine."
+#~ msgstr ""
+#~ "Por favor, forneça o nome de domínio e a porta totalmente qualificados do "
+#~ "motor da oVirt."
+
+#~ msgid ""
+#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
+#~ "port (443 by default)"
+#~ msgstr ""
+#~ "Por favor, forneça o nome de domínio totalmente qualificado (FQDN) do "
+#~ "motor oVirt e a porta (443 por padrão)"
+
+#~ msgid ""
+#~ "Please refer to oVirt's $0 for more information about Remote Viewer setup."
+#~ msgstr ""
+#~ "Por favor, consulte o $0 da oVirt para mais informações sobre a "
+#~ "configuração do Visualizador Remoto."
+
+#~ msgid "Please select a valid access mode"
+#~ msgstr "Por favor, selecione um modo de acesso válido"
+
+#~ msgid "Please select a valid endpoint"
+#~ msgstr "Por favor, selecione um ponto de extremidade válido"
+
+#~ msgid "Please select a valid policy option."
+#~ msgstr "Por favor, selecione uma opção de diretiva válida."
+
+#~ msgid "Please type an address"
+#~ msgstr "Por favor, digite um endereço"
+
+#~ msgid "Please wait till VMs list is loaded from the server."
+#~ msgstr ""
+#~ "Por favor, aguarde até que a lista de VMs seja carregada do servidor."
+
+#~ msgid "Please wait till list of templates is loaded from the server."
+#~ msgstr ""
+#~ "Por favor, aguarde até que a lista de modelos seja carregada do servidor."
+
+#~ msgid "Pod"
+#~ msgstr "Pod"
+
+#~ msgid "Pod Address"
+#~ msgstr "Endereço Pod"
+
+#~ msgid "Pod Endpoints"
+#~ msgstr "Extremidades Pod"
+
+#~ msgid "Pod Replicated"
+#~ msgstr "Pod Replicado"
+
+#~ msgid "Pod Selector"
+#~ msgstr "Seletor Pod"
+
+#~ msgid "Pods"
+#~ msgstr "Pods"
+
+#~ msgid ""
+#~ "Pods contain one or more containers that run together on a node, "
+#~ "containing your application code."
+#~ msgstr ""
+#~ "Pods contêm um ou mais conteiners que são executados juntos em um nó, que "
+#~ "contém o código do aplicativo."
+
+#~ msgid "Pool Name"
+#~ msgstr "Nome do Pool"
+
+#~ msgid "Populate"
+#~ msgstr "Preencher"
+
+#~ msgid "Preparing for Maintenance"
+#~ msgstr "Preparando-se para manutenção"
+
+#~ msgid "Private: Allow only specific users or groups to pull images"
+#~ msgstr ""
+#~ "Privado: permite que apenas usuários específicos ou grupos puxem imagens"
+
+#~ msgid "Product ID"
+#~ msgstr "ID do Produto"
+
+#~ msgid "Product name"
+#~ msgstr "Nome do produto"
+
+#~ msgid "Project"
+#~ msgstr "Projeto"
+
+#~ msgid "Project Members"
+#~ msgstr "Membros do Projeto"
+
+#~ msgid "Project access policy allows anonymous users to pull images."
+#~ msgstr ""
+#~ "A diretiva de acesso ao projeto permite que usuários anônimos baixem "
+#~ "imagens."
+
+#~ msgid "Project access policy allows any authenticated user to pull images."
+#~ msgstr ""
+#~ "A diretiva de acesso a projetos permite que qualquer usuário autenticado "
+#~ "puxe imagens."
+
+#~ msgid "Project access policy only allows specific members to access images."
+#~ msgstr ""
+#~ "A diretiva de acesso ao projeto só permite que membros específicos "
+#~ "acessem imagens."
+
+#~ msgid "Project:"
+#~ msgstr "Projeto:"
+
+#~ msgid "Projects"
+#~ msgstr "Projetos"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "Proxy Version"
+#~ msgstr "Versão do Proxy"
+
+#~ msgid "Pull an image:"
+#~ msgstr "Baixar uma imagem:"
+
+#~ msgid "Pull from"
+#~ msgstr "Baixar de"
+
+#~ msgid "Pull specific tags from another image repository"
+#~ msgstr "Resgatar tags específicas de outro repositório de imagem"
+
+#~ msgid "Push an image:"
+#~ msgstr "Enviar uma imagem:"
+
+#~ msgid "Qualified Name"
+#~ msgstr "Nome Qualificado"
+
+#~ msgid "REBOOT action failed"
+#~ msgstr "A ação REBOOT falhou"
+
+#~ msgid "Rados Block Device"
+#~ msgstr "Dispositivo Rados Bloqueado"
+
+#~ msgid "Read Only"
+#~ msgstr "Somente leitura"
+
+#~ msgid "Read and write from a single node"
+#~ msgstr "Ler e gravar a partir de um único nó"
+
+#~ msgid "Read and write from multiple nodes"
+#~ msgstr "Ler e gravar a partir de vários nós"
+
+#~ msgid "Read only from multiple nodes"
+#~ msgstr "Somente leitura de vários nós"
+
+#~ msgid "Reason"
+#~ msgstr "Razão"
+
+#~ msgid "Reclaim Policy"
+#~ msgstr "Recuperar Política"
+
+#~ msgid "Recycle"
+#~ msgstr "Reciclar"
+
+#~ msgid "Register"
+#~ msgstr "Registrar"
+
+#~ msgid "Register New Volume"
+#~ msgstr "Registrar Novo Volume"
+
+#~ msgid "Register Persistent Volume"
+#~ msgstr "Registrar Volume Persistente"
+
+#~ msgid "Register oVirt"
+#~ msgstr "Registrar oVirt"
+
+#~ msgid "Register system"
+#~ msgstr "Registrar sistema"
+
+#~ msgid "Registering oVirt to Cockpit"
+#~ msgstr "Registrando oVirt no Cockpit"
+
+#~ msgid "Remote registry is insecure"
+#~ msgstr "Registro remoto é inseguro"
+
+#~ msgid "Remove Group"
+#~ msgstr "Remover Grupo"
+
+#~ msgid "Remove Member"
+#~ msgstr "Remover Membro"
+
+#~ msgid "Remove Role"
+#~ msgstr "Remover Função"
+
+#~ msgid "Remove User"
+#~ msgstr "Remover Usuário"
+
+#~ msgid "Remove image tag"
+#~ msgstr "Remover tag de imagem"
+
+#~ msgid "Remove membership"
+#~ msgstr "Remover associação"
+
+#~ msgid "Replicas"
+#~ msgstr "Réplicas"
+
+#~ msgid "Replication Controller"
+#~ msgstr "Controlador de Replicação"
+
+#~ msgid "Replication Controllers"
+#~ msgstr "Controladores de Replicação"
+
+#~ msgid ""
+#~ "Replication controllers dynamically create instances of pods from "
+#~ "templates, and remove pods when necessary."
+#~ msgstr ""
+#~ "Os controladores de replicação criam dinamicamente instâncias modelos de "
+#~ "pods e removem esses pods quando necessário."
+
+#~ msgid "Repository URL"
+#~ msgstr "URL do Repositório"
+
+#~ msgid "Requested"
+#~ msgstr "Requisitado"
+
+#~ msgid "Requests"
+#~ msgstr "Requisições"
+
+#~ msgid "Requires Authentication"
+#~ msgstr "Requer Autenticação"
+
+#~ msgid "Restart Count"
+#~ msgstr "Reiniciar Contagem"
+
+#~ msgid "Retain"
+#~ msgstr "Manter"
+
+#~ msgid "Retrieving subscription status..."
+#~ msgstr "Recuperando o status da assinatura..."
+
+#~ msgid "Revision"
+#~ msgstr "Revisão"
+
+#~ msgid "Role"
+#~ msgstr "Função"
+
+#~ msgid "Route"
+#~ msgstr "Rota"
+
+#~ msgid "Run Here"
+#~ msgstr "Rodar aqui"
+
+#~ msgid "Running Since:"
+#~ msgstr "Correndo desde:"
+
+#~ msgid "SET VCPU SETTINGS action failed"
+#~ msgstr "A ação SET SETUP VCPU falhou"
+
+#~ msgid "SHUTDOWN action failed"
+#~ msgstr "A ação SHUTDOWN falhou"
+
+#~ msgid "START action failed"
+#~ msgstr "START Ação: falhou"
+
+#~ msgid "SUSPEND action failed"
+#~ msgstr "SUSPEND Ação: falhou"
+
+#~ msgid "Scheduled Pods"
+#~ msgstr "Pods Agendados"
+
+#~ msgid "Scheduling Disabled"
+#~ msgstr "Agendamento Desativado"
+
+#~ msgid "Secret"
+#~ msgstr "Secreto"
+
+#~ msgid "Secret File"
+#~ msgstr "Arquivo Secreto"
+
+#~ msgid "Secret Name"
+#~ msgstr "Nome Secreto"
+
+#~ msgid "Secret Volume"
+#~ msgstr "Volume Secreto"
+
+#~ msgid "Select Manifest File..."
+#~ msgstr "Selecione Arquivo Manifest ..."
+
+#~ msgid "Select Member"
+#~ msgstr "Selecione o membro"
+
+#~ msgid "Select Role"
+#~ msgstr "Selecionar Função"
+
+#~ msgid "Select an object to see more details."
+#~ msgstr "Selecione um objeto para ver mais detalhes."
+
+#~ msgid "Service Account"
+#~ msgstr "Serviço de Conta"
+
+#~ msgid ""
+#~ "Services group pods and provide a common DNS name and an optional, load-"
+#~ "balanced IP address to access them."
+#~ msgstr ""
+#~ "Pods de grupo de serviços fornecem um nome DNS comum e um endereço IP "
+#~ "opcional, balanceado por carga para acessá-los."
+
+#~ msgid "Session Affinity"
+#~ msgstr "Afinidade de Sessão"
+
+#~ msgid "Share Name"
+#~ msgstr "Compartilhar Nome"
+
+#~ msgid "Shared: Allow any authenticated user to pull images"
+#~ msgstr ""
+#~ "Compartilhado: permitir que qualquer usuário autenticado baixe imagens"
+
+#~ msgid "Shell"
+#~ msgstr "Shell"
+
+#~ msgid "Show all Containers"
+#~ msgstr "Exibir todos os Contêineres"
+
+#~ msgid "Show all Deployment Configs"
+#~ msgstr "Exibir todas as Configs de Implantação"
+
+#~ msgid "Show all Nodes"
+#~ msgstr "Exibir todos os Nós"
+
+#~ msgid "Show all Persistent Volumes"
+#~ msgstr "Exibir todos os Volumes Persistentes"
+
+#~ msgid "Show all Pod Containers"
+#~ msgstr "Exibir todos os Contêineres Pod"
+
+#~ msgid "Show all Pods"
+#~ msgstr "Exibir todos os Pods"
+
+#~ msgid "Show all Projects"
+#~ msgstr "Exibir todos os Projetos"
+
+#~ msgid "Show all Replication Controllers"
+#~ msgstr "Exibir todos os Controladores de Replicação"
+
+#~ msgid "Show all Routes"
+#~ msgstr "Exibir todas as Rotas"
+
+#~ msgid "Show all Services"
+#~ msgstr "Exibir todos os Serviços"
+
+#~ msgid "Show all image streams"
+#~ msgstr "Exibir todos os streams de imagem"
+
+#~ msgid "Since"
+#~ msgstr "Desde"
+
+#~ msgid "Skip Certificate Verification"
+#~ msgstr "Ignorar Verificação de Certificado"
+
+#~ msgid "Sorry, I don't know how to modify this volume"
+#~ msgstr "Desculpe, eu não sei como modificar este volume"
+
+#~ msgid "Starts"
+#~ msgstr "Começa"
+
+#~ msgid "Stateless"
+#~ msgstr "Sem estado"
+
+#~ msgid "Stateless:"
+#~ msgstr "Sem estado:"
+
+#~ msgid "Status: $0"
+#~ msgstr "Status: $0"
+
+#~ msgid "Status: System isn't registered"
+#~ msgstr "Status: O sistema não está registrado"
+
+#~ msgid "Strategy"
+#~ msgstr "Estratégia"
+
+#~ msgid "Subscriptions"
+#~ msgstr "Assinaturas"
+
+#~ msgid "Suspend"
+#~ msgstr "Suspender"
+
+#~ msgid "Switch Host to Maintenance"
+#~ msgstr "Trocar de host para manutenção"
+
+#~ msgid "Switching host to maintenance mode failed. Received error: "
+#~ msgstr ""
+#~ "A comutação do host para o modo de manutenção falhou. Erro recebido:"
+
+#~ msgid "Switching host to maintenance mode in progress ..."
+#~ msgstr "Mudando o host para o modo de manutenção em andamento ..."
+
+#~ msgid "Sync all tags from a remote image repository"
+#~ msgstr "Sincronizar todas as tags de um repositório de imagens remotas"
+
+#~ msgid "TLS Termination"
+#~ msgstr "Término de TLS"
+
+#~ msgid "Target Portal"
+#~ msgstr "Portal Alvo"
+
+#~ msgid "Target World Wide Names"
+#~ msgstr "Nomes de Alvos Mundiais"
+
+#~ msgid "Template"
+#~ msgstr "Modelo"
+
+#~ msgid "Templates"
+#~ msgstr "Templates"
+
+#~ msgid "Templates of $0 cluster"
+#~ msgstr "Templates de $0 cluster"
+
+#~ msgid "The address contains invalid characters"
+#~ msgstr "O endereço contém caracteres inválidos"
+
+#~ msgid "The container '{{ target }}' does not exist."
+#~ msgstr "O contêiner '{{ target }}' não existe."
+
+#~ msgid "The current user isn't allowed to access system subscription status."
+#~ msgstr ""
+#~ "O usuário atual não tem permissão para acessar o status de assinatura do "
+#~ "sistema."
+
+#~ msgid "The deployment config '{{ target }}' does not exist."
+#~ msgstr "O Deployment config '{{target}}' não existe."
+
+#~ msgid "The group '{{ groupName }}' does not exist."
+#~ msgstr "O grupo '{{ groupName }}' não existe."
+
+#~ msgid "The maximum number of replicas is 128"
+#~ msgstr "O número máximo de réplicas é 128"
+
+#~ msgid "The name contains invalid characters"
+#~ msgstr "O nome contém caracteres inválidos"
+
+#~ msgid "The node '{{ target }}' does not exist."
+#~ msgstr "O nó '{{ target }}' não existe."
+
+#~ msgid "The node doesn't have enough disk space"
+#~ msgstr "O nó não tem espaço em disco suficiente"
+
+#~ msgid "The node doesn't have enough free memory"
+#~ msgstr "O nó não tem memória livre suficiente"
+
+#~ msgid "The persistent volume '{{ target }}' does not exist."
+#~ msgstr "O volume persistente '{{ target }}' não existe."
+
+#~ msgid "The pod '{{ target }}' does not exist."
+#~ msgstr "O pod '{{ target }}' não existe."
+
+#~ msgid "The project '{{ projName }}' does not exist."
+#~ msgstr "O projeto '{{ projName }}' não existe."
+
+#~ msgid "The replication controller '{{ target }}' does not exist."
+#~ msgstr "O controlador de replicação '{{ target }}' não existe."
+
+#~ msgid "The route '{{ target }}' does not exist."
+#~ msgstr "A rota '{{ target }}' não existe."
+
+#~ msgid "The selected file is not a valid Kubernetes application manifest."
+#~ msgstr ""
+#~ "O arquivo selecionado não é um manifesto do aplicativo Kubernetes válido."
+
+#~ msgid "The server uses a certificate signed by an unknown authority."
+#~ msgstr ""
+#~ "O servidor usa um certificado assinado por uma autoridade desconhecida."
+
+#~ msgid "The service '{{ target }}' does not exist."
+#~ msgstr "O serviço '{{ target }}' não existe."
+
+#~ msgid "The user '{{ userName }}' does not exist."
+#~ msgstr "O usuário '{{ userName }}' não existe."
+
+#~ msgid ""
+#~ "This claim is in use. Deleting it may cause issues with the following pod:"
+#~ msgstr ""
+#~ "Esta afirmação está em uso. Excluí-lo pode causar problemas com o "
+#~ "seguinte pod:"
+
+#~ msgid ""
+#~ "This host is managed by a virtualization manager, so creation of new VMs "
+#~ "from the host is not possible."
+#~ msgstr ""
+#~ "Esse host é gerenciado por um gerenciador de virtualização, portanto, a "
+#~ "criação de novas VMs a partir do host não é possível."
+
+#~ msgid ""
+#~ "This option is for single node testing only – local storage will not work "
+#~ "in a multi-node cluster"
+#~ msgstr ""
+#~ "Esta opção é apenas para testes de nó único – o armazenamento local não "
+#~ "funcionará em um cluster de vários nós"
+
+#~ msgid "This virtual machine is not managed by oVirt"
+#~ msgstr "Esta máquina virtual não é gerenciada pelo oVirt"
+
+#~ msgid ""
+#~ "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+#~ "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+#~ "may cause issues with any pods depending on it."
+#~ msgstr ""
+#~ "Este volume foi reivindicado por {{ item.item.spec.claimRef."
+#~ "namespace }} / {{ item.item.spec.claimRef.name }}. Excluí-lo vai parar "
+#~ "essa reivindicação e pode causar problemas com quaisquer pods, dependendo "
+#~ "dele."
+
+#~ msgid "This volume has not been claimed"
+#~ msgstr "Este volume não foi reivindicado"
+
+#~ msgid "Token"
+#~ msgstr "Token"
+
+#~ msgid "Topology"
+#~ msgstr "Topologia"
+
+#~ msgid "Trust this certificate for this connection"
+#~ msgstr "Confie neste certificado para esta conexão"
+
+#~ msgid "Type:"
+#~ msgstr "Tipo:"
+
+#~ msgid "Unable to connect"
+#~ msgstr "Não é possível conectar"
+
+#~ msgid "Unable to decode Kubernetes application manifest."
+#~ msgstr "Não é possível decodificar o manifesto do aplicativo Kubernetes."
+
+#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
+#~ msgstr ""
+#~ "Não é possível ler o manifesto do aplicativo Kubernetes . Código $0."
+
+#~ msgid "Unregister"
+#~ msgstr "Cancelar o registro"
+
+#~ msgid "Unregistering system..."
+#~ msgstr "Cancelando o registro do sistema..."
+
+#~ msgid "Updating $0..."
+#~ msgstr "Atualizando $0..."
+
+#~ msgid "Use proxy server"
+#~ msgstr "Usar servidor proxy"
+
+#~ msgid "User or Group"
+#~ msgstr "Usuário ou Grupo"
+
+#~ msgid "Users"
+#~ msgstr "Usuários"
+
+#~ msgid "VDSM"
+#~ msgstr "VDSM"
+
+#~ msgid "VDSM Service Management"
+#~ msgstr "VDSM Gerenciamento de Serviços"
+
+#~ msgid "VM icon"
+#~ msgstr "VM icone"
+
+#~ msgid "Version num"
+#~ msgstr "Versão num"
+
+#~ msgid "Virtual Machines of $0 cluster"
+#~ msgstr "Máquinas Virtuais de $0 cluster"
+
+#~ msgid "Volume ID"
+#~ msgstr "ID do Volume"
+
+#~ msgid "Volume Name"
+#~ msgstr "Nome do Volume"
+
+#~ msgid "Volume Type"
+#~ msgstr "Tipo do Volume"
+
+#~ msgid "Warning:"
+#~ msgstr "Aviso:"
+
+#~ msgid "Welcome to the Image Registry"
+#~ msgstr "Bem vindo ao Registro de Imagem"
+
+#~ msgid "When"
+#~ msgstr "Quando"
+
+#~ msgid ""
+#~ "You can bypass the certificate check, but any data you send to the server "
+#~ "could be intercepted by others."
+#~ msgstr ""
+#~ "Você pode ignorar a verificação do certificado, mas os dados que você "
+#~ "enviar para o servidor podem ser interceptados por outros."
+
+#~ msgid "You can deploy an application to your cluster."
+#~ msgstr "Você pode implantar um aplicativo para o seu cluster."
+
+#~ msgid ""
+#~ "Your login credentials do not give you access to use the docker registry "
+#~ "from the command line."
+#~ msgstr ""
+#~ "As credenciais de login não lhe dão acesso para usar o registro de docker "
+#~ "na linha de comando."
+
+#~ msgid "connecting"
+#~ msgstr "conectando"
+
+#~ msgid "cores"
+#~ msgstr "cores"
+
+#~ msgid "eg: my-image-stream"
+#~ msgstr "eg: meu-stream-de-imagem"
+
+#~ msgid "error"
+#~ msgstr "erro"
+
+#~ msgid "initializing"
+#~ msgstr "inicializando"
+
+#~ msgid "installation failed"
+#~ msgstr "Instalação falhada"
+
+#~ msgid "installing OS"
+#~ msgstr "instalando o sistema operacional"
+
+#~ msgid "kdumping"
+#~ msgstr "kdumping"
+
+#~ msgid "maintenance"
+#~ msgstr "manutenção"
+
+#~ msgid "non operational"
+#~ msgstr "não operacional"
+
+#~ msgid "non responsive"
+#~ msgstr "não responsivo"
+
+#~ msgid "oVirt"
+#~ msgstr "oVirt"
+
+#~ msgid "oVirt Host State:"
+#~ msgstr "oVirt Host State:"
+
+#~ msgid "oVirt Provider installation script failed due to missing arguments."
+#~ msgstr ""
+#~ "O script de instalação do Provedor oVirt falhou devido a argumentos "
+#~ "ausentes."
+
+#~ msgid ""
+#~ "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
+#~ "machines-ovirt.config, try as root."
+#~ msgstr ""
+#~ "Falha no script de instalação do Provedor oVirt: Não é possível gravar "
+#~ "em /etc/cockpit/machines-ovirt.config, tente como root."
+
+#~ msgid "oVirt installation script failed with following output: "
+#~ msgstr "O script de instalação do ivirt falhou com a seguinte saída: "
+
+#~ msgid "pending approval"
+#~ msgstr "aprovação pendente"
+
+#~ msgid "pending volume claims"
+#~ msgstr "declarações de volume pendentes"
+
+#~ msgid "reboot"
+#~ msgstr "reiniciar"
+
+#~ msgid "sockets"
+#~ msgstr "sockets"
+
+#~ msgid "threads"
+#~ msgstr "threads"
+
+#~ msgid "unassigned"
+#~ msgstr "não assinado"

--- a/po/ru.po
+++ b/po/ru.po
@@ -6,17 +6,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-25 16:37+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-06-25 08:32+0000\n"
 "Last-Translator: Dmitry Astankov <mornie@basealt.ru>\n"
 "Language-Team: Russian\n"
 "Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
 #: pkg/docker/storage.jsx:259
 #, fuzzy
@@ -28,11 +28,11 @@ msgstr " (в общем доступе с ОС)"
 msgid "$0 Block Device"
 msgstr "$0 Блочное устройство"
 
-#: pkg/storaged/mdraid-details.jsx:193
+#: pkg/storaged/mdraid-details.jsx:192
 msgid "$0 Chunk Size"
 msgstr "размер блока: $0"
 
-#: pkg/storaged/mdraid-details.jsx:191
+#: pkg/storaged/mdraid-details.jsx:190
 msgid "$0 Disks"
 msgstr "дисков: $0"
 
@@ -93,7 +93,7 @@ msgstr "$0 данных + $1 служебной информации испол�
 
 #: src/base1/test-locale.js:62 src/base1/test-locale.js:63
 #: src/base1/test-locale.js:64 pkg/playground/translate.js:26
-#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:213
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
 #, fuzzy
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
@@ -149,10 +149,10 @@ msgstr ""
 "действия:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:237
-#: pkg/storaged/mdraid-details.jsx:290 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:203
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 активно используется"
 
@@ -198,7 +198,7 @@ msgstr "$0 используется $1 ($2 Сохраненный)"
 msgid "$0 will be installed."
 msgstr "$0 будет установлен."
 
-#: pkg/storaged/vgroup-details.jsx:118
+#: pkg/storaged/vgroup-details.jsx:117
 msgid "$0, $1 free"
 msgstr "$0, $1 свободно"
 
@@ -225,19 +225,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/subscriptions/subscriptions-client.js:197
-msgid "'Organization' required to register."
-msgstr "Название организации, необходимое для регистрации."
-
-#: pkg/subscriptions/subscriptions-client.js:201
-msgid "'Organization' required when using activation keys."
-msgstr "Название организации, необходимое при использовании ключей активации."
-
-#: pkg/networkmanager/firewall.jsx:547
+#: pkg/networkmanager/firewall.jsx:549
 msgid "(Optional)"
 msgstr "(необязательно)"
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:616
+#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(по умолчанию)"
@@ -500,8 +492,7 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Совместимая версия Cockpit не установлена ​​на {{#strong}}{{host}}{{/"
-"strong}}."
+"Совместимая версия Cockpit не установлена ​​на {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:59
 msgid "A disk is needed."
@@ -545,10 +536,6 @@ msgstr "Доступ"
 msgid "Access Policy"
 msgstr "Политика доступа"
 
-#: pkg/subscriptions/subscriptions-view.jsx:213
-msgid "Access denied"
-msgstr "Доступ запрещён"
-
 #: pkg/users/index.html:249
 msgid "Account Expiration"
 msgstr "Срок действия учётной записи"
@@ -565,13 +552,13 @@ msgstr "Учётная запись недоступна или не может 
 msgid "Accounts"
 msgstr "Учётные записи"
 
-#: pkg/users/local.js:335 pkg/users/local.js:642
+#: pkg/users/local.js:339 pkg/users/local.js:646
 msgctxt "page-title"
 msgid "Accounts"
 msgstr "Учётные записи"
 
-#: pkg/machines/components/networks/network.jsx:147
 #: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Включить"
@@ -579,10 +566,6 @@ msgstr "Включить"
 #: pkg/storaged/jobs-panel.jsx:68
 msgid "Activating $target"
 msgstr "Включение $target"
-
-#: pkg/subscriptions/subscriptions-register.jsx:168
-msgid "Activation Key"
-msgstr "Ключ активации"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
 #: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
@@ -601,7 +584,7 @@ msgstr "Активные страницы"
 msgid "Active since"
 msgstr "Активно с"
 
-#: pkg/networkmanager/firewall.jsx:922
+#: pkg/networkmanager/firewall.jsx:924
 msgid "Active zones"
 msgstr "Активные зоны"
 
@@ -613,10 +596,10 @@ msgstr "Адаптивная балансировка нагрузки"
 msgid "Adaptive transmit load balancing"
 msgstr "Адаптивная балансировка нагрузки передачи"
 
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:534 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Добавить"
@@ -638,7 +621,7 @@ msgstr "Добавить связь"
 msgid "Add Bridge"
 msgstr "Добавить мост"
 
-#: pkg/machines/components/diskAdd.jsx:356
+#: pkg/machines/components/diskAdd.jsx:360
 msgid "Add Disk"
 msgstr "Добавить диск"
 
@@ -658,8 +641,8 @@ msgstr "Добавление компьютера на информационн�
 msgid "Add Ports"
 msgstr "Добавить порты"
 
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:872
-#: pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
+#: pkg/networkmanager/firewall.jsx:886
 msgid "Add Services"
 msgstr "Добавить службы"
 
@@ -675,8 +658,8 @@ msgstr "Добавить сопряжение"
 msgid "Add VLAN"
 msgstr "Добавить VLAN"
 
-#: pkg/networkmanager/firewall.jsx:698 pkg/networkmanager/firewall.jsx:878
-#: pkg/networkmanager/firewall.jsx:889
+#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
+#: pkg/networkmanager/firewall.jsx:891
 msgid "Add Zone"
 msgstr "Добавить зону"
 
@@ -700,7 +683,7 @@ msgstr "Добавить открытый ключ"
 msgid "Add services to following zones:"
 msgstr "Добавить службы в следующие зоны:"
 
-#: pkg/networkmanager/firewall.jsx:774
+#: pkg/networkmanager/firewall.jsx:776
 msgid "Add zone"
 msgstr "Добавить зону"
 
@@ -732,7 +715,7 @@ msgstr "Дополнительный DNS $val"
 msgid "Additional DNS Search Domains $val"
 msgstr "Дополнительные домены поиска DNS $val"
 
-#: pkg/docker/index.html:307
+#: pkg/docker/index.html:309
 msgid "Additional Storage"
 msgstr "Дополнительное хранилище"
 
@@ -776,7 +759,7 @@ msgstr "Адреса"
 msgid "Administration with Cockpit Web Console"
 msgstr "Администрирование с помощью веб-панели управления Cockpit"
 
-#: pkg/realmd/operation.js:336
+#: pkg/realmd/operation.js:335
 msgid "Administrator Password"
 msgstr "Пароль администратора"
 
@@ -826,15 +809,15 @@ msgstr ""
 "Все данные на выбранных дисках будут удалены, а диски будут добавлены в пул "
 "носителей."
 
-#: pkg/networkmanager/firewall.jsx:749
+#: pkg/networkmanager/firewall.jsx:751
 msgid "Allowed Addresses"
 msgstr "Разрешённые адреса"
 
-#: pkg/networkmanager/firewall.jsx:935
+#: pkg/networkmanager/firewall.jsx:937
 msgid "Allowed Services"
 msgstr "Разрешённые службы"
 
-#: pkg/docker/index.html:548 pkg/docker/util.js:108
+#: pkg/docker/index.html:550 pkg/docker/util.js:108
 msgid "Always"
 msgstr "Всегда"
 
@@ -846,7 +829,7 @@ msgstr "Всегда подключать"
 msgid "Annotations"
 msgstr "Примечания"
 
-#: pkg/systemd/terminal.jsx:94
+#: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr "Стиль отображения:"
 
@@ -859,10 +842,10 @@ msgstr "Приложения"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Применить"
 
@@ -891,7 +874,6 @@ msgid "Applying updates failed"
 msgstr "Не удалось применить обновления"
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
-#: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Architecture"
 msgstr "Архитектура"
 
@@ -905,8 +887,8 @@ msgstr "Ярлык/Тег актива"
 msgid "At least $0 disks are needed."
 msgstr "Минимально необходимое количество дисков: $0."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Необходим хотя бы один диск."
 
@@ -922,8 +904,8 @@ msgstr "Журнал аудита"
 msgid "Authenticating"
 msgstr "Проверка подлинности"
 
-#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
-#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Проверка подлинности"
 
@@ -951,7 +933,7 @@ msgstr ""
 msgid "Authentication required"
 msgstr "Необходима проверка подлинности"
 
-#: pkg/docker/index.html:700
+#: pkg/docker/index.html:702
 #: node_modules/registry-image-widgets/views/image-body.html:12
 #: pkg/docker/containers-view.jsx:413
 msgid "Author"
@@ -964,7 +946,7 @@ msgstr "Авторизованные открытые SSH-ключи"
 #: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
 #: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
 #: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:339
+#: pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Автоматически"
 
@@ -996,9 +978,9 @@ msgstr "Автоматическое использование NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Автоматическое использование определённых NTP-серверов"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:155
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "Автозапуск"
 
@@ -1091,7 +1073,7 @@ msgid "Bond Settings"
 msgstr "Параметры объединения"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:312
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:153
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:164
 msgid "Boot Order"
 msgstr "Порядок загрузки"
 
@@ -1152,7 +1134,7 @@ msgstr "Шина"
 msgid "Bus Expansion Chassis"
 msgstr "Корпус расширения шины"
 
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:270
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:272
 #: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
 msgid "CPU"
 msgstr "ЦП"
@@ -1170,20 +1152,20 @@ msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Состояние процессора"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:154
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:165
 msgid "CPU Type"
 msgstr "Тип процессора"
 
-#: pkg/docker/index.html:469 pkg/docker/index.html:641
+#: pkg/docker/index.html:471 pkg/docker/index.html:643
 msgid "CPU priority"
 msgstr "Приоритет ЦП"
 
-#: pkg/docker/index.html:217
+#: pkg/docker/index.html:218
 msgid "CPU usage:"
 msgstr "Использование ЦП:"
 
-#: pkg/machines/components/diskAdd.jsx:235
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr "Кэш"
 
@@ -1203,41 +1185,42 @@ msgstr "Невозможно удалить в разблокированном 
 msgid "Can't load image"
 msgstr "Не удаётся загрузить образ"
 
-#: pkg/dashboard/index.html:175 pkg/docker/index.html:563
-#: pkg/docker/index.html:597 pkg/docker/index.html:661
-#: pkg/docker/index.html:715 pkg/docker/index.html:755
-#: pkg/docker/index.html:784 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
+#: pkg/dashboard/index.html:175 pkg/docker/index.html:565
+#: pkg/docker/index.html:599 pkg/docker/index.html:663
+#: pkg/docker/index.html:717 pkg/docker/index.html:757
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:719
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:531
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:485
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:558 pkg/networkmanager/firewall.jsx:626
-#: pkg/networkmanager/firewall.jsx:769 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Отмена"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:415
 msgid "Cannot connect to an unknown machine"
 msgstr "Не удаётся подключиться к неизвестному компьютеру"
 
@@ -1257,7 +1240,7 @@ msgstr "Ёмкость"
 msgid "Carrier"
 msgstr "Несущая частота"
 
-#: pkg/docker/index.html:662 pkg/systemd/index.html:333
+#: pkg/docker/index.html:664 pkg/systemd/index.html:333
 #: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
 #: pkg/storaged/iscsi-panel.jsx:181
 msgid "Change"
@@ -1291,11 +1274,11 @@ msgstr "Изменить имя инициатора iSCSI"
 msgid "Change passphrase"
 msgstr "Изменить парольную фразу"
 
-#: pkg/docker/index.html:228
+#: pkg/docker/index.html:229
 msgid "Change resource limits"
 msgstr "Изменить ограничения ресурсов"
 
-#: pkg/docker/index.html:612
+#: pkg/docker/index.html:614
 msgid "Change resources limits"
 msgstr "Изменение ограничений ресурсов"
 
@@ -1303,10 +1286,10 @@ msgstr "Изменение ограничений ресурсов"
 msgid "Change the settings"
 msgstr "Изменение настроек"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Изменения вступят в силу после выключения виртуальной машины"
 
@@ -1390,15 +1373,16 @@ msgstr ""
 msgid "Client Software"
 msgstr "Клиентское программное обеспечение"
 
-#: pkg/docker/index.html:736 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
-#: pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Закрыть"
 
@@ -1444,8 +1428,8 @@ msgstr ""
 "Cockpit представляет собой диспетчер серверов, упрощающий администрирование "
 "серверов Linux через веб-браузер. Переключение между терминалом и веб-"
 "инструментом не представляет сложности. Служба, запущенная с помощью "
-"Cockpit, может быть остановлена ​​через терминал. Аналогично, если в "
-"терминале возникает ошибка, её можно увидеть в интерфейсе журнала Cockpit."
+"Cockpit, может быть остановлена ​​через терминал. Аналогично, если в терминале "
+"возникает ошибка, её можно увидеть в интерфейсе журнала Cockpit."
 
 #: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
@@ -1485,13 +1469,13 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью Cockpit."
-" {{#can_sync}}Вы можете попытаться {{#sync_link}}синхронизировать "
+"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью "
+"Cockpit. {{#can_sync}}Вы можете попытаться {{#sync_link}}синхронизировать "
 "пользователей{{/sync_link}}.{{/can_sync}} Для получения дополнительных "
 "параметров проверки подлинности и устранения неполадок обновите cockpit-ws "
 "до новой версии."
@@ -1500,7 +1484,6 @@ msgstr ""
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
 msgstr ""
 "Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью Cockpit."
-""
 
 #: pkg/lib/machine-auth-failed.html:6
 msgid ""
@@ -1508,10 +1491,10 @@ msgid ""
 "machine with cockpit you will need to enable one of the following "
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
-"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью Cockpit."
-" Для использования Cockpit на этом компьютере вам необходимо включить один "
-"из следующих методов проверки подлинности в конфигурации SSHD на "
-"{{#strong}}{{host}}{{/strong}}:"
+"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью "
+"Cockpit. Для использования Cockpit на этом компьютере вам необходимо "
+"включить один из следующих методов проверки подлинности в конфигурации SSHD "
+"на {{#strong}}{{host}}{{/strong}}:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1519,8 +1502,8 @@ msgid ""
 "change your authentication credentials below. {{#can_sync}}You may prefer to "
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
-"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью Cockpit."
-" Вы можете изменить учётные данные для проверки подлинности ниже. "
+"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью "
+"Cockpit. Вы можете изменить учётные данные для проверки подлинности ниже. "
 "{{#can_sync}}Возможно, вы предпочтёте {{#sync_link}}синхронизировать учётные "
 "записи и пароли{{/sync_link}}.{{/can_sync}}"
 
@@ -1541,12 +1524,12 @@ msgstr[0] "Комбинированное использование $0 ядра
 msgstr[1] "Комбинированное использование $0 ядер процессора"
 msgstr[2] "Комбинированное использование $0 ядер процессора"
 
-#: pkg/networkmanager/firewall.jsx:527
+#: pkg/networkmanager/firewall.jsx:529
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "Допустимы порты, диапазоны и псевдонимы с разделителями-запятыми"
 
-#: pkg/docker/index.html:269 pkg/docker/index.html:445
-#: pkg/docker/index.html:706 pkg/systemd/services.html:427
+#: pkg/docker/index.html:271 pkg/docker/index.html:447
+#: pkg/docker/index.html:708 pkg/systemd/services.html:427
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1557,7 +1540,7 @@ msgstr "Команда"
 msgid "Command can't be empty"
 msgstr "Команда не может быть пустой"
 
-#: pkg/docker/index.html:163
+#: pkg/docker/index.html:164
 msgid "Command:"
 msgstr "Команда:"
 
@@ -1565,12 +1548,12 @@ msgstr "Команда:"
 msgid "Comment"
 msgstr "Комментарий"
 
-#: pkg/docker/index.html:137 pkg/docker/index.html:716
+#: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
 msgstr "Сохранить"
 
-#: pkg/docker/index.html:676
+#: pkg/docker/index.html:678
 msgid "Commit Image"
 msgstr "Сохранить образ"
 
@@ -1596,8 +1579,8 @@ msgstr ""
 msgid "Compress crash dumps to save space"
 msgstr "Сжимать аварийные дампы для экономии места"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Сжатие"
 
@@ -1639,6 +1622,10 @@ msgstr "Подтверждение"
 msgid "Confirm New Password"
 msgstr "Подтвердите новый пароль"
 
+#: pkg/machines/components/networks/networkDelete.jsx:95
+msgid "Confirm deletion of the Virtual Network"
+msgstr ""
+
 #: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Confirm removal with passphrase"
 msgstr "Подтвердить удаление с помощью парольной фразы"
@@ -1679,8 +1666,8 @@ msgstr "Подключение"
 msgid ""
 "Connecting simultaneously to more than {{ limit }} machines is unsupported."
 msgstr ""
-"Одновременное подключение к количеству компьютеров, превышающему {{ limit "
-"}}, не поддерживается."
+"Одновременное подключение к количеству компьютеров, превышающему "
+"{{ limit }}, не поддерживается."
 
 #: pkg/docker/index.html:54
 msgid "Connecting to Docker"
@@ -1694,15 +1681,15 @@ msgstr "Подключение к демону SETroubleshoot..."
 msgid "Connecting to Virtualization Service"
 msgstr "Подключение к службе виртуализации"
 
-#: pkg/shell/indexes.js:411
+#: pkg/shell/indexes.js:410
 msgid "Connecting to the machine"
 msgstr "Подключение к компьютеру"
 
 # ctx::sourcefile::Navigation Menu
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:637
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Подключение"
@@ -1731,7 +1718,7 @@ msgstr "Тип консоли"
 msgid "Consoles"
 msgstr "Консоли"
 
-#: pkg/realmd/operation.js:274
+#: pkg/realmd/operation.js:273
 msgid "Contacted domain"
 msgstr "Связь с доменом установлена"
 
@@ -1740,12 +1727,12 @@ msgstr "Связь с доменом установлена"
 msgid "Container"
 msgstr "Контейнер"
 
-#: pkg/users/local.js:748
+#: pkg/users/local.js:752
 msgid "Container Administrator"
 msgstr "Администратор контейнера"
 
-#: pkg/docker/index.html:438 pkg/docker/index.html:618
-#: pkg/docker/index.html:682
+#: pkg/docker/index.html:440 pkg/docker/index.html:620
+#: pkg/docker/index.html:684
 msgid "Container Name"
 msgstr "Имя контейнера"
 
@@ -1760,11 +1747,11 @@ msgstr ""
 msgid "Container is currently running."
 msgstr "Контейнер сейчас запущен."
 
-#: pkg/docker/index.html:141
+#: pkg/docker/index.html:133
 msgid "Container:"
 msgstr "Контейнер:"
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:287
+#: pkg/docker/index.html:23 pkg/docker/index.html:289
 #: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "Контейнеры"
@@ -1822,21 +1809,13 @@ msgstr "Не удалось изменить группы пользовател
 msgid "Couldn't change user password"
 msgstr "Не удалось изменить пароль пользователя"
 
-#: pkg/shell/indexes.js:414
+#: pkg/shell/indexes.js:413
 msgid "Couldn't connect to the machine"
 msgstr "Не удалось подключиться к компьютеру"
 
 #: src/bridge/cockpitdbussetup.c:544
 msgid "Couldn't create new users"
 msgstr "Не удалось создать новых пользователей"
-
-#: pkg/subscriptions/subscriptions-view.jsx:218
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"Не удалось получить статус системной подписки. Убедитесь, что диспетчер "
-"подписок установлен."
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -1860,11 +1839,11 @@ msgid "Crash system"
 msgstr "Аварийная система"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:722
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:488
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Создать"
 
@@ -1872,7 +1851,7 @@ msgstr "Создать"
 msgid "Create Logical Volume"
 msgstr "Создание логического тома"
 
-#: pkg/machines/components/diskAdd.jsx:487
+#: pkg/machines/components/diskAdd.jsx:515
 msgid "Create New"
 msgstr "Создать новый"
 
@@ -1904,7 +1883,7 @@ msgstr "Создать отчёт"
 msgid "Create Snapshot"
 msgstr "Создание моментального снимка"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:522
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
 msgid "Create Storage Pool"
 msgstr "Создать пул носителей"
 
@@ -1924,7 +1903,7 @@ msgstr "Создание таймера"
 msgid "Create VDO Device"
 msgstr "Создание устройства VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:755
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
 msgid "Create VM"
 msgstr "Создать виртуальную машину"
 
@@ -1952,7 +1931,7 @@ msgid "Created"
 msgstr "Дата создания"
 
 # ctx::sourcefile::/rhn/account/UserDetails
-#: pkg/docker/index.html:152
+#: pkg/docker/index.html:153
 msgid "Created:"
 msgstr "Дата создания:"
 
@@ -2012,7 +1991,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Создание группы томов $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:623
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
 msgid "Creation of VM $0 failed"
 msgstr "Ошибка создания виртуальной машины $0"
 
@@ -2041,23 +2020,19 @@ msgstr "Текущая сессия"
 msgid "Custom"
 msgstr "Настраиваемое"
 
-#: pkg/networkmanager/firewall.jsx:521
+#: pkg/networkmanager/firewall.jsx:523
 msgid "Custom Ports"
 msgstr "Настраиваемые порты"
-
-#: pkg/subscriptions/subscriptions-register.jsx:103
-msgid "Custom URL"
-msgstr "Настраиваемый URL-адрес"
 
 #: pkg/storaged/format-dialog.jsx:118
 msgid "Custom encryption options"
 msgstr "Пользовательские параметры шифрования"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Пользовательские параметры подключения"
 
-#: pkg/networkmanager/firewall.jsx:716
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Custom zones"
 msgstr "Настраиваемые зоны"
 
@@ -2098,8 +2073,8 @@ msgstr "Панель мониторинга"
 msgid "Data Used"
 msgstr "Использованные данные"
 
-#: pkg/machines/components/networks/network.jsx:143
 #: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Отключить"
@@ -2121,10 +2096,9 @@ msgstr "Отладка и выше"
 msgid "Deduplication"
 msgstr "Дедупликация"
 
-#: pkg/docker/index.html:357 pkg/docker/index.html:361
+#: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: node_modules/registry-image-widgets/views/image-config.html:10
 #: pkg/storaged/format-dialog.jsx:68
-#: pkg/subscriptions/subscriptions-register.jsx:102
 msgid "Default"
 msgstr "По умолчанию"
 
@@ -2132,22 +2106,24 @@ msgstr "По умолчанию"
 msgid "Delay"
 msgstr "Задержка"
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:246
+#: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/machines/components/networks/networkDelete.jsx:86
+#: pkg/machines/components/networks/networkDelete.jsx:103
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:300 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:214 pkg/storaged/vgroup-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Удалить"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1179
+#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Удалить $0"
 
@@ -2158,6 +2134,11 @@ msgstr "Удалить содержимое"
 #: pkg/users/index.html:351
 msgid "Delete Files"
 msgstr "Удалить файлы"
+
+#: pkg/machines/components/networks/networkDelete.jsx:92
+#, fuzzy
+msgid "Delete Network $0"
+msgstr "Удалить $0"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
 msgid "Delete Storage Pool $0"
@@ -2183,7 +2164,7 @@ msgstr ""
 "Удаление <b>$0</b> приведёт к разрыву соединения с сервером и недоступности "
 "интерфейса администратора."
 
-#: pkg/storaged/mdraid-details.jsx:301
+#: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "Удаление RAID-устройства приведёт к удалению всех данных на нём."
 
@@ -2191,7 +2172,7 @@ msgstr "Удаление RAID-устройства приведёт к удал�
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Удаление устройства VDO приведёт к удалению всех данных на нём."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "Удаление контейнера приведёт к удалению всех данных в нем."
 
@@ -2203,7 +2184,7 @@ msgstr "Удаление логического тома приведёт к у�
 msgid "Deleting a partition will delete all data in it."
 msgstr "Удаление раздела приведёт к удалению всех данных в нём."
 
-#: pkg/storaged/vgroup-details.jsx:213
+#: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
 msgstr "Удаление группы томов приведёт к удалению всех данных в них."
 
@@ -2221,7 +2202,7 @@ msgstr "Удаление группы томов $target"
 
 #: pkg/systemd/services.html:413
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:725 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
 msgid "Description"
 msgstr "Описание"
 
@@ -2237,13 +2218,12 @@ msgstr "Съёмный компьютер"
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/packagekit/updates.jsx:383 pkg/subscriptions/subscriptions-view.jsx:232
-#: pkg/systemd/host.js:745
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Подробности"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2296,7 +2276,7 @@ msgid "Disconnect"
 msgstr "Отключиться"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:604
+#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
 msgid "Disconnected"
 msgstr "Отключено"
 
@@ -2319,11 +2299,11 @@ msgstr "Не удалось отключить диск $0 от виртуаль
 msgid "Disk I/O"
 msgstr "Дисковый ввод-вывод"
 
-#: pkg/machines/components/diskAdd.jsx:461
+#: pkg/machines/components/diskAdd.jsx:489
 msgid "Disk failed to be attached"
 msgstr "Не удалось подключить диск"
 
-#: pkg/machines/components/diskAdd.jsx:443
+#: pkg/machines/components/diskAdd.jsx:468
 msgid "Disk failed to be created"
 msgstr "Не удалось создать диск"
 
@@ -2335,9 +2315,9 @@ msgstr "Диск в порядке"
 msgid "Disk passphrase"
 msgstr "Парольная фраза диска"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Диски"
 
@@ -2363,15 +2343,15 @@ msgid "Docking Station"
 msgstr "Док-станция"
 
 #: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
-#: pkg/realmd/operation.js:123
+#: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Домен"
 
-#: pkg/realmd/operation.js:192
+#: pkg/realmd/operation.js:191
 msgid "Domain $0 could not be contacted"
 msgstr "Не удалось установить связь с доменом $0"
 
-#: pkg/realmd/operation.js:279
+#: pkg/realmd/operation.js:278
 msgid "Domain $0 is not supported"
 msgstr "Домен $0 не поддерживается"
 
@@ -2400,7 +2380,7 @@ msgstr "Не заменять существующие данные"
 msgid "Done!"
 msgstr "Завершено."
 
-#: pkg/docker/index.html:598
+#: pkg/docker/index.html:600
 msgid "Download"
 msgstr "Загрузить"
 
@@ -2437,7 +2417,7 @@ msgctxt "storage"
 msgid "Drive"
 msgstr "Накопитель"
 
-#: pkg/storaged/drives-panel.jsx:119
+#: pkg/storaged/drives-panel.jsx:120
 msgid "Drives"
 msgstr "Устройства"
 
@@ -2493,7 +2473,7 @@ msgstr "Очистить"
 msgid "Emptying $target"
 msgstr "Очистка $target"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:151
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:162
 msgid "Emulated Machine"
 msgstr "Эмулированный компьютер"
 
@@ -2556,10 +2536,6 @@ msgstr "Шифрование"
 msgid "Encryption Options"
 msgstr "Параметры шифрования"
 
-#: pkg/subscriptions/subscriptions-view.jsx:39
-msgid "Ends"
-msgstr "Дата окончания"
-
 #: pkg/selinux/setroubleshoot-view.jsx:299
 msgid "Enforce policy:"
 msgstr "Применить политику:"
@@ -2580,7 +2556,7 @@ msgstr ""
 "Ввод другого пароля здесь приведёт к тому, что вам придётся вводить его "
 "заново при каждом подключении к этому компьютеру"
 
-#: pkg/networkmanager/firewall.jsx:752
+#: pkg/networkmanager/firewall.jsx:754
 msgid "Entire subnet"
 msgstr "Адрес всей подсети"
 
@@ -2593,7 +2569,7 @@ msgid "Entrypoint"
 msgstr "Точка входа"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: pkg/docker/index.html:526
+#: pkg/docker/index.html:528
 #: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Среда"
@@ -2615,9 +2591,9 @@ msgid "Errata:"
 msgstr "Опечатки:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1472
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Ошибка"
 
@@ -2662,23 +2638,23 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Все"
 
-#: pkg/networkmanager/firewall.jsx:534
+#: pkg/networkmanager/firewall.jsx:536
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "Пример: 22, ssh, 8080, 5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:542
+#: pkg/networkmanager/firewall.jsx:544
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "Пример: 88, 2019, nfs, rsync"
 
-#: pkg/users/local.js:473 pkg/users/local.js:1417
+#: pkg/users/local.js:477 pkg/users/local.js:1421
 msgid "Excellent password"
 msgstr "Отличный пароль"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
 msgid "Existing Disk Image"
 msgstr "Существующий образ диска"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:202
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 msgid "Existing disk image on host's file system"
 msgstr "Существующий образ диска в файловой системе узла"
 
@@ -2690,7 +2666,7 @@ msgstr "Выход с кодом $ExitCode"
 msgid "Expansion Chassis"
 msgstr "Шасси расширения"
 
-#: pkg/docker/index.html:508
+#: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "Показывать порты контейнера"
 
@@ -2718,11 +2694,11 @@ msgstr ""
 msgid "Failed to add service"
 msgstr "Не удалось добавить службу"
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:679
 msgid "Failed to add zone"
 msgstr "Не удалось добавить зону"
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Не удалось изменить пароль"
 
@@ -2754,7 +2730,7 @@ msgstr "Не удалось получить IP-адреса интерфейс�
 msgid "Failed to load authorized keys."
 msgstr "Не удалось загрузить авторизованные ключи."
 
-#: pkg/networkmanager/firewall.jsx:589
+#: pkg/networkmanager/firewall.jsx:591
 msgid "Failed to remove service"
 msgstr "Не удалось удалить службу"
 
@@ -2802,7 +2778,7 @@ msgstr "Имя файловой системы"
 msgid "Filesystems"
 msgstr "Файловые системы"
 
-#: pkg/networkmanager/firewall.jsx:490
+#: pkg/networkmanager/firewall.jsx:491
 msgid "Filter Services"
 msgstr "Фильтровать службы"
 
@@ -2810,16 +2786,16 @@ msgstr "Фильтровать службы"
 msgid "Filter by name or description..."
 msgstr "Фильтровать по имени или описанию..."
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Отпечаток"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:913 pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
 msgid "Firewall"
 msgstr "Межсетевой экран"
 
-#: pkg/networkmanager/firewall.jsx:861
+#: pkg/networkmanager/firewall.jsx:863
 msgid "Firewall is not available"
 msgstr "Межсетевой экран недоступен"
 
@@ -2858,10 +2834,9 @@ msgstr "Принудительно изменить пароль"
 msgid "Force remove passphrase in $0"
 msgstr "Принудительно удалить парольную фразу в $0"
 
-#: pkg/machines/components/diskAdd.jsx:167
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:258
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Форматировать"
 
@@ -2924,7 +2899,7 @@ msgid "Full Name"
 msgstr "Полное имя"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:183
+#: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "Шлюз:"
 
@@ -2941,11 +2916,11 @@ msgstr "Создание отчёта"
 msgid "Get new image"
 msgstr "Получить новый образ"
 
-#: pkg/machines/components/diskAdd.jsx:162
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "ГиБ"
 
@@ -3026,14 +3001,14 @@ msgstr "Сведения об оборудовании"
 msgid "Hello time $hello_time"
 msgstr "Время приветствия $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Hide Performance Options"
 msgstr "Скрыть параметры быстродействия"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:150
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:334
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Узел"
 
@@ -3042,7 +3017,7 @@ msgid "Host Device"
 msgstr "Главное устройство"
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:155
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
 msgid "Host Name"
 msgstr "Имя узла"
 
@@ -3050,11 +3025,11 @@ msgstr "Имя узла"
 msgid "Host key is incorrect"
 msgstr "Неверный ключ узла"
 
-#: pkg/realmd/operation.js:602
+#: pkg/realmd/operation.js:601
 msgid "Host name should not be changed in a domain"
 msgstr "Имя узла не должно изменяться в домене"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:161
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
 msgid "Host should not be empty"
 msgstr "Имя узла не должно быть пустым"
 
@@ -3079,15 +3054,15 @@ msgstr "Ожидание ввода-вывода"
 msgid "IP Address"
 msgstr "IP-адрес"
 
-#: pkg/docker/index.html:175
+#: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "IP-адрес:"
 
-#: pkg/docker/index.html:179
+#: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "Длина префикса сети:"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "IP Range"
 msgstr "Диапазон IP-адресов"
 
@@ -3128,7 +3103,7 @@ msgstr "Идентификатор"
 msgid "Id $id"
 msgstr "Идентификатор $id"
 
-#: pkg/docker/index.html:148
+#: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "Идентификатор:"
 
@@ -3146,7 +3121,7 @@ msgstr "Если клавиши танга-шоу недоступны, выпо
 msgid "Ignore"
 msgstr "Игнорировать"
 
-#: pkg/docker/index.html:268 pkg/docker/index.html:431
+#: pkg/docker/index.html:270 pkg/docker/index.html:433
 #: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
@@ -3156,11 +3131,11 @@ msgstr "Образ"
 msgid "Image $0"
 msgstr "Образ $0"
 
-#: pkg/users/local.js:749
+#: pkg/users/local.js:753
 msgid "Image Builder"
 msgstr "Image Builder"
 
-#: pkg/docker/index.html:578
+#: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Поиск образов"
 
@@ -3172,7 +3147,7 @@ msgstr "Количество образов"
 msgid "Image stream"
 msgstr "Поток образа"
 
-#: pkg/docker/index.html:156
+#: pkg/docker/index.html:157
 msgid "Image:"
 msgstr "Образ:"
 
@@ -3207,7 +3182,7 @@ msgid "Images may only be pulled by specific users or groups"
 msgstr ""
 "Образы могут быть загружены только определёнными пользователями или группами"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:702
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
 msgstr "Немедленно запустите VM"
 
@@ -3215,7 +3190,7 @@ msgstr "Немедленно запустите VM"
 msgid "In Sync"
 msgstr "В синхронизации"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:210
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3238,7 +3213,7 @@ msgstr "Неактивно"
 msgid "Inactive volume"
 msgstr "Неактивный том"
 
-#: pkg/networkmanager/firewall.jsx:730
+#: pkg/networkmanager/firewall.jsx:732
 msgid "Included services"
 msgstr ""
 
@@ -3262,17 +3237,17 @@ msgstr "Информация о пуле хранения Docker недосту�
 msgid "Initializing..."
 msgstr "Инициализация ..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:177
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:188
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Установка"
 
@@ -3300,11 +3275,11 @@ msgstr "Установить поддержку VDO"
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "Установите setroubleshoot-server для устранения неполадок в SELinux."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
 msgid "Installation Source"
 msgstr "Источник установки"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:251
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
 msgid "Installation Source Type"
 msgstr "Тип источника установки"
 
@@ -3316,10 +3291,6 @@ msgstr "Источник установки не должен быть пуст�
 #: pkg/packagekit/updates.jsx:59
 msgid "Installed"
 msgstr "Установлен"
-
-#: pkg/subscriptions/subscriptions-view.jsx:245
-msgid "Installed products"
-msgstr "Установленные продукты"
 
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:51
@@ -3339,8 +3310,8 @@ msgid "Interface Type"
 msgstr ""
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:735 pkg/networkmanager/firewall.jsx:923
-#: pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Интерфейсы"
 
@@ -3356,15 +3327,11 @@ msgstr "Внутренняя ошибка"
 msgid "Invalid address $0"
 msgstr "Недействительный адрес $0"
 
-#: pkg/subscriptions/subscriptions-client.js:195
-msgid "Invalid credentials"
-msgstr "Недопустимые учетные данные"
-
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Неверный формат даты"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Недопустимый формат даты и неверный формат времени"
 
@@ -3372,7 +3339,7 @@ msgstr "Недопустимый формат даты и неверный фо�
 msgid "Invalid date format."
 msgstr "Неверный формат даты."
 
-#: pkg/users/local.js:1237
+#: pkg/users/local.js:1241
 msgid "Invalid expiration date"
 msgstr "Недопустимая дата истечения срока действия"
 
@@ -3392,7 +3359,7 @@ msgstr "Неправильный ключ"
 msgid "Invalid metric $0"
 msgstr "Недопустимый показатель $0"
 
-#: pkg/users/local.js:1313
+#: pkg/users/local.js:1317
 msgid "Invalid number of days"
 msgstr "Недопустимое количество дней"
 
@@ -3420,7 +3387,7 @@ msgstr "Недопустимый префикс или сетевая маска
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Недопустимый формат времени"
 
@@ -3429,7 +3396,6 @@ msgid "Invalid time zone"
 msgstr "Недействительный часовой пояс"
 
 #: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
-#: pkg/subscriptions/subscriptions-client.js:193
 msgid "Invalid username or password"
 msgstr "Неверное имя пользователя или пароль"
 
@@ -3450,19 +3416,19 @@ msgid "Jobs"
 msgstr "Задания"
 
 # ctx::sourcefile::Navigation Menu
-#: pkg/realmd/operation.js:117
+#: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "Присоединиться"
 
-#: pkg/realmd/operation.js:597
+#: pkg/realmd/operation.js:596
 msgid "Join Domain"
 msgstr "Войти в домен"
 
-#: pkg/realmd/operation.js:116
+#: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "Присоединиться к домену"
 
-#: pkg/realmd/operation.js:506
+#: pkg/realmd/operation.js:505
 msgid "Joining this domain is not supported"
 msgstr "Присоединение к этому домену не поддерживается"
 
@@ -3592,7 +3558,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Оставьте пустым, чтобы подключиться к этому аппарату в качестве текущего "
 "пользователя{{#default_user}} ({{default_user}}){{/default_user}}Если вы "
@@ -3623,7 +3588,7 @@ msgstr "Задержка разрыва соединения"
 msgid "Link local"
 msgstr "Ссылка локальная"
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:499
 msgid "Link to another container"
 msgstr "Ссылка на другой контейнер"
 
@@ -3631,11 +3596,11 @@ msgstr "Ссылка на другой контейнер"
 msgid "Link up delay"
 msgstr "Задержка установки соединения"
 
-#: pkg/docker/index.html:493
+#: pkg/docker/index.html:495
 msgid "Links"
 msgstr "связи"
 
-#: pkg/docker/index.html:195
+#: pkg/docker/index.html:196
 msgid "Links:"
 msgstr "Ссылки:"
 
@@ -3660,9 +3625,9 @@ msgid "Loading available updates, please wait..."
 msgstr "Загружайте доступные обновления, подождите ..."
 
 # translation auto-copied from project webkitgtk3, version 2.0.3, document webkitgtk3, author ypoyarko
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Загрузка..."
 
@@ -3678,7 +3643,7 @@ msgstr "Локальные диски"
 msgid "Local Filesystem"
 msgstr "Локальная файловая система"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:257
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
 msgid "Local Install Media"
 msgstr ""
 
@@ -3698,7 +3663,7 @@ msgstr "Заблокировать"
 msgid "Lock Account"
 msgstr "Заблокировать учётную запись"
 
-#: pkg/users/local.js:879 pkg/users/local.js:1218
+#: pkg/users/local.js:883 pkg/users/local.js:1222
 msgid "Lock account on $0"
 msgstr "Блокировать учетную запись $0"
 
@@ -3730,7 +3695,7 @@ msgstr "Войдите в систему с учетной записью пол
 msgid "Log messages"
 msgstr "Журнальные сообщения"
 
-#: pkg/users/local.js:961
+#: pkg/users/local.js:965
 msgid "Logged In"
 msgstr "Записан"
 
@@ -3754,10 +3719,6 @@ msgstr "Логический том (моментальный снимок)"
 msgid "Logical Volume of $0"
 msgstr "Логический том $0"
 
-#: pkg/subscriptions/subscriptions-register.jsx:144
-msgid "Login"
-msgstr "Вход"
-
 #: src/ws/login.js:300
 msgid "Login Again"
 msgstr "Войти снова"
@@ -3777,11 +3738,6 @@ msgstr "Ошибка входа"
 #: pkg/shell/index.html:36
 msgid "Login has escalated admin privileges"
 msgstr "Вход имеет повышенные привилегии администратора"
-
-#: pkg/subscriptions/subscriptions-client.js:199
-msgid "Login/password or activation key required to register."
-msgstr ""
-"Имя/пароль пользователя или ключ активации, необходимые для регистрации."
 
 #: src/ws/login.js:301
 msgid "Logout Successful"
@@ -3812,7 +3768,7 @@ msgstr "MAC"
 msgid "MAC Address"
 msgstr "MAC-адрес"
 
-#: pkg/docker/index.html:187
+#: pkg/docker/index.html:188
 msgid "MAC Address:"
 msgstr "MAC-адрес:"
 
@@ -3920,10 +3876,10 @@ msgstr "Член RAID-устройства"
 msgid "Member of RAID Device $0"
 msgstr "Член RAID-устройства $0"
 
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:271
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:343
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
 #: pkg/machines/components/vmOverviewTab.jsx:74
 msgid "Memory"
 msgstr "Память"
@@ -3942,15 +3898,20 @@ msgstr "Память и обмен"
 msgid "Memory could not be saved"
 msgstr ""
 
-#: pkg/docker/index.html:452 pkg/docker/index.html:624
+#: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "Предел памяти"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#, fuzzy
+msgid "Memory must not be 0"
+msgstr "Использование памяти:"
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
 msgstr ""
 
-#: pkg/docker/index.html:210
+#: pkg/docker/index.html:211
 msgid "Memory usage:"
 msgstr "Использование памяти:"
 
@@ -3967,11 +3928,11 @@ msgstr "Метаданные"
 msgid "Metadata Used"
 msgstr "Используемые метаданные"
 
-#: pkg/docker/index.html:466 pkg/docker/index.html:638
-#: pkg/machines/components/diskAdd.jsx:159
-#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/docker/index.html:468 pkg/docker/index.html:640
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "МиБ"
 
@@ -4028,7 +3989,7 @@ msgstr "Интервал мониторинга"
 msgid "Monitoring Targets"
 msgstr "Цели мониторинга"
 
-#: pkg/realmd/operation.js:530
+#: pkg/realmd/operation.js:529
 msgid "More"
 msgstr "Больше"
 
@@ -4041,27 +4002,27 @@ msgstr "Дополнительная информация"
 msgid "More details"
 msgstr "Подробности"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "гора"
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Параметры крепления"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Точка подключения"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Гора при загрузке"
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:521
 msgid "Mount container volumes"
 msgstr "Объемы контейнеров"
 
@@ -4077,7 +4038,7 @@ msgstr "Точка монтирования не может быть пуста.
 msgid "Mount point must start with \"/\"."
 msgstr "Точка монтирования должна начинаться с \"/\"."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Только для чтения"
 
@@ -4125,30 +4086,29 @@ msgstr "NSNA Ping"
 msgid "NTP Server"
 msgstr "Сервер NTP"
 
-#: pkg/docker/index.html:267 pkg/networkmanager/index.html:119
+#: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
 #: pkg/networkmanager/index.html:319
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:164
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:181
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Имя"
 
@@ -4201,15 +4161,15 @@ msgstr "Маска сети"
 msgid "Network"
 msgstr "Сеть"
 
-#: pkg/machines/components/networks/network.jsx:117
+#: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/networks/network.jsx:129
+#: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:260
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
 msgid "Network Boot (PXE)"
 msgstr ""
 
@@ -4221,7 +4181,7 @@ msgstr "Сетевая файловая система"
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:216
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Network Selection does not support PXE."
 msgstr ""
 
@@ -4242,7 +4202,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager не работает."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:914
 msgid "Networking"
 msgstr "Сеть"
 
@@ -4260,16 +4220,16 @@ msgstr "Сетевые журналы"
 msgid "Networks"
 msgstr "Сети"
 
-#: pkg/users/local.js:963
+#: pkg/users/local.js:967
 msgid "Never"
 msgstr "Никогда"
 
-#: pkg/users/index.html:297 pkg/users/local.js:868
+#: pkg/users/index.html:297 pkg/users/local.js:872
 #, fuzzy
 msgid "Never expire password"
 msgstr "Никогда не истекает пароль"
 
-#: pkg/users/index.html:258 pkg/users/local.js:876
+#: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "Никогда не блокировать аккаунт"
 
@@ -4289,7 +4249,7 @@ msgstr "Новое имя тома"
 msgid "New passphrase"
 msgstr "Новая кодовая фраза"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 #, fuzzy
 msgid "New password was not accepted"
 msgstr "Новый пароль не был принят"
@@ -4306,7 +4266,7 @@ msgstr "Следующий запуск"
 msgid "Nice"
 msgstr "Приоритет"
 
-#: pkg/docker/index.html:542 pkg/docker/index.html:546 pkg/docker/run.js:239
+#: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
 #: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
 msgid "No"
 msgstr "Нет"
@@ -4335,8 +4295,8 @@ msgstr "Подключения по NFS отсутствуют"
 msgid "No SELinux alerts."
 msgstr "Оповещения SELinux отсутствуют."
 
-#: pkg/machines/components/diskAdd.jsx:193
-#: pkg/machines/components/diskAdd.jsx:205
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:216
 msgid "No Storage Pools available"
 msgstr ""
 
@@ -4346,14 +4306,13 @@ msgstr "Для этого пула хранения не определены т
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
-msgstr ""
-"Никакая виртуальная машина не запущена или не определена на этом хосте"
+msgstr "Никакая виртуальная машина не запущена или не определена на этом хосте"
 
 #: pkg/machines/components/nicEdit.jsx:110
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/networkmanager/firewall.jsx:926
 msgid "No active zones"
 msgstr ""
 
@@ -4405,7 +4364,7 @@ msgstr "Контейнеры отсутствуют"
 msgid "No containers that match the current filter"
 msgstr "Отсутствуют контейнеры, соответствующие текущему фильтру"
 
-#: pkg/networkmanager/firewall.jsx:727
+#: pkg/networkmanager/firewall.jsx:729
 msgid "No description available"
 msgstr ""
 
@@ -4413,9 +4372,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "Нет описания."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Нет доступных дисков."
 
@@ -4423,7 +4382,7 @@ msgstr "Нет доступных дисков."
 msgid "No disks defined for this VM"
 msgstr "Диски, определенные для этой виртуальной машины"
 
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:121
 msgid "No drives attached"
 msgstr "Приводы не подключены"
 
@@ -4459,10 +4418,6 @@ msgstr "Отсутствуют образы, соответствующие те
 msgid "No installation package found for this application."
 msgstr "Пакет установки для этого приложения не установлен."
 
-#: pkg/subscriptions/subscriptions-view.jsx:246
-msgid "No installed products on the system."
-msgstr "Нет установленных продуктов в системе."
-
 #: pkg/storaged/crypto-keyslots.jsx:520
 msgid "No keys added"
 msgstr "Не добавлены ключи"
@@ -4497,7 +4452,7 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:939
 msgid "No open ports"
 msgstr "Нет открытых портов"
 
@@ -4505,7 +4460,7 @@ msgstr "Нет открытых портов"
 msgid "No partitioning"
 msgstr "Без разбиения"
 
-#: pkg/users/local.js:449
+#: pkg/users/local.js:453
 msgid "No real name specified"
 msgstr "Не указано настоящее имя"
 
@@ -4546,7 +4501,7 @@ msgstr "Метки/теги отсутствуют."
 msgid "No updates pending"
 msgstr "Нет ожидающих обновления"
 
-#: pkg/users/local.js:444
+#: pkg/users/local.js:448
 msgid "No user name specified"
 msgstr "Не указано имя пользователя"
 
@@ -4555,8 +4510,8 @@ msgid "No volume groups created"
 msgstr "Нет групп томов"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:732
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Нет"
 
@@ -4604,7 +4559,7 @@ msgstr "Не установлен"
 msgid "Not permitted to perform this action."
 msgstr "Не разрешено выполнять это действие."
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Not running"
 msgstr "Не бегать"
 
@@ -4628,7 +4583,7 @@ msgstr "Ноутбук"
 msgid "Notice and above"
 msgstr "Извещение и выше"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:313
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
 msgid "OS Vendor"
 msgstr "Поставщик ОС"
 
@@ -4656,7 +4611,7 @@ msgstr "Старый пароль"
 msgid "Old passphrase"
 msgstr "Старая кодовая фраза"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 #, fuzzy
 msgid "Old password not accepted"
 msgstr "Старый пароль не принимается"
@@ -4669,7 +4624,7 @@ msgstr "Вкл"
 msgid "On Build"
 msgstr "Построить"
 
-#: pkg/docker/index.html:547 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/init.js:731
 msgid "On Failure"
 msgstr "О неисправности"
 
@@ -4692,7 +4647,7 @@ msgstr ""
 "Как только Cockpit установлен, включите его с помощью «systemctl enable --"
 "now cockpit.socket»."
 
-#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:338
+#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
 msgstr "Одноразовый пароль"
 
@@ -4727,7 +4682,7 @@ msgid "Open"
 msgstr ""
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:328
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
 msgid "Operating System"
 msgstr "Операционная система"
 
@@ -4754,11 +4709,6 @@ msgstr "Параметры"
 msgid "Or use a bundled browser"
 msgstr "Или используйте связанный браузер"
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: pkg/subscriptions/subscriptions-register.jsx:180
-msgid "Organization"
-msgstr "Организация"
-
 # translation auto-copied from project Satellite6 Katello, version Sam-1.3.0, document katello, author ypoyarko
 #: pkg/lib/machine-info.js:64
 msgid "Other"
@@ -4778,9 +4728,9 @@ msgid "Other Options"
 msgstr "Другие опции"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:297 pkg/machines/components/networks/network.jsx:71
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Обзор"
 
@@ -4861,13 +4811,11 @@ msgstr "Удаление парольной фразы может предотв
 msgid "Passphrases do not match"
 msgstr "Парольные фразы не совпадают"
 
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
-#: pkg/subscriptions/subscriptions-register.jsx:89
-#: pkg/subscriptions/subscriptions-register.jsx:156
 msgid "Password"
 msgstr "Пароль"
 
@@ -4884,7 +4832,7 @@ msgstr "Пароль не приемлем"
 msgid "Password is too weak"
 msgstr "Пароль слишком слабый"
 
-#: pkg/users/local.js:870
+#: pkg/users/local.js:874
 msgid "Password must be changed"
 msgstr "Пароль должен быть изменен"
 
@@ -4923,7 +4871,7 @@ msgstr "Стоимость пути $path_Стоимость"
 msgid "Path on Server"
 msgstr "Путь на сервере"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:129
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
 msgid "Path on host's filesystem"
 msgstr "Путь в файловой системе хоста"
 
@@ -4935,7 +4883,7 @@ msgstr "Путь на сервере не может быть пустым."
 msgid "Path on server must start with \"/\"."
 msgstr "Путь на сервере должен начинаться с «/»."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:193
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
 msgid "Path to ISO file on host's file system"
 msgstr "Путь к файлу ISO в файловой системе хоста"
 
@@ -4971,8 +4919,8 @@ msgstr "Отказано в разрешении"
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr ""
 
@@ -4989,11 +4937,11 @@ msgstr ""
 msgid "Physical Volume"
 msgstr "Физический объем"
 
-#: pkg/storaged/vgroup-details.jsx:134
+#: pkg/storaged/vgroup-details.jsx:133
 msgid "Physical Volumes"
 msgstr "Физические тома"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:210
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -5017,10 +4965,10 @@ msgstr "Ping Target"
 msgid "Pizza Box"
 msgstr "Коробка для пиццы"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:210
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Пожалуйста, подтвердите удаление $0"
 
@@ -5028,23 +4976,23 @@ msgstr "Пожалуйста, подтвердите удаление $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Пожалуйста, подтвердите принудительное удаление $0"
 
-#: pkg/storaged/mdraid-details.jsx:244 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Пожалуйста, подтвердите прекращение $0"
 
-#: pkg/machines/components/diskAdd.jsx:425
+#: pkg/machines/components/diskAdd.jsx:447
 msgid "Please enter new volume name"
 msgstr "Введите новое имя тома"
 
-#: pkg/machines/components/diskAdd.jsx:428
+#: pkg/machines/components/diskAdd.jsx:450
 msgid "Please enter new volume size"
 msgstr "Введите новый размер тома"
 
-#: pkg/networkmanager/firewall.jsx:862
+#: pkg/networkmanager/firewall.jsx:864
 msgid "Please install the $0 package"
 msgstr "Пожалуйста, установите $0 пакет"
 
-#: pkg/users/local.js:1232
+#: pkg/users/local.js:1236
 msgid "Please specify an expiration date"
 msgstr "Укажите срок действия"
 
@@ -5056,7 +5004,6 @@ msgstr "Укажите хост для подключения к"
 msgid "Please start the virtual machine to access its console."
 msgstr ""
 "Пожалуйста, запустите виртуальную машину, чтобы получить доступ к ее консоли."
-""
 
 #: pkg/docker/search.js:148
 msgid "Please try another term"
@@ -5066,11 +5013,10 @@ msgstr "Попробуйте другой термин"
 msgid "Plug"
 msgstr "штепсель"
 
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Пул"
 
@@ -5104,14 +5050,14 @@ msgstr "Номер и тип порта не совпадают"
 msgid "Portable"
 msgstr "Портативный"
 
-#: pkg/docker/index.html:504 pkg/networkmanager/index.html:213
+#: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
 #: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
 msgid "Ports"
 msgstr "Порты"
 
-#: pkg/docker/index.html:191
+#: pkg/docker/index.html:192
 msgid "Ports:"
 msgstr "Порты:"
 
@@ -5201,14 +5147,6 @@ msgstr "Процесс"
 msgid "Product"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:34
-msgid "Product ID"
-msgstr "Идентификатор продукта"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product name"
-msgstr "Название продукта"
-
 #: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
 msgstr "Веб-сайт проекта"
@@ -5235,11 +5173,7 @@ msgstr "Продвигает"
 msgid "Protocol"
 msgstr "Протокол"
 
-#: pkg/subscriptions/subscriptions-register.jsx:129
-msgid "Proxy"
-msgstr "Прокси"
-
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Открытый ключ"
 
@@ -5259,11 +5193,11 @@ msgstr "QEMU / KVM Системное соединение"
 msgid "QEMU/KVM User connection"
 msgstr "QEMU / KVM Подключение пользователя"
 
-#: pkg/storaged/mdraid-details.jsx:186
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 0"
 msgstr "RAID 0"
 
@@ -5271,7 +5205,7 @@ msgstr "RAID 0"
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (полоса)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 1"
 msgstr "RAID 1"
 
@@ -5279,7 +5213,7 @@ msgstr "RAID 1"
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (зеркало)"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 10"
 msgstr "RAID 10"
 
@@ -5287,7 +5221,7 @@ msgstr "RAID 10"
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (полоса зеркал)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 4"
 msgstr "RAID 4"
 
@@ -5295,7 +5229,7 @@ msgstr "RAID 4"
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (выделенная четность)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 5"
 msgstr "RAID 5"
 
@@ -5303,7 +5237,7 @@ msgstr "RAID 5"
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (распределенная четность)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 6"
 msgstr "RAID 6"
 
@@ -5320,7 +5254,7 @@ msgstr "Шасси RAID"
 msgid "RAID Device"
 msgstr "Устройство RAID"
 
-#: pkg/storaged/mdraid-details.jsx:316 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "Устройство RAID $0"
 
@@ -5344,7 +5278,7 @@ msgstr "Корпус для монтажа в стойку"
 msgid "Random"
 msgstr "Случайный"
 
-#: pkg/networkmanager/firewall.jsx:757
+#: pkg/networkmanager/firewall.jsx:759
 msgid "Range"
 msgstr ""
 
@@ -5360,11 +5294,11 @@ msgstr "Необработанные устройства"
 msgid "Read more..."
 msgstr ""
 
-#: pkg/docker/index.html:363
+#: pkg/docker/index.html:365
 msgid "ReadOnly"
 msgstr "ReadOnly"
 
-#: pkg/docker/index.html:362
+#: pkg/docker/index.html:364
 msgid "ReadWrite"
 msgstr "Читай пиши"
 
@@ -5456,15 +5390,6 @@ msgstr "Отказ от подключения. Хост-ключ не соот�
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Отказ от подключения. Хост-ключ неизвестен"
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: pkg/subscriptions/main.js:46 pkg/subscriptions/subscriptions-view.jsx:159
-msgid "Register"
-msgstr "Регистрация"
-
-#: pkg/subscriptions/main.js:73
-msgid "Register system"
-msgstr "Система регистрации"
-
 #: pkg/packagekit/updates.jsx:777
 msgid "Register…"
 msgstr "Регистр…"
@@ -5477,7 +5402,7 @@ msgstr "Перезагрузить"
 msgid "Reload Propagated From"
 msgstr "Перезагрузить Пропагандированный"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:241
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
 msgid "Remote URL"
 msgstr "Удаленный URL"
 
@@ -5498,9 +5423,9 @@ msgstr "Съемный диск"
 msgid "Removals:"
 msgstr "Удаления:"
 
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Удалить зону"
 
@@ -5528,11 +5453,11 @@ msgstr "Удалить кодовую фразу"
 msgid "Remove passphrase in $0?"
 msgstr "Удалить кодовую фразу в $0?"
 
-#: pkg/networkmanager/firewall.jsx:629
+#: pkg/networkmanager/firewall.jsx:631
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:608
+#: pkg/networkmanager/firewall.jsx:610
 msgid "Remove service from zones"
 msgstr ""
 
@@ -5561,8 +5486,8 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Удаление физического объема из $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:187
-#: pkg/storaged/vgroup-details.jsx:235
+#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:234
 msgid "Rename"
 msgstr "Переименовать"
 
@@ -5570,7 +5495,7 @@ msgstr "Переименовать"
 msgid "Rename Logical Volume"
 msgstr "Переименовать логический том"
 
-#: pkg/storaged/vgroup-details.jsx:179
+#: pkg/storaged/vgroup-details.jsx:178
 msgid "Rename Volume Group"
 msgstr "Переименовать группу томов"
 
@@ -5627,16 +5552,16 @@ msgstr ""
 "Отчетность была неприемлемой. Попробуйте запустить `reporter-ureport -d "
 
 # translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
-#: pkg/docker/index.html:688
+#: pkg/docker/index.html:690
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Репозиторий"
 
-#: pkg/users/local.js:1296
+#: pkg/users/local.js:1300
 msgid "Require password change every $0 days"
 msgstr "Требовать изменение пароля каждый $0 дней"
 
-#: pkg/users/local.js:872
+#: pkg/users/local.js:876
 msgid "Require password change on $0"
 msgstr "Требовать изменения пароля $0"
 
@@ -5661,7 +5586,7 @@ msgstr "Реквизиты"
 msgid "Reserved memory"
 msgstr "Зарезервированная память"
 
-#: pkg/docker/index.html:301 pkg/users/index.html:333
+#: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:105
 msgid "Reset"
 msgstr "Сброс"
@@ -5690,10 +5615,10 @@ msgid ""
 msgstr ""
 
 # ctx::sourcefile::/rhn/admin/config/Restart.do
-#: pkg/docker/index.html:135 pkg/systemd/index.html:134
+#: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Перезапустить"
 
@@ -5701,11 +5626,11 @@ msgstr "Перезапустить"
 msgid "Restart Now"
 msgstr "Перезагрузить сейчас"
 
-#: pkg/docker/index.html:537
+#: pkg/docker/index.html:539
 msgid "Restart Policy"
 msgstr "Политика перезагрузки"
 
-#: pkg/docker/index.html:171
+#: pkg/docker/index.html:172
 msgid "Restart Policy:"
 msgstr "Политика перезагрузки:"
 
@@ -5725,21 +5650,16 @@ msgstr "Восстановление соединения"
 msgid "Resume"
 msgstr ""
 
-#: pkg/docker/index.html:553
+#: pkg/docker/index.html:555
 msgid "Retries:"
 msgstr "Повторы:"
-
-#: pkg/subscriptions/subscriptions-view.jsx:210
-msgid "Retrieving subscription status..."
-msgstr "Получение статуса подписки ..."
 
 #: src/ws/login.html:57
 msgid "Reuse my password for privileged tasks"
 msgstr "Повторное использование моего пароля для привилегированных задач"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Повторное использование моего пароля для привилегированных задач и "
 "подключение к другим машинам"
@@ -5764,12 +5684,12 @@ msgstr ""
 msgid "Routes"
 msgstr "Маршруты"
 
-#: pkg/docker/index.html:244 pkg/docker/index.html:564
+#: pkg/docker/index.html:253 pkg/docker/index.html:566
 #: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
 msgid "Run"
 msgstr "Запуск"
 
-#: pkg/docker/index.html:425
+#: pkg/docker/index.html:427
 #, fuzzy
 msgid "Run Image"
 msgstr "Запустить изображение"
@@ -5779,7 +5699,7 @@ msgid "Run as"
 msgstr "Беги как"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:128
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
 msgstr ""
 
@@ -5787,7 +5707,7 @@ msgstr ""
 msgid "Runner"
 msgstr "полоз"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Running"
 msgstr "Работает"
 
@@ -5863,10 +5783,11 @@ msgstr "Суббота"
 msgid "Saturdays"
 msgstr "По субботам"
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Сохранить"
 
@@ -5921,11 +5842,11 @@ msgstr "Выбрать"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Выберите пользователей, с которыми вы хотите синхронизировать "
-"{{#strong}}{{host}}{{/strong}}"
+"Выберите пользователей, с которыми вы хотите синхронизировать {{#strong}}"
+"{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 #, fuzzy
@@ -5947,9 +5868,8 @@ msgid "Serial Console"
 msgstr "Серийная консоль"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:65
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Сервер"
 
@@ -5957,7 +5877,7 @@ msgstr "Сервер"
 msgid "Server Address"
 msgstr "Адрес сервера"
 
-#: pkg/users/local.js:746 pkg/users/local.js:747
+#: pkg/users/local.js:750 pkg/users/local.js:751
 msgid "Server Administrator"
 msgstr "Администратор сервера"
 
@@ -5981,7 +5901,7 @@ msgstr "Сервер закрыл соединение."
 msgid "Servers"
 msgstr "Серверы"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:936
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
 #: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Служба"
@@ -6039,7 +5959,7 @@ msgstr "Задать пароль"
 msgid "Set Time"
 msgstr "Установленное время"
 
-#: pkg/docker/index.html:530
+#: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Установка переменных среды контейнера"
 
@@ -6083,7 +6003,7 @@ msgstr "Общее"
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Show Performance Options"
 msgstr "Показать параметры быстродействия"
 
@@ -6091,7 +6011,7 @@ msgstr "Показать параметры быстродействия"
 msgid "Show all"
 msgstr ""
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:122
 msgid "Show all $0 drives"
 msgstr ""
 
@@ -6099,7 +6019,7 @@ msgstr ""
 msgid "Show all containers"
 msgstr "Показать все контейнеры"
 
-#: pkg/docker/index.html:254
+#: pkg/docker/index.html:249
 msgid "Show all images"
 msgstr "Показать все изображения"
 
@@ -6126,16 +6046,15 @@ msgid "Shut Down"
 msgstr "Выключение"
 
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:420
-#: pkg/machines/components/diskAdd.jsx:143
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Размер"
 
@@ -6211,14 +6130,14 @@ msgstr ""
 "Некоторые другие программы в настоящее время используют диспетчер пакетов, "
 "пожалуйста, подождите ..."
 
-#: pkg/networkmanager/firewall.jsx:707
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:476
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Источник"
 
@@ -6226,10 +6145,10 @@ msgstr "Источник"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:217
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:244
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Путь к источнику"
 
@@ -6237,8 +6156,8 @@ msgstr "Путь к источнику"
 msgid "Source URL"
 msgstr "Исходный URL"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:254
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
 msgid "Source path should not be empty"
 msgstr "Исходный путь не должен быть пустым"
 
@@ -6270,9 +6189,9 @@ msgstr "Конкретное время"
 msgid "Stable"
 msgstr "Стабильный"
 
-#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:320 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Запустить"
 
@@ -6292,7 +6211,7 @@ msgstr "Начало службы"
 msgid "Start libvirt"
 msgstr "Начать libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:291
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
 msgid "Start pool when host boots"
 msgstr "Запуск пула при загрузке хоста"
 
@@ -6304,24 +6223,20 @@ msgstr "Запуск устройства RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Запуск swapspace $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Starts"
-msgstr "Дата начала"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
 msgid "Startup"
 msgstr "Запускать"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
 #: pkg/systemd/init.js:285
 msgid "State"
 msgstr "Состояние"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:167
+#: pkg/docker/index.html:168
 msgid "State:"
 msgstr "Состояние:"
 
@@ -6330,17 +6245,8 @@ msgid "Static"
 msgstr "Статически"
 
 #: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
-#: pkg/subscriptions/subscriptions-view.jsx:37
 msgid "Status"
 msgstr "Состояние"
-
-#: pkg/subscriptions/subscriptions-view.jsx:162
-msgid "Status: $0"
-msgstr "Статус: $0"
-
-#: pkg/subscriptions/subscriptions-view.jsx:157
-msgid "Status: System isn't registered"
-msgstr "Статус: система не зарегистрирована"
 
 #: pkg/lib/machine-info.js:99
 msgid "Stick PC"
@@ -6350,14 +6256,14 @@ msgstr "Stick PC"
 msgid "Sticky"
 msgstr "липкий"
 
-#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Остановить"
 
-#: pkg/storaged/mdraid-details.jsx:248
+#: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Остановить устройство"
 
@@ -6390,8 +6296,8 @@ msgid "Stopping swapspace $target"
 msgstr "Остановка обмена $target"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:288 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:383
+#: pkg/docker/index.html:290 pkg/storaged/index.html:23
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
 #: pkg/storaged/details.jsx:127
 msgid "Storage"
 msgstr "Хранилище"
@@ -6412,7 +6318,7 @@ msgstr ""
 msgid "Storage Pool Name"
 msgstr "Имя пула хранения"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:437
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
 msgid "Storage Pool failed to be created"
 msgstr "Не удалось создать пул хранения"
 
@@ -6433,7 +6339,7 @@ msgstr ""
 msgid "Storage can not be managed on this system."
 msgstr ""
 
-#: pkg/docker/index.html:302
+#: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Пул"
 
@@ -6460,11 +6366,6 @@ msgstr "Sub Chassis"
 #: pkg/lib/machine-info.js:77
 msgid "Sub Notebook"
 msgstr "Sub Notebook"
-
-# translation auto-copied from project Customer Portal Translations, version management_page, document Management_Prototype.html, author ypoyarko
-#: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:177
-msgid "Subscriptions"
-msgstr "Подписки"
 
 #: node_modules/registry-image-widgets/views/image-body.html:4
 #, fuzzy
@@ -6579,8 +6480,8 @@ msgstr "Система до даты"
 msgid "System is up to date"
 msgstr "Система не нуждается в обновлении"
 
-#: pkg/docker/index.html:327 pkg/docker/index.html:331
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:329 pkg/docker/index.html:333
+#: pkg/networkmanager/firewall.jsx:938
 msgid "TCP"
 msgstr "TCP"
 
@@ -6589,7 +6490,7 @@ msgid "Tablet"
 msgstr "Планшет"
 
 # translation auto-copied from project shotwell-core, version 0.14.1, document shotwell-core
-#: pkg/docker/index.html:694
+#: pkg/docker/index.html:696
 #: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Метка"
@@ -6611,12 +6512,12 @@ msgstr "Tang keyserver"
 msgid "Target"
 msgstr "Целевой"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Целевой путь"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:133
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
 msgid "Target path should not be empty"
 msgstr "Целевой путь не должен быть пустым"
 
@@ -6673,11 +6574,11 @@ msgstr "Пул хранения Docker нельзя управлять в это
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "IP-адрес или имя хоста не могут содержать пробелы."
 
-#: pkg/storaged/mdraid-details.jsx:219
+#: pkg/storaged/mdraid-details.jsx:218
 msgid "The RAID Array is in a degraded state"
 msgstr "RAID-массив находится в деградированном состоянии"
 
-#: pkg/storaged/mdraid-details.jsx:149
+#: pkg/storaged/mdraid-details.jsx:148
 msgid "The RAID device must be running in order to add spare disks."
 msgstr "Устройство RAID должно работать, чтобы добавить запасные диски."
 
@@ -6726,15 +6627,15 @@ msgstr "VM запущена."
 msgid "The VM is suspended by guest power management."
 msgstr "VM приостанавливается управлением гостевой системой."
 
-#: pkg/users/local.js:1338
+#: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
 msgstr ""
 "Счет '$0'будет вынужден изменить свой пароль при следующем входе в систему"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Подлинность хоста {{#strong}}{{host}}{{/strong}} не может быть установлена. "
 "Вы действительно хотите продолжить соединение?"
@@ -6756,11 +6657,6 @@ msgstr ""
 "Создание этого устройства VDO не завершилось, и устройство не может быть "
 "использовано."
 
-#: pkg/subscriptions/subscriptions-view.jsx:214
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-"Текущему пользователю не разрешен доступ к системному состоянию подписки."
-
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
@@ -6768,7 +6664,7 @@ msgstr ""
 "Пользователю в настоящий момент не разрешено просматривать информацию о "
 "ключах."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:204
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
 msgid "The directory on the server being exported"
 msgstr "Каталог на экспортируемом сервере"
 
@@ -6777,12 +6673,11 @@ msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
 msgstr ""
-"Файловая система используется сеансами входа в систему и системными службами."
-" Продолжающие действия остановят их."
+"Файловая система используется сеансами входа в систему и системными "
+"службами. Продолжающие действия остановят их."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Файловая система используется сеансами входа в систему. Продолжающие "
 "действия остановят их."
@@ -6795,8 +6690,7 @@ msgstr ""
 "остановлены."
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "Следующие контейнеры зависят от этого изображения и станут непригодными для "
 "использования."
@@ -6837,12 +6731,17 @@ msgstr "Последний ключевой слот нельзя удалить
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "Последний физический том группы томов не может быть удален."
 
-#: pkg/shell/indexes.js:408
+#: pkg/shell/indexes.js:407
 #, fuzzy
 msgid "The machine is restarting"
 msgstr "Аппарат перезапускается"
 
-#: pkg/users/local.js:439 pkg/users/local.js:1395
+#: pkg/machines/components/networks/networkDelete.jsx:76
+#, fuzzy
+msgid "The network could not be deleted"
+msgstr "Целевой путь не должен быть пустым"
+
+#: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
 msgstr "пароли не совпадают"
 
@@ -6916,22 +6815,20 @@ msgstr "Пользователь <b>$0</b> не разрешается изме�
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "Пользователь <b>$0</b> не разрешено изменять настройки сети"
 
-#: pkg/realmd/operation.js:643
+#: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "Пользователь <b>$0</b> не разрешено изменять сферы"
 
 #: pkg/systemd/host.js:62
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr ""
-"Пользователь <b>$0</b> не разрешено выключение или перезагрузка этого "
-"сервера"
+"Пользователь <b>$0</b> не разрешено выключение или перезагрузка этого сервера"
 
 #: pkg/systemd/init.js:606 pkg/systemd/init.js:610
 msgid "The user <b>$0</b> is not permitted to start or stop services"
-msgstr ""
-"Пользователь <b>$0</b> не разрешено запускать или останавливать услуги"
+msgstr "Пользователь <b>$0</b> не разрешено запускать или останавливать услуги"
 
-#: pkg/users/local.js:549
+#: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
@@ -6941,8 +6838,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "Конфигурация веб-браузера предотвращает запуск Cockpit (недоступный $0)"
 
@@ -7094,7 +6990,7 @@ msgstr "Это устройство является экземпляром $0 �
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Этот элемент не предназначено для включения явно."
 
-#: pkg/users/local.js:557
+#: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "Такое имя пользователя уже существует"
 
@@ -7106,14 +7002,13 @@ msgstr ""
 "Эта версия cockpit-ws не поддерживает подключение к хосту с другим "
 "пользователем или портом"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
 msgid "This volume is already used by another VM."
 msgstr ""
 
 #: pkg/storaged/lvol-tabs.jsx:186
 msgid "This volume needs to be activated before it can be resized."
-msgstr ""
-"Этот том необходимо активировать, прежде чем его можно будет изменить."
+msgstr "Этот том необходимо активировать, прежде чем его можно будет изменить."
 
 #: src/ws/login.js:122
 msgid "This web browser is too old to run Cockpit (missing $0)"
@@ -7130,9 +7025,9 @@ msgid ""
 "Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
 msgstr ""
-"Это проверит настройки kdump, разбив ядро ​​и тем самым систему. В "
-"зависимости от настроек система может не перезагружаться автоматически, и "
-"процесс может занять некоторое время."
+"Это проверит настройки kdump, разбив ядро ​​и тем самым систему. В зависимости "
+"от настроек система может не перезагружаться автоматически, и процесс может "
+"занять некоторое время."
 
 #: pkg/kdump/kdump-view.jsx:489
 msgid "This will test the kdump configuration by crashing the kernel."
@@ -7231,7 +7126,7 @@ msgstr "Диагностика"
 msgid "Trust key"
 msgstr "Целевой ключ"
 
-#: pkg/networkmanager/firewall.jsx:703
+#: pkg/networkmanager/firewall.jsx:705
 msgid "Trust level"
 msgstr ""
 
@@ -7275,18 +7170,17 @@ msgstr "Демон tuned не запущен"
 msgid "Tuned is off"
 msgstr "Демон tuned отключен"
 
-#: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Тип"
 
@@ -7302,12 +7196,11 @@ msgstr "Введите пароль"
 msgid "Type to filter…"
 msgstr "Тип фильтра ..."
 
-#: pkg/docker/index.html:332 pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:258
-#: pkg/subscriptions/subscriptions-register.jsx:112
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
 msgid "URL"
 msgstr "Ссылка (URL)"
 
@@ -7323,10 +7216,6 @@ msgstr "Невозможно применить настройки: $0"
 #: pkg/selinux/setroubleshoot-view.jsx:119
 msgid "Unable to apply this solution automatically"
 msgstr "Невозможно применить это решение автоматически"
-
-#: pkg/subscriptions/subscriptions-view.jsx:217
-msgid "Unable to connect"
-msgstr "Не удалось подключиться"
 
 #: src/ws/login.js:649
 msgid "Unable to connect to that address"
@@ -7377,12 +7266,12 @@ msgstr "Не удалось отключить файловую систему"
 msgid "Unavailable"
 msgstr "Недоступно"
 
-#: pkg/docker/index.html:730 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1481
+#: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
+#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Непредвиденная ошибка"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:171
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid "Unique name"
 msgstr "Уникальное имя"
 
@@ -7394,10 +7283,11 @@ msgstr "Сервис"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/lib/machine-info.js:65 pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:139
 #: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
 #: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Неизвестно"
 
@@ -7433,7 +7323,7 @@ msgstr ""
 msgid "Unknown type"
 msgstr "Неизвестный тип"
 
-#: pkg/docker/index.html:549 pkg/docker/util.js:110
+#: pkg/docker/index.html:551 pkg/docker/util.js:110
 msgid "Unless Stopped"
 msgstr "Если не остановлено"
 
@@ -7499,14 +7389,6 @@ msgstr "Непризнанные данные"
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Здесь не могут быть уменьшены нераспознанные данные."
 
-#: pkg/subscriptions/subscriptions-view.jsx:164
-msgid "Unregister"
-msgstr "Удалить регистрацию"
-
-#: pkg/subscriptions/subscriptions-view.jsx:170
-msgid "Unregistering system..."
-msgstr "Незарегистрированная система ..."
-
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
 msgstr "неразрешенный"
@@ -7528,11 +7410,11 @@ msgstr "Неверный хозяин"
 msgid "Up since $0"
 msgstr "С тех пор $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:432
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
 msgid "Up to $0 $1 available in the default location"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:355
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -7561,7 +7443,7 @@ msgstr "Обновленные пакеты могут потребовать п
 msgid "Updates Available"
 msgstr "Доступные обновления"
 
-#: pkg/packagekit/updates.jsx:52 pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/packagekit/updates.jsx:52
 msgid "Updating"
 msgstr "обновление"
 
@@ -7581,13 +7463,9 @@ msgstr[2] "Использование $0 ядер процессора"
 msgid "Use 512 Byte emulation"
 msgstr "Использовать эмуляцию 512 байт"
 
-#: pkg/machines/components/diskAdd.jsx:496
+#: pkg/machines/components/diskAdd.jsx:524
 msgid "Use Existing"
 msgstr "Использовать существующие"
-
-#: pkg/subscriptions/subscriptions-register.jsx:136
-msgid "Use proxy server"
-msgstr "Использовать прокси-сервер"
 
 #: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
@@ -7605,13 +7483,13 @@ msgstr "Использовано"
 msgid "Used by"
 msgstr ""
 
-#: pkg/docker/index.html:262
+#: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "Используется контейнерами"
 
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/subscriptions/subscriptions-register.jsx:77 pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1584
 msgid "User"
 msgstr "Пользователь"
 
@@ -7620,11 +7498,11 @@ msgstr "Пользователь"
 msgid "User Name"
 msgstr "Имя пользователя"
 
-#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:337
+#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:336
 msgid "User Password"
 msgstr "Пользовательский пароль"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Пользователь"
@@ -7704,7 +7582,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1320
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -7744,7 +7622,7 @@ msgstr "Порт VNC:"
 msgid "VNC TLS Port:"
 msgstr "Порт VNC TLS:"
 
-#: pkg/realmd/operation.js:165
+#: pkg/realmd/operation.js:164
 msgid "Validating address"
 msgstr ""
 
@@ -7777,8 +7655,7 @@ msgstr "Проверка"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/subscriptions/subscriptions-view.jsx:35
-#: pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Версия"
 
@@ -7786,8 +7663,8 @@ msgstr "Версия"
 msgid "Very securely erasing $target"
 msgstr "Очень надежно стирает $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Виртуальные машины"
@@ -7804,12 +7681,11 @@ msgstr "Служба виртуализации (libvirt) не активна"
 msgid "Virtualization Service is Available"
 msgstr "Доступна служба виртуализации"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:403
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Том"
 
@@ -7817,7 +7693,7 @@ msgstr "Том"
 msgid "Volume Group"
 msgstr "Группа томов"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:233
+#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Группа томов $0"
 
@@ -7829,12 +7705,12 @@ msgstr "Группы томов"
 msgid "Volume size is $0. Content size is $1."
 msgstr ""
 
-#: pkg/docker/index.html:515
+#: pkg/docker/index.html:517
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Список томов"
 
-#: pkg/docker/index.html:199
+#: pkg/docker/index.html:200
 msgid "Volumes:"
 msgstr "Объемы:"
 
@@ -7898,7 +7774,7 @@ msgstr "Что делать, если танг-шоу-ключи недосту�
 msgid "White"
 msgstr "Белый"
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:488
 msgid "With terminal"
 msgstr "С терминалом"
 
@@ -7938,7 +7814,7 @@ msgstr ""
 "можете удалить его."
 
 #: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:871 pkg/networkmanager/firewall.jsx:877
+#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
 msgid "You are not authorized to modify the firewall."
 msgstr "У вас нет прав на изменение брандмауэра."
 
@@ -7988,11 +7864,11 @@ msgstr "Ваша сессия завершена."
 msgid "Your session has expired. Please log in again."
 msgstr "Время сеанса истекло. Пожалуйста, войдите снова."
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/networkmanager/firewall.jsx:938
 msgid "Zones"
 msgstr ""
 
@@ -8008,8 +7884,12 @@ msgstr "[двоичные данные]"
 msgid "[no data]"
 msgstr "[нет данных]"
 
-#: pkg/machines/components/networks/network.jsx:58
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "Активно"
@@ -8080,7 +7960,7 @@ msgstr "вниз"
 msgid "dying"
 msgstr "умирающий"
 
-#: pkg/realmd/operation.js:299 pkg/realmd/operation.js:305
+#: pkg/realmd/operation.js:298 pkg/realmd/operation.js:304
 msgid "e.g. \"$0\""
 msgstr "например, \"$0\""
 
@@ -8116,7 +7996,7 @@ msgstr ""
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:182
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
@@ -8132,7 +8012,7 @@ msgstr "Цели iSCSI"
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -8140,8 +8020,8 @@ msgstr ""
 msgid "idle"
 msgstr "вхолостую"
 
-#: pkg/machines/components/networks/network.jsx:58
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "Неактивно"
 
@@ -8177,9 +8057,9 @@ msgstr "сеть"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "Назначение дампа nfs не отформатировано как сервер: путь"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "нет"
@@ -8201,11 +8081,11 @@ msgstr[2] "из $0 ядер процессора"
 msgid "paused"
 msgstr "приостановлено"
 
-#: pkg/machines/components/diskAdd.jsx:174
+#: pkg/machines/components/diskAdd.jsx:154
 msgid "qcow2"
 msgstr "qcow2"
 
-#: pkg/machines/components/diskAdd.jsx:177
+#: pkg/machines/components/diskAdd.jsx:157
 msgid "raw"
 msgstr "raw"
 
@@ -8229,7 +8109,7 @@ msgstr "Поиск по имени, пространству имён или о�
 msgid "security"
 msgstr "безопасность"
 
-#: pkg/docker/index.html:404
+#: pkg/docker/index.html:406
 msgid "select container"
 msgstr "выбрать контейнер"
 
@@ -8237,7 +8117,7 @@ msgstr "выбрать контейнер"
 msgid "server"
 msgstr "сервер"
 
-#: pkg/docker/index.html:483 pkg/docker/index.html:655
+#: pkg/docker/index.html:485 pkg/docker/index.html:657
 msgid "shares"
 msgstr "акции"
 
@@ -8341,9 +8221,15 @@ msgstr "значение"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+msgid ""
+"virt-install package needs to be installed on the system in order to create "
+"new VMs"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "да"
@@ -8355,3 +8241,97 @@ msgid ""
 msgstr ""
 "{{ condition.message }}, Отметка: {{ condition.lastTransitionTime }} "
 "Количество ошибок: {{ condition.generation }}"
+
+#~ msgid "'Organization' required to register."
+#~ msgstr "Название организации, необходимое для регистрации."
+
+#~ msgid "'Organization' required when using activation keys."
+#~ msgstr ""
+#~ "Название организации, необходимое при использовании ключей активации."
+
+#~ msgid "Access denied"
+#~ msgstr "Доступ запрещён"
+
+#~ msgid "Activation Key"
+#~ msgstr "Ключ активации"
+
+#~ msgid ""
+#~ "Couldn't get system subscription status. Please ensure subscription-"
+#~ "manager is installed."
+#~ msgstr ""
+#~ "Не удалось получить статус системной подписки. Убедитесь, что диспетчер "
+#~ "подписок установлен."
+
+#~ msgid "Custom URL"
+#~ msgstr "Настраиваемый URL-адрес"
+
+#~ msgid "Ends"
+#~ msgstr "Дата окончания"
+
+#~ msgid "Installed products"
+#~ msgstr "Установленные продукты"
+
+#~ msgid "Invalid credentials"
+#~ msgstr "Недопустимые учетные данные"
+
+#~ msgid "Login"
+#~ msgstr "Вход"
+
+#~ msgid "Login/password or activation key required to register."
+#~ msgstr ""
+#~ "Имя/пароль пользователя или ключ активации, необходимые для регистрации."
+
+#~ msgid "No installed products on the system."
+#~ msgstr "Нет установленных продуктов в системе."
+
+# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+#~ msgid "Organization"
+#~ msgstr "Организация"
+
+#~ msgid "Product ID"
+#~ msgstr "Идентификатор продукта"
+
+#~ msgid "Product name"
+#~ msgstr "Название продукта"
+
+#~ msgid "Proxy"
+#~ msgstr "Прокси"
+
+# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+#~ msgid "Register"
+#~ msgstr "Регистрация"
+
+#~ msgid "Register system"
+#~ msgstr "Система регистрации"
+
+#~ msgid "Retrieving subscription status..."
+#~ msgstr "Получение статуса подписки ..."
+
+#~ msgid "Starts"
+#~ msgstr "Дата начала"
+
+#~ msgid "Status: $0"
+#~ msgstr "Статус: $0"
+
+#~ msgid "Status: System isn't registered"
+#~ msgstr "Статус: система не зарегистрирована"
+
+# translation auto-copied from project Customer Portal Translations, version management_page, document Management_Prototype.html, author ypoyarko
+#~ msgid "Subscriptions"
+#~ msgstr "Подписки"
+
+#~ msgid "The current user isn't allowed to access system subscription status."
+#~ msgstr ""
+#~ "Текущему пользователю не разрешен доступ к системному состоянию подписки."
+
+#~ msgid "Unable to connect"
+#~ msgstr "Не удалось подключиться"
+
+#~ msgid "Unregister"
+#~ msgstr "Удалить регистрацию"
+
+#~ msgid "Unregistering system..."
+#~ msgstr "Незарегистрированная система ..."
+
+#~ msgid "Use proxy server"
+#~ msgstr "Использовать прокси-сервер"

--- a/po/sv.po
+++ b/po/sv.po
@@ -4,14 +4,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-03 06:24+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-06-02 09:24+0000\n"
 "Last-Translator: Göran Uddeborg <goeran@uddeborg.se>\n"
 "Language-Team: Swedish\n"
 "Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -19,19 +19,15 @@ msgstr ""
 msgid " (shared with the OS)"
 msgstr "(delat med OS:et)"
 
-#: pkg/kubernetes/views/node-delete.html:8
-msgid " 1\"Do you want to delete the following Nodes?"
-msgstr " 1\"Vill du radera följande noder?"
-
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0 blockenhet"
 
-#: pkg/storaged/mdraid-details.jsx:193
+#: pkg/storaged/mdraid-details.jsx:192
 msgid "$0 Chunk Size"
 msgstr "$0 styckesstorlek"
 
-#: pkg/storaged/mdraid-details.jsx:191
+#: pkg/storaged/mdraid-details.jsx:190
 msgid "$0 Disks"
 msgstr "$0 diskar"
 
@@ -80,16 +76,16 @@ msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 data + $1 överskjutande använt av $2 ($3)"
 
 #: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:213
+#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 disk saknas"
 msgstr[1] "$0 diskar saknas"
 
 #: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:34
-#: pkg/playground/translate.js:37
+#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
@@ -129,10 +125,10 @@ msgstr ""
 "programvara för att installera det eller kör följande:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:237
-#: pkg/storaged/mdraid-details.jsx:290 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:203
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 används aktivt"
 
@@ -172,27 +168,11 @@ msgstr[1] "$0 uppdateringar"
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 använt av $1 ($2 sparat)"
 
-#: pkg/ovirt/components/vcpuModal.jsx:98
-msgid "$0 vCPU Details"
-msgstr "$0 vCPU-detaljer"
-
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "$0 kommer att installeras."
 
-#: pkg/kubernetes/scripts/nodes.js:871
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0 % fritt"
-msgstr[1] "$0 % fritt"
-
-#: pkg/kubernetes/scripts/nodes.js:873
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0 % använt"
-msgstr[1] "$0 % använt"
-
-#: pkg/storaged/vgroup-details.jsx:118
+#: pkg/storaged/vgroup-details.jsx:117
 msgid "$0, $1 free"
 msgstr "$0, $1 fritt"
 
@@ -218,19 +198,11 @@ msgstr "${hip}:${hport} → $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/subscriptions/subscriptions-client.js:197
-msgid "'Organization' required to register."
-msgstr "“Organisation” krävs för att registrera."
-
-#: pkg/subscriptions/subscriptions-client.js:201
-msgid "'Organization' required when using activation keys."
-msgstr "“Organisation” krävs vid användning av aktiveringsnycklar."
-
-#: pkg/networkmanager/firewall.jsx:547
+#: pkg/networkmanager/firewall.jsx:549
 msgid "(Optional)"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:616
+#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(standard)"
@@ -520,12 +492,8 @@ msgstr "ARP-övervakning"
 msgid "ARP Ping"
 msgstr "ARP-ping"
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "AWS elastisk blocklagring"
-
 #: pkg/shell/index.html:56 pkg/shell/index.html:82 pkg/shell/simple.html:42
-#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
+#: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Om Cockpit"
 
@@ -533,19 +501,9 @@ msgstr "Om Cockpit"
 msgid "Access"
 msgstr "Åtkomst"
 
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
-msgid "Access Modes"
-msgstr "Åtkomstlägen"
-
-#: pkg/kubernetes/views/project-modify.html:49
 #: node_modules/registry-image-widgets/views/imagestream-body.html:12
 msgid "Access Policy"
 msgstr "Åtkomstpolicy"
-
-#: pkg/subscriptions/subscriptions-view.jsx:213
-msgid "Access denied"
-msgstr "Åtkomst nekas"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -563,18 +521,13 @@ msgstr "Kontot är inte tillgängligt eller kan inte redigeras."
 msgid "Accounts"
 msgstr "Konton"
 
-#: pkg/users/local.js:335 pkg/users/local.js:642
+#: pkg/users/local.js:339 pkg/users/local.js:646
 msgctxt "page-title"
 msgid "Accounts"
 msgstr "Konton"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:183
-msgid "Action"
-msgstr "Åtgärd"
-
-#: pkg/machines/components/networks/network.jsx:147
-#: pkg/machines/components/storagePools/storagePool.jsx:167
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Aktivera"
@@ -582,10 +535,6 @@ msgstr "Aktivera"
 #: pkg/storaged/jobs-panel.jsx:68
 msgid "Activating $target"
 msgstr "Aktivera $target"
-
-#: pkg/subscriptions/subscriptions-register.jsx:168
-msgid "Activation Key"
-msgstr "Aktiveringsnyckel"
 
 #: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
 msgid "Active"
@@ -595,7 +544,7 @@ msgstr "Aktivt"
 msgid "Active Backup"
 msgstr "Aktiv reserv"
 
-#: pkg/shell/index.html:59 pkg/shell/stub.html:49 pkg/shell/active-pages.js:95
+#: pkg/shell/index.html:59 pkg/shell/active-pages.js:95
 msgid "Active Pages"
 msgstr "Aktiva sidor"
 
@@ -603,13 +552,9 @@ msgstr "Aktiva sidor"
 msgid "Active since"
 msgstr "Aktivt sedan"
 
-#: pkg/networkmanager/firewall.jsx:922
+#: pkg/networkmanager/firewall.jsx:924
 msgid "Active zones"
 msgstr ""
-
-#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
-msgid "Actual"
-msgstr "Aktuell"
 
 #: pkg/networkmanager/interfaces.js:1980
 msgid "Adaptive load balancing"
@@ -619,16 +564,11 @@ msgstr "Adaptiv lastbalansering"
 msgid "Adaptive transmit load balancing"
 msgstr "Adaptiv lastbalansering av sändning"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/add-role-dialog.html:8
-#: pkg/kubernetes/views/add-user-dialog.html:27
-#: pkg/kubernetes/views/node-add.html:50
-#: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:534
-#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/vgroup-details.jsx:63
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Lägg till"
 
@@ -648,11 +588,7 @@ msgstr "Lägg till bindning"
 msgid "Add Bridge"
 msgstr "Lägg till brygga"
 
-#: pkg/kubernetes/views/node-add.html:3
-msgid "Add Cluster Node"
-msgstr "Lägg till klusternod"
-
-#: pkg/machines/components/diskAdd.jsx:356
+#: pkg/machines/components/diskAdd.jsx:360
 msgid "Add Disk"
 msgstr "Lägg till disk"
 
@@ -660,55 +596,20 @@ msgstr "Lägg till disk"
 msgid "Add Disks"
 msgstr "Lägg till diskar"
 
-#: pkg/kubernetes/views/add-group-dialog.html:3
-msgid "Add Group"
-msgstr "Lägg till grupp"
-
 #: pkg/storaged/crypto-keyslots.jsx:200
 msgid "Add Key"
 msgstr "Lägg till nyckel"
-
-#: pkg/kubernetes/views/nodes-page.html:34
-msgid "Add Kubernetes Node"
-msgstr "Lägg till Kubernetesnod"
 
 #: pkg/lib/machine-add.html:4
 msgid "Add Machine to Dashboard"
 msgstr "Lägg till en maskin till panelen"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:4
-#: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/group-panel.html:29
-#: pkg/kubernetes/views/project-body.html:108
-#: pkg/kubernetes/views/user-group-add.html:3
-msgid "Add Member"
-msgstr "Lägg till medlem"
-
-#: pkg/kubernetes/views/user-body.html:67
-#: pkg/kubernetes/views/user-panel.html:76
-msgid "Add Membership"
-msgstr "Lägg till medlemskap"
-
-#: pkg/kubernetes/views/auth-form.html:11
-#: pkg/kubernetes/views/auth-form.html:20
-msgid "Add New Cluster"
-msgstr "Lägg till nytt kluster"
-
-#: pkg/kubernetes/views/auth-form.html:67
-#: pkg/kubernetes/views/auth-form.html:76
-msgid "Add New User"
-msgstr "Lägg till ny användare"
-
 #: pkg/networkmanager/firewall.jsx:457
 msgid "Add Ports"
 msgstr ""
 
-#: pkg/kubernetes/views/add-role-dialog.html:3
-msgid "Add Role"
-msgstr "Lägg till roll"
-
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:872
-#: pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
+#: pkg/networkmanager/firewall.jsx:886
 msgid "Add Services"
 msgstr "Lägg till tjänster"
 
@@ -720,17 +621,12 @@ msgstr "Lägg till lagring"
 msgid "Add Team"
 msgstr "Lägg till team"
 
-#: pkg/kubernetes/views/add-user-dialog.html:3
-#: pkg/kubernetes/views/project-listing.html:83
-msgid "Add User"
-msgstr "Lägg till användare"
-
 #: pkg/networkmanager/index.html:113
 msgid "Add VLAN"
 msgstr " Lägg till VLAN"
 
-#: pkg/networkmanager/firewall.jsx:698 pkg/networkmanager/firewall.jsx:878
-#: pkg/networkmanager/firewall.jsx:889
+#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
+#: pkg/networkmanager/firewall.jsx:891
 msgid "Add Zone"
 msgstr ""
 
@@ -741,10 +637,6 @@ msgstr "Lägg till iSCSI-portal"
 #: pkg/shell/index.html:172 pkg/users/index.html:414
 msgid "Add key"
 msgstr "Lägg till nyckel"
-
-#: pkg/kubernetes/views/user-add-membership.html:3
-msgid "Add membership"
-msgstr "Lägg till medlemskap"
 
 #: pkg/networkmanager/firewall.jsx:458
 msgid "Add ports to the following zones:"
@@ -758,7 +650,7 @@ msgstr "Lägg till publik nyckel"
 msgid "Add services to following zones:"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:774
+#: pkg/networkmanager/firewall.jsx:776
 msgid "Add zone"
 msgstr ""
 
@@ -790,7 +682,7 @@ msgstr "Ytterligare DNS $val"
 msgid "Additional DNS Search Domains $val"
 msgstr "Ytterligare DNS-sökdomäner $val"
 
-#: pkg/docker/index.html:307
+#: pkg/docker/index.html:309
 msgid "Additional Storage"
 msgstr "Ytterligare lagring"
 
@@ -802,14 +694,11 @@ msgstr "Ytterligare adress $val"
 msgid "Additional packages:"
 msgstr "Ytterligare paket:"
 
-#: pkg/kubernetes/views/auth-form.html:29
-#: pkg/kubernetes/views/dashboard-page.html:157
-#: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
+#: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:77 pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:107
+#: pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "Adress"
 
@@ -826,44 +715,18 @@ msgid "Address is not a valid URL"
 msgstr "Adressen är inte en giltig URL"
 
 #: pkg/machines/components/desktopConsole.jsx:153
-#: pkg/ovirt/components/VmOverviewColumn.jsx:53
 msgid "Address:"
 msgstr "Adress:"
 
-#: pkg/kubernetes/views/details-page.html:37
 #: pkg/networkmanager/interfaces.js:3309
 msgid "Addresses"
 msgstr "Adresser"
-
-#: pkg/kubernetes/views/service-modify.html:25
-msgid "Adjust"
-msgstr "Justera"
-
-#: pkg/kubernetes/views/pv-modify.html:3
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "Justera beständig volym ”{{ item.metadata.name }}”"
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html:3
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "Justera replikeringskontroll {{ item.metadata.name }}"
-
-#: pkg/kubernetes/views/route-modify.html:3
-msgid "Adjust Route"
-msgstr "Justera rutt"
-
-#: pkg/kubernetes/views/service-modify.html:3
-msgid "Adjust Service"
-msgstr "Justera tjänst"
-
-#: pkg/kubernetes/views/project-body.html:56
-msgid "Admin"
-msgstr "Admin"
 
 #: org.cockpit-project.cockpit-bridge.policy.in.h:1
 msgid "Administration with Cockpit Web Console"
 msgstr "Administration med Cockpits webbkonsol"
 
-#: pkg/realmd/operation.js:336
+#: pkg/realmd/operation.js:335
 msgid "Administrator Password"
 msgstr "Administratörslösenord"
 
@@ -899,14 +762,6 @@ msgstr ""
 msgid "All In One"
 msgstr "Allt-i-ett"
 
-#: pkg/kubernetes/views/filter-project.html:4
-msgid "All Projects"
-msgstr "Alla projekt"
-
-#: pkg/kubernetes/views/details-page.html:6
-msgid "All Types"
-msgstr "Alla typer"
-
 #: pkg/docker/storage.jsx:381
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
@@ -915,35 +770,15 @@ msgstr ""
 "Alla data på valda diskar kommer raderas och diskarna kommer läggas till i "
 "lagringspoolen."
 
-#: pkg/kubernetes/views/dashboard-page.html:112
-msgid "All healthy"
-msgstr "Alla friska"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:74
-msgid "All images"
-msgstr "Alla bilder"
-
-#: pkg/kubernetes/views/dashboard-page.html:69
-msgid "All in use"
-msgstr "Alla används"
-
-#: pkg/kubernetes/views/dashboard-page.html:37
-msgid "All running"
-msgstr "Alla kör"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:36
-msgid "All running virtual machines will be turned off."
-msgstr "Alla körande virtuella maskiner kommer stängas av."
-
-#: pkg/networkmanager/firewall.jsx:749
+#: pkg/networkmanager/firewall.jsx:751
 msgid "Allowed Addresses"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:935
+#: pkg/networkmanager/firewall.jsx:937
 msgid "Allowed Services"
 msgstr "Tillåtna tjänster"
 
-#: pkg/docker/index.html:548 pkg/docker/util.js:108
+#: pkg/docker/index.html:550 pkg/docker/util.js:108
 msgid "Always"
 msgstr "Alltid"
 
@@ -951,17 +786,11 @@ msgstr "Alltid"
 msgid "Always attach"
 msgstr "Anslut alltid"
 
-#: pkg/kubernetes/views/node-body.html:57
-#: pkg/kubernetes/views/route-body.html:27
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "Noteringar"
 
-#: pkg/kubernetes/scripts/projects.js:1044
-msgid "Anonymous: Allow all unauthenticated users to pull images"
-msgstr "Anonymt: tillåt alla oautentiserade användare att hämta avbilder"
-
-#: pkg/systemd/terminal.jsx:94
+#: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr ""
 
@@ -974,11 +803,10 @@ msgstr "Program"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235
-#: pkg/ovirt/components/vcpuModal.jsx:104 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Lägg på"
 
@@ -1007,7 +835,6 @@ msgid "Applying updates failed"
 msgstr "Att lägga på uppdateringar misslyckades"
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
-#: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Architecture"
 msgstr "Arkitektur"
 
@@ -1019,8 +846,8 @@ msgstr "Inventariebeteckning"
 msgid "At least $0 disks are needed."
 msgstr "Åtminstone $0 diskar behövs."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Åtminstone en disk behövs."
 
@@ -1036,9 +863,8 @@ msgstr "Granskningslogg"
 msgid "Authenticating"
 msgstr "Autentiserar"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
 #: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Autentisering"
 
@@ -1066,7 +892,7 @@ msgstr ""
 msgid "Authentication required"
 msgstr "Autentisering krävs"
 
-#: pkg/docker/index.html:700
+#: pkg/docker/index.html:702
 #: node_modules/registry-image-widgets/views/image-body.html:12
 #: pkg/docker/containers-view.jsx:413
 msgid "Author"
@@ -1079,7 +905,7 @@ msgstr "Auktoriserade publika SSH-nycklar"
 #: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
 #: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
 #: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:339
+#: pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automatisk"
 
@@ -1099,10 +925,6 @@ msgstr ""
 msgid "Automatic Updates"
 msgstr "Automatiska uppdateringar"
 
-#: pkg/ovirt/components/OVirtTab.jsx:81
-msgid "Automatically selected host"
-msgstr "Automatiskt vald värd"
-
 #: pkg/machines/components/libvirtSlate.jsx:90
 msgid "Automatically start libvirt on boot"
 msgstr "Starta automatiskt libvirt vid uppstart"
@@ -1115,9 +937,9 @@ msgstr "Använder automatiskt NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Använder automatiskt specifika NTP-servrar"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:155
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
 
@@ -1138,10 +960,6 @@ msgstr "Tillgängliga mål på $0"
 #: pkg/dashboard/index.html:163
 msgid "Avatar"
 msgstr "Avatar"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
 
 #: pkg/systemd/hwinfo.jsx:92
 msgid "BIOS"
@@ -1170,18 +988,6 @@ msgstr "Felaktiga data skickade för passwd1-mekanismen"
 #: pkg/networkmanager/index.html:333
 msgid "Balancer"
 msgstr "Balanserare"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-msgid "Base Template"
-msgstr "Basmall"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Base template"
-msgstr "Basmall"
-
-#: pkg/ovirt/components/OVirtTab.jsx:106 pkg/ovirt/components/OVirtTab.jsx:113
-msgid "Base template:"
-msgstr "Basmall:"
 
 #: pkg/systemd/init.js:729
 msgid "Before"
@@ -1224,12 +1030,8 @@ msgstr "Binda"
 msgid "Bond Settings"
 msgstr "Bindinställningar"
 
-#: pkg/kubernetes/views/node-body.html:17
-msgid "Boot ID"
-msgstr "Start-ID"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:312
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:153
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:164
 msgid "Boot Order"
 msgstr ""
 
@@ -1288,10 +1090,8 @@ msgstr "Buss"
 msgid "Bus Expansion Chassis"
 msgstr "Bussexpansionschassi"
 
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:270
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:603
-#: pkg/kubernetes/scripts/nodes.js:711 pkg/kubernetes/scripts/nodes.js:818
-#: pkg/systemd/hwinfo.jsx:108
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:272
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
 msgid "CPU"
 msgstr "CPU"
 
@@ -1308,28 +1108,20 @@ msgctxt "page-title"
 msgid "CPU Status"
 msgstr "CPU-status"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:154
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:165
 msgid "CPU Type"
 msgstr ""
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "CPU-användning: $0 %"
-
-#: pkg/docker/index.html:469 pkg/docker/index.html:641
+#: pkg/docker/index.html:471 pkg/docker/index.html:643
 msgid "CPU priority"
 msgstr "CPU-prioritet"
 
-#: pkg/docker/index.html:217
+#: pkg/docker/index.html:218
 msgid "CPU usage:"
 msgstr "CPU-användning:"
 
-#: pkg/ovirt/provider.js:256
-msgid "CREATE VM action failed"
-msgstr "Åtgärden SKAPA VM misslyckades"
-
-#: pkg/machines/components/diskAdd.jsx:235
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
@@ -1349,79 +1141,44 @@ msgstr "Kan inte radera när olåst"
 msgid "Can't load image"
 msgstr "Kan inte ladda avbilden"
 
-#: pkg/dashboard/index.html:175 pkg/docker/index.html:563
-#: pkg/docker/index.html:597 pkg/docker/index.html:661
-#: pkg/docker/index.html:715 pkg/docker/index.html:755
-#: pkg/docker/index.html:784 pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/add-role-dialog.html:7
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/image-delete.html:7
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/user-group-add.html:29
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
-#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:477 pkg/networkmanager/index.html:501
-#: pkg/networkmanager/index.html:525 pkg/networkmanager/index.html:549
-#: pkg/networkmanager/index.html:573 pkg/networkmanager/index.html:597
-#: pkg/networkmanager/index.html:621 pkg/networkmanager/index.html:645
-#: pkg/networkmanager/index.html:669 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:81 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/systemd/index.html:332
+#: pkg/dashboard/index.html:175 pkg/docker/index.html:565
+#: pkg/docker/index.html:599 pkg/docker/index.html:663
+#: pkg/docker/index.html:717 pkg/docker/index.html:757
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
+#: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
+#: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
+#: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:654
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:531
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:485
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:558 pkg/networkmanager/firewall.jsx:626
-#: pkg/networkmanager/firewall.jsx:769
-#: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:415
 msgid "Cannot connect to an unknown machine"
 msgstr "Kan inte ansluta till en okänd maskin"
-
-#: src/ws/cockpitcertificate.c:483
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "Kan inte dektryptera en PEM-kodad privat nyckel"
 
 #: src/base1/cockpit.js:4031
 msgid "Cannot forward login credentials"
@@ -1431,8 +1188,6 @@ msgstr "Kan inte vidarebefordra inloggningskreditiven"
 msgid "Cannot schedule event in the past"
 msgstr "Kan inte schemalägga händelser i det förflutna"
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
 #: pkg/machines/components/vmDisksTab.jsx:70
 msgid "Capacity"
 msgstr "Kapacitet"
@@ -1441,18 +1196,7 @@ msgstr "Kapacitet"
 msgid "Carrier"
 msgstr "Transportör"
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Ceph-filsystemsmontering"
-
-#: pkg/kubernetes/views/volume-body.html:97
-msgid "Ceph Monitors"
-msgstr "Ceph-övervakare"
-
-#: pkg/docker/index.html:662 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
-#: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:333
+#: pkg/docker/index.html:664 pkg/systemd/index.html:333
 #: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
 #: pkg/storaged/iscsi-panel.jsx:181
 msgid "Change"
@@ -1478,31 +1222,19 @@ msgstr "Ändra profil"
 msgid "Change System Time"
 msgstr "Ändra systemtid"
 
-#: pkg/kubernetes/views/user-modify.html:3
-msgid "Change User"
-msgstr "Ändra användare"
-
 #: pkg/storaged/iscsi-panel.jsx:176
 msgid "Change iSCSI Initiator Name"
 msgstr "Ändra iSCSI-initierarnamn"
-
-#: pkg/kubernetes/views/imagestream-modify.html:4
-msgid "Change image stream"
-msgstr "Ändra avbildsström"
 
 #: pkg/storaged/crypto-keyslots.jsx:247
 msgid "Change passphrase"
 msgstr "Ändra lösenfras"
 
-#: pkg/kubernetes/views/project-modify.html:10
-msgid "Change project"
-msgstr "Ändra projekt"
-
-#: pkg/docker/index.html:228
+#: pkg/docker/index.html:229
 msgid "Change resource limits"
 msgstr "Ändra resursgränser"
 
-#: pkg/docker/index.html:612
+#: pkg/docker/index.html:614
 msgid "Change resources limits"
 msgstr "Ändra resursgränser"
 
@@ -1510,10 +1242,10 @@ msgstr "Ändra resursgränser"
 msgid "Change the settings"
 msgstr "Ändra inställningarna"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Ändringar kommer verkställas efter att VM:en stängs av"
 
@@ -1561,25 +1293,13 @@ msgstr "Kontrollerar om det finns uppdateringar …"
 msgid "Checking installed software"
 msgstr "Kontrollerar installerad programvara"
 
-#: pkg/shell/index.html:117 pkg/shell/simple.html:85 pkg/shell/stub.html:100
+#: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "Välj språk som skall användas i programmet"
 
 #: pkg/storaged/mdraids-panel.jsx:57
 msgid "Chunk Size"
 msgstr "Styckesstorlek"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinder"
-
-#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
-msgid "Claim"
-msgstr "Anspråk"
-
-#: pkg/kubernetes/views/pvc-body.html:4
-msgid "Claim Name"
-msgstr "Anspråksnamn"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Class"
@@ -1602,42 +1322,26 @@ msgid ""
 "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr "Att klicka ”Starta fjärrvisare” kommer hämta en .vv-fil och starta $0"
 
-#: pkg/kubernetes/views/auth-form.html:88
-msgid "Client Certificate"
-msgstr "Klientcertifikat"
-
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:736 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/systemd/index.html:278
-#: pkg/systemd/services.html:363 pkg/systemd/services.html:381
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:108 pkg/sosreport/index.js:45
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
 #: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Stäng"
 
 #: pkg/shell/active-pages.js:103
 msgid "Close Selected Pages"
 msgstr "Stäng valda sidor"
-
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
-#: pkg/ovirt/components/App.jsx:107
-msgid "Cluster"
-msgstr "Kluster"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:128
-msgid "Cluster Templates"
-msgstr "Klustermallar"
-
-#: pkg/ovirt/components/ClusterVms.jsx:174
-msgid "Cluster Virtual Machines"
-msgstr "Klustrets virtuella maskiner"
 
 #: src/ws/login.js:346
 msgid "Cockpit authentication is configured incorrectly."
@@ -1680,7 +1384,7 @@ msgstr ""
 "stoppas via terminalen.  Likaledes, om ett fel uppstår i terminalen kan det "
 "ses i Cockpits journalgränssnitt."
 
-#: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
+#: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit är ett interaktivt administratörsgränssnitt för Linuxservrar."
 
@@ -1716,15 +1420,15 @@ msgstr "Cockpit kunde inte kontakta {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit kunde inte logga in på {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}Du kan vilja försöka att {{#sync_link}}synkronisera användare{{/"
-"sync_link}}.{{/can_sync}}  För fler autentiseringsalternativ och hjälp med "
-"felsökning, uppgradera cockpit-ws till en nyare version."
+"Cockpit kunde inte logga in på {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"Du kan vilja försöka att {{#sync_link}}synkronisera användare{{/sync_link}}."
+"{{/can_sync}}  För fler autentiseringsalternativ och hjälp med felsökning, "
+"uppgradera cockpit-ws till en nyare version."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1765,12 +1469,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Kombinerad användning av $0 CPU-kärna"
 msgstr[1] "Kombinerad användning av $0 CPU-kärnor"
 
-#: pkg/networkmanager/firewall.jsx:527
+#: pkg/networkmanager/firewall.jsx:529
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
-#: pkg/docker/index.html:269 pkg/docker/index.html:445
-#: pkg/docker/index.html:706 pkg/systemd/services.html:427
+#: pkg/docker/index.html:271 pkg/docker/index.html:447
+#: pkg/docker/index.html:708 pkg/systemd/services.html:427
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1781,7 +1485,7 @@ msgstr "Kommando"
 msgid "Command can't be empty"
 msgstr "Kommandot får inte vara tomt"
 
-#: pkg/docker/index.html:163
+#: pkg/docker/index.html:164
 msgid "Command:"
 msgstr "Kommando:"
 
@@ -1789,12 +1493,12 @@ msgstr "Kommando:"
 msgid "Comment"
 msgstr "Kommentar"
 
-#: pkg/docker/index.html:137 pkg/docker/index.html:716
+#: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
 msgstr "Fastställ"
 
-#: pkg/docker/index.html:676
+#: pkg/docker/index.html:678
 msgid "Commit Image"
 msgstr "Fastställ avbild"
 
@@ -1818,8 +1522,8 @@ msgstr "Kompatibel med moderna system och hårddiskar > 2 TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Komprimera kraschdumpar för att spara utrymme"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Komprimering"
 
@@ -1835,21 +1539,9 @@ msgstr "Villkoret $0=$1 uppfylldes inte"
 msgid "Condition failed"
 msgstr "Villkoret misslyckades"
 
-#: pkg/kubernetes/views/node-add.html:24
-msgid "Configuration"
-msgstr "Konfiguration"
-
 #: pkg/networkmanager/interfaces.js:2725
 msgid "Configure"
 msgstr "Konfigurera"
-
-#: pkg/kubernetes/views/node-add.html:42
-msgid "Configure Flannel networking"
-msgstr "Konfigurera Flannel-nätverk"
-
-#: pkg/kubernetes/views/node-add.html:32
-msgid "Configure Kubelet and Proxy"
-msgstr "Konfigurerar Kubelet och Proxy"
 
 #: pkg/docker/storage.jsx:331
 msgid "Configure storage..."
@@ -1872,21 +1564,13 @@ msgstr "Bekräfta"
 msgid "Confirm New Password"
 msgstr "Bekräfta nytt lösenord"
 
-#: pkg/ovirt/components/OVirtTab.jsx:65
-msgid "Confirm migration"
-msgstr "Bekräfta migrering"
-
-#: pkg/ovirt/components/VdsmView.jsx:95
-msgid "Confirm reload:"
-msgstr "Bekräfta omladdning:"
+#: pkg/machines/components/networks/networkDelete.jsx:95
+msgid "Confirm deletion of the Virtual Network"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Confirm removal with passphrase"
 msgstr "Bekräfta borttagandet med en lösenfras"
-
-#: pkg/ovirt/components/VdsmView.jsx:108
-msgid "Confirm save:"
-msgstr "Bekräfta sparandet:"
 
 #: pkg/systemd/init.js:728
 msgid "Conflicted By"
@@ -1896,8 +1580,6 @@ msgstr "Står i konflikt med"
 msgid "Conflicts"
 msgstr "Konflikter"
 
-#: pkg/kubernetes/views/auth-form.html:130
-#: pkg/kubernetes/views/auth-rejected-cert.html:33
 #: pkg/lib/machine-unknown-hostkey.html:22
 msgid "Connect"
 msgstr "Anslut"
@@ -1910,10 +1592,6 @@ msgstr "Anslut automatiskt"
 msgid "Connect to"
 msgstr "Anslut till"
 
-#: pkg/ovirt/components/InstallationDialog.jsx:102
-msgid "Connect to oVirt Engine"
-msgstr "Anslut till oVirt Engine"
-
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "Connect with any $0 viewer application."
 msgstr "Anslut med godtycklig $0-visarprogram."
@@ -1922,7 +1600,7 @@ msgstr "Anslut med godtycklig $0-visarprogram."
 msgid "Connect with any SPICE or VNC viewer application."
 msgstr "Anslut med godtycklig SPICE- eller VNC-visarprogram."
 
-#: pkg/machines/components/vnc.jsx:107
+#: pkg/machines/components/vnc.jsx:106
 msgid "Connecting"
 msgstr "Ansluter"
 
@@ -1943,33 +1621,21 @@ msgstr "Anslut till SETroubleshoot-demonen …"
 msgid "Connecting to Virtualization Service"
 msgstr "Ansluter till virtualiseringstjänsten"
 
-#: pkg/shell/indexes.js:411
+#: pkg/shell/indexes.js:410
 msgid "Connecting to the machine"
 msgstr "Ansluter till maskinen"
 
-#: pkg/kubernetes/index.html:104 pkg/kubernetes/registry.html:71
-msgid "Connecting..."
-msgstr "Ansluter …"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:573
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Anslutning"
 
-#: pkg/kubernetes/views/auth-dialog.html:4 pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:406
 msgid "Connection Error"
 msgstr "Anslutningsfel"
-
-#: pkg/kubernetes/scripts/connection.js:512
-msgid "Connection Error: $0"
-msgstr "Anslutningsfel: $0"
-
-#: pkg/kubernetes/views/auth-dialog.html:3
-msgid "Connection Settings"
-msgstr "Anslutningsinställningar"
 
 #: src/base1/cockpit.js:4027
 msgid "Connection has timed out."
@@ -1991,34 +1657,23 @@ msgstr "Konsoltyp"
 msgid "Consoles"
 msgstr "Konsoler"
 
-#: pkg/realmd/operation.js:274
+#: pkg/realmd/operation.js:273
 msgid "Contacted domain"
 msgstr ""
 
-#: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
-#: pkg/kubernetes/views/container-page-inline.html:2
-#: pkg/kubernetes/views/container-panel.html:4
-#: pkg/kubernetes/views/image-page.html:23
+#: pkg/docker/console.html:4
 #: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Behållare"
 
-#: pkg/users/local.js:748
+#: pkg/users/local.js:752
 msgid "Container Administrator"
 msgstr "Behållaradministratör"
 
-#: pkg/kubernetes/views/container-body.html:10
-msgid "Container ID"
-msgstr "Behållar-ID"
-
-#: pkg/docker/index.html:438 pkg/docker/index.html:618
-#: pkg/docker/index.html:682
+#: pkg/docker/index.html:440 pkg/docker/index.html:620
+#: pkg/docker/index.html:684
 msgid "Container Name"
 msgstr "Behållarnamn"
-
-#: pkg/kubernetes/views/node-body.html:21
-msgid "Container Runtime Version"
-msgstr "Behållarnas körtidsversion"
 
 #: pkg/docker/util.js:506
 msgid ""
@@ -2031,15 +1686,12 @@ msgstr ""
 msgid "Container is currently running."
 msgstr "Behållaren kör för närvarande."
 
-#: pkg/docker/index.html:141
+#: pkg/docker/index.html:133
 msgid "Container:"
 msgstr "Behållare:"
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:287
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
-#: pkg/kubernetes/views/dashboard-page.html:158
-#: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:375
+#: pkg/docker/index.html:23 pkg/docker/index.html:289
+#: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "Behållare"
 
@@ -2053,12 +1705,12 @@ msgid "Content"
 msgstr "Innehåll"
 
 #: src/base1/test-locale.js:42 src/base1/test-locale.js:53
-#: pkg/playground/translate.js:22
+#: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Styrning"
 
 #: src/base1/test-locale.js:43 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:25
+#: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
 msgstr "Styrning"
@@ -2072,7 +1724,6 @@ msgid "Copy"
 msgstr ""
 
 #: pkg/machines/components/vcpuModal.jsx:209
-#: pkg/ovirt/components/vcpuModal.jsx:67
 msgid "Cores per socket"
 msgstr "Kärnor per sockel"
 
@@ -2083,18 +1734,6 @@ msgstr "Kunde inte lägga till alla diskar"
 #: pkg/lib/machine-change-port.html:4
 msgid "Could not contact {{host}}"
 msgstr "Kunde inte kontakta {{host}}"
-
-#: pkg/kubernetes/views/dashboard-page.html:142
-msgid "Could not list services"
-msgstr "Kunde inte lista tjänster"
-
-#: src/ws/cockpitcertificate.c:531
-msgid "Could not parse PEM-encoded certificate"
-msgstr "Kunde inte tolka PEM-kodat certifikat"
-
-#: src/ws/cockpitcertificate.c:498
-msgid "Could not parse PEM-encoded private key"
-msgstr "Kunde inte tolka PEM-kodad privat nyckel"
 
 #: pkg/docker/storage.jsx:468
 msgid "Could not reset the storage pool"
@@ -2108,30 +1747,13 @@ msgstr "Kunde inte ändra användarens grupper"
 msgid "Couldn't change user password"
 msgstr "Kunde inte ändra användarens lösenord"
 
-#: pkg/kubernetes/index.html:105 pkg/kubernetes/registry.html:72
-msgid "Couldn't connect to server"
-msgstr "Kunde inte ansluta till servern"
-
-#: pkg/shell/indexes.js:414
+#: pkg/shell/indexes.js:413
 msgid "Couldn't connect to the machine"
 msgstr "Kunde inte ansluta till maskinen"
 
 #: src/bridge/cockpitdbussetup.c:544
 msgid "Couldn't create new users"
 msgstr "Kunde inte skapa nya användare"
-
-#: pkg/kubernetes/scripts/connection.js:510
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:957
-msgid "Couldn't find running API server"
-msgstr "Kunde inte hitta en körande API-server"
-
-#: pkg/subscriptions/subscriptions-view.jsx:218
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr ""
-"Kunde inte få fram systemets prenumerationsstatus.  Se till att subscription-"
-"manager är installerad."
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -2153,14 +1775,12 @@ msgstr "Kraschdumpplats"
 msgid "Crash system"
 msgstr "Krashsystem"
 
-#: pkg/kubernetes/views/add-group-dialog.html:19
-#: pkg/kubernetes/views/project-modify.html:72 pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:657
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:488
-#: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/users/index.html:199
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Skapa"
 
@@ -2168,17 +1788,13 @@ msgstr "Skapa"
 msgid "Create Logical Volume"
 msgstr "Skapa en logisk volym"
 
-#: pkg/machines/components/diskAdd.jsx:487
+#: pkg/machines/components/diskAdd.jsx:515
 msgid "Create New"
 msgstr "Skapa ny"
 
 #: pkg/users/index.html:52 pkg/users/index.html:163
 msgid "Create New Account"
 msgstr "Skapa ett nytt konto"
-
-#: pkg/ovirt/components/App.jsx:162
-msgid "Create New VM"
-msgstr "Skapa en ny VM"
 
 #: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
 msgid "Create Partition"
@@ -2204,7 +1820,7 @@ msgstr "Skapa en rapport"
 msgid "Create Snapshot"
 msgstr "Skapa en ögonblicksbild"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:522
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
 msgid "Create Storage Pool"
 msgstr "Skapa en lagringspool"
 
@@ -2224,8 +1840,7 @@ msgstr "Skapa timrar"
 msgid "Create VDO Device"
 msgstr "Skapa en VDO-enhet"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:690
-#: pkg/ovirt/components/ClusterTemplates.jsx:81
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
 msgid "Create VM"
 msgstr "Skapa en VM"
 
@@ -2237,14 +1852,6 @@ msgstr "Skapa en volymgrupp"
 msgid "Create diagnostic report"
 msgstr "Skapa en diagnostisk rapport"
 
-#: pkg/kubernetes/scripts/images.js:643
-msgid "Create empty image stream"
-msgstr "Skapa en tom avbildsström"
-
-#: pkg/kubernetes/views/imagestream-modify.html:3
-msgid "Create image stream"
-msgstr "Skapa en avbildsström"
-
 #: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
 #: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
 msgid "Create it"
@@ -2254,16 +1861,12 @@ msgstr "Skapa den"
 msgid "Create new Logical Volume"
 msgstr "Skapa en ny logisk volym"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/kubernetes/views/replicationcontroller-body.html:7
-#: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:129
-#: pkg/docker/containers-view.jsx:412 pkg/docker/containers-view.jsx:683
+#: pkg/docker/containers-view.jsx:129 pkg/docker/containers-view.jsx:412
+#: pkg/docker/containers-view.jsx:683
 msgid "Created"
 msgstr "Skapad"
 
-#: pkg/docker/index.html:152
+#: pkg/docker/index.html:153
 msgid "Created:"
 msgstr "Skapad:"
 
@@ -2323,7 +1926,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Skapar en volymgrupp $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:559
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
 msgid "Creation of VM $0 failed"
 msgstr ""
 
@@ -2331,7 +1934,7 @@ msgstr ""
 msgid "Critical and above"
 msgstr "Kritisk och högre"
 
-#: pkg/machines/components/vnc.jsx:110
+#: pkg/machines/components/vnc.jsx:109
 msgid "Ctrl+Alt+Del"
 msgstr "Ctrl+Alt+Del"
 
@@ -2351,23 +1954,19 @@ msgstr "Nuvarande uppstart"
 msgid "Custom"
 msgstr "Anpassat"
 
-#: pkg/networkmanager/firewall.jsx:521
+#: pkg/networkmanager/firewall.jsx:523
 msgid "Custom Ports"
 msgstr ""
-
-#: pkg/subscriptions/subscriptions-register.jsx:103
-msgid "Custom URL"
-msgstr "Anpassad URL"
 
 #: pkg/storaged/format-dialog.jsx:118
 msgid "Custom encryption options"
 msgstr "Anpassade krypteringsalternativ"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Anpassade monteringsalternativ"
 
-#: pkg/networkmanager/firewall.jsx:716
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Custom zones"
 msgstr ""
 
@@ -2387,10 +1986,6 @@ msgstr "DNS"
 #: pkg/networkmanager/interfaces.js:2656
 msgid "DNS $val"
 msgstr "DNS $val"
-
-#: pkg/kubernetes/views/pod-body.html:14
-msgid "DNS Policy"
-msgstr "DNS-policy"
 
 #: pkg/networkmanager/interfaces.js:3320
 msgid "DNS Search Domains"
@@ -2412,8 +2007,8 @@ msgstr "Panel"
 msgid "Data Used"
 msgstr "Data använt"
 
-#: pkg/machines/components/networks/network.jsx:143
-#: pkg/machines/components/storagePools/storagePool.jsx:163
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Avaktivera"
@@ -2434,10 +2029,9 @@ msgstr "Felsökning och högre"
 msgid "Deduplication"
 msgstr "Avduplicering"
 
-#: pkg/docker/index.html:357 pkg/docker/index.html:361
+#: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: node_modules/registry-image-widgets/views/image-config.html:10
 #: pkg/storaged/format-dialog.jsx:68
-#: pkg/subscriptions/subscriptions-register.jsx:102
 msgid "Default"
 msgstr "Standard"
 
@@ -2445,37 +2039,26 @@ msgstr "Standard"
 msgid "Delay"
 msgstr "Fördröjning"
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:246
-#: pkg/kubernetes/views/image-delete.html:8
-#: pkg/kubernetes/views/imagestream-delete.html:8
-#: pkg/kubernetes/views/item-delete.html:11
-#: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/project-delete.html:9
-#: pkg/kubernetes/views/pv-delete.html:11
-#: pkg/kubernetes/views/pvc-delete.html:15
-#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/machines/components/networks/networkDelete.jsx:86
+#: pkg/machines/components/networks/networkDelete.jsx:103
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:300 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:214 pkg/storaged/vgroup-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Ta bort"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1179
+#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Ta bort $0"
-
-#: pkg/playground/translate.html:189
-msgid "Delete '{{ name }}'"
-msgstr "Ta bort”{{ name }}”"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
 msgid "Delete Content"
@@ -2485,25 +2068,10 @@ msgstr ""
 msgid "Delete Files"
 msgstr "Ta bort filer"
 
-#: pkg/kubernetes/views/node-delete.html:4
-msgid "Delete Node"
-msgstr "Ta bort en nod"
-
-#: pkg/kubernetes/views/pv-delete.html:3
-msgid "Delete Persistent Volume"
-msgstr "Ta bort en beständig volym"
-
-#: pkg/kubernetes/views/pvc-delete.html:3
-msgid "Delete Persistent Volume Claim"
-msgstr "Ta bort anspråk på en beständig volym"
-
-#: pkg/kubernetes/views/project-delete.html:3
-msgid "Delete Project"
-msgstr "Ta bort ett projekt"
-
-#: pkg/kubernetes/views/nodes-page.html:3
-msgid "Delete Selected"
-msgstr "Ta bort det valda"
+#: pkg/machines/components/networks/networkDelete.jsx:92
+#, fuzzy
+msgid "Delete Network $0"
+msgstr "Ta bort $0"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
 msgid "Delete Storage Pool $0"
@@ -2513,17 +2081,9 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr "Ta bort assoicierade lagringsfiler:"
 
-#: pkg/kubernetes/views/imagestream-delete.html:3
-msgid "Delete image stream"
-msgstr "Ta bort en avbildsström"
-
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
-
-#: pkg/kubernetes/views/item-delete.html:3
-msgid "Delete {{ item.kind }}"
-msgstr "Ta bort en {{ item.kind }}"
 
 #: pkg/storaged/jobs-panel.jsx:53 pkg/storaged/jobs-panel.jsx:67
 msgid "Deleting $target"
@@ -2537,15 +2097,7 @@ msgstr ""
 "Att ta bort <b>$0</b> kommer bryta anslutningen till servern, och kommer "
 "göra administrationsgränssnittet otillgängligt."
 
-#: pkg/kubernetes/views/item-delete.html:7
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr ""
-"Att ta bort en kapsel kommer döda tillhörande behållare.  Kapslar kan "
-"automatiskt skapas igen i några fall."
-
-#: pkg/storaged/mdraid-details.jsx:301
+#: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "Att ta bort en RAID-enhet kommer att radera all data på den."
 
@@ -2553,7 +2105,7 @@ msgstr "Att ta bort en RAID-enhet kommer att radera all data på den."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Att ta bort en VDO-enhet kommer att ta bort all data på den."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "Att ta bort en behållare kommer att radera all data i den."
 
@@ -2565,7 +2117,7 @@ msgstr "Att ta bort en logisk volym kommer att ta bort all data i den."
 msgid "Deleting a partition will delete all data in it."
 msgstr "Att ta bort en partition kommer att ta bort all data i den."
 
-#: pkg/storaged/vgroup-details.jsx:213
+#: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
 msgstr "Att ta bort en volymgrupp kommer att radera all data i den."
 
@@ -2579,44 +2131,11 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Tar bort volymgruppen $target"
 
-#: pkg/kubernetes/views/dashboard-page.html:131
-#: pkg/kubernetes/views/deploy.html:62
-msgid "Deploy"
-msgstr "Placera ut"
-
-#: pkg/kubernetes/views/deploy.html:3
-msgid "Deploy Application"
-msgstr "Placera ut ett program"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:22
-msgid "Deployment Causes"
-msgstr "Utplaceringsorsaker"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:12
-#: pkg/kubernetes/views/deploymentconfig-panel.html:8
-msgid "Deployment Config"
-msgstr "Utplaceringskonfiguration"
-
-#: pkg/kubernetes/views/details-page.html:98
-#: pkg/kubernetes/scripts/details.js:220
-msgid "Deployment Configs"
-msgstr "Utplaceringskonfigurationer"
-
-#: pkg/kubernetes/views/project-listing.html:15
-#: pkg/kubernetes/views/project-listing.html:54
-#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:413
+#: pkg/systemd/services.html:413
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:725
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
 msgid "Description"
 msgstr "Beskrivning"
-
-#: pkg/ovirt/components/OVirtTab.jsx:146
-#: pkg/ovirt/components/VmOverviewColumn.jsx:52
-msgid "Description:"
-msgstr "Beskrivning:"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2626,16 +2145,15 @@ msgstr "Skrivbord"
 msgid "Detachable"
 msgstr "Frånkopplingsbar"
 
-#: pkg/kubernetes/index.html:67 pkg/shell/index.html:229
-#: pkg/docker/containers-view.jsx:336 pkg/docker/containers-view.jsx:504
-#: pkg/docker/containers-view.jsx:514 pkg/docker/containers-view.jsx:642
-#: pkg/networkmanager/firewall.jsx:94 pkg/packagekit/updates.jsx:383
-#: pkg/subscriptions/subscriptions-view.jsx:232 pkg/systemd/host.js:745
+#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
+#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Detaljer"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2657,7 +2175,6 @@ msgstr "Diagnostikrapporter"
 msgid "Digest"
 msgstr "Kontrollsumma"
 
-#: pkg/kubernetes/views/volume-body.html:28
 #: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
@@ -2688,8 +2205,8 @@ msgstr "Avaktiverad"
 msgid "Disconnect"
 msgstr "Koppla ifrån"
 
-#: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:108
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:604
+#: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
+#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
 msgid "Disconnected"
 msgstr "Frånkopplad"
 
@@ -2697,7 +2214,6 @@ msgstr "Frånkopplad"
 msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr "Frånkopplad från seriekonsolen.  Klicka på återanslutknappen."
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:836
 #: pkg/storaged/vdos-panel.jsx:55
 msgid "Disk"
 msgstr "Disk"
@@ -2710,15 +2226,11 @@ msgstr ""
 msgid "Disk I/O"
 msgstr "Disk-I/O"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "Diskanvändning: $0 %"
-
-#: pkg/machines/components/diskAdd.jsx:461
+#: pkg/machines/components/diskAdd.jsx:489
 msgid "Disk failed to be attached"
 msgstr "Disken kunde inte anslutas"
 
-#: pkg/machines/components/diskAdd.jsx:443
+#: pkg/machines/components/diskAdd.jsx:468
 msgid "Disk failed to be created"
 msgstr "Disken kunde inte skapas"
 
@@ -2730,9 +2242,9 @@ msgstr "Disken är OK"
 msgid "Disk passphrase"
 msgstr "Disklösenfras"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Diskar"
 
@@ -2741,60 +2253,9 @@ msgid "Disks cannot be removed from $0 VMs"
 msgstr ""
 
 #: pkg/shell/index.html:52 pkg/shell/index.html:114 pkg/shell/simple.html:38
-#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
+#: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Visningsspråk"
-
-#: pkg/kubernetes/views/project-modify.html:31
-msgid "Display name"
-msgstr "Visningsnamn"
-
-#: pkg/kubernetes/views/add-role-dialog.html:5
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "Vill du lägga till rollen ”{{ fields.displayRole }}”?"
-
-#: pkg/kubernetes/views/imagestream-delete.html:5
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr ""
-"Vill du ta bort avbildsströmmen ”{{stream.metadata.namespace}}/{{stream."
-"metadata.name}}”?"
-
-#: pkg/kubernetes/views/pv-delete.html:6
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "Vill du ta bort den beständiga volymen ”{{item.metadata.name}}”?"
-
-#: pkg/kubernetes/views/pvc-delete.html:6
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr ""
-"Vill du ta bort anspråket på den beständiga volymen ”{{item.metadata."
-"name}}”?"
-
-#: pkg/kubernetes/views/item-delete.html:6
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "Vill du ta bort {{ item.kind }} ”{{item.metadata.name}}”?"
-
-#: pkg/kubernetes/views/node-delete.html:7
-msgid "Do you want to delete this Node?"
-msgstr "Vill du ta bort denna nod?"
-
-#: pkg/kubernetes/views/image-delete.html:5
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"Vill du ta bort avbilden med etiketten ”{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}”?"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:5
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
-msgstr ""
-"Vill du ta bort rollen ”{{ fields.displayRole }}” från medlemmen {{ fields."
-"member.metadata.name }}?"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2809,15 +2270,15 @@ msgid "Docking Station"
 msgstr "Dockningsstation"
 
 #: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
-#: pkg/realmd/operation.js:123
+#: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Domän"
 
-#: pkg/realmd/operation.js:192
+#: pkg/realmd/operation.js:191
 msgid "Domain $0 could not be contacted"
 msgstr "Domänen $0 kunde inte kontaktas"
 
-#: pkg/realmd/operation.js:279
+#: pkg/realmd/operation.js:278
 msgid "Domain $0 is not supported"
 msgstr "Domänen $0 stödjs inte"
 
@@ -2842,15 +2303,11 @@ msgstr "Upprepa inte"
 msgid "Don't overwrite existing data"
 msgstr "Skriv inte över befintliga data"
 
-#: pkg/kubernetes/scripts/images.js:633
-msgid "Don't pull images automatically"
-msgstr "Hämta inte avbilder automatiskt"
-
 #: pkg/sosreport/index.html:63
 msgid "Done!"
 msgstr "Klar!"
 
-#: pkg/docker/index.html:598
+#: pkg/docker/index.html:600
 msgid "Download"
 msgstr "Hämta"
 
@@ -2887,11 +2344,7 @@ msgctxt "storage"
 msgid "Drive"
 msgstr "Enhet"
 
-#: pkg/kubernetes/views/volume-body.html:128
-msgid "Driver"
-msgstr "Drivrutin"
-
-#: pkg/storaged/drives-panel.jsx:119
+#: pkg/storaged/drives-panel.jsx:120
 msgid "Drives"
 msgstr "Enheter"
 
@@ -2920,10 +2373,6 @@ msgstr "Redigera Tang-nyckelserver"
 msgid "Edit image stream"
 msgstr "Redigera avbildsström"
 
-#: pkg/ovirt/components/VdsmView.jsx:125
-msgid "Edit the vdsm.conf"
-msgstr "Redigera vdsm.conf"
-
 #: pkg/storaged/crypto-keyslots.jsx:535
 msgid "Editing a key requires a free slot"
 msgstr "Att redigera en nyckel kräver ett fritt fack"
@@ -2937,25 +2386,21 @@ msgid "Embedded PC"
 msgstr "Inbäddad PC"
 
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:13
+#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Tom"
 
 #: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:19
+#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Töm"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "Tom katalog"
 
 #: pkg/storaged/jobs-panel.jsx:75
 msgid "Emptying $target"
 msgstr "Tömmer $target"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:151
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:162
 msgid "Emulated Machine"
 msgstr ""
 
@@ -3016,23 +2461,6 @@ msgstr "Kryptering"
 msgid "Encryption Options"
 msgstr "Krypteringsalternativ"
 
-#: pkg/kubernetes/views/pv-modify.html:93
-msgid "Endpoint"
-msgstr "Ändpunkt"
-
-#: pkg/kubernetes/views/volume-body.html:40
-msgid "Endpoint Name"
-msgstr "Ändpunktsnamn"
-
-#: pkg/kubernetes/views/service-page.html:14
-#: pkg/kubernetes/views/service-panel.html:9
-msgid "Endpoints"
-msgstr "Ändpunkter"
-
-#: pkg/subscriptions/subscriptions-view.jsx:39
-msgid "Ends"
-msgstr "Slutar"
-
 #: pkg/selinux/setroubleshoot-view.jsx:299
 msgid "Enforce policy:"
 msgstr "Tvingande policy:"
@@ -3045,10 +2473,6 @@ msgstr "Förbättringsuppdateringar är tillgängliga"
 msgid "Enter IP address or host name"
 msgstr "Ange en IP-adress eller ett värdnamn"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:74
-msgid "Enter New VM name"
-msgstr "Ange nytt VM-namn"
-
 #: pkg/lib/machine-change-auth.html:57
 msgid ""
 "Entering a different password here means you will need to retype it every "
@@ -3057,7 +2481,7 @@ msgstr ""
 "Att ange ett annat lösenord här innebär att du kommer behöva skriva in det "
 "igen varje gång du återansluter till denna maskin"
 
-#: pkg/networkmanager/firewall.jsx:752
+#: pkg/networkmanager/firewall.jsx:754
 msgid "Entire subnet"
 msgstr ""
 
@@ -3069,7 +2493,7 @@ msgstr "Post"
 msgid "Entrypoint"
 msgstr "Ingångspunkt"
 
-#: pkg/docker/index.html:526 pkg/kubernetes/views/container-body.html:26
+#: pkg/docker/index.html:528
 #: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Miljö"
@@ -3091,19 +2515,15 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1472
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Fel"
 
 #: pkg/systemd/logs.html:59
 msgid "Error and above"
 msgstr "Fel och högre"
-
-#: pkg/kubernetes/scripts/connection.js:646
-msgid "Error getting certificate details: $0"
-msgstr "Fel när certifikatdetaljer hämtades: $0"
 
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
@@ -3125,10 +2545,6 @@ msgstr "Fel när larmet togs bort: $0"
 msgid "Error while setting SELinux mode: '$0'"
 msgstr "Fel när SELinux-läge ställdes in: ”$0”"
 
-#: pkg/kubernetes/scripts/connection.js:85
-msgid "Error writing kubectl config"
-msgstr "Fel när konfiguration av kubectl skrevs"
-
 #: pkg/networkmanager/index.html:658
 msgid "Ethernet MAC"
 msgstr "Ethernet-MAC"
@@ -3145,23 +2561,23 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Allting"
 
-#: pkg/networkmanager/firewall.jsx:534
+#: pkg/networkmanager/firewall.jsx:536
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:542
+#: pkg/networkmanager/firewall.jsx:544
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
-#: pkg/users/local.js:473 pkg/users/local.js:1417
+#: pkg/users/local.js:477 pkg/users/local.js:1421
 msgid "Excellent password"
 msgstr "Utmärkt lösenord"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:222
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
 msgid "Existing Disk Image"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -3173,7 +2589,7 @@ msgstr "Avslutade $ExitCode"
 msgid "Expansion Chassis"
 msgstr "Expansionschassin"
 
-#: pkg/docker/index.html:508
+#: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "Exponerade behållarportar"
 
@@ -3185,14 +2601,6 @@ msgstr "Utökad partition"
 msgid "FAILED"
 msgstr "MISSLYCKADES"
 
-#: pkg/ovirt/provider.js:130
-msgid "FORCEOFF action failed: $0"
-msgstr ""
-
-#: pkg/ovirt/components/InstallationDialog.jsx:47
-msgid "FQDN"
-msgstr "FQDN"
-
 #: pkg/networkmanager/interfaces.js:842
 msgid "Failed"
 msgstr "Misslyckades"
@@ -3202,14 +2610,19 @@ msgid "Failed to add machine: $0"
 msgstr "Misslyckades att lägga till en maskin: $0"
 
 #: pkg/networkmanager/firewall.jsx:237
+#, fuzzy
+msgid "Failed to add port"
+msgstr "Misslyckades att ändra lösenord"
+
+#: pkg/networkmanager/firewall.jsx:237
 msgid "Failed to add service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:679
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Misslyckades att ändra lösenord"
 
@@ -3233,11 +2646,15 @@ msgstr "Misslyckades att redigera en makin: $0"
 msgid "Failed to enable tuned"
 msgstr "Misslyckades att aktivera tuned"
 
+#: pkg/machines/components/vmnetworktab.jsx:55
+msgid "Failed to fetch the IP addresses of the interfaces present in $0"
+msgstr ""
+
 #: pkg/users/index.html:393
 msgid "Failed to load authorized keys."
 msgstr "Misslyckades att läsa in auktoriserade nycklar."
 
-#: pkg/networkmanager/firewall.jsx:589
+#: pkg/networkmanager/firewall.jsx:591
 msgid "Failed to remove service"
 msgstr ""
 
@@ -3256,10 +2673,6 @@ msgstr "Misslyckades att byta profil"
 #: pkg/machines/components/vcpuModal.jsx:193
 msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr "Färre än det maximala antalet virtuella CPU:er skall vara aktiverade."
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "Fiberkanal"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:92
 #: pkg/machines/components/vmDiskColumns.jsx:42
@@ -3282,22 +2695,11 @@ msgstr "Filsystemmontering"
 msgid "Filesystem Name"
 msgstr "Filsystemsnamn"
 
-#: pkg/kubernetes/views/pv-modify.html:181
-#: pkg/kubernetes/views/volume-body.html:6
-#: pkg/kubernetes/views/volume-body.html:16
-#: pkg/kubernetes/views/volume-body.html:62
-#: pkg/kubernetes/views/volume-body.html:83
-#: pkg/kubernetes/views/volume-body.html:91
-#: pkg/kubernetes/views/volume-body.html:120
-#: pkg/kubernetes/views/volume-body.html:132
-msgid "Filesystem Type"
-msgstr "Filsystemstyp"
-
 #: pkg/storaged/fsys-panel.jsx:103
 msgid "Filesystems"
 msgstr "Filsystem"
 
-#: pkg/networkmanager/firewall.jsx:490
+#: pkg/networkmanager/firewall.jsx:491
 msgid "Filter Services"
 msgstr "Filtrera tjänster"
 
@@ -3305,30 +2707,18 @@ msgstr "Filtrera tjänster"
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Fingeravtryck"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:913 pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
 msgid "Firewall"
 msgstr "Brandvägg"
 
-#: pkg/networkmanager/firewall.jsx:861
+#: pkg/networkmanager/firewall.jsx:863
 msgid "Firewall is not available"
 msgstr "Brandväggen är inte tillgänglig"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "Flex"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/views/volume-body.html:125
-msgid "Flocker Dataset Name"
-msgstr "Flockers datamängdsnamn"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:35
 msgid "Follows docker repo"
@@ -3362,10 +2752,9 @@ msgstr "Framtvinga lösenordsändring"
 msgid "Force remove passphrase in $0"
 msgstr "Framtvinga borttagande av lösenfras i $0"
 
-#: pkg/machines/components/diskAdd.jsx:167
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:258
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formater"
 
@@ -3426,11 +2815,7 @@ msgstr "Från"
 msgid "Full Name"
 msgstr "Fullständigt namn"
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "GCE beständig disk"
-
-#: pkg/docker/index.html:183
+#: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "Gateway:"
 
@@ -3447,25 +2832,13 @@ msgstr "Genererar en rapport"
 msgid "Get new image"
 msgstr "Hämta ny avbild"
 
-#: pkg/machines/components/diskAdd.jsx:162
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Git-förråd"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster-FS"
-
-#: pkg/kubernetes/scripts/volumes.js:877
-msgid "GlusterFS"
-msgstr "GlusterFS"
 
 #: pkg/systemd/logs.js:199
 msgid "Go to"
@@ -3481,13 +2854,6 @@ msgstr "Gå till programmet"
 msgid "Go to now"
 msgstr "Gå till nu"
 
-#: pkg/kubernetes/views/project-body.html:3
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Grant additional push or admin access to specific members below."
-msgstr ""
-"Ge ytterligare push- eller admin-åtkomst till de specifika medlemmarna nedan."
-""
-
 #: pkg/machines/components/consoles.jsx:51
 msgid "Graphics Console (VNC)"
 msgstr "Grafisk konsol (VNC)"
@@ -3495,20 +2861,6 @@ msgstr "Grafisk konsol (VNC)"
 #: pkg/machines/components/consoles.jsx:60
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Grafisk konsol i skrivbordsvisare"
-
-#: pkg/kubernetes/views/group-page.html:21
-#: pkg/kubernetes/views/group-panel.html:12
-msgid "Group Members"
-msgstr "Gruppmedlemmar"
-
-#: pkg/kubernetes/views/user-add-membership.html:9
-msgid "Group or Project"
-msgstr "Grupp eller projekt"
-
-#: pkg/kubernetes/views/project-listing.html:48
-#: pkg/kubernetes/views/user-delete.html:14
-msgid "Groups"
-msgstr "Grupper"
 
 #: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
 #: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
@@ -3531,15 +2883,6 @@ msgstr "Utöka den logiska storleken av $0"
 #: pkg/storaged/vdo-details.jsx:130
 msgid "Grow to take all space"
 msgstr "Utöka till att ta allt utrymme"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "HA"
-msgstr "HA"
-
-#: pkg/ovirt/components/OVirtTab.jsx:128
-msgid "HA:"
-msgstr "HA:"
 
 #: pkg/networkmanager/index.html:252
 msgid "Hair Pin mode"
@@ -3574,19 +2917,14 @@ msgstr "Hårdvaruinformation"
 msgid "Hello time $hello_time"
 msgstr "Hälsningstid $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:73
-#: pkg/kubernetes/views/route-body.html:9
-#: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:150
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47
-#: pkg/ovirt/components/App.jsx:103 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:334
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Värd"
 
@@ -3595,29 +2933,21 @@ msgid "Host Device"
 msgstr ""
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:155
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
 msgid "Host Name"
 msgstr "Värdnamn"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:869
-msgid "Host Path"
-msgstr "Värdsökväg"
 
 #: src/base1/cockpit.js:4023
 msgid "Host key is incorrect"
 msgstr "Värdnyckeln är felaktig"
 
-#: pkg/realmd/operation.js:602
+#: pkg/realmd/operation.js:601
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:161
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
 msgid "Host should not be empty"
 msgstr "Värden får inte vara tom"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:75
-msgid "Host to Maintenance"
-msgstr "Värd till underhåll"
 
 #: pkg/systemd/services.html:499
 msgid "Hour : Minute"
@@ -3635,24 +2965,20 @@ msgstr "Timmar"
 msgid "I/O Wait"
 msgstr "I/O-väntan"
 
-#: pkg/kubernetes/views/node-body.html:10
-#: pkg/kubernetes/views/service-body.html:9
-msgid "IP"
-msgstr "IP"
-
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
+#: pkg/machines/components/vmnetworktab.jsx:133
 msgid "IP Address"
 msgstr "IP-adress"
 
-#: pkg/docker/index.html:175
+#: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "IP-adress:"
 
-#: pkg/docker/index.html:179
+#: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "IP-prefixlängd:"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "IP Range"
 msgstr ""
 
@@ -3684,10 +3010,6 @@ msgstr ""
 msgid "IPv6 Settings"
 msgstr "IPv6-inställningar"
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:873
-msgid "ISCSI"
-msgstr "ISCSI"
-
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
@@ -3696,7 +3018,7 @@ msgstr "Id"
 msgid "Id $id"
 msgstr "Id $id"
 
-#: pkg/docker/index.html:148
+#: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "Id:"
 
@@ -3704,17 +3026,6 @@ msgstr "Id:"
 #: node_modules/registry-image-widgets/views/image-listing.html:7
 msgid "Identifier"
 msgstr "Identifierare"
-
-#: pkg/kubernetes/views/user-page.html:22
-#: pkg/kubernetes/views/user-panel.html:18
-msgid "Identities"
-msgstr "Identiteter"
-
-#: pkg/kubernetes/views/add-user-dialog.html:17
-#: pkg/kubernetes/views/project-listing.html:91
-#: pkg/kubernetes/views/user-modify.html:17
-msgid "Identity"
-msgstr "Identitet"
 
 #: pkg/storaged/crypto-keyslots.jsx:325
 msgid "If tang-show-keys is not available, run the following:"
@@ -3724,9 +3035,7 @@ msgstr "Om tang-show-keys inte är tillgängligt, kör det följande:"
 msgid "Ignore"
 msgstr "Ignorera"
 
-#: pkg/docker/index.html:268 pkg/docker/index.html:431
-#: pkg/kubernetes/views/container-body.html:6
-#: pkg/kubernetes/views/image-page.html:15
+#: pkg/docker/index.html:270 pkg/docker/index.html:433
 #: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
@@ -3736,33 +3045,13 @@ msgstr "Avbild"
 msgid "Image $0"
 msgstr "Avbild $0"
 
-#: pkg/users/local.js:749
+#: pkg/users/local.js:753
 msgid "Image Builder"
 msgstr "Avbildsbyggare"
 
-#: pkg/kubernetes/views/container-body.html:8
-msgid "Image ID"
-msgstr "Avbilds-ID"
-
-#: pkg/kubernetes/views/volume-body.html:58
-msgid "Image Name"
-msgstr "Avbildsnamn"
-
-#: pkg/kubernetes/registry.html:23
-msgid "Image Registry"
-msgstr "Avbildsregister"
-
-#: pkg/docker/index.html:578
+#: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Avbildssökning"
-
-#: pkg/kubernetes/views/imagestream-page.html:16
-msgid "Image Stream"
-msgstr "Avbildsström"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:135
-msgid "Image commands"
-msgstr "Avbildskommandon"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:41
 msgid "Image count"
@@ -3772,14 +3061,10 @@ msgstr "Avbildsantal"
 msgid "Image stream"
 msgstr "Avbildsström"
 
-#: pkg/docker/index.html:156
+#: pkg/docker/index.html:157
 msgid "Image:"
 msgstr "Avbild:"
 
-#: pkg/kubernetes/index.html:81 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
-#: pkg/kubernetes/views/registry-dashboard-page.html:19
 #: pkg/docker/containers-view.jsx:711
 msgid "Images"
 msgstr "Avbilder"
@@ -3792,10 +3077,6 @@ msgstr "Avbilder"
 #: pkg/docker/containers-view.jsx:109
 msgid "Images and running containers"
 msgstr "Avbilder och körande behållare"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:17
-msgid "Images by project"
-msgstr "Avbilder per projekt"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:15
 #: node_modules/registry-image-widgets/views/imagestream-body.html:16
@@ -3813,11 +3094,7 @@ msgstr ""
 msgid "Images may only be pulled by specific users or groups"
 msgstr "Avbilder kan endast dras ner av specifika användare eller grupper"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:54
-msgid "Images pushed recently"
-msgstr "Avbilder trycktes upp nyligen"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:637
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
 msgstr "Starta VM:en omedelbart"
 
@@ -3825,24 +3102,11 @@ msgstr "Starta VM:en omedelbart"
 msgid "In Sync"
 msgstr "I synk"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:171
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
 msgstr ""
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:81
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr ""
-"För att börja trycka avbilder till registret, använd kommandona nedan."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:6
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr ""
-"För att börja trycka avbilder till registret behöver du skapa ett projekt."
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
@@ -3861,7 +3125,7 @@ msgstr "Inaktiv"
 msgid "Inactive volume"
 msgstr "Inaktiv volym"
 
-#: pkg/networkmanager/firewall.jsx:730
+#: pkg/networkmanager/firewall.jsx:732
 msgid "Included services"
 msgstr ""
 
@@ -3885,17 +3149,17 @@ msgstr "Information om Dockers lagringspool är inte tillgängligt."
 msgid "Initializing..."
 msgstr "Initierar …"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:177
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:188
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Installera"
 
@@ -3923,25 +3187,21 @@ msgstr "Installera VDO-stöd"
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "Installera setroubleshoot-server för att felsöka SELinux-händelser."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:226
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
 msgid "Installation Source"
 msgstr "Installationskälla"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:212
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
 msgid "Installation Source Type"
 msgstr "Installatinskälltyp"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:113
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
 msgid "Installation Source should not be empty"
 msgstr "Installationskällan skall inte vara tom"
 
 #: pkg/packagekit/updates.jsx:59
 msgid "Installed"
 msgstr "Installerad"
-
-#: pkg/subscriptions/subscriptions-view.jsx:245
-msgid "Installed products"
-msgstr "Installerade produkter"
 
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:51
@@ -3956,17 +3216,13 @@ msgstr "Installerar $0"
 msgid "Instantiate"
 msgstr "Instatiera"
 
-#: pkg/kubernetes/views/pv-modify.html:170
-#: pkg/kubernetes/views/volume-body.html:81
-msgid "Interface"
-msgstr "Gränssnitt"
-
 #: pkg/machines/components/nicEdit.jsx:123
 msgid "Interface Type"
 msgstr ""
 
-#: pkg/networkmanager/index.html:108 pkg/networkmanager/firewall.jsx:735
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Gränssnitt"
 
@@ -3982,15 +3238,11 @@ msgstr "Internt fel"
 msgid "Invalid address $0"
 msgstr "Felaktig adress $0"
 
-#: pkg/subscriptions/subscriptions-client.js:195
-msgid "Invalid credentials"
-msgstr "Felaktiga kreditiv"
-
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Felaktigt datumformat"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Felaktigt datumformat och felaktigt tidsformat"
 
@@ -3998,7 +3250,7 @@ msgstr "Felaktigt datumformat och felaktigt tidsformat"
 msgid "Invalid date format."
 msgstr "Felaktigt datumformat."
 
-#: pkg/users/local.js:1237
+#: pkg/users/local.js:1241
 msgid "Invalid expiration date"
 msgstr "Felaktigt utgångsdatum"
 
@@ -4006,7 +3258,7 @@ msgstr "Felaktigt utgångsdatum"
 msgid "Invalid file permissions"
 msgstr "Felaktiga filrättigheter"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
 msgid "Invalid filename"
 msgstr "Felaktigt filnamn"
 
@@ -4018,7 +3270,7 @@ msgstr "Felaktig nyckel"
 msgid "Invalid metric $0"
 msgstr "Felaktigt mått $0"
 
-#: pkg/users/local.js:1313
+#: pkg/users/local.js:1317
 msgid "Invalid number of days"
 msgstr "Felaktigt antal dagar"
 
@@ -4046,7 +3298,7 @@ msgstr "Felaktigt prefix eller nätmask $0"
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Felaktigt tidsformat"
 
@@ -4055,7 +3307,6 @@ msgid "Invalid time zone"
 msgstr "Felaktigt tidszon"
 
 #: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
-#: pkg/subscriptions/subscriptions-client.js:193
 msgid "Invalid username or password"
 msgstr "Felaktigt användarnamn eller lösenord"
 
@@ -4075,19 +3326,19 @@ msgstr ""
 msgid "Jobs"
 msgstr "Jobb"
 
-#: pkg/realmd/operation.js:117
+#: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "Gå med"
 
-#: pkg/realmd/operation.js:597
+#: pkg/realmd/operation.js:596
 msgid "Join Domain"
 msgstr "Gå med i domän"
 
-#: pkg/realmd/operation.js:116
+#: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "Gå med i en domän"
 
-#: pkg/realmd/operation.js:506
+#: pkg/realmd/operation.js:505
 msgid "Joining this domain is not supported"
 msgstr "Att gå med i denna domän stödjs inte"
 
@@ -4134,14 +3385,6 @@ msgstr "Kärnan"
 msgid "Kernel Dump"
 msgstr "Kärndump"
 
-#: pkg/kubernetes/views/node-body.html:19
-msgid "Kernel Version"
-msgstr "Kärnversion"
-
-#: pkg/kubernetes/views/volume-body.html:67
-msgid "Key Ring Path"
-msgstr "Nyckelringssökväg"
-
 #: pkg/storaged/crypto-keyslots.jsx:563
 msgid "Key slots with unknown types can not be edited here"
 msgstr "Nyckelfack med okända typer kan inte redigeras här"
@@ -4166,23 +3409,10 @@ msgstr "Nyckelserverns adress"
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "Att ta bort nyckelservern kan förhindra upplåsning av $0."
 
-#: pkg/kubernetes/views/node-body.html:23
-msgid "Kubelet Version"
-msgstr "Kubelet-version"
-
-#: pkg/kubernetes/index.html:23
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes-kluster"
-
 #: pkg/networkmanager/index.html:377
 msgid "LACP Key"
 msgstr "LACP-nyckel"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: pkg/kubernetes/views/replicationcontroller-body.html:17
-#: pkg/kubernetes/views/route-body.html:22
-#: pkg/kubernetes/views/service-body.html:26
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Etiketter"
@@ -4199,17 +3429,9 @@ msgstr "Senaste 24 timmarna"
 msgid "Last 7 days"
 msgstr "Senaste 7 datgarna"
 
-#: pkg/kubernetes/views/node-body.html:49
-msgid "Last Heartbeat"
-msgstr "Senaste hjärtslag"
-
 #: pkg/users/index.html:100
 msgid "Last Login"
 msgstr "Senaste inloggning"
-
-#: pkg/kubernetes/views/node-body.html:51
-msgid "Last Status Change"
-msgstr "Senaste statusändring"
 
 #: pkg/systemd/init.js:284
 msgid "Last Trigger"
@@ -4222,11 +3444,6 @@ msgstr "Senast uppdaterad"
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
 msgstr "Senast kontrollerad: $0 sedan"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
-#: pkg/kubernetes/views/details-page.html:107
-msgid "Latest Version"
-msgstr "Senaste version"
 
 #: pkg/machines/components/desktopConsole.jsx:128
 msgid "Launch Remote Viewer"
@@ -4242,23 +3459,22 @@ msgid ""
 "you enter a different username, that user will always be used when "
 "connecting to this machine."
 msgstr ""
-"Lämna tomt för att ansluta till denna maskin som den nu inloggade användaren."
-"  Om du anger ett annat användarnamn kommer den användaren alltid användas "
-"när man ansluter till denna maskin."
+"Lämna tomt för att ansluta till denna maskin som den nu inloggade "
+"användaren.  Om du anger ett annat användarnamn kommer den användaren alltid "
+"användas när man ansluter till denna maskin."
 
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Lämna tomt för att ansluta till denna maskin som den nu inloggade "
 "användaren{{#default_user}} ({{default_user}}){{/default_user}}.  Om du "
 "anger ett annat användarnamn kommer den användaren alltid användas när man "
 "ansluter till denna maskin."
 
-#: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
+#: pkg/shell/index.html:90 pkg/shell/simple.html:66
 msgid "Licensed under:"
 msgstr "Licensierad under:"
 
@@ -4282,7 +3498,7 @@ msgstr "Länk nere fördröjning"
 msgid "Link local"
 msgstr "Länklokal"
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:499
 msgid "Link to another container"
 msgstr "Länka till en annan behållare"
 
@@ -4290,11 +3506,11 @@ msgstr "Länka till en annan behållare"
 msgid "Link up delay"
 msgstr "Länk uppe fördröjning"
 
-#: pkg/docker/index.html:493
+#: pkg/docker/index.html:495
 msgid "Links"
 msgstr "Länkar"
 
-#: pkg/docker/index.html:195
+#: pkg/docker/index.html:196
 msgid "Links:"
 msgstr "Länkar:"
 
@@ -4318,13 +3534,9 @@ msgstr "Inläsningen av tillgängliga uppdateringar misslyckades"
 msgid "Loading available updates, please wait..."
 msgstr "Läser in tillgängliga uppdateringar, var god dröj …"
 
-#: pkg/ovirt/components/VdsmView.jsx:34
-msgid "Loading data ..."
-msgstr "Läser in data …"
-
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Läser in …"
 
@@ -4340,7 +3552,7 @@ msgstr "Lokala diskar"
 msgid "Local Filesystem"
 msgstr "Lokala filsystem"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:218
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
 msgid "Local Install Media"
 msgstr ""
 
@@ -4360,7 +3572,7 @@ msgstr "Lås"
 msgid "Lock Account"
 msgstr "Lås kontot"
 
-#: pkg/users/local.js:879 pkg/users/local.js:1218
+#: pkg/users/local.js:883 pkg/users/local.js:1222
 msgid "Lock account on $0"
 msgstr "Lås kontot på $0"
 
@@ -4372,7 +3584,7 @@ msgstr "Låser $target"
 msgid "Log In"
 msgstr "Logga in"
 
-#: pkg/shell/index.html:70 pkg/shell/simple.html:46 pkg/shell/stub.html:53
+#: pkg/shell/index.html:70 pkg/shell/simple.html:46
 msgid "Log Out"
 msgstr "Logga ut"
 
@@ -4388,19 +3600,11 @@ msgstr "Logga in på {{host}}"
 msgid "Log in with your server user account."
 msgstr "Logga in med ditt serveranvändarkonto."
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:116
-msgid "Log into OpenShift command line tools:"
-msgstr "Logga in till OpenShifts kommandoradsverktyg:"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:101
-msgid "Log into the registry:"
-msgstr "Logga in i registret:"
-
 #: pkg/systemd/index.html:65
 msgid "Log messages"
 msgstr "Loggmeddelanden"
 
-#: pkg/users/local.js:961
+#: pkg/users/local.js:965
 msgid "Logged In"
 msgstr "Inloggad"
 
@@ -4411,12 +3615,6 @@ msgstr "Logisk"
 #: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
 msgid "Logical Size"
 msgstr "Logisk storlek"
-
-#: pkg/kubernetes/views/pv-modify.html:159
-#: pkg/kubernetes/views/volume-body.html:79
-#: pkg/kubernetes/views/volume-body.html:118
-msgid "Logical Unit Number"
-msgstr "Logiskt enhetsnummer"
 
 #: pkg/storaged/utils.js:197
 msgid "Logical Volume"
@@ -4430,10 +3628,6 @@ msgstr "Logisk volym (ögonblicksbild)"
 msgid "Logical Volume of $0"
 msgstr "Logisk voly av $0"
 
-#: pkg/subscriptions/subscriptions-register.jsx:144
-msgid "Login"
-msgstr "Inloggning"
-
 #: src/ws/login.js:300
 msgid "Login Again"
 msgstr "Logga in igen"
@@ -4446,10 +3640,6 @@ msgstr ""
 msgid "Login Password"
 msgstr "Inloggningslösenord"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:96
-msgid "Login commands"
-msgstr "Inloggningskommandon"
-
 #: src/base1/cockpit.js:4015
 msgid "Login failed"
 msgstr "Inloggningen misslyckades"
@@ -4458,16 +3648,11 @@ msgstr "Inloggningen misslyckades"
 msgid "Login has escalated admin privileges"
 msgstr "Inloggningen har upphöjda administratörsprivilegier"
 
-#: pkg/subscriptions/subscriptions-client.js:199
-msgid "Login/password or activation key required to register."
-msgstr "Inloggning/lösenord eller aktiveringsnyckel krävs för att registrera."
-
 #: src/ws/login.js:301
 msgid "Logout Successful"
 msgstr "Utloggningen lyckades"
 
-#: pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82
 msgid "Logs"
 msgstr "Loggar"
 
@@ -4487,17 +3672,13 @@ msgstr "Lunchlåda"
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:102
+#: pkg/machines/components/vmnetworktab.jsx:132
 msgid "MAC Address"
 msgstr "MAC-adress"
 
-#: pkg/docker/index.html:187
+#: pkg/docker/index.html:188
 msgid "MAC Address:"
 msgstr "MAC-adress:"
-
-#: pkg/ovirt/provider.js:283
-msgid "MIGRATE action failed"
-msgstr "Åtgärden MIGRATE misslyckades"
 
 #: pkg/networkmanager/interfaces.js:1985
 msgid "MII (Recommended)"
@@ -4519,7 +3700,7 @@ msgstr ""
 msgid "Mac Address"
 msgstr "Mac-adress"
 
-#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:95
+#: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "Makin-ID"
 
@@ -4538,10 +3719,6 @@ msgstr "Huvudserverchassi"
 #: pkg/storaged/crypto-keyslots.jsx:319
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Se till att kontrollsumman för nyckeln från Tang-servern stämmer:"
-
-#: pkg/kubernetes/scripts/dashboard.js:457
-msgid "Manifest"
-msgstr "Förteckning"
 
 #: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
 msgid "Manual"
@@ -4599,16 +3776,6 @@ msgstr ""
 "Maximalt antal virtuella CPU:er allokerade till gäst-OS:et, vilket måste "
 "vara mellan 1 och $0"
 
-#: pkg/kubernetes/views/volume-body.html:34
-msgid "Medium"
-msgstr "Medium"
-
-#: pkg/kubernetes/views/project-listing.html:92
-#: pkg/kubernetes/views/user-body.html:4
-#: pkg/kubernetes/views/user-panel.html:27
-msgid "Member of"
-msgstr "Medlem i"
-
 #: pkg/storaged/content-views.jsx:345
 msgid "Member of RAID Device"
 msgstr "Medlem i RAID-enhet"
@@ -4617,26 +3784,11 @@ msgstr "Medlem i RAID-enhet"
 msgid "Member of RAID Device $0"
 msgstr "Medlem i RAID-enhet $0"
 
-#: pkg/kubernetes/views/project-listing.html:16
-#: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/index.html:266 pkg/networkmanager/interfaces.js:2986
-msgid "Members"
-msgstr "Medlemmar"
-
-#: pkg/kubernetes/views/project-page.html:29
-#: pkg/kubernetes/views/user-page.html:25
-#: pkg/kubernetes/views/user-panel.html:11
-msgid "Membership"
-msgstr "Medlemskap"
-
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:271
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:608
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:827
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:304
+#: pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
 #: pkg/machines/components/vmOverviewTab.jsx:74
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Memory"
 msgstr "Minne"
 
@@ -4649,38 +3801,32 @@ msgstr "Minne"
 msgid "Memory & Swap"
 msgstr "Minne och växling"
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "Minnesanvändning: $0 %"
-
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
 msgid "Memory could not be saved"
 msgstr ""
 
-#: pkg/docker/index.html:452 pkg/docker/index.html:624
+#: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "Minnesgräns"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#, fuzzy
+msgid "Memory must not be 0"
+msgstr "Minnesanvändning:"
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
 msgstr ""
 
-#: pkg/docker/index.html:210
+#: pkg/docker/index.html:211
 msgid "Memory usage:"
 msgstr "Minnesanvändning:"
-
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
-msgid "Message"
-msgstr "Meddelande"
 
 #: pkg/systemd/shutdown.js:79
 msgid "Message to logged in users"
 msgstr "Meddelande till inloggade användare"
 
-#: pkg/kubernetes/views/image-page.html:29
-#: pkg/kubernetes/views/imagestream-page.html:30
 #: node_modules/registry-image-widgets/views/image-panel.html:15
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
@@ -4690,17 +3836,13 @@ msgstr "Metadata"
 msgid "Metadata Used"
 msgstr "Metadata använt"
 
-#: pkg/docker/index.html:466 pkg/docker/index.html:638
-#: pkg/machines/components/diskAdd.jsx:159
-#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/docker/index.html:468 pkg/docker/index.html:640
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
-
-#: pkg/ovirt/components/OVirtTab.jsx:70
-msgid "Migrate To:"
-msgstr "Migrera till:"
 
 #: pkg/lib/machine-info.js:98
 msgid "Mini PC"
@@ -4730,13 +3872,9 @@ msgstr "Läge"
 msgid "Model"
 msgstr "Modell"
 
-#: pkg/machines/components/vmnetworktab.jsx:93
+#: pkg/machines/components/vmnetworktab.jsx:123
 msgid "Model type"
 msgstr "Modelltyp"
-
-#: pkg/kubernetes/views/user-modify.html:27
-msgid "Modify"
-msgstr "Modifiera"
 
 #: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:45
 #: pkg/storaged/jobs-panel.jsx:52
@@ -4759,11 +3897,7 @@ msgstr "Övervakningsintervall"
 msgid "Monitoring Targets"
 msgstr "Övervakningsmål"
 
-#: pkg/kubernetes/views/volume-body.html:54
-msgid "Monitors"
-msgstr "Övervakare"
-
-#: pkg/realmd/operation.js:530
+#: pkg/realmd/operation.js:529
 msgid "More"
 msgstr "Mera"
 
@@ -4776,31 +3910,27 @@ msgstr "Mer information"
 msgid "More details"
 msgstr "Fler detaljer"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Montering"
 
-#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
-msgid "Mount Location"
-msgstr "Monteringsplats"
-
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Monteringsflaggor"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Monteringspunkt"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Montera vid uppstart"
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:521
 msgid "Mount container volumes"
 msgstr "Montera behållarvolymer"
 
@@ -4816,7 +3946,7 @@ msgstr "Monteringspunkten får inte vara tom."
 msgid "Mount point must start with \"/\"."
 msgstr "Monteringspunkten måste börja med ”/”."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Montera skrivskyddat"
 
@@ -4840,11 +3970,7 @@ msgstr "Multisystemschassi"
 msgid "NAT to $0"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:865
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:140
 msgid "NFS Mount"
 msgstr "NFS-montering"
 
@@ -4856,7 +3982,7 @@ msgstr "NFS-monteringar"
 msgid "NFS Support not installed"
 msgstr "Stöd för NFS är inte installerat"
 
-#: pkg/machines/components/vmnetworktab.jsx:67
+#: pkg/machines/components/vmnetworktab.jsx:97
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
@@ -4868,54 +3994,29 @@ msgstr "NSNA-ping"
 msgid "NTP Server"
 msgstr "NTP-server"
 
-#: pkg/docker/index.html:267 pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/containers-listing.html:11
-#: pkg/kubernetes/views/dashboard-page.html:156
-#: pkg/kubernetes/views/dashboard-page.html:198
-#: pkg/kubernetes/views/details-page.html:34
-#: pkg/kubernetes/views/details-page.html:70
-#: pkg/kubernetes/views/details-page.html:103
-#: pkg/kubernetes/views/details-page.html:137
-#: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/service-modify.html:9
-#: pkg/kubernetes/views/user-modify.html:9
-#: pkg/kubernetes/views/volume-body.html:31
-#: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:119
+#: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
 #: pkg/networkmanager/index.html:319
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:181
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Namn"
 
@@ -4947,7 +4048,7 @@ msgstr "Namnet får inte innehålla tecknet ”$0”."
 msgid "Name cannot contain whitespace."
 msgstr "Namnet får inte innehålla blanktecken."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:82
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
 msgid "Name should not be empty"
 msgstr "Namnet får inte vara tomt"
@@ -4955,26 +4056,6 @@ msgstr "Namnet får inte vara tomt"
 #: pkg/machines/components/networks/networkOverviewTab.jsx:36
 msgid "Name: "
 msgstr ""
-
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
-#: pkg/kubernetes/views/details-page.html:36
-#: pkg/kubernetes/views/details-page.html:72
-#: pkg/kubernetes/views/details-page.html:105
-#: pkg/kubernetes/views/details-page.html:139
-#: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
-#: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
-#: pkg/kubernetes/views/service-body.html:5
-#: pkg/kubernetes/views/volumes-page.html:59
-msgid "Namespace"
-msgstr "Namnrymd"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "Namnrymden får inte vara tom."
 
 #: pkg/systemd/host.js:1348
 msgid "Need at least one NTP server"
@@ -4985,19 +4066,18 @@ msgid "Netmask"
 msgstr ""
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:613
 msgid "Network"
 msgstr "Nätverk"
 
-#: pkg/machines/components/networks/network.jsx:117
+#: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/networks/network.jsx:129
+#: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
 msgid "Network Boot (PXE)"
 msgstr ""
 
@@ -5009,7 +4089,7 @@ msgstr "Nätverksfilsystem"
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:177
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Network Selection does not support PXE."
 msgstr ""
 
@@ -5030,7 +4110,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager kör inte."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:914
 msgid "Networking"
 msgstr "Nätverk"
 
@@ -5048,21 +4128,17 @@ msgstr "Nätverksloggar"
 msgid "Networks"
 msgstr "Nätverk"
 
-#: pkg/users/local.js:963
+#: pkg/users/local.js:967
 msgid "Never"
 msgstr "Aldrig"
 
-#: pkg/users/index.html:297 pkg/users/local.js:868
+#: pkg/users/index.html:297 pkg/users/local.js:872
 msgid "Never expire password"
 msgstr "Låt aldrig lösenord gå ut"
 
-#: pkg/users/index.html:258 pkg/users/local.js:876
+#: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "Lås aldrig konton"
-
-#: pkg/kubernetes/views/project-listing.html:46
-msgid "New Group"
-msgstr "Ny grupp"
 
 #: pkg/storaged/nfs-details.jsx:140
 msgid "New NFS Mount"
@@ -5072,32 +4148,17 @@ msgstr "Ny NFS-montering"
 msgid "New Password"
 msgstr "Nytt lösenord"
 
-#: pkg/kubernetes/views/project-listing.html:7
-msgid "New Project"
-msgstr "Nytt projekt"
-
 #: pkg/machines/components/diskAdd.jsx:132
 msgid "New Volume Name"
 msgstr "Nytt volymnamn"
-
-#: pkg/kubernetes/views/images-page.html:11
-#: pkg/kubernetes/views/registry-dashboard-page.html:86
-msgid "New image stream"
-msgstr "Ny avbildsström"
 
 #: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
 msgid "New passphrase"
 msgstr "Ny lösenfras"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Det nya lösenordet godtogs inte"
-
-#: pkg/kubernetes/views/project-modify.html:4
-#: pkg/kubernetes/views/registry-dashboard-page.html:9
-#: pkg/kubernetes/views/registry-dashboard-page.html:48
-msgid "New project"
-msgstr "Nytt projekt"
 
 #: pkg/realmd/operation.html:82 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
@@ -5111,9 +4172,8 @@ msgstr "Nästa körning"
 msgid "Nice"
 msgstr "Nice"
 
-#: pkg/docker/index.html:542 pkg/docker/index.html:546 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/kubernetes/scripts/volumes.js:998
-#: pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
 msgid "No"
 msgstr "Nej"
 
@@ -5137,35 +4197,18 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Inga NFS-monteringar uppsatta"
 
-#: src/ws/cockpitcertificate.c:522
-msgid "No PEM-encoded certificate found"
-msgstr "Inget PEM-kodat certifikat hittat"
-
-#: src/ws/cockpitcertificate.c:488
-msgid "No PEM-encoded private key found"
-msgstr "Ingen PEM-kodad privat nyckel hittad"
-
-#: pkg/kubernetes/views/pv-claim.html:39
-msgid "No Pods are using this claim"
-msgstr "Inga kapslar använder detta anspråk"
-
 #: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "No SELinux alerts."
 msgstr "Inga SELinux-larm."
 
-#: pkg/machines/components/diskAdd.jsx:193
-#: pkg/machines/components/diskAdd.jsx:205
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:216
 msgid "No Storage Pools available"
 msgstr ""
 
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr "Inga lagringsvolymer är definierade för denna lagringspool"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:29
-#: pkg/ovirt/components/ClusterVms.jsx:36
-msgid "No VM found in oVirt."
-msgstr "Ingen VM hittad i oVirt."
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
@@ -5175,11 +4218,7 @@ msgstr "Ingen VM kör eller är definierad på denna värd."
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/kubernetes/views/pvc-body.html:10
-msgid "No Volume Bound"
-msgstr "Ingen volymgräns"
-
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/networkmanager/firewall.jsx:926
 msgid "No active zones"
 msgstr ""
 
@@ -5231,7 +4270,7 @@ msgstr "Inga behållare"
 msgid "No containers that match the current filter"
 msgstr "Inga behållare som stämmer med det aktuella filtret"
 
-#: pkg/networkmanager/firewall.jsx:727
+#: pkg/networkmanager/firewall.jsx:729
 msgid "No description available"
 msgstr ""
 
@@ -5239,9 +4278,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "Ingen besrkivning tillhandahållen."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Inga diskar är tillgängliga."
 
@@ -5249,7 +4288,7 @@ msgstr "Inga diskar är tillgängliga."
 msgid "No disks defined for this VM"
 msgstr "Inga diskar är definerade för denna VM"
 
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:121
 msgid "No drives attached"
 msgstr "Inga diskar är anslutna"
 
@@ -5260,10 +4299,6 @@ msgstr "Inga fria nyckelfack"
 #: pkg/storaged/content-views.jsx:700
 msgid "No free space"
 msgstr "Inget ledigt utrymme"
-
-#: pkg/kubernetes/views/project-listing.html:74
-msgid "No groups are present."
-msgstr "Inga grupper finns."
 
 #: pkg/systemd/index.html:29
 msgid "No host keys found."
@@ -5281,10 +4316,6 @@ msgstr "Ingen avbildsström finns."
 msgid "No images"
 msgstr "Inga avbilder"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:80
-msgid "No images pushed"
-msgstr "Inga avbilder trycktes"
-
 #: pkg/docker/containers-view.jsx:707
 msgid "No images that match the current filter"
 msgstr "Inga avbilder som stämmer med det aktuella filtret"
@@ -5292,10 +4323,6 @@ msgstr "Inga avbilder som stämmer med det aktuella filtret"
 #: pkg/apps/utils.jsx:96
 msgid "No installation package found for this application."
 msgstr "Inget installationspaket hittat för detta program."
-
-#: pkg/subscriptions/subscriptions-view.jsx:246
-msgid "No installed products on the system."
-msgstr "Inga installerade produkter på systemet."
 
 #: pkg/storaged/crypto-keyslots.jsx:520
 msgid "No keys added"
@@ -5319,12 +4346,7 @@ msgstr ""
 "kommandorad (t.ex. i /etc/default/grub) för att reservera minne vid "
 "uppstartstillfället.  Exempel: crashkernel=512M"
 
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr "Ingen metadatafil valdes.  Välj en fil med Kubernetes metadata."
-
-#: pkg/machines/components/vmnetworktab.jsx:40
+#: pkg/machines/components/vmnetworktab.jsx:70
 msgid "No network interfaces defined for this VM"
 msgstr "Inga nätverksgränssnitt är definierade för denna VM"
 
@@ -5336,15 +4358,7 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/kubernetes/views/dashboard-page.html:117
-msgid "No nodes in cluster"
-msgstr "Inga noder i klustret"
-
-#: pkg/ovirt/components/App.jsx:61
-msgid "No oVirt connection"
-msgstr "Ingen oVirt-förbindelse"
-
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:939
 msgid "No open ports"
 msgstr "Inga öppna portar"
 
@@ -5352,27 +4366,7 @@ msgstr "Inga öppna portar"
 msgid "No partitioning"
 msgstr "Ingen partitionering"
 
-#: pkg/kubernetes/views/dashboard-page.html:40
-msgid "No pods deployed"
-msgstr "Inga kapslar är utplacerade"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:6
-msgid "No pods replicated"
-msgstr "Inga kapslar är replikerade"
-
-#: pkg/kubernetes/views/node-capacity.html:11
-msgid "No pods scheduled"
-msgstr "Inga kapslar är schemalagda"
-
-#: pkg/kubernetes/views/service-endpoint.html:10
-msgid "No pods selected"
-msgstr "Inga kapslar är valda"
-
-#: pkg/kubernetes/views/project-listing.html:37
-msgid "No projects are present."
-msgstr "Inga projekt finns."
-
-#: pkg/users/local.js:449
+#: pkg/users/local.js:453
 msgid "No real name specified"
 msgstr "Inget verkligt namn angivet"
 
@@ -5412,48 +4406,17 @@ msgstr "Inga taggar finns."
 msgid "No updates pending"
 msgstr "Inga väntande uppdateringar"
 
-#: pkg/users/local.js:444
+#: pkg/users/local.js:448
 msgid "No user name specified"
 msgstr "Inget användarnamn angivet."
-
-#: pkg/kubernetes/views/project-listing.html:112
-msgid "No users are present."
-msgstr "Inga användare finns."
 
 #: pkg/storaged/vgroups-panel.jsx:114
 msgid "No volume groups created"
 msgstr "Inga volymgrupper skapade"
 
-#: pkg/kubernetes/views/volumes-page.html:44
-msgid "No volumes are present."
-msgstr "Inga volymer finns."
-
-#: pkg/kubernetes/views/dashboard-page.html:73
-msgid "No volumes in use"
-msgstr "Inga volymer används"
-
-#: pkg/kubernetes/views/containers-listing.html:15
-#: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
-#: pkg/kubernetes/views/topology-page.html:38
-msgid "Node"
-msgstr "Nod"
-
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
-#: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
-msgid "Nodes"
-msgstr "Noder"
-
-#: pkg/kubernetes/views/topology-page.html:39
-msgid "Nodes are the machines that run your containers."
-msgstr "Noder är maskinerna som kör dina behållare."
-
-#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
-#: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:732
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Inga"
 
@@ -5461,23 +4424,13 @@ msgstr "Inga"
 msgid "None (Isolated Network)"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
-#: pkg/kubernetes/scripts/nodes.js:319
+#: pkg/playground/translate.html:29
 msgid "Not Ready"
 msgstr "Inte klar"
-
-#: pkg/kubernetes/scripts/details.js:496 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "Inte ett giltigt antal repliker"
 
 #: pkg/lib/credentials.js:255
 msgid "Not a valid private key"
 msgstr "Inte en giltig privat nyckel"
-
-#: pkg/kubernetes/scripts/details.js:547
-msgid "Not a valid value for Host"
-msgstr "Inte ett giltigt värde på värd"
 
 #: pkg/docker/index.html:57
 msgid "Not authorized to access Docker on this system"
@@ -5495,11 +4448,6 @@ msgstr "Inte tillgängligt"
 msgid "Not connected"
 msgstr "Inte ansluten"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
-#: pkg/kubernetes/views/details-page.html:122
-msgid "Not deployed"
-msgstr "Inte utplacerad"
-
 #: pkg/storaged/lvol-tabs.jsx:369
 msgid "Not enough space to grow."
 msgstr "Inte tillräckligt med utrymme för att växa"
@@ -5516,7 +4464,7 @@ msgstr "Inte monterat"
 msgid "Not permitted to perform this action."
 msgstr "Inte tillåtet att utföra denna åtgärd."
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Not running"
 msgstr "Kör inte"
 
@@ -5540,32 +4488,9 @@ msgstr "Bärbar (notebook)"
 msgid "Notice and above"
 msgstr "Notering och högre"
 
-#: pkg/ovirt/components/vcpuModal.jsx:55
-msgid "Number of virtual CPUs that gonna be used."
-msgstr "Antal virtuella CPU:er som kommer användas."
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
-#: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
-msgid "OK"
-msgstr "OK"
-
-#: pkg/kubernetes/views/node-body.html:13
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "OS"
-msgstr "OS"
-
-#: pkg/ovirt/components/OVirtTab.jsx:148
-msgid "OS Type:"
-msgstr "OS-typ:"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:274
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
 msgid "OS Vendor"
 msgstr "OS-leverantör"
-
-#: pkg/kubernetes/views/nodes-page.html:19
-msgid "OS Versions"
-msgstr "OS-versioner"
 
 #: pkg/selinux/setroubleshoot-view.jsx:394
 msgid "Occurred $0"
@@ -5591,7 +4516,7 @@ msgstr "Gammalt lösenord"
 msgid "Old passphrase"
 msgstr "Gammal lösenfras"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Det gamla lösenordet accepterades inte"
 
@@ -5603,7 +4528,7 @@ msgstr "På"
 msgid "On Build"
 msgstr "Vid bygge"
 
-#: pkg/docker/index.html:547 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/init.js:731
 msgid "On Failure"
 msgstr "Vid misslyckande"
 
@@ -5625,7 +4550,7 @@ msgstr ""
 "När Cockpit är installerat, aktivera det med ”systemctl enable --now cockpit."
 "socket”."
 
-#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:338
+#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
 msgstr "Engångslösenord"
 
@@ -5651,7 +4576,7 @@ msgstr "Endast alfabetet, nummer, :, _, ., @, - är tillåtna."
 msgid "Only editable when the guest is shut off"
 msgstr ""
 
-#: pkg/shell/index.html:43 pkg/shell/simple.html:29 pkg/shell/stub.html:33
+#: pkg/shell/index.html:43 pkg/shell/simple.html:29
 msgid "Ooops!"
 msgstr "Hoppsan!"
 
@@ -5659,8 +4584,8 @@ msgstr "Hoppsan!"
 msgid "Open"
 msgstr ""
 
-#: pkg/kubernetes/views/nodes-page.html:42 pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+#: pkg/systemd/index.html:98
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
 msgid "Operating System"
 msgstr "Operativsystem"
 
@@ -5668,27 +4593,24 @@ msgstr "Operativsystem"
 msgid "Operation '$operation' on $target"
 msgstr "Åtgärden ”$operation” på $target"
 
+#: pkg/machines/components/storagePools/storagePool.jsx:175
+#: pkg/machines/components/storagePools/storagePool.jsx:180
+#, fuzzy
+msgid "Operation is in progress"
+msgstr "oVirt-inloggning pågår"
+
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Optisk enhet"
 
-#: pkg/ovirt/components/OVirtTab.jsx:157
-msgid "Optimized for:"
-msgstr "Optimerad för:"
-
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:134
-#: pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
 msgid "Options"
 msgstr "Alternativ"
 
 #: src/ws/login.html:125
 msgid "Or use a bundled browser"
 msgstr "Eller använd en medpackad bläddrare"
-
-#: pkg/subscriptions/subscriptions-register.jsx:180
-msgid "Organization"
-msgstr "Organisation"
 
 #: pkg/lib/machine-info.js:64
 msgid "Other"
@@ -5707,11 +4629,9 @@ msgstr "Andra enheter"
 msgid "Other Options"
 msgstr "Andra alternativ"
 
-#: pkg/docker/index.html:297 pkg/kubernetes/index.html:43
-#: pkg/kubernetes/registry.html:43
-#: pkg/machines/components/networks/network.jsx:71
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Översikt"
 
@@ -5722,10 +4642,6 @@ msgstr "Skriv över befintliga data med nollor"
 #: pkg/systemd/hwinfo.jsx:249
 msgid "PCI"
 msgstr "PCI"
-
-#: pkg/kubernetes/views/volume-body.html:4
-msgid "PD Name"
-msgstr "PD-namn"
 
 #: pkg/packagekit/updates.jsx:501
 msgid "Package information"
@@ -5759,8 +4675,7 @@ msgstr "Del av"
 msgid "Part of "
 msgstr "Del av"
 
-#: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:141
 msgid "Partition"
 msgstr "Partition"
 
@@ -5796,13 +4711,11 @@ msgstr "Att ta bort lösenfrasen kan förhindra upplåsning av $0."
 msgid "Passphrases do not match"
 msgstr "Lösenfraserna stämmer inte överens"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
 #: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
-#: pkg/subscriptions/subscriptions-register.jsx:89
-#: pkg/subscriptions/subscriptions-register.jsx:156
 msgid "Password"
 msgstr "Lösenord"
 
@@ -5818,7 +4731,7 @@ msgstr "Lösenordet är inte godtagbart"
 msgid "Password is too weak"
 msgstr "Lösenordet är för svagt"
 
-#: pkg/users/local.js:870
+#: pkg/users/local.js:874
 msgid "Password must be changed"
 msgstr "Lösenordet måste ändras"
 
@@ -5841,11 +4754,7 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Klistra in innehållet i din publika SSH-nyckelfil här"
 
-#: pkg/kubernetes/views/pv-modify.html:126
-#: pkg/kubernetes/views/volume-body.html:37
-#: pkg/kubernetes/views/volume-body.html:49
-#: pkg/kubernetes/views/volume-body.html:101 pkg/systemd/services.html:126
-#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
 msgid "Path"
 msgstr "Sökväg"
 
@@ -5861,7 +4770,7 @@ msgstr "Sökvägskostnad $path_cost"
 msgid "Path on Server"
 msgstr "Sökväg på servern"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:129
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
 msgid "Path on host's filesystem"
 msgstr "Sökväg på värdens filsystem"
 
@@ -5873,7 +4782,7 @@ msgstr "Sökvägen på servern får inte vara tom."
 msgid "Path on server must start with \"/\"."
 msgstr "Sökvägen på servern måste börja med ”/”."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:154
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
 msgid "Path to ISO file on host's file system"
 msgstr "Sökväg till ISO-fil på värdens filsystem"
 
@@ -5888,10 +4797,6 @@ msgstr "Sökvägar"
 #: pkg/machines/components/vm/vmActions.jsx:77
 msgid "Pause"
 msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html:53
-msgid "Pending Volume Claims"
-msgstr "Väntande volymanspråk"
 
 #: pkg/systemd/index.html:152
 msgid "Performance Profile"
@@ -5913,18 +4818,10 @@ msgstr "Åtkomst nekas"
 msgid "Persistence"
 msgstr "Varaktighet"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr ""
-
-#: pkg/kubernetes/views/volumes-page.html:14
-msgid "Persistent Volumes"
-msgstr "Beständiga volymer"
-
-#: pkg/kubernetes/views/pod-body.html:16
-msgid "Phase"
-msgstr "Fas"
 
 #: pkg/storaged/vdo-details.jsx:277
 msgid "Physical"
@@ -5938,11 +4835,11 @@ msgstr ""
 msgid "Physical Volume"
 msgstr "Fysisk volym"
 
-#: pkg/storaged/vgroup-details.jsx:134
+#: pkg/storaged/vgroup-details.jsx:133
 msgid "Physical Volumes"
 msgstr "Fysiska volymer"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:210
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -5966,10 +4863,10 @@ msgstr "Ping-mål"
 msgid "Pizza Box"
 msgstr "Pizzalåda"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:210
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Bekräfta raderingen av $0"
 
@@ -5977,113 +4874,23 @@ msgstr "Bekräfta raderingen av $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Bekräfta den tvingande raderingen av $0"
 
-#: pkg/storaged/mdraid-details.jsx:244 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Bekräfta stoppandet av $0"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:34
-msgid "Please confirm, the host shall be switched to maintenance mode."
-msgstr "Bekräfta att värden skall slås om till underhållsläge."
-
-#: pkg/kubernetes/scripts/dashboard.js:439
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "Skapa en annan namnrymd för $0 ”$1”"
-
-#: pkg/machines/components/diskAdd.jsx:425
+#: pkg/machines/components/diskAdd.jsx:447
 msgid "Please enter new volume name"
 msgstr "Ange ett nytt volymnamn"
 
-#: pkg/machines/components/diskAdd.jsx:428
+#: pkg/machines/components/diskAdd.jsx:450
 msgid "Please enter new volume size"
 msgstr "Ange en ny volymstorlek"
 
-#: pkg/networkmanager/firewall.jsx:862
+#: pkg/networkmanager/firewall.jsx:864
 msgid "Please install the $0 package"
 msgstr "Installera paketet $0"
 
-#: pkg/kubernetes/scripts/volumes.js:582
-msgid "Please provide a GlusterFS volume name"
-msgstr "Ge ett GlusterFS-volymnamn"
-
-#: pkg/kubernetes/scripts/connection.js:550
-msgid "Please provide a username"
-msgstr "Ange ett användarnamn"
-
-#: pkg/kubernetes/scripts/volumes.js:640
-msgid "Please provide a valid NFS server"
-msgstr "Ange en giltig NFS-server"
-
-#: pkg/kubernetes/scripts/connection.js:535
-msgid "Please provide a valid address"
-msgstr "Ange en giltig adress"
-
-#: pkg/kubernetes/scripts/volumes.js:810
-msgid "Please provide a valid filesystem type"
-msgstr "Ange en giltig filsystemtyp"
-
-#: pkg/kubernetes/scripts/volumes.js:818
-msgid "Please provide a valid interface"
-msgstr "Ange ett giltigt gränssnitt"
-
-#: pkg/kubernetes/scripts/volumes.js:802
-msgid "Please provide a valid logical unit number"
-msgstr "Ange ett giltigt nummer på en logisk enhet"
-
-#: pkg/kubernetes/scripts/volumes.js:483
-msgid "Please provide a valid name"
-msgstr "Ange ett giltigt namn"
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "Ange en giltig namnrymd."
-
-#: pkg/kubernetes/scripts/volumes.js:648 pkg/kubernetes/scripts/volumes.js:703
-msgid "Please provide a valid path"
-msgstr "Ange en giltig sökväg"
-
-#: pkg/kubernetes/scripts/volumes.js:794
-msgid "Please provide a valid qualified name"
-msgstr "Ange ett giltigt kvalificerat namn"
-
-#: pkg/kubernetes/scripts/volumes.js:491
-msgid "Please provide a valid storage capacity."
-msgstr "Ange en giltig lagringskapacitet."
-
-#: pkg/kubernetes/scripts/volumes.js:786
-msgid "Please provide a valid target"
-msgstr "Ange ett giltigt mål"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:83
-msgid ""
-"Please provide fully qualified domain name and port of the oVirt engine."
-msgstr "Ange ett full kvalificerat domännamn och en port till oVirt-motorn."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:137
-msgid ""
-"Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-"port (443 by default)"
-msgstr ""
-"Ange ett giltigt fullständigt kvalificerat domännamn (FQDN) och en port (443 "
-"som standard) till oVirt-motorn"
-
-#: pkg/ovirt/components/ConsoleClientResources.jsx:32
-msgid ""
-"Please refer to oVirt's $0 for more information about Remote Viewer setup."
-msgstr "Referera oVirts $0 för mer information om uppsättning av fjärrvisare."
-
-#: pkg/kubernetes/scripts/volumes.js:475
-msgid "Please select a valid access mode"
-msgstr "Välj ett giltigt åtkomstläge"
-
-#: pkg/kubernetes/scripts/volumes.js:573
-msgid "Please select a valid endpoint"
-msgstr "Välj en giltig slutpunkt"
-
-#: pkg/kubernetes/scripts/volumes.js:499
-msgid "Please select a valid policy option."
-msgstr "Välj ett giltigt policyalternativ."
-
-#: pkg/users/local.js:1232
+#: pkg/users/local.js:1236
 msgid "Please specify an expiration date"
 msgstr "Ange ett utgångsdatum"
 
@@ -6099,74 +4906,16 @@ msgstr "Starta den virtuella maskinen för att komma åt dess konsol."
 msgid "Please try another term"
 msgstr "Försök med en annan term"
 
-#: pkg/kubernetes/scripts/nodes.js:401
-msgid "Please type an address"
-msgstr "Skriv en adress"
-
-#: pkg/ovirt/components/ClusterVms.jsx:37
-msgid "Please wait till VMs list is loaded from the server."
-msgstr "Vänta tills VM-listan är inläst från servern."
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:30
-msgid "Please wait till list of templates is loaded from the server."
-msgstr "Vänta till listan av mallar är inläst från servern."
-
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Plug"
 msgstr "Plugg"
 
-#: pkg/kubernetes/views/containers-listing.html:12
-#: pkg/kubernetes/views/pod-page.html:12
-#: pkg/kubernetes/views/topology-page.html:14
-msgid "Pod"
-msgstr "Kapsel"
-
-#: pkg/kubernetes/views/pod-body.html:20
-msgid "Pod Address"
-msgstr "Kapseladress"
-
-#: pkg/kubernetes/views/service-endpoint.html:4
-#: pkg/kubernetes/views/service-endpoint.html:9
-msgid "Pod Endpoints"
-msgstr "Kapseländpunkter"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:4
-msgid "Pod Replicated"
-msgstr "Kapsel replikerad"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:11
-#: pkg/kubernetes/views/service-endpoint.html:15
-msgid "Pod Selector"
-msgstr "Kapselväljare"
-
-#: pkg/kubernetes/views/dashboard-page.html:18
-#: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/pv-claim.html:37
-#: pkg/kubernetes/views/replicationcontroller-page.html:17
-#: pkg/kubernetes/views/replicationcontroller-panel.html:12
-#: pkg/kubernetes/scripts/details.js:227
-msgid "Pods"
-msgstr "Kapslar"
-
-#: pkg/kubernetes/views/topology-page.html:15
-msgid ""
-"Pods contain one or more containers that run together on a node, containing "
-"your application code."
-msgstr ""
-"Kapslar innehåller en eller flera behållare som kör tillsamans på en nod, "
-"och innehåller din programkod."
-
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Pool"
-
-#: pkg/kubernetes/views/volume-body.html:60
-msgid "Pool Name"
-msgstr "Poolnamn"
 
 #: pkg/storaged/utils.js:191
 msgid "Pool for Thin Logical Volumes"
@@ -6180,16 +4929,11 @@ msgstr "Pool för tunna volymer"
 msgid "Pool for thinly provisioned volumes"
 msgstr "Pool för tunt underhållna volymer"
 
-#: pkg/kubernetes/views/imagestream-modify.html:45
-msgid "Populate"
-msgstr "Populera"
-
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:78
-#: pkg/ovirt/components/InstallationDialog.jsx:65
+#: pkg/machines/components/vmnetworktab.jsx:108
 #: pkg/storaged/iscsi-panel.jsx:127
 msgid "Port"
 msgstr "Port"
@@ -6202,15 +4946,14 @@ msgstr ""
 msgid "Portable"
 msgstr "Bärbar"
 
-#: pkg/docker/index.html:504 pkg/kubernetes/views/container-body.html:12
-#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:213
+#: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
 #: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
 msgid "Ports"
 msgstr "Portar"
 
-#: pkg/docker/index.html:191
+#: pkg/docker/index.html:192
 msgid "Ports:"
 msgstr "Portar:"
 
@@ -6219,7 +4962,6 @@ msgid "Power Options"
 msgstr "Strömalternativ"
 
 #: pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Preferred number of sockets to expose to the guest."
 msgstr "Föredraget antal uttag att exponera för gästen."
 
@@ -6238,10 +4980,6 @@ msgstr "Nätmaskens prefixlängd"
 #: pkg/networkmanager/interfaces.js:826
 msgid "Preparing"
 msgstr "Förbereder"
-
-#: pkg/ovirt/rephraseUI.js:25
-msgid "Preparing for Maintenance"
-msgstr "Förbereder för underhåll"
 
 #: pkg/networkmanager/interfaces.js:3631
 msgid "Preserve"
@@ -6280,11 +5018,6 @@ msgstr "Prioritet $priority"
 msgid "Private"
 msgstr ""
 
-#: pkg/kubernetes/scripts/projects.js:1042
-msgid "Private: Allow only specific users or groups to pull images"
-msgstr ""
-"Privat: tillåt endast specifika användare eller grupper att hämta avbilder"
-
 #: pkg/shell/index.html:39
 msgid "Privileged"
 msgstr "Priviligierad"
@@ -6310,65 +5043,9 @@ msgstr "Process"
 msgid "Product"
 msgstr ""
 
-#: pkg/subscriptions/subscriptions-view.jsx:34
-msgid "Product ID"
-msgstr "Produkt-ID"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product name"
-msgstr "Produktnamn"
-
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
-#: pkg/kubernetes/views/details-page.html:35
-#: pkg/kubernetes/views/details-page.html:71
-#: pkg/kubernetes/views/details-page.html:104
-#: pkg/kubernetes/views/details-page.html:138
-#: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/pod-body.html:4
-#: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/route-body.html:4
-#: pkg/kubernetes/views/service-body.html:4
-#: pkg/kubernetes/views/volumes-page.html:58
-msgid "Project"
-msgstr "Projekt"
-
-#: pkg/kubernetes/views/project-body.html:20
-msgid "Project Members"
-msgstr "Projektmedlemmar"
-
-#: pkg/kubernetes/views/project-body.html:3
-msgid "Project access policy allows anonymous users to pull images."
-msgstr "Projektåtkomstpolicyn tillåter anonyma användare att hämta avbilder."
-
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Project access policy allows any authenticated user to pull images."
-msgstr ""
-"Projektåtkomstpolicyn tillåter alla autentiserade användare att hämta "
-"avbilder."
-
-#: pkg/kubernetes/views/project-body.html:13
-msgid "Project access policy only allows specific members to access images."
-msgstr ""
-"Projektåtkomstpolicyn tillåter endast specifika medlemmar att komma åt "
-"avbilder."
-
-#: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
+#: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
 msgstr "Projektwebbsajt"
-
-#: pkg/kubernetes/views/filter-project.html:5
-msgid "Project:"
-msgstr "Projekt:"
-
-#: pkg/kubernetes/index.html:88 pkg/kubernetes/registry.html:55
-#: pkg/kubernetes/views/group-delete.html:10
-#: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
-msgid "Projects"
-msgstr "Projekt"
 
 #: pkg/users/local.js:91
 msgid "Prompting via passwd timed out"
@@ -6392,15 +5069,7 @@ msgstr "Vidarebefordrar omladdning till"
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: pkg/subscriptions/subscriptions-register.jsx:129
-msgid "Proxy"
-msgstr "Proxy"
-
-#: pkg/kubernetes/views/node-body.html:25
-msgid "Proxy Version"
-msgstr "Proxy-version"
-
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Publik nyckel"
 
@@ -6408,25 +5077,9 @@ msgstr "Publik nyckel"
 msgid "Public pulling repo"
 msgstr "Publikt hämtningsförråd"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:152
-msgid "Pull an image:"
-msgstr "Hämta en avbild:"
-
-#: pkg/kubernetes/views/imagestream-modify.html:66
-msgid "Pull from"
-msgstr "Hämta ifrån"
-
-#: pkg/kubernetes/scripts/images.js:635
-msgid "Pull specific tags from another image repository"
-msgstr "Hämta specifika taggar från ett annat avbildsförråd"
-
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Syfte"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:141
-msgid "Push an image:"
-msgstr "Tryck ut en avbild:"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:31
 msgid "QEMU/KVM System connection"
@@ -6436,16 +5089,11 @@ msgstr "QEMU/KVM-systemanslutning"
 msgid "QEMU/KVM User connection"
 msgstr "QEMU/KVM-användaranslutning"
 
-#: pkg/kubernetes/views/pv-modify.html:148
-#: pkg/kubernetes/views/volume-body.html:77
-msgid "Qualified Name"
-msgstr "Kvalificerat namn"
-
-#: pkg/storaged/mdraid-details.jsx:186
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 0"
 msgstr "RAID 0"
 
@@ -6453,7 +5101,7 @@ msgstr "RAID 0"
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (Strimlor)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 1"
 msgstr "RAID 1"
 
@@ -6461,7 +5109,7 @@ msgstr "RAID 1"
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (Spegel)"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 10"
 msgstr "RAID 10"
 
@@ -6469,7 +5117,7 @@ msgstr "RAID 10"
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (Strimlor av speglar)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 4"
 msgstr "RAID 4"
 
@@ -6477,7 +5125,7 @@ msgstr "RAID 4"
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (dedikerad paritet)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 5"
 msgstr "RAID 5"
 
@@ -6485,7 +5133,7 @@ msgstr "RAID 5"
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (distribuerad paritet)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 6"
 msgstr "RAID 6"
 
@@ -6501,7 +5149,7 @@ msgstr "RAID-chassi"
 msgid "RAID Device"
 msgstr "RAID-enhet"
 
-#: pkg/storaged/mdraid-details.jsx:316 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "RAID-enhet $0"
 
@@ -6517,27 +5165,15 @@ msgstr "RAID-nivå"
 msgid "RAID Member"
 msgstr "RAID-medlem"
 
-#: pkg/ovirt/provider.js:179
-msgid "REBOOT action failed"
-msgstr "Åtgärden REBOOT misslyckades"
-
-#: pkg/ovirt/provider.js:164
-msgid "REBOOT_VM action failed: %s0"
-msgstr ""
-
 #: pkg/lib/machine-info.js:86
 msgid "Rack Mount Chassis"
 msgstr "Rackmonteringschassi"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Rados-blockenhet"
 
 #: pkg/networkmanager/interfaces.js:3632
 msgid "Random"
 msgstr "Slumpvis"
 
-#: pkg/networkmanager/firewall.jsx:757
+#: pkg/networkmanager/firewall.jsx:759
 msgid "Range"
 msgstr ""
 
@@ -6549,42 +5185,15 @@ msgstr ""
 msgid "Raw to a device"
 msgstr "Rå till en enhet"
 
-#: pkg/kubernetes/views/pv-modify.html:195
-#: pkg/kubernetes/views/volume-body.html:10
-#: pkg/kubernetes/views/volume-body.html:20
-#: pkg/kubernetes/views/volume-body.html:44
-#: pkg/kubernetes/views/volume-body.html:51
-#: pkg/kubernetes/views/volume-body.html:71
-#: pkg/kubernetes/views/volume-body.html:85
-#: pkg/kubernetes/views/volume-body.html:93
-#: pkg/kubernetes/views/volume-body.html:110
-#: pkg/kubernetes/views/volume-body.html:122
-#: pkg/kubernetes/views/volume-body.html:136
-#: pkg/kubernetes/views/volume-body.html:143
-msgid "Read Only"
-msgstr "Skrivskyddad"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "Läs och skriv från en enstaka nod"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "Läs och skriv från flera noder"
-
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "Läs endast från flera noder"
-
-#: pkg/docker/index.html:363
+#: pkg/docker/index.html:365
 msgid "ReadOnly"
 msgstr "LäsEndast"
 
-#: pkg/docker/index.html:362
+#: pkg/docker/index.html:364
 msgid "ReadWrite"
 msgstr "LäsSkriv"
 
@@ -6600,13 +5209,11 @@ msgstr "Läser …"
 msgid "Readonly"
 msgstr "Skrivskyddat"
 
-#: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
-#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/playground/translate.html:19
 msgid "Ready"
 msgstr "Klar"
 
-#: pkg/playground/translate.html:24 pkg/playground/translate.html:184
+#: pkg/playground/translate.html:24
 msgctxt "verb"
 msgid "Ready"
 msgstr "Klar"
@@ -6627,10 +5234,6 @@ msgstr ""
 msgid "Real host name must be 64 characters or less"
 msgstr "Det verkliga värdnamnet får bara vara 64 tecken eller mindre"
 
-#: pkg/kubernetes/views/node-body.html:45
-msgid "Reason"
-msgstr "Orsak"
-
 #: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
 msgid "Reboot"
 msgstr "Starta om"
@@ -6645,16 +5248,11 @@ msgstr "Tar emot"
 msgid "Recent"
 msgstr "Senaste"
 
-#: pkg/kubernetes/views/pv-body.html:6 pkg/kubernetes/views/pv-modify.html:56
-msgid "Reclaim Policy"
-msgstr "Återvinningspolicy"
-
 #: pkg/storaged/format-dialog.jsx:248
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/kubernetes/index.html:108 pkg/kubernetes/registry.html:75
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138 pkg/shell/stub.html:180
+#: pkg/shell/index.html:386 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Återanslut"
@@ -6666,10 +5264,6 @@ msgstr "Återställer"
 #: pkg/storaged/jobs-panel.jsx:65
 msgid "Recovering RAID Device $target"
 msgstr "Återställer RAID-enhet $target"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "Återvinn"
 
 #: pkg/docker/storage.jsx:389
 msgid "Reformat and add disks"
@@ -6691,36 +5285,10 @@ msgstr "Vägrar att ansluta.  Värdnyckeln stämmer inte"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Vägrar att ansluta.  Värdnyckeln är okänd"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:159
-msgid "Register"
-msgstr "Registrera"
-
-#: pkg/kubernetes/views/volumes-page.html:12
-msgid "Register New Volume"
-msgstr "Registrera en ny volym"
-
-#: pkg/kubernetes/views/pv-modify.html:4
-msgid "Register Persistent Volume"
-msgstr "Registrera en beständig volym"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:108
-msgid "Register oVirt"
-msgstr "Registrera oVirt"
-
-#: pkg/subscriptions/main.js:73
-msgid "Register system"
-msgstr "Registrera system"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:128
-msgid "Registering oVirt to Cockpit"
-msgstr "Registrera oVirt i Cockpit"
-
 #: pkg/packagekit/updates.jsx:777
 msgid "Register…"
 msgstr "Registrera …"
 
-#: pkg/ovirt/components/App.jsx:62 pkg/ovirt/components/VdsmView.jsx:100
 #: pkg/systemd/init.js:546
 msgid "Reload"
 msgstr "Läs om"
@@ -6729,7 +5297,7 @@ msgstr "Läs om"
 msgid "Reload Propagated From"
 msgstr "Omläsning vidarebefordrad från"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:202
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
 msgid "Remote URL"
 msgstr "Fjärr-URL"
 
@@ -6741,10 +5309,6 @@ msgstr "Fjärr över NFS"
 msgid "Remote over SSH"
 msgstr "Fjärr över SSH"
 
-#: pkg/kubernetes/views/imagestream-modify.html:89
-msgid "Remote registry is insecure"
-msgstr "Fjärregistret är osäkert"
-
 #: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
 msgctxt "storage"
 msgid "Removable Drive"
@@ -6754,13 +5318,9 @@ msgstr "Löstagbar disk"
 msgid "Removals:"
 msgstr "Borttagningar:"
 
-#: pkg/kubernetes/views/group-delete.html:21
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-delete.html:25
-#: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Ta bort"
 
@@ -6772,37 +5332,13 @@ msgstr "Ta bort $0"
 msgid "Remove $0?"
 msgstr "Ta bort $0?"
 
-#: pkg/kubernetes/views/group-delete.html:3
-msgid "Remove Group"
-msgstr "Ta bort grupp"
-
-#: pkg/kubernetes/views/user-group-remove.html:3
-msgid "Remove Member"
-msgstr "Ta bort medlem"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:3
-msgid "Remove Role"
-msgstr "Ta bort roll"
-
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove Tang keyserver"
 msgstr "Ta bort Tang-nyckelserver"
 
-#: pkg/kubernetes/views/user-delete.html:3
-msgid "Remove User"
-msgstr "Ta bort användare"
-
 #: pkg/storaged/vdo-details.jsx:116
 msgid "Remove device"
 msgstr "Ta bort enhet"
-
-#: pkg/kubernetes/views/image-delete.html:3
-msgid "Remove image tag"
-msgstr "Ta bort avbildstagg"
-
-#: pkg/kubernetes/views/user-remove-membership.html:3
-msgid "Remove membership"
-msgstr "Ta bort medlemskap"
 
 #: pkg/storaged/crypto-keyslots.jsx:387
 msgid "Remove passphrase"
@@ -6812,11 +5348,11 @@ msgstr "Ta bort lösenfras"
 msgid "Remove passphrase in $0?"
 msgstr "Ta bort lösenfrasen i $0?"
 
-#: pkg/networkmanager/firewall.jsx:629
+#: pkg/networkmanager/firewall.jsx:631
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:608
+#: pkg/networkmanager/firewall.jsx:610
 msgid "Remove service from zones"
 msgstr ""
 
@@ -6844,8 +5380,8 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Tar bort den fysiska volymen från $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:187
-#: pkg/storaged/vgroup-details.jsx:235
+#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:234
 msgid "Rename"
 msgstr "Byt namn"
 
@@ -6853,7 +5389,7 @@ msgstr "Byt namn"
 msgid "Rename Logical Volume"
 msgstr "Byt namn på en logisk volym"
 
-#: pkg/storaged/vgroup-details.jsx:179
+#: pkg/storaged/vgroup-details.jsx:178
 msgid "Rename Volume Group"
 msgstr "Byt namn på en volymgrupp"
 
@@ -6890,32 +5426,6 @@ msgstr "Upprepa årligen"
 msgid "Repeat passphrase"
 msgstr "Upprepa lösenfrasen"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
-#: pkg/kubernetes/views/details-page.html:141
-#: pkg/kubernetes/views/replicationcontroller-body.html:9
-#: pkg/kubernetes/views/replicationcontroller-modify.html:8
-msgid "Replicas"
-msgstr "Repliker"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/replicationcontroller-panel.html:10
-#: pkg/kubernetes/views/topology-page.html:22
-msgid "Replication Controller"
-msgstr "Replikeringsstyrare"
-
-#: pkg/kubernetes/views/details-page.html:132
-#: pkg/kubernetes/scripts/details.js:224
-msgid "Replication Controllers"
-msgstr "Replikeringsstyrare"
-
-#: pkg/kubernetes/views/topology-page.html:23
-msgid ""
-"Replication controllers dynamically create instances of pods from templates, "
-"and remove pods when necessary."
-msgstr ""
-"Replikeringsstyrare skapar dynamiskt instanser av kapslar från mallar, och "
-"tar bort kapslar vid behov."
-
 #: pkg/systemd/logs.js:512
 msgid "Report"
 msgstr "Rapport"
@@ -6932,28 +5442,16 @@ msgstr "Rapporteraren ”reporter-ureport” finns inte."
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr "Rapporterandet misslyckades.  Försök att köra ”reporter-ureport -d"
 
-#: pkg/docker/index.html:688
+#: pkg/docker/index.html:690
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Förråd"
 
-#: pkg/kubernetes/views/volume-body.html:24
-msgid "Repository URL"
-msgstr "Förråds-URL"
-
-#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
-msgid "Requested"
-msgstr "Begärd"
-
-#: pkg/kubernetes/views/pv-claim.html:13
-msgid "Requests"
-msgstr "Begäranden"
-
-#: pkg/users/local.js:1296
+#: pkg/users/local.js:1300
 msgid "Require password change every $0 days"
 msgstr "Begär en lösenordsändring var $0:e dag"
 
-#: pkg/users/local.js:872
+#: pkg/users/local.js:876
 msgid "Require password change on $0"
 msgstr "Begär lösenordsändring den $0"
 
@@ -6964,10 +5462,6 @@ msgstr "Begärd av"
 #: pkg/systemd/init.js:717
 msgid "Requires"
 msgstr "Begär"
-
-#: pkg/kubernetes/views/auth-form.html:54
-msgid "Requires Authentication"
-msgstr "Begär autentisering"
 
 #: pkg/systemd/init.js:718
 msgid "Requisite"
@@ -6981,7 +5475,7 @@ msgstr "Behov av"
 msgid "Reserved memory"
 msgstr "Reserverat minne"
 
-#: pkg/docker/index.html:301 pkg/users/index.html:333
+#: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:105
 msgid "Reset"
 msgstr "Återställ"
@@ -7009,26 +5503,22 @@ msgid ""
 "a current disk passphrase."
 msgstr ""
 
-#: pkg/docker/index.html:135 pkg/systemd/index.html:134
+#: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Starta om"
-
-#: pkg/kubernetes/views/container-body.html:20
-msgid "Restart Count"
-msgstr "Omstartsräknare"
 
 #: pkg/packagekit/updates.jsx:498
 msgid "Restart Now"
 msgstr "Starta om nu"
 
-#: pkg/docker/index.html:537 pkg/kubernetes/views/pod-body.html:10
+#: pkg/docker/index.html:539
 msgid "Restart Policy"
 msgstr "Omstartspolicy"
 
-#: pkg/docker/index.html:171
+#: pkg/docker/index.html:172
 msgid "Restart Policy:"
 msgstr "Omstartspolicy:"
 
@@ -7048,52 +5538,27 @@ msgstr "Återställer förbindelsen"
 msgid "Resume"
 msgstr ""
 
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "Behåll"
-
-#: pkg/docker/index.html:553
+#: pkg/docker/index.html:555
 msgid "Retries:"
 msgstr "Omförsök:"
-
-#: pkg/subscriptions/subscriptions-view.jsx:210
-msgid "Retrieving subscription status..."
-msgstr "Hämtar prenumerationsstatus …"
 
 #: src/ws/login.html:57
 msgid "Reuse my password for privileged tasks"
 msgstr "Återanvänd mitt lösenord för priviligierade uppgifter"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Återanvänd mitt lösenord för priviligierade uppgifter och för att ansluta "
 "till andra maskiner"
 
-#: pkg/kubernetes/views/volume-body.html:26
-msgid "Revision"
-msgstr "Revision"
-
-#: pkg/kubernetes/views/user-add-membership.html:28
-#: pkg/kubernetes/views/user-body.html:5
-#: pkg/kubernetes/views/user-panel.html:28
-msgid "Role"
-msgstr "Roll"
-
-#: pkg/kubernetes/views/add-member-role-dialog.html:39
-#: pkg/kubernetes/views/project-body.html:21 pkg/users/index.html:94
+#: pkg/users/index.html:94
 msgid "Roles"
 msgstr "Roller"
 
 #: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
 msgid "Round Robin"
 msgstr "Turas om"
-
-#: pkg/kubernetes/views/route-page.html:14
-#: pkg/kubernetes/views/route-panel.html:9
-msgid "Route"
-msgstr "Rutt"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:98
 msgid "Route to $0"
@@ -7103,22 +5568,16 @@ msgstr ""
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/kubernetes/views/details-page.html:65
-#: pkg/kubernetes/scripts/details.js:216 pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3325
 msgid "Routes"
 msgstr "Rutter"
 
-#: pkg/docker/index.html:244 pkg/docker/index.html:564
+#: pkg/docker/index.html:253 pkg/docker/index.html:566
 #: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
-#: pkg/ovirt/components/ClusterVms.jsx:92
 msgid "Run"
 msgstr "Kör"
 
-#: pkg/ovirt/components/ClusterVms.jsx:97
-msgid "Run Here"
-msgstr "Kör här"
-
-#: pkg/docker/index.html:425
+#: pkg/docker/index.html:427
 msgid "Run Image"
 msgstr "Kör avbild"
 
@@ -7127,7 +5586,7 @@ msgid "Run as"
 msgstr "Kör som"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:128
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
 msgstr ""
 
@@ -7135,17 +5594,13 @@ msgstr ""
 msgid "Runner"
 msgstr "Körare"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Running"
 msgstr "Kör"
 
 #: pkg/systemd/services.html:123
 msgid "Running Since"
 msgstr ""
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:54
-msgid "Running Since:"
-msgstr "Kör sedan:"
 
 #: pkg/selinux/setroubleshoot-view.jsx:364
 msgid "SELinux Access Control Errors"
@@ -7171,14 +5626,6 @@ msgstr "SELinux är avaktiverat på systemet."
 msgid "SELinux system status is unknown."
 msgstr "SELinux systemstatus är okänd."
 
-#: pkg/ovirt/provider.js:440
-msgid "SET VCPU SETTINGS action failed"
-msgstr "Åtgärden SET VCPU SETTINGS misslyckades"
-
-#: pkg/ovirt/provider.js:111 pkg/ovirt/provider.js:145
-msgid "SHUTDOWN action failed"
-msgstr "Åtgärden SHUTDOWN misslyckades"
-
 #: pkg/storaged/jobs-panel.jsx:35
 msgid "SMART self-test of $target"
 msgstr "SMART-självtest av $target"
@@ -7199,14 +5646,6 @@ msgstr "SPICE-port:"
 msgid "SPICE TLS Port:"
 msgstr "SPICE TLS-port:"
 
-#: pkg/ovirt/provider.js:225
-msgid "START action failed"
-msgstr "Åtgärden START misslyckades"
-
-#: pkg/ovirt/provider.js:203
-msgid "START_VM action failed: %s0"
-msgstr ""
-
 #: pkg/networkmanager/index.html:228
 msgid "STP Forward delay"
 msgstr "Fördröjning av STP-vidarebefordran"
@@ -7223,10 +5662,6 @@ msgstr "STP maximal meddelandeålder"
 msgid "STP Priority"
 msgstr "STP-prioritet"
 
-#: pkg/ovirt/provider.js:303
-msgid "SUSPEND action failed"
-msgstr "Åtgärden SUSPEND misslyckades"
-
 #: pkg/systemd/services.html:240
 msgid "Saturday"
 msgstr "Lördag"
@@ -7235,10 +5670,10 @@ msgstr "Lördag"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/ovirt/components/VdsmView.jsx:114 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
 #: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Spara"
@@ -7263,14 +5698,6 @@ msgstr ""
 "Att spara en ny lösenfras kräver att disken låses upp.  Ge en aktuell "
 "disklösenfras."
 
-#: pkg/kubernetes/views/node-capacity.html:9
-msgid "Scheduled Pods"
-msgstr "Schemalagda kapslar"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "Schemaläggningen avaktiverad"
-
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
 msgstr "PC med slutet hölje"
@@ -7279,24 +5706,6 @@ msgstr "PC med slutet hölje"
 #: pkg/systemd/init.js:1076
 msgid "Seconds"
 msgstr "Sekunder"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "Hemlighet"
-
-#: pkg/kubernetes/views/volume-body.html:106
-msgid "Secret File"
-msgstr "Hemlig fil"
-
-#: pkg/kubernetes/views/volume-body.html:141
-msgid "Secret Name"
-msgstr "Hemligt namn"
-
-#: pkg/kubernetes/views/volume-body.html:69
-#: pkg/kubernetes/views/volume-body.html:108
-#: pkg/kubernetes/views/volume-body.html:134
-msgid "Secret Volume"
-msgstr "Hemlig volym"
 
 #: pkg/systemd/index.html:106
 msgid "Secure Shell Keys"
@@ -7314,33 +5723,14 @@ msgstr "Säkerhet"
 msgid "Security Updates Available"
 msgstr "Säkerhetsuppdateringar tillgängliga"
 
-#: pkg/shell/index.html:123 pkg/shell/simple.html:91 pkg/shell/stub.html:106
+#: pkg/shell/index.html:123 pkg/shell/simple.html:91
 msgid "Select"
 msgstr "Välj"
 
-#: pkg/kubernetes/views/file-button.html:4
-msgid "Select Manifest File..."
-msgstr "Välj förteckningsfil …"
-
-#: pkg/kubernetes/scripts/projects.js:899
-#: pkg/kubernetes/scripts/projects.js:1205
-#: pkg/kubernetes/scripts/projects.js:1335
-msgid "Select Member"
-msgstr "Välj medlem"
-
-#: pkg/kubernetes/scripts/projects.js:901
-#: pkg/kubernetes/scripts/projects.js:1208
-msgid "Select Role"
-msgstr "Välj roll"
-
-#: pkg/kubernetes/views/topology-page.html:7
-msgid "Select an object to see more details."
-msgstr "Välj ett objekt för att se fler detaljer."
-
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
 "Välj användaren som du vill skall synkorniseras med {{#strong}}{{host}}{{/"
 "strong}}"
@@ -7349,7 +5739,7 @@ msgstr ""
 msgid "Send Non-Maskable Interrupt"
 msgstr "Skicka ej maskerbart avbrott"
 
-#: pkg/machines/components/vnc.jsx:109
+#: pkg/machines/components/vnc.jsx:108
 msgid "Send key"
 msgstr "Skicka tangenttryck"
 
@@ -7363,11 +5753,8 @@ msgstr "Skickar"
 msgid "Serial Console"
 msgstr "Seriekonsol"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:116 pkg/storaged/nfs-details.jsx:315
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:65
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Server"
 
@@ -7375,7 +5762,7 @@ msgstr "Server"
 msgid "Server Address"
 msgstr "Serveradress"
 
-#: pkg/users/local.js:746 pkg/users/local.js:747
+#: pkg/users/local.js:750 pkg/users/local.js:751
 msgid "Server Administrator"
 msgstr "Serveradministratör"
 
@@ -7399,16 +5786,10 @@ msgstr "Servern har stängt förbindelsen."
 msgid "Servers"
 msgstr "Servrar"
 
-#: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/service-panel.html:8
-#: pkg/kubernetes/views/topology-page.html:30 pkg/systemd/logs.html:66
-#: pkg/networkmanager/firewall.jsx:936 pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Tjänst"
-
-#: pkg/kubernetes/views/pod-body.html:12
-msgid "Service Account"
-msgstr "Tjänstekonto"
 
 #: pkg/systemd/services.html:337
 msgid "Service Logs"
@@ -7438,28 +5819,14 @@ msgstr "Tjänsten stoppas"
 msgid "Service name"
 msgstr "Tjänstenamn"
 
-#: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
-#: pkg/systemd/services.html:330 pkg/kubernetes/scripts/details.js:213
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
 #: pkg/networkmanager/firewall.jsx:483
 msgid "Services"
 msgstr "Tjänster"
 
-#: pkg/kubernetes/views/topology-page.html:31
-msgid ""
-"Services group pods and provide a common DNS name and an optional, load-"
-"balanced IP address to access them."
-msgstr ""
-"Tjänster grupperar kapslar och tillhandahåller ett gemensamt DNS-namn och om "
-"så önskas en lastbalanserad IP-adress för att komma åt dem."
-
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Session"
-
-#: pkg/kubernetes/views/service-body.html:20
-msgid "Session Affinity"
-msgstr "Sessionsaffinitet"
 
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
@@ -7477,7 +5844,7 @@ msgstr "Sätt lösenord"
 msgid "Set Time"
 msgstr "Ställ in tiden"
 
-#: pkg/docker/index.html:530
+#: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Sätt behållarens miljövariabler"
 
@@ -7512,28 +5879,15 @@ msgstr "Allvarsgrad"
 msgid "Severity:"
 msgstr "Allvarsgrad:"
 
-#: pkg/kubernetes/views/volume-body.html:139
-msgid "Share Name"
-msgstr "Delat namn"
-
 #: pkg/networkmanager/interfaces.js:1959
 msgid "Shared"
 msgstr "Delad"
-
-#: pkg/kubernetes/scripts/projects.js:1043
-msgid "Shared: Allow any authenticated user to pull images"
-msgstr "Delat: tillåt alla autentiserade användare att hämta avbilder"
-
-#: pkg/kubernetes/views/container-page-inline.html:14
-#: pkg/kubernetes/views/container-panel.html:9
-msgid "Shell"
-msgstr "Skal"
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Show Performance Options"
 msgstr ""
 
@@ -7541,61 +5895,15 @@ msgstr ""
 msgid "Show all"
 msgstr ""
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:122
 msgid "Show all $0 drives"
 msgstr ""
-
-#: pkg/kubernetes/views/container-page.html:4
-msgid "Show all Containers"
-msgstr "Visa alla behållare"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:8
-msgid "Show all Deployment Configs"
-msgstr "Visa alla utplaceringskonfigurationer"
-
-#: pkg/kubernetes/views/node-page.html:8
-msgid "Show all Nodes"
-msgstr "Visa alla noder"
-
-#: pkg/kubernetes/views/pv-page.html:9
-msgid "Show all Persistent Volumes"
-msgstr "Visa alla beständiga volymer"
-
-#: pkg/kubernetes/views/pod-container.html:4
-msgid "Show all Pod Containers"
-msgstr "Visa alla kapselbehållare"
-
-#: pkg/kubernetes/views/pod-page.html:8
-msgid "Show all Pods"
-msgstr "Visa alla kapslar"
-
-#: pkg/kubernetes/views/group-page.html:14
-#: pkg/kubernetes/views/project-page.html:23
-#: pkg/kubernetes/views/user-page.html:16
-msgid "Show all Projects"
-msgstr "Visa alla projekt"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:10
-msgid "Show all Replication Controllers"
-msgstr "Visa alla replikeringsstyrare"
-
-#: pkg/kubernetes/views/route-page.html:10
-msgid "Show all Routes"
-msgstr "Visa alla rutter"
-
-#: pkg/kubernetes/views/service-page.html:8
-msgid "Show all Services"
-msgstr "Visa alla tjänster"
 
 #: pkg/docker/index.html:128
 msgid "Show all containers"
 msgstr "Visa alla behållare"
 
-#: pkg/kubernetes/views/imagestream-page.html:12
-msgid "Show all image streams"
-msgstr "Visa alla avbildsströmmar"
-
-#: pkg/docker/index.html:254 pkg/kubernetes/views/image-page.html:10
+#: pkg/docker/index.html:249
 msgid "Show all images"
 msgstr "Visa alla avbilder"
 
@@ -7620,21 +5928,16 @@ msgstr ""
 msgid "Shut Down"
 msgstr "Stäng av"
 
-#: pkg/kubernetes/views/container-body.html:18
-msgid "Since"
-msgstr "Sedan"
-
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:376
-#: pkg/machines/components/diskAdd.jsx:143
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Storlek"
 
@@ -7658,11 +5961,6 @@ msgstr "Storleken måste vara ett tal"
 msgid "Size must be at least $0"
 msgstr "Storleken måste vara åtminstone $0"
 
-#: pkg/kubernetes/views/auth-form.html:43
-#: pkg/kubernetes/views/auth-rejected-cert.html:11
-msgid "Skip Certificate Verification"
-msgstr "Hoppa över certifikatverifikation"
-
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Slot"
 msgstr "Plats"
@@ -7672,7 +5970,6 @@ msgid "Slot $0"
 msgstr "Plats $0"
 
 #: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Sockets"
 msgstr "Uttag"
 
@@ -7713,18 +6010,14 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr "Något annat program använder just nu pakethanteraren, var god dröj …"
 
-#: pkg/kubernetes/scripts/volumes.js:914
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "Ledsen, jag vet inte hur man ändrar denna volym"
-
-#: pkg/networkmanager/firewall.jsx:707
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:476
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:103
+#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Källa"
 
@@ -7732,10 +6025,10 @@ msgstr "Källa"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:217
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:244
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Källsökväg"
 
@@ -7743,12 +6036,12 @@ msgstr "Källsökväg"
 msgid "Source URL"
 msgstr "Käll-URL"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:254
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
 msgid "Source path should not be empty"
 msgstr "Källsökvägen får inte vara tom"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:108
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "Källan skall börja med ett av protokollen http, ftp eller nfs"
 
@@ -7776,9 +6069,9 @@ msgstr "Specifik tid"
 msgid "Stable"
 msgstr "Stabilt"
 
-#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:320 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Starta"
 
@@ -7798,7 +6091,7 @@ msgstr "Starta tjänst"
 msgid "Start libvirt"
 msgstr "Starta libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:291
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
 msgid "Start pool when host boots"
 msgstr "Starta poolen när värden startar upp"
 
@@ -7810,59 +6103,29 @@ msgstr "Starta RAID-enhet $target"
 msgid "Starting swapspace $target"
 msgstr "Starta växlingsutrymmet $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Starts"
-msgstr "Startar"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
 msgid "Startup"
 msgstr "Uppstart"
 
-#: pkg/kubernetes/views/container-body.html:16
-#: pkg/kubernetes/views/details-page.html:38
-#: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:127 pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/init.js:285
 msgid "State"
 msgstr "Tillstånd"
 
-#: pkg/docker/index.html:167
+#: pkg/docker/index.html:168
 msgid "State:"
 msgstr "Tillstånd:"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "Stateless"
-msgstr "Tillståndslös"
-
-#: pkg/ovirt/components/OVirtTab.jsx:156
-msgid "Stateless:"
-msgstr "Tillståndslös:"
 
 #: pkg/systemd/services.html:74 pkg/systemd/init.js:207
 msgid "Static"
 msgstr "Statisk"
 
-#: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/volumes-page.html:21 pkg/systemd/services.html:121
-#: pkg/networkmanager/interfaces.js:2613
-#: pkg/subscriptions/subscriptions-view.jsx:37
+#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
 msgid "Status"
 msgstr "Status"
-
-#: pkg/subscriptions/subscriptions-view.jsx:162
-msgid "Status: $0"
-msgstr "Status: $0"
-
-#: pkg/subscriptions/subscriptions-view.jsx:157
-msgid "Status: System isn't registered"
-msgstr "Status: systemet är inte registrerat"
 
 #: pkg/lib/machine-info.js:99
 msgid "Stick PC"
@@ -7872,14 +6135,14 @@ msgstr "Pinndator"
 msgid "Sticky"
 msgstr "Fast"
 
-#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Stoppa"
 
-#: pkg/storaged/mdraid-details.jsx:248
+#: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Stoppa enhet"
 
@@ -7911,8 +6174,8 @@ msgstr "Stoppar RAID-enhet $target"
 msgid "Stopping swapspace $target"
 msgstr "Stoppar växlingsutrymmet $target"
 
-#: pkg/docker/index.html:288 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
+#: pkg/docker/index.html:290 pkg/storaged/index.html:23
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
 #: pkg/storaged/details.jsx:127
 msgid "Storage"
 msgstr "Lagring"
@@ -7921,11 +6184,11 @@ msgstr "Lagring"
 msgid "Storage Logs"
 msgstr "Lagringsloggar"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:137
+#: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePool.jsx:149
+#: pkg/machines/components/storagePools/storagePool.jsx:153
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
@@ -7933,7 +6196,7 @@ msgstr ""
 msgid "Storage Pool Name"
 msgstr "Lagringspoolsnamn"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:437
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
 msgid "Storage Pool failed to be created"
 msgstr "Lagringspoolen kunde inte skapas"
 
@@ -7954,7 +6217,7 @@ msgstr ""
 msgid "Storage can not be managed on this system."
 msgstr ""
 
-#: pkg/docker/index.html:302
+#: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Lagringspool"
 
@@ -7974,10 +6237,6 @@ msgstr "Lagrad lösenfras"
 msgid "Stored passphrase"
 msgstr "Lagrad lösenfras"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:12
-msgid "Strategy"
-msgstr "Strategi"
-
 #: pkg/lib/machine-info.js:82
 msgid "Sub Chassis"
 msgstr "Underchassi"
@@ -7985,10 +6244,6 @@ msgstr "Underchassi"
 #: pkg/lib/machine-info.js:77
 msgid "Sub Notebook"
 msgstr "ULPC"
-
-#: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:177
-msgid "Subscriptions"
-msgstr "Prenumerationer"
 
 #: node_modules/registry-image-widgets/views/image-body.html:4
 msgid "Summary"
@@ -8006,10 +6261,6 @@ msgstr ""
 msgid "Support is installed."
 msgstr "Stöd är installerat."
 
-#: pkg/ovirt/components/VmActions.jsx:40
-msgid "Suspend"
-msgstr "Vila"
-
 #: pkg/storaged/content-views.jsx:157
 msgid "Swap"
 msgstr "Växlingsutrymme"
@@ -8023,10 +6274,6 @@ msgstr "Växlingsutrymme"
 msgid "Swap Used"
 msgstr "Använt växlingsutrymme"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:40
-msgid "Switch Host to Maintenance"
-msgstr "Slå om värden till underhåll"
-
 #: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
 msgid "Switch off $0"
 msgstr "Stäng av $0"
@@ -8034,14 +6281,6 @@ msgstr "Stäng av $0"
 #: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
 msgid "Switch on $0"
 msgstr "Sätt på $0"
-
-#: pkg/ovirt/provider.js:414
-msgid "Switching host to maintenance mode failed. Received error: "
-msgstr "Att slå om värden till underhållsläge misslyckades.  Mottog felet: "
-
-#: pkg/ovirt/provider.js:408
-msgid "Switching host to maintenance mode in progress ..."
-msgstr "Att slå om värden till underhållsläge pågår …"
 
 #: pkg/networkmanager/interfaces.js:2491
 msgid ""
@@ -8066,10 +6305,6 @@ msgid ""
 msgstr ""
 "Att sätta på <b>$0</b> kommer bryta anslutningen till servern, och kommer "
 "göra administrationsgränssnittet otillgängligt."
-
-#: pkg/kubernetes/scripts/images.js:634
-msgid "Sync all tags from a remote image repository"
-msgstr "Synkronisera alla taggar från ett fjärravbildsförråd"
 
 #: pkg/lib/machine-sync-users.html:75
 msgid "Synchronize"
@@ -8120,25 +6355,20 @@ msgstr "Systemet är uppdaterat"
 msgid "System is up to date"
 msgstr "Systemet är uppdaterat"
 
-#: pkg/docker/index.html:327 pkg/docker/index.html:331
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:329 pkg/docker/index.html:333
+#: pkg/networkmanager/firewall.jsx:938
 msgid "TCP"
 msgstr "TCP"
-
-#: pkg/kubernetes/views/route-body.html:12
-msgid "TLS Termination"
-msgstr "TLS-avslutning"
 
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
 msgstr "Platta"
 
-#: pkg/docker/index.html:694
+#: pkg/docker/index.html:696
 #: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Tagg"
 
-#: pkg/kubernetes/views/imagestream-modify.html:76
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
@@ -8150,25 +6380,16 @@ msgstr "Taggar"
 msgid "Tang keyserver"
 msgstr "Tang-nyckelserver"
 
-#: pkg/kubernetes/views/pv-modify.html:137
 #: pkg/machines/components/vm/bootOrderModal.jsx:133
 msgid "Target"
 msgstr "Mål"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Målsökväg"
 
-#: pkg/kubernetes/views/volume-body.html:75
-msgid "Target Portal"
-msgstr "Målportal"
-
-#: pkg/kubernetes/views/volume-body.html:114
-msgid "Target World Wide Names"
-msgstr "Målets världsvida namn"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:133
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
 msgid "Target path should not be empty"
 msgstr "Målsökvägen får inte vara tom"
 
@@ -8192,22 +6413,6 @@ msgstr "Team-portsinställningar"
 #: pkg/networkmanager/index.html:514
 msgid "Team Settings"
 msgstr "Team-inställningar"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:15
-#: pkg/kubernetes/views/deploymentconfig-panel.html:10
-#: pkg/kubernetes/views/replicationcontroller-page.html:20
-#: pkg/kubernetes/views/replicationcontroller-panel.html:14
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "Template"
-msgstr "Mall"
-
-#: pkg/ovirt/components/App.jsx:111
-msgid "Templates"
-msgstr "Mallar"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:130
-msgid "Templates of $0 cluster"
-msgstr "Mallar över $0 kluster"
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
@@ -8241,11 +6446,11 @@ msgstr "Dockers lagringspool kan inte hanteras på det här system."
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "IP-adressen och värdnamnet får inte innehålla blanktecken."
 
-#: pkg/storaged/mdraid-details.jsx:219
+#: pkg/storaged/mdraid-details.jsx:218
 msgid "The RAID Array is in a degraded state"
 msgstr "RAID-vektor är i ett nedsatt tillstånd"
 
-#: pkg/storaged/mdraid-details.jsx:149
+#: pkg/storaged/mdraid-details.jsx:148
 msgid "The RAID device must be running in order to add spare disks."
 msgstr "RAID-enheten måste köra för att kunna lägga till reservdiskar."
 
@@ -8295,19 +6500,15 @@ msgstr "VM:en kör."
 msgid "The VM is suspended by guest power management."
 msgstr "VM:en är i vila av gästens strömhantering."
 
-#: pkg/users/local.js:1338
+#: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
 msgstr ""
 "Kontot ”$0” kommer att tvingas ändra sitt lösenord vid nästa inloggning"
 
-#: pkg/kubernetes/scripts/nodes.js:403
-msgid "The address contains invalid characters"
-msgstr "Adressen innehåller otillåtna tecken"
-
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Autenticiteten hos värden {{#strong}}{{host}}{{/strong}} kan inte "
 "fastställas.  Är du säker på att du vill fortsätta ansluta?"
@@ -8320,23 +6521,12 @@ msgstr "Den insamlade informationen kommer lagras lokalt på systemet."
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 "Det konfigurerade tillståndet är okänt, det kan ändra sig vid nästa uppstart."
-""
-
-#: pkg/kubernetes/views/container-page-inline.html:22
-msgid "The container '{{ target }}' does not exist."
-msgstr "Behållaren ”{{ target }}” finns inte."
 
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
 msgstr ""
 "Skapandet av denna VDO-enhet avslutade inte och enheten kan inte användas."
-
-#: pkg/subscriptions/subscriptions-view.jsx:214
-msgid "The current user isn't allowed to access system subscription status."
-msgstr ""
-"Den aktuella användaren har inte tillåtelse att komma åt systemets "
-"prenumerationsstatus."
 
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
@@ -8345,11 +6535,7 @@ msgstr ""
 "Användaren som för närvarande är inloggad har inte tillstånd att se "
 "information om nycklar."
 
-#: pkg/kubernetes/views/deploymentconfig-page.html:25
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "Utplaceringskonfigurationen ”{{ target }}” finns inte."
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:204
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
 msgid "The directory on the server being exported"
 msgstr "Katalogen på servern exporteras"
 
@@ -8362,8 +6548,7 @@ msgstr ""
 "vidare kommer stoppa dessa."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Filsystemet används av inloggningssessioner.  Att gå vidare kommer stoppa "
 "dessa."
@@ -8375,8 +6560,7 @@ msgstr ""
 "Filsystemet används av systemtjänster.  Att gå vidare kommer stoppa dessa."
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr "Följande behållare beror på denna avbild och kommer bli oanvändbara."
 
 #: pkg/sosreport/index.html:51
@@ -8388,10 +6572,6 @@ msgstr ""
 "Det genererade arkivet innehåller data som betraktas som känsligt och dess "
 "innehåll bör granskas av ursprungsorganisationen innan den skickas till "
 "någon tredje part."
-
-#: pkg/kubernetes/views/group-page.html:47
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "Gruppen ”{{ groupName }}” finns inte."
 
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
@@ -8419,31 +6599,16 @@ msgstr "Det sista nyckelfacket kan inte tas bort"
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "Den sista fysiska volymen i en volymgrupp kan inte tas bort."
 
-#: pkg/shell/indexes.js:408
+#: pkg/shell/indexes.js:407
 msgid "The machine is restarting"
 msgstr "Maskinen startar om"
 
-#: pkg/kubernetes/scripts/details.js:498 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "Det maximala antalet repliker är 128"
+#: pkg/machines/components/networks/networkDelete.jsx:76
+#, fuzzy
+msgid "The network could not be deleted"
+msgstr "Målsökvägen får inte vara tom"
 
-#: pkg/kubernetes/scripts/nodes.js:411
-msgid "The name contains invalid characters"
-msgstr "Namnet innehåller ogiltiga tecken"
-
-#: pkg/kubernetes/views/node-page.html:23
-msgid "The node '{{ target }}' does not exist."
-msgstr "Noden ”{{ target }}” finns inte."
-
-#: pkg/kubernetes/views/node-alerts.html:7
-msgid "The node doesn't have enough disk space"
-msgstr "Noden har inte tillräckligt med diskutrymme"
-
-#: pkg/kubernetes/views/node-alerts.html:11
-msgid "The node doesn't have enough free memory"
-msgstr "Noden har inte tillräckligt med fritt minne"
-
-#: pkg/users/local.js:439 pkg/users/local.js:1395
+#: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
 msgstr "Lösenorden stämmer inte överens"
 
@@ -8451,29 +6616,9 @@ msgstr "Lösenorden stämmer inte överens"
 msgid "The passwords do not match."
 msgstr "Lösenorden stämmer inte överens."
 
-#: pkg/kubernetes/views/pv-page.html:21
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "Den beständiga volymen ”{{ target }}” finns inte."
-
-#: pkg/kubernetes/views/pod-page.html:40
-msgid "The pod '{{ target }}' does not exist."
-msgstr "Kapseln ”{{ target }}” finns inte."
-
 #: pkg/machines/components/diskAdd.jsx:80
 msgid "The pool is empty"
 msgstr "Poolen är tom"
-
-#: pkg/kubernetes/views/project-page.html:34
-msgid "The project '{{ projName }}' does not exist."
-msgstr "Projektet ”{{ projName }}” finns inte."
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:30
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "Replikeringsstyraren ”{{ target }}” finns inte."
-
-#: pkg/kubernetes/views/route-page.html:19
-msgid "The route '{{ target }}' does not exist."
-msgstr "Rutten ”{{ target }}” finns inte."
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
@@ -8482,10 +6627,6 @@ msgstr "Skanningen från $time ($type) hittade inga sårbarheter."
 #: pkg/docker/containers-view.jsx:432
 msgid "The scan from $time ($type) was not successful."
 msgstr "Skanningen från $time ($type) lyckades inte."
-
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "Den valda filen är inte en giltig programförteckning för Kubernetes."
 
 #: src/ws/login.js:645
 msgid ""
@@ -8499,21 +6640,9 @@ msgstr ""
 msgid "The server refused to authenticate using any supported methods."
 msgstr "Servern vägrade att autentisera med några stödda metoder."
 
-#: pkg/kubernetes/views/auth-rejected-cert.html:2
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr "Servern använder ett certifikat signerat av en okänd auktoritet."
-
-#: pkg/kubernetes/views/service-page.html:19
-msgid "The service '{{ target }}' does not exist."
-msgstr "Tjänsten ”{{ target }}” finns inte."
-
 #: pkg/systemd/hwinfo.jsx:65
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
-
-#: pkg/kubernetes/views/user-page.html:29
-msgid "The user '{{ userName }}' does not exist."
-msgstr "Användaren ”{{ target }}” finns inte."
 
 #: pkg/systemd/init.js:922
 msgid "The user <b>$0</b> does not have permissions for creating timers"
@@ -8554,7 +6683,7 @@ msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
 "Användaren <b>$0</b> har inte rättighet att ändra nätverksinställningar"
 
-#: pkg/realmd/operation.js:643
+#: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "Användaren <b>$0</b> har inte rättighet att ändra riken"
 
@@ -8567,7 +6696,7 @@ msgid "The user <b>$0</b> is not permitted to start or stop services"
 msgstr ""
 "Användaren <b>$0</b> har inte rättighet att starta eller stoppa tjänster"
 
-#: pkg/users/local.js:549
+#: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
@@ -8577,8 +6706,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "Webbläsarens konfiguration förhindrar Cockpit från att köra (oåtkomlig $0)"
 
@@ -8617,13 +6745,6 @@ msgstr "Denna NFS-montering används och endast dess alternativ kan ändras."
 #: pkg/storaged/vdo-details.jsx:133
 msgid "This VDO device does not use all of its backing device."
 msgstr "Denna VDO-enhet använder inte alla sina underliggande enheter."
-
-#: pkg/kubernetes/views/pvc-delete.html:8
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr ""
-"Detta anspråk används.  Att ta bort den kan orsaka problem med följande "
-"kapsel:"
 
 #: pkg/systemd/init.js:1371
 msgid ""
@@ -8681,14 +6802,6 @@ msgstr "Denna disk kan inte tas bort medans enheten återhämtar sig."
 msgid "This field cannot be empty."
 msgstr "Detta fält får inte vara tomt."
 
-#: pkg/ovirt/components/App.jsx:155
-msgid ""
-"This host is managed by a virtualization manager, so creation of new VMs "
-"from the host is not possible."
-msgstr ""
-"Denna värd hanteras av en virtualiseringshanterare, så att skapa nya VM:er "
-"av värden är inte möjligt."
-
 #: pkg/docker/containers-view.jsx:494
 msgid "This image does not exist."
 msgstr "Denna avbild finns inte."
@@ -8704,14 +6817,6 @@ msgstr "Denna maskin har redan lagts till."
 #: pkg/realmd/operation.html:80
 msgid "This may take a while"
 msgstr "Detta kan ta ett tag"
-
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr ""
-"Denna flagga är endast för test av enstaka noder — lokal lagring kommer inte "
-"fungera i ett flernodskluster"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
@@ -8751,7 +6856,7 @@ msgstr "Denna enhet är en instans av mallen $0."
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Denna enhet är inte gjord för att aktiveras explicit."
 
-#: pkg/users/local.js:557
+#: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "Detta användarnamn finns redan"
 
@@ -8763,25 +6868,7 @@ msgstr ""
 "Denna version av cockpit-ws stödjer inte att ansluta till en värd med en "
 "alternativ användare eller port"
 
-#: pkg/ovirt/components/OVirtTab.jsx:134
-msgid "This virtual machine is not managed by oVirt"
-msgstr "Denna virtuella maskin hanteras inte av oVirt"
-
-#: pkg/kubernetes/views/pv-delete.html:7
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
-msgstr ""
-"Denna volym har tagits i anspråk av {{ item.item.spec.claimRef.namespace }} /"
-" {{ item.item.spec.claimRef.name }}.  Att ta bort den kommer bryta detta "
-"anspråk och kan orsaka problem med de kapslar som beror på den."
-
-#: pkg/kubernetes/views/pv-claim.html:23
-msgid "This volume has not been claimed"
-msgstr "Denna volym har inte tagits  anspråk"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:369
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
 msgid "This volume is already used by another VM."
 msgstr ""
 
@@ -8812,7 +6899,6 @@ msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Detta kommer testa kdump-inställningarna genom att krascha kärnan."
 
 #: pkg/machines/components/vcpuModal.jsx:212
-#: pkg/ovirt/components/vcpuModal.jsx:70
 msgid "Threads per core"
 msgstr "Trådar per kärna"
 
@@ -8865,10 +6951,6 @@ msgstr ""
 "För att använda en annan port behöver du uppgradera cockpit-ws till en nyare "
 "version."
 
-#: pkg/kubernetes/views/auth-form.html:116
-msgid "Token"
-msgstr "Symbol"
-
 #: pkg/lib/cockpit-components-file-autocomplete.jsx:148
 msgid "Too many files found"
 msgstr "För många filer hittade"
@@ -8876,10 +6958,6 @@ msgstr "För många filer hittade"
 #: src/base1/cockpit.js:4039
 msgid "Too much data"
 msgstr "För mycket data"
-
-#: pkg/kubernetes/index.html:61
-msgid "Topology"
-msgstr "Topologi"
 
 #: pkg/docker/storage.jsx:341
 msgid "Total"
@@ -8897,12 +6975,11 @@ msgstr "Torn"
 msgid "Triggered By"
 msgstr "Utlöst av"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:32 pkg/systemd/init.js:732
+#: pkg/systemd/init.js:732
 msgid "Triggers"
 msgstr "Utlösare"
 
-#: pkg/kubernetes/index.html:109 pkg/shell/index.html:387
-#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/shell/index.html:387 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Felsök"
@@ -8911,13 +6988,9 @@ msgstr "Felsök"
 msgid "Trust key"
 msgstr "Förtroendenyckel"
 
-#: pkg/networkmanager/firewall.jsx:703
+#: pkg/networkmanager/firewall.jsx:705
 msgid "Trust level"
 msgstr ""
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:21
-msgid "Trust this certificate for this connection"
-msgstr "Lita på detta certifikat för denna anslutning"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -8959,20 +7032,17 @@ msgstr "Tuned kör inte"
 msgid "Tuned is off"
 msgstr "Tuned är avslagen"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:84
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Typ"
 
@@ -8988,16 +7058,11 @@ msgstr "Skriv ett lösenord"
 msgid "Type to filter…"
 msgstr "Skriv för att filtrera …"
 
-#: pkg/kubernetes/views/details-page.html:7
-msgid "Type:"
-msgstr "Typ:"
-
-#: pkg/docker/index.html:332 pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
-#: pkg/subscriptions/subscriptions-register.jsx:112
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
 msgid "URL"
 msgstr "URL"
 
@@ -9013,17 +7078,9 @@ msgstr "Kan inte verkställa inställningarna: $0"
 msgid "Unable to apply this solution automatically"
 msgstr "Kan inte verkställa denna lösning automatiskt"
 
-#: pkg/subscriptions/subscriptions-view.jsx:217
-msgid "Unable to connect"
-msgstr "Kan inte ansluta"
-
 #: src/ws/login.js:649
 msgid "Unable to connect to that address"
 msgstr "Kan inte ansluta till den adressen"
-
-#: pkg/kubernetes/scripts/dashboard.js:412
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "Kan inte avkoda programförteckningen för Kubernetes"
 
 #: pkg/users/local.js:58
 msgid "Unable to delete root account"
@@ -9041,10 +7098,6 @@ msgstr "Kan inte hämta larmet: $0"
 #: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "Kan inte nå servern"
-
-#: pkg/kubernetes/scripts/dashboard.js:400
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "Kan inte läsa programförteckningen för Kubernetes.  Kod $0."
 
 #: pkg/storaged/nfs-details.jsx:282
 msgid "Unable to remove mount"
@@ -9071,16 +7124,15 @@ msgid "Unable to unmount filesystem"
 msgstr "Kan inte avmontera filsystem"
 
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
-#: pkg/kubernetes/scripts/charts.js:110
 msgid "Unavailable"
 msgstr "Otillgänglig"
 
-#: pkg/docker/index.html:730 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1481
+#: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
+#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Oväntat fel"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:132
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid "Unique name"
 msgstr "Unikt namn"
 
@@ -9089,19 +7141,14 @@ msgstr "Unikt namn"
 msgid "Unit"
 msgstr "Enhet"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
-#: pkg/kubernetes/views/volumes-page.html:35
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:754 pkg/kubernetes/scripts/volumes.js:267
-#: pkg/lib/machine-info.js:65 pkg/networkmanager/interfaces.js:596
-#: pkg/networkmanager/interfaces.js:1067 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2534 pkg/storaged/fsys-tab.jsx:64
-#: pkg/storaged/swap-tab.jsx:57
+#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
+#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Okänd"
 
@@ -9137,7 +7184,7 @@ msgstr ""
 msgid "Unknown type"
 msgstr "Okänd typ"
 
-#: pkg/docker/index.html:549 pkg/docker/util.js:110
+#: pkg/docker/index.html:551 pkg/docker/util.js:110
 msgid "Unless Stopped"
 msgstr "Om inte stoppad"
 
@@ -9186,7 +7233,7 @@ msgstr "Avmonterar $target"
 msgid "Unnamed"
 msgstr "Namnlös"
 
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Unplug"
 msgstr "Koppla ur"
 
@@ -9202,14 +7249,6 @@ msgstr "Okända data"
 #: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Okända data får inte göras mindre här."
-
-#: pkg/subscriptions/subscriptions-view.jsx:164
-msgid "Unregister"
-msgstr "Avregistrera"
-
-#: pkg/subscriptions/subscriptions-view.jsx:170
-msgid "Unregistering system..."
-msgstr "Avregistrerar systemet …"
 
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
@@ -9232,7 +7271,11 @@ msgstr "Ej betrodd värd"
 msgid "Up since $0"
 msgstr "Uppe sedan $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:316
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+msgid "Up to $0 $1 available in the default location"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -9260,13 +7303,9 @@ msgstr "Uppdaterade paket kan behöva en omstart för att få effekt."
 msgid "Updates Available"
 msgstr "Uppdateringar tillgängliga"
 
-#: pkg/packagekit/updates.jsx:52 pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/packagekit/updates.jsx:52
 msgid "Updating"
 msgstr "Uppdaterar"
-
-#: pkg/kubernetes/scripts/details.js:654
-msgid "Updating $0..."
-msgstr "Uppdaterar $0 …"
 
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
@@ -9282,20 +7321,15 @@ msgstr[1] "Användning av $0 CPU-kärnor"
 msgid "Use 512 Byte emulation"
 msgstr "Använd 512-byteemulering"
 
-#: pkg/machines/components/diskAdd.jsx:496
+#: pkg/machines/components/diskAdd.jsx:524
 msgid "Use Existing"
 msgstr "Använd befintlig"
-
-#: pkg/subscriptions/subscriptions-register.jsx:136
-msgid "Use proxy server"
-msgstr "Använd en proxyserver"
 
 #: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Använd följande nycklar för att autentisera mot andra system"
 
 #: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
-#: pkg/kubernetes/scripts/nodes.js:829 pkg/kubernetes/scripts/nodes.js:838
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
@@ -9307,18 +7341,13 @@ msgstr "Använt"
 msgid "Used by"
 msgstr ""
 
-#: pkg/docker/index.html:262
+#: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "Används av behållare"
 
-#: pkg/dashboard/index.html:144 pkg/kubernetes/views/auth-form.html:61
-#: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
-#: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/subscriptions/subscriptions-register.jsx:77 pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1584
 msgid "User"
 msgstr "Användare"
 
@@ -9327,11 +7356,11 @@ msgstr "Användare"
 msgid "User Name"
 msgstr "Användarnamn"
 
-#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:337
+#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:336
 msgid "User Password"
 msgstr "Användarens lösenord"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Användarnamn"
@@ -9340,18 +7369,9 @@ msgstr "Användarnamn"
 msgid "User name cannot be empty"
 msgstr "Användarnamnet får inte vara tomt"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:15
-msgid "User or Group"
-msgstr "Användare eller grupp"
-
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
-#: pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
 msgid "Username"
 msgstr "Användarnamn"
-
-#: pkg/kubernetes/views/project-listing.html:85
-msgid "Users"
-msgstr "Användare"
 
 #: pkg/lib/machine-change-auth.html:44
 msgid "Using available credentials"
@@ -9390,14 +7410,6 @@ msgstr "VDO-underlagsenheter kan inte göras mindre"
 msgid "VDO support not installed"
 msgstr "VDO-stöd är inte installerat"
 
-#: pkg/ovirt/components/App.jsx:115
-msgid "VDSM"
-msgstr "VDSM"
-
-#: pkg/ovirt/components/VdsmView.jsx:128
-msgid "VDSM Service Management"
-msgstr "VDSM tjänstehantering"
-
 #: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
 #: pkg/networkmanager/interfaces.js:2906
 msgid "VLAN"
@@ -9427,7 +7439,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1317
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -9451,10 +7463,6 @@ msgstr ""
 msgid "VM $0 failed to start"
 msgstr ""
 
-#: pkg/ovirt/components/VmOverviewColumn.jsx:37
-msgid "VM icon"
-msgstr "VM-ikon"
-
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
 msgstr "VNC"
@@ -9471,7 +7479,7 @@ msgstr "VNC-port:"
 msgid "VNC TLS Port:"
 msgstr "VNC TLS-port:"
 
-#: pkg/realmd/operation.js:165
+#: pkg/realmd/operation.js:164
 msgid "Validating address"
 msgstr ""
 
@@ -9500,30 +7508,20 @@ msgstr "Verifiera nyckel"
 msgid "Verifying"
 msgstr "Verifierar"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:110 pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:381
-#: pkg/subscriptions/subscriptions-view.jsx:35 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Version"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Version num"
-msgstr "Version nummer"
 
 #: pkg/storaged/jobs-panel.jsx:57
 msgid "Very securely erasing $target"
 msgstr "Raderar mycket säkert $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Virtuella maskiner"
-
-#: pkg/ovirt/components/ClusterVms.jsx:176
-msgid "Virtual Machines of $0 cluster"
-msgstr "Virtuella maskiner i klustret $0"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
@@ -9537,14 +7535,11 @@ msgstr "Virtualiseringstjänsten (libvirt) är inte aktiv"
 msgid "Virtualization Service is Available"
 msgstr "Virtualiseringstjänsten är tillgänglig"
 
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
-#: pkg/kubernetes/views/pvc-body.html:6
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:359
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Volym"
 
@@ -9552,7 +7547,7 @@ msgstr "Volym"
 msgid "Volume Group"
 msgstr "Volymgrupp"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:233
+#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Volymgrupp $0"
 
@@ -9560,32 +7555,16 @@ msgstr "Volymgrupp $0"
 msgid "Volume Groups"
 msgstr "Volymgrupper"
 
-#: pkg/kubernetes/views/volume-body.html:14
-#: pkg/kubernetes/views/volume-body.html:89
-msgid "Volume ID"
-msgstr "Volym-ID"
-
-#: pkg/kubernetes/views/pv-modify.html:115
-#: pkg/kubernetes/views/volume-body.html:42
-msgid "Volume Name"
-msgstr "Volymnamn"
-
-#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
-msgid "Volume Type"
-msgstr "Volymtyp"
-
 #: pkg/storaged/lvol-tabs.jsx:410
 msgid "Volume size is $0. Content size is $1."
 msgstr ""
 
-#: pkg/docker/index.html:515 pkg/kubernetes/index.html:74
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:517
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volymer"
 
-#: pkg/docker/index.html:199
+#: pkg/docker/index.html:200
 msgid "Volumes:"
 msgstr "Volymer:"
 
@@ -9623,10 +7602,6 @@ msgstr "Önskar"
 msgid "Warning and above"
 msgstr "Varning och högre"
 
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid "Warning:"
-msgstr "Varning:"
-
 #: cockpit.appdata.xml.in.h:1
 msgid "Web Console for Linux servers"
 msgstr "Webbkonsol för Linuxservrar"
@@ -9643,23 +7618,15 @@ msgstr ""
 msgid "Weeks"
 msgstr "Veckor"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:5
-msgid "Welcome to the Image Registry"
-msgstr "Välkommen till avbildsregistret"
-
 #: pkg/storaged/crypto-keyslots.jsx:324
 msgid "What if tang-show-keys is not available?"
 msgstr "Vad gör man om tang-show-keys inte är tillgängligt?"
-
-#: pkg/kubernetes/views/volumes-page.html:61
-msgid "When"
-msgstr "När"
 
 #: pkg/systemd/terminal.jsx:101
 msgid "White"
 msgstr ""
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:488
 msgid "With terminal"
 msgstr "Med terminal"
 
@@ -9679,7 +7646,7 @@ msgstr "Fel användarnamn eller lösenord"
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:996 pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2593
 msgid "Yes"
 msgstr "Ja"
 
@@ -9699,21 +7666,9 @@ msgstr ""
 "den."
 
 #: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:871 pkg/networkmanager/firewall.jsx:877
+#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
 msgid "You are not authorized to modify the firewall."
 msgstr "Du har inte rättigheter att ändra brandväggen."
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:3
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr ""
-"Du kan hoppa över certifikatkontrollen, men alla data du skickar till "
-"servern skulle kunna avlyssnas av andra."
-
-#: pkg/kubernetes/views/dashboard-page.html:150
-msgid "You can deploy an application to your cluster."
-msgstr "Du kan placera ut ett program i ditt kluster."
 
 #: pkg/users/index.html:390
 msgid ""
@@ -9731,7 +7686,7 @@ msgstr "Du har inte rättigheter att hantera lagringspoolen för Docker."
 msgid "You must wait longer to change your password"
 msgstr "Du måste vänta längre på att ändra ditt lösenord"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
 msgid ""
 "You need to select the most closely matching OS vendor and Operating System"
 msgstr ""
@@ -9744,14 +7699,6 @@ msgstr ""
 "Din webbläsare kommer kopplas ifrån, men detta påverkar inte "
 "uppdateringsprocessen.  Du kan återansluta om några ögonblick för att "
 "fortsätta följa förloppet."
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:112
-msgid ""
-"Your login credentials do not give you access to use the docker registry "
-"from the command line."
-msgstr ""
-"Dina inloggningskreditiv ger dig inte åtkomst till att använda docker-"
-"registret från kommandoraden."
 
 #: pkg/packagekit/updates.jsx:865
 msgid ""
@@ -9769,11 +7716,11 @@ msgstr "Din session har avslutats."
 msgid "Your session has expired. Please log in again."
 msgstr "Din session har gått ut.  Logga in igen."
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/networkmanager/firewall.jsx:938
 msgid "Zones"
 msgstr ""
 
@@ -9789,8 +7736,12 @@ msgstr "[binärdata]"
 msgid "[no data]"
 msgstr "[inga data]"
 
-#: pkg/machines/components/networks/network.jsx:58
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "aktiv"
@@ -9824,17 +7775,9 @@ msgstr "byte"
 msgid "cdrom"
 msgstr "cdrom"
 
-#: pkg/ovirt/rephraseUI.js:35
-msgid "connecting"
-msgstr "ansluter"
-
 #: pkg/machines/components/infoRecord.jsx:29
 msgid "control-label $0"
 msgstr ""
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "cores"
-msgstr "kärnor"
 
 #: pkg/machines/helpers.js:193
 msgid "crashed"
@@ -9853,7 +7796,6 @@ msgid "direct"
 msgstr "direkt"
 
 #: pkg/machines/helpers.js:177 pkg/machines/helpers.js:180
-#: pkg/ovirt/components/OVirtTab.jsx:123
 msgid "disabled"
 msgstr "avaktiverat"
 
@@ -9861,7 +7803,7 @@ msgstr "avaktiverat"
 msgid "disk"
 msgstr "disk"
 
-#: pkg/machines/helpers.js:238 pkg/ovirt/rephraseUI.js:27
+#: pkg/machines/helpers.js:238
 msgid "down"
 msgstr "nere"
 
@@ -9869,26 +7811,17 @@ msgstr "nere"
 msgid "dying"
 msgstr "döende"
 
-#: pkg/realmd/operation.js:299 pkg/realmd/operation.js:305
+#: pkg/realmd/operation.js:298 pkg/realmd/operation.js:304
 msgid "e.g. \"$0\""
 msgstr "t.ex. ”$0”"
 
-#: pkg/kubernetes/scripts/images.js:639
-msgid "eg: my-image-stream"
-msgstr "t.ex.: min-avbildsström"
-
 #: pkg/machines/helpers.js:178 pkg/machines/helpers.js:181
-#: pkg/ovirt/components/OVirtTab.jsx:125
 msgid "enabled"
 msgstr "aktiverat"
 
 #: pkg/packagekit/updates.jsx:267
 msgid "enhancement"
 msgstr "förbättring"
-
-#: pkg/ovirt/rephraseUI.js:28
-msgid "error"
-msgstr "fel"
 
 #: pkg/machines/helpers.js:214
 msgid "ethernet"
@@ -9914,7 +7847,7 @@ msgstr ""
 msgid "hostdev"
 msgstr "värdenhet"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:182
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
@@ -9930,7 +7863,7 @@ msgstr "iSCSI-mål"
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -9938,22 +7871,10 @@ msgstr ""
 msgid "idle"
 msgstr "overksam"
 
-#: pkg/machines/components/networks/network.jsx:58
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "inaktiv"
-
-#: pkg/ovirt/rephraseUI.js:29
-msgid "initializing"
-msgstr "initierar"
-
-#: pkg/ovirt/rephraseUI.js:30
-msgid "installation failed"
-msgstr "installationen misslyckades"
-
-#: pkg/ovirt/rephraseUI.js:38
-msgid "installing OS"
-msgstr "installerar OS"
 
 #: pkg/kdump/kdump-view.jsx:376
 msgid "invalid: multiple targets defined"
@@ -9962,10 +7883,6 @@ msgstr "felaktigt: flera mål definierade"
 #: pkg/kdump/kdump-view.jsx:493
 msgid "kdump status"
 msgstr "kdump-status"
-
-#: pkg/ovirt/rephraseUI.js:39
-msgid "kdumping"
-msgstr "kdumpar"
 
 #: pkg/docker/run.js:527
 msgid "key"
@@ -9979,10 +7896,6 @@ msgstr "nyckelfack $0"
 msgid "locally in $0"
 msgstr "lokalt i $0"
 
-#: pkg/ovirt/rephraseUI.js:31
-msgid "maintenance"
-msgstr "underhåll"
-
 #: pkg/machines/helpers.js:216
 msgid "mcast"
 msgstr "mcast"
@@ -9995,62 +7908,18 @@ msgstr "nätverk"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs-dumpmålet är inte formaterat som server:sökväg"
 
-#: pkg/kubernetes/views/route-body.html:14
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:43
 msgid "no"
 msgstr "nej"
 
-#: pkg/ovirt/rephraseUI.js:32
-msgid "non operational"
-msgstr "inte i drift"
-
-#: pkg/ovirt/rephraseUI.js:33
-msgid "non responsive"
-msgstr "svarar inte"
-
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
-#: pkg/kubernetes/views/route-body.html:24
-#: pkg/kubernetes/views/route-body.html:29
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "ingen"
-
-#: pkg/ovirt/provider.js:62
-msgid "oVirt"
-msgstr "oVirt"
-
-#: pkg/ovirt/components/HostStatus.jsx:37
-msgid "oVirt Host State:"
-msgstr "oVirt-värdtillstånd:"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:35
-msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr ""
-"oVirt-leverantörsinstallationsskript misslyckades på grund av saknade "
-"argument."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:36
-msgid ""
-"oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-"machines-ovirt.config, try as root."
-msgstr ""
-"oVirt-leverantörsinstallationsskript misslyckades: kan inte skriva till /etc/"
-"cockpit/machines-ovirt.config, försök som root."
-
-#: pkg/ovirt/components/InstallationDialog.jsx:164
-msgid "oVirt installation script failed with following output: "
-msgstr "oVirt-installationsskript misslyckades med följande utdata: "
-
-#: pkg/ovirt/components/App.jsx:51
-msgid "oVirt login in progress"
-msgstr "oVirt-inloggning pågår"
 
 #: pkg/systemd/host.js:691
 msgid "of $0 CPU core"
@@ -10062,25 +7931,13 @@ msgstr[1] "av $0 CPU-kärnor"
 msgid "paused"
 msgstr "stannad"
 
-#: pkg/ovirt/rephraseUI.js:34
-msgid "pending approval"
-msgstr "väntande godkännande"
-
-#: pkg/kubernetes/views/dashboard-page.html:83
-msgid "pending volume claims"
-msgstr "väntande volymanspråk"
-
-#: pkg/machines/components/diskAdd.jsx:174
+#: pkg/machines/components/diskAdd.jsx:154
 msgid "qcow2"
 msgstr "qcow2"
 
-#: pkg/machines/components/diskAdd.jsx:177
+#: pkg/machines/components/diskAdd.jsx:157
 msgid "raw"
 msgstr "rå"
-
-#: pkg/ovirt/rephraseUI.js:36
-msgid "reboot"
-msgstr "starta om"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -10102,7 +7959,7 @@ msgstr "leta efter namn, namnrymd eller beskrivning"
 msgid "security"
 msgstr "säkerhet"
 
-#: pkg/docker/index.html:404
+#: pkg/docker/index.html:406
 msgid "select container"
 msgstr "välj behållare"
 
@@ -10110,7 +7967,7 @@ msgstr "välj behållare"
 msgid "server"
 msgstr "server"
 
-#: pkg/docker/index.html:483 pkg/docker/index.html:655
+#: pkg/docker/index.html:485 pkg/docker/index.html:657
 msgid "shares"
 msgstr "utdelningar"
 
@@ -10129,10 +7986,6 @@ msgstr "stäng av"
 #: pkg/machines/helpers.js:191
 msgid "shutdown"
 msgstr "avstängning"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "sockets"
-msgstr "uttag"
 
 #: pkg/selinux/setroubleshoot-view.jsx:123
 msgid "solution details"
@@ -10154,10 +8007,6 @@ msgstr "ssh-servern är tom"
 msgid "suspended (PM)"
 msgstr "vilande (SH)"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "threads"
-msgstr "trådar"
-
 #: pkg/docker/run.js:474
 msgid "to host path"
 msgstr "till värdsökväg"
@@ -10173,10 +8022,6 @@ msgstr "översättningsbar"
 #: pkg/machines/helpers.js:218
 msgid "udp"
 msgstr "udp"
-
-#: pkg/ovirt/rephraseUI.js:37
-msgid "unassigned"
-msgstr "ej tilldelad"
 
 #: pkg/lib/cockpit-components-select.jsx:28
 msgid "undefined"
@@ -10195,7 +8040,7 @@ msgstr "okänt mål"
 msgid "unpartitioned space on $0"
 msgstr "opartitionerat utrymmer på $0"
 
-#: pkg/machines/helpers.js:237 pkg/ovirt/rephraseUI.js:26
+#: pkg/machines/helpers.js:237
 msgid "up"
 msgstr "uppe"
 
@@ -10204,7 +8049,6 @@ msgid "user"
 msgstr "användare"
 
 #: pkg/machines/components/vcpuModal.jsx:192
-#: pkg/ovirt/components/vcpuModal.jsx:54
 msgid "vCPU Count"
 msgstr "vCPU-antal"
 
@@ -10213,8 +8057,6 @@ msgid "vCPU Maximum"
 msgstr "vCPU-maximum"
 
 #: pkg/machines/components/vmOverviewTab.jsx:75
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "vCPUs"
 msgstr "vCPU:er"
 
@@ -10226,12 +8068,16 @@ msgstr "värde"
 msgid "vhostuser"
 msgstr "vhost-användare"
 
-#: pkg/kubernetes/views/route-body.html:13
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+msgid ""
+"virt-install package needs to be installed on the system in order to create "
+"new VMs"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:42
 msgid "yes"
 msgstr "ja"
 
@@ -10242,3 +8088,1403 @@ msgid ""
 msgstr ""
 "{{ condition.message }}.  Tidsstämpel: {{ condition.lastTransitionTime }}  "
 "Felantal: {{ condition.generation }}"
+
+#~ msgid " 1\"Do you want to delete the following Nodes?"
+#~ msgstr " 1\"Vill du radera följande noder?"
+
+#~ msgid "$0 vCPU Details"
+#~ msgstr "$0 vCPU-detaljer"
+
+#~ msgid "$0% Free"
+#~ msgid_plural "$0% Free"
+#~ msgstr[0] "$0 % fritt"
+#~ msgstr[1] "$0 % fritt"
+
+#~ msgid "$0% Used"
+#~ msgid_plural "$0% Used"
+#~ msgstr[0] "$0 % använt"
+#~ msgstr[1] "$0 % använt"
+
+#~ msgid "'Organization' required to register."
+#~ msgstr "“Organisation” krävs för att registrera."
+
+#~ msgid "'Organization' required when using activation keys."
+#~ msgstr "“Organisation” krävs vid användning av aktiveringsnycklar."
+
+#~ msgid "AWS Elastic Block Store"
+#~ msgstr "AWS elastisk blocklagring"
+
+#~ msgid "Access Modes"
+#~ msgstr "Åtkomstlägen"
+
+#~ msgid "Access denied"
+#~ msgstr "Åtkomst nekas"
+
+#~ msgid "Action"
+#~ msgstr "Åtgärd"
+
+#~ msgid "Activation Key"
+#~ msgstr "Aktiveringsnyckel"
+
+#~ msgid "Actual"
+#~ msgstr "Aktuell"
+
+#~ msgid "Add Cluster Node"
+#~ msgstr "Lägg till klusternod"
+
+#~ msgid "Add Group"
+#~ msgstr "Lägg till grupp"
+
+#~ msgid "Add Kubernetes Node"
+#~ msgstr "Lägg till Kubernetesnod"
+
+#~ msgid "Add Member"
+#~ msgstr "Lägg till medlem"
+
+#~ msgid "Add Membership"
+#~ msgstr "Lägg till medlemskap"
+
+#~ msgid "Add New Cluster"
+#~ msgstr "Lägg till nytt kluster"
+
+#~ msgid "Add New User"
+#~ msgstr "Lägg till ny användare"
+
+#~ msgid "Add Role"
+#~ msgstr "Lägg till roll"
+
+#~ msgid "Add User"
+#~ msgstr "Lägg till användare"
+
+#~ msgid "Add membership"
+#~ msgstr "Lägg till medlemskap"
+
+#~ msgid "Adjust"
+#~ msgstr "Justera"
+
+#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+#~ msgstr "Justera beständig volym ”{{ item.metadata.name }}”"
+
+#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
+#~ msgstr "Justera replikeringskontroll {{ item.metadata.name }}"
+
+#~ msgid "Adjust Route"
+#~ msgstr "Justera rutt"
+
+#~ msgid "Adjust Service"
+#~ msgstr "Justera tjänst"
+
+#~ msgid "Admin"
+#~ msgstr "Admin"
+
+#~ msgid "All Projects"
+#~ msgstr "Alla projekt"
+
+#~ msgid "All Types"
+#~ msgstr "Alla typer"
+
+#~ msgid "All healthy"
+#~ msgstr "Alla friska"
+
+#~ msgid "All images"
+#~ msgstr "Alla bilder"
+
+#~ msgid "All in use"
+#~ msgstr "Alla används"
+
+#~ msgid "All running"
+#~ msgstr "Alla kör"
+
+#~ msgid "All running virtual machines will be turned off."
+#~ msgstr "Alla körande virtuella maskiner kommer stängas av."
+
+#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
+#~ msgstr "Anonymt: tillåt alla oautentiserade användare att hämta avbilder"
+
+#~ msgid "Automatically selected host"
+#~ msgstr "Automatiskt vald värd"
+
+#~ msgid "Azure"
+#~ msgstr "Azure"
+
+#~ msgid "Base Template"
+#~ msgstr "Basmall"
+
+#~ msgid "Base template"
+#~ msgstr "Basmall"
+
+#~ msgid "Base template:"
+#~ msgstr "Basmall:"
+
+#~ msgid "Boot ID"
+#~ msgstr "Start-ID"
+
+#~ msgid "CPU Utilization: $0%"
+#~ msgstr "CPU-användning: $0 %"
+
+#~ msgid "CREATE VM action failed"
+#~ msgstr "Åtgärden SKAPA VM misslyckades"
+
+#~ msgid "Cannot decrypt PEM-encoded private key"
+#~ msgstr "Kan inte dektryptera en PEM-kodad privat nyckel"
+
+#~ msgid "Ceph Filesystem Mount"
+#~ msgstr "Ceph-filsystemsmontering"
+
+#~ msgid "Ceph Monitors"
+#~ msgstr "Ceph-övervakare"
+
+#~ msgid "Change User"
+#~ msgstr "Ändra användare"
+
+#~ msgid "Change image stream"
+#~ msgstr "Ändra avbildsström"
+
+#~ msgid "Change project"
+#~ msgstr "Ändra projekt"
+
+#~ msgid "Cinder"
+#~ msgstr "Cinder"
+
+#~ msgid "Claim"
+#~ msgstr "Anspråk"
+
+#~ msgid "Claim Name"
+#~ msgstr "Anspråksnamn"
+
+#~ msgid "Client Certificate"
+#~ msgstr "Klientcertifikat"
+
+#~ msgid "Cluster"
+#~ msgstr "Kluster"
+
+#~ msgid "Cluster Templates"
+#~ msgstr "Klustermallar"
+
+#~ msgid "Cluster Virtual Machines"
+#~ msgstr "Klustrets virtuella maskiner"
+
+#~ msgid "Configuration"
+#~ msgstr "Konfiguration"
+
+#~ msgid "Configure Flannel networking"
+#~ msgstr "Konfigurera Flannel-nätverk"
+
+#~ msgid "Configure Kubelet and Proxy"
+#~ msgstr "Konfigurerar Kubelet och Proxy"
+
+#~ msgid "Confirm migration"
+#~ msgstr "Bekräfta migrering"
+
+#~ msgid "Confirm reload:"
+#~ msgstr "Bekräfta omladdning:"
+
+#~ msgid "Confirm save:"
+#~ msgstr "Bekräfta sparandet:"
+
+#~ msgid "Connect to oVirt Engine"
+#~ msgstr "Anslut till oVirt Engine"
+
+#~ msgid "Connecting..."
+#~ msgstr "Ansluter …"
+
+#~ msgid "Connection Error: $0"
+#~ msgstr "Anslutningsfel: $0"
+
+#~ msgid "Connection Settings"
+#~ msgstr "Anslutningsinställningar"
+
+#~ msgid "Container ID"
+#~ msgstr "Behållar-ID"
+
+#~ msgid "Container Runtime Version"
+#~ msgstr "Behållarnas körtidsversion"
+
+#~ msgid "Could not list services"
+#~ msgstr "Kunde inte lista tjänster"
+
+#~ msgid "Could not parse PEM-encoded certificate"
+#~ msgstr "Kunde inte tolka PEM-kodat certifikat"
+
+#~ msgid "Could not parse PEM-encoded private key"
+#~ msgstr "Kunde inte tolka PEM-kodad privat nyckel"
+
+#~ msgid "Couldn't connect to server"
+#~ msgstr "Kunde inte ansluta till servern"
+
+#~ msgid "Couldn't find running API server"
+#~ msgstr "Kunde inte hitta en körande API-server"
+
+#~ msgid ""
+#~ "Couldn't get system subscription status. Please ensure subscription-"
+#~ "manager is installed."
+#~ msgstr ""
+#~ "Kunde inte få fram systemets prenumerationsstatus.  Se till att "
+#~ "subscription-manager är installerad."
+
+#~ msgid "Create New VM"
+#~ msgstr "Skapa en ny VM"
+
+#~ msgid "Create empty image stream"
+#~ msgstr "Skapa en tom avbildsström"
+
+#~ msgid "Create image stream"
+#~ msgstr "Skapa en avbildsström"
+
+#~ msgid "Custom URL"
+#~ msgstr "Anpassad URL"
+
+#~ msgid "DNS Policy"
+#~ msgstr "DNS-policy"
+
+#~ msgid "Delete '{{ name }}'"
+#~ msgstr "Ta bort”{{ name }}”"
+
+#~ msgid "Delete Node"
+#~ msgstr "Ta bort en nod"
+
+#~ msgid "Delete Persistent Volume"
+#~ msgstr "Ta bort en beständig volym"
+
+#~ msgid "Delete Persistent Volume Claim"
+#~ msgstr "Ta bort anspråk på en beständig volym"
+
+#~ msgid "Delete Project"
+#~ msgstr "Ta bort ett projekt"
+
+#~ msgid "Delete Selected"
+#~ msgstr "Ta bort det valda"
+
+#~ msgid "Delete image stream"
+#~ msgstr "Ta bort en avbildsström"
+
+#~ msgid "Delete {{ item.kind }}"
+#~ msgstr "Ta bort en {{ item.kind }}"
+
+#~ msgid ""
+#~ "Deleting a Pod will kill all associated containers. Pods may be "
+#~ "automatically created again in some cases."
+#~ msgstr ""
+#~ "Att ta bort en kapsel kommer döda tillhörande behållare.  Kapslar kan "
+#~ "automatiskt skapas igen i några fall."
+
+#~ msgid "Deploy"
+#~ msgstr "Placera ut"
+
+#~ msgid "Deploy Application"
+#~ msgstr "Placera ut ett program"
+
+#~ msgid "Deployment Causes"
+#~ msgstr "Utplaceringsorsaker"
+
+#~ msgid "Deployment Config"
+#~ msgstr "Utplaceringskonfiguration"
+
+#~ msgid "Deployment Configs"
+#~ msgstr "Utplaceringskonfigurationer"
+
+#~ msgid "Description:"
+#~ msgstr "Beskrivning:"
+
+#~ msgid "Disk Utilization: $0%"
+#~ msgstr "Diskanvändning: $0 %"
+
+#~ msgid "Display name"
+#~ msgstr "Visningsnamn"
+
+#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#~ msgstr "Vill du lägga till rollen ”{{ fields.displayRole }}”?"
+
+#~ msgid ""
+#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}' image stream?"
+#~ msgstr ""
+#~ "Vill du ta bort avbildsströmmen ”{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}”?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+#~ msgstr "Vill du ta bort den beständiga volymen ”{{item.metadata.name}}”?"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume Claim '{{item.metadata."
+#~ "name}}'?"
+#~ msgstr ""
+#~ "Vill du ta bort anspråket på den beständiga volymen ”{{item.metadata."
+#~ "name}}”?"
+
+#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+#~ msgstr "Vill du ta bort {{ item.kind }} ”{{item.metadata.name}}”?"
+
+#~ msgid "Do you want to delete this Node?"
+#~ msgstr "Vill du ta bort denna nod?"
+
+#~ msgid ""
+#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+#~ msgstr ""
+#~ "Vill du ta bort avbilden med etiketten ”{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}”?"
+
+#~ msgid ""
+#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
+#~ "{{ fields.member.metadata.name }}?"
+#~ msgstr ""
+#~ "Vill du ta bort rollen ”{{ fields.displayRole }}” från medlemmen "
+#~ "{{ fields.member.metadata.name }}?"
+
+#~ msgid "Don't pull images automatically"
+#~ msgstr "Hämta inte avbilder automatiskt"
+
+#~ msgid "Driver"
+#~ msgstr "Drivrutin"
+
+#~ msgid "Edit the vdsm.conf"
+#~ msgstr "Redigera vdsm.conf"
+
+#~ msgid "Empty Directory"
+#~ msgstr "Tom katalog"
+
+#~ msgid "Endpoint"
+#~ msgstr "Ändpunkt"
+
+#~ msgid "Endpoint Name"
+#~ msgstr "Ändpunktsnamn"
+
+#~ msgid "Endpoints"
+#~ msgstr "Ändpunkter"
+
+#~ msgid "Ends"
+#~ msgstr "Slutar"
+
+#~ msgid "Enter New VM name"
+#~ msgstr "Ange nytt VM-namn"
+
+#~ msgid "Error getting certificate details: $0"
+#~ msgstr "Fel när certifikatdetaljer hämtades: $0"
+
+#~ msgid "Error writing kubectl config"
+#~ msgstr "Fel när konfiguration av kubectl skrevs"
+
+#~ msgid "FQDN"
+#~ msgstr "FQDN"
+
+#~ msgid "Fibre Channel"
+#~ msgstr "Fiberkanal"
+
+#~ msgid "Filesystem Type"
+#~ msgstr "Filsystemstyp"
+
+#~ msgid "Flex"
+#~ msgstr "Flex"
+
+#~ msgid "Flocker"
+#~ msgstr "Flocker"
+
+#~ msgid "Flocker Dataset Name"
+#~ msgstr "Flockers datamängdsnamn"
+
+#~ msgid "GCE Persistent Disk"
+#~ msgstr "GCE beständig disk"
+
+#~ msgid "Git Repository"
+#~ msgstr "Git-förråd"
+
+#~ msgid "Gluster FS"
+#~ msgstr "Gluster-FS"
+
+#~ msgid "GlusterFS"
+#~ msgstr "GlusterFS"
+
+#~ msgid "Grant additional push or admin access to specific members below."
+#~ msgstr ""
+#~ "Ge ytterligare push- eller admin-åtkomst till de specifika medlemmarna "
+#~ "nedan."
+
+#~ msgid "Group Members"
+#~ msgstr "Gruppmedlemmar"
+
+#~ msgid "Group or Project"
+#~ msgstr "Grupp eller projekt"
+
+#~ msgid "Groups"
+#~ msgstr "Grupper"
+
+#~ msgid "HA"
+#~ msgstr "HA"
+
+#~ msgid "HA:"
+#~ msgstr "HA:"
+
+#~ msgid "Host Path"
+#~ msgstr "Värdsökväg"
+
+#~ msgid "Host to Maintenance"
+#~ msgstr "Värd till underhåll"
+
+#~ msgid "IP"
+#~ msgstr "IP"
+
+#~ msgid "ISCSI"
+#~ msgstr "ISCSI"
+
+#~ msgid "Identities"
+#~ msgstr "Identiteter"
+
+#~ msgid "Identity"
+#~ msgstr "Identitet"
+
+#~ msgid "Image ID"
+#~ msgstr "Avbilds-ID"
+
+#~ msgid "Image Name"
+#~ msgstr "Avbildsnamn"
+
+#~ msgid "Image Registry"
+#~ msgstr "Avbildsregister"
+
+#~ msgid "Image Stream"
+#~ msgstr "Avbildsström"
+
+#~ msgid "Image commands"
+#~ msgstr "Avbildskommandon"
+
+#~ msgid "Images by project"
+#~ msgstr "Avbilder per projekt"
+
+#~ msgid "Images pushed recently"
+#~ msgstr "Avbilder trycktes upp nyligen"
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, use the commands below."
+#~ msgstr ""
+#~ "För att börja trycka avbilder till registret, använd kommandona nedan."
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, you need to create a "
+#~ "project."
+#~ msgstr ""
+#~ "För att börja trycka avbilder till registret behöver du skapa ett projekt."
+
+#~ msgid "Installed products"
+#~ msgstr "Installerade produkter"
+
+#~ msgid "Interface"
+#~ msgstr "Gränssnitt"
+
+#~ msgid "Invalid credentials"
+#~ msgstr "Felaktiga kreditiv"
+
+#~ msgid "Kernel Version"
+#~ msgstr "Kärnversion"
+
+#~ msgid "Key Ring Path"
+#~ msgstr "Nyckelringssökväg"
+
+#~ msgid "Kubelet Version"
+#~ msgstr "Kubelet-version"
+
+#~ msgid "Kubernetes Cluster"
+#~ msgstr "Kubernetes-kluster"
+
+#~ msgid "Last Heartbeat"
+#~ msgstr "Senaste hjärtslag"
+
+#~ msgid "Last Status Change"
+#~ msgstr "Senaste statusändring"
+
+#~ msgid "Latest Version"
+#~ msgstr "Senaste version"
+
+#~ msgid "Loading data ..."
+#~ msgstr "Läser in data …"
+
+#~ msgid "Log into OpenShift command line tools:"
+#~ msgstr "Logga in till OpenShifts kommandoradsverktyg:"
+
+#~ msgid "Log into the registry:"
+#~ msgstr "Logga in i registret:"
+
+#~ msgid "Logical Unit Number"
+#~ msgstr "Logiskt enhetsnummer"
+
+#~ msgid "Login"
+#~ msgstr "Inloggning"
+
+#~ msgid "Login commands"
+#~ msgstr "Inloggningskommandon"
+
+#~ msgid "Login/password or activation key required to register."
+#~ msgstr ""
+#~ "Inloggning/lösenord eller aktiveringsnyckel krävs för att registrera."
+
+#~ msgid "MIGRATE action failed"
+#~ msgstr "Åtgärden MIGRATE misslyckades"
+
+#~ msgid "Manifest"
+#~ msgstr "Förteckning"
+
+#~ msgid "Medium"
+#~ msgstr "Medium"
+
+#~ msgid "Member of"
+#~ msgstr "Medlem i"
+
+#~ msgid "Members"
+#~ msgstr "Medlemmar"
+
+#~ msgid "Membership"
+#~ msgstr "Medlemskap"
+
+#~ msgid "Memory Utilization: $0%"
+#~ msgstr "Minnesanvändning: $0 %"
+
+#~ msgid "Message"
+#~ msgstr "Meddelande"
+
+#~ msgid "Migrate To:"
+#~ msgstr "Migrera till:"
+
+#~ msgid "Modify"
+#~ msgstr "Modifiera"
+
+#~ msgid "Monitors"
+#~ msgstr "Övervakare"
+
+#~ msgid "Mount Location"
+#~ msgstr "Monteringsplats"
+
+#~ msgid "NFS"
+#~ msgstr "NFS"
+
+#~ msgid "Namespace"
+#~ msgstr "Namnrymd"
+
+#~ msgid "Namespace cannot be empty."
+#~ msgstr "Namnrymden får inte vara tom."
+
+#~ msgid "New Group"
+#~ msgstr "Ny grupp"
+
+#~ msgid "New Project"
+#~ msgstr "Nytt projekt"
+
+#~ msgid "New image stream"
+#~ msgstr "Ny avbildsström"
+
+#~ msgid "New project"
+#~ msgstr "Nytt projekt"
+
+#~ msgid "No PEM-encoded certificate found"
+#~ msgstr "Inget PEM-kodat certifikat hittat"
+
+#~ msgid "No PEM-encoded private key found"
+#~ msgstr "Ingen PEM-kodad privat nyckel hittad"
+
+#~ msgid "No Pods are using this claim"
+#~ msgstr "Inga kapslar använder detta anspråk"
+
+#~ msgid "No VM found in oVirt."
+#~ msgstr "Ingen VM hittad i oVirt."
+
+#~ msgid "No Volume Bound"
+#~ msgstr "Ingen volymgräns"
+
+#~ msgid "No groups are present."
+#~ msgstr "Inga grupper finns."
+
+#~ msgid "No images pushed"
+#~ msgstr "Inga avbilder trycktes"
+
+#~ msgid "No installed products on the system."
+#~ msgstr "Inga installerade produkter på systemet."
+
+#~ msgid ""
+#~ "No metadata file was selected. Please select a Kubernetes metadata file."
+#~ msgstr "Ingen metadatafil valdes.  Välj en fil med Kubernetes metadata."
+
+#~ msgid "No nodes in cluster"
+#~ msgstr "Inga noder i klustret"
+
+#~ msgid "No oVirt connection"
+#~ msgstr "Ingen oVirt-förbindelse"
+
+#~ msgid "No pods deployed"
+#~ msgstr "Inga kapslar är utplacerade"
+
+#~ msgid "No pods replicated"
+#~ msgstr "Inga kapslar är replikerade"
+
+#~ msgid "No pods scheduled"
+#~ msgstr "Inga kapslar är schemalagda"
+
+#~ msgid "No pods selected"
+#~ msgstr "Inga kapslar är valda"
+
+#~ msgid "No projects are present."
+#~ msgstr "Inga projekt finns."
+
+#~ msgid "No users are present."
+#~ msgstr "Inga användare finns."
+
+#~ msgid "No volumes are present."
+#~ msgstr "Inga volymer finns."
+
+#~ msgid "No volumes in use"
+#~ msgstr "Inga volymer används"
+
+#~ msgid "Node"
+#~ msgstr "Nod"
+
+#~ msgid "Nodes"
+#~ msgstr "Noder"
+
+#~ msgid "Nodes are the machines that run your containers."
+#~ msgstr "Noder är maskinerna som kör dina behållare."
+
+#~ msgid "Not a valid number of replicas"
+#~ msgstr "Inte ett giltigt antal repliker"
+
+#~ msgid "Not a valid value for Host"
+#~ msgstr "Inte ett giltigt värde på värd"
+
+#~ msgid "Not deployed"
+#~ msgstr "Inte utplacerad"
+
+#~ msgid "Number of virtual CPUs that gonna be used."
+#~ msgstr "Antal virtuella CPU:er som kommer användas."
+
+#~ msgid "OK"
+#~ msgstr "OK"
+
+#~ msgid "OS"
+#~ msgstr "OS"
+
+#~ msgid "OS Type:"
+#~ msgstr "OS-typ:"
+
+#~ msgid "OS Versions"
+#~ msgstr "OS-versioner"
+
+#~ msgid "Optimized for:"
+#~ msgstr "Optimerad för:"
+
+#~ msgid "Organization"
+#~ msgstr "Organisation"
+
+#~ msgid "PD Name"
+#~ msgstr "PD-namn"
+
+#~ msgid "Pending Volume Claims"
+#~ msgstr "Väntande volymanspråk"
+
+#~ msgid "Persistent Volumes"
+#~ msgstr "Beständiga volymer"
+
+#~ msgid "Phase"
+#~ msgstr "Fas"
+
+#~ msgid "Please confirm, the host shall be switched to maintenance mode."
+#~ msgstr "Bekräfta att värden skall slås om till underhållsläge."
+
+#~ msgid "Please create another namespace for $0 \"$1\""
+#~ msgstr "Skapa en annan namnrymd för $0 ”$1”"
+
+#~ msgid "Please provide a GlusterFS volume name"
+#~ msgstr "Ge ett GlusterFS-volymnamn"
+
+#~ msgid "Please provide a username"
+#~ msgstr "Ange ett användarnamn"
+
+#~ msgid "Please provide a valid NFS server"
+#~ msgstr "Ange en giltig NFS-server"
+
+#~ msgid "Please provide a valid address"
+#~ msgstr "Ange en giltig adress"
+
+#~ msgid "Please provide a valid filesystem type"
+#~ msgstr "Ange en giltig filsystemtyp"
+
+#~ msgid "Please provide a valid interface"
+#~ msgstr "Ange ett giltigt gränssnitt"
+
+#~ msgid "Please provide a valid logical unit number"
+#~ msgstr "Ange ett giltigt nummer på en logisk enhet"
+
+#~ msgid "Please provide a valid name"
+#~ msgstr "Ange ett giltigt namn"
+
+#~ msgid "Please provide a valid namespace."
+#~ msgstr "Ange en giltig namnrymd."
+
+#~ msgid "Please provide a valid path"
+#~ msgstr "Ange en giltig sökväg"
+
+#~ msgid "Please provide a valid qualified name"
+#~ msgstr "Ange ett giltigt kvalificerat namn"
+
+#~ msgid "Please provide a valid storage capacity."
+#~ msgstr "Ange en giltig lagringskapacitet."
+
+#~ msgid "Please provide a valid target"
+#~ msgstr "Ange ett giltigt mål"
+
+#~ msgid ""
+#~ "Please provide fully qualified domain name and port of the oVirt engine."
+#~ msgstr "Ange ett full kvalificerat domännamn och en port till oVirt-motorn."
+
+#~ msgid ""
+#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
+#~ "port (443 by default)"
+#~ msgstr ""
+#~ "Ange ett giltigt fullständigt kvalificerat domännamn (FQDN) och en port "
+#~ "(443 som standard) till oVirt-motorn"
+
+#~ msgid ""
+#~ "Please refer to oVirt's $0 for more information about Remote Viewer setup."
+#~ msgstr ""
+#~ "Referera oVirts $0 för mer information om uppsättning av fjärrvisare."
+
+#~ msgid "Please select a valid access mode"
+#~ msgstr "Välj ett giltigt åtkomstläge"
+
+#~ msgid "Please select a valid endpoint"
+#~ msgstr "Välj en giltig slutpunkt"
+
+#~ msgid "Please select a valid policy option."
+#~ msgstr "Välj ett giltigt policyalternativ."
+
+#~ msgid "Please type an address"
+#~ msgstr "Skriv en adress"
+
+#~ msgid "Please wait till VMs list is loaded from the server."
+#~ msgstr "Vänta tills VM-listan är inläst från servern."
+
+#~ msgid "Please wait till list of templates is loaded from the server."
+#~ msgstr "Vänta till listan av mallar är inläst från servern."
+
+#~ msgid "Pod"
+#~ msgstr "Kapsel"
+
+#~ msgid "Pod Address"
+#~ msgstr "Kapseladress"
+
+#~ msgid "Pod Endpoints"
+#~ msgstr "Kapseländpunkter"
+
+#~ msgid "Pod Replicated"
+#~ msgstr "Kapsel replikerad"
+
+#~ msgid "Pod Selector"
+#~ msgstr "Kapselväljare"
+
+#~ msgid "Pods"
+#~ msgstr "Kapslar"
+
+#~ msgid ""
+#~ "Pods contain one or more containers that run together on a node, "
+#~ "containing your application code."
+#~ msgstr ""
+#~ "Kapslar innehåller en eller flera behållare som kör tillsamans på en nod, "
+#~ "och innehåller din programkod."
+
+#~ msgid "Pool Name"
+#~ msgstr "Poolnamn"
+
+#~ msgid "Populate"
+#~ msgstr "Populera"
+
+#~ msgid "Preparing for Maintenance"
+#~ msgstr "Förbereder för underhåll"
+
+#~ msgid "Private: Allow only specific users or groups to pull images"
+#~ msgstr ""
+#~ "Privat: tillåt endast specifika användare eller grupper att hämta avbilder"
+
+#~ msgid "Product ID"
+#~ msgstr "Produkt-ID"
+
+#~ msgid "Product name"
+#~ msgstr "Produktnamn"
+
+#~ msgid "Project"
+#~ msgstr "Projekt"
+
+#~ msgid "Project Members"
+#~ msgstr "Projektmedlemmar"
+
+#~ msgid "Project access policy allows anonymous users to pull images."
+#~ msgstr ""
+#~ "Projektåtkomstpolicyn tillåter anonyma användare att hämta avbilder."
+
+#~ msgid "Project access policy allows any authenticated user to pull images."
+#~ msgstr ""
+#~ "Projektåtkomstpolicyn tillåter alla autentiserade användare att hämta "
+#~ "avbilder."
+
+#~ msgid "Project access policy only allows specific members to access images."
+#~ msgstr ""
+#~ "Projektåtkomstpolicyn tillåter endast specifika medlemmar att komma åt "
+#~ "avbilder."
+
+#~ msgid "Project:"
+#~ msgstr "Projekt:"
+
+#~ msgid "Projects"
+#~ msgstr "Projekt"
+
+#~ msgid "Proxy"
+#~ msgstr "Proxy"
+
+#~ msgid "Proxy Version"
+#~ msgstr "Proxy-version"
+
+#~ msgid "Pull an image:"
+#~ msgstr "Hämta en avbild:"
+
+#~ msgid "Pull from"
+#~ msgstr "Hämta ifrån"
+
+#~ msgid "Pull specific tags from another image repository"
+#~ msgstr "Hämta specifika taggar från ett annat avbildsförråd"
+
+#~ msgid "Push an image:"
+#~ msgstr "Tryck ut en avbild:"
+
+#~ msgid "Qualified Name"
+#~ msgstr "Kvalificerat namn"
+
+#~ msgid "REBOOT action failed"
+#~ msgstr "Åtgärden REBOOT misslyckades"
+
+#~ msgid "Rados Block Device"
+#~ msgstr "Rados-blockenhet"
+
+#~ msgid "Read Only"
+#~ msgstr "Skrivskyddad"
+
+#~ msgid "Read and write from a single node"
+#~ msgstr "Läs och skriv från en enstaka nod"
+
+#~ msgid "Read and write from multiple nodes"
+#~ msgstr "Läs och skriv från flera noder"
+
+#~ msgid "Read only from multiple nodes"
+#~ msgstr "Läs endast från flera noder"
+
+#~ msgid "Reason"
+#~ msgstr "Orsak"
+
+#~ msgid "Reclaim Policy"
+#~ msgstr "Återvinningspolicy"
+
+#~ msgid "Recycle"
+#~ msgstr "Återvinn"
+
+#~ msgid "Register"
+#~ msgstr "Registrera"
+
+#~ msgid "Register New Volume"
+#~ msgstr "Registrera en ny volym"
+
+#~ msgid "Register Persistent Volume"
+#~ msgstr "Registrera en beständig volym"
+
+#~ msgid "Register oVirt"
+#~ msgstr "Registrera oVirt"
+
+#~ msgid "Register system"
+#~ msgstr "Registrera system"
+
+#~ msgid "Registering oVirt to Cockpit"
+#~ msgstr "Registrera oVirt i Cockpit"
+
+#~ msgid "Remote registry is insecure"
+#~ msgstr "Fjärregistret är osäkert"
+
+#~ msgid "Remove Group"
+#~ msgstr "Ta bort grupp"
+
+#~ msgid "Remove Member"
+#~ msgstr "Ta bort medlem"
+
+#~ msgid "Remove Role"
+#~ msgstr "Ta bort roll"
+
+#~ msgid "Remove User"
+#~ msgstr "Ta bort användare"
+
+#~ msgid "Remove image tag"
+#~ msgstr "Ta bort avbildstagg"
+
+#~ msgid "Remove membership"
+#~ msgstr "Ta bort medlemskap"
+
+#~ msgid "Replicas"
+#~ msgstr "Repliker"
+
+#~ msgid "Replication Controller"
+#~ msgstr "Replikeringsstyrare"
+
+#~ msgid "Replication Controllers"
+#~ msgstr "Replikeringsstyrare"
+
+#~ msgid ""
+#~ "Replication controllers dynamically create instances of pods from "
+#~ "templates, and remove pods when necessary."
+#~ msgstr ""
+#~ "Replikeringsstyrare skapar dynamiskt instanser av kapslar från mallar, "
+#~ "och tar bort kapslar vid behov."
+
+#~ msgid "Repository URL"
+#~ msgstr "Förråds-URL"
+
+#~ msgid "Requested"
+#~ msgstr "Begärd"
+
+#~ msgid "Requests"
+#~ msgstr "Begäranden"
+
+#~ msgid "Requires Authentication"
+#~ msgstr "Begär autentisering"
+
+#~ msgid "Restart Count"
+#~ msgstr "Omstartsräknare"
+
+#~ msgid "Retain"
+#~ msgstr "Behåll"
+
+#~ msgid "Retrieving subscription status..."
+#~ msgstr "Hämtar prenumerationsstatus …"
+
+#~ msgid "Revision"
+#~ msgstr "Revision"
+
+#~ msgid "Role"
+#~ msgstr "Roll"
+
+#~ msgid "Route"
+#~ msgstr "Rutt"
+
+#~ msgid "Run Here"
+#~ msgstr "Kör här"
+
+#~ msgid "Running Since:"
+#~ msgstr "Kör sedan:"
+
+#~ msgid "SET VCPU SETTINGS action failed"
+#~ msgstr "Åtgärden SET VCPU SETTINGS misslyckades"
+
+#~ msgid "SHUTDOWN action failed"
+#~ msgstr "Åtgärden SHUTDOWN misslyckades"
+
+#~ msgid "START action failed"
+#~ msgstr "Åtgärden START misslyckades"
+
+#~ msgid "SUSPEND action failed"
+#~ msgstr "Åtgärden SUSPEND misslyckades"
+
+#~ msgid "Scheduled Pods"
+#~ msgstr "Schemalagda kapslar"
+
+#~ msgid "Scheduling Disabled"
+#~ msgstr "Schemaläggningen avaktiverad"
+
+#~ msgid "Secret"
+#~ msgstr "Hemlighet"
+
+#~ msgid "Secret File"
+#~ msgstr "Hemlig fil"
+
+#~ msgid "Secret Name"
+#~ msgstr "Hemligt namn"
+
+#~ msgid "Secret Volume"
+#~ msgstr "Hemlig volym"
+
+#~ msgid "Select Manifest File..."
+#~ msgstr "Välj förteckningsfil …"
+
+#~ msgid "Select Member"
+#~ msgstr "Välj medlem"
+
+#~ msgid "Select Role"
+#~ msgstr "Välj roll"
+
+#~ msgid "Select an object to see more details."
+#~ msgstr "Välj ett objekt för att se fler detaljer."
+
+#~ msgid "Service Account"
+#~ msgstr "Tjänstekonto"
+
+#~ msgid ""
+#~ "Services group pods and provide a common DNS name and an optional, load-"
+#~ "balanced IP address to access them."
+#~ msgstr ""
+#~ "Tjänster grupperar kapslar och tillhandahåller ett gemensamt DNS-namn och "
+#~ "om så önskas en lastbalanserad IP-adress för att komma åt dem."
+
+#~ msgid "Session Affinity"
+#~ msgstr "Sessionsaffinitet"
+
+#~ msgid "Share Name"
+#~ msgstr "Delat namn"
+
+#~ msgid "Shared: Allow any authenticated user to pull images"
+#~ msgstr "Delat: tillåt alla autentiserade användare att hämta avbilder"
+
+#~ msgid "Shell"
+#~ msgstr "Skal"
+
+#~ msgid "Show all Containers"
+#~ msgstr "Visa alla behållare"
+
+#~ msgid "Show all Deployment Configs"
+#~ msgstr "Visa alla utplaceringskonfigurationer"
+
+#~ msgid "Show all Nodes"
+#~ msgstr "Visa alla noder"
+
+#~ msgid "Show all Persistent Volumes"
+#~ msgstr "Visa alla beständiga volymer"
+
+#~ msgid "Show all Pod Containers"
+#~ msgstr "Visa alla kapselbehållare"
+
+#~ msgid "Show all Pods"
+#~ msgstr "Visa alla kapslar"
+
+#~ msgid "Show all Projects"
+#~ msgstr "Visa alla projekt"
+
+#~ msgid "Show all Replication Controllers"
+#~ msgstr "Visa alla replikeringsstyrare"
+
+#~ msgid "Show all Routes"
+#~ msgstr "Visa alla rutter"
+
+#~ msgid "Show all Services"
+#~ msgstr "Visa alla tjänster"
+
+#~ msgid "Show all image streams"
+#~ msgstr "Visa alla avbildsströmmar"
+
+#~ msgid "Since"
+#~ msgstr "Sedan"
+
+#~ msgid "Skip Certificate Verification"
+#~ msgstr "Hoppa över certifikatverifikation"
+
+#~ msgid "Sorry, I don't know how to modify this volume"
+#~ msgstr "Ledsen, jag vet inte hur man ändrar denna volym"
+
+#~ msgid "Starts"
+#~ msgstr "Startar"
+
+#~ msgid "Stateless"
+#~ msgstr "Tillståndslös"
+
+#~ msgid "Stateless:"
+#~ msgstr "Tillståndslös:"
+
+#~ msgid "Status: $0"
+#~ msgstr "Status: $0"
+
+#~ msgid "Status: System isn't registered"
+#~ msgstr "Status: systemet är inte registrerat"
+
+#~ msgid "Strategy"
+#~ msgstr "Strategi"
+
+#~ msgid "Subscriptions"
+#~ msgstr "Prenumerationer"
+
+#~ msgid "Suspend"
+#~ msgstr "Vila"
+
+#~ msgid "Switch Host to Maintenance"
+#~ msgstr "Slå om värden till underhåll"
+
+#~ msgid "Switching host to maintenance mode failed. Received error: "
+#~ msgstr "Att slå om värden till underhållsläge misslyckades.  Mottog felet: "
+
+#~ msgid "Switching host to maintenance mode in progress ..."
+#~ msgstr "Att slå om värden till underhållsläge pågår …"
+
+#~ msgid "Sync all tags from a remote image repository"
+#~ msgstr "Synkronisera alla taggar från ett fjärravbildsförråd"
+
+#~ msgid "TLS Termination"
+#~ msgstr "TLS-avslutning"
+
+#~ msgid "Target Portal"
+#~ msgstr "Målportal"
+
+#~ msgid "Target World Wide Names"
+#~ msgstr "Målets världsvida namn"
+
+#~ msgid "Template"
+#~ msgstr "Mall"
+
+#~ msgid "Templates"
+#~ msgstr "Mallar"
+
+#~ msgid "Templates of $0 cluster"
+#~ msgstr "Mallar över $0 kluster"
+
+#~ msgid "The address contains invalid characters"
+#~ msgstr "Adressen innehåller otillåtna tecken"
+
+#~ msgid "The container '{{ target }}' does not exist."
+#~ msgstr "Behållaren ”{{ target }}” finns inte."
+
+#~ msgid "The current user isn't allowed to access system subscription status."
+#~ msgstr ""
+#~ "Den aktuella användaren har inte tillåtelse att komma åt systemets "
+#~ "prenumerationsstatus."
+
+#~ msgid "The deployment config '{{ target }}' does not exist."
+#~ msgstr "Utplaceringskonfigurationen ”{{ target }}” finns inte."
+
+#~ msgid "The group '{{ groupName }}' does not exist."
+#~ msgstr "Gruppen ”{{ groupName }}” finns inte."
+
+#~ msgid "The maximum number of replicas is 128"
+#~ msgstr "Det maximala antalet repliker är 128"
+
+#~ msgid "The name contains invalid characters"
+#~ msgstr "Namnet innehåller ogiltiga tecken"
+
+#~ msgid "The node '{{ target }}' does not exist."
+#~ msgstr "Noden ”{{ target }}” finns inte."
+
+#~ msgid "The node doesn't have enough disk space"
+#~ msgstr "Noden har inte tillräckligt med diskutrymme"
+
+#~ msgid "The node doesn't have enough free memory"
+#~ msgstr "Noden har inte tillräckligt med fritt minne"
+
+#~ msgid "The persistent volume '{{ target }}' does not exist."
+#~ msgstr "Den beständiga volymen ”{{ target }}” finns inte."
+
+#~ msgid "The pod '{{ target }}' does not exist."
+#~ msgstr "Kapseln ”{{ target }}” finns inte."
+
+#~ msgid "The project '{{ projName }}' does not exist."
+#~ msgstr "Projektet ”{{ projName }}” finns inte."
+
+#~ msgid "The replication controller '{{ target }}' does not exist."
+#~ msgstr "Replikeringsstyraren ”{{ target }}” finns inte."
+
+#~ msgid "The route '{{ target }}' does not exist."
+#~ msgstr "Rutten ”{{ target }}” finns inte."
+
+#~ msgid "The selected file is not a valid Kubernetes application manifest."
+#~ msgstr ""
+#~ "Den valda filen är inte en giltig programförteckning för Kubernetes."
+
+#~ msgid "The server uses a certificate signed by an unknown authority."
+#~ msgstr "Servern använder ett certifikat signerat av en okänd auktoritet."
+
+#~ msgid "The service '{{ target }}' does not exist."
+#~ msgstr "Tjänsten ”{{ target }}” finns inte."
+
+#~ msgid "The user '{{ userName }}' does not exist."
+#~ msgstr "Användaren ”{{ target }}” finns inte."
+
+#~ msgid ""
+#~ "This claim is in use. Deleting it may cause issues with the following pod:"
+#~ msgstr ""
+#~ "Detta anspråk används.  Att ta bort den kan orsaka problem med följande "
+#~ "kapsel:"
+
+#~ msgid ""
+#~ "This host is managed by a virtualization manager, so creation of new VMs "
+#~ "from the host is not possible."
+#~ msgstr ""
+#~ "Denna värd hanteras av en virtualiseringshanterare, så att skapa nya VM:"
+#~ "er av värden är inte möjligt."
+
+#~ msgid ""
+#~ "This option is for single node testing only – local storage will not work "
+#~ "in a multi-node cluster"
+#~ msgstr ""
+#~ "Denna flagga är endast för test av enstaka noder — lokal lagring kommer "
+#~ "inte fungera i ett flernodskluster"
+
+#~ msgid "This virtual machine is not managed by oVirt"
+#~ msgstr "Denna virtuella maskin hanteras inte av oVirt"
+
+#~ msgid ""
+#~ "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+#~ "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+#~ "may cause issues with any pods depending on it."
+#~ msgstr ""
+#~ "Denna volym har tagits i anspråk av {{ item.item.spec.claimRef."
+#~ "namespace }} / {{ item.item.spec.claimRef.name }}.  Att ta bort den "
+#~ "kommer bryta detta anspråk och kan orsaka problem med de kapslar som "
+#~ "beror på den."
+
+#~ msgid "This volume has not been claimed"
+#~ msgstr "Denna volym har inte tagits  anspråk"
+
+#~ msgid "Token"
+#~ msgstr "Symbol"
+
+#~ msgid "Topology"
+#~ msgstr "Topologi"
+
+#~ msgid "Trust this certificate for this connection"
+#~ msgstr "Lita på detta certifikat för denna anslutning"
+
+#~ msgid "Type:"
+#~ msgstr "Typ:"
+
+#~ msgid "Unable to connect"
+#~ msgstr "Kan inte ansluta"
+
+#~ msgid "Unable to decode Kubernetes application manifest."
+#~ msgstr "Kan inte avkoda programförteckningen för Kubernetes"
+
+#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
+#~ msgstr "Kan inte läsa programförteckningen för Kubernetes.  Kod $0."
+
+#~ msgid "Unregister"
+#~ msgstr "Avregistrera"
+
+#~ msgid "Unregistering system..."
+#~ msgstr "Avregistrerar systemet …"
+
+#~ msgid "Updating $0..."
+#~ msgstr "Uppdaterar $0 …"
+
+#~ msgid "Use proxy server"
+#~ msgstr "Använd en proxyserver"
+
+#~ msgid "User or Group"
+#~ msgstr "Användare eller grupp"
+
+#~ msgid "Users"
+#~ msgstr "Användare"
+
+#~ msgid "VDSM"
+#~ msgstr "VDSM"
+
+#~ msgid "VDSM Service Management"
+#~ msgstr "VDSM tjänstehantering"
+
+#~ msgid "VM icon"
+#~ msgstr "VM-ikon"
+
+#~ msgid "Version num"
+#~ msgstr "Version nummer"
+
+#~ msgid "Virtual Machines of $0 cluster"
+#~ msgstr "Virtuella maskiner i klustret $0"
+
+#~ msgid "Volume ID"
+#~ msgstr "Volym-ID"
+
+#~ msgid "Volume Name"
+#~ msgstr "Volymnamn"
+
+#~ msgid "Volume Type"
+#~ msgstr "Volymtyp"
+
+#~ msgid "Warning:"
+#~ msgstr "Varning:"
+
+#~ msgid "Welcome to the Image Registry"
+#~ msgstr "Välkommen till avbildsregistret"
+
+#~ msgid "When"
+#~ msgstr "När"
+
+#~ msgid ""
+#~ "You can bypass the certificate check, but any data you send to the server "
+#~ "could be intercepted by others."
+#~ msgstr ""
+#~ "Du kan hoppa över certifikatkontrollen, men alla data du skickar till "
+#~ "servern skulle kunna avlyssnas av andra."
+
+#~ msgid "You can deploy an application to your cluster."
+#~ msgstr "Du kan placera ut ett program i ditt kluster."
+
+#~ msgid ""
+#~ "Your login credentials do not give you access to use the docker registry "
+#~ "from the command line."
+#~ msgstr ""
+#~ "Dina inloggningskreditiv ger dig inte åtkomst till att använda docker-"
+#~ "registret från kommandoraden."
+
+#~ msgid "connecting"
+#~ msgstr "ansluter"
+
+#~ msgid "cores"
+#~ msgstr "kärnor"
+
+#~ msgid "eg: my-image-stream"
+#~ msgstr "t.ex.: min-avbildsström"
+
+#~ msgid "error"
+#~ msgstr "fel"
+
+#~ msgid "initializing"
+#~ msgstr "initierar"
+
+#~ msgid "installation failed"
+#~ msgstr "installationen misslyckades"
+
+#~ msgid "installing OS"
+#~ msgstr "installerar OS"
+
+#~ msgid "kdumping"
+#~ msgstr "kdumpar"
+
+#~ msgid "maintenance"
+#~ msgstr "underhåll"
+
+#~ msgid "non operational"
+#~ msgstr "inte i drift"
+
+#~ msgid "non responsive"
+#~ msgstr "svarar inte"
+
+#~ msgid "oVirt"
+#~ msgstr "oVirt"
+
+#~ msgid "oVirt Host State:"
+#~ msgstr "oVirt-värdtillstånd:"
+
+#~ msgid "oVirt Provider installation script failed due to missing arguments."
+#~ msgstr ""
+#~ "oVirt-leverantörsinstallationsskript misslyckades på grund av saknade "
+#~ "argument."
+
+#~ msgid ""
+#~ "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
+#~ "machines-ovirt.config, try as root."
+#~ msgstr ""
+#~ "oVirt-leverantörsinstallationsskript misslyckades: kan inte skriva till /"
+#~ "etc/cockpit/machines-ovirt.config, försök som root."
+
+#~ msgid "oVirt installation script failed with following output: "
+#~ msgstr "oVirt-installationsskript misslyckades med följande utdata: "
+
+#~ msgid "pending approval"
+#~ msgstr "väntande godkännande"
+
+#~ msgid "pending volume claims"
+#~ msgstr "väntande volymanspråk"
+
+#~ msgid "reboot"
+#~ msgstr "starta om"
+
+#~ msgid "sockets"
+#~ msgstr "uttag"
+
+#~ msgid "threads"
+#~ msgstr "trådar"
+
+#~ msgid "unassigned"
+#~ msgstr "ej tilldelad"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,17 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 04:52+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-06-26 06:18+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
 "Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
 #: pkg/docker/storage.jsx:259
 msgid " (shared with the OS)"
@@ -137,10 +137,10 @@ msgstr ""
 "або віддайте таку команду:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 активно використовується"
 
@@ -543,8 +543,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Облікові записи"
 
-#: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Задіяти"
@@ -581,10 +581,10 @@ msgstr "Адаптивне урівноваження навантаження"
 msgid "Adaptive transmit load balancing"
 msgstr "Адаптивне урівноваження навантаження за передаванням"
 
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Додати"
@@ -824,10 +824,10 @@ msgstr "Програми"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "Застосувати"
 
@@ -867,8 +867,8 @@ msgstr "Мітка активу"
 msgid "At least $0 disks are needed."
 msgstr "Потрібно принаймні $0 дисків."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "Потрібен принаймні один диск."
 
@@ -884,8 +884,8 @@ msgstr "Журнал інспектування"
 msgid "Authenticating"
 msgstr "Автентифікація"
 
-#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
-#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "Розпізнавання"
 
@@ -958,8 +958,8 @@ msgstr "Автоматично на основі NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Автоматично за допомогою певних серверів NTP"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "Автозапуск"
@@ -1141,8 +1141,8 @@ msgstr "Пріоритетність процесора"
 msgid "CPU usage:"
 msgstr "Використання процесора:"
 
-#: pkg/machines/components/diskAdd.jsx:246
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr "Кеш"
 
@@ -1165,35 +1165,35 @@ msgstr "Не вдалося завантажити образ"
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:560
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:560 pkg/networkmanager/firewall.jsx:628
-#: pkg/networkmanager/firewall.jsx:771 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -1263,10 +1263,10 @@ msgstr "Змінити обмеження ресурсів"
 msgid "Change the settings"
 msgstr "Змінити параметри"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Зміни буде застосовано після завершення роботи ВМ"
 
@@ -1342,22 +1342,23 @@ msgstr "Натисніть, щоб побачити дані щодо облад
 msgid ""
 "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr ""
-"У результаті натискання «Запустити віддалений переглядач» буде отримано файл "
-".vv і запущено $0."
+"У результаті натискання «Запустити віддалений переглядач» буде отримано "
+"файл .vv і запущено $0."
 
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr "Клієнтське програмне забезпечення"
 
-#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
-#: pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Закрити"
 
@@ -1446,16 +1447,15 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}Вам варто спробувати {{#sync_link}}синхронізувати "
-"користувачів{{/sync_link}}.{{/can_sync}} Щоб отримати доступ до ширшого "
-"спектра способів розпізнавання та до підтримки діагностики помилок, будь "
-"ласка, оновіть cockpit-ws."
+"Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"Вам варто спробувати {{#sync_link}}синхронізувати користувачів{{/sync_link}}."
+"{{/can_sync}} Щоб отримати доступ до ширшого спектра способів розпізнавання "
+"та до підтримки діагностики помилок, будь ласка, оновіть cockpit-ws."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1469,8 +1469,8 @@ msgid ""
 msgstr ""
 "Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. Щоб "
 "користуватися цим комп’ютером за допомогою cockpit, вам слід увімкнути "
-"вказані нижче способи розпізнавання у налаштуваннях sshd на "
-"{{#strong}}{{host}}{{/strong}}:"
+"вказані нижче способи розпізнавання у налаштуваннях sshd на {{#strong}}"
+"{{host}}{{/strong}}:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1479,9 +1479,9 @@ msgid ""
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
 "Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. Ви можете "
-"змінити ваші реєстраційні дані для розпізнавання нижче. "
-"{{#can_sync}}Можливо, варто надати перевагу {{#sync_link}}синхронізації "
-"облікових записів і паролів{{/sync_link}}.{{/can_sync}}"
+"змінити ваші реєстраційні дані для розпізнавання нижче. {{#can_sync}}"
+"Можливо, варто надати перевагу {{#sync_link}}синхронізації облікових записів "
+"і паролів{{/sync_link}}.{{/can_sync}}"
 
 #: pkg/dashboard/index.html:157 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1551,8 +1551,8 @@ msgstr "Сумісний зі сучасними системами та жор�
 msgid "Compress crash dumps to save space"
 msgstr "Стиснути дампи аварійних завершень для заощадження місця"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "Стискання"
 
@@ -1657,9 +1657,9 @@ msgid "Connecting to the machine"
 msgstr "Встановлюємо з’єднання із комп’ютером"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "З’єднання"
@@ -1809,9 +1809,9 @@ msgstr "Аварійно завершити роботу системи"
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "Створити"
 
@@ -1993,7 +1993,7 @@ msgstr "Нетипові порти"
 msgid "Custom encryption options"
 msgstr "Нетипові параметри шифрування"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "Нетипові параметри монтування"
 
@@ -2038,8 +2038,8 @@ msgstr "Панель приладів"
 msgid "Data Used"
 msgstr "Використано даних"
 
-#: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Вимкнути"
@@ -2072,17 +2072,17 @@ msgstr "Затримка"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Вилучити"
@@ -2135,7 +2135,7 @@ msgstr "Вилучення пристрою RAID призведе до вити�
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Вилучення пристрою VDO призведе до витирання усіх даних на ньому."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 "Вилучення контейнера призведе до витирання усіх даних, що на ньому "
@@ -2151,7 +2151,6 @@ msgstr ""
 msgid "Deleting a partition will delete all data in it."
 msgstr ""
 "Вилучення розділу призведе до вилучення усіх даних, що на ньому зберігаються."
-""
 
 #: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
@@ -2188,12 +2187,12 @@ msgstr "Змінний"
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:745
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "Подробиці"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2283,9 +2282,9 @@ msgstr "З диском усе гаразд"
 msgid "Disk passphrase"
 msgstr "Пароль до диска"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "Диски"
 
@@ -2559,9 +2558,9 @@ msgid "Errata:"
 msgstr "Помилки:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1476
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "Помилка"
 
@@ -2665,7 +2664,7 @@ msgstr "Не вдалося додати службу"
 msgid "Failed to add zone"
 msgstr "Не вдалося додати зону"
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "Не вдалося змінити пароль"
 
@@ -2751,7 +2750,7 @@ msgstr "Фільтрувати служби"
 msgid "Filter by name or description..."
 msgstr "Фільтрувати за назвою або описом…"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "Відбиток"
 
@@ -2796,10 +2795,9 @@ msgstr "Примусова зміна пароля"
 msgid "Force remove passphrase in $0"
 msgstr "Примусово вилучити пароль у $0"
 
-#: pkg/machines/components/diskAdd.jsx:147
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Формат"
 
@@ -2880,11 +2878,11 @@ msgstr "Створюємо звіт"
 msgid "Get new image"
 msgstr "Отримати новий образ"
 
-#: pkg/machines/components/diskAdd.jsx:186
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "ГіБ"
 
@@ -2969,9 +2967,9 @@ msgstr "Час вітання $hello_time"
 msgid "Hide Performance Options"
 msgstr "Приховати параметри швидкодії"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
 #: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "Вузол"
@@ -3165,8 +3163,8 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Для синхронізації параметрів користувачів, слід увійти до "
-"{{#strong}}{{host}}{{/strong}}. "
+"Для синхронізації параметрів користувачів, слід увійти до {{#strong}}{{host}}"
+"{{/strong}}. "
 
 #: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
 #: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
@@ -3209,9 +3207,9 @@ msgstr "Ініціатор"
 msgid "Initiator IQN should not be empty"
 msgstr "IQN ініціатора має бути непорожнімy"
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "Встановити"
 
@@ -3275,8 +3273,8 @@ msgid "Interface Type"
 msgstr "Тип інтерфейсу"
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:737 pkg/networkmanager/firewall.jsx:925
-#: pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "Інтерфейси"
 
@@ -3292,11 +3290,11 @@ msgstr "Внутрішня помилка"
 msgid "Invalid address $0"
 msgstr "Некоректна адреса $0"
 
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "Некоректний формат дати"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "Некоректний формат дати і часу"
 
@@ -3352,7 +3350,7 @@ msgstr "Некоректний префікс або маска мережі $0"
 msgid "Invalid range"
 msgstr "Некоректний діапазон"
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "Некоректний формат визначення часу"
 
@@ -3522,7 +3520,6 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "Не заповнюйте, щоб встановити з’єднання із цією машиною від імені поточного "
 "користувача системи{{#default_user}} ({{default_user}}){{/default_user}}. "
@@ -3589,9 +3586,9 @@ msgstr "Не вдалося завантажити список доступни
 msgid "Loading available updates, please wait..."
 msgstr "Завантажуємо доступні оновлення, зачекайте…"
 
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "Завантаження…"
 
@@ -3891,10 +3888,10 @@ msgid "Metadata Used"
 msgstr "Використано метаданих"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
-#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "МіБ"
 
@@ -3964,23 +3961,23 @@ msgstr "Докладніше"
 msgid "More details"
 msgstr "Докладніше"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "Змонтувати"
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "Параметри монтування"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "Точка монтування"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "Змонтувати при завантаженні"
 
@@ -4000,7 +3997,7 @@ msgstr "Точка монтування не може бути порожньо�
 msgid "Mount point must start with \"/\"."
 msgstr "Запис точки монтування має починатися з «/»."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "Змонтувати лише для читання"
 
@@ -4056,22 +4053,21 @@ msgstr "Сервер NTP"
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "Назва"
 
@@ -4213,7 +4209,7 @@ msgstr "Назва нового тому"
 msgid "New passphrase"
 msgstr "Новий пароль"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "Новий пароль не прийнято"
 
@@ -4335,9 +4331,9 @@ msgstr "Немає опису"
 msgid "No description provided."
 msgstr "Опису не надано."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "Немає доступних дисків."
 
@@ -4472,8 +4468,8 @@ msgid "No volume groups created"
 msgstr "Груп томів не створено"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:734
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "Немає"
 
@@ -4573,7 +4569,7 @@ msgstr "Старий пароль"
 msgid "Old passphrase"
 msgstr "Старий пароль"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "Старий пароль не прийнято"
 
@@ -4688,9 +4684,9 @@ msgstr "Інші пристрої"
 msgid "Other Options"
 msgstr "Інші параметри"
 
-#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "Огляд"
 
@@ -4770,10 +4766,10 @@ msgstr "Вилучення пароля може завадити розблок
 msgid "Passphrases do not match"
 msgstr "Паролі не збігаються"
 
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "Пароль"
@@ -4877,8 +4873,8 @@ msgstr "Доступ заборонено"
 msgid "Persistence"
 msgstr "Сталість"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr "Постійний"
 
@@ -4922,9 +4918,9 @@ msgstr "Ціль тестування луною"
 msgid "Pizza Box"
 msgstr "З коробку для піци"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Будь ласка, підтвердьте вилучення $0"
@@ -4933,7 +4929,7 @@ msgstr "Будь ласка, підтвердьте вилучення $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Будь ласка, підтвердьте примусове вилучення $0"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "Будь ласка, підтвердьте зупинку $0"
 
@@ -4970,11 +4966,10 @@ msgstr "Будь ласка, спробуйте інший ключ"
 msgid "Plug"
 msgstr "З'єднати"
 
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Буфер"
 
@@ -5130,7 +5125,7 @@ msgstr "Поширює перезавантаження на"
 msgid "Protocol"
 msgstr "Протокол"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "Відкритий ключ"
 
@@ -5210,7 +5205,7 @@ msgstr "Апаратний блок RAID"
 msgid "RAID Device"
 msgstr "пристрій RAID"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "Пристій RAID $0"
 
@@ -5379,9 +5374,9 @@ msgstr "Портативний диск"
 msgid "Removals:"
 msgstr "Вилучення:"
 
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "Вилучити"
 
@@ -5569,8 +5564,8 @@ msgstr ""
 
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "Перезапустити"
 
@@ -5611,8 +5606,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Повторно використати ваш пароль для привілейованих завдань"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Повторно використати ваш пароль для привілейованих завдань та з’єднання з "
 "іншими комп’ютерами"
@@ -5735,10 +5729,11 @@ msgstr "субота"
 msgid "Saturdays"
 msgstr "Суботи"
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Зберегти"
 
@@ -5793,11 +5788,11 @@ msgstr "Вибрати"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr ""
-"Виберіть користувачів, записи яких ви б хотіли синхронізувати з "
-"{{#strong}}{{host}}{{/strong}}"
+"Виберіть користувачів, записи яких ви б хотіли синхронізувати з {{#strong}}"
+"{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
@@ -5817,8 +5812,8 @@ msgstr "Надсилання"
 msgid "Serial Console"
 msgstr "Послідовна консоль"
 
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "Сервер"
 
@@ -5994,15 +5989,14 @@ msgstr "Вимкнути"
 
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/diskAdd.jsx:167
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "Розмір"
 
@@ -6084,10 +6078,10 @@ msgstr ""
 msgid "Sorted from least trusted to most trusted"
 msgstr "Упорядковано від найменшої до найбільшої довіри"
 
-#: pkg/machines/components/diskAdd.jsx:504
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Джерело"
 
@@ -6095,10 +6089,10 @@ msgstr "Джерело"
 msgid "Source Format"
 msgstr "Початковий формат"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Шлях до джерела"
 
@@ -6140,8 +6134,8 @@ msgid "Stable"
 msgstr "Стабільний"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "Почати"
 
@@ -6178,8 +6172,8 @@ msgid "Startup"
 msgstr "Запуск"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
 #: pkg/systemd/init.js:285
 msgid "State"
@@ -6206,8 +6200,8 @@ msgid "Sticky"
 msgstr "Липкий"
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "Зупинити"
@@ -6454,8 +6448,8 @@ msgstr "Сервер ключів Tang"
 msgid "Target"
 msgstr "Призначення"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "Шлях призначення"
 
@@ -6581,8 +6575,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Не вдалося встановити ідентичність вузла {{#strong}}{{host}}{{/strong}}. Ви "
 "справді хочете продовжити спробу встановити з’єднання?"
@@ -6600,8 +6594,7 @@ msgstr ""
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
-msgstr ""
-"Створення цього пристрою VDO не завершено, ним не можна користуватися."
+msgstr "Створення цього пристрою VDO не завершено, ним не можна користуватися."
 
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
@@ -6623,8 +6616,7 @@ msgstr ""
 "Виконання цієї дії призведе до припинення роботи цих служб та сеансів."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Файлова система використовується сеансами користувачів. Виконання цієї дії "
 "призведе до припинення роботи цих сеансів."
@@ -6637,8 +6629,7 @@ msgstr ""
 "призведе до припинення роботи цих служб."
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr ""
 "Вказані нижче контейнери залежать від цього образу, отже стануть "
 "непридатними до використання."
@@ -6659,9 +6650,9 @@ msgid ""
 "in use. Unless this machine was recently replaced, it is likely that someone "
 "is trying to attack your connection to this machine."
 msgstr ""
-"Ключ {{#strong}}{{host}}{{/strong}} не відповідає раніше використаному ключу."
-" Якщо нещодавно ніхто не міняв цього комп’ютера, ймовірною причиною є спроба "
-"атаки на ваше з’єднання із цим комп’ютером."
+"Ключ {{#strong}}{{host}}{{/strong}} не відповідає раніше використаному "
+"ключу. Якщо нещодавно ніхто не міняв цього комп’ютера, ймовірною причиною є "
+"спроба атаки на ваше з’єднання із цим комп’ютером."
 
 #: pkg/users/authorized-keys.js:124
 msgid "The key you provided was not valid."
@@ -6784,8 +6775,7 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr ""
 "Налаштування програми для перегляду інтернету забороняють запуск Cockpit "
 "(недоступна можливість $0)"
@@ -6958,8 +6948,7 @@ msgstr "Цей том вже використано іншою ВМ."
 
 #: pkg/storaged/lvol-tabs.jsx:186
 msgid "This volume needs to be activated before it can be resized."
-msgstr ""
-"Перш ніж розмір цього тому можна буде змінювати, його слід активувати."
+msgstr "Перш ніж розмір цього тому можна буде змінювати, його слід активувати."
 
 #: src/ws/login.js:122
 msgid "This web browser is too old to run Cockpit (missing $0)"
@@ -7117,18 +7106,17 @@ msgstr "Tuned не запущено"
 msgid "Tuned is off"
 msgstr "Tuned вимкнено"
 
-#: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "Тип"
 
@@ -7230,10 +7218,11 @@ msgstr "Модуль"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/lib/machine-info.js:65 pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:139
 #: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
 #: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Невідомий"
 
@@ -7446,7 +7435,7 @@ msgstr "Ім'я користувача"
 msgid "User Password"
 msgstr "Пароль користувача"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Ім'я користувача"
@@ -7595,7 +7584,7 @@ msgid "Verifying"
 msgstr "Перевіряємо"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "Версія"
 
@@ -7603,8 +7592,8 @@ msgstr "Версія"
 msgid "Very securely erasing $target"
 msgstr "Дуже безпечно витираємо $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "Віртуальні машини"
@@ -7622,11 +7611,10 @@ msgid "Virtualization Service is Available"
 msgstr "Доступна служба віртуалізації"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Том"
 
@@ -7770,8 +7758,7 @@ msgstr ""
 
 #: pkg/docker/storage.jsx:504
 msgid "You don't have permission to manage the Docker storage pool."
-msgstr ""
-"У вас немає прав доступу до керування резервним сховищем даних Docker."
+msgstr "У вас немає прав доступу до керування резервним сховищем даних Docker."
 
 #: pkg/users/local.js:120
 msgid "You must wait longer to change your password"
@@ -7831,8 +7818,12 @@ msgstr "[двійкові дані]"
 msgid "[no data]"
 msgstr "[немає даних]"
 
-#: pkg/machines/components/networks/network.jsx:59
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "активний"
@@ -7962,8 +7953,8 @@ msgstr "IQN цілі iSCSI"
 msgid "idle"
 msgstr "бездіяльний"
 
-#: pkg/machines/components/networks/network.jsx:59
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "неактивний"
 
@@ -8000,9 +7991,9 @@ msgid "nfs dump target isn't formated as server:path"
 msgstr ""
 "форматування місця для дампів у nfs не збігається із потрібним: сервер:шлях"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "ні"
@@ -8167,9 +8158,9 @@ msgid ""
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "так"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -15,14 +15,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-03 06:24+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2019-05-30 01:12+0000\n"
 "Last-Translator: Tony Fu <tfu@redhat.com>\n"
 "Language-Team: Chinese (Simplified)\n"
 "Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
@@ -30,19 +30,15 @@ msgstr ""
 msgid " (shared with the OS)"
 msgstr " (与操作系统共享)"
 
-#: pkg/kubernetes/views/node-delete.html:8
-msgid " 1\"Do you want to delete the following Nodes?"
-msgstr " 1\"是否要删除以下节点？"
-
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0 块设备"
 
-#: pkg/storaged/mdraid-details.jsx:193
+#: pkg/storaged/mdraid-details.jsx:192
 msgid "$0 Chunk Size"
 msgstr "$0 区块大小"
 
-#: pkg/storaged/mdraid-details.jsx:191
+#: pkg/storaged/mdraid-details.jsx:190
 msgid "$0 Disks"
 msgstr "$0 磁盘"
 
@@ -87,15 +83,15 @@ msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 数据 + $1 过渡使用 $2（$3）"
 
 #: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:28
-#: pkg/playground/translate.js:31 pkg/storaged/mdraid-details.jsx:213
+#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 磁盘无法找到"
 
 #: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:34
-#: pkg/playground/translate.js:37
+#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
@@ -129,13 +125,14 @@ msgstr "$0文件系统不能在这里改变大小。"
 msgid ""
 "$0 is available for most operating systems. To install it, search for it in "
 "GNOME Software or run the following:"
-msgstr "$0 大多数操作系统可用。为了安装它，请在 GNOME 中搜索它，或运行以下命令： "
+msgstr ""
+"$0 大多数操作系统可用。为了安装它，请在 GNOME 中搜索它，或运行以下命令： "
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:237
-#: pkg/storaged/mdraid-details.jsx:290 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:203
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 已激活"
 
@@ -173,25 +170,11 @@ msgstr[0] "$0 个更新"
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 使用 $1（已保存 $2）"
 
-#: pkg/ovirt/components/vcpuModal.jsx:98
-msgid "$0 vCPU Details"
-msgstr "$0 vCPU 详情"
-
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "将安装 $0。"
 
-#: pkg/kubernetes/scripts/nodes.js:871
-msgid "$0% Free"
-msgid_plural "$0% Free"
-msgstr[0] "$0% 剩余"
-
-#: pkg/kubernetes/scripts/nodes.js:873
-msgid "$0% Used"
-msgid_plural "$0% Used"
-msgstr[0] "$0% 已使用"
-
-#: pkg/storaged/vgroup-details.jsx:118
+#: pkg/storaged/vgroup-details.jsx:117
 msgid "$0, $1 free"
 msgstr "$0, $1 可用"
 
@@ -216,19 +199,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/subscriptions/subscriptions-client.js:197
-msgid "'Organization' required to register."
-msgstr "需要注册“组织”。"
-
-#: pkg/subscriptions/subscriptions-client.js:201
-msgid "'Organization' required when using activation keys."
-msgstr "当使用激活码时需要“组织”。"
-
-#: pkg/networkmanager/firewall.jsx:547
+#: pkg/networkmanager/firewall.jsx:549
 msgid "(Optional)"
 msgstr "(可选)"
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:616
+#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "（默认）"
@@ -515,12 +490,8 @@ msgstr "ARP 监控"
 msgid "ARP Ping"
 msgstr "ARP Ping"
 
-#: pkg/kubernetes/scripts/volumes.js:193
-msgid "AWS Elastic Block Store"
-msgstr "AWS 弹性块存储"
-
 #: pkg/shell/index.html:56 pkg/shell/index.html:82 pkg/shell/simple.html:42
-#: pkg/shell/simple.html:58 pkg/shell/stub.html:46 pkg/shell/stub.html:65
+#: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "关于 Cockpit"
 
@@ -528,19 +499,9 @@ msgstr "关于 Cockpit"
 msgid "Access"
 msgstr "访问"
 
-#: pkg/kubernetes/views/pv-body.html:9 pkg/kubernetes/views/pv-claim.html:9
-#: pkg/kubernetes/views/pv-modify.html:69 pkg/kubernetes/views/pvc-body.html:18
-msgid "Access Modes"
-msgstr "访问模式"
-
-#: pkg/kubernetes/views/project-modify.html:49
 #: node_modules/registry-image-widgets/views/imagestream-body.html:12
 msgid "Access Policy"
 msgstr "访问策略"
-
-#: pkg/subscriptions/subscriptions-view.jsx:213
-msgid "Access denied"
-msgstr "访问被拒绝"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -558,18 +519,13 @@ msgstr "帐户不可用或不可编辑."
 msgid "Accounts"
 msgstr "账户"
 
-#: pkg/users/local.js:335 pkg/users/local.js:642
+#: pkg/users/local.js:339 pkg/users/local.js:646
 msgctxt "page-title"
 msgid "Accounts"
 msgstr "账户"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:183
-msgid "Action"
-msgstr "操作"
-
-#: pkg/machines/components/networks/network.jsx:147
-#: pkg/machines/components/storagePools/storagePool.jsx:167
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "激活"
@@ -577,10 +533,6 @@ msgstr "激活"
 #: pkg/storaged/jobs-panel.jsx:68
 msgid "Activating $target"
 msgstr "激活 $target"
-
-#: pkg/subscriptions/subscriptions-register.jsx:168
-msgid "Activation Key"
-msgstr "激活码"
 
 #: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
 msgid "Active"
@@ -590,7 +542,7 @@ msgstr "激活"
 msgid "Active Backup"
 msgstr "激活备份"
 
-#: pkg/shell/index.html:59 pkg/shell/stub.html:49 pkg/shell/active-pages.js:95
+#: pkg/shell/index.html:59 pkg/shell/active-pages.js:95
 msgid "Active Pages"
 msgstr "激活页面"
 
@@ -598,13 +550,9 @@ msgstr "激活页面"
 msgid "Active since"
 msgstr "活跃自"
 
-#: pkg/networkmanager/firewall.jsx:922
+#: pkg/networkmanager/firewall.jsx:924
 msgid "Active zones"
 msgstr "活动区域"
-
-#: pkg/kubernetes/views/pvc-body.html:25 pkg/kubernetes/views/pvc-body.html:45
-msgid "Actual"
-msgstr "真实的"
 
 #: pkg/networkmanager/interfaces.js:1980
 msgid "Adaptive load balancing"
@@ -614,16 +562,11 @@ msgstr "自适应负载均衡"
 msgid "Adaptive transmit load balancing"
 msgstr "自适应传输负载均衡"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:61
-#: pkg/kubernetes/views/add-role-dialog.html:8
-#: pkg/kubernetes/views/add-user-dialog.html:27
-#: pkg/kubernetes/views/node-add.html:50
-#: pkg/kubernetes/views/user-add-membership.html:49
-#: pkg/kubernetes/views/user-group-add.html:30 pkg/lib/machine-add.html:43
-#: pkg/shell/index.html:181 pkg/machines/components/diskAdd.jsx:534
-#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/vgroup-details.jsx:63
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "添加"
 
@@ -643,11 +586,7 @@ msgstr "添加绑定"
 msgid "Add Bridge"
 msgstr "添加网桥"
 
-#: pkg/kubernetes/views/node-add.html:3
-msgid "Add Cluster Node"
-msgstr "添加集群节点"
-
-#: pkg/machines/components/diskAdd.jsx:356
+#: pkg/machines/components/diskAdd.jsx:360
 msgid "Add Disk"
 msgstr "添加磁盘"
 
@@ -655,55 +594,20 @@ msgstr "添加磁盘"
 msgid "Add Disks"
 msgstr "添加磁盘"
 
-#: pkg/kubernetes/views/add-group-dialog.html:3
-msgid "Add Group"
-msgstr "添加组"
-
 #: pkg/storaged/crypto-keyslots.jsx:200
 msgid "Add Key"
 msgstr "添加密钥"
-
-#: pkg/kubernetes/views/nodes-page.html:34
-msgid "Add Kubernetes Node"
-msgstr "添加 Kubernetes 节点"
 
 #: pkg/lib/machine-add.html:4
 msgid "Add Machine to Dashboard"
 msgstr "把机器添加到仪表板"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:4
-#: pkg/kubernetes/views/group-page.html:38
-#: pkg/kubernetes/views/group-panel.html:29
-#: pkg/kubernetes/views/project-body.html:108
-#: pkg/kubernetes/views/user-group-add.html:3
-msgid "Add Member"
-msgstr "添加成员"
-
-#: pkg/kubernetes/views/user-body.html:67
-#: pkg/kubernetes/views/user-panel.html:76
-msgid "Add Membership"
-msgstr "添加成员关系"
-
-#: pkg/kubernetes/views/auth-form.html:11
-#: pkg/kubernetes/views/auth-form.html:20
-msgid "Add New Cluster"
-msgstr "添加新集群"
-
-#: pkg/kubernetes/views/auth-form.html:67
-#: pkg/kubernetes/views/auth-form.html:76
-msgid "Add New User"
-msgstr "添加新用户"
-
 #: pkg/networkmanager/firewall.jsx:457
 msgid "Add Ports"
 msgstr "添加端口"
 
-#: pkg/kubernetes/views/add-role-dialog.html:3
-msgid "Add Role"
-msgstr "添加角色"
-
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:872
-#: pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
+#: pkg/networkmanager/firewall.jsx:886
 msgid "Add Services"
 msgstr "添加服务"
 
@@ -715,17 +619,12 @@ msgstr "添加存储"
 msgid "Add Team"
 msgstr "添加组"
 
-#: pkg/kubernetes/views/add-user-dialog.html:3
-#: pkg/kubernetes/views/project-listing.html:83
-msgid "Add User"
-msgstr "添加用户"
-
 #: pkg/networkmanager/index.html:113
 msgid "Add VLAN"
 msgstr "添加 VLAN"
 
-#: pkg/networkmanager/firewall.jsx:698 pkg/networkmanager/firewall.jsx:878
-#: pkg/networkmanager/firewall.jsx:889
+#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
+#: pkg/networkmanager/firewall.jsx:891
 msgid "Add Zone"
 msgstr "添加区域"
 
@@ -736,10 +635,6 @@ msgstr "添加 iSCSI 门户"
 #: pkg/shell/index.html:172 pkg/users/index.html:414
 msgid "Add key"
 msgstr "添加密钥"
-
-#: pkg/kubernetes/views/user-add-membership.html:3
-msgid "Add membership"
-msgstr "添加成员关系"
 
 #: pkg/networkmanager/firewall.jsx:458
 msgid "Add ports to the following zones:"
@@ -753,7 +648,7 @@ msgstr "添加公钥"
 msgid "Add services to following zones:"
 msgstr "把服务添加到以下区："
 
-#: pkg/networkmanager/firewall.jsx:774
+#: pkg/networkmanager/firewall.jsx:776
 msgid "Add zone"
 msgstr "添加区域"
 
@@ -783,7 +678,7 @@ msgstr "额外的 DNS $val"
 msgid "Additional DNS Search Domains $val"
 msgstr "额外的 DNS 搜索域 $val"
 
-#: pkg/docker/index.html:307
+#: pkg/docker/index.html:309
 msgid "Additional Storage"
 msgstr "额外的存储"
 
@@ -795,14 +690,11 @@ msgstr "额外的地址 $val"
 msgid "Additional packages:"
 msgstr "额外的软件包："
 
-#: pkg/kubernetes/views/auth-form.html:29
-#: pkg/kubernetes/views/dashboard-page.html:157
-#: pkg/kubernetes/views/details-page.html:174
-#: pkg/kubernetes/views/node-add.html:8 pkg/kubernetes/views/node-body.html:5
-#: pkg/kubernetes/views/nodes-page.html:43 pkg/lib/machine-add.html:11
+#: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:77 pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:107
+#: pkg/storaged/iscsi-panel.jsx:127
 msgid "Address"
 msgstr "地址"
 
@@ -819,44 +711,18 @@ msgid "Address is not a valid URL"
 msgstr "该地址无效"
 
 #: pkg/machines/components/desktopConsole.jsx:153
-#: pkg/ovirt/components/VmOverviewColumn.jsx:53
 msgid "Address:"
 msgstr "地址："
 
-#: pkg/kubernetes/views/details-page.html:37
 #: pkg/networkmanager/interfaces.js:3309
 msgid "Addresses"
 msgstr "地址"
-
-#: pkg/kubernetes/views/service-modify.html:25
-msgid "Adjust"
-msgstr "调整"
-
-#: pkg/kubernetes/views/pv-modify.html:3
-msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-msgstr "调整持久卷 '{{ item.metadata.name }}'"
-
-#: pkg/kubernetes/views/replicationcontroller-modify.html:3
-msgid "Adjust Replication Controller {{ item.metadata.name }}"
-msgstr "调整复制控制器 {{ item.metadata.name }}"
-
-#: pkg/kubernetes/views/route-modify.html:3
-msgid "Adjust Route"
-msgstr "调整路由"
-
-#: pkg/kubernetes/views/service-modify.html:3
-msgid "Adjust Service"
-msgstr "调整服务"
-
-#: pkg/kubernetes/views/project-body.html:56
-msgid "Admin"
-msgstr "管理"
 
 #: org.cockpit-project.cockpit-bridge.policy.in.h:1
 msgid "Administration with Cockpit Web Console"
 msgstr "使用 Cockpit Web 控制台管理"
 
-#: pkg/realmd/operation.js:336
+#: pkg/realmd/operation.js:335
 msgid "Administrator Password"
 msgstr "管理员密码"
 
@@ -873,7 +739,9 @@ msgid ""
 "After leaving the domain, only users with local credentials will be able to "
 "log into this machine. This may also affect other services as DNS resolution "
 "settings and the list of trusted CAs may change."
-msgstr "从域离开后，仅有使用本地凭据的用户可以登录到该主机。这也可能影响到包括DNS解析设置以及信任的CA在内的一系列设置"
+msgstr ""
+"从域离开后，仅有使用本地凭据的用户可以登录到该主机。这也可能影响到包括DNS解析"
+"设置以及信任的CA在内的一系列设置"
 
 #: pkg/systemd/services.html:446 pkg/systemd/services.html:450
 #: pkg/systemd/init.js:1073
@@ -892,49 +760,21 @@ msgstr "所有"
 msgid "All In One"
 msgstr "多合一"
 
-#: pkg/kubernetes/views/filter-project.html:4
-msgid "All Projects"
-msgstr "所有项目"
-
-#: pkg/kubernetes/views/details-page.html:6
-msgid "All Types"
-msgstr "所有类型"
-
 #: pkg/docker/storage.jsx:381
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
 msgstr "所选磁盘上的所有数据将会被删除，磁盘将会被添加到存储池。"
 
-#: pkg/kubernetes/views/dashboard-page.html:112
-msgid "All healthy"
-msgstr "所有健康的"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:74
-msgid "All images"
-msgstr "所有镜像"
-
-#: pkg/kubernetes/views/dashboard-page.html:69
-msgid "All in use"
-msgstr "所有正在使用的"
-
-#: pkg/kubernetes/views/dashboard-page.html:37
-msgid "All running"
-msgstr "所有运行的"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:36
-msgid "All running virtual machines will be turned off."
-msgstr "将关闭所有正在运行的虚拟机。"
-
-#: pkg/networkmanager/firewall.jsx:749
+#: pkg/networkmanager/firewall.jsx:751
 msgid "Allowed Addresses"
 msgstr "允许的地址"
 
-#: pkg/networkmanager/firewall.jsx:935
+#: pkg/networkmanager/firewall.jsx:937
 msgid "Allowed Services"
 msgstr "允许的服务"
 
-#: pkg/docker/index.html:548 pkg/docker/util.js:108
+#: pkg/docker/index.html:550 pkg/docker/util.js:108
 msgid "Always"
 msgstr "总是"
 
@@ -942,17 +782,11 @@ msgstr "总是"
 msgid "Always attach"
 msgstr "保证连接"
 
-#: pkg/kubernetes/views/node-body.html:57
-#: pkg/kubernetes/views/route-body.html:27
 #: node_modules/registry-image-widgets/views/annotations.html:1
 msgid "Annotations"
 msgstr "注释"
 
-#: pkg/kubernetes/scripts/projects.js:1044
-msgid "Anonymous: Allow all unauthenticated users to pull images"
-msgstr "匿名用户：允许所有未验证的用户获取镜像"
-
-#: pkg/systemd/terminal.jsx:94
+#: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr "外观："
 
@@ -965,11 +799,10 @@ msgstr "应用"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235
-#: pkg/ovirt/components/vcpuModal.jsx:104 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "应用"
 
@@ -998,7 +831,6 @@ msgid "Applying updates failed"
 msgstr "应用更新失败"
 
 #: node_modules/registry-image-widgets/views/image-config.html:16
-#: pkg/subscriptions/subscriptions-view.jsx:36
 msgid "Architecture"
 msgstr "架构"
 
@@ -1010,8 +842,8 @@ msgstr "资产标签"
 msgid "At least $0 disks are needed."
 msgstr "至少需要 $0 块磁盘。"
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "至少需要 1 块磁盘。"
 
@@ -1027,9 +859,8 @@ msgstr "审计日志"
 msgid "Authenticating"
 msgstr "验证中"
 
-#: pkg/kubernetes/views/auth-form.html:85 pkg/lib/machine-change-auth.html:32
 #: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "验证"
 
@@ -1055,7 +886,7 @@ msgstr "通过Cockpit Web Console进行验证后才能执行特权操作"
 msgid "Authentication required"
 msgstr "需要验证"
 
-#: pkg/docker/index.html:700
+#: pkg/docker/index.html:702
 #: node_modules/registry-image-widgets/views/image-body.html:12
 #: pkg/docker/containers-view.jsx:413
 msgid "Author"
@@ -1068,7 +899,7 @@ msgstr "授权公共 SSH 密钥"
 #: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
 #: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
 #: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:339
+#: pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "自动"
 
@@ -1088,10 +919,6 @@ msgstr "自动启动"
 msgid "Automatic Updates"
 msgstr "自动更新"
 
-#: pkg/ovirt/components/OVirtTab.jsx:81
-msgid "Automatically selected host"
-msgstr "自动选择的主机"
-
 #: pkg/machines/components/libvirtSlate.jsx:90
 msgid "Automatically start libvirt on boot"
 msgstr "在引导时自动启动 libvirt"
@@ -1104,9 +931,9 @@ msgstr "自动使用 NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "自动使用指定的 NTP 服务器"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:155
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "自动启动"
 
@@ -1127,10 +954,6 @@ msgstr "$0 上可用的目标"
 #: pkg/dashboard/index.html:163
 msgid "Avatar"
 msgstr "头像"
-
-#: pkg/kubernetes/scripts/volumes.js:207
-msgid "Azure"
-msgstr "Azure"
 
 #: pkg/systemd/hwinfo.jsx:92
 msgid "BIOS"
@@ -1159,18 +982,6 @@ msgstr "为 passwd1 传递了坏数据"
 #: pkg/networkmanager/index.html:333
 msgid "Balancer"
 msgstr "平衡器"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-msgid "Base Template"
-msgstr "基础模板"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Base template"
-msgstr "基础模板"
-
-#: pkg/ovirt/components/OVirtTab.jsx:106 pkg/ovirt/components/OVirtTab.jsx:113
-msgid "Base template:"
-msgstr "基础模板："
 
 #: pkg/systemd/init.js:729
 msgid "Before"
@@ -1213,12 +1024,8 @@ msgstr "绑定"
 msgid "Bond Settings"
 msgstr "绑定设置"
 
-#: pkg/kubernetes/views/node-body.html:17
-msgid "Boot ID"
-msgstr "引导 ID"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:312
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:153
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:164
 msgid "Boot Order"
 msgstr "启动顺序"
 
@@ -1277,10 +1084,8 @@ msgstr "总线"
 msgid "Bus Expansion Chassis"
 msgstr "总线扩展机箱"
 
-#: pkg/dashboard/index.html:70 pkg/docker/index.html:270
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:603
-#: pkg/kubernetes/scripts/nodes.js:711 pkg/kubernetes/scripts/nodes.js:818
-#: pkg/systemd/hwinfo.jsx:108
+#: pkg/dashboard/index.html:70 pkg/docker/index.html:272
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
 msgid "CPU"
 msgstr "CPU"
 
@@ -1297,28 +1102,20 @@ msgctxt "page-title"
 msgid "CPU Status"
 msgstr "CPU 状态"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:154
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:165
 msgid "CPU Type"
 msgstr "CPU类型"
 
-#: pkg/kubernetes/scripts/nodes.js:712
-msgid "CPU Utilization: $0%"
-msgstr "CPU 使用率: $0%"
-
-#: pkg/docker/index.html:469 pkg/docker/index.html:641
+#: pkg/docker/index.html:471 pkg/docker/index.html:643
 msgid "CPU priority"
 msgstr "CPU 优先级"
 
-#: pkg/docker/index.html:217
+#: pkg/docker/index.html:218
 msgid "CPU usage:"
 msgstr "CPU 使用率："
 
-#: pkg/ovirt/provider.js:256
-msgid "CREATE VM action failed"
-msgstr "创建虚拟机操作失败"
-
-#: pkg/machines/components/diskAdd.jsx:235
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr "缓存"
 
@@ -1338,79 +1135,44 @@ msgstr "解锁时无法删除"
 msgid "Can't load image"
 msgstr "无法加载镜像"
 
-#: pkg/dashboard/index.html:175 pkg/docker/index.html:563
-#: pkg/docker/index.html:597 pkg/docker/index.html:661
-#: pkg/docker/index.html:715 pkg/docker/index.html:755
-#: pkg/docker/index.html:784 pkg/kubernetes/views/add-group-dialog.html:18
-#: pkg/kubernetes/views/add-member-role-dialog.html:60
-#: pkg/kubernetes/views/add-role-dialog.html:7
-#: pkg/kubernetes/views/add-user-dialog.html:26
-#: pkg/kubernetes/views/auth-form.html:128
-#: pkg/kubernetes/views/auth-rejected-cert.html:31
-#: pkg/kubernetes/views/deploy.html:61
-#: pkg/kubernetes/views/group-delete.html:20
-#: pkg/kubernetes/views/image-delete.html:7
-#: pkg/kubernetes/views/imagestream-delete.html:7
-#: pkg/kubernetes/views/imagestream-modify.html:96
-#: pkg/kubernetes/views/item-delete.html:10
-#: pkg/kubernetes/views/node-add.html:49
-#: pkg/kubernetes/views/node-delete.html:14
-#: pkg/kubernetes/views/project-delete.html:8
-#: pkg/kubernetes/views/project-modify.html:71
-#: pkg/kubernetes/views/pv-delete.html:10
-#: pkg/kubernetes/views/pv-modify.html:203
-#: pkg/kubernetes/views/pvc-delete.html:14
-#: pkg/kubernetes/views/remove-role-dialog.html:7
-#: pkg/kubernetes/views/replicationcontroller-modify.html:16
-#: pkg/kubernetes/views/route-modify.html:16
-#: pkg/kubernetes/views/service-modify.html:24
-#: pkg/kubernetes/views/user-add-membership.html:48
-#: pkg/kubernetes/views/user-delete.html:24
-#: pkg/kubernetes/views/user-group-add.html:29
-#: pkg/kubernetes/views/user-group-remove.html:9
-#: pkg/kubernetes/views/user-modify.html:26
-#: pkg/kubernetes/views/user-remove-membership.html:9
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-auth.html:80
-#: pkg/lib/machine-change-port.html:40 pkg/lib/machine-sync-users.html:74
-#: pkg/networkmanager/index.html:477 pkg/networkmanager/index.html:501
-#: pkg/networkmanager/index.html:525 pkg/networkmanager/index.html:549
-#: pkg/networkmanager/index.html:573 pkg/networkmanager/index.html:597
-#: pkg/networkmanager/index.html:621 pkg/networkmanager/index.html:645
-#: pkg/networkmanager/index.html:669 pkg/playground/translate.html:39
-#: pkg/realmd/operation.html:81 pkg/shell/index.html:122
-#: pkg/shell/simple.html:90 pkg/shell/stub.html:105 pkg/systemd/index.html:332
+#: pkg/dashboard/index.html:175 pkg/docker/index.html:565
+#: pkg/docker/index.html:599 pkg/docker/index.html:663
+#: pkg/docker/index.html:717 pkg/docker/index.html:757
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
+#: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
+#: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
+#: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
+#: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:654
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:531
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:485
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:558 pkg/networkmanager/firewall.jsx:626
-#: pkg/networkmanager/firewall.jsx:769
-#: pkg/ovirt/components/ClusterTemplates.jsx:75
-#: pkg/ovirt/components/OVirtTab.jsx:66 pkg/ovirt/components/VdsmView.jsx:97
-#: pkg/ovirt/components/VdsmView.jsx:111 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "取消"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:415
 msgid "Cannot connect to an unknown machine"
 msgstr "不能连接至未知主机"
-
-#: src/ws/cockpitcertificate.c:483
-msgid "Cannot decrypt PEM-encoded private key"
-msgstr "无法解密 PEM 编码的私钥"
 
 #: src/base1/cockpit.js:4031
 msgid "Cannot forward login credentials"
@@ -1420,8 +1182,6 @@ msgstr "无法转发登录凭证"
 msgid "Cannot schedule event in the past"
 msgstr "无法调度以前的事件"
 
-#: pkg/kubernetes/views/node-page.html:17 pkg/kubernetes/views/pv-body.html:13
-#: pkg/kubernetes/views/pv-modify.html:44 pkg/kubernetes/views/pvc-body.html:32
 #: pkg/machines/components/vmDisksTab.jsx:70
 msgid "Capacity"
 msgstr "容量"
@@ -1430,18 +1190,7 @@ msgstr "容量"
 msgid "Carrier"
 msgstr "载体"
 
-#: pkg/kubernetes/scripts/volumes.js:203
-msgid "Ceph Filesystem Mount"
-msgstr "Ceph 文件系统挂载"
-
-#: pkg/kubernetes/views/volume-body.html:97
-msgid "Ceph Monitors"
-msgstr "Ceph 监视器"
-
-#: pkg/docker/index.html:662 pkg/kubernetes/views/project-modify.html:74
-#: pkg/kubernetes/views/pv-modify.html:205
-#: pkg/kubernetes/views/replicationcontroller-modify.html:17
-#: pkg/kubernetes/views/route-modify.html:17 pkg/systemd/index.html:333
+#: pkg/docker/index.html:664 pkg/systemd/index.html:333
 #: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
 #: pkg/storaged/iscsi-panel.jsx:181
 msgid "Change"
@@ -1467,31 +1216,19 @@ msgstr "变更配置"
 msgid "Change System Time"
 msgstr "修改系统时间"
 
-#: pkg/kubernetes/views/user-modify.html:3
-msgid "Change User"
-msgstr "变更用户"
-
 #: pkg/storaged/iscsi-panel.jsx:176
 msgid "Change iSCSI Initiator Name"
 msgstr "变更 iSCSI Initiator 名称"
-
-#: pkg/kubernetes/views/imagestream-modify.html:4
-msgid "Change image stream"
-msgstr "变更镜像流"
 
 #: pkg/storaged/crypto-keyslots.jsx:247
 msgid "Change passphrase"
 msgstr "修改密码"
 
-#: pkg/kubernetes/views/project-modify.html:10
-msgid "Change project"
-msgstr "变更项目"
-
-#: pkg/docker/index.html:228
+#: pkg/docker/index.html:229
 msgid "Change resource limits"
 msgstr "修改资源限制"
 
-#: pkg/docker/index.html:612
+#: pkg/docker/index.html:614
 msgid "Change resources limits"
 msgstr "修改资源限制"
 
@@ -1499,10 +1236,10 @@ msgstr "修改资源限制"
 msgid "Change the settings"
 msgstr "修改设置"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "改变生效需要关机。"
 
@@ -1548,25 +1285,13 @@ msgstr "检查更新"
 msgid "Checking installed software"
 msgstr "检查安装的软件"
 
-#: pkg/shell/index.html:117 pkg/shell/simple.html:85 pkg/shell/stub.html:100
+#: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "选择应用程序使用的语言"
 
 #: pkg/storaged/mdraids-panel.jsx:57
 msgid "Chunk Size"
 msgstr "区块大小"
-
-#: pkg/kubernetes/scripts/volumes.js:202
-msgid "Cinder"
-msgstr "Cinder"
-
-#: pkg/kubernetes/views/pv-page.html:16 pkg/kubernetes/views/pv-panel.html:13
-msgid "Claim"
-msgstr "声明"
-
-#: pkg/kubernetes/views/pvc-body.html:4
-msgid "Claim Name"
-msgstr "声明名称"
 
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Class"
@@ -1589,42 +1314,26 @@ msgid ""
 "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr "点击 \"启动 Remote Viewer\" 将下载一个  .vv 文件并加载 $0。"
 
-#: pkg/kubernetes/views/auth-form.html:88
-msgid "Client Certificate"
-msgstr "客户端证书"
-
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr "客户端软件"
 
-#: pkg/docker/index.html:736 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/shell/stub.html:79 pkg/shell/stub.html:122 pkg/systemd/index.html:278
-#: pkg/systemd/services.html:363 pkg/systemd/services.html:381
-#: pkg/users/index.html:45 pkg/apps/utils.jsx:108 pkg/sosreport/index.js:45
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
 #: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "关闭"
 
 #: pkg/shell/active-pages.js:103
 msgid "Close Selected Pages"
 msgstr "关闭已选的页面"
-
-#: pkg/kubernetes/index.html:37 pkg/kubernetes/views/auth-form.html:5
-#: pkg/ovirt/components/App.jsx:107
-msgid "Cluster"
-msgstr "集群"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:128
-msgid "Cluster Templates"
-msgstr "集群模板"
-
-#: pkg/ovirt/components/ClusterVms.jsx:174
-msgid "Cluster Virtual Machines"
-msgstr "集群虚拟机"
 
 #: src/ws/login.js:346
 msgid "Cockpit authentication is configured incorrectly."
@@ -1634,7 +1343,9 @@ msgstr "Cockpit 验证的配置不正确。"
 msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
-msgstr "Cockpit 无法与指定主机 $0 联系。请确认已经在端口 $1 上运行 SSH，或者在地址中指定另一个端口。"
+msgstr ""
+"Cockpit 无法与指定主机 $0 联系。请确认已经在端口 $1 上运行 SSH，或者在地址中"
+"指定另一个端口。"
 
 #: src/base1/cockpit.js:4037
 msgid "Cockpit could not contact the given host."
@@ -1646,8 +1357,9 @@ msgid ""
 "Cockpit by pressing refresh in your browser. The javascript console contains "
 "details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
-"Cockpit 遇到意外的内部错误。 <br/><br/>可以尝试通过刷新浏览器重启 Cockpit。Javascript 控制台包含关于该错误的详情 "
-"（在大多数浏览器中按<b>Ctrl-Shift-J</b> ）。"
+"Cockpit 遇到意外的内部错误。 <br/><br/>可以尝试通过刷新浏览器重启 Cockpit。"
+"Javascript 控制台包含关于该错误的详情 （在大多数浏览器中按<b>Ctrl-Shift-J</"
+"b> ）。"
 
 #: cockpit.appdata.xml.in.h:2
 msgid ""
@@ -1657,10 +1369,11 @@ msgid ""
 "Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
 "journal interface."
 msgstr ""
-"Cockpit 是一个服务器管理工具, 可以方便地通过浏览器来管理 Linux 服务器。在终端和 web 工具间自由切换。通过 Cockpit "
-"启动的服务可以通过终端停止。同样，如果在终端中发生错误, 也可以​​在 Cockpit 的日志接口中看到。"
+"Cockpit 是一个服务器管理工具, 可以方便地通过浏览器来管理 Linux 服务器。在终端"
+"和 web 工具间自由切换。通过 Cockpit 启动的服务可以通过终端停止。同样，如果在"
+"终端中发生错误, 也可以​​在 Cockpit 的日志接口中看到。"
 
-#: pkg/shell/index.html:85 pkg/shell/simple.html:61 pkg/shell/stub.html:68
+#: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit 是一个交互式 Linux 服务器管理接口。"
 
@@ -1684,8 +1397,9 @@ msgid ""
 "same time. Just add them with a single click and your machines will look "
 "after its buddies."
 msgstr ""
-"Cockpit 是完美的系统管理员工具，它可以轻松完成简单的任务, 如存储管理, 检查日志信息，以及启动/停止服务。 "
-"您可以同时监控和管理多个服务器。点一键就可以添加服务器，并开始进行管理。"
+"Cockpit 是完美的系统管理员工具，它可以轻松完成简单的任务, 如存储管理, 检查日"
+"志信息，以及启动/停止服务。 您可以同时监控和管理多个服务器。点一键就可以添加"
+"服务器，并开始进行管理。"
 
 #: pkg/lib/machine-change-port.html:9
 msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
@@ -1693,14 +1407,14 @@ msgstr "Cockpit 无法联系 {{#strong}}{{host}}{{/strong}}。"
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 {{#can_sync}}您可以尝试使用 "
-"{{#sync_link}}对用户进行同步{{/sync_link}}。{{/can_sync}} 如需更多验证选项和排错支持，请把 cockpit-"
-"ws 更新到一个新版本。"
+"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 {{#can_sync}}您可以尝试使"
+"用 {{#sync_link}}对用户进行同步{{/sync_link}}。{{/can_sync}} 如需更多验证选项"
+"和排错支持，请把 cockpit-ws 更新到一个新版本。"
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1712,8 +1426,9 @@ msgid ""
 "machine with cockpit you will need to enable one of the following "
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
-"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 为了可以使这个机器可以使用 cockpit， 需要在 "
-"{{#strong}}{{host}}{{/strong}} 上的 sshd 配置中启用以下验证方式之一："
+"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。 为了可以使这个机器可以使"
+"用 cockpit， 需要在 {{#strong}}{{host}}{{/strong}} 上的 sshd 配置中启用以下验"
+"证方式之一："
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1721,9 +1436,9 @@ msgid ""
 "change your authentication credentials below. {{#can_sync}}You may prefer to "
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
-"Cockpit 无法登录到 {{#strong}}{{host}}{{/"
-"strong}}。可以变更以下验证凭证。{{#can_sync}}您也可以尝试{{#sync_link}}同步账号和密码{{/"
-"sync_link}}。{{/can_sync}}"
+"Cockpit 无法登录到 {{#strong}}{{host}}{{/strong}}。可以变更以下验证凭证。"
+"{{#can_sync}}您也可以尝试{{#sync_link}}同步账号和密码{{/sync_link}}。{{/"
+"can_sync}}"
 
 #: pkg/dashboard/index.html:157 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1738,12 +1453,12 @@ msgid "Combined usage of $0 CPU core"
 msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "总计使用 $0 CPU 内核"
 
-#: pkg/networkmanager/firewall.jsx:527
+#: pkg/networkmanager/firewall.jsx:529
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "可以使用逗号隔开的端口、范围和别名"
 
-#: pkg/docker/index.html:269 pkg/docker/index.html:445
-#: pkg/docker/index.html:706 pkg/systemd/services.html:427
+#: pkg/docker/index.html:271 pkg/docker/index.html:447
+#: pkg/docker/index.html:708 pkg/systemd/services.html:427
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1754,7 +1469,7 @@ msgstr "命令"
 msgid "Command can't be empty"
 msgstr "命令不能为空"
 
-#: pkg/docker/index.html:163
+#: pkg/docker/index.html:164
 msgid "Command:"
 msgstr "命令："
 
@@ -1762,12 +1477,12 @@ msgstr "命令："
 msgid "Comment"
 msgstr "注释"
 
-#: pkg/docker/index.html:137 pkg/docker/index.html:716
+#: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
 msgstr "提交"
 
-#: pkg/docker/index.html:676
+#: pkg/docker/index.html:678
 msgid "Commit Image"
 msgstr "提交镜像"
 
@@ -1791,8 +1506,8 @@ msgstr "兼容现代系统，且硬盘空间大于 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "对崩溃转储数据进行压缩以节省空间"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "压缩"
 
@@ -1808,21 +1523,9 @@ msgstr "条件 $0=$1 不满足"
 msgid "Condition failed"
 msgstr "条件失败"
 
-#: pkg/kubernetes/views/node-add.html:24
-msgid "Configuration"
-msgstr "配置"
-
 #: pkg/networkmanager/interfaces.js:2725
 msgid "Configure"
 msgstr "配置"
-
-#: pkg/kubernetes/views/node-add.html:42
-msgid "Configure Flannel networking"
-msgstr "配置 Flannel 网络"
-
-#: pkg/kubernetes/views/node-add.html:32
-msgid "Configure Kubelet and Proxy"
-msgstr "配置 Kubelet 和代理"
 
 #: pkg/docker/storage.jsx:331
 msgid "Configure storage..."
@@ -1845,21 +1548,13 @@ msgstr "确认"
 msgid "Confirm New Password"
 msgstr "确认新密码"
 
-#: pkg/ovirt/components/OVirtTab.jsx:65
-msgid "Confirm migration"
-msgstr "确认迁移"
-
-#: pkg/ovirt/components/VdsmView.jsx:95
-msgid "Confirm reload:"
-msgstr "确认重新加载："
+#: pkg/machines/components/networks/networkDelete.jsx:95
+msgid "Confirm deletion of the Virtual Network"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Confirm removal with passphrase"
 msgstr "使用密码确认删除"
-
-#: pkg/ovirt/components/VdsmView.jsx:108
-msgid "Confirm save:"
-msgstr "确认保存："
 
 #: pkg/systemd/init.js:728
 msgid "Conflicted By"
@@ -1869,8 +1564,6 @@ msgstr "冲突"
 msgid "Conflicts"
 msgstr "冲突"
 
-#: pkg/kubernetes/views/auth-form.html:130
-#: pkg/kubernetes/views/auth-rejected-cert.html:33
 #: pkg/lib/machine-unknown-hostkey.html:22
 msgid "Connect"
 msgstr "连接"
@@ -1883,10 +1576,6 @@ msgstr "自动连接"
 msgid "Connect to"
 msgstr "连接至"
 
-#: pkg/ovirt/components/InstallationDialog.jsx:102
-msgid "Connect to oVirt Engine"
-msgstr "连接至 oVirt 引擎"
-
 #: pkg/machines/components/desktopConsole.jsx:188
 msgid "Connect with any $0 viewer application."
 msgstr "使用任何 $0 查看器应用来连接。"
@@ -1895,7 +1584,7 @@ msgstr "使用任何 $0 查看器应用来连接。"
 msgid "Connect with any SPICE or VNC viewer application."
 msgstr "使用任何 SPICE 或 VNC 查看器应用来连接。"
 
-#: pkg/machines/components/vnc.jsx:107
+#: pkg/machines/components/vnc.jsx:106
 msgid "Connecting"
 msgstr "连接"
 
@@ -1916,33 +1605,21 @@ msgstr "连接到 SETroubleshoot 守护进程..."
 msgid "Connecting to Virtualization Service"
 msgstr "连接虚拟化服务"
 
-#: pkg/shell/indexes.js:411
+#: pkg/shell/indexes.js:410
 msgid "Connecting to the machine"
 msgstr "正在连接至主机"
 
-#: pkg/kubernetes/index.html:104 pkg/kubernetes/registry.html:71
-msgid "Connecting..."
-msgstr "连接中..."
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:573
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "连接"
 
-#: pkg/kubernetes/views/auth-dialog.html:4 pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:406
 msgid "Connection Error"
 msgstr "连接错误"
-
-#: pkg/kubernetes/scripts/connection.js:512
-msgid "Connection Error: $0"
-msgstr "连接错误: $0"
-
-#: pkg/kubernetes/views/auth-dialog.html:3
-msgid "Connection Settings"
-msgstr "连接设置"
 
 #: src/base1/cockpit.js:4027
 msgid "Connection has timed out."
@@ -1964,34 +1641,23 @@ msgstr "控制台类型"
 msgid "Consoles"
 msgstr "控制台"
 
-#: pkg/realmd/operation.js:274
+#: pkg/realmd/operation.js:273
 msgid "Contacted domain"
 msgstr "联系的域"
 
-#: pkg/docker/console.html:4 pkg/kubernetes/views/container-body.html:4
-#: pkg/kubernetes/views/container-page-inline.html:2
-#: pkg/kubernetes/views/container-panel.html:4
-#: pkg/kubernetes/views/image-page.html:23
+#: pkg/docker/console.html:4
 #: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "容器"
 
-#: pkg/users/local.js:748
+#: pkg/users/local.js:752
 msgid "Container Administrator"
 msgstr "容器管理员"
 
-#: pkg/kubernetes/views/container-body.html:10
-msgid "Container ID"
-msgstr "容器 ID"
-
-#: pkg/docker/index.html:438 pkg/docker/index.html:618
-#: pkg/docker/index.html:682
+#: pkg/docker/index.html:440 pkg/docker/index.html:620
+#: pkg/docker/index.html:684
 msgid "Container Name"
 msgstr "容器名称"
-
-#: pkg/kubernetes/views/node-body.html:21
-msgid "Container Runtime Version"
-msgstr "容器运行时版本"
 
 #: pkg/docker/util.js:506
 msgid ""
@@ -2002,15 +1668,12 @@ msgstr "容器当前标记为未运行, 但正常停止失败。"
 msgid "Container is currently running."
 msgstr "当前容器正在运行。"
 
-#: pkg/docker/index.html:141
+#: pkg/docker/index.html:133
 msgid "Container:"
 msgstr "容器："
 
-#: pkg/docker/index.html:23 pkg/docker/index.html:287
-#: pkg/kubernetes/index.html:55 pkg/kubernetes/views/containers-listing.html:5
-#: pkg/kubernetes/views/dashboard-page.html:158
-#: pkg/kubernetes/views/dashboard-page.html:199
-#: pkg/kubernetes/views/pod-page.html:36 pkg/docker/containers-view.jsx:375
+#: pkg/docker/index.html:23 pkg/docker/index.html:289
+#: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "容器"
 
@@ -2024,12 +1687,12 @@ msgid "Content"
 msgstr "内容"
 
 #: src/base1/test-locale.js:42 src/base1/test-locale.js:53
-#: pkg/playground/translate.js:22
+#: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "控制"
 
 #: src/base1/test-locale.js:43 src/base1/test-locale.js:55
-#: pkg/playground/translate.js:25
+#: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
 msgstr "控制"
@@ -2043,7 +1706,6 @@ msgid "Copy"
 msgstr "复制"
 
 #: pkg/machines/components/vcpuModal.jsx:209
-#: pkg/ovirt/components/vcpuModal.jsx:67
 msgid "Cores per socket"
 msgstr "每个插槽的内核数"
 
@@ -2054,18 +1716,6 @@ msgstr "无法添加所有磁盘"
 #: pkg/lib/machine-change-port.html:4
 msgid "Could not contact {{host}}"
 msgstr "无法联系 {{host}}"
-
-#: pkg/kubernetes/views/dashboard-page.html:142
-msgid "Could not list services"
-msgstr "无法列出服务"
-
-#: src/ws/cockpitcertificate.c:531
-msgid "Could not parse PEM-encoded certificate"
-msgstr "无法解析 PEM 编码的证书"
-
-#: src/ws/cockpitcertificate.c:498
-msgid "Could not parse PEM-encoded private key"
-msgstr "无法解析 PEM 编码的私钥"
 
 #: pkg/docker/storage.jsx:468
 msgid "Could not reset the storage pool"
@@ -2079,28 +1729,13 @@ msgstr "不能修改用户组"
 msgid "Couldn't change user password"
 msgstr "不能修改用户密码"
 
-#: pkg/kubernetes/index.html:105 pkg/kubernetes/registry.html:72
-msgid "Couldn't connect to server"
-msgstr "无法连接到服务器"
-
-#: pkg/shell/indexes.js:414
+#: pkg/shell/indexes.js:413
 msgid "Couldn't connect to the machine"
 msgstr "不能连接至主机"
 
 #: src/bridge/cockpitdbussetup.c:544
 msgid "Couldn't create new users"
 msgstr "不能创建新用户"
-
-#: pkg/kubernetes/scripts/connection.js:510
-#: pkg/kubernetes/scripts/kube-client-cockpit.js:957
-msgid "Couldn't find running API server"
-msgstr "无法找到运行的 API 服务器"
-
-#: pkg/subscriptions/subscriptions-view.jsx:218
-msgid ""
-"Couldn't get system subscription status. Please ensure subscription-manager "
-"is installed."
-msgstr "无法获取系统订阅状态。请确认 subscription-manager 已安装。"
 
 #: src/bridge/cockpitdbussetup.c:642
 msgid "Couldn't list local users"
@@ -2122,14 +1757,12 @@ msgstr "崩溃信息存放在"
 msgid "Crash system"
 msgstr "导致系统崩溃"
 
-#: pkg/kubernetes/views/add-group-dialog.html:19
-#: pkg/kubernetes/views/project-modify.html:72 pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:657
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:488
-#: pkg/ovirt/components/ClusterTemplates.jsx:76
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/users/index.html:199
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "创建"
 
@@ -2137,17 +1770,13 @@ msgstr "创建"
 msgid "Create Logical Volume"
 msgstr "创建逻辑卷"
 
-#: pkg/machines/components/diskAdd.jsx:487
+#: pkg/machines/components/diskAdd.jsx:515
 msgid "Create New"
 msgstr "新建"
 
 #: pkg/users/index.html:52 pkg/users/index.html:163
 msgid "Create New Account"
 msgstr "创建新账户"
-
-#: pkg/ovirt/components/App.jsx:162
-msgid "Create New VM"
-msgstr "新建 VM"
 
 #: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
 msgid "Create Partition"
@@ -2173,7 +1802,7 @@ msgstr "创建报表"
 msgid "Create Snapshot"
 msgstr "创建快照"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:522
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
 msgid "Create Storage Pool"
 msgstr "创建存储池"
 
@@ -2193,8 +1822,7 @@ msgstr "创建定时器"
 msgid "Create VDO Device"
 msgstr "创建 VDO 设备"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:690
-#: pkg/ovirt/components/ClusterTemplates.jsx:81
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
 msgid "Create VM"
 msgstr "创建虚拟机"
 
@@ -2206,14 +1834,6 @@ msgstr "创建卷组"
 msgid "Create diagnostic report"
 msgstr "创建诊断报告"
 
-#: pkg/kubernetes/scripts/images.js:643
-msgid "Create empty image stream"
-msgstr "创建空镜像流"
-
-#: pkg/kubernetes/views/imagestream-modify.html:3
-msgid "Create image stream"
-msgstr "创建镜像流"
-
 #: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
 #: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
 msgid "Create it"
@@ -2223,16 +1843,12 @@ msgstr "创建它"
 msgid "Create new Logical Volume"
 msgstr "创建新逻辑卷"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:7
-#: pkg/kubernetes/views/node-body.html:3 pkg/kubernetes/views/pod-body.html:7
-#: pkg/kubernetes/views/replicationcontroller-body.html:7
-#: pkg/kubernetes/views/route-body.html:7
-#: pkg/kubernetes/views/service-body.html:7 pkg/docker/containers-view.jsx:129
-#: pkg/docker/containers-view.jsx:412 pkg/docker/containers-view.jsx:683
+#: pkg/docker/containers-view.jsx:129 pkg/docker/containers-view.jsx:412
+#: pkg/docker/containers-view.jsx:683
 msgid "Created"
 msgstr "创建于"
 
-#: pkg/docker/index.html:152
+#: pkg/docker/index.html:153
 msgid "Created:"
 msgstr "创建于："
 
@@ -2284,7 +1900,7 @@ msgstr "创建该组将断开与服务器的连接，并且将会导致管理界
 msgid "Creating volume group $target"
 msgstr "创建卷组 $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:559
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
 msgid "Creation of VM $0 failed"
 msgstr "虚拟机$0创建失败"
 
@@ -2292,7 +1908,7 @@ msgstr "虚拟机$0创建失败"
 msgid "Critical and above"
 msgstr "关键及以上级别"
 
-#: pkg/machines/components/vnc.jsx:110
+#: pkg/machines/components/vnc.jsx:109
 msgid "Ctrl+Alt+Del"
 msgstr "Ctrl+Alt+Del"
 
@@ -2312,23 +1928,19 @@ msgstr "当前启动"
 msgid "Custom"
 msgstr "自定义"
 
-#: pkg/networkmanager/firewall.jsx:521
+#: pkg/networkmanager/firewall.jsx:523
 msgid "Custom Ports"
 msgstr "自定义端口"
-
-#: pkg/subscriptions/subscriptions-register.jsx:103
-msgid "Custom URL"
-msgstr "自定义 URL"
 
 #: pkg/storaged/format-dialog.jsx:118
 msgid "Custom encryption options"
 msgstr "自定义加密选项"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "自定义挂载选项"
 
-#: pkg/networkmanager/firewall.jsx:716
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Custom zones"
 msgstr "自定义区域"
 
@@ -2348,10 +1960,6 @@ msgstr "DNS"
 #: pkg/networkmanager/interfaces.js:2656
 msgid "DNS $val"
 msgstr "DNS $val"
-
-#: pkg/kubernetes/views/pod-body.html:14
-msgid "DNS Policy"
-msgstr "DNS 策略"
 
 #: pkg/networkmanager/interfaces.js:3320
 msgid "DNS Search Domains"
@@ -2373,8 +1981,8 @@ msgstr "仪表板"
 msgid "Data Used"
 msgstr "数据已使用空间"
 
-#: pkg/machines/components/networks/network.jsx:143
-#: pkg/machines/components/storagePools/storagePool.jsx:163
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "取消激活"
@@ -2395,10 +2003,9 @@ msgstr "Debug 及以上"
 msgid "Deduplication"
 msgstr "复制"
 
-#: pkg/docker/index.html:357 pkg/docker/index.html:361
+#: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: node_modules/registry-image-widgets/views/image-config.html:10
 #: pkg/storaged/format-dialog.jsx:68
-#: pkg/subscriptions/subscriptions-register.jsx:102
 msgid "Default"
 msgstr "默认"
 
@@ -2406,37 +2013,26 @@ msgstr "默认"
 msgid "Delay"
 msgstr "延时"
 
-#: pkg/docker/index.html:136 pkg/docker/index.html:246
-#: pkg/kubernetes/views/image-delete.html:8
-#: pkg/kubernetes/views/imagestream-delete.html:8
-#: pkg/kubernetes/views/item-delete.html:11
-#: pkg/kubernetes/views/node-delete.html:15
-#: pkg/kubernetes/views/project-delete.html:9
-#: pkg/kubernetes/views/pv-delete.html:11
-#: pkg/kubernetes/views/pvc-delete.html:15
-#: pkg/kubernetes/views/user-remove-membership.html:10
+#: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/kubernetes/scripts/volumes.js:218
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/machines/components/networks/networkDelete.jsx:86
+#: pkg/machines/components/networks/networkDelete.jsx:103
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:300 pkg/storaged/mdraid-details.jsx:323
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:214 pkg/storaged/vgroup-details.jsx:237
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "删除"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1179
+#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "删除 $0"
-
-#: pkg/playground/translate.html:189
-msgid "Delete '{{ name }}'"
-msgstr "删除 '{{ name }}'"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
 msgid "Delete Content"
@@ -2446,25 +2042,10 @@ msgstr "删除内容"
 msgid "Delete Files"
 msgstr "删除文件"
 
-#: pkg/kubernetes/views/node-delete.html:4
-msgid "Delete Node"
-msgstr "删除节点"
-
-#: pkg/kubernetes/views/pv-delete.html:3
-msgid "Delete Persistent Volume"
-msgstr "删除持久卷"
-
-#: pkg/kubernetes/views/pvc-delete.html:3
-msgid "Delete Persistent Volume Claim"
-msgstr "删除持久卷声明"
-
-#: pkg/kubernetes/views/project-delete.html:3
-msgid "Delete Project"
-msgstr "删除项目"
-
-#: pkg/kubernetes/views/nodes-page.html:3
-msgid "Delete Selected"
-msgstr "删除所选的"
+#: pkg/machines/components/networks/networkDelete.jsx:92
+#, fuzzy
+msgid "Delete Network $0"
+msgstr "删除 $0"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
 msgid "Delete Storage Pool $0"
@@ -2474,17 +2055,9 @@ msgstr "删除存储池$0"
 msgid "Delete associated storage files:"
 msgstr "删除关联的存储文件："
 
-#: pkg/kubernetes/views/imagestream-delete.html:3
-msgid "Delete image stream"
-msgstr "删除镜像流"
-
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
 msgid "Delete the Volumes inside this Pool"
 msgstr "删除这个存储池中的卷"
-
-#: pkg/kubernetes/views/item-delete.html:3
-msgid "Delete {{ item.kind }}"
-msgstr "删除 {{ item.kind }}"
 
 #: pkg/storaged/jobs-panel.jsx:53 pkg/storaged/jobs-panel.jsx:67
 msgid "Deleting $target"
@@ -2496,13 +2069,7 @@ msgid ""
 "the administration UI unavailable."
 msgstr "删除 <b>$0</b> 将会中断与服务器的连接，并且将会导致管理界面不可用。"
 
-#: pkg/kubernetes/views/item-delete.html:7
-msgid ""
-"Deleting a Pod will kill all associated containers. Pods may be "
-"automatically created again in some cases."
-msgstr "删除 Pod 将会终止所有相关的容器。Pod 可能会在某些情况下被自动创建。"
-
-#: pkg/storaged/mdraid-details.jsx:301
+#: pkg/storaged/mdraid-details.jsx:300
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "删除 RAID 设备将擦除其中的所有数据."
 
@@ -2510,7 +2077,7 @@ msgstr "删除 RAID 设备将擦除其中的所有数据."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "删除 RAID 设备将擦除其中的所有数据."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "删除容器将清除其中的所有数据。"
 
@@ -2522,7 +2089,7 @@ msgstr "删除逻辑卷将擦除其中的所有数据。"
 msgid "Deleting a partition will delete all data in it."
 msgstr "删除分区将擦除其中的所有数据。"
 
-#: pkg/storaged/vgroup-details.jsx:213
+#: pkg/storaged/vgroup-details.jsx:212
 msgid "Deleting a volume group will erase all data on it."
 msgstr "删除卷组将擦除其中的所有数据。"
 
@@ -2536,44 +2103,11 @@ msgstr "删除一个不活跃的池指挥取消定义这个池，而不会删除
 msgid "Deleting volume group $target"
 msgstr "删除卷组 $target"
 
-#: pkg/kubernetes/views/dashboard-page.html:131
-#: pkg/kubernetes/views/deploy.html:62
-msgid "Deploy"
-msgstr "部署"
-
-#: pkg/kubernetes/views/deploy.html:3
-msgid "Deploy Application"
-msgstr "部署应用"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:22
-msgid "Deployment Causes"
-msgstr "部署原因"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:12
-#: pkg/kubernetes/views/deploymentconfig-panel.html:8
-msgid "Deployment Config"
-msgstr "部署配置"
-
-#: pkg/kubernetes/views/details-page.html:98
-#: pkg/kubernetes/scripts/details.js:220
-msgid "Deployment Configs"
-msgstr "部署配置"
-
-#: pkg/kubernetes/views/project-listing.html:15
-#: pkg/kubernetes/views/project-listing.html:54
-#: pkg/kubernetes/views/project-modify.html:40 pkg/systemd/services.html:413
+#: pkg/systemd/services.html:413
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:725
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
 msgid "Description"
 msgstr "描述"
-
-#: pkg/ovirt/components/OVirtTab.jsx:146
-#: pkg/ovirt/components/VmOverviewColumn.jsx:52
-msgid "Description:"
-msgstr "描述："
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2583,16 +2117,15 @@ msgstr "桌面"
 msgid "Detachable"
 msgstr "可拆开"
 
-#: pkg/kubernetes/index.html:67 pkg/shell/index.html:229
-#: pkg/docker/containers-view.jsx:336 pkg/docker/containers-view.jsx:504
-#: pkg/docker/containers-view.jsx:514 pkg/docker/containers-view.jsx:642
-#: pkg/networkmanager/firewall.jsx:94 pkg/packagekit/updates.jsx:383
-#: pkg/subscriptions/subscriptions-view.jsx:232 pkg/systemd/host.js:745
+#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
+#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "详情"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2614,7 +2147,6 @@ msgstr "诊断报告"
 msgid "Digest"
 msgstr "摘要"
 
-#: pkg/kubernetes/views/volume-body.html:28
 #: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
@@ -2645,8 +2177,8 @@ msgstr "禁用"
 msgid "Disconnect"
 msgstr "断开"
 
-#: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:108
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:604
+#: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
+#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
 msgid "Disconnected"
 msgstr "已断开连接"
 
@@ -2654,7 +2186,6 @@ msgstr "已断开连接"
 msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr "从串行控制台断开连接。单击“重新连接”按钮。"
 
-#: pkg/kubernetes/scripts/nodes.js:719 pkg/kubernetes/scripts/nodes.js:836
 #: pkg/storaged/vdos-panel.jsx:55
 msgid "Disk"
 msgstr "磁盘"
@@ -2667,15 +2198,11 @@ msgstr "磁盘$0无法从虚拟机$1上分离"
 msgid "Disk I/O"
 msgstr "磁盘 I/O"
 
-#: pkg/kubernetes/scripts/nodes.js:720
-msgid "Disk Utilization: $0%"
-msgstr "磁盘使用率: $0%"
-
-#: pkg/machines/components/diskAdd.jsx:461
+#: pkg/machines/components/diskAdd.jsx:489
 msgid "Disk failed to be attached"
 msgstr "挂载磁盘失败"
 
-#: pkg/machines/components/diskAdd.jsx:443
+#: pkg/machines/components/diskAdd.jsx:468
 msgid "Disk failed to be created"
 msgstr "创建磁盘失败"
 
@@ -2687,9 +2214,9 @@ msgstr "磁盘良好"
 msgid "Disk passphrase"
 msgstr "磁盘口令"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:154 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "磁盘"
 
@@ -2698,55 +2225,9 @@ msgid "Disks cannot be removed from $0 VMs"
 msgstr "磁盘不能从 $0 VM 删除"
 
 #: pkg/shell/index.html:52 pkg/shell/index.html:114 pkg/shell/simple.html:38
-#: pkg/shell/simple.html:82 pkg/shell/stub.html:42 pkg/shell/stub.html:97
+#: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "显示语言"
-
-#: pkg/kubernetes/views/project-modify.html:31
-msgid "Display name"
-msgstr "显示名称"
-
-#: pkg/kubernetes/views/add-role-dialog.html:5
-msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-msgstr "是否想要添加角色 '{{ fields.displayRole }}'？"
-
-#: pkg/kubernetes/views/imagestream-delete.html:5
-msgid ""
-"Do you want to delete the '{{stream.metadata.namespace}}/{{stream.metadata."
-"name}}' image stream?"
-msgstr "是否想要删除镜像流 '{{stream.metadata.namespace}}/{{stream.metadata.name}}' ？"
-
-#: pkg/kubernetes/views/pv-delete.html:6
-msgid "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-msgstr "是否想要删除持久卷 '{{item.metadata.name}}'？"
-
-#: pkg/kubernetes/views/pvc-delete.html:6
-msgid ""
-"Do you want to delete the Persistent Volume Claim '{{item.metadata.name}}'?"
-msgstr "是否想要删除持久卷声明 '{{item.metadata.name}}'？"
-
-#: pkg/kubernetes/views/item-delete.html:6
-msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-msgstr "是否想要删除 {{ item.kind }} '{{item.metadata.name}}'？"
-
-#: pkg/kubernetes/views/node-delete.html:7
-msgid "Do you want to delete this Node?"
-msgstr "是否想要删除该节点？"
-
-#: pkg/kubernetes/views/image-delete.html:5
-msgid ""
-"Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-"{{stream.metadata.name}}:{{tag.tag}}'?"
-msgstr ""
-"是否想要移除标记为 '{{stream.metadata.namespace}}/{{stream.metadata.name}}:{{tag."
-"tag}}' 的镜像？"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:5
-msgid ""
-"Do you want to remove the role '{{ fields.displayRole }}' from member {{ "
-"fields.member.metadata.name }}?"
-msgstr ""
-"是否想要从成员 {{ fields.member.metadata.name }} 中移除角色 '{{ fields.displayRole }}'？"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2761,15 +2242,15 @@ msgid "Docking Station"
 msgstr "Docking Station"
 
 #: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
-#: pkg/realmd/operation.js:123
+#: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "域"
 
-#: pkg/realmd/operation.js:192
+#: pkg/realmd/operation.js:191
 msgid "Domain $0 could not be contacted"
 msgstr "域 $0 无法联系"
 
-#: pkg/realmd/operation.js:279
+#: pkg/realmd/operation.js:278
 msgid "Domain $0 is not supported"
 msgstr "不支持域 $0"
 
@@ -2794,15 +2275,11 @@ msgstr "不要重复"
 msgid "Don't overwrite existing data"
 msgstr "不覆盖已存在数据"
 
-#: pkg/kubernetes/scripts/images.js:633
-msgid "Don't pull images automatically"
-msgstr "不自动下载镜像"
-
 #: pkg/sosreport/index.html:63
 msgid "Done!"
 msgstr "已完成！"
 
-#: pkg/docker/index.html:598
+#: pkg/docker/index.html:600
 msgid "Download"
 msgstr "下载"
 
@@ -2839,11 +2316,7 @@ msgctxt "storage"
 msgid "Drive"
 msgstr "驱动"
 
-#: pkg/kubernetes/views/volume-body.html:128
-msgid "Driver"
-msgstr "驱动器"
-
-#: pkg/storaged/drives-panel.jsx:119
+#: pkg/storaged/drives-panel.jsx:120
 msgid "Drives"
 msgstr "驱动器"
 
@@ -2872,10 +2345,6 @@ msgstr "编辑Tang keyserver"
 msgid "Edit image stream"
 msgstr "编辑镜像流"
 
-#: pkg/ovirt/components/VdsmView.jsx:125
-msgid "Edit the vdsm.conf"
-msgstr "编辑 vdsm.conf"
-
 #: pkg/storaged/crypto-keyslots.jsx:535
 msgid "Editing a key requires a free slot"
 msgstr "编辑密钥需要一个空闲插槽"
@@ -2889,25 +2358,21 @@ msgid "Embedded PC"
 msgstr "嵌入式 PC"
 
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:13
+#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "空"
 
 #: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:19
+#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "空"
-
-#: pkg/kubernetes/scripts/volumes.js:196
-msgid "Empty Directory"
-msgstr "空目录"
 
 #: pkg/storaged/jobs-panel.jsx:75
 msgid "Emptying $target"
 msgstr "清空 $target"
 
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:151
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:162
 msgid "Emulated Machine"
 msgstr "虚拟的机器"
 
@@ -2968,23 +2433,6 @@ msgstr "加密"
 msgid "Encryption Options"
 msgstr "加密选项"
 
-#: pkg/kubernetes/views/pv-modify.html:93
-msgid "Endpoint"
-msgstr "端点"
-
-#: pkg/kubernetes/views/volume-body.html:40
-msgid "Endpoint Name"
-msgstr "端点名称"
-
-#: pkg/kubernetes/views/service-page.html:14
-#: pkg/kubernetes/views/service-panel.html:9
-msgid "Endpoints"
-msgstr "端点"
-
-#: pkg/subscriptions/subscriptions-view.jsx:39
-msgid "Ends"
-msgstr "结尾"
-
 #: pkg/selinux/setroubleshoot-view.jsx:299
 msgid "Enforce policy:"
 msgstr "强制策略："
@@ -2997,17 +2445,13 @@ msgstr "可用的功能增强更新"
 msgid "Enter IP address or host name"
 msgstr "输入 IP 地址或主机名"
 
-#: pkg/ovirt/components/ClusterTemplates.jsx:74
-msgid "Enter New VM name"
-msgstr "输入新的虚拟机名称"
-
 #: pkg/lib/machine-change-auth.html:57
 msgid ""
 "Entering a different password here means you will need to retype it every "
 "time you reconnect to this machine"
 msgstr "在这里输入不同的密码意味着将要在每次重新连接该主机时重新输入"
 
-#: pkg/networkmanager/firewall.jsx:752
+#: pkg/networkmanager/firewall.jsx:754
 msgid "Entire subnet"
 msgstr "整个子网"
 
@@ -3019,7 +2463,7 @@ msgstr "条目"
 msgid "Entrypoint"
 msgstr "入口点"
 
-#: pkg/docker/index.html:526 pkg/kubernetes/views/container-body.html:26
+#: pkg/docker/index.html:528
 #: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "环境"
@@ -3041,19 +2485,15 @@ msgid "Errata:"
 msgstr "勘误："
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1472
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "错误"
 
 #: pkg/systemd/logs.html:59
 msgid "Error and above"
 msgstr "错误及以上级别"
-
-#: pkg/kubernetes/scripts/connection.js:646
-msgid "Error getting certificate details: $0"
-msgstr "获取证书详情出错: $0"
 
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
@@ -3075,10 +2515,6 @@ msgstr "删除警告： $0 时出错"
 msgid "Error while setting SELinux mode: '$0'"
 msgstr "设置 SELinux 模式时出错: '$0'"
 
-#: pkg/kubernetes/scripts/connection.js:85
-msgid "Error writing kubectl config"
-msgstr "写 kubectl 配置时出错"
-
 #: pkg/networkmanager/index.html:658
 msgid "Ethernet MAC"
 msgstr "以太网 MAC"
@@ -3095,23 +2531,23 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "所有"
 
-#: pkg/networkmanager/firewall.jsx:534
+#: pkg/networkmanager/firewall.jsx:536
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "例如: 22,ssh,8080,5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:542
+#: pkg/networkmanager/firewall.jsx:544
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "例如: 88,2019,nfs,rsync"
 
-#: pkg/users/local.js:473 pkg/users/local.js:1417
+#: pkg/users/local.js:477 pkg/users/local.js:1421
 msgid "Excellent password"
 msgstr "密码强度良好"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:222
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
 msgid "Existing Disk Image"
 msgstr "现有磁盘镜像"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
 msgid "Existing disk image on host's file system"
 msgstr "主机文件系统上存在的磁盘镜像"
 
@@ -3123,7 +2559,7 @@ msgstr "已退出 $ExitCode"
 msgid "Expansion Chassis"
 msgstr "扩展机箱"
 
-#: pkg/docker/index.html:508
+#: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "暴露容器端口"
 
@@ -3135,14 +2571,6 @@ msgstr "扩展分区"
 msgid "FAILED"
 msgstr "失败"
 
-#: pkg/ovirt/provider.js:130
-msgid "FORCEOFF action failed: $0"
-msgstr "FORCEOFF 操作失败 : $0"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:47
-msgid "FQDN"
-msgstr "FQDN"
-
 #: pkg/networkmanager/interfaces.js:842
 msgid "Failed"
 msgstr "已失败"
@@ -3152,14 +2580,19 @@ msgid "Failed to add machine: $0"
 msgstr "添加主机失败: $0"
 
 #: pkg/networkmanager/firewall.jsx:237
+#, fuzzy
+msgid "Failed to add port"
+msgstr "添加区域失败"
+
+#: pkg/networkmanager/firewall.jsx:237
 msgid "Failed to add service"
 msgstr "添加服务失败"
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:679
 msgid "Failed to add zone"
 msgstr "添加区域失败"
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "修改密码失败"
 
@@ -3183,11 +2616,15 @@ msgstr "编辑主机失败: $0"
 msgid "Failed to enable tuned"
 msgstr "启用 tuned 失败"
 
+#: pkg/machines/components/vmnetworktab.jsx:55
+msgid "Failed to fetch the IP addresses of the interfaces present in $0"
+msgstr ""
+
 #: pkg/users/index.html:393
 msgid "Failed to load authorized keys."
 msgstr "载入 authorized key 失败。"
 
-#: pkg/networkmanager/firewall.jsx:589
+#: pkg/networkmanager/firewall.jsx:591
 msgid "Failed to remove service"
 msgstr "删除服务失败"
 
@@ -3206,10 +2643,6 @@ msgstr "切换配置集失败"
 #: pkg/machines/components/vcpuModal.jsx:193
 msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr "启用的虚拟 CPU 数量应少于最大虚拟 CPU 数量。"
-
-#: pkg/kubernetes/scripts/volumes.js:204
-msgid "Fibre Channel"
-msgstr "光纤通道"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:92
 #: pkg/machines/components/vmDiskColumns.jsx:42
@@ -3232,22 +2665,11 @@ msgstr "文件系统挂载"
 msgid "Filesystem Name"
 msgstr "文件系统名称"
 
-#: pkg/kubernetes/views/pv-modify.html:181
-#: pkg/kubernetes/views/volume-body.html:6
-#: pkg/kubernetes/views/volume-body.html:16
-#: pkg/kubernetes/views/volume-body.html:62
-#: pkg/kubernetes/views/volume-body.html:83
-#: pkg/kubernetes/views/volume-body.html:91
-#: pkg/kubernetes/views/volume-body.html:120
-#: pkg/kubernetes/views/volume-body.html:132
-msgid "Filesystem Type"
-msgstr "文件系统类型"
-
 #: pkg/storaged/fsys-panel.jsx:103
 msgid "Filesystems"
 msgstr "文件系统"
 
-#: pkg/networkmanager/firewall.jsx:490
+#: pkg/networkmanager/firewall.jsx:491
 msgid "Filter Services"
 msgstr "过滤服务"
 
@@ -3255,30 +2677,18 @@ msgstr "过滤服务"
 msgid "Filter by name or description..."
 msgstr "根据名称或描述进行过滤..."
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "指纹"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:913 pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
 msgid "Firewall"
 msgstr "防火墙"
 
-#: pkg/networkmanager/firewall.jsx:861
+#: pkg/networkmanager/firewall.jsx:863
 msgid "Firewall is not available"
 msgstr "防火墙不可用"
-
-#: pkg/kubernetes/scripts/volumes.js:206
-msgid "Flex"
-msgstr "收缩"
-
-#: pkg/kubernetes/scripts/volumes.js:205
-msgid "Flocker"
-msgstr "Flocker"
-
-#: pkg/kubernetes/views/volume-body.html:125
-msgid "Flocker Dataset Name"
-msgstr "Flocker 数据集名称"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:35
 msgid "Follows docker repo"
@@ -3312,10 +2722,9 @@ msgstr "强制密码变更"
 msgid "Force remove passphrase in $0"
 msgstr "强制删除 $0 中的密码"
 
-#: pkg/machines/components/diskAdd.jsx:167
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:258
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "格式化"
 
@@ -3374,11 +2783,7 @@ msgstr "从"
 msgid "Full Name"
 msgstr "全名"
 
-#: pkg/kubernetes/scripts/volumes.js:192
-msgid "GCE Persistent Disk"
-msgstr "GCE 持久盘"
-
-#: pkg/docker/index.html:183
+#: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "网关:"
 
@@ -3395,25 +2800,13 @@ msgstr "正在生成报告"
 msgid "Get new image"
 msgstr "获取新镜像"
 
-#: pkg/machines/components/diskAdd.jsx:162
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
-
-#: pkg/kubernetes/scripts/volumes.js:194
-msgid "Git Repository"
-msgstr "Git 仓库"
-
-#: pkg/kubernetes/scripts/volumes.js:198
-msgid "Gluster FS"
-msgstr "Gluster FS"
-
-#: pkg/kubernetes/scripts/volumes.js:877
-msgid "GlusterFS"
-msgstr "GlusterFS"
 
 #: pkg/systemd/logs.js:199
 msgid "Go to"
@@ -3429,11 +2822,6 @@ msgstr "到应用"
 msgid "Go to now"
 msgstr "转到现在"
 
-#: pkg/kubernetes/views/project-body.html:3
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Grant additional push or admin access to specific members below."
-msgstr "对以下成员授权额外的推送，或赋予管理员权限。"
-
 #: pkg/machines/components/consoles.jsx:51
 msgid "Graphics Console (VNC)"
 msgstr "图形控制台（VNC）"
@@ -3441,20 +2829,6 @@ msgstr "图形控制台（VNC）"
 #: pkg/machines/components/consoles.jsx:60
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Desktop Viewer 中的图形控制台"
-
-#: pkg/kubernetes/views/group-page.html:21
-#: pkg/kubernetes/views/group-panel.html:12
-msgid "Group Members"
-msgstr "组成员"
-
-#: pkg/kubernetes/views/user-add-membership.html:9
-msgid "Group or Project"
-msgstr "组或项目"
-
-#: pkg/kubernetes/views/project-listing.html:48
-#: pkg/kubernetes/views/user-delete.html:14
-msgid "Groups"
-msgstr "组"
 
 #: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
 #: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
@@ -3477,15 +2851,6 @@ msgstr "增长 $0 的逻辑大小"
 #: pkg/storaged/vdo-details.jsx:130
 msgid "Grow to take all space"
 msgstr "增长到占据所有空间"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "HA"
-msgstr "高可用"
-
-#: pkg/ovirt/components/OVirtTab.jsx:128
-msgid "HA:"
-msgstr "高可用："
 
 #: pkg/networkmanager/index.html:252
 msgid "Hair Pin mode"
@@ -3520,19 +2885,14 @@ msgstr "硬件信息"
 msgid "Hello time $hello_time"
 msgstr "Hello 时间 $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Hide Performance Options"
 msgstr "隐藏性能选项"
 
-#: pkg/kubernetes/views/details-page.html:73
-#: pkg/kubernetes/views/route-body.html:9
-#: pkg/kubernetes/views/route-modify.html:8
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:150
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47
-#: pkg/ovirt/components/App.jsx:103 pkg/ovirt/components/ClusterVms.jsx:65
-#: pkg/ovirt/components/ClusterVms.jsx:182 pkg/shell/indexes.js:334
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "主机"
 
@@ -3541,29 +2901,21 @@ msgid "Host Device"
 msgstr "主机设备"
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:155
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
 msgid "Host Name"
 msgstr "主机名"
-
-#: pkg/kubernetes/scripts/volumes.js:197 pkg/kubernetes/scripts/volumes.js:869
-msgid "Host Path"
-msgstr "主机路径"
 
 #: src/base1/cockpit.js:4023
 msgid "Host key is incorrect"
 msgstr "主机密钥不正确"
 
-#: pkg/realmd/operation.js:602
+#: pkg/realmd/operation.js:601
 msgid "Host name should not be changed in a domain"
 msgstr "在域内的主机不可更改主机名"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:161
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
 msgid "Host should not be empty"
 msgstr "主机不能为空"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:75
-msgid "Host to Maintenance"
-msgstr "主机维护"
 
 #: pkg/systemd/services.html:499
 msgid "Hour : Minute"
@@ -3581,24 +2933,20 @@ msgstr "小时"
 msgid "I/O Wait"
 msgstr "I/O 等待"
 
-#: pkg/kubernetes/views/node-body.html:10
-#: pkg/kubernetes/views/service-body.html:9
-msgid "IP"
-msgstr "IP"
-
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
+#: pkg/machines/components/vmnetworktab.jsx:133
 msgid "IP Address"
 msgstr "IP 地址"
 
-#: pkg/docker/index.html:175
+#: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "IP 地址:"
 
-#: pkg/docker/index.html:179
+#: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "IP 前缀长度:"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "IP Range"
 msgstr "IP 地址范围"
 
@@ -3630,10 +2978,6 @@ msgstr "IPv6 地址"
 msgid "IPv6 Settings"
 msgstr "IPv6 设置"
 
-#: pkg/kubernetes/scripts/volumes.js:201 pkg/kubernetes/scripts/volumes.js:873
-msgid "ISCSI"
-msgstr "ISCSI"
-
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "ID"
@@ -3642,7 +2986,7 @@ msgstr "ID"
 msgid "Id $id"
 msgstr "Id $id"
 
-#: pkg/docker/index.html:148
+#: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "编号："
 
@@ -3650,17 +2994,6 @@ msgstr "编号："
 #: node_modules/registry-image-widgets/views/image-listing.html:7
 msgid "Identifier"
 msgstr "身份标识"
-
-#: pkg/kubernetes/views/user-page.html:22
-#: pkg/kubernetes/views/user-panel.html:18
-msgid "Identities"
-msgstr "身份"
-
-#: pkg/kubernetes/views/add-user-dialog.html:17
-#: pkg/kubernetes/views/project-listing.html:91
-#: pkg/kubernetes/views/user-modify.html:17
-msgid "Identity"
-msgstr "身份"
 
 #: pkg/storaged/crypto-keyslots.jsx:325
 msgid "If tang-show-keys is not available, run the following:"
@@ -3670,9 +3003,7 @@ msgstr "如果没有 tang-show-keys，请运行以下命令："
 msgid "Ignore"
 msgstr "忽略"
 
-#: pkg/docker/index.html:268 pkg/docker/index.html:431
-#: pkg/kubernetes/views/container-body.html:6
-#: pkg/kubernetes/views/image-page.html:15
+#: pkg/docker/index.html:270 pkg/docker/index.html:433
 #: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
@@ -3682,33 +3013,13 @@ msgstr "镜像"
 msgid "Image $0"
 msgstr "镜像 $0"
 
-#: pkg/users/local.js:749
+#: pkg/users/local.js:753
 msgid "Image Builder"
 msgstr "图像生成器"
 
-#: pkg/kubernetes/views/container-body.html:8
-msgid "Image ID"
-msgstr "镜像编号"
-
-#: pkg/kubernetes/views/volume-body.html:58
-msgid "Image Name"
-msgstr "镜像名称"
-
-#: pkg/kubernetes/registry.html:23
-msgid "Image Registry"
-msgstr "镜像注册"
-
-#: pkg/docker/index.html:578
+#: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "搜索镜像"
-
-#: pkg/kubernetes/views/imagestream-page.html:16
-msgid "Image Stream"
-msgstr "镜像流"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:135
-msgid "Image commands"
-msgstr "镜像命令"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:41
 msgid "Image count"
@@ -3718,14 +3029,10 @@ msgstr "镜像计数"
 msgid "Image stream"
 msgstr "镜像流"
 
-#: pkg/docker/index.html:156
+#: pkg/docker/index.html:157
 msgid "Image:"
 msgstr "镜像："
 
-#: pkg/kubernetes/index.html:81 pkg/kubernetes/registry.html:49
-#: pkg/kubernetes/views/images-page.html:13
-#: pkg/kubernetes/views/imagestream-page.html:24
-#: pkg/kubernetes/views/registry-dashboard-page.html:19
 #: pkg/docker/containers-view.jsx:711
 msgid "Images"
 msgstr "镜像"
@@ -3738,10 +3045,6 @@ msgstr "镜像"
 #: pkg/docker/containers-view.jsx:109
 msgid "Images and running containers"
 msgstr "镜像和运行的容器"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:17
-msgid "Images by project"
-msgstr "镜像（按项目）"
 
 #: node_modules/registry-image-widgets/views/imagestream-body.html:15
 #: node_modules/registry-image-widgets/views/imagestream-body.html:16
@@ -3758,11 +3061,7 @@ msgstr "镜像可以被任何已验证的用户或组获取"
 msgid "Images may only be pulled by specific users or groups"
 msgstr "镜像仅可被指定用户或组获取"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:54
-msgid "Images pushed recently"
-msgstr "最近推送的镜像"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:637
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
 msgid "Immediately Start VM"
 msgstr "立即启动 VM"
 
@@ -3770,22 +3069,11 @@ msgstr "立即启动 VM"
 msgid "In Sync"
 msgstr "同步中"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:171
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
 msgstr "在多数配置中，macvtap 不能为主机到客户机的网络通信工作。"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:81
-msgid ""
-"In order to begin pushing images to the registry, use the commands below."
-msgstr "为了开始推送镜像到 registry，使用以下命令。"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:6
-msgid ""
-"In order to begin pushing images to the registry, you need to create a "
-"project."
-msgstr "为了开始推送镜像到 registry，需要创建一个项目。"
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
@@ -3802,7 +3090,7 @@ msgstr "未激活"
 msgid "Inactive volume"
 msgstr "暂停卷"
 
-#: pkg/networkmanager/firewall.jsx:730
+#: pkg/networkmanager/firewall.jsx:732
 msgid "Included services"
 msgstr "包括的服务"
 
@@ -3826,17 +3114,17 @@ msgstr "关于容器存储池的信息不可用。"
 msgid "Initializing..."
 msgstr "初始化中..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:177
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
 msgid "Initiator"
 msgstr "启动器"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:188
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
 msgid "Initiator IQN should not be empty"
 msgstr "启动器 IQN 不能为空"
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "安装"
 
@@ -3864,25 +3152,21 @@ msgstr "安装 VDO 支持"
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "安装 setroubleshoot-server 来排查 SELinux 事件。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:226
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
 msgid "Installation Source"
 msgstr "安装源"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:212
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
 msgid "Installation Source Type"
 msgstr "安装源类型"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:113
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
 msgid "Installation Source should not be empty"
 msgstr "安装源不应为空"
 
 #: pkg/packagekit/updates.jsx:59
 msgid "Installed"
 msgstr "已安装"
-
-#: pkg/subscriptions/subscriptions-view.jsx:245
-msgid "Installed products"
-msgstr "已安装的产品"
 
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:51
@@ -3897,17 +3181,13 @@ msgstr "正在安装 $0"
 msgid "Instantiate"
 msgstr "实例"
 
-#: pkg/kubernetes/views/pv-modify.html:170
-#: pkg/kubernetes/views/volume-body.html:81
-msgid "Interface"
-msgstr "接口"
-
 #: pkg/machines/components/nicEdit.jsx:123
 msgid "Interface Type"
 msgstr "接口类型"
 
-#: pkg/networkmanager/index.html:108 pkg/networkmanager/firewall.jsx:735
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "接口"
 
@@ -3923,15 +3203,11 @@ msgstr "内部错误"
 msgid "Invalid address $0"
 msgstr "无效的地址 $0"
 
-#: pkg/subscriptions/subscriptions-client.js:195
-msgid "Invalid credentials"
-msgstr "无效的凭证"
-
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "无效的日期格式"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "无效的日期格式和时间格式"
 
@@ -3939,7 +3215,7 @@ msgstr "无效的日期格式和时间格式"
 msgid "Invalid date format."
 msgstr "无效的数据格式。"
 
-#: pkg/users/local.js:1237
+#: pkg/users/local.js:1241
 msgid "Invalid expiration date"
 msgstr "无效的过期时间"
 
@@ -3947,7 +3223,7 @@ msgstr "无效的过期时间"
 msgid "Invalid file permissions"
 msgstr "无效的文件权限"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
 msgid "Invalid filename"
 msgstr "无效的文件名"
 
@@ -3959,7 +3235,7 @@ msgstr "无效的 key"
 msgid "Invalid metric $0"
 msgstr "无效的度量 $0"
 
-#: pkg/users/local.js:1313
+#: pkg/users/local.js:1317
 msgid "Invalid number of days"
 msgstr "无效的天数"
 
@@ -3987,7 +3263,7 @@ msgstr "无效的前缀或掩码 $0"
 msgid "Invalid range"
 msgstr "无效范围"
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "无效的时间格式"
 
@@ -3996,7 +3272,6 @@ msgid "Invalid time zone"
 msgstr "无效的时区"
 
 #: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
-#: pkg/subscriptions/subscriptions-client.js:193
 msgid "Invalid username or password"
 msgstr "无效的用户名或密码"
 
@@ -4016,19 +3291,19 @@ msgstr "隔离的网络"
 msgid "Jobs"
 msgstr "任务"
 
-#: pkg/realmd/operation.js:117
+#: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "加入"
 
-#: pkg/realmd/operation.js:597
+#: pkg/realmd/operation.js:596
 msgid "Join Domain"
 msgstr "加入域"
 
-#: pkg/realmd/operation.js:116
+#: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "加入域"
 
-#: pkg/realmd/operation.js:506
+#: pkg/realmd/operation.js:505
 msgid "Joining this domain is not supported"
 msgstr "不支持加入该域"
 
@@ -4073,14 +3348,6 @@ msgstr "内核"
 msgid "Kernel Dump"
 msgstr "内核转储"
 
-#: pkg/kubernetes/views/node-body.html:19
-msgid "Kernel Version"
-msgstr "内核版本"
-
-#: pkg/kubernetes/views/volume-body.html:67
-msgid "Key Ring Path"
-msgstr "密钥环路径"
-
 #: pkg/storaged/crypto-keyslots.jsx:563
 msgid "Key slots with unknown types can not be edited here"
 msgstr "这里无法编辑未知类型的密钥 slot"
@@ -4105,23 +3372,10 @@ msgstr "Keyserver 地址"
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "删除 keyserver 可能会阻止解锁 $0。"
 
-#: pkg/kubernetes/views/node-body.html:23
-msgid "Kubelet Version"
-msgstr "Kubelet 版本"
-
-#: pkg/kubernetes/index.html:23
-msgid "Kubernetes Cluster"
-msgstr "Kubernetes 集群"
-
 #: pkg/networkmanager/index.html:377
 msgid "LACP Key"
 msgstr "LACP 密钥"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:41
-#: pkg/kubernetes/views/node-body.html:31 pkg/kubernetes/views/pod-body.html:26
-#: pkg/kubernetes/views/replicationcontroller-body.html:17
-#: pkg/kubernetes/views/route-body.html:22
-#: pkg/kubernetes/views/service-body.html:26
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "标签"
@@ -4138,17 +3392,9 @@ msgstr "最近 24 小时"
 msgid "Last 7 days"
 msgstr "最近 7 天"
 
-#: pkg/kubernetes/views/node-body.html:49
-msgid "Last Heartbeat"
-msgstr "最近的保活心跳"
-
 #: pkg/users/index.html:100
 msgid "Last Login"
 msgstr "最近登陆"
-
-#: pkg/kubernetes/views/node-body.html:51
-msgid "Last Status Change"
-msgstr "最近的状态变更"
 
 #: pkg/systemd/init.js:284
 msgid "Last Trigger"
@@ -4161,11 +3407,6 @@ msgstr "最近更新时间"
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
 msgstr "最后检查于： $0 前"
-
-#: pkg/kubernetes/views/deploymentconfig-body.html:15
-#: pkg/kubernetes/views/details-page.html:107
-msgid "Latest Version"
-msgstr "最近的版本"
 
 #: pkg/machines/components/desktopConsole.jsx:128
 msgid "Launch Remote Viewer"
@@ -4180,19 +3421,20 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in user. If "
 "you enter a different username, that user will always be used when "
 "connecting to this machine."
-msgstr "以当前登录用户来连接到该主机则保留为空。如果输入另一个用户名，连接到该主机时通常将会使用该用户。"
+msgstr ""
+"以当前登录用户来连接到该主机则保留为空。如果输入另一个用户名，连接到该主机时"
+"通常将会使用该用户。"
 
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
-"以当前登录的用户 {{#default_user}} ({{default_user}}){{/default_user}} "
-"来连接该主机则保留为空。如果输入一个不同的用户名，将总会用那个用户连接该主机。"
+"以当前登录的用户 {{#default_user}} ({{default_user}}){{/default_user}} 来连接"
+"该主机则保留为空。如果输入一个不同的用户名，将总会用那个用户连接该主机。"
 
-#: pkg/shell/index.html:90 pkg/shell/simple.html:66 pkg/shell/stub.html:73
+#: pkg/shell/index.html:90 pkg/shell/simple.html:66
 msgid "Licensed under:"
 msgstr "授权为："
 
@@ -4216,7 +3458,7 @@ msgstr "链路断开延时"
 msgid "Link local"
 msgstr "本地链路"
 
-#: pkg/docker/index.html:497
+#: pkg/docker/index.html:499
 msgid "Link to another container"
 msgstr "链接到另一个容器"
 
@@ -4224,11 +3466,11 @@ msgstr "链接到另一个容器"
 msgid "Link up delay"
 msgstr "链路启用延时"
 
-#: pkg/docker/index.html:493
+#: pkg/docker/index.html:495
 msgid "Links"
 msgstr "连接"
 
-#: pkg/docker/index.html:195
+#: pkg/docker/index.html:196
 msgid "Links:"
 msgstr "链接："
 
@@ -4252,13 +3494,9 @@ msgstr "加载可用的更新失败"
 msgid "Loading available updates, please wait..."
 msgstr "正在加载可用的更新，请等待..."
 
-#: pkg/ovirt/components/VdsmView.jsx:34
-msgid "Loading data ..."
-msgstr "正在加载数据 ..."
-
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "载入中..."
 
@@ -4274,7 +3512,7 @@ msgstr "本地磁盘"
 msgid "Local Filesystem"
 msgstr "本地文件系统"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:218
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
 msgid "Local Install Media"
 msgstr "本地安装介质"
 
@@ -4294,7 +3532,7 @@ msgstr "锁定"
 msgid "Lock Account"
 msgstr "锁定账户"
 
-#: pkg/users/local.js:879 pkg/users/local.js:1218
+#: pkg/users/local.js:883 pkg/users/local.js:1222
 msgid "Lock account on $0"
 msgstr "锁定 $0 上的账号"
 
@@ -4306,7 +3544,7 @@ msgstr "锁定 $target"
 msgid "Log In"
 msgstr "登录"
 
-#: pkg/shell/index.html:70 pkg/shell/simple.html:46 pkg/shell/stub.html:53
+#: pkg/shell/index.html:70 pkg/shell/simple.html:46
 msgid "Log Out"
 msgstr "注销"
 
@@ -4322,19 +3560,11 @@ msgstr "登录到 {{host}}"
 msgid "Log in with your server user account."
 msgstr "使用您的服务器用户帐户登录。"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:116
-msgid "Log into OpenShift command line tools:"
-msgstr "登录到 OpenShift 命令行工具："
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:101
-msgid "Log into the registry:"
-msgstr "登录到 registry："
-
 #: pkg/systemd/index.html:65
 msgid "Log messages"
 msgstr "日志消息"
 
-#: pkg/users/local.js:961
+#: pkg/users/local.js:965
 msgid "Logged In"
 msgstr "登录"
 
@@ -4345,12 +3575,6 @@ msgstr "逻辑"
 #: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
 msgid "Logical Size"
 msgstr "逻辑大小"
-
-#: pkg/kubernetes/views/pv-modify.html:159
-#: pkg/kubernetes/views/volume-body.html:79
-#: pkg/kubernetes/views/volume-body.html:118
-msgid "Logical Unit Number"
-msgstr "逻辑单元编号"
 
 #: pkg/storaged/utils.js:197
 msgid "Logical Volume"
@@ -4364,10 +3588,6 @@ msgstr "逻辑卷 (快照)"
 msgid "Logical Volume of $0"
 msgstr "$0 的逻辑卷"
 
-#: pkg/subscriptions/subscriptions-register.jsx:144
-msgid "Login"
-msgstr "登录"
-
 #: src/ws/login.js:300
 msgid "Login Again"
 msgstr "再次登录"
@@ -4380,10 +3600,6 @@ msgstr "登陆格式"
 msgid "Login Password"
 msgstr "登录密码"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:96
-msgid "Login commands"
-msgstr "登录命令"
-
 #: src/base1/cockpit.js:4015
 msgid "Login failed"
 msgstr "登录失败"
@@ -4392,16 +3608,11 @@ msgstr "登录失败"
 msgid "Login has escalated admin privileges"
 msgstr "登录已升级管理员权限"
 
-#: pkg/subscriptions/subscriptions-client.js:199
-msgid "Login/password or activation key required to register."
-msgstr "注册需要登录/密码或激活码。"
-
 #: src/ws/login.js:301
 msgid "Logout Successful"
 msgstr "注销成功"
 
-#: pkg/kubernetes/views/container-page-inline.html:8
-#: pkg/kubernetes/views/container-panel.html:6 pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82
 msgid "Logs"
 msgstr "日志"
 
@@ -4421,17 +3632,13 @@ msgstr "主机类型"
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:102
+#: pkg/machines/components/vmnetworktab.jsx:132
 msgid "MAC Address"
 msgstr "MAC 地址"
 
-#: pkg/docker/index.html:187
+#: pkg/docker/index.html:188
 msgid "MAC Address:"
 msgstr "MAC 地址:"
-
-#: pkg/ovirt/provider.js:283
-msgid "MIGRATE action failed"
-msgstr "迁移操作失败"
 
 #: pkg/networkmanager/interfaces.js:1985
 msgid "MII (Recommended)"
@@ -4453,7 +3660,7 @@ msgstr "Mac"
 msgid "Mac Address"
 msgstr "MAC 地址"
 
-#: pkg/kubernetes/views/node-body.html:15 pkg/systemd/index.html:95
+#: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "机器编号"
 
@@ -4472,10 +3679,6 @@ msgstr "主服务器机箱"
 #: pkg/storaged/crypto-keyslots.jsx:319
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "确保来自 Tang 服务器的密钥哈希匹配："
-
-#: pkg/kubernetes/scripts/dashboard.js:457
-msgid "Manifest"
-msgstr "清单"
 
 #: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
 msgid "Manual"
@@ -4531,16 +3734,6 @@ msgid ""
 "between 1 and $0"
 msgstr "为客户机操作系统分配的最大虚拟 CPU 数，必须介于 1 和 $0 之间"
 
-#: pkg/kubernetes/views/volume-body.html:34
-msgid "Medium"
-msgstr "媒介"
-
-#: pkg/kubernetes/views/project-listing.html:92
-#: pkg/kubernetes/views/user-body.html:4
-#: pkg/kubernetes/views/user-panel.html:27
-msgid "Member of"
-msgstr "属于"
-
 #: pkg/storaged/content-views.jsx:345
 msgid "Member of RAID Device"
 msgstr "RAID 设备的成员"
@@ -4549,26 +3742,11 @@ msgstr "RAID 设备的成员"
 msgid "Member of RAID Device $0"
 msgstr "RAID 设备 $0 的成员"
 
-#: pkg/kubernetes/views/project-listing.html:16
-#: pkg/kubernetes/views/project-listing.html:55
-#: pkg/networkmanager/index.html:266 pkg/networkmanager/interfaces.js:2986
-msgid "Members"
-msgstr "成员"
-
-#: pkg/kubernetes/views/project-page.html:29
-#: pkg/kubernetes/views/user-page.html:25
-#: pkg/kubernetes/views/user-panel.html:11
-msgid "Membership"
-msgstr "成员关系"
-
-#: pkg/dashboard/index.html:71 pkg/docker/index.html:271
+#: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
-#: pkg/docker/containers-view.jsx:359 pkg/kubernetes/scripts/graphs.js:608
-#: pkg/kubernetes/scripts/nodes.js:715 pkg/kubernetes/scripts/nodes.js:827
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:304
+#: pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
 #: pkg/machines/components/vmOverviewTab.jsx:74
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "Memory"
 msgstr "内存"
 
@@ -4581,38 +3759,32 @@ msgstr "内存"
 msgid "Memory & Swap"
 msgstr "内存和交换空间"
 
-#: pkg/kubernetes/scripts/nodes.js:716
-msgid "Memory Utilization: $0%"
-msgstr "内存使用率: $0%"
-
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
 msgid "Memory could not be saved"
 msgstr "内存不能被保存"
 
-#: pkg/docker/index.html:452 pkg/docker/index.html:624
+#: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "内存限制"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#, fuzzy
+msgid "Memory must not be 0"
+msgstr "内存不能被保存"
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
 msgstr "内存大小应该在 128 MiB 和最大分配值之间"
 
-#: pkg/docker/index.html:210
+#: pkg/docker/index.html:211
 msgid "Memory usage:"
 msgstr "内存使用："
-
-#: pkg/kubernetes/views/node-body.html:47 pkg/kubernetes/views/pv-body.html:27
-#: pkg/kubernetes/views/pv-claim.html:32 pkg/kubernetes/views/pvc-body.html:15
-msgid "Message"
-msgstr "消息"
 
 #: pkg/systemd/shutdown.js:79
 msgid "Message to logged in users"
 msgstr "登录用户的信息"
 
-#: pkg/kubernetes/views/image-page.html:29
-#: pkg/kubernetes/views/imagestream-page.html:30
 #: node_modules/registry-image-widgets/views/image-panel.html:15
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:14
 msgid "Metadata"
@@ -4622,17 +3794,13 @@ msgstr "元数据"
 msgid "Metadata Used"
 msgstr "已使用的元数据"
 
-#: pkg/docker/index.html:466 pkg/docker/index.html:638
-#: pkg/machines/components/diskAdd.jsx:159
-#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/docker/index.html:468 pkg/docker/index.html:640
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
-
-#: pkg/ovirt/components/OVirtTab.jsx:70
-msgid "Migrate To:"
-msgstr "迁移到："
 
 #: pkg/lib/machine-info.js:98
 msgid "Mini PC"
@@ -4662,13 +3830,9 @@ msgstr "模式"
 msgid "Model"
 msgstr "型号"
 
-#: pkg/machines/components/vmnetworktab.jsx:93
+#: pkg/machines/components/vmnetworktab.jsx:123
 msgid "Model type"
 msgstr "型号类型"
-
-#: pkg/kubernetes/views/user-modify.html:27
-msgid "Modify"
-msgstr "修改"
 
 #: pkg/storaged/jobs-panel.jsx:39 pkg/storaged/jobs-panel.jsx:45
 #: pkg/storaged/jobs-panel.jsx:52
@@ -4691,11 +3855,7 @@ msgstr "监控间隔"
 msgid "Monitoring Targets"
 msgstr "监控目标"
 
-#: pkg/kubernetes/views/volume-body.html:54
-msgid "Monitors"
-msgstr "监视器"
-
-#: pkg/realmd/operation.js:530
+#: pkg/realmd/operation.js:529
 msgid "More"
 msgstr "更多"
 
@@ -4708,31 +3868,27 @@ msgstr "更多信息"
 msgid "More details"
 msgstr "更多详情"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "挂载"
 
-#: pkg/kubernetes/views/pod-page.html:25 pkg/kubernetes/views/pod-panel.html:51
-msgid "Mount Location"
-msgstr "挂载位置"
-
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "挂载选项"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "挂载点"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "引导时挂载"
 
-#: pkg/docker/index.html:519
+#: pkg/docker/index.html:521
 msgid "Mount container volumes"
 msgstr "挂载容器卷"
 
@@ -4748,7 +3904,7 @@ msgstr "挂载点不能为空"
 msgid "Mount point must start with \"/\"."
 msgstr "挂载点必须以“/”开头。"
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "只读挂载"
 
@@ -4772,11 +3928,7 @@ msgstr "多系统机箱"
 msgid "NAT to $0"
 msgstr "NAT 到 $0"
 
-#: pkg/kubernetes/scripts/volumes.js:865
-msgid "NFS"
-msgstr "NFS"
-
-#: pkg/kubernetes/scripts/volumes.js:199 pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:140
 msgid "NFS Mount"
 msgstr "NFS 挂载"
 
@@ -4788,7 +3940,7 @@ msgstr "NFS 挂载"
 msgid "NFS Support not installed"
 msgstr "未安装 NFS 的支持"
 
-#: pkg/machines/components/vmnetworktab.jsx:67
+#: pkg/machines/components/vmnetworktab.jsx:97
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "VM $1 的 NIC $0 改变状态失败"
 
@@ -4800,54 +3952,29 @@ msgstr "NSNA Ping"
 msgid "NTP Server"
 msgstr "NTP 服务器"
 
-#: pkg/docker/index.html:267 pkg/kubernetes/views/add-group-dialog.html:9
-#: pkg/kubernetes/views/add-user-dialog.html:9
-#: pkg/kubernetes/views/containers-listing.html:11
-#: pkg/kubernetes/views/dashboard-page.html:156
-#: pkg/kubernetes/views/dashboard-page.html:198
-#: pkg/kubernetes/views/details-page.html:34
-#: pkg/kubernetes/views/details-page.html:70
-#: pkg/kubernetes/views/details-page.html:103
-#: pkg/kubernetes/views/details-page.html:137
-#: pkg/kubernetes/views/details-page.html:171
-#: pkg/kubernetes/views/imagestream-modify.html:10
-#: pkg/kubernetes/views/node-add.html:16
-#: pkg/kubernetes/views/nodes-page.html:41
-#: pkg/kubernetes/views/project-listing.html:14
-#: pkg/kubernetes/views/project-listing.html:53
-#: pkg/kubernetes/views/project-listing.html:90
-#: pkg/kubernetes/views/project-modify.html:16
-#: pkg/kubernetes/views/pv-claim.html:4 pkg/kubernetes/views/pv-modify.html:32
-#: pkg/kubernetes/views/service-modify.html:9
-#: pkg/kubernetes/views/user-modify.html:9
-#: pkg/kubernetes/views/volume-body.html:31
-#: pkg/kubernetes/views/volumes-page.html:19
-#: pkg/kubernetes/views/volumes-page.html:57 pkg/networkmanager/index.html:119
+#: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
 #: pkg/networkmanager/index.html:319
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:181
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "名称"
 
@@ -4879,7 +4006,7 @@ msgstr "名称不能包含字符 '$0'。"
 msgid "Name cannot contain whitespace."
 msgstr "名称不能包含空格。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:82
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
 msgid "Name should not be empty"
 msgstr "名称不应为空"
@@ -4887,26 +4014,6 @@ msgstr "名称不应为空"
 #: pkg/machines/components/networks/networkOverviewTab.jsx:36
 msgid "Name: "
 msgstr "名称："
-
-#: pkg/kubernetes/views/containers-listing.html:14
-#: pkg/kubernetes/views/dashboard-page.html:160
-#: pkg/kubernetes/views/deploymentconfig-body.html:5
-#: pkg/kubernetes/views/details-page.html:36
-#: pkg/kubernetes/views/details-page.html:72
-#: pkg/kubernetes/views/details-page.html:105
-#: pkg/kubernetes/views/details-page.html:139
-#: pkg/kubernetes/views/details-page.html:173
-#: pkg/kubernetes/views/pod-body.html:5 pkg/kubernetes/views/pv-claim.html:6
-#: pkg/kubernetes/views/replicationcontroller-body.html:5
-#: pkg/kubernetes/views/route-body.html:5
-#: pkg/kubernetes/views/service-body.html:5
-#: pkg/kubernetes/views/volumes-page.html:59
-msgid "Namespace"
-msgstr "命名空间"
-
-#: pkg/kubernetes/scripts/dashboard.js:374
-msgid "Namespace cannot be empty."
-msgstr "命名空间不能为空。"
 
 #: pkg/systemd/host.js:1348
 msgid "Need at least one NTP server"
@@ -4917,19 +4024,18 @@ msgid "Netmask"
 msgstr "网络掩码"
 
 #: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
-#: pkg/kubernetes/scripts/graphs.js:613
 msgid "Network"
 msgstr "网络"
 
-#: pkg/machines/components/networks/network.jsx:117
+#: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
 msgstr "网络 $0 激活失败"
 
-#: pkg/machines/components/networks/network.jsx:129
+#: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
 msgstr "网络 $0 取消激活失败"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
 msgid "Network Boot (PXE)"
 msgstr "网络引导 (PXE)"
 
@@ -4941,7 +4047,7 @@ msgstr "网络文件系统"
 msgid "Network Interfaces"
 msgstr "网络接口"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:177
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Network Selection does not support PXE."
 msgstr "网络选择不支持 PXE。"
 
@@ -4962,7 +4068,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager 没有运行。"
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:914
 msgid "Networking"
 msgstr "网络"
 
@@ -4980,21 +4086,17 @@ msgstr "网络日志"
 msgid "Networks"
 msgstr "网络"
 
-#: pkg/users/local.js:963
+#: pkg/users/local.js:967
 msgid "Never"
 msgstr "从不"
 
-#: pkg/users/index.html:297 pkg/users/local.js:868
+#: pkg/users/index.html:297 pkg/users/local.js:872
 msgid "Never expire password"
 msgstr "密码从不过期"
 
-#: pkg/users/index.html:258 pkg/users/local.js:876
+#: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "账号从不锁定"
-
-#: pkg/kubernetes/views/project-listing.html:46
-msgid "New Group"
-msgstr "新建组"
 
 #: pkg/storaged/nfs-details.jsx:140
 msgid "New NFS Mount"
@@ -5004,32 +4106,17 @@ msgstr "新的 NFS 挂载"
 msgid "New Password"
 msgstr "新密码"
 
-#: pkg/kubernetes/views/project-listing.html:7
-msgid "New Project"
-msgstr "新项目"
-
 #: pkg/machines/components/diskAdd.jsx:132
 msgid "New Volume Name"
 msgstr "新卷名称"
-
-#: pkg/kubernetes/views/images-page.html:11
-#: pkg/kubernetes/views/registry-dashboard-page.html:86
-msgid "New image stream"
-msgstr "新镜像流"
 
 #: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
 msgid "New passphrase"
 msgstr "新口令"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "新密码不被接受"
-
-#: pkg/kubernetes/views/project-modify.html:4
-#: pkg/kubernetes/views/registry-dashboard-page.html:9
-#: pkg/kubernetes/views/registry-dashboard-page.html:48
-msgid "New project"
-msgstr "新项目"
 
 #: pkg/realmd/operation.html:82 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
@@ -5043,9 +4130,8 @@ msgstr "下次运行"
 msgid "Nice"
 msgstr "Nice"
 
-#: pkg/docker/index.html:542 pkg/docker/index.html:546 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/kubernetes/scripts/volumes.js:998
-#: pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
 msgid "No"
 msgstr "否"
 
@@ -5069,35 +4155,18 @@ msgstr "没有找到匹配的结果"
 msgid "No NFS mounts set up"
 msgstr "没有设置 NFS 挂载"
 
-#: src/ws/cockpitcertificate.c:522
-msgid "No PEM-encoded certificate found"
-msgstr "没有找到 PEM 编码的证书"
-
-#: src/ws/cockpitcertificate.c:488
-msgid "No PEM-encoded private key found"
-msgstr "没有找到 PEM 编码的私钥"
-
-#: pkg/kubernetes/views/pv-claim.html:39
-msgid "No Pods are using this claim"
-msgstr "没有 pod 使用该声明"
-
 #: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "No SELinux alerts."
 msgstr "没有 SELinux 警告。"
 
-#: pkg/machines/components/diskAdd.jsx:193
-#: pkg/machines/components/diskAdd.jsx:205
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:216
 msgid "No Storage Pools available"
 msgstr "没有可用的存储池"
 
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr "没有为这个存储池定义存储卷"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:29
-#: pkg/ovirt/components/ClusterVms.jsx:36
-msgid "No VM found in oVirt."
-msgstr "oVirt 中没有找到虚拟机。"
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
@@ -5107,11 +4176,7 @@ msgstr "该主机上没有定义或运行虚拟机。"
 msgid "No Virtual Networks"
 msgstr "没有虚拟网络"
 
-#: pkg/kubernetes/views/pvc-body.html:10
-msgid "No Volume Bound"
-msgstr "未绑定卷"
-
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/networkmanager/firewall.jsx:926
 msgid "No active zones"
 msgstr "没有活动区域"
 
@@ -5163,7 +4228,7 @@ msgstr "没有容器"
 msgid "No containers that match the current filter"
 msgstr "没有容器匹配当前的过滤条件"
 
-#: pkg/networkmanager/firewall.jsx:727
+#: pkg/networkmanager/firewall.jsx:729
 msgid "No description available"
 msgstr "没有可用描述"
 
@@ -5171,9 +4236,9 @@ msgstr "没有可用描述"
 msgid "No description provided."
 msgstr "没有提供说明。"
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "没有可用的磁盘。"
 
@@ -5181,7 +4246,7 @@ msgstr "没有可用的磁盘。"
 msgid "No disks defined for this VM"
 msgstr "没有为该虚拟机定义磁盘"
 
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:121
 msgid "No drives attached"
 msgstr "没有附件的驱动器"
 
@@ -5192,10 +4257,6 @@ msgstr "没有空闲的密钥 slot"
 #: pkg/storaged/content-views.jsx:700
 msgid "No free space"
 msgstr "没有剩余空间"
-
-#: pkg/kubernetes/views/project-listing.html:74
-msgid "No groups are present."
-msgstr "没有组。"
 
 #: pkg/systemd/index.html:29
 msgid "No host keys found."
@@ -5213,10 +4274,6 @@ msgstr "没有镜像流。"
 msgid "No images"
 msgstr "没有镜像"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:80
-msgid "No images pushed"
-msgstr "没有推送的镜像"
-
 #: pkg/docker/containers-view.jsx:707
 msgid "No images that match the current filter"
 msgstr "没有匹配当前过滤器的镜像"
@@ -5224,10 +4281,6 @@ msgstr "没有匹配当前过滤器的镜像"
 #: pkg/apps/utils.jsx:96
 msgid "No installation package found for this application."
 msgstr "没有找到为该应用的安装包"
-
-#: pkg/subscriptions/subscriptions-view.jsx:246
-msgid "No installed products on the system."
-msgstr "该系统上没有安装的产品。"
 
 #: pkg/storaged/crypto-keyslots.jsx:520
 msgid "No keys added"
@@ -5247,15 +4300,10 @@ msgid ""
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
 "crashkernel=512M"
 msgstr ""
-"没有内存预留。在内核命令行（例如在 /etc/default/grub 文件）中增加一个 crashkernel "
-"选项以在启动时预留内存。例如：crashkernel=512M"
+"没有内存预留。在内核命令行（例如在 /etc/default/grub 文件）中增加一个 "
+"crashkernel 选项以在启动时预留内存。例如：crashkernel=512M"
 
-#: pkg/kubernetes/scripts/dashboard.js:384
-msgid ""
-"No metadata file was selected. Please select a Kubernetes metadata file."
-msgstr "未选择元数据文件。请选择一个 Kubernetes 元数据文件."
-
-#: pkg/machines/components/vmnetworktab.jsx:40
+#: pkg/machines/components/vmnetworktab.jsx:70
 msgid "No network interfaces defined for this VM"
 msgstr "没有为此 VM 定义网络接口"
 
@@ -5267,15 +4315,7 @@ msgstr "没有在这个主机上定义网络"
 msgid "No networks available"
 msgstr "没有可用的网络"
 
-#: pkg/kubernetes/views/dashboard-page.html:117
-msgid "No nodes in cluster"
-msgstr "集群中没有节点"
-
-#: pkg/ovirt/components/App.jsx:61
-msgid "No oVirt connection"
-msgstr "没有 oVirt 连接"
-
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:939
 msgid "No open ports"
 msgstr "没有开放的端口"
 
@@ -5283,27 +4323,7 @@ msgstr "没有开放的端口"
 msgid "No partitioning"
 msgstr "无分区"
 
-#: pkg/kubernetes/views/dashboard-page.html:40
-msgid "No pods deployed"
-msgstr "没有部署的 pod"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:6
-msgid "No pods replicated"
-msgstr "没有复制的 pod"
-
-#: pkg/kubernetes/views/node-capacity.html:11
-msgid "No pods scheduled"
-msgstr "没有被调度的 pod"
-
-#: pkg/kubernetes/views/service-endpoint.html:10
-msgid "No pods selected"
-msgstr "没有选中的 pod"
-
-#: pkg/kubernetes/views/project-listing.html:37
-msgid "No projects are present."
-msgstr "没有项目。"
-
-#: pkg/users/local.js:449
+#: pkg/users/local.js:453
 msgid "No real name specified"
 msgstr "未指定真实姓名"
 
@@ -5343,48 +4363,17 @@ msgstr "没有标记。"
 msgid "No updates pending"
 msgstr "没有待完成的更新"
 
-#: pkg/users/local.js:444
+#: pkg/users/local.js:448
 msgid "No user name specified"
 msgstr "未指定用户名"
-
-#: pkg/kubernetes/views/project-listing.html:112
-msgid "No users are present."
-msgstr "没有用户。"
 
 #: pkg/storaged/vgroups-panel.jsx:114
 msgid "No volume groups created"
 msgstr "没有创建的卷组"
 
-#: pkg/kubernetes/views/volumes-page.html:44
-msgid "No volumes are present."
-msgstr "没有卷。"
-
-#: pkg/kubernetes/views/dashboard-page.html:73
-msgid "No volumes in use"
-msgstr "没有正在使用的卷"
-
-#: pkg/kubernetes/views/containers-listing.html:15
-#: pkg/kubernetes/views/node-page.html:14
-#: pkg/kubernetes/views/node-panel.html:7 pkg/kubernetes/views/pod-body.html:18
-#: pkg/kubernetes/views/topology-page.html:38
-msgid "Node"
-msgstr "节点"
-
-#: pkg/kubernetes/index.html:49 pkg/kubernetes/views/dashboard-page.html:90
-#: pkg/kubernetes/views/dashboard-page.html:192
-#: pkg/kubernetes/views/nodes-page.html:36
-msgid "Nodes"
-msgstr "节点"
-
-#: pkg/kubernetes/views/topology-page.html:39
-msgid "Nodes are the machines that run your containers."
-msgstr "节点是运行容器的主机。"
-
-#: pkg/kubernetes/views/pod-page.html:27 pkg/kubernetes/views/pod-panel.html:53
-#: pkg/kubernetes/views/service-body.html:15
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:732
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "无"
 
@@ -5392,23 +4381,13 @@ msgstr "无"
 msgid "None (Isolated Network)"
 msgstr "无 (隔离的网络)"
 
-#: pkg/kubernetes/views/details-page.html:53
-#: pkg/kubernetes/views/node-body.html:42 pkg/playground/translate.html:29
-#: pkg/kubernetes/scripts/nodes.js:319
+#: pkg/playground/translate.html:29
 msgid "Not Ready"
 msgstr "未就绪"
-
-#: pkg/kubernetes/scripts/details.js:496 pkg/kubernetes/scripts/details.js:618
-msgid "Not a valid number of replicas"
-msgstr "副本数量无效"
 
 #: pkg/lib/credentials.js:255
 msgid "Not a valid private key"
 msgstr "无效的私钥"
-
-#: pkg/kubernetes/scripts/details.js:547
-msgid "Not a valid value for Host"
-msgstr "无效的主机值"
 
 #: pkg/docker/index.html:57
 msgid "Not authorized to access Docker on this system"
@@ -5426,11 +4405,6 @@ msgstr "不可用"
 msgid "Not connected"
 msgstr "未连接"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:17
-#: pkg/kubernetes/views/details-page.html:122
-msgid "Not deployed"
-msgstr "未部署"
-
 #: pkg/storaged/lvol-tabs.jsx:369
 msgid "Not enough space to grow."
 msgstr "没有足够空间增长"
@@ -5447,7 +4421,7 @@ msgstr "未加载"
 msgid "Not permitted to perform this action."
 msgstr "不允许执行该操作。"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Not running"
 msgstr "未运行"
 
@@ -5471,32 +4445,9 @@ msgstr "笔记本"
 msgid "Notice and above"
 msgstr "Notice 及以上"
 
-#: pkg/ovirt/components/vcpuModal.jsx:55
-msgid "Number of virtual CPUs that gonna be used."
-msgstr "要使用的虚拟 CPU 数量。"
-
-#: pkg/ovirt/components/HostToMaintenance.jsx:47
-#: pkg/ovirt/components/VdsmView.jsx:96 pkg/ovirt/components/VdsmView.jsx:109
-msgid "OK"
-msgstr "确认"
-
-#: pkg/kubernetes/views/node-body.html:13
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "OS"
-msgstr "操作系统"
-
-#: pkg/ovirt/components/OVirtTab.jsx:148
-msgid "OS Type:"
-msgstr "操作系统类型："
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:274
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
 msgid "OS Vendor"
 msgstr "操作系统厂商"
-
-#: pkg/kubernetes/views/nodes-page.html:19
-msgid "OS Versions"
-msgstr "操作系统版本"
 
 #: pkg/selinux/setroubleshoot-view.jsx:394
 msgid "Occurred $0"
@@ -5522,7 +4473,7 @@ msgstr "旧密码"
 msgid "Old passphrase"
 msgstr "旧密码口令"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "旧密码不被接受"
 
@@ -5534,7 +4485,7 @@ msgstr "开"
 msgid "On Build"
 msgstr "构建中"
 
-#: pkg/docker/index.html:547 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/init.js:731
 msgid "On Failure"
 msgstr "失败时"
 
@@ -5551,9 +4502,10 @@ msgstr[0] "失败时, 重试 $0 次"
 msgid ""
 "Once Cockpit is installed, enable it with \"systemctl enable --now cockpit."
 "socket\"."
-msgstr "在安装 Cockpit 后，使用 \"systemctl enable --now cockpit.socket\" 启用它。"
+msgstr ""
+"在安装 Cockpit 后，使用 \"systemctl enable --now cockpit.socket\" 启用它。"
 
-#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:338
+#: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
 msgstr "一次性密码"
 
@@ -5579,7 +4531,7 @@ msgstr "只有许使用字母、数字、 : 、 _ 、 . 、 @ 、 - 。"
 msgid "Only editable when the guest is shut off"
 msgstr "只有在客户机关闭后才可以编辑"
 
-#: pkg/shell/index.html:43 pkg/shell/simple.html:29 pkg/shell/stub.html:33
+#: pkg/shell/index.html:43 pkg/shell/simple.html:29
 msgid "Ooops!"
 msgstr "糟糕！"
 
@@ -5587,8 +4539,8 @@ msgstr "糟糕！"
 msgid "Open"
 msgstr "打开"
 
-#: pkg/kubernetes/views/nodes-page.html:42 pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+#: pkg/systemd/index.html:98
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
 msgid "Operating System"
 msgstr "操作系统"
 
@@ -5596,27 +4548,24 @@ msgstr "操作系统"
 msgid "Operation '$operation' on $target"
 msgstr "在 $target 操作 '$operation'"
 
+#: pkg/machines/components/storagePools/storagePool.jsx:175
+#: pkg/machines/components/storagePools/storagePool.jsx:180
+#, fuzzy
+msgid "Operation is in progress"
+msgstr "正在登录oVirt"
+
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "光盘驱动器"
 
-#: pkg/ovirt/components/OVirtTab.jsx:157
-msgid "Optimized for:"
-msgstr "优化目标："
-
-#: pkg/kubernetes/views/volume-body.html:130 pkg/storaged/crypto-tab.jsx:134
-#: pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
 msgid "Options"
 msgstr "选项"
 
 #: src/ws/login.html:125
 msgid "Or use a bundled browser"
 msgstr "或者使用捆绑的浏览器"
-
-#: pkg/subscriptions/subscriptions-register.jsx:180
-msgid "Organization"
-msgstr "组织"
 
 #: pkg/lib/machine-info.js:64
 msgid "Other"
@@ -5635,11 +4584,9 @@ msgstr "其他设备"
 msgid "Other Options"
 msgstr "其他选项"
 
-#: pkg/docker/index.html:297 pkg/kubernetes/index.html:43
-#: pkg/kubernetes/registry.html:43
-#: pkg/machines/components/networks/network.jsx:71
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "概览"
 
@@ -5650,10 +4597,6 @@ msgstr "使用 0 覆盖已存在数据"
 #: pkg/systemd/hwinfo.jsx:249
 msgid "PCI"
 msgstr "PCI"
-
-#: pkg/kubernetes/views/volume-body.html:4
-msgid "PD Name"
-msgstr "PD 名称"
 
 #: pkg/packagekit/updates.jsx:501
 msgid "Package information"
@@ -5687,8 +4630,7 @@ msgstr "部分"
 msgid "Part of "
 msgstr "部分"
 
-#: pkg/kubernetes/views/volume-body.html:8
-#: pkg/kubernetes/views/volume-body.html:18 pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:141
 msgid "Partition"
 msgstr "分区"
 
@@ -5724,13 +4666,11 @@ msgstr "删除密码口令可能会阻止解锁 $0。"
 msgid "Passphrases do not match"
 msgstr "口令不匹配"
 
-#: pkg/kubernetes/views/auth-form.html:105 pkg/lib/machine-auth-failed.html:8
-#: pkg/lib/machine-change-auth.html:52 pkg/lib/machine-sync-users.html:61
 #: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
-#: pkg/subscriptions/subscriptions-register.jsx:89
-#: pkg/subscriptions/subscriptions-register.jsx:156
 msgid "Password"
 msgstr "密码"
 
@@ -5746,7 +4686,7 @@ msgstr "不接受该密码"
 msgid "Password is too weak"
 msgstr "密码太弱"
 
-#: pkg/users/local.js:870
+#: pkg/users/local.js:874
 msgid "Password must be changed"
 msgstr "密码必须被修改"
 
@@ -5767,11 +4707,7 @@ msgstr "粘贴 "
 msgid "Paste the contents of your public SSH key file here"
 msgstr "在这里粘贴 SSH 公钥文件内容"
 
-#: pkg/kubernetes/views/pv-modify.html:126
-#: pkg/kubernetes/views/volume-body.html:37
-#: pkg/kubernetes/views/volume-body.html:49
-#: pkg/kubernetes/views/volume-body.html:101 pkg/systemd/services.html:126
-#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
 msgid "Path"
 msgstr "路径"
 
@@ -5787,7 +4723,7 @@ msgstr "路径开销 $path_cost"
 msgid "Path on Server"
 msgstr "服务器上的路径"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:129
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
 msgid "Path on host's filesystem"
 msgstr "主机文件系统上的路径"
 
@@ -5799,7 +4735,7 @@ msgstr "服务器上的路径不能为空。"
 msgid "Path on server must start with \"/\"."
 msgstr "服务器上的路径必须以“/”开头。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:154
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
 msgid "Path to ISO file on host's file system"
 msgstr "主机文件系统中到 ISO 文件的路径"
 
@@ -5814,10 +4750,6 @@ msgstr "路径"
 #: pkg/machines/components/vm/vmActions.jsx:77
 msgid "Pause"
 msgstr "暂停"
-
-#: pkg/kubernetes/views/volumes-page.html:53
-msgid "Pending Volume Claims"
-msgstr "卷声明待定"
 
 #: pkg/systemd/index.html:152
 msgid "Performance Profile"
@@ -5839,18 +4771,10 @@ msgstr "权限被拒绝"
 msgid "Persistence"
 msgstr "持久"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr "持久"
-
-#: pkg/kubernetes/views/volumes-page.html:14
-msgid "Persistent Volumes"
-msgstr "持久卷"
-
-#: pkg/kubernetes/views/pod-body.html:16
-msgid "Phase"
-msgstr "阶段"
 
 #: pkg/storaged/vdo-details.jsx:277
 msgid "Physical"
@@ -5864,11 +4788,11 @@ msgstr "物理磁盘设备"
 msgid "Physical Volume"
 msgstr "物理卷"
 
-#: pkg/storaged/vgroup-details.jsx:134
+#: pkg/storaged/vgroup-details.jsx:133
 msgid "Physical Volumes"
 msgstr "物理卷"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:210
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
 msgid "Physical disk device on host"
 msgstr "主机上的物理磁盘设备"
 
@@ -5892,10 +4816,10 @@ msgstr "Ping 目标"
 msgid "Pizza Box"
 msgstr "披萨盒"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:296 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:210
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "请确认删除 $0"
 
@@ -5903,111 +4827,23 @@ msgstr "请确认删除 $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "请确认强制删除 $0"
 
-#: pkg/storaged/mdraid-details.jsx:244 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "请确认停止$0"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:34
-msgid "Please confirm, the host shall be switched to maintenance mode."
-msgstr "请确认，主机应切换到维护模式。"
-
-#: pkg/kubernetes/scripts/dashboard.js:439
-msgid "Please create another namespace for $0 \"$1\""
-msgstr "请重新为 $0 创建一个命名空间 \"$1\""
-
-#: pkg/machines/components/diskAdd.jsx:425
+#: pkg/machines/components/diskAdd.jsx:447
 msgid "Please enter new volume name"
 msgstr "请输入新的卷名"
 
-#: pkg/machines/components/diskAdd.jsx:428
+#: pkg/machines/components/diskAdd.jsx:450
 msgid "Please enter new volume size"
 msgstr "请输入新的卷大小"
 
-#: pkg/networkmanager/firewall.jsx:862
+#: pkg/networkmanager/firewall.jsx:864
 msgid "Please install the $0 package"
 msgstr "请安装 $0 软件包"
 
-#: pkg/kubernetes/scripts/volumes.js:582
-msgid "Please provide a GlusterFS volume name"
-msgstr "请提供一个 GlusterFS 卷名称"
-
-#: pkg/kubernetes/scripts/connection.js:550
-msgid "Please provide a username"
-msgstr "请提供一个用户名"
-
-#: pkg/kubernetes/scripts/volumes.js:640
-msgid "Please provide a valid NFS server"
-msgstr "请提供一个有效的 NFS 服务器"
-
-#: pkg/kubernetes/scripts/connection.js:535
-msgid "Please provide a valid address"
-msgstr "请提供一个有效的地址"
-
-#: pkg/kubernetes/scripts/volumes.js:810
-msgid "Please provide a valid filesystem type"
-msgstr "请提供一个有效的文件系统类型"
-
-#: pkg/kubernetes/scripts/volumes.js:818
-msgid "Please provide a valid interface"
-msgstr "请提供一个有效的接口"
-
-#: pkg/kubernetes/scripts/volumes.js:802
-msgid "Please provide a valid logical unit number"
-msgstr "请提供一个有效的逻辑单元编号"
-
-#: pkg/kubernetes/scripts/volumes.js:483
-msgid "Please provide a valid name"
-msgstr "请提供有效的名称"
-
-#: pkg/kubernetes/scripts/dashboard.js:376
-msgid "Please provide a valid namespace."
-msgstr "请提供有效的命名空间."
-
-#: pkg/kubernetes/scripts/volumes.js:648 pkg/kubernetes/scripts/volumes.js:703
-msgid "Please provide a valid path"
-msgstr "请提供一个有效的路径"
-
-#: pkg/kubernetes/scripts/volumes.js:794
-msgid "Please provide a valid qualified name"
-msgstr "请提供一个有效的限定名"
-
-#: pkg/kubernetes/scripts/volumes.js:491
-msgid "Please provide a valid storage capacity."
-msgstr "请提供有效的存储容量。"
-
-#: pkg/kubernetes/scripts/volumes.js:786
-msgid "Please provide a valid target"
-msgstr "请提供一个有效的目标"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:83
-msgid ""
-"Please provide fully qualified domain name and port of the oVirt engine."
-msgstr "请提供 oVirt 引擎的完整的合法域名和端口。"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:137
-msgid ""
-"Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-"port (443 by default)"
-msgstr "请提供有效的 oVirt 引擎完整的合法域名（FQDN）和端口（默认为443 ）"
-
-#: pkg/ovirt/components/ConsoleClientResources.jsx:32
-msgid ""
-"Please refer to oVirt's $0 for more information about Remote Viewer setup."
-msgstr "请参考 oVirt 的 $0 来获取更新关于 Remote Viewer 的设置。"
-
-#: pkg/kubernetes/scripts/volumes.js:475
-msgid "Please select a valid access mode"
-msgstr "请选择有效的访问模式"
-
-#: pkg/kubernetes/scripts/volumes.js:573
-msgid "Please select a valid endpoint"
-msgstr "请选择有效的端点"
-
-#: pkg/kubernetes/scripts/volumes.js:499
-msgid "Please select a valid policy option."
-msgstr "请选择有效的策略选项。"
-
-#: pkg/users/local.js:1232
+#: pkg/users/local.js:1236
 msgid "Please specify an expiration date"
 msgstr "请指定一个过期时间"
 
@@ -6023,72 +4859,16 @@ msgstr "请启动虚拟机来访问其控制台。"
 msgid "Please try another term"
 msgstr "请尝试另一个终端"
 
-#: pkg/kubernetes/scripts/nodes.js:401
-msgid "Please type an address"
-msgstr "请输入一个地址"
-
-#: pkg/ovirt/components/ClusterVms.jsx:37
-msgid "Please wait till VMs list is loaded from the server."
-msgstr "请等待直到虚拟机列表从服务器加载。"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:30
-msgid "Please wait till list of templates is loaded from the server."
-msgstr "请等待直到模板列表从服务器加载。"
-
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Plug"
 msgstr "插"
 
-#: pkg/kubernetes/views/containers-listing.html:12
-#: pkg/kubernetes/views/pod-page.html:12
-#: pkg/kubernetes/views/topology-page.html:14
-msgid "Pod"
-msgstr "Pod"
-
-#: pkg/kubernetes/views/pod-body.html:20
-msgid "Pod Address"
-msgstr "pod 地址"
-
-#: pkg/kubernetes/views/service-endpoint.html:4
-#: pkg/kubernetes/views/service-endpoint.html:9
-msgid "Pod Endpoints"
-msgstr "pod 端点"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:4
-msgid "Pod Replicated"
-msgstr "复制的 pod"
-
-#: pkg/kubernetes/views/replicationcontroller-pods.html:11
-#: pkg/kubernetes/views/service-endpoint.html:15
-msgid "Pod Selector"
-msgstr "pod 选择器"
-
-#: pkg/kubernetes/views/dashboard-page.html:18
-#: pkg/kubernetes/views/details-page.html:166
-#: pkg/kubernetes/views/pv-claim.html:37
-#: pkg/kubernetes/views/replicationcontroller-page.html:17
-#: pkg/kubernetes/views/replicationcontroller-panel.html:12
-#: pkg/kubernetes/scripts/details.js:227
-msgid "Pods"
-msgstr "Pod"
-
-#: pkg/kubernetes/views/topology-page.html:15
-msgid ""
-"Pods contain one or more containers that run together on a node, containing "
-"your application code."
-msgstr "pod 包含一个或多个运行在同一节点上包含应用代码的容器。"
-
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "池"
-
-#: pkg/kubernetes/views/volume-body.html:60
-msgid "Pool Name"
-msgstr "池名称"
 
 #: pkg/storaged/utils.js:191
 msgid "Pool for Thin Logical Volumes"
@@ -6102,16 +4882,11 @@ msgstr "瘦卷的池"
 msgid "Pool for thinly provisioned volumes"
 msgstr "瘦分配配置卷的池"
 
-#: pkg/kubernetes/views/imagestream-modify.html:45
-msgid "Populate"
-msgstr "产生"
-
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:78
-#: pkg/ovirt/components/InstallationDialog.jsx:65
+#: pkg/machines/components/vmnetworktab.jsx:108
 #: pkg/storaged/iscsi-panel.jsx:127
 msgid "Port"
 msgstr "端口"
@@ -6124,15 +4899,14 @@ msgstr "端口号和类型不匹配"
 msgid "Portable"
 msgstr "手提"
 
-#: pkg/docker/index.html:504 pkg/kubernetes/views/container-body.html:12
-#: pkg/kubernetes/views/service-body.html:13 pkg/networkmanager/index.html:213
+#: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
 #: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
 msgid "Ports"
 msgstr "端口"
 
-#: pkg/docker/index.html:191
+#: pkg/docker/index.html:192
 msgid "Ports:"
 msgstr "端口："
 
@@ -6141,7 +4915,6 @@ msgid "Power Options"
 msgstr "电源选项"
 
 #: pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Preferred number of sockets to expose to the guest."
 msgstr "向客户机公开的首选插槽数。"
 
@@ -6160,10 +4933,6 @@ msgstr "前缀长度或网络掩码"
 #: pkg/networkmanager/interfaces.js:826
 msgid "Preparing"
 msgstr "准备中"
-
-#: pkg/ovirt/rephraseUI.js:25
-msgid "Preparing for Maintenance"
-msgstr "正在准备维护"
 
 #: pkg/networkmanager/interfaces.js:3631
 msgid "Preserve"
@@ -6202,10 +4971,6 @@ msgstr "优先级 $priority"
 msgid "Private"
 msgstr "私有"
 
-#: pkg/kubernetes/scripts/projects.js:1042
-msgid "Private: Allow only specific users or groups to pull images"
-msgstr "私有的：仅允许指定用户或组拉取镜像"
-
 #: pkg/shell/index.html:39
 msgid "Privileged"
 msgstr "有特权的"
@@ -6231,61 +4996,9 @@ msgstr "流程"
 msgid "Product"
 msgstr "产品"
 
-#: pkg/subscriptions/subscriptions-view.jsx:34
-msgid "Product ID"
-msgstr "产品 ID"
-
-#: pkg/subscriptions/subscriptions-view.jsx:33
-msgid "Product name"
-msgstr "产品名"
-
-#: pkg/kubernetes/views/containers-listing.html:13
-#: pkg/kubernetes/views/dashboard-page.html:159
-#: pkg/kubernetes/views/deploymentconfig-body.html:4
-#: pkg/kubernetes/views/details-page.html:35
-#: pkg/kubernetes/views/details-page.html:71
-#: pkg/kubernetes/views/details-page.html:104
-#: pkg/kubernetes/views/details-page.html:138
-#: pkg/kubernetes/views/details-page.html:172
-#: pkg/kubernetes/views/imagestream-modify.html:21
-#: pkg/kubernetes/views/pod-body.html:4
-#: pkg/kubernetes/views/replicationcontroller-body.html:4
-#: pkg/kubernetes/views/route-body.html:4
-#: pkg/kubernetes/views/service-body.html:4
-#: pkg/kubernetes/views/volumes-page.html:58
-msgid "Project"
-msgstr "项目"
-
-#: pkg/kubernetes/views/project-body.html:20
-msgid "Project Members"
-msgstr "项目成员"
-
-#: pkg/kubernetes/views/project-body.html:3
-msgid "Project access policy allows anonymous users to pull images."
-msgstr "项目访问策略允许匿名用户拉取镜像。"
-
-#: pkg/kubernetes/views/project-body.html:8
-msgid "Project access policy allows any authenticated user to pull images."
-msgstr "项目访问策略允许任何认证的用户拉取镜像。"
-
-#: pkg/kubernetes/views/project-body.html:13
-msgid "Project access policy only allows specific members to access images."
-msgstr "项目访问策略允许指定的用户拉取镜像。"
-
-#: pkg/shell/index.html:86 pkg/shell/simple.html:62 pkg/shell/stub.html:69
+#: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
 msgstr "项目网站"
-
-#: pkg/kubernetes/views/filter-project.html:5
-msgid "Project:"
-msgstr "项目:"
-
-#: pkg/kubernetes/index.html:88 pkg/kubernetes/registry.html:55
-#: pkg/kubernetes/views/group-delete.html:10
-#: pkg/kubernetes/views/project-listing.html:9
-#: pkg/kubernetes/views/user-delete.html:10
-msgid "Projects"
-msgstr "项目"
 
 #: pkg/users/local.js:91
 msgid "Prompting via passwd timed out"
@@ -6309,15 +5022,7 @@ msgstr "传播重新加载到"
 msgid "Protocol"
 msgstr "协议"
 
-#: pkg/subscriptions/subscriptions-register.jsx:129
-msgid "Proxy"
-msgstr "代理"
-
-#: pkg/kubernetes/views/node-body.html:25
-msgid "Proxy Version"
-msgstr "代理版本"
-
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "公钥"
 
@@ -6325,25 +5030,9 @@ msgstr "公钥"
 msgid "Public pulling repo"
 msgstr "公开的拉取 repo"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:152
-msgid "Pull an image:"
-msgstr "拉取镜像:"
-
-#: pkg/kubernetes/views/imagestream-modify.html:66
-msgid "Pull from"
-msgstr "拉取自"
-
-#: pkg/kubernetes/scripts/images.js:635
-msgid "Pull specific tags from another image repository"
-msgstr "从另一个镜像仓库拉取指定标记"
-
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "目的"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:141
-msgid "Push an image:"
-msgstr "推送镜像:"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:31
 msgid "QEMU/KVM System connection"
@@ -6353,16 +5042,11 @@ msgstr "QEMU/KVM 系统连接"
 msgid "QEMU/KVM User connection"
 msgstr "QEMU/KVM 用户连接"
 
-#: pkg/kubernetes/views/pv-modify.html:148
-#: pkg/kubernetes/views/volume-body.html:77
-msgid "Qualified Name"
-msgstr "限定名"
-
-#: pkg/storaged/mdraid-details.jsx:186
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 0"
 msgstr "RAID 0"
 
@@ -6370,7 +5054,7 @@ msgstr "RAID 0"
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (条带)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID 1"
 msgstr "RAID 1"
 
@@ -6378,7 +5062,7 @@ msgstr "RAID 1"
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (镜像)"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:184
 msgid "RAID 10"
 msgstr "RAID 10"
 
@@ -6386,7 +5070,7 @@ msgstr "RAID 10"
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (条带镜像)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:181
 msgid "RAID 4"
 msgstr "RAID 4"
 
@@ -6394,7 +5078,7 @@ msgstr "RAID 4"
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (奇偶校验)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:182
 msgid "RAID 5"
 msgstr "RAID 5"
 
@@ -6402,7 +5086,7 @@ msgstr "RAID 5"
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (奇偶校验)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:183
 msgid "RAID 6"
 msgstr "RAID 6"
 
@@ -6418,7 +5102,7 @@ msgstr "RAID 机箱"
 msgid "RAID Device"
 msgstr "RAID 设备"
 
-#: pkg/storaged/mdraid-details.jsx:316 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "RAID 设备 $0"
 
@@ -6434,27 +5118,15 @@ msgstr "RAID 级别"
 msgid "RAID Member"
 msgstr "RAID 成员"
 
-#: pkg/ovirt/provider.js:179
-msgid "REBOOT action failed"
-msgstr "重启操作失败"
-
-#: pkg/ovirt/provider.js:164
-msgid "REBOOT_VM action failed: %s0"
-msgstr "REBOOT_VM 操作失败: %s0"
-
 #: pkg/lib/machine-info.js:86
 msgid "Rack Mount Chassis"
 msgstr "机架式机箱"
-
-#: pkg/kubernetes/scripts/volumes.js:200
-msgid "Rados Block Device"
-msgstr "Rados 块设备"
 
 #: pkg/networkmanager/interfaces.js:3632
 msgid "Random"
 msgstr "随机"
 
-#: pkg/networkmanager/firewall.jsx:757
+#: pkg/networkmanager/firewall.jsx:759
 msgid "Range"
 msgstr "范围"
 
@@ -6466,42 +5138,15 @@ msgstr "范围必须排序"
 msgid "Raw to a device"
 msgstr "格式化设备"
 
-#: pkg/kubernetes/views/pv-modify.html:195
-#: pkg/kubernetes/views/volume-body.html:10
-#: pkg/kubernetes/views/volume-body.html:20
-#: pkg/kubernetes/views/volume-body.html:44
-#: pkg/kubernetes/views/volume-body.html:51
-#: pkg/kubernetes/views/volume-body.html:71
-#: pkg/kubernetes/views/volume-body.html:85
-#: pkg/kubernetes/views/volume-body.html:93
-#: pkg/kubernetes/views/volume-body.html:110
-#: pkg/kubernetes/views/volume-body.html:122
-#: pkg/kubernetes/views/volume-body.html:136
-#: pkg/kubernetes/views/volume-body.html:143
-msgid "Read Only"
-msgstr "只读"
-
-#: pkg/kubernetes/scripts/volumes.js:211
-msgid "Read and write from a single node"
-msgstr "从单节点读和写"
-
-#: pkg/kubernetes/scripts/volumes.js:213
-msgid "Read and write from multiple nodes"
-msgstr "从多节点读和写"
-
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr "了解更多..."
 
-#: pkg/kubernetes/scripts/volumes.js:212
-msgid "Read only from multiple nodes"
-msgstr "仅从多节点读"
-
-#: pkg/docker/index.html:363
+#: pkg/docker/index.html:365
 msgid "ReadOnly"
 msgstr "只读"
 
-#: pkg/docker/index.html:362
+#: pkg/docker/index.html:364
 msgid "ReadWrite"
 msgstr "读写"
 
@@ -6517,13 +5162,11 @@ msgstr "读取中..."
 msgid "Readonly"
 msgstr "只读"
 
-#: pkg/kubernetes/views/details-page.html:52
-#: pkg/kubernetes/views/node-body.html:41 pkg/playground/translate.html:19
-#: pkg/playground/translate.html:179 pkg/kubernetes/scripts/nodes.js:324
+#: pkg/playground/translate.html:19
 msgid "Ready"
 msgstr "就绪"
 
-#: pkg/playground/translate.html:24 pkg/playground/translate.html:184
+#: pkg/playground/translate.html:24
 msgctxt "verb"
 msgid "Ready"
 msgstr "就绪"
@@ -6542,10 +5185,6 @@ msgstr "实际主机名仅包含小写字母、数字、破折号和句号（包
 msgid "Real host name must be 64 characters or less"
 msgstr "实际主机名必须小于等于64个字符"
 
-#: pkg/kubernetes/views/node-body.html:45
-msgid "Reason"
-msgstr "原因"
-
 #: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
 msgid "Reboot"
 msgstr "重启"
@@ -6560,16 +5199,11 @@ msgstr "接收中"
 msgid "Recent"
 msgstr "最近"
 
-#: pkg/kubernetes/views/pv-body.html:6 pkg/kubernetes/views/pv-modify.html:56
-msgid "Reclaim Policy"
-msgstr "重新声明策略"
-
 #: pkg/storaged/format-dialog.jsx:248
 msgid "Recommended default"
 msgstr "推荐的默认"
 
-#: pkg/kubernetes/index.html:108 pkg/kubernetes/registry.html:75
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138 pkg/shell/stub.html:180
+#: pkg/shell/index.html:386 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "重新连接"
@@ -6581,10 +5215,6 @@ msgstr "恢复"
 #: pkg/storaged/jobs-panel.jsx:65
 msgid "Recovering RAID Device $target"
 msgstr "恢复 RAID 设备 $target"
-
-#: pkg/kubernetes/scripts/volumes.js:219
-msgid "Recycle"
-msgstr "回收"
 
 #: pkg/docker/storage.jsx:389
 msgid "Reformat and add disks"
@@ -6606,36 +5236,10 @@ msgstr "拒绝连接。主机密钥不匹配"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "拒绝连接。未知主机密钥"
 
-#: pkg/kubernetes/views/pv-modify.html:206 pkg/subscriptions/main.js:46
-#: pkg/subscriptions/subscriptions-view.jsx:159
-msgid "Register"
-msgstr "注册"
-
-#: pkg/kubernetes/views/volumes-page.html:12
-msgid "Register New Volume"
-msgstr "注册新卷"
-
-#: pkg/kubernetes/views/pv-modify.html:4
-msgid "Register Persistent Volume"
-msgstr "注册持久卷"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:108
-msgid "Register oVirt"
-msgstr "注册 oVirt"
-
-#: pkg/subscriptions/main.js:73
-msgid "Register system"
-msgstr "注册系统"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:128
-msgid "Registering oVirt to Cockpit"
-msgstr "注册 oVirt 到 Cockpit"
-
 #: pkg/packagekit/updates.jsx:777
 msgid "Register…"
 msgstr "注册…"
 
-#: pkg/ovirt/components/App.jsx:62 pkg/ovirt/components/VdsmView.jsx:100
 #: pkg/systemd/init.js:546
 msgid "Reload"
 msgstr "重载"
@@ -6644,7 +5248,7 @@ msgstr "重载"
 msgid "Reload Propagated From"
 msgstr "重新加载的传播来自"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:202
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
 msgid "Remote URL"
 msgstr "远程 URL"
 
@@ -6656,10 +5260,6 @@ msgstr "通过 NFS 远程"
 msgid "Remote over SSH"
 msgstr "通过 SSH 远程"
 
-#: pkg/kubernetes/views/imagestream-modify.html:89
-msgid "Remote registry is insecure"
-msgstr "远程 registry 不安全"
-
 #: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
 msgctxt "storage"
 msgid "Removable Drive"
@@ -6669,13 +5269,9 @@ msgstr "可移动驱动器"
 msgid "Removals:"
 msgstr "移除"
 
-#: pkg/kubernetes/views/group-delete.html:21
-#: pkg/kubernetes/views/remove-role-dialog.html:8
-#: pkg/kubernetes/views/user-delete.html:25
-#: pkg/kubernetes/views/user-group-remove.html:10
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "删除"
 
@@ -6687,37 +5283,13 @@ msgstr "移除 $0"
 msgid "Remove $0?"
 msgstr "移除 $0"
 
-#: pkg/kubernetes/views/group-delete.html:3
-msgid "Remove Group"
-msgstr "移除组"
-
-#: pkg/kubernetes/views/user-group-remove.html:3
-msgid "Remove Member"
-msgstr "移除成员"
-
-#: pkg/kubernetes/views/remove-role-dialog.html:3
-msgid "Remove Role"
-msgstr "移除角色"
-
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove Tang keyserver"
 msgstr "删除 Tang keyserver"
 
-#: pkg/kubernetes/views/user-delete.html:3
-msgid "Remove User"
-msgstr "移除用户"
-
 #: pkg/storaged/vdo-details.jsx:116
 msgid "Remove device"
 msgstr "删除设备"
-
-#: pkg/kubernetes/views/image-delete.html:3
-msgid "Remove image tag"
-msgstr "移除镜像标记"
-
-#: pkg/kubernetes/views/user-remove-membership.html:3
-msgid "Remove membership"
-msgstr "移除成员关系"
 
 #: pkg/storaged/crypto-keyslots.jsx:387
 msgid "Remove passphrase"
@@ -6727,11 +5299,11 @@ msgstr "删除密码"
 msgid "Remove passphrase in $0?"
 msgstr "在 $0 中删除密码？"
 
-#: pkg/networkmanager/firewall.jsx:629
+#: pkg/networkmanager/firewall.jsx:631
 msgid "Remove service"
 msgstr "删除服务"
 
-#: pkg/networkmanager/firewall.jsx:608
+#: pkg/networkmanager/firewall.jsx:610
 msgid "Remove service from zones"
 msgstr "从区中删除服务"
 
@@ -6757,8 +5329,8 @@ msgstr "移除  <b>$0</b> 将断开与服务器的连接，并将导致管理界
 msgid "Removing physical volume from $target"
 msgstr "从 $target 删除物理卷"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:187
-#: pkg/storaged/vgroup-details.jsx:235
+#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
+#: pkg/storaged/vgroup-details.jsx:234
 msgid "Rename"
 msgstr "重命名"
 
@@ -6766,7 +5338,7 @@ msgstr "重命名"
 msgid "Rename Logical Volume"
 msgstr "重命名逻辑卷"
 
-#: pkg/storaged/vgroup-details.jsx:179
+#: pkg/storaged/vgroup-details.jsx:178
 msgid "Rename Volume Group"
 msgstr "重命名卷组"
 
@@ -6803,30 +5375,6 @@ msgstr "每年重复"
 msgid "Repeat passphrase"
 msgstr "重复密码"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:9
-#: pkg/kubernetes/views/details-page.html:141
-#: pkg/kubernetes/views/replicationcontroller-body.html:9
-#: pkg/kubernetes/views/replicationcontroller-modify.html:8
-msgid "Replicas"
-msgstr "复制"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:14
-#: pkg/kubernetes/views/replicationcontroller-panel.html:10
-#: pkg/kubernetes/views/topology-page.html:22
-msgid "Replication Controller"
-msgstr "复制控制器"
-
-#: pkg/kubernetes/views/details-page.html:132
-#: pkg/kubernetes/scripts/details.js:224
-msgid "Replication Controllers"
-msgstr "复制控制器"
-
-#: pkg/kubernetes/views/topology-page.html:23
-msgid ""
-"Replication controllers dynamically create instances of pods from templates, "
-"and remove pods when necessary."
-msgstr "复制控制器动态地从模板创建 pod 实例，并且在必要的时候移除 pod。"
-
 #: pkg/systemd/logs.js:512
 msgid "Report"
 msgstr "报表"
@@ -6843,28 +5391,16 @@ msgstr "未发现报告器 'reporter-ureport'。"
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr "报告未执行成功。尝试运行`reporter-ureport -d "
 
-#: pkg/docker/index.html:688
+#: pkg/docker/index.html:690
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "仓库"
 
-#: pkg/kubernetes/views/volume-body.html:24
-msgid "Repository URL"
-msgstr "仓库 URL"
-
-#: pkg/kubernetes/views/pvc-body.html:21 pkg/kubernetes/views/pvc-body.html:35
-msgid "Requested"
-msgstr "请求的"
-
-#: pkg/kubernetes/views/pv-claim.html:13
-msgid "Requests"
-msgstr "请求"
-
-#: pkg/users/local.js:1296
+#: pkg/users/local.js:1300
 msgid "Require password change every $0 days"
 msgstr "要求每 $0 天修改密码"
 
-#: pkg/users/local.js:872
+#: pkg/users/local.js:876
 msgid "Require password change on $0"
 msgstr "要求于 $0 修改密码"
 
@@ -6875,10 +5411,6 @@ msgstr "要求的"
 #: pkg/systemd/init.js:717
 msgid "Requires"
 msgstr "要求"
-
-#: pkg/kubernetes/views/auth-form.html:54
-msgid "Requires Authentication"
-msgstr "需要验证"
 
 #: pkg/systemd/init.js:718
 msgid "Requisite"
@@ -6892,7 +5424,7 @@ msgstr "必备的"
 msgid "Reserved memory"
 msgstr "保留内存"
 
-#: pkg/docker/index.html:301 pkg/users/index.html:333
+#: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:105
 msgid "Reset"
 msgstr "重置"
@@ -6918,26 +5450,22 @@ msgid ""
 "a current disk passphrase."
 msgstr "对一个加密的文件系统调整大小需要解锁磁盘。请提供磁盘的密码。"
 
-#: pkg/docker/index.html:135 pkg/systemd/index.html:134
+#: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "重启"
-
-#: pkg/kubernetes/views/container-body.html:20
-msgid "Restart Count"
-msgstr "重启次数"
 
 #: pkg/packagekit/updates.jsx:498
 msgid "Restart Now"
 msgstr "立刻重启"
 
-#: pkg/docker/index.html:537 pkg/kubernetes/views/pod-body.html:10
+#: pkg/docker/index.html:539
 msgid "Restart Policy"
 msgstr "重启策略"
 
-#: pkg/docker/index.html:171
+#: pkg/docker/index.html:172
 msgid "Restart Policy:"
 msgstr "重启策略："
 
@@ -6957,50 +5485,25 @@ msgstr "恢复连接"
 msgid "Resume"
 msgstr "恢复"
 
-#: pkg/kubernetes/scripts/volumes.js:217
-msgid "Retain"
-msgstr "留存"
-
-#: pkg/docker/index.html:553
+#: pkg/docker/index.html:555
 msgid "Retries:"
 msgstr "重试次数:"
-
-#: pkg/subscriptions/subscriptions-view.jsx:210
-msgid "Retrieving subscription status..."
-msgstr "正在获取订阅状态..."
 
 #: src/ws/login.html:57
 msgid "Reuse my password for privileged tasks"
 msgstr "重用我的密码以执行特权任务"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr "为特权任务和连接其他主机重用我的密码"
 
-#: pkg/kubernetes/views/volume-body.html:26
-msgid "Revision"
-msgstr "修订"
-
-#: pkg/kubernetes/views/user-add-membership.html:28
-#: pkg/kubernetes/views/user-body.html:5
-#: pkg/kubernetes/views/user-panel.html:28
-msgid "Role"
-msgstr "角色"
-
-#: pkg/kubernetes/views/add-member-role-dialog.html:39
-#: pkg/kubernetes/views/project-body.html:21 pkg/users/index.html:94
+#: pkg/users/index.html:94
 msgid "Roles"
 msgstr "角色"
 
 #: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
 msgid "Round Robin"
 msgstr "轮循"
-
-#: pkg/kubernetes/views/route-page.html:14
-#: pkg/kubernetes/views/route-panel.html:9
-msgid "Route"
-msgstr "路由"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:98
 msgid "Route to $0"
@@ -7010,22 +5513,16 @@ msgstr "路由到 $0"
 msgid "Routed Network"
 msgstr "路由的网络"
 
-#: pkg/kubernetes/views/details-page.html:65
-#: pkg/kubernetes/scripts/details.js:216 pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3325
 msgid "Routes"
 msgstr "路由"
 
-#: pkg/docker/index.html:244 pkg/docker/index.html:564
+#: pkg/docker/index.html:253 pkg/docker/index.html:566
 #: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
-#: pkg/ovirt/components/ClusterVms.jsx:92
 msgid "Run"
 msgstr "运行"
 
-#: pkg/ovirt/components/ClusterVms.jsx:97
-msgid "Run Here"
-msgstr "运行到此"
-
-#: pkg/docker/index.html:425
+#: pkg/docker/index.html:427
 msgid "Run Image"
 msgstr "运行镜像"
 
@@ -7034,7 +5531,7 @@ msgid "Run as"
 msgstr "运行为"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
-#: pkg/machines/components/vmOverviewTabLibvirt.jsx:128
+#: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
 msgstr "在主机引导时运行"
 
@@ -7042,17 +5539,13 @@ msgstr "在主机引导时运行"
 msgid "Runner"
 msgstr "运行者"
 
-#: pkg/storaged/mdraid-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342
 msgid "Running"
 msgstr "运行中"
 
 #: pkg/systemd/services.html:123
 msgid "Running Since"
 msgstr "运行自"
-
-#: pkg/ovirt/components/VmOverviewColumn.jsx:54
-msgid "Running Since:"
-msgstr "运行自："
 
 #: pkg/selinux/setroubleshoot-view.jsx:364
 msgid "SELinux Access Control Errors"
@@ -7078,14 +5571,6 @@ msgstr "该系统上 SELinux 已禁用。"
 msgid "SELinux system status is unknown."
 msgstr "SELinux 系统状态未知。"
 
-#: pkg/ovirt/provider.js:440
-msgid "SET VCPU SETTINGS action failed"
-msgstr "SET VCPU SETTINGS 操作失败"
-
-#: pkg/ovirt/provider.js:111 pkg/ovirt/provider.js:145
-msgid "SHUTDOWN action failed"
-msgstr "关机操作失败"
-
 #: pkg/storaged/jobs-panel.jsx:35
 msgid "SMART self-test of $target"
 msgstr "$target SMART 自检"
@@ -7106,14 +5591,6 @@ msgstr "SPICE 端口："
 msgid "SPICE TLS Port:"
 msgstr "SPICE TLS 端口："
 
-#: pkg/ovirt/provider.js:225
-msgid "START action failed"
-msgstr "启动操作失败"
-
-#: pkg/ovirt/provider.js:203
-msgid "START_VM action failed: %s0"
-msgstr "START_VM 操作失败 : %s0"
-
 #: pkg/networkmanager/index.html:228
 msgid "STP Forward delay"
 msgstr "STP 转发延迟"
@@ -7130,10 +5607,6 @@ msgstr "STP 最大消息有效期"
 msgid "STP Priority"
 msgstr "STP 优先级"
 
-#: pkg/ovirt/provider.js:303
-msgid "SUSPEND action failed"
-msgstr "挂起操作失败"
-
 #: pkg/systemd/services.html:240
 msgid "Saturday"
 msgstr "星期六"
@@ -7142,10 +5615,10 @@ msgstr "星期六"
 msgid "Saturdays"
 msgstr "周六"
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/ovirt/components/VdsmView.jsx:114 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
 #: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "保存"
@@ -7168,14 +5641,6 @@ msgid ""
 "current disk passphrase."
 msgstr "保存新密码需要解锁磁盘。请提供当前的磁盘密码。"
 
-#: pkg/kubernetes/views/node-capacity.html:9
-msgid "Scheduled Pods"
-msgstr "被调度的 pod"
-
-#: pkg/kubernetes/scripts/nodes.js:322
-msgid "Scheduling Disabled"
-msgstr "调度被禁用"
-
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
 msgstr "密封式 PC"
@@ -7184,24 +5649,6 @@ msgstr "密封式 PC"
 #: pkg/systemd/init.js:1076
 msgid "Seconds"
 msgstr "秒"
-
-#: pkg/kubernetes/scripts/volumes.js:195
-msgid "Secret"
-msgstr "秘密"
-
-#: pkg/kubernetes/views/volume-body.html:106
-msgid "Secret File"
-msgstr "秘密文件"
-
-#: pkg/kubernetes/views/volume-body.html:141
-msgid "Secret Name"
-msgstr "秘密名称"
-
-#: pkg/kubernetes/views/volume-body.html:69
-#: pkg/kubernetes/views/volume-body.html:108
-#: pkg/kubernetes/views/volume-body.html:134
-msgid "Secret Volume"
-msgstr "秘密卷"
 
 #: pkg/systemd/index.html:106
 msgid "Secure Shell Keys"
@@ -7219,40 +5666,21 @@ msgstr "安全性"
 msgid "Security Updates Available"
 msgstr "可用的错误修复更新"
 
-#: pkg/shell/index.html:123 pkg/shell/simple.html:91 pkg/shell/stub.html:106
+#: pkg/shell/index.html:123 pkg/shell/simple.html:91
 msgid "Select"
 msgstr "选择"
 
-#: pkg/kubernetes/views/file-button.html:4
-msgid "Select Manifest File..."
-msgstr "选择 Manifest 文件..."
-
-#: pkg/kubernetes/scripts/projects.js:899
-#: pkg/kubernetes/scripts/projects.js:1205
-#: pkg/kubernetes/scripts/projects.js:1335
-msgid "Select Member"
-msgstr "选择成员"
-
-#: pkg/kubernetes/scripts/projects.js:901
-#: pkg/kubernetes/scripts/projects.js:1208
-msgid "Select Role"
-msgstr "选择角色"
-
-#: pkg/kubernetes/views/topology-page.html:7
-msgid "Select an object to see more details."
-msgstr "选择一个对象来查看更多详情。"
-
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr "选择您需要与 {{#strong}}{{host}}{{/strong}} 同步的用户"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
 msgstr "发送不可屏蔽中断"
 
-#: pkg/machines/components/vnc.jsx:109
+#: pkg/machines/components/vnc.jsx:108
 msgid "Send key"
 msgstr "发送密钥"
 
@@ -7266,11 +5694,8 @@ msgstr "发送中"
 msgid "Serial Console"
 msgstr "串行控制台"
 
-#: pkg/kubernetes/views/pv-modify.html:82
-#: pkg/kubernetes/views/volume-body.html:47 src/ws/login.html:94
-#: pkg/kdump/kdump-view.jsx:116 pkg/storaged/nfs-details.jsx:315
-#: pkg/storaged/nfs-panel.jsx:101
-#: pkg/subscriptions/subscriptions-register.jsx:65
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "服务器"
 
@@ -7278,7 +5703,7 @@ msgstr "服务器"
 msgid "Server Address"
 msgstr "服务器地址"
 
-#: pkg/users/local.js:746 pkg/users/local.js:747
+#: pkg/users/local.js:750 pkg/users/local.js:751
 msgid "Server Administrator"
 msgstr "服务器管理员"
 
@@ -7302,16 +5727,10 @@ msgstr "服务器关闭了连接。"
 msgid "Servers"
 msgstr "服务器"
 
-#: pkg/kubernetes/views/service-page.html:12
-#: pkg/kubernetes/views/service-panel.html:8
-#: pkg/kubernetes/views/topology-page.html:30 pkg/systemd/logs.html:66
-#: pkg/networkmanager/firewall.jsx:936 pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "服务"
-
-#: pkg/kubernetes/views/pod-body.html:12
-msgid "Service Account"
-msgstr "服务账号"
 
 #: pkg/systemd/services.html:337
 msgid "Service Logs"
@@ -7341,26 +5760,14 @@ msgstr "服务正在停止"
 msgid "Service name"
 msgstr "服务名称"
 
-#: pkg/kubernetes/views/dashboard-page.html:134
-#: pkg/kubernetes/views/details-page.html:29 pkg/systemd/services.html:4
-#: pkg/systemd/services.html:330 pkg/kubernetes/scripts/details.js:213
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
 #: pkg/networkmanager/firewall.jsx:483
 msgid "Services"
 msgstr "服务"
 
-#: pkg/kubernetes/views/topology-page.html:31
-msgid ""
-"Services group pods and provide a common DNS name and an optional, load-"
-"balanced IP address to access them."
-msgstr "服务组 pod 并提供一个通用 DNS 名称和一个可选的负载均衡的 IP 地址来访问它们。"
-
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "会话"
-
-#: pkg/kubernetes/views/service-body.html:20
-msgid "Session Affinity"
-msgstr "会话关联"
 
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
@@ -7378,7 +5785,7 @@ msgstr "设置密码"
 msgid "Set Time"
 msgstr "设置时间"
 
-#: pkg/docker/index.html:530
+#: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "设置容器环境变量"
 
@@ -7411,28 +5818,15 @@ msgstr "严重性"
 msgid "Severity:"
 msgstr "严重性"
 
-#: pkg/kubernetes/views/volume-body.html:139
-msgid "Share Name"
-msgstr "共享名称"
-
 #: pkg/networkmanager/interfaces.js:1959
 msgid "Shared"
 msgstr "共享"
-
-#: pkg/kubernetes/scripts/projects.js:1043
-msgid "Shared: Allow any authenticated user to pull images"
-msgstr "共享的：运行任何已验证的用户拉取镜像"
-
-#: pkg/kubernetes/views/container-page-inline.html:14
-#: pkg/kubernetes/views/container-panel.html:9
-msgid "Shell"
-msgstr "Shell"
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr "Shift+Insert"
 
-#: pkg/machines/components/diskAdd.jsx:227
+#: pkg/machines/components/diskAdd.jsx:238
 msgid "Show Performance Options"
 msgstr "显示性能选项"
 
@@ -7440,61 +5834,15 @@ msgstr "显示性能选项"
 msgid "Show all"
 msgstr "显示全部"
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:122
 msgid "Show all $0 drives"
 msgstr "显示所有 $0 驱动"
-
-#: pkg/kubernetes/views/container-page.html:4
-msgid "Show all Containers"
-msgstr "显示所有容器"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:8
-msgid "Show all Deployment Configs"
-msgstr "显示所有部署配置"
-
-#: pkg/kubernetes/views/node-page.html:8
-msgid "Show all Nodes"
-msgstr "显示所有节点"
-
-#: pkg/kubernetes/views/pv-page.html:9
-msgid "Show all Persistent Volumes"
-msgstr "显示所有持久卷"
-
-#: pkg/kubernetes/views/pod-container.html:4
-msgid "Show all Pod Containers"
-msgstr "显示所有 pod 容器"
-
-#: pkg/kubernetes/views/pod-page.html:8
-msgid "Show all Pods"
-msgstr "显示所有 pod"
-
-#: pkg/kubernetes/views/group-page.html:14
-#: pkg/kubernetes/views/project-page.html:23
-#: pkg/kubernetes/views/user-page.html:16
-msgid "Show all Projects"
-msgstr "显示所有项目"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:10
-msgid "Show all Replication Controllers"
-msgstr "显示所有复制控制器"
-
-#: pkg/kubernetes/views/route-page.html:10
-msgid "Show all Routes"
-msgstr "显示所有路由"
-
-#: pkg/kubernetes/views/service-page.html:8
-msgid "Show all Services"
-msgstr "显示所有服务"
 
 #: pkg/docker/index.html:128
 msgid "Show all containers"
 msgstr "显示所有容器"
 
-#: pkg/kubernetes/views/imagestream-page.html:12
-msgid "Show all image streams"
-msgstr "显示所有镜像流"
-
-#: pkg/docker/index.html:254 pkg/kubernetes/views/image-page.html:10
+#: pkg/docker/index.html:249
 msgid "Show all images"
 msgstr "显示所有镜像"
 
@@ -7519,21 +5867,16 @@ msgstr "缩小卷"
 msgid "Shut Down"
 msgstr "关机"
 
-#: pkg/kubernetes/views/container-body.html:18
-msgid "Since"
-msgstr "自从"
-
-#: pkg/kubernetes/views/volumes-page.html:60 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:376
-#: pkg/machines/components/diskAdd.jsx:143
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "大小"
 
@@ -7557,11 +5900,6 @@ msgstr "大小必须是一个数字"
 msgid "Size must be at least $0"
 msgstr "大小必须最小为 $0"
 
-#: pkg/kubernetes/views/auth-form.html:43
-#: pkg/kubernetes/views/auth-rejected-cert.html:11
-msgid "Skip Certificate Verification"
-msgstr "跳过证书验证"
-
 #: pkg/systemd/hwinfo.jsx:249
 msgid "Slot"
 msgstr "插槽"
@@ -7571,7 +5909,6 @@ msgid "Slot $0"
 msgstr "插槽 $0"
 
 #: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
-#: pkg/ovirt/components/vcpuModal.jsx:64
 msgid "Sockets"
 msgstr "套接字"
 
@@ -7584,7 +5921,9 @@ msgid ""
 "Software-based workarounds help prevent CPU security issues. These "
 "mitigations have the side effect of reducing performance. Change these "
 "settings at your own risk."
-msgstr "基于软件的临时解决方案可以帮助防止 CPU 安全问题。这些缓解方案会对性能有一定影响。改变这些设置可能会存在风险。"
+msgstr ""
+"基于软件的临时解决方案可以帮助防止 CPU 安全问题。这些缓解方案会对性能有一定影"
+"响。改变这些设置可能会存在风险。"
 
 #: pkg/docker/storage.jsx:165
 msgid "Solid-State Disk"
@@ -7612,18 +5951,14 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr "某些其他程序正在使用软件包管理器，请等待..."
 
-#: pkg/kubernetes/scripts/volumes.js:914
-msgid "Sorry, I don't know how to modify this volume"
-msgstr "抱歉，不知道如何修改该卷"
-
-#: pkg/networkmanager/firewall.jsx:707
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Sorted from least trusted to most trusted"
 msgstr "按最不被信任到最被信任的顺序排序"
 
-#: pkg/machines/components/diskAdd.jsx:476
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:103
+#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "源"
 
@@ -7631,10 +5966,10 @@ msgstr "源"
 msgid "Source Format"
 msgstr "源格式"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:217
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:244
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "源路径"
 
@@ -7642,12 +5977,12 @@ msgstr "源路径"
 msgid "Source URL"
 msgstr "源 URL"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:254
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
 msgid "Source path should not be empty"
 msgstr "源路径不能为空"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:108
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "源应该以 http、ftp 或 nfs 协议开头"
 
@@ -7675,9 +6010,9 @@ msgstr "指定时间"
 msgid "Stable"
 msgstr "稳定的"
 
-#: pkg/docker/index.html:133 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:320 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "启动"
 
@@ -7697,7 +6032,7 @@ msgstr "启动服务"
 msgid "Start libvirt"
 msgstr "启动 libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:291
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
 msgid "Start pool when host boots"
 msgstr "在主机引导时启动池"
 
@@ -7709,59 +6044,29 @@ msgstr "启动 RAID 设备 $target"
 msgid "Starting swapspace $target"
 msgstr "启动交换空间 $target"
 
-#: pkg/subscriptions/subscriptions-view.jsx:38
-msgid "Starts"
-msgstr "开始"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
 msgid "Startup"
 msgstr "启动"
 
-#: pkg/kubernetes/views/container-body.html:16
-#: pkg/kubernetes/views/details-page.html:38
-#: pkg/kubernetes/views/details-page.html:175
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:127 pkg/machines/hostvmslist.jsx:83
-#: pkg/ovirt/components/ClusterVms.jsx:184 pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/init.js:285
 msgid "State"
 msgstr "状态"
 
-#: pkg/docker/index.html:167
+#: pkg/docker/index.html:168
 msgid "State:"
 msgstr "阶段："
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:136
-#: pkg/ovirt/components/ClusterVms.jsx:182
-msgid "Stateless"
-msgstr "无状态"
-
-#: pkg/ovirt/components/OVirtTab.jsx:156
-msgid "Stateless:"
-msgstr "无状态："
 
 #: pkg/systemd/services.html:74 pkg/systemd/init.js:207
 msgid "Static"
 msgstr "静态"
 
-#: pkg/kubernetes/views/containers-listing.html:16
-#: pkg/kubernetes/views/node-body.html:39
-#: pkg/kubernetes/views/nodes-page.html:44 pkg/kubernetes/views/pv-body.html:24
-#: pkg/kubernetes/views/pv-claim.html:29 pkg/kubernetes/views/pvc-body.html:13
-#: pkg/kubernetes/views/volumes-page.html:21 pkg/systemd/services.html:121
-#: pkg/networkmanager/interfaces.js:2613
-#: pkg/subscriptions/subscriptions-view.jsx:37
+#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
 msgid "Status"
 msgstr "状态"
-
-#: pkg/subscriptions/subscriptions-view.jsx:162
-msgid "Status: $0"
-msgstr "状态：$0"
-
-#: pkg/subscriptions/subscriptions-view.jsx:157
-msgid "Status: System isn't registered"
-msgstr "状态：系统未注册"
 
 #: pkg/lib/machine-info.js:99
 msgid "Stick PC"
@@ -7771,14 +6076,14 @@ msgstr "Stick PC"
 msgid "Sticky"
 msgstr "Sticky"
 
-#: pkg/docker/index.html:134 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "停止"
 
-#: pkg/storaged/mdraid-details.jsx:248
+#: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "停止设备"
 
@@ -7810,8 +6115,8 @@ msgstr "停止 RAID 设备 $target"
 msgid "Stopping swapspace $target"
 msgstr "停止启动交换空间 $target"
 
-#: pkg/docker/index.html:288 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
+#: pkg/docker/index.html:290 pkg/storaged/index.html:23
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
 #: pkg/storaged/details.jsx:127
 msgid "Storage"
 msgstr "存储"
@@ -7820,11 +6125,11 @@ msgstr "存储"
 msgid "Storage Logs"
 msgstr "存储日志"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:137
+#: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr "存储池 $0 激活失败"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:149
+#: pkg/machines/components/storagePools/storagePool.jsx:153
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr "存储池 $0 取消激活失败"
 
@@ -7832,7 +6137,7 @@ msgstr "存储池 $0 取消激活失败"
 msgid "Storage Pool Name"
 msgstr "存储池名"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:437
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
 msgid "Storage Pool failed to be created"
 msgstr "创建存储池失败"
 
@@ -7853,7 +6158,7 @@ msgstr "存储卷不能被删除"
 msgid "Storage can not be managed on this system."
 msgstr "存储不能在这个系统上管理。"
 
-#: pkg/docker/index.html:302
+#: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "存储池"
 
@@ -7873,10 +6178,6 @@ msgstr "已存储的口令"
 msgid "Stored passphrase"
 msgstr "保存的密码"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:12
-msgid "Strategy"
-msgstr "策略"
-
 #: pkg/lib/machine-info.js:82
 msgid "Sub Chassis"
 msgstr "子机箱"
@@ -7884,10 +6185,6 @@ msgstr "子机箱"
 #: pkg/lib/machine-info.js:77
 msgid "Sub Notebook"
 msgstr "子笔记本"
-
-#: pkg/subscriptions/index.html:22 pkg/subscriptions/subscriptions-view.jsx:177
-msgid "Subscriptions"
-msgstr "订阅"
 
 #: node_modules/registry-image-widgets/views/image-body.html:4
 msgid "Summary"
@@ -7905,10 +6202,6 @@ msgstr "周日"
 msgid "Support is installed."
 msgstr "已安装支持。"
 
-#: pkg/ovirt/components/VmActions.jsx:40
-msgid "Suspend"
-msgstr "挂起"
-
 #: pkg/storaged/content-views.jsx:157
 msgid "Swap"
 msgstr "交换空间"
@@ -7922,10 +6215,6 @@ msgstr "交换空间"
 msgid "Swap Used"
 msgstr "使用的交换空间"
 
-#: pkg/ovirt/components/HostToMaintenance.jsx:40
-msgid "Switch Host to Maintenance"
-msgstr "把主机切换到维护模式"
-
 #: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
 msgid "Switch off $0"
 msgstr "关掉 $0"
@@ -7933,14 +6222,6 @@ msgstr "关掉 $0"
 #: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
 msgid "Switch on $0"
 msgstr "打开 $0"
-
-#: pkg/ovirt/provider.js:414
-msgid "Switching host to maintenance mode failed. Received error: "
-msgstr "将主机切换到维护模式失败。收到错误： "
-
-#: pkg/ovirt/provider.js:408
-msgid "Switching host to maintenance mode in progress ..."
-msgstr "将主机切换到维护模式正在进行中... "
 
 #: pkg/networkmanager/interfaces.js:2491
 msgid ""
@@ -7959,10 +6240,6 @@ msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr "打开 <b>$0</b> 将中断与服务器的连接，并将导致管理界面不可用。"
-
-#: pkg/kubernetes/scripts/images.js:634
-msgid "Sync all tags from a remote image repository"
-msgstr "从远程镜像仓库同步所有标记"
 
 #: pkg/lib/machine-sync-users.html:75
 msgid "Synchronize"
@@ -8013,25 +6290,20 @@ msgstr "系统已是最新"
 msgid "System is up to date"
 msgstr "系统已更新到最新"
 
-#: pkg/docker/index.html:327 pkg/docker/index.html:331
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:329 pkg/docker/index.html:333
+#: pkg/networkmanager/firewall.jsx:938
 msgid "TCP"
 msgstr "TCP"
-
-#: pkg/kubernetes/views/route-body.html:12
-msgid "TLS Termination"
-msgstr "TLS 终止"
 
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
 msgstr "平板"
 
-#: pkg/docker/index.html:694
+#: pkg/docker/index.html:696
 #: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "标签"
 
-#: pkg/kubernetes/views/imagestream-modify.html:76
 #: node_modules/registry-image-widgets/views/image-body.html:29
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:6
 #: node_modules/registry-image-widgets/views/imagestream-panel.html:16
@@ -8043,25 +6315,16 @@ msgstr "标记"
 msgid "Tang keyserver"
 msgstr "Tang keyserver"
 
-#: pkg/kubernetes/views/pv-modify.html:137
 #: pkg/machines/components/vm/bootOrderModal.jsx:133
 msgid "Target"
 msgstr "目标"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "目标路径"
 
-#: pkg/kubernetes/views/volume-body.html:75
-msgid "Target Portal"
-msgstr "目标门户"
-
-#: pkg/kubernetes/views/volume-body.html:114
-msgid "Target World Wide Names"
-msgstr "目标全球通用名称"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:133
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
 msgid "Target path should not be empty"
 msgstr "目标路径不能为空"
 
@@ -8085,22 +6348,6 @@ msgstr "组端口设置"
 #: pkg/networkmanager/index.html:514
 msgid "Team Settings"
 msgstr "组设置"
-
-#: pkg/kubernetes/views/deploymentconfig-page.html:15
-#: pkg/kubernetes/views/deploymentconfig-panel.html:10
-#: pkg/kubernetes/views/replicationcontroller-page.html:20
-#: pkg/kubernetes/views/replicationcontroller-panel.html:14
-#: pkg/ovirt/components/ClusterVms.jsx:181
-msgid "Template"
-msgstr "模板"
-
-#: pkg/ovirt/components/App.jsx:111
-msgid "Templates"
-msgstr "模板"
-
-#: pkg/ovirt/components/ClusterTemplates.jsx:130
-msgid "Templates of $0 cluster"
-msgstr "$0 集群模板"
 
 #: pkg/systemd/terminal.html:4
 msgid "Terminal"
@@ -8134,11 +6381,11 @@ msgstr "Docker 存储池不能在这个系统上被管理。"
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "IP 地址或主机名不能包含空格。"
 
-#: pkg/storaged/mdraid-details.jsx:219
+#: pkg/storaged/mdraid-details.jsx:218
 msgid "The RAID Array is in a degraded state"
 msgstr "RAID 阵列处于降级状态"
 
-#: pkg/storaged/mdraid-details.jsx:149
+#: pkg/storaged/mdraid-details.jsx:148
 msgid "The RAID device must be running in order to add spare disks."
 msgstr "为了添加备用的磁盘，RAID 设备必须在运行。"
 
@@ -8187,18 +6434,14 @@ msgstr "虚拟机正在运行。"
 msgid "The VM is suspended by guest power management."
 msgstr "虚拟机已被客户机电源管理暂停。"
 
-#: pkg/users/local.js:1338
+#: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
 msgstr "账号 '$0' 将在下次登录时被强制变更其密码"
 
-#: pkg/kubernetes/scripts/nodes.js:403
-msgid "The address contains invalid characters"
-msgstr "地址包含无效字符"
-
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr "主机 {{#strong}}{{host}}{{/strong}} 的认证无法完成。确认想要继续连接？"
 
 #: pkg/sosreport/index.html:35
@@ -8209,29 +6452,17 @@ msgstr "搜集的信息将保存在系统本地。"
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr "配置状态未知，下一次启动时会改变。"
 
-#: pkg/kubernetes/views/container-page-inline.html:22
-msgid "The container '{{ target }}' does not exist."
-msgstr "容器 '{{ target }}' 不存在。"
-
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
 msgstr "此 VDO 设备的创建未完成，无法使用该设备。"
-
-#: pkg/subscriptions/subscriptions-view.jsx:214
-msgid "The current user isn't allowed to access system subscription status."
-msgstr "当前用户不允许访问系统订阅状态。"
 
 #: pkg/storaged/crypto-keyslots.jsx:516
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr "当前登录的用户不允许查看有关密钥的信息。"
 
-#: pkg/kubernetes/views/deploymentconfig-page.html:25
-msgid "The deployment config '{{ target }}' does not exist."
-msgstr "部署配置 '{{ target }}' 不存在。"
-
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:204
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
 msgid "The directory on the server being exported"
 msgstr "服务器上的目录被导出"
 
@@ -8242,8 +6473,7 @@ msgid ""
 msgstr "登录会话和系统服务正在使用文件系统。继续进行将停止这些。"
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr "登录会话正在使用文件系统。继续进行将停止这些。"
 
 #: pkg/storaged/dialog.jsx:1016
@@ -8252,8 +6482,7 @@ msgid ""
 msgstr "系统服务正在使用文件系统。继续进行将停止这些。"
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr "以下容器依赖于此镜像，将变得不可用。"
 
 #: pkg/sosreport/index.html:51
@@ -8263,17 +6492,14 @@ msgid ""
 "any third party."
 msgstr "生成的文档包含敏感数据，其内容在传递到第三方前应该由原始组织检查通过。"
 
-#: pkg/kubernetes/views/group-page.html:47
-msgid "The group '{{ groupName }}' does not exist."
-msgstr "组 '{{ groupName }}' 不存在。"
-
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
 "The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
 "in use. Unless this machine was recently replaced, it is likely that someone "
 "is trying to attack your connection to this machine."
 msgstr ""
-"{{#strong}}{{host}}{{/strong}} 的密钥与之前使用的不匹配。除非该主机最近被替换，否则可能有人正在攻击与该主机的连接。"
+"{{#strong}}{{host}}{{/strong}} 的密钥与之前使用的不匹配。除非该主机最近被替"
+"换，否则可能有人正在攻击与该主机的连接。"
 
 #: pkg/users/authorized-keys.js:124
 msgid "The key you provided was not valid."
@@ -8291,31 +6517,16 @@ msgstr "无法删除最后一个密钥槽"
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "不能删除一个卷组的最后一个物理卷。"
 
-#: pkg/shell/indexes.js:408
+#: pkg/shell/indexes.js:407
 msgid "The machine is restarting"
 msgstr "正在重启主机"
 
-#: pkg/kubernetes/scripts/details.js:498 pkg/kubernetes/scripts/details.js:620
-msgid "The maximum number of replicas is 128"
-msgstr "副本最大数量为 128"
+#: pkg/machines/components/networks/networkDelete.jsx:76
+#, fuzzy
+msgid "The network could not be deleted"
+msgstr "存储池不能被删除"
 
-#: pkg/kubernetes/scripts/nodes.js:411
-msgid "The name contains invalid characters"
-msgstr "名称包含无效的字符"
-
-#: pkg/kubernetes/views/node-page.html:23
-msgid "The node '{{ target }}' does not exist."
-msgstr "节点 '{{ target }}' 不存在。"
-
-#: pkg/kubernetes/views/node-alerts.html:7
-msgid "The node doesn't have enough disk space"
-msgstr "节点没有足够的磁盘空间"
-
-#: pkg/kubernetes/views/node-alerts.html:11
-msgid "The node doesn't have enough free memory"
-msgstr "节点没有足够的空闲内存"
-
-#: pkg/users/local.js:439 pkg/users/local.js:1395
+#: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
 msgstr "密码不匹配"
 
@@ -8323,29 +6534,9 @@ msgstr "密码不匹配"
 msgid "The passwords do not match."
 msgstr "密码不匹配"
 
-#: pkg/kubernetes/views/pv-page.html:21
-msgid "The persistent volume '{{ target }}' does not exist."
-msgstr "持久卷 '{{ target }}' 不存在。"
-
-#: pkg/kubernetes/views/pod-page.html:40
-msgid "The pod '{{ target }}' does not exist."
-msgstr "pod '{{ target }}' 不存在。"
-
 #: pkg/machines/components/diskAdd.jsx:80
 msgid "The pool is empty"
 msgstr "池为空"
-
-#: pkg/kubernetes/views/project-page.html:34
-msgid "The project '{{ projName }}' does not exist."
-msgstr "项目 '{{ projName }}' 不存在。"
-
-#: pkg/kubernetes/views/replicationcontroller-page.html:30
-msgid "The replication controller '{{ target }}' does not exist."
-msgstr "复制控制器 '{{ target }}' 不存在。"
-
-#: pkg/kubernetes/views/route-page.html:19
-msgid "The route '{{ target }}' does not exist."
-msgstr "路由 '{{ target }}' 不存在。"
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
@@ -8355,35 +6546,20 @@ msgstr "从 $time ($type) 开始的扫描没有找到漏洞。"
 msgid "The scan from $time ($type) was not successful."
 msgstr "从 $time ($type) 开始的扫描未成功。"
 
-#: pkg/kubernetes/scripts/dashboard.js:386
-msgid "The selected file is not a valid Kubernetes application manifest."
-msgstr "所选的文件不是有效的 Kubernetes 应用程序清单."
-
 #: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
 "no other supported authentication methods are available."
-msgstr "服务器拒绝使用密码验证的方法来验证 '$0'，并且没有其他支持的验证途径可以使用。"
+msgstr ""
+"服务器拒绝使用密码验证的方法来验证 '$0'，并且没有其他支持的验证途径可以使用。"
 
 #: src/base1/cockpit.js:4017
 msgid "The server refused to authenticate using any supported methods."
 msgstr "服务器拒绝使用任何支持的方式来验证。"
 
-#: pkg/kubernetes/views/auth-rejected-cert.html:2
-msgid "The server uses a certificate signed by an unknown authority."
-msgstr "服务器使用由一个未知机构签名的证书。"
-
-#: pkg/kubernetes/views/service-page.html:19
-msgid "The service '{{ target }}' does not exist."
-msgstr "服务 '{{ target }}' 不存在。"
-
 #: pkg/systemd/hwinfo.jsx:65
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr "用户 $0 没有权限修改 cpu 安全缓解方案设置"
-
-#: pkg/kubernetes/views/user-page.html:29
-msgid "The user '{{ userName }}' does not exist."
-msgstr "用户 '{{ userName }}' 不存在。"
 
 #: pkg/systemd/init.js:922
 msgid "The user <b>$0</b> does not have permissions for creating timers"
@@ -8421,7 +6597,7 @@ msgstr "用户 <b>$0</b> 不允许修改主机名"
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "用户 <b>$0</b> 不允许修改网络设置"
 
-#: pkg/realmd/operation.js:643
+#: pkg/realmd/operation.js:642
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "用户 <b>$0</b> 不允许修改 realms"
 
@@ -8433,7 +6609,7 @@ msgstr "用户 <b>$0</b> 不允许关闭或重启该服务器"
 msgid "The user <b>$0</b> is not permitted to start or stop services"
 msgstr "用户<b>$0</ b>不允许启用或禁用服务"
 
-#: pkg/users/local.js:549
+#: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
 "underscores."
@@ -8441,8 +6617,7 @@ msgstr "用户名仅能包含 a-z、数字、点、破折号和下划线的字�
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr "浏览器配置阻止 Cockpit 运行 （无法访问 $0）"
 
 #: pkg/shell/active-pages-dialog.jsx:58
@@ -8463,7 +6638,8 @@ msgstr "没有这个帐户的授权公钥."
 msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
-msgstr "其它地方没有足够的空闲空间来移除这个物理卷。至少需要 $0 或更多空闲空间。"
+msgstr ""
+"其它地方没有足够的空闲空间来移除这个物理卷。至少需要 $0 或更多空闲空间。"
 
 #: pkg/storaged/utils.js:193
 msgid "Thin Logical Volume"
@@ -8476,11 +6652,6 @@ msgstr "此 NFS 挂载正在使用中，只能更改其选项。"
 #: pkg/storaged/vdo-details.jsx:133
 msgid "This VDO device does not use all of its backing device."
 msgstr "此 VDO 设备不使用其所有后台设备。"
-
-#: pkg/kubernetes/views/pvc-delete.html:8
-msgid ""
-"This claim is in use. Deleting it may cause issues with the following pod:"
-msgstr "该声明正在使用。删除它会对以下 pod 产生影响:"
 
 #: pkg/systemd/init.js:1371
 msgid ""
@@ -8506,7 +6677,8 @@ msgstr "该设备正在被 RAID 设备使用。"
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
-msgstr "该设备正在被 RAID 设备使用。                继续进行将从 RAID 设备中移除它。"
+msgstr ""
+"该设备正在被 RAID 设备使用。                继续进行将从 RAID 设备中移除它。"
 
 #: pkg/storaged/dialog.jsx:980
 msgid "This device is currently used for VDO devices."
@@ -8530,12 +6702,6 @@ msgstr "当设备正在恢复时，该磁盘不能被移除。"
 msgid "This field cannot be empty."
 msgstr "该字段不能为空。"
 
-#: pkg/ovirt/components/App.jsx:155
-msgid ""
-"This host is managed by a virtualization manager, so creation of new VMs "
-"from the host is not possible."
-msgstr "该主机由虚拟化管理器管理，因此无法从主机创建新VM。"
-
 #: pkg/docker/containers-view.jsx:494
 msgid "This image does not exist."
 msgstr "该镜像不存在。"
@@ -8551,12 +6717,6 @@ msgstr "该主机已经被添加。"
 #: pkg/realmd/operation.html:80
 msgid "This may take a while"
 msgstr "这可能需要一些时间"
-
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid ""
-"This option is for single node testing only – local storage will not work in "
-"a multi-node cluster"
-msgstr "该选项仅适用于单节点测试 – 本地存储将无法在多节点集群中工作"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
@@ -8593,7 +6753,7 @@ msgstr "该单元是模板 $0 的实例."
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "该单元没有设计为需要明确启用。"
 
-#: pkg/users/local.js:557
+#: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "用户名已存在"
 
@@ -8603,24 +6763,7 @@ msgid ""
 "alternate user or port"
 msgstr "该版本的 cockpit-ws 不支持连接到有交替的用户或端口的主机"
 
-#: pkg/ovirt/components/OVirtTab.jsx:134
-msgid "This virtual machine is not managed by oVirt"
-msgstr "该虚拟机没有被 oVirt 管理"
-
-#: pkg/kubernetes/views/pv-delete.html:7
-msgid ""
-"This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / {{ "
-"item.item.spec.claimRef.name }}. Deleting it will break that claim and may "
-"cause issues with any pods depending on it."
-msgstr ""
-"该卷已经被 {{ item.item.spec.claimRef.namespace }} / {{ item.item.spec.claimRef."
-"name }} 声明。删除它将会损坏该声明，并会影响到依赖它的 pod。"
-
-#: pkg/kubernetes/views/pv-claim.html:23
-msgid "This volume has not been claimed"
-msgstr "该卷未被声明"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:369
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
 msgid "This volume is already used by another VM."
 msgstr "这个卷已被另外一个虚拟机使用"
 
@@ -8641,14 +6784,15 @@ msgid ""
 "This will test kdump settings by crashing the kernel and thereby the system. "
 "Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
-msgstr "这将通过崩溃内核和系统来测试 kdump 设置。取决于这些设置，系统也许不会自动重启，并且过程将持续一段时间。"
+msgstr ""
+"这将通过崩溃内核和系统来测试 kdump 设置。取决于这些设置，系统也许不会自动重"
+"启，并且过程将持续一段时间。"
 
 #: pkg/kdump/kdump-view.jsx:489
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "这将通过崩溃内核来测试 kdump 配置。"
 
 #: pkg/machines/components/vcpuModal.jsx:212
-#: pkg/ovirt/components/vcpuModal.jsx:70
 msgid "Threads per core"
 msgstr "每个内核的线程数"
 
@@ -8678,7 +6822,8 @@ msgstr "提示：确保您的关键密码匹配登录密码来自动验证其他
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
-msgstr "为了获取软件更新，该系统需要通过红帽客户门户网站或本地订阅服务器注册到红帽。"
+msgstr ""
+"为了获取软件更新，该系统需要通过红帽客户门户网站或本地订阅服务器注册到红帽。"
 
 #: node_modules/registry-image-widgets/views/image-pull.html:4
 msgid "To pull this image:"
@@ -8694,10 +6839,6 @@ msgid ""
 "version."
 msgstr "为了尝试一个不同的端口，需要把 cockpit-ws 升级到一个新版本。"
 
-#: pkg/kubernetes/views/auth-form.html:116
-msgid "Token"
-msgstr "令牌"
-
 #: pkg/lib/cockpit-components-file-autocomplete.jsx:148
 msgid "Too many files found"
 msgstr "找到太多文件"
@@ -8705,10 +6846,6 @@ msgstr "找到太多文件"
 #: src/base1/cockpit.js:4039
 msgid "Too much data"
 msgstr "太多数据"
-
-#: pkg/kubernetes/index.html:61
-msgid "Topology"
-msgstr "拓扑"
 
 #: pkg/docker/storage.jsx:341
 msgid "Total"
@@ -8726,12 +6863,11 @@ msgstr "Tower"
 msgid "Triggered By"
 msgstr "触发于"
 
-#: pkg/kubernetes/views/deploymentconfig-body.html:32 pkg/systemd/init.js:732
+#: pkg/systemd/init.js:732
 msgid "Triggers"
 msgstr "触发器"
 
-#: pkg/kubernetes/index.html:109 pkg/shell/index.html:387
-#: pkg/shell/simple.html:139 pkg/shell/stub.html:181
+#: pkg/shell/index.html:387 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "排错"
@@ -8740,13 +6876,9 @@ msgstr "排错"
 msgid "Trust key"
 msgstr "信任密钥"
 
-#: pkg/networkmanager/firewall.jsx:703
+#: pkg/networkmanager/firewall.jsx:705
 msgid "Trust level"
 msgstr "信任级别"
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:21
-msgid "Trust this certificate for this connection"
-msgstr "为该连接信任该证书"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -8788,20 +6920,17 @@ msgstr "Tuned 未运行"
 msgid "Tuned is off"
 msgstr "Tuned 已关闭"
 
-#: pkg/kubernetes/views/deploy.html:9 pkg/kubernetes/views/pv-modify.html:10
-#: pkg/kubernetes/views/service-body.html:11
-#: pkg/kubernetes/views/volumes-page.html:20 pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:84
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "类型"
 
@@ -8817,16 +6946,11 @@ msgstr "输入密码"
 msgid "Type to filter…"
 msgstr "输入内容来过滤…"
 
-#: pkg/kubernetes/views/details-page.html:7
-msgid "Type:"
-msgstr "类型:"
-
-#: pkg/docker/index.html:332 pkg/networkmanager/firewall.jsx:936
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
-#: pkg/subscriptions/subscriptions-register.jsx:112
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
 msgid "URL"
 msgstr "URL"
 
@@ -8842,17 +6966,9 @@ msgstr "无法应用设置： $0"
 msgid "Unable to apply this solution automatically"
 msgstr "无法自动应用该方案"
 
-#: pkg/subscriptions/subscriptions-view.jsx:217
-msgid "Unable to connect"
-msgstr "无法连接"
-
 #: src/ws/login.js:649
 msgid "Unable to connect to that address"
 msgstr "无法连接至该地址"
-
-#: pkg/kubernetes/scripts/dashboard.js:412
-msgid "Unable to decode Kubernetes application manifest."
-msgstr "无法解码 Kubernetes 应用清单。"
 
 #: pkg/users/local.js:58
 msgid "Unable to delete root account"
@@ -8870,10 +6986,6 @@ msgstr "无法获取警告： $0"
 #: pkg/storaged/iscsi-panel.jsx:88
 msgid "Unable to reach server"
 msgstr "无法到达服务器"
-
-#: pkg/kubernetes/scripts/dashboard.js:400
-msgid "Unable to read the Kubernetes application manifest. Code $0."
-msgstr "无法读取 Kubernetes 应用程序清单。代码 $0."
 
 #: pkg/storaged/nfs-details.jsx:282
 msgid "Unable to remove mount"
@@ -8900,16 +7012,15 @@ msgid "Unable to unmount filesystem"
 msgstr "无法卸载文件系统"
 
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
-#: pkg/kubernetes/scripts/charts.js:110
 msgid "Unavailable"
 msgstr "不可用"
 
-#: pkg/docker/index.html:730 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1481
+#: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
+#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "意外的错误"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:132
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid "Unique name"
 msgstr "唯一名称"
 
@@ -8918,19 +7029,14 @@ msgstr "唯一名称"
 msgid "Unit"
 msgstr "单位"
 
-#: pkg/kubernetes/views/node-body.html:12
-#: pkg/kubernetes/views/node-body.html:43 pkg/kubernetes/views/pv-body.html:26
-#: pkg/kubernetes/views/pv-claim.html:31
-#: pkg/kubernetes/views/volumes-page.html:35
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/kubernetes/scripts/nodes.js:316 pkg/kubernetes/scripts/nodes.js:660
-#: pkg/kubernetes/scripts/nodes.js:754 pkg/kubernetes/scripts/volumes.js:267
-#: pkg/lib/machine-info.js:65 pkg/networkmanager/interfaces.js:596
-#: pkg/networkmanager/interfaces.js:1067 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2534 pkg/storaged/fsys-tab.jsx:64
-#: pkg/storaged/swap-tab.jsx:57
+#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
+#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "未知"
 
@@ -8966,7 +7072,7 @@ msgstr "未知的服务名"
 msgid "Unknown type"
 msgstr "未知类型"
 
-#: pkg/docker/index.html:549 pkg/docker/util.js:110
+#: pkg/docker/index.html:551 pkg/docker/util.js:110
 msgid "Unless Stopped"
 msgstr "直到被停止"
 
@@ -9015,7 +7121,7 @@ msgstr "卸载 $target"
 msgid "Unnamed"
 msgstr "未命名"
 
-#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:184
 msgid "Unplug"
 msgstr "拔"
 
@@ -9031,14 +7137,6 @@ msgstr "无法识别的数据"
 #: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
 msgid "Unrecognized data can not be made smaller here."
 msgstr "这里不能把无法识别的数据变小。"
-
-#: pkg/subscriptions/subscriptions-view.jsx:164
-msgid "Unregister"
-msgstr "注销"
-
-#: pkg/subscriptions/subscriptions-view.jsx:170
-msgid "Unregistering system..."
-msgstr "正在注销系统..."
 
 #: node_modules/registry-image-widgets/views/image-listing.html:46
 msgid "Unresolved"
@@ -9061,7 +7159,12 @@ msgstr "不可信的主机"
 msgid "Up since $0"
 msgstr "运行自 $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:316
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+#, fuzzy
+msgid "Up to $0 $1 available in the default location"
+msgstr "在主机上最多有 $0 $1 可用"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
 msgid "Up to $0 $1 available on the host"
 msgstr "在主机上最多有 $0 $1 可用"
 
@@ -9089,13 +7192,9 @@ msgstr "已更新的软件包可能需要重启生效。"
 msgid "Updates Available"
 msgstr "可用的更新"
 
-#: pkg/packagekit/updates.jsx:52 pkg/subscriptions/subscriptions-view.jsx:209
+#: pkg/packagekit/updates.jsx:52
 msgid "Updating"
 msgstr "更新"
-
-#: pkg/kubernetes/scripts/details.js:654
-msgid "Updating $0..."
-msgstr "更新 $0..."
 
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
@@ -9110,20 +7209,15 @@ msgstr[0] "使用 $0 CPU 内核"
 msgid "Use 512 Byte emulation"
 msgstr "使用 512 字节模拟"
 
-#: pkg/machines/components/diskAdd.jsx:496
+#: pkg/machines/components/diskAdd.jsx:524
 msgid "Use Existing"
 msgstr "使用现有的"
-
-#: pkg/subscriptions/subscriptions-register.jsx:136
-msgid "Use proxy server"
-msgstr "使用代理服务器"
 
 #: pkg/shell/index.html:168
 msgid "Use the following keys to authenticate against other systems"
 msgstr "使用以下密钥来验证其他系统"
 
 #: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
-#: pkg/kubernetes/scripts/nodes.js:829 pkg/kubernetes/scripts/nodes.js:838
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
@@ -9135,18 +7229,13 @@ msgstr "已使用"
 msgid "Used by"
 msgstr "用于"
 
-#: pkg/docker/index.html:262
+#: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "被容器使用"
 
-#: pkg/dashboard/index.html:144 pkg/kubernetes/views/auth-form.html:61
-#: pkg/kubernetes/views/user-group-add.html:9
-#: pkg/kubernetes/views/user-page.html:20
-#: pkg/kubernetes/views/user-panel.html:9
-#: pkg/kubernetes/views/volume-body.html:64
-#: pkg/kubernetes/views/volume-body.html:103 pkg/playground/translate.html:85
+#: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/subscriptions/subscriptions-register.jsx:77 pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1584
 msgid "User"
 msgstr "用户"
 
@@ -9155,11 +7244,11 @@ msgstr "用户"
 msgid "User Name"
 msgstr "用户名"
 
-#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:337
+#: pkg/realmd/operation.html:59 pkg/realmd/operation.js:336
 msgid "User Password"
 msgstr "用户密码"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "用户名"
@@ -9168,18 +7257,9 @@ msgstr "用户名"
 msgid "User name cannot be empty"
 msgstr "用户名不能为空"
 
-#: pkg/kubernetes/views/add-member-role-dialog.html:15
-msgid "User or Group"
-msgstr "用户或组"
-
-#: pkg/kubernetes/views/auth-form.html:94 pkg/storaged/iscsi-panel.jsx:46
-#: pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
 msgid "Username"
 msgstr "用户名"
-
-#: pkg/kubernetes/views/project-listing.html:85
-msgid "Users"
-msgstr "用户"
 
 #: pkg/lib/machine-change-auth.html:44
 msgid "Using available credentials"
@@ -9218,14 +7298,6 @@ msgstr "VDO 后台设备不能更小"
 msgid "VDO support not installed"
 msgstr "未安装 VDO 的支持"
 
-#: pkg/ovirt/components/App.jsx:115
-msgid "VDSM"
-msgstr "VDSM"
-
-#: pkg/ovirt/components/VdsmView.jsx:128
-msgid "VDSM Service Management"
-msgstr "VDSM 服务管理"
-
 #: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
 #: pkg/networkmanager/interfaces.js:2906
 msgid "VLAN"
@@ -9255,7 +7327,7 @@ msgstr "VM $0 强制关闭失败"
 msgid "VM $0 failed to get deleted"
 msgstr "VM $0 删除失败"
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1317
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
 msgid "VM $0 failed to get installed"
 msgstr "VM $0 安装失败"
 
@@ -9279,10 +7351,6 @@ msgstr "VM $0 关闭失败"
 msgid "VM $0 failed to start"
 msgstr "VM $0 启动失败"
 
-#: pkg/ovirt/components/VmOverviewColumn.jsx:37
-msgid "VM icon"
-msgstr "虚拟机图标"
-
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
 msgstr "VNC"
@@ -9299,7 +7367,7 @@ msgstr "VNC 端口："
 msgid "VNC TLS Port:"
 msgstr "VNC TLS 端口："
 
-#: pkg/realmd/operation.js:165
+#: pkg/realmd/operation.js:164
 msgid "Validating address"
 msgstr "验证地址"
 
@@ -9328,30 +7396,20 @@ msgstr "验证密钥"
 msgid "Verifying"
 msgstr "正在验证"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/shell/stub.html:71
-#: pkg/systemd/index.html:110 pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:83 pkg/packagekit/updates.jsx:381
-#: pkg/subscriptions/subscriptions-view.jsx:35 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "版本"
-
-#: pkg/ovirt/components/ClusterVms.jsx:83
-msgid "Version num"
-msgstr "版本号"
 
 #: pkg/storaged/jobs-panel.jsx:57
 msgid "Very securely erasing $target"
 msgstr "非常安全地擦除 $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "虚拟机"
-
-#: pkg/ovirt/components/ClusterVms.jsx:176
-msgid "Virtual Machines of $0 cluster"
-msgstr "$0 集群地虚拟机"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
@@ -9365,14 +7423,11 @@ msgstr "虚拟化服务（libvirt）未激活"
 msgid "Virtualization Service is Available"
 msgstr "虚拟化服务可用"
 
-#: pkg/kubernetes/views/pv-page.html:13 pkg/kubernetes/views/pv-panel.html:10
-#: pkg/kubernetes/views/pvc-body.html:6
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:359
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "卷"
 
@@ -9380,7 +7435,7 @@ msgstr "卷"
 msgid "Volume Group"
 msgstr "卷组"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:233
+#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "卷组 $0"
 
@@ -9388,32 +7443,16 @@ msgstr "卷组 $0"
 msgid "Volume Groups"
 msgstr "卷组"
 
-#: pkg/kubernetes/views/volume-body.html:14
-#: pkg/kubernetes/views/volume-body.html:89
-msgid "Volume ID"
-msgstr "卷 ID"
-
-#: pkg/kubernetes/views/pv-modify.html:115
-#: pkg/kubernetes/views/volume-body.html:42
-msgid "Volume Name"
-msgstr "卷名称"
-
-#: pkg/kubernetes/views/pvc-body.html:2 pkg/kubernetes/views/volume-body.html:1
-msgid "Volume Type"
-msgstr "卷类型"
-
 #: pkg/storaged/lvol-tabs.jsx:410
 msgid "Volume size is $0. Content size is $1."
 msgstr "卷大小为 $0。内容大小为 $1。"
 
-#: pkg/docker/index.html:515 pkg/kubernetes/index.html:74
-#: pkg/kubernetes/views/dashboard-page.html:47
-#: pkg/kubernetes/views/pod-page.html:18
+#: pkg/docker/index.html:517
 #: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "卷"
 
-#: pkg/docker/index.html:199
+#: pkg/docker/index.html:200
 msgid "Volumes:"
 msgstr "卷"
 
@@ -9451,10 +7490,6 @@ msgstr "需要"
 msgid "Warning and above"
 msgstr "Warning 及以上"
 
-#: pkg/kubernetes/views/pv-modify.html:24
-msgid "Warning:"
-msgstr "警告:"
-
 #: cockpit.appdata.xml.in.h:1
 msgid "Web Console for Linux servers"
 msgstr "Linux 服务器的 Web 控制台"
@@ -9471,23 +7506,15 @@ msgstr "周三"
 msgid "Weeks"
 msgstr "周"
 
-#: pkg/kubernetes/views/registry-dashboard-page.html:5
-msgid "Welcome to the Image Registry"
-msgstr "欢迎使用 Image Registry"
-
 #: pkg/storaged/crypto-keyslots.jsx:324
 msgid "What if tang-show-keys is not available?"
 msgstr "如果没有 tang-show-keys？"
-
-#: pkg/kubernetes/views/volumes-page.html:61
-msgid "When"
-msgstr "当"
 
 #: pkg/systemd/terminal.jsx:101
 msgid "White"
 msgstr "白"
 
-#: pkg/docker/index.html:486
+#: pkg/docker/index.html:488
 msgid "With terminal"
 msgstr "带有终端"
 
@@ -9507,7 +7534,7 @@ msgstr "错误的用户名或密码"
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/kubernetes/scripts/volumes.js:996 pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2593
 msgid "Yes"
 msgstr "是"
 
@@ -9515,7 +7542,9 @@ msgstr "是"
 msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
-msgstr "已经连接到 {{#strong}}{{host}}{{/strong}}，然而为了同步用户，需要一个特权用户。"
+msgstr ""
+"已经连接到 {{#strong}}{{host}}{{/strong}}，然而为了同步用户，需要一个特权用"
+"户。"
 
 #: pkg/dashboard/list.js:440
 msgid ""
@@ -9523,19 +7552,9 @@ msgid ""
 msgstr "您当前已直接连接到该服务器。您不能删除它。"
 
 #: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:871 pkg/networkmanager/firewall.jsx:877
+#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
 msgid "You are not authorized to modify the firewall."
 msgstr "您无权修改防火墙。"
-
-#: pkg/kubernetes/views/auth-rejected-cert.html:3
-msgid ""
-"You can bypass the certificate check, but any data you send to the server "
-"could be intercepted by others."
-msgstr "可以通过证书检查，但是发送到服务器的任何数据可能被其他人拦截。"
-
-#: pkg/kubernetes/views/dashboard-page.html:150
-msgid "You can deploy an application to your cluster."
-msgstr "可以部署一个应用到集群中。"
 
 #: pkg/users/index.html:390
 msgid ""
@@ -9551,7 +7570,7 @@ msgstr "您没有权限管理 Docker 存储池"
 msgid "You must wait longer to change your password"
 msgstr "您需要等待更长时间来修改您的密码"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:89
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
 msgid ""
 "You need to select the most closely matching OS vendor and Operating System"
 msgstr "您需要选择最接近的 OS 厂商和操作系统"
@@ -9560,13 +7579,9 @@ msgstr "您需要选择最接近的 OS 厂商和操作系统"
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
-msgstr "您的浏览器将断开连接，但这不会影响更新过程。您可以在几分钟后重新连接以继续观察进度。"
-
-#: pkg/kubernetes/views/registry-dashboard-page.html:112
-msgid ""
-"Your login credentials do not give you access to use the docker registry "
-"from the command line."
-msgstr "登录凭证没有从命令行使用 Docker  registry 的权限"
+msgstr ""
+"您的浏览器将断开连接，但这不会影响更新过程。您可以在几分钟后重新连接以继续观"
+"察进度。"
 
 #: pkg/packagekit/updates.jsx:865
 msgid ""
@@ -9582,11 +7597,11 @@ msgstr "会话被终止。"
 msgid "Your session has expired. Please log in again."
 msgstr "会话超时。请重新登录。"
 
-#: pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Zone"
 msgstr "区域"
 
-#: pkg/networkmanager/firewall.jsx:936
+#: pkg/networkmanager/firewall.jsx:938
 msgid "Zones"
 msgstr "区域"
 
@@ -9602,8 +7617,12 @@ msgstr "[二进制数据]"
 msgid "[no data]"
 msgstr "[没有数据]"
 
-#: pkg/machines/components/networks/network.jsx:58
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "激活"
@@ -9637,17 +7656,9 @@ msgstr "字节"
 msgid "cdrom"
 msgstr "光驱"
 
-#: pkg/ovirt/rephraseUI.js:35
-msgid "connecting"
-msgstr "正在连接"
-
 #: pkg/machines/components/infoRecord.jsx:29
 msgid "control-label $0"
 msgstr "control-label $0"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "cores"
-msgstr "核"
 
 #: pkg/machines/helpers.js:193
 msgid "crashed"
@@ -9666,7 +7677,6 @@ msgid "direct"
 msgstr "直接"
 
 #: pkg/machines/helpers.js:177 pkg/machines/helpers.js:180
-#: pkg/ovirt/components/OVirtTab.jsx:123
 msgid "disabled"
 msgstr "已禁用"
 
@@ -9674,7 +7684,7 @@ msgstr "已禁用"
 msgid "disk"
 msgstr "磁盘"
 
-#: pkg/machines/helpers.js:238 pkg/ovirt/rephraseUI.js:27
+#: pkg/machines/helpers.js:238
 msgid "down"
 msgstr "已关闭"
 
@@ -9682,26 +7692,17 @@ msgstr "已关闭"
 msgid "dying"
 msgstr "失活的"
 
-#: pkg/realmd/operation.js:299 pkg/realmd/operation.js:305
+#: pkg/realmd/operation.js:298 pkg/realmd/operation.js:304
 msgid "e.g. \"$0\""
 msgstr "例如 \"$0\""
 
-#: pkg/kubernetes/scripts/images.js:639
-msgid "eg: my-image-stream"
-msgstr "例如：my-image-stream"
-
 #: pkg/machines/helpers.js:178 pkg/machines/helpers.js:181
-#: pkg/ovirt/components/OVirtTab.jsx:125
 msgid "enabled"
 msgstr "已启用"
 
 #: pkg/packagekit/updates.jsx:267
 msgid "enhancement"
 msgstr "性能强化"
-
-#: pkg/ovirt/rephraseUI.js:28
-msgid "error"
-msgstr "错误"
 
 #: pkg/machines/helpers.js:214
 msgid "ethernet"
@@ -9727,7 +7728,7 @@ msgstr "主机设备"
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:182
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
 msgid "iSCSI Initiator IQN"
 msgstr "iSCSI Initiator IQN"
 
@@ -9743,7 +7744,7 @@ msgstr "iSCSI 目标"
 msgid "iSCSI direct Target"
 msgstr "iSCSI 直接目标"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
 msgid "iSCSI target IQN"
 msgstr "iSCSI 目标 IQN"
 
@@ -9751,22 +7752,10 @@ msgstr "iSCSI 目标 IQN"
 msgid "idle"
 msgstr "休眠"
 
-#: pkg/machines/components/networks/network.jsx:58
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "未激活"
-
-#: pkg/ovirt/rephraseUI.js:29
-msgid "initializing"
-msgstr "正在初始化"
-
-#: pkg/ovirt/rephraseUI.js:30
-msgid "installation failed"
-msgstr "安装失败"
-
-#: pkg/ovirt/rephraseUI.js:38
-msgid "installing OS"
-msgstr "正在安装操作系统"
 
 #: pkg/kdump/kdump-view.jsx:376
 msgid "invalid: multiple targets defined"
@@ -9775,10 +7764,6 @@ msgstr "无效：定义了多个目标"
 #: pkg/kdump/kdump-view.jsx:493
 msgid "kdump status"
 msgstr "kdump 状态"
-
-#: pkg/ovirt/rephraseUI.js:39
-msgid "kdumping"
-msgstr "正在执行内核转储"
 
 #: pkg/docker/run.js:527
 msgid "key"
@@ -9792,10 +7777,6 @@ msgstr "钥匙槽 $0"
 msgid "locally in $0"
 msgstr "位于 $0 本地"
 
-#: pkg/ovirt/rephraseUI.js:31
-msgid "maintenance"
-msgstr "维护"
-
 #: pkg/machines/helpers.js:216
 msgid "mcast"
 msgstr "MCAST"
@@ -9808,58 +7789,18 @@ msgstr "网络"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs dump 目标的格式不是 server:path"
 
-#: pkg/kubernetes/views/route-body.html:14
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:43
 msgid "no"
 msgstr "否"
 
-#: pkg/ovirt/rephraseUI.js:32
-msgid "non operational"
-msgstr "不可操作"
-
-#: pkg/ovirt/rephraseUI.js:33
-msgid "non responsive"
-msgstr "未响应"
-
-#: pkg/kubernetes/views/node-body.html:33
-#: pkg/kubernetes/views/node-body.html:59
-#: pkg/kubernetes/views/route-body.html:24
-#: pkg/kubernetes/views/route-body.html:29
 #: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "空"
-
-#: pkg/ovirt/provider.js:62
-msgid "oVirt"
-msgstr "oVirt"
-
-#: pkg/ovirt/components/HostStatus.jsx:37
-msgid "oVirt Host State:"
-msgstr "oVirt 主机状态："
-
-#: pkg/ovirt/components/InstallationDialog.jsx:35
-msgid "oVirt Provider installation script failed due to missing arguments."
-msgstr "oVirt 供应商安装脚本因缺少参数失败。"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:36
-msgid ""
-"oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-"machines-ovirt.config, try as root."
-msgstr "oVirt 供应商安装脚本失败：无法写入 /etc/cockpit/machines-ovirt.config，尝试重启。"
-
-#: pkg/ovirt/components/InstallationDialog.jsx:164
-msgid "oVirt installation script failed with following output: "
-msgstr "oVirt 供应商安装脚本失败，输出以下信息："
-
-#: pkg/ovirt/components/App.jsx:51
-msgid "oVirt login in progress"
-msgstr "正在登录oVirt"
 
 #: pkg/systemd/host.js:691
 msgid "of $0 CPU core"
@@ -9870,25 +7811,13 @@ msgstr[0] "$0 CPU 内核"
 msgid "paused"
 msgstr "已暂停"
 
-#: pkg/ovirt/rephraseUI.js:34
-msgid "pending approval"
-msgstr "等待批准"
-
-#: pkg/kubernetes/views/dashboard-page.html:83
-msgid "pending volume claims"
-msgstr "挂起的卷声明"
-
-#: pkg/machines/components/diskAdd.jsx:174
+#: pkg/machines/components/diskAdd.jsx:154
 msgid "qcow2"
 msgstr "qcow2"
 
-#: pkg/machines/components/diskAdd.jsx:177
+#: pkg/machines/components/diskAdd.jsx:157
 msgid "raw"
 msgstr "raw"
-
-#: pkg/ovirt/rephraseUI.js:36
-msgid "reboot"
-msgstr "重启"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -9910,7 +7839,7 @@ msgstr "通过名称、命名空间或描述来搜索"
 msgid "security"
 msgstr "安全"
 
-#: pkg/docker/index.html:404
+#: pkg/docker/index.html:406
 msgid "select container"
 msgstr "选择容器"
 
@@ -9918,7 +7847,7 @@ msgstr "选择容器"
 msgid "server"
 msgstr "服务器"
 
-#: pkg/docker/index.html:483 pkg/docker/index.html:655
+#: pkg/docker/index.html:485 pkg/docker/index.html:657
 msgid "shares"
 msgstr "共享"
 
@@ -9937,10 +7866,6 @@ msgstr "关闭"
 #: pkg/machines/helpers.js:191
 msgid "shutdown"
 msgstr "关机"
-
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "sockets"
-msgstr "套接字"
 
 #: pkg/selinux/setroubleshoot-view.jsx:123
 msgid "solution details"
@@ -9962,10 +7887,6 @@ msgstr "ssh 服务器为空"
 msgid "suspended (PM)"
 msgstr "已挂起 （电源管理）"
 
-#: pkg/ovirt/components/ClusterVms.jsx:46
-msgid "threads"
-msgstr "线程"
-
 #: pkg/docker/run.js:474
 msgid "to host path"
 msgstr "到主机路径"
@@ -9981,10 +7902,6 @@ msgstr "翻译"
 #: pkg/machines/helpers.js:218
 msgid "udp"
 msgstr "udp"
-
-#: pkg/ovirt/rephraseUI.js:37
-msgid "unassigned"
-msgstr "未指定"
 
 #: pkg/lib/cockpit-components-select.jsx:28
 msgid "undefined"
@@ -10003,7 +7920,7 @@ msgstr "未知目标"
 msgid "unpartitioned space on $0"
 msgstr "$0 上未分区的空间"
 
-#: pkg/machines/helpers.js:237 pkg/ovirt/rephraseUI.js:26
+#: pkg/machines/helpers.js:237
 msgid "up"
 msgstr "运行中"
 
@@ -10012,7 +7929,6 @@ msgid "user"
 msgstr "用户"
 
 #: pkg/machines/components/vcpuModal.jsx:192
-#: pkg/ovirt/components/vcpuModal.jsx:54
 msgid "vCPU Count"
 msgstr "vCPU 数"
 
@@ -10021,8 +7937,6 @@ msgid "vCPU Maximum"
 msgstr "vCPU 的最大值"
 
 #: pkg/machines/components/vmOverviewTab.jsx:75
-#: pkg/ovirt/components/ClusterTemplates.jsx:135
-#: pkg/ovirt/components/ClusterVms.jsx:181
 msgid "vCPUs"
 msgstr "vCPU"
 
@@ -10034,12 +7948,16 @@ msgstr "值"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/kubernetes/views/route-body.html:13
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+msgid ""
+"virt-install package needs to be installed on the system in order to create "
+"new VMs"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
-#: pkg/ovirt/components/ClusterVms.jsx:38 pkg/ovirt/rephraseUI.js:42
 msgid "yes"
 msgstr "是"
 
@@ -10048,5 +7966,1371 @@ msgid ""
 "{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
 "count: {{ condition.generation }}"
 msgstr ""
-"{{ condition.message }}。时间戳： {{ condition.lastTransitionTime }} 错误计数： {{ "
-"condition.generation }}"
+"{{ condition.message }}。时间戳： {{ condition.lastTransitionTime }} 错误计"
+"数： {{ condition.generation }}"
+
+#~ msgid " 1\"Do you want to delete the following Nodes?"
+#~ msgstr " 1\"是否要删除以下节点？"
+
+#~ msgid "$0 vCPU Details"
+#~ msgstr "$0 vCPU 详情"
+
+#~ msgid "$0% Free"
+#~ msgid_plural "$0% Free"
+#~ msgstr[0] "$0% 剩余"
+
+#~ msgid "$0% Used"
+#~ msgid_plural "$0% Used"
+#~ msgstr[0] "$0% 已使用"
+
+#~ msgid "'Organization' required to register."
+#~ msgstr "需要注册“组织”。"
+
+#~ msgid "'Organization' required when using activation keys."
+#~ msgstr "当使用激活码时需要“组织”。"
+
+#~ msgid "AWS Elastic Block Store"
+#~ msgstr "AWS 弹性块存储"
+
+#~ msgid "Access Modes"
+#~ msgstr "访问模式"
+
+#~ msgid "Access denied"
+#~ msgstr "访问被拒绝"
+
+#~ msgid "Action"
+#~ msgstr "操作"
+
+#~ msgid "Activation Key"
+#~ msgstr "激活码"
+
+#~ msgid "Actual"
+#~ msgstr "真实的"
+
+#~ msgid "Add Cluster Node"
+#~ msgstr "添加集群节点"
+
+#~ msgid "Add Group"
+#~ msgstr "添加组"
+
+#~ msgid "Add Kubernetes Node"
+#~ msgstr "添加 Kubernetes 节点"
+
+#~ msgid "Add Member"
+#~ msgstr "添加成员"
+
+#~ msgid "Add Membership"
+#~ msgstr "添加成员关系"
+
+#~ msgid "Add New Cluster"
+#~ msgstr "添加新集群"
+
+#~ msgid "Add New User"
+#~ msgstr "添加新用户"
+
+#~ msgid "Add Role"
+#~ msgstr "添加角色"
+
+#~ msgid "Add User"
+#~ msgstr "添加用户"
+
+#~ msgid "Add membership"
+#~ msgstr "添加成员关系"
+
+#~ msgid "Adjust"
+#~ msgstr "调整"
+
+#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
+#~ msgstr "调整持久卷 '{{ item.metadata.name }}'"
+
+#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
+#~ msgstr "调整复制控制器 {{ item.metadata.name }}"
+
+#~ msgid "Adjust Route"
+#~ msgstr "调整路由"
+
+#~ msgid "Adjust Service"
+#~ msgstr "调整服务"
+
+#~ msgid "Admin"
+#~ msgstr "管理"
+
+#~ msgid "All Projects"
+#~ msgstr "所有项目"
+
+#~ msgid "All Types"
+#~ msgstr "所有类型"
+
+#~ msgid "All healthy"
+#~ msgstr "所有健康的"
+
+#~ msgid "All images"
+#~ msgstr "所有镜像"
+
+#~ msgid "All in use"
+#~ msgstr "所有正在使用的"
+
+#~ msgid "All running"
+#~ msgstr "所有运行的"
+
+#~ msgid "All running virtual machines will be turned off."
+#~ msgstr "将关闭所有正在运行的虚拟机。"
+
+#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
+#~ msgstr "匿名用户：允许所有未验证的用户获取镜像"
+
+#~ msgid "Automatically selected host"
+#~ msgstr "自动选择的主机"
+
+#~ msgid "Azure"
+#~ msgstr "Azure"
+
+#~ msgid "Base Template"
+#~ msgstr "基础模板"
+
+#~ msgid "Base template"
+#~ msgstr "基础模板"
+
+#~ msgid "Base template:"
+#~ msgstr "基础模板："
+
+#~ msgid "Boot ID"
+#~ msgstr "引导 ID"
+
+#~ msgid "CPU Utilization: $0%"
+#~ msgstr "CPU 使用率: $0%"
+
+#~ msgid "CREATE VM action failed"
+#~ msgstr "创建虚拟机操作失败"
+
+#~ msgid "Cannot decrypt PEM-encoded private key"
+#~ msgstr "无法解密 PEM 编码的私钥"
+
+#~ msgid "Ceph Filesystem Mount"
+#~ msgstr "Ceph 文件系统挂载"
+
+#~ msgid "Ceph Monitors"
+#~ msgstr "Ceph 监视器"
+
+#~ msgid "Change User"
+#~ msgstr "变更用户"
+
+#~ msgid "Change image stream"
+#~ msgstr "变更镜像流"
+
+#~ msgid "Change project"
+#~ msgstr "变更项目"
+
+#~ msgid "Cinder"
+#~ msgstr "Cinder"
+
+#~ msgid "Claim"
+#~ msgstr "声明"
+
+#~ msgid "Claim Name"
+#~ msgstr "声明名称"
+
+#~ msgid "Client Certificate"
+#~ msgstr "客户端证书"
+
+#~ msgid "Cluster"
+#~ msgstr "集群"
+
+#~ msgid "Cluster Templates"
+#~ msgstr "集群模板"
+
+#~ msgid "Cluster Virtual Machines"
+#~ msgstr "集群虚拟机"
+
+#~ msgid "Configuration"
+#~ msgstr "配置"
+
+#~ msgid "Configure Flannel networking"
+#~ msgstr "配置 Flannel 网络"
+
+#~ msgid "Configure Kubelet and Proxy"
+#~ msgstr "配置 Kubelet 和代理"
+
+#~ msgid "Confirm migration"
+#~ msgstr "确认迁移"
+
+#~ msgid "Confirm reload:"
+#~ msgstr "确认重新加载："
+
+#~ msgid "Confirm save:"
+#~ msgstr "确认保存："
+
+#~ msgid "Connect to oVirt Engine"
+#~ msgstr "连接至 oVirt 引擎"
+
+#~ msgid "Connecting..."
+#~ msgstr "连接中..."
+
+#~ msgid "Connection Error: $0"
+#~ msgstr "连接错误: $0"
+
+#~ msgid "Connection Settings"
+#~ msgstr "连接设置"
+
+#~ msgid "Container ID"
+#~ msgstr "容器 ID"
+
+#~ msgid "Container Runtime Version"
+#~ msgstr "容器运行时版本"
+
+#~ msgid "Could not list services"
+#~ msgstr "无法列出服务"
+
+#~ msgid "Could not parse PEM-encoded certificate"
+#~ msgstr "无法解析 PEM 编码的证书"
+
+#~ msgid "Could not parse PEM-encoded private key"
+#~ msgstr "无法解析 PEM 编码的私钥"
+
+#~ msgid "Couldn't connect to server"
+#~ msgstr "无法连接到服务器"
+
+#~ msgid "Couldn't find running API server"
+#~ msgstr "无法找到运行的 API 服务器"
+
+#~ msgid ""
+#~ "Couldn't get system subscription status. Please ensure subscription-"
+#~ "manager is installed."
+#~ msgstr "无法获取系统订阅状态。请确认 subscription-manager 已安装。"
+
+#~ msgid "Create New VM"
+#~ msgstr "新建 VM"
+
+#~ msgid "Create empty image stream"
+#~ msgstr "创建空镜像流"
+
+#~ msgid "Create image stream"
+#~ msgstr "创建镜像流"
+
+#~ msgid "Custom URL"
+#~ msgstr "自定义 URL"
+
+#~ msgid "DNS Policy"
+#~ msgstr "DNS 策略"
+
+#~ msgid "Delete '{{ name }}'"
+#~ msgstr "删除 '{{ name }}'"
+
+#~ msgid "Delete Node"
+#~ msgstr "删除节点"
+
+#~ msgid "Delete Persistent Volume"
+#~ msgstr "删除持久卷"
+
+#~ msgid "Delete Persistent Volume Claim"
+#~ msgstr "删除持久卷声明"
+
+#~ msgid "Delete Project"
+#~ msgstr "删除项目"
+
+#~ msgid "Delete Selected"
+#~ msgstr "删除所选的"
+
+#~ msgid "Delete image stream"
+#~ msgstr "删除镜像流"
+
+#~ msgid "Delete {{ item.kind }}"
+#~ msgstr "删除 {{ item.kind }}"
+
+#~ msgid ""
+#~ "Deleting a Pod will kill all associated containers. Pods may be "
+#~ "automatically created again in some cases."
+#~ msgstr "删除 Pod 将会终止所有相关的容器。Pod 可能会在某些情况下被自动创建。"
+
+#~ msgid "Deploy"
+#~ msgstr "部署"
+
+#~ msgid "Deploy Application"
+#~ msgstr "部署应用"
+
+#~ msgid "Deployment Causes"
+#~ msgstr "部署原因"
+
+#~ msgid "Deployment Config"
+#~ msgstr "部署配置"
+
+#~ msgid "Deployment Configs"
+#~ msgstr "部署配置"
+
+#~ msgid "Description:"
+#~ msgstr "描述："
+
+#~ msgid "Disk Utilization: $0%"
+#~ msgstr "磁盘使用率: $0%"
+
+#~ msgid "Display name"
+#~ msgstr "显示名称"
+
+#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
+#~ msgstr "是否想要添加角色 '{{ fields.displayRole }}'？"
+
+#~ msgid ""
+#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
+#~ "metadata.name}}' image stream?"
+#~ msgstr ""
+#~ "是否想要删除镜像流 '{{stream.metadata.namespace}}/{{stream.metadata."
+#~ "name}}' ？"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
+#~ msgstr "是否想要删除持久卷 '{{item.metadata.name}}'？"
+
+#~ msgid ""
+#~ "Do you want to delete the Persistent Volume Claim '{{item.metadata."
+#~ "name}}'?"
+#~ msgstr "是否想要删除持久卷声明 '{{item.metadata.name}}'？"
+
+#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
+#~ msgstr "是否想要删除 {{ item.kind }} '{{item.metadata.name}}'？"
+
+#~ msgid "Do you want to delete this Node?"
+#~ msgstr "是否想要删除该节点？"
+
+#~ msgid ""
+#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
+#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
+#~ msgstr ""
+#~ "是否想要移除标记为 '{{stream.metadata.namespace}}/{{stream.metadata."
+#~ "name}}:{{tag.tag}}' 的镜像？"
+
+#~ msgid ""
+#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
+#~ "{{ fields.member.metadata.name }}?"
+#~ msgstr ""
+#~ "是否想要从成员 {{ fields.member.metadata.name }} 中移除角色 '{{ fields."
+#~ "displayRole }}'？"
+
+#~ msgid "Don't pull images automatically"
+#~ msgstr "不自动下载镜像"
+
+#~ msgid "Driver"
+#~ msgstr "驱动器"
+
+#~ msgid "Edit the vdsm.conf"
+#~ msgstr "编辑 vdsm.conf"
+
+#~ msgid "Empty Directory"
+#~ msgstr "空目录"
+
+#~ msgid "Endpoint"
+#~ msgstr "端点"
+
+#~ msgid "Endpoint Name"
+#~ msgstr "端点名称"
+
+#~ msgid "Endpoints"
+#~ msgstr "端点"
+
+#~ msgid "Ends"
+#~ msgstr "结尾"
+
+#~ msgid "Enter New VM name"
+#~ msgstr "输入新的虚拟机名称"
+
+#~ msgid "Error getting certificate details: $0"
+#~ msgstr "获取证书详情出错: $0"
+
+#~ msgid "Error writing kubectl config"
+#~ msgstr "写 kubectl 配置时出错"
+
+#~ msgid "FORCEOFF action failed: $0"
+#~ msgstr "FORCEOFF 操作失败 : $0"
+
+#~ msgid "FQDN"
+#~ msgstr "FQDN"
+
+#~ msgid "Fibre Channel"
+#~ msgstr "光纤通道"
+
+#~ msgid "Filesystem Type"
+#~ msgstr "文件系统类型"
+
+#~ msgid "Flex"
+#~ msgstr "收缩"
+
+#~ msgid "Flocker"
+#~ msgstr "Flocker"
+
+#~ msgid "Flocker Dataset Name"
+#~ msgstr "Flocker 数据集名称"
+
+#~ msgid "GCE Persistent Disk"
+#~ msgstr "GCE 持久盘"
+
+#~ msgid "Git Repository"
+#~ msgstr "Git 仓库"
+
+#~ msgid "Gluster FS"
+#~ msgstr "Gluster FS"
+
+#~ msgid "GlusterFS"
+#~ msgstr "GlusterFS"
+
+#~ msgid "Grant additional push or admin access to specific members below."
+#~ msgstr "对以下成员授权额外的推送，或赋予管理员权限。"
+
+#~ msgid "Group Members"
+#~ msgstr "组成员"
+
+#~ msgid "Group or Project"
+#~ msgstr "组或项目"
+
+#~ msgid "Groups"
+#~ msgstr "组"
+
+#~ msgid "HA"
+#~ msgstr "高可用"
+
+#~ msgid "HA:"
+#~ msgstr "高可用："
+
+#~ msgid "Host Path"
+#~ msgstr "主机路径"
+
+#~ msgid "Host to Maintenance"
+#~ msgstr "主机维护"
+
+#~ msgid "IP"
+#~ msgstr "IP"
+
+#~ msgid "ISCSI"
+#~ msgstr "ISCSI"
+
+#~ msgid "Identities"
+#~ msgstr "身份"
+
+#~ msgid "Identity"
+#~ msgstr "身份"
+
+#~ msgid "Image ID"
+#~ msgstr "镜像编号"
+
+#~ msgid "Image Name"
+#~ msgstr "镜像名称"
+
+#~ msgid "Image Registry"
+#~ msgstr "镜像注册"
+
+#~ msgid "Image Stream"
+#~ msgstr "镜像流"
+
+#~ msgid "Image commands"
+#~ msgstr "镜像命令"
+
+#~ msgid "Images by project"
+#~ msgstr "镜像（按项目）"
+
+#~ msgid "Images pushed recently"
+#~ msgstr "最近推送的镜像"
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, use the commands below."
+#~ msgstr "为了开始推送镜像到 registry，使用以下命令。"
+
+#~ msgid ""
+#~ "In order to begin pushing images to the registry, you need to create a "
+#~ "project."
+#~ msgstr "为了开始推送镜像到 registry，需要创建一个项目。"
+
+#~ msgid "Installed products"
+#~ msgstr "已安装的产品"
+
+#~ msgid "Interface"
+#~ msgstr "接口"
+
+#~ msgid "Invalid credentials"
+#~ msgstr "无效的凭证"
+
+#~ msgid "Kernel Version"
+#~ msgstr "内核版本"
+
+#~ msgid "Key Ring Path"
+#~ msgstr "密钥环路径"
+
+#~ msgid "Kubelet Version"
+#~ msgstr "Kubelet 版本"
+
+#~ msgid "Kubernetes Cluster"
+#~ msgstr "Kubernetes 集群"
+
+#~ msgid "Last Heartbeat"
+#~ msgstr "最近的保活心跳"
+
+#~ msgid "Last Status Change"
+#~ msgstr "最近的状态变更"
+
+#~ msgid "Latest Version"
+#~ msgstr "最近的版本"
+
+#~ msgid "Loading data ..."
+#~ msgstr "正在加载数据 ..."
+
+#~ msgid "Log into OpenShift command line tools:"
+#~ msgstr "登录到 OpenShift 命令行工具："
+
+#~ msgid "Log into the registry:"
+#~ msgstr "登录到 registry："
+
+#~ msgid "Logical Unit Number"
+#~ msgstr "逻辑单元编号"
+
+#~ msgid "Login"
+#~ msgstr "登录"
+
+#~ msgid "Login commands"
+#~ msgstr "登录命令"
+
+#~ msgid "Login/password or activation key required to register."
+#~ msgstr "注册需要登录/密码或激活码。"
+
+#~ msgid "MIGRATE action failed"
+#~ msgstr "迁移操作失败"
+
+#~ msgid "Manifest"
+#~ msgstr "清单"
+
+#~ msgid "Medium"
+#~ msgstr "媒介"
+
+#~ msgid "Member of"
+#~ msgstr "属于"
+
+#~ msgid "Members"
+#~ msgstr "成员"
+
+#~ msgid "Membership"
+#~ msgstr "成员关系"
+
+#~ msgid "Memory Utilization: $0%"
+#~ msgstr "内存使用率: $0%"
+
+#~ msgid "Message"
+#~ msgstr "消息"
+
+#~ msgid "Migrate To:"
+#~ msgstr "迁移到："
+
+#~ msgid "Modify"
+#~ msgstr "修改"
+
+#~ msgid "Monitors"
+#~ msgstr "监视器"
+
+#~ msgid "Mount Location"
+#~ msgstr "挂载位置"
+
+#~ msgid "NFS"
+#~ msgstr "NFS"
+
+#~ msgid "Namespace"
+#~ msgstr "命名空间"
+
+#~ msgid "Namespace cannot be empty."
+#~ msgstr "命名空间不能为空。"
+
+#~ msgid "New Group"
+#~ msgstr "新建组"
+
+#~ msgid "New Project"
+#~ msgstr "新项目"
+
+#~ msgid "New image stream"
+#~ msgstr "新镜像流"
+
+#~ msgid "New project"
+#~ msgstr "新项目"
+
+#~ msgid "No PEM-encoded certificate found"
+#~ msgstr "没有找到 PEM 编码的证书"
+
+#~ msgid "No PEM-encoded private key found"
+#~ msgstr "没有找到 PEM 编码的私钥"
+
+#~ msgid "No Pods are using this claim"
+#~ msgstr "没有 pod 使用该声明"
+
+#~ msgid "No VM found in oVirt."
+#~ msgstr "oVirt 中没有找到虚拟机。"
+
+#~ msgid "No Volume Bound"
+#~ msgstr "未绑定卷"
+
+#~ msgid "No groups are present."
+#~ msgstr "没有组。"
+
+#~ msgid "No images pushed"
+#~ msgstr "没有推送的镜像"
+
+#~ msgid "No installed products on the system."
+#~ msgstr "该系统上没有安装的产品。"
+
+#~ msgid ""
+#~ "No metadata file was selected. Please select a Kubernetes metadata file."
+#~ msgstr "未选择元数据文件。请选择一个 Kubernetes 元数据文件."
+
+#~ msgid "No nodes in cluster"
+#~ msgstr "集群中没有节点"
+
+#~ msgid "No oVirt connection"
+#~ msgstr "没有 oVirt 连接"
+
+#~ msgid "No pods deployed"
+#~ msgstr "没有部署的 pod"
+
+#~ msgid "No pods replicated"
+#~ msgstr "没有复制的 pod"
+
+#~ msgid "No pods scheduled"
+#~ msgstr "没有被调度的 pod"
+
+#~ msgid "No pods selected"
+#~ msgstr "没有选中的 pod"
+
+#~ msgid "No projects are present."
+#~ msgstr "没有项目。"
+
+#~ msgid "No users are present."
+#~ msgstr "没有用户。"
+
+#~ msgid "No volumes are present."
+#~ msgstr "没有卷。"
+
+#~ msgid "No volumes in use"
+#~ msgstr "没有正在使用的卷"
+
+#~ msgid "Node"
+#~ msgstr "节点"
+
+#~ msgid "Nodes"
+#~ msgstr "节点"
+
+#~ msgid "Nodes are the machines that run your containers."
+#~ msgstr "节点是运行容器的主机。"
+
+#~ msgid "Not a valid number of replicas"
+#~ msgstr "副本数量无效"
+
+#~ msgid "Not a valid value for Host"
+#~ msgstr "无效的主机值"
+
+#~ msgid "Not deployed"
+#~ msgstr "未部署"
+
+#~ msgid "Number of virtual CPUs that gonna be used."
+#~ msgstr "要使用的虚拟 CPU 数量。"
+
+#~ msgid "OK"
+#~ msgstr "确认"
+
+#~ msgid "OS"
+#~ msgstr "操作系统"
+
+#~ msgid "OS Type:"
+#~ msgstr "操作系统类型："
+
+#~ msgid "OS Versions"
+#~ msgstr "操作系统版本"
+
+#~ msgid "Optimized for:"
+#~ msgstr "优化目标："
+
+#~ msgid "Organization"
+#~ msgstr "组织"
+
+#~ msgid "PD Name"
+#~ msgstr "PD 名称"
+
+#~ msgid "Pending Volume Claims"
+#~ msgstr "卷声明待定"
+
+#~ msgid "Persistent Volumes"
+#~ msgstr "持久卷"
+
+#~ msgid "Phase"
+#~ msgstr "阶段"
+
+#~ msgid "Please confirm, the host shall be switched to maintenance mode."
+#~ msgstr "请确认，主机应切换到维护模式。"
+
+#~ msgid "Please create another namespace for $0 \"$1\""
+#~ msgstr "请重新为 $0 创建一个命名空间 \"$1\""
+
+#~ msgid "Please provide a GlusterFS volume name"
+#~ msgstr "请提供一个 GlusterFS 卷名称"
+
+#~ msgid "Please provide a username"
+#~ msgstr "请提供一个用户名"
+
+#~ msgid "Please provide a valid NFS server"
+#~ msgstr "请提供一个有效的 NFS 服务器"
+
+#~ msgid "Please provide a valid address"
+#~ msgstr "请提供一个有效的地址"
+
+#~ msgid "Please provide a valid filesystem type"
+#~ msgstr "请提供一个有效的文件系统类型"
+
+#~ msgid "Please provide a valid interface"
+#~ msgstr "请提供一个有效的接口"
+
+#~ msgid "Please provide a valid logical unit number"
+#~ msgstr "请提供一个有效的逻辑单元编号"
+
+#~ msgid "Please provide a valid name"
+#~ msgstr "请提供有效的名称"
+
+#~ msgid "Please provide a valid namespace."
+#~ msgstr "请提供有效的命名空间."
+
+#~ msgid "Please provide a valid path"
+#~ msgstr "请提供一个有效的路径"
+
+#~ msgid "Please provide a valid qualified name"
+#~ msgstr "请提供一个有效的限定名"
+
+#~ msgid "Please provide a valid storage capacity."
+#~ msgstr "请提供有效的存储容量。"
+
+#~ msgid "Please provide a valid target"
+#~ msgstr "请提供一个有效的目标"
+
+#~ msgid ""
+#~ "Please provide fully qualified domain name and port of the oVirt engine."
+#~ msgstr "请提供 oVirt 引擎的完整的合法域名和端口。"
+
+#~ msgid ""
+#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
+#~ "port (443 by default)"
+#~ msgstr "请提供有效的 oVirt 引擎完整的合法域名（FQDN）和端口（默认为443 ）"
+
+#~ msgid ""
+#~ "Please refer to oVirt's $0 for more information about Remote Viewer setup."
+#~ msgstr "请参考 oVirt 的 $0 来获取更新关于 Remote Viewer 的设置。"
+
+#~ msgid "Please select a valid access mode"
+#~ msgstr "请选择有效的访问模式"
+
+#~ msgid "Please select a valid endpoint"
+#~ msgstr "请选择有效的端点"
+
+#~ msgid "Please select a valid policy option."
+#~ msgstr "请选择有效的策略选项。"
+
+#~ msgid "Please type an address"
+#~ msgstr "请输入一个地址"
+
+#~ msgid "Please wait till VMs list is loaded from the server."
+#~ msgstr "请等待直到虚拟机列表从服务器加载。"
+
+#~ msgid "Please wait till list of templates is loaded from the server."
+#~ msgstr "请等待直到模板列表从服务器加载。"
+
+#~ msgid "Pod"
+#~ msgstr "Pod"
+
+#~ msgid "Pod Address"
+#~ msgstr "pod 地址"
+
+#~ msgid "Pod Endpoints"
+#~ msgstr "pod 端点"
+
+#~ msgid "Pod Replicated"
+#~ msgstr "复制的 pod"
+
+#~ msgid "Pod Selector"
+#~ msgstr "pod 选择器"
+
+#~ msgid "Pods"
+#~ msgstr "Pod"
+
+#~ msgid ""
+#~ "Pods contain one or more containers that run together on a node, "
+#~ "containing your application code."
+#~ msgstr "pod 包含一个或多个运行在同一节点上包含应用代码的容器。"
+
+#~ msgid "Pool Name"
+#~ msgstr "池名称"
+
+#~ msgid "Populate"
+#~ msgstr "产生"
+
+#~ msgid "Preparing for Maintenance"
+#~ msgstr "正在准备维护"
+
+#~ msgid "Private: Allow only specific users or groups to pull images"
+#~ msgstr "私有的：仅允许指定用户或组拉取镜像"
+
+#~ msgid "Product ID"
+#~ msgstr "产品 ID"
+
+#~ msgid "Product name"
+#~ msgstr "产品名"
+
+#~ msgid "Project"
+#~ msgstr "项目"
+
+#~ msgid "Project Members"
+#~ msgstr "项目成员"
+
+#~ msgid "Project access policy allows anonymous users to pull images."
+#~ msgstr "项目访问策略允许匿名用户拉取镜像。"
+
+#~ msgid "Project access policy allows any authenticated user to pull images."
+#~ msgstr "项目访问策略允许任何认证的用户拉取镜像。"
+
+#~ msgid "Project access policy only allows specific members to access images."
+#~ msgstr "项目访问策略允许指定的用户拉取镜像。"
+
+#~ msgid "Project:"
+#~ msgstr "项目:"
+
+#~ msgid "Projects"
+#~ msgstr "项目"
+
+#~ msgid "Proxy"
+#~ msgstr "代理"
+
+#~ msgid "Proxy Version"
+#~ msgstr "代理版本"
+
+#~ msgid "Pull an image:"
+#~ msgstr "拉取镜像:"
+
+#~ msgid "Pull from"
+#~ msgstr "拉取自"
+
+#~ msgid "Pull specific tags from another image repository"
+#~ msgstr "从另一个镜像仓库拉取指定标记"
+
+#~ msgid "Push an image:"
+#~ msgstr "推送镜像:"
+
+#~ msgid "Qualified Name"
+#~ msgstr "限定名"
+
+#~ msgid "REBOOT action failed"
+#~ msgstr "重启操作失败"
+
+#~ msgid "REBOOT_VM action failed: %s0"
+#~ msgstr "REBOOT_VM 操作失败: %s0"
+
+#~ msgid "Rados Block Device"
+#~ msgstr "Rados 块设备"
+
+#~ msgid "Read Only"
+#~ msgstr "只读"
+
+#~ msgid "Read and write from a single node"
+#~ msgstr "从单节点读和写"
+
+#~ msgid "Read and write from multiple nodes"
+#~ msgstr "从多节点读和写"
+
+#~ msgid "Read only from multiple nodes"
+#~ msgstr "仅从多节点读"
+
+#~ msgid "Reason"
+#~ msgstr "原因"
+
+#~ msgid "Reclaim Policy"
+#~ msgstr "重新声明策略"
+
+#~ msgid "Recycle"
+#~ msgstr "回收"
+
+#~ msgid "Register"
+#~ msgstr "注册"
+
+#~ msgid "Register New Volume"
+#~ msgstr "注册新卷"
+
+#~ msgid "Register Persistent Volume"
+#~ msgstr "注册持久卷"
+
+#~ msgid "Register oVirt"
+#~ msgstr "注册 oVirt"
+
+#~ msgid "Register system"
+#~ msgstr "注册系统"
+
+#~ msgid "Registering oVirt to Cockpit"
+#~ msgstr "注册 oVirt 到 Cockpit"
+
+#~ msgid "Remote registry is insecure"
+#~ msgstr "远程 registry 不安全"
+
+#~ msgid "Remove Group"
+#~ msgstr "移除组"
+
+#~ msgid "Remove Member"
+#~ msgstr "移除成员"
+
+#~ msgid "Remove Role"
+#~ msgstr "移除角色"
+
+#~ msgid "Remove User"
+#~ msgstr "移除用户"
+
+#~ msgid "Remove image tag"
+#~ msgstr "移除镜像标记"
+
+#~ msgid "Remove membership"
+#~ msgstr "移除成员关系"
+
+#~ msgid "Replicas"
+#~ msgstr "复制"
+
+#~ msgid "Replication Controller"
+#~ msgstr "复制控制器"
+
+#~ msgid "Replication Controllers"
+#~ msgstr "复制控制器"
+
+#~ msgid ""
+#~ "Replication controllers dynamically create instances of pods from "
+#~ "templates, and remove pods when necessary."
+#~ msgstr "复制控制器动态地从模板创建 pod 实例，并且在必要的时候移除 pod。"
+
+#~ msgid "Repository URL"
+#~ msgstr "仓库 URL"
+
+#~ msgid "Requested"
+#~ msgstr "请求的"
+
+#~ msgid "Requests"
+#~ msgstr "请求"
+
+#~ msgid "Requires Authentication"
+#~ msgstr "需要验证"
+
+#~ msgid "Restart Count"
+#~ msgstr "重启次数"
+
+#~ msgid "Retain"
+#~ msgstr "留存"
+
+#~ msgid "Retrieving subscription status..."
+#~ msgstr "正在获取订阅状态..."
+
+#~ msgid "Revision"
+#~ msgstr "修订"
+
+#~ msgid "Role"
+#~ msgstr "角色"
+
+#~ msgid "Route"
+#~ msgstr "路由"
+
+#~ msgid "Run Here"
+#~ msgstr "运行到此"
+
+#~ msgid "Running Since:"
+#~ msgstr "运行自："
+
+#~ msgid "SET VCPU SETTINGS action failed"
+#~ msgstr "SET VCPU SETTINGS 操作失败"
+
+#~ msgid "SHUTDOWN action failed"
+#~ msgstr "关机操作失败"
+
+#~ msgid "START action failed"
+#~ msgstr "启动操作失败"
+
+#~ msgid "START_VM action failed: %s0"
+#~ msgstr "START_VM 操作失败 : %s0"
+
+#~ msgid "SUSPEND action failed"
+#~ msgstr "挂起操作失败"
+
+#~ msgid "Scheduled Pods"
+#~ msgstr "被调度的 pod"
+
+#~ msgid "Scheduling Disabled"
+#~ msgstr "调度被禁用"
+
+#~ msgid "Secret"
+#~ msgstr "秘密"
+
+#~ msgid "Secret File"
+#~ msgstr "秘密文件"
+
+#~ msgid "Secret Name"
+#~ msgstr "秘密名称"
+
+#~ msgid "Secret Volume"
+#~ msgstr "秘密卷"
+
+#~ msgid "Select Manifest File..."
+#~ msgstr "选择 Manifest 文件..."
+
+#~ msgid "Select Member"
+#~ msgstr "选择成员"
+
+#~ msgid "Select Role"
+#~ msgstr "选择角色"
+
+#~ msgid "Select an object to see more details."
+#~ msgstr "选择一个对象来查看更多详情。"
+
+#~ msgid "Service Account"
+#~ msgstr "服务账号"
+
+#~ msgid ""
+#~ "Services group pods and provide a common DNS name and an optional, load-"
+#~ "balanced IP address to access them."
+#~ msgstr ""
+#~ "服务组 pod 并提供一个通用 DNS 名称和一个可选的负载均衡的 IP 地址来访问它"
+#~ "们。"
+
+#~ msgid "Session Affinity"
+#~ msgstr "会话关联"
+
+#~ msgid "Share Name"
+#~ msgstr "共享名称"
+
+#~ msgid "Shared: Allow any authenticated user to pull images"
+#~ msgstr "共享的：运行任何已验证的用户拉取镜像"
+
+#~ msgid "Shell"
+#~ msgstr "Shell"
+
+#~ msgid "Show all Containers"
+#~ msgstr "显示所有容器"
+
+#~ msgid "Show all Deployment Configs"
+#~ msgstr "显示所有部署配置"
+
+#~ msgid "Show all Nodes"
+#~ msgstr "显示所有节点"
+
+#~ msgid "Show all Persistent Volumes"
+#~ msgstr "显示所有持久卷"
+
+#~ msgid "Show all Pod Containers"
+#~ msgstr "显示所有 pod 容器"
+
+#~ msgid "Show all Pods"
+#~ msgstr "显示所有 pod"
+
+#~ msgid "Show all Projects"
+#~ msgstr "显示所有项目"
+
+#~ msgid "Show all Replication Controllers"
+#~ msgstr "显示所有复制控制器"
+
+#~ msgid "Show all Routes"
+#~ msgstr "显示所有路由"
+
+#~ msgid "Show all Services"
+#~ msgstr "显示所有服务"
+
+#~ msgid "Show all image streams"
+#~ msgstr "显示所有镜像流"
+
+#~ msgid "Since"
+#~ msgstr "自从"
+
+#~ msgid "Skip Certificate Verification"
+#~ msgstr "跳过证书验证"
+
+#~ msgid "Sorry, I don't know how to modify this volume"
+#~ msgstr "抱歉，不知道如何修改该卷"
+
+#~ msgid "Starts"
+#~ msgstr "开始"
+
+#~ msgid "Stateless"
+#~ msgstr "无状态"
+
+#~ msgid "Stateless:"
+#~ msgstr "无状态："
+
+#~ msgid "Status: $0"
+#~ msgstr "状态：$0"
+
+#~ msgid "Status: System isn't registered"
+#~ msgstr "状态：系统未注册"
+
+#~ msgid "Strategy"
+#~ msgstr "策略"
+
+#~ msgid "Subscriptions"
+#~ msgstr "订阅"
+
+#~ msgid "Suspend"
+#~ msgstr "挂起"
+
+#~ msgid "Switch Host to Maintenance"
+#~ msgstr "把主机切换到维护模式"
+
+#~ msgid "Switching host to maintenance mode failed. Received error: "
+#~ msgstr "将主机切换到维护模式失败。收到错误： "
+
+#~ msgid "Switching host to maintenance mode in progress ..."
+#~ msgstr "将主机切换到维护模式正在进行中... "
+
+#~ msgid "Sync all tags from a remote image repository"
+#~ msgstr "从远程镜像仓库同步所有标记"
+
+#~ msgid "TLS Termination"
+#~ msgstr "TLS 终止"
+
+#~ msgid "Target Portal"
+#~ msgstr "目标门户"
+
+#~ msgid "Target World Wide Names"
+#~ msgstr "目标全球通用名称"
+
+#~ msgid "Template"
+#~ msgstr "模板"
+
+#~ msgid "Templates"
+#~ msgstr "模板"
+
+#~ msgid "Templates of $0 cluster"
+#~ msgstr "$0 集群模板"
+
+#~ msgid "The address contains invalid characters"
+#~ msgstr "地址包含无效字符"
+
+#~ msgid "The container '{{ target }}' does not exist."
+#~ msgstr "容器 '{{ target }}' 不存在。"
+
+#~ msgid "The current user isn't allowed to access system subscription status."
+#~ msgstr "当前用户不允许访问系统订阅状态。"
+
+#~ msgid "The deployment config '{{ target }}' does not exist."
+#~ msgstr "部署配置 '{{ target }}' 不存在。"
+
+#~ msgid "The group '{{ groupName }}' does not exist."
+#~ msgstr "组 '{{ groupName }}' 不存在。"
+
+#~ msgid "The maximum number of replicas is 128"
+#~ msgstr "副本最大数量为 128"
+
+#~ msgid "The name contains invalid characters"
+#~ msgstr "名称包含无效的字符"
+
+#~ msgid "The node '{{ target }}' does not exist."
+#~ msgstr "节点 '{{ target }}' 不存在。"
+
+#~ msgid "The node doesn't have enough disk space"
+#~ msgstr "节点没有足够的磁盘空间"
+
+#~ msgid "The node doesn't have enough free memory"
+#~ msgstr "节点没有足够的空闲内存"
+
+#~ msgid "The persistent volume '{{ target }}' does not exist."
+#~ msgstr "持久卷 '{{ target }}' 不存在。"
+
+#~ msgid "The pod '{{ target }}' does not exist."
+#~ msgstr "pod '{{ target }}' 不存在。"
+
+#~ msgid "The project '{{ projName }}' does not exist."
+#~ msgstr "项目 '{{ projName }}' 不存在。"
+
+#~ msgid "The replication controller '{{ target }}' does not exist."
+#~ msgstr "复制控制器 '{{ target }}' 不存在。"
+
+#~ msgid "The route '{{ target }}' does not exist."
+#~ msgstr "路由 '{{ target }}' 不存在。"
+
+#~ msgid "The selected file is not a valid Kubernetes application manifest."
+#~ msgstr "所选的文件不是有效的 Kubernetes 应用程序清单."
+
+#~ msgid "The server uses a certificate signed by an unknown authority."
+#~ msgstr "服务器使用由一个未知机构签名的证书。"
+
+#~ msgid "The service '{{ target }}' does not exist."
+#~ msgstr "服务 '{{ target }}' 不存在。"
+
+#~ msgid "The user '{{ userName }}' does not exist."
+#~ msgstr "用户 '{{ userName }}' 不存在。"
+
+#~ msgid ""
+#~ "This claim is in use. Deleting it may cause issues with the following pod:"
+#~ msgstr "该声明正在使用。删除它会对以下 pod 产生影响:"
+
+#~ msgid ""
+#~ "This host is managed by a virtualization manager, so creation of new VMs "
+#~ "from the host is not possible."
+#~ msgstr "该主机由虚拟化管理器管理，因此无法从主机创建新VM。"
+
+#~ msgid ""
+#~ "This option is for single node testing only – local storage will not work "
+#~ "in a multi-node cluster"
+#~ msgstr "该选项仅适用于单节点测试 – 本地存储将无法在多节点集群中工作"
+
+#~ msgid "This virtual machine is not managed by oVirt"
+#~ msgstr "该虚拟机没有被 oVirt 管理"
+
+#~ msgid ""
+#~ "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
+#~ "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
+#~ "may cause issues with any pods depending on it."
+#~ msgstr ""
+#~ "该卷已经被 {{ item.item.spec.claimRef.namespace }} / {{ item.item.spec."
+#~ "claimRef.name }} 声明。删除它将会损坏该声明，并会影响到依赖它的 pod。"
+
+#~ msgid "This volume has not been claimed"
+#~ msgstr "该卷未被声明"
+
+#~ msgid "Token"
+#~ msgstr "令牌"
+
+#~ msgid "Topology"
+#~ msgstr "拓扑"
+
+#~ msgid "Trust this certificate for this connection"
+#~ msgstr "为该连接信任该证书"
+
+#~ msgid "Type:"
+#~ msgstr "类型:"
+
+#~ msgid "Unable to connect"
+#~ msgstr "无法连接"
+
+#~ msgid "Unable to decode Kubernetes application manifest."
+#~ msgstr "无法解码 Kubernetes 应用清单。"
+
+#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
+#~ msgstr "无法读取 Kubernetes 应用程序清单。代码 $0."
+
+#~ msgid "Unregister"
+#~ msgstr "注销"
+
+#~ msgid "Unregistering system..."
+#~ msgstr "正在注销系统..."
+
+#~ msgid "Updating $0..."
+#~ msgstr "更新 $0..."
+
+#~ msgid "Use proxy server"
+#~ msgstr "使用代理服务器"
+
+#~ msgid "User or Group"
+#~ msgstr "用户或组"
+
+#~ msgid "Users"
+#~ msgstr "用户"
+
+#~ msgid "VDSM"
+#~ msgstr "VDSM"
+
+#~ msgid "VDSM Service Management"
+#~ msgstr "VDSM 服务管理"
+
+#~ msgid "VM icon"
+#~ msgstr "虚拟机图标"
+
+#~ msgid "Version num"
+#~ msgstr "版本号"
+
+#~ msgid "Virtual Machines of $0 cluster"
+#~ msgstr "$0 集群地虚拟机"
+
+#~ msgid "Volume ID"
+#~ msgstr "卷 ID"
+
+#~ msgid "Volume Name"
+#~ msgstr "卷名称"
+
+#~ msgid "Volume Type"
+#~ msgstr "卷类型"
+
+#~ msgid "Warning:"
+#~ msgstr "警告:"
+
+#~ msgid "Welcome to the Image Registry"
+#~ msgstr "欢迎使用 Image Registry"
+
+#~ msgid "When"
+#~ msgstr "当"
+
+#~ msgid ""
+#~ "You can bypass the certificate check, but any data you send to the server "
+#~ "could be intercepted by others."
+#~ msgstr "可以通过证书检查，但是发送到服务器的任何数据可能被其他人拦截。"
+
+#~ msgid "You can deploy an application to your cluster."
+#~ msgstr "可以部署一个应用到集群中。"
+
+#~ msgid ""
+#~ "Your login credentials do not give you access to use the docker registry "
+#~ "from the command line."
+#~ msgstr "登录凭证没有从命令行使用 Docker  registry 的权限"
+
+#~ msgid "connecting"
+#~ msgstr "正在连接"
+
+#~ msgid "cores"
+#~ msgstr "核"
+
+#~ msgid "eg: my-image-stream"
+#~ msgstr "例如：my-image-stream"
+
+#~ msgid "error"
+#~ msgstr "错误"
+
+#~ msgid "initializing"
+#~ msgstr "正在初始化"
+
+#~ msgid "installation failed"
+#~ msgstr "安装失败"
+
+#~ msgid "installing OS"
+#~ msgstr "正在安装操作系统"
+
+#~ msgid "kdumping"
+#~ msgstr "正在执行内核转储"
+
+#~ msgid "maintenance"
+#~ msgstr "维护"
+
+#~ msgid "non operational"
+#~ msgstr "不可操作"
+
+#~ msgid "non responsive"
+#~ msgstr "未响应"
+
+#~ msgid "oVirt"
+#~ msgstr "oVirt"
+
+#~ msgid "oVirt Host State:"
+#~ msgstr "oVirt 主机状态："
+
+#~ msgid "oVirt Provider installation script failed due to missing arguments."
+#~ msgstr "oVirt 供应商安装脚本因缺少参数失败。"
+
+#~ msgid ""
+#~ "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
+#~ "machines-ovirt.config, try as root."
+#~ msgstr ""
+#~ "oVirt 供应商安装脚本失败：无法写入 /etc/cockpit/machines-ovirt.config，尝"
+#~ "试重启。"
+
+#~ msgid "oVirt installation script failed with following output: "
+#~ msgstr "oVirt 供应商安装脚本失败，输出以下信息："
+
+#~ msgid "pending approval"
+#~ msgstr "等待批准"
+
+#~ msgid "pending volume claims"
+#~ msgstr "挂起的卷声明"
+
+#~ msgid "reboot"
+#~ msgstr "重启"
+
+#~ msgid "sockets"
+#~ msgstr "套接字"
+
+#~ msgid "threads"
+#~ msgstr "线程"
+
+#~ msgid "unassigned"
+#~ msgstr "未指定"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4,14 +4,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 04:52+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-07-03 08:58+0200\n"
 "PO-Revision-Date: 2018-12-11 10:51+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Chinese (Traditional)\n"
 "Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
@@ -114,13 +114,14 @@ msgstr "$0 文件系統無法在此處調整大小。"
 msgid ""
 "$0 is available for most operating systems. To install it, search for it in "
 "GNOME Software or run the following:"
-msgstr "$0 適用於大多數操作系統。要安裝它，請在GNOME軟件中搜索它或運行以下命令："
+msgstr ""
+"$0 適用於大多數操作系統。要安裝它，請在GNOME軟件中搜索它或運行以下命令："
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
+#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 正在積極使用"
 
@@ -512,8 +513,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "帳號"
 
-#: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/machines/components/networks/network.jsx:148
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "使用"
@@ -551,10 +552,10 @@ msgstr "適應性負載平衡"
 msgid "Adaptive transmit load balancing"
 msgstr "適應性傳輸負載平衡"
 
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
+#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
+#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
+#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "加入"
@@ -786,10 +787,10 @@ msgstr "應用程式"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
+#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
+#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
+#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
 msgid "Apply"
 msgstr "套用"
 
@@ -830,8 +831,8 @@ msgstr "資產標籤"
 msgid "At least $0 disks are needed."
 msgstr "至少 $0 需要磁盤。"
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
+#: pkg/storaged/vgroup-details.jsx:57
 msgid "At least one disk is needed."
 msgstr "至少需要一個磁盤。"
 
@@ -847,8 +848,8 @@ msgstr "稽核日誌"
 msgid "Authenticating"
 msgstr "認證"
 
-#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
-#: pkg/shell/index.html:66 pkg/shell/index.html:149
+#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
+#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
 msgid "Authentication"
 msgstr "核對"
 
@@ -919,8 +920,8 @@ msgstr "自動使用NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "自動使用特定的NTP服務器"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/networks/networkOverviewTab.jsx:86
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
@@ -1103,8 +1104,8 @@ msgstr "CPU優先級"
 msgid "CPU usage:"
 msgstr "CPU使用率："
 
-#: pkg/machines/components/diskAdd.jsx:246
 #: pkg/machines/components/vmDiskColumns.jsx:75
+#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
@@ -1127,35 +1128,35 @@ msgstr "無法加載圖片"
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
-#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
+#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
+#: pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:560
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:560 pkg/networkmanager/firewall.jsx:628
-#: pkg/networkmanager/firewall.jsx:771 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/vcpuModal.jsx:232
+#: pkg/machines/components/nicEdit.jsx:296
+#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
+#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
+#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
+#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
+#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
+#: pkg/packagekit/updates.jsx:179
 msgid "Cancel"
 msgstr "取消"
 
@@ -1225,10 +1226,10 @@ msgstr "更改資源限制"
 msgid "Change the settings"
 msgstr "更改設置"
 
-#: pkg/machines/components/nicEdit.jsx:272
-#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/warningInactive.jsx:11
+#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "關閉VM後，更改將生效"
 
@@ -1307,15 +1308,16 @@ msgstr "單擊“啟動遠程查看器”將下載.vv文件並啟動 $0。"
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
-#: pkg/storaged/dialog.jsx:393
+#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
+#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
+#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
+#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "關閉"
 
@@ -1331,7 +1333,9 @@ msgstr "駕駛艙身份驗證配置不正確。"
 msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
-msgstr "駕駛艙無法聯繫給定的主人 $0。確保它在端口上運行ssh $1, ，或在地址中指定另一個端口。"
+msgstr ""
+"駕駛艙無法聯繫給定的主人 $0。確保它在端口上運行ssh $1, ，或在地址中指定另一個"
+"端口。"
 
 #: src/base1/cockpit.js:4037
 msgid "Cockpit could not contact the given host."
@@ -1343,8 +1347,9 @@ msgid ""
 "Cockpit by pressing refresh in your browser. The javascript console contains "
 "details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
-"駕駛艙出現意外的內部錯誤。 <br/><br/>您可以嘗試通過在瀏覽器中按刷新來重新啟動Cockpit。 "
-"javascript控制台包含有關此錯誤的詳細信息（<b>CTRL-Shift-J鍵</b> 在大多數瀏覽器中）。"
+"駕駛艙出現意外的內部錯誤。 <br/><br/>您可以嘗試通過在瀏覽器中按刷新來重新啟動"
+"Cockpit。 javascript控制台包含有關此錯誤的詳細信息（<b>CTRL-Shift-J鍵</b> 在"
+"大多數瀏覽器中）。"
 
 #: cockpit.appdata.xml.in.h:2
 msgid ""
@@ -1354,7 +1359,9 @@ msgid ""
 "Likewise, if an error occurs in the terminal, it can be seen in the Cockpit "
 "journal interface."
 msgstr ""
-"Cockpit是一個服務器管理器，可以通過Web瀏覽器輕鬆管理Linux服務器。在終端和Web工具之間跳轉是沒有問題的。可以通過終端停止通過Cockpit啟動的服務。同樣，如果終端中發生錯誤，可以在駕駛艙日誌界面中看到。"
+"Cockpit是一個服務器管理器，可以通過Web瀏覽器輕鬆管理Linux服務器。在終端和Web"
+"工具之間跳轉是沒有問題的。可以通過終端停止通過Cockpit啟動的服務。同樣，如果終"
+"端中發生錯誤，可以在駕駛艙日誌界面中看到。"
 
 #: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
@@ -1380,7 +1387,9 @@ msgid ""
 "same time. Just add them with a single click and your machines will look "
 "after its buddies."
 msgstr ""
-"駕駛艙非常適合新的系統管理員，使他們能夠輕鬆執行簡單的任務，如存儲管理，檢查期刊以及啟動和停止服務。您可以同時監視和管理多個服務器。只需點擊一下即可添加它們，您的機器將照顧好友。"
+"駕駛艙非常適合新的系統管理員，使他們能夠輕鬆執行簡單的任務，如存儲管理，檢查"
+"期刊以及啟動和停止服務。您可以同時監視和管理多個服務器。只需點擊一下即可添加"
+"它們，您的機器將照顧好友。"
 
 #: pkg/lib/machine-change-port.html:9
 msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
@@ -1388,14 +1397,14 @@ msgstr "駕駛艙無法聯繫 {{#strong}}{{host}}{{/strong}}。"
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
-"troubleshooting support please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
+"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
+"can_sync}} For more authentication options and troubleshooting support "
+"please upgrade cockpit-ws to a newer version."
 msgstr ""
 "駕駛艙無法登錄 {{#strong}}{{host}}{{/strong}}。 {{#can_sync}}你可能想嘗試 "
-"{{#sync_link}}同步用戶{{/sync_link}}。{{/can_sync}} 有關更多身份驗證選項和故障排除支持，請將cockpit-"
-"ws升級到更新版本。"
+"{{#sync_link}}同步用戶{{/sync_link}}。{{/can_sync}} 有關更多身份驗證選項和故"
+"障排除支持，請將cockpit-ws升級到更新版本。"
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1407,8 +1416,9 @@ msgid ""
 "machine with cockpit you will need to enable one of the following "
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
-"駕駛艙無法登錄 {{#strong}}{{host}}{{/strong}}。要將此計算機與駕駛艙一起使用，您需要在sshd "
-"config中啟用以下身份驗證方法之一 {{#strong}}{{host}}{{/strong}}："
+"駕駛艙無法登錄 {{#strong}}{{host}}{{/strong}}。要將此計算機與駕駛艙一起使用，"
+"您需要在sshd config中啟用以下身份驗證方法之一 {{#strong}}{{host}}{{/"
+"strong}}："
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1416,8 +1426,9 @@ msgid ""
 "change your authentication credentials below. {{#can_sync}}You may prefer to "
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
-"駕駛艙無法登錄 {{#strong}}{{host}}{{/strong}}。您可以在下面更改身份驗證憑據。 {{#can_sync}}你可能更喜歡 "
-"{{#sync_link}}同步帳戶和密碼{{/sync_link}}。{{/can_sync}}"
+"駕駛艙無法登錄 {{#strong}}{{host}}{{/strong}}。您可以在下面更改身份驗證憑"
+"據。 {{#can_sync}}你可能更喜歡 {{#sync_link}}同步帳戶和密碼{{/sync_link}}。"
+"{{/can_sync}}"
 
 #: pkg/dashboard/index.html:157 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1485,8 +1496,8 @@ msgstr "兼容現代系統和硬盤> 2TB（GPT）"
 msgid "Compress crash dumps to save space"
 msgstr "壓縮故障轉儲以節省空間"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156
 msgid "Compression"
 msgstr "壓縮"
 
@@ -1590,9 +1601,9 @@ msgstr "連接到機器"
 
 # ctx::sourcefile::Navigation Menu
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "連線"
@@ -1741,9 +1752,9 @@ msgstr "崩潰系統"
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
+#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
+#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
 msgid "Create"
 msgstr "建立"
 
@@ -1919,7 +1930,7 @@ msgstr ""
 msgid "Custom encryption options"
 msgstr "自定義加密選項"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
 msgid "Custom mount options"
 msgstr "自定義安裝選項"
 
@@ -1964,8 +1975,8 @@ msgstr "控制面板"
 msgid "Data Used"
 msgstr "使用的數據"
 
-#: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/machines/components/networks/network.jsx:144
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "取消啟動"
@@ -1998,17 +2009,17 @@ msgstr "延遲"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/containers-view.jsx:202
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
+#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "刪除"
@@ -2059,7 +2070,7 @@ msgstr "刪除RAID設備將清除其上的所有數據。"
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "刪除VDO設備將清除其上的所有數據。"
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
 msgid "Deleting a container will erase all data in it."
 msgstr "刪除容器將清除其中的所有數據。"
 
@@ -2103,12 +2114,12 @@ msgstr "可拆開"
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:745
+#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
 msgid "Details"
 msgstr "詳情"
 
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2198,9 +2209,9 @@ msgstr "磁盤沒問題"
 msgid "Disk passphrase"
 msgstr "磁盤密碼"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
 msgid "Disks"
 msgstr "磁盤"
 
@@ -2470,9 +2481,9 @@ msgid "Errata:"
 msgstr "勘誤："
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1476
+#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
 msgid "Error"
 msgstr "錯誤"
 
@@ -2576,7 +2587,7 @@ msgstr ""
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
+#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
 msgid "Failed to change password"
 msgstr "無法更改密碼"
 
@@ -2661,7 +2672,7 @@ msgstr "過濾服務"
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
 msgid "Fingerprint"
 msgstr "指紋"
 
@@ -2706,10 +2717,9 @@ msgstr "強制更改密碼"
 msgid "Force remove passphrase in $0"
 msgstr "強制刪除密碼 $0"
 
-#: pkg/machines/components/diskAdd.jsx:147
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
+#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "格式"
 
@@ -2785,11 +2795,11 @@ msgstr "生成報告"
 msgid "Get new image"
 msgstr "獲取新圖片"
 
-#: pkg/machines/components/diskAdd.jsx:186
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
 
@@ -2874,9 +2884,9 @@ msgstr "你好時間 $hello_時間"
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
 #: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
 msgid "Host"
 msgstr "主機"
@@ -3109,9 +3119,9 @@ msgstr ""
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/machines/components/vm/vmActions.jsx:98
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
 msgid "Install"
 msgstr "安裝"
 
@@ -3174,8 +3184,8 @@ msgid "Interface Type"
 msgstr ""
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:737 pkg/networkmanager/firewall.jsx:925
-#: pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:925
 msgid "Interfaces"
 msgstr "介面"
 
@@ -3191,11 +3201,11 @@ msgstr "內部錯誤"
 msgid "Invalid address $0"
 msgstr "無效地址 $0"
 
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
 msgid "Invalid date format"
 msgstr "日期格式無效"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
 msgid "Invalid date format and invalid time format"
 msgstr "日期格式無效，時間格式無效"
 
@@ -3251,7 +3261,7 @@ msgstr "無效的前綴或網絡掩碼 $0"
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
 msgid "Invalid time format"
 msgstr "時間格式無效"
 
@@ -3411,14 +3421,15 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in user. If "
 "you enter a different username, that user will always be used when "
 "connecting to this machine."
-msgstr "留空以連接到當前登錄用戶的本機。如果輸入其他用戶名，則在連接到此計算機時將始終使用該用戶。"
+msgstr ""
+"留空以連接到當前登錄用戶的本機。如果輸入其他用戶名，則在連接到此計算機時將始"
+"終使用該用戶。"
 
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
-""
 msgstr ""
 "留空以連接到當前登錄用戶的本機{{#default_user}} （{{default_user}}）{{/"
 "default_user}}。如果輸入其他用戶名，將始終使用該用戶連接到此計算機。"
@@ -3483,9 +3494,9 @@ msgstr "加載可用更新失敗"
 msgid "Loading available updates, please wait..."
 msgstr "正在加載可用的更新，請稍候..."
 
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
+#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
+#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
 msgid "Loading..."
 msgstr "正在載入..."
 
@@ -3784,10 +3795,10 @@ msgid "Metadata Used"
 msgstr "使用的元數據"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
-#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -3857,23 +3868,23 @@ msgstr "更多信息"
 msgid "More details"
 msgstr "更多詳細資訊"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
+#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
 msgid "Mount"
 msgstr "安裝"
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount Options"
 msgstr "裝載選項"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/nfs-panel.jsx:102
+#: pkg/storaged/format-dialog.jsx:71
 msgid "Mount Point"
 msgstr "登山點"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
 msgid "Mount at boot"
 msgstr "在靴子上安裝"
 
@@ -3893,7 +3904,7 @@ msgstr "掛載點不能為空。"
 msgid "Mount point must start with \"/\"."
 msgstr "掛載點必須以“/”開頭。"
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
 msgid "Mount read only"
 msgstr "安裝只讀"
 
@@ -3949,22 +3960,21 @@ msgstr "NTP服務器"
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
 #: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
+#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
+#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
 msgid "Name"
 msgstr "名稱"
 
@@ -4104,7 +4114,7 @@ msgstr "新卷名稱"
 msgid "New passphrase"
 msgstr "新密碼"
 
-#: pkg/lib/credentials.js:237 pkg/users/local.js:139
+#: pkg/users/local.js:139 pkg/lib/credentials.js:237
 msgid "New password was not accepted"
 msgstr "不接受新密碼"
 
@@ -4226,9 +4236,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "沒有提供說明。"
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
+#: pkg/storaged/vgroup-details.jsx:54
 msgid "No disks are available."
 msgstr "沒有磁盤可用。"
 
@@ -4362,8 +4372,8 @@ msgid "No volume groups created"
 msgstr "沒有創建卷組"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:734
-#: pkg/tuned/dialog.js:231
+#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
 msgid "None"
 msgstr "沒有"
 
@@ -4463,7 +4473,7 @@ msgstr "舊密碼"
 msgid "Old passphrase"
 msgstr "舊密碼"
 
-#: pkg/lib/credentials.js:218 pkg/users/local.js:86
+#: pkg/users/local.js:86 pkg/lib/credentials.js:218
 msgid "Old password not accepted"
 msgstr "舊密碼不被接受"
 
@@ -4575,9 +4585,9 @@ msgid "Other Options"
 msgstr "其他選擇"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
+#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/networks/network.jsx:72
 msgid "Overview"
 msgstr "簡介"
 
@@ -4657,10 +4667,10 @@ msgstr "密碼短語刪除可能會阻止解鎖 $0。"
 msgid "Passphrases do not match"
 msgstr "密碼短語不匹配"
 
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
+#: pkg/users/index.html:118 pkg/users/index.html:173
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
+#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "密碼"
@@ -4762,8 +4772,8 @@ msgstr "使用權限被拒"
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/networks/networkOverviewTab.jsx:83
 msgid "Persistent"
 msgstr ""
 
@@ -4808,9 +4818,9 @@ msgstr "Ping目標"
 msgid "Pizza Box"
 msgstr "披薩盒"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
+#: pkg/docker/details.js:290 pkg/docker/util.js:612
+#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "請確認刪除 $0"
@@ -4819,7 +4829,7 @@ msgstr "請確認刪除 $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "請確認強制刪除 $0"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
 msgid "Please confirm stopping of $0"
 msgstr "請確認停止 $0"
 
@@ -4855,11 +4865,10 @@ msgstr "請嘗試另一個學期"
 msgid "Plug"
 msgstr "插頭"
 
-#: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "集池"
 
@@ -5015,7 +5024,7 @@ msgstr "宣傳重新加載"
 msgid "Protocol"
 msgstr "協定"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
 msgid "Public Key"
 msgstr "公鑰"
 
@@ -5096,7 +5105,7 @@ msgstr "RAID機箱"
 msgid "RAID Device"
 msgstr "RAID 裝置"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
 msgid "RAID Device $0"
 msgstr "RAID設備 $0"
 
@@ -5264,9 +5273,9 @@ msgstr "可拆卸驅動器"
 msgid "Removals:"
 msgstr "清除："
 
-#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
+#: pkg/apps/application.jsx:109
 msgid "Remove"
 msgstr "移除"
 
@@ -5452,8 +5461,8 @@ msgstr ""
 # ctx::sourcefile::/rhn/admin/config/Restart.do
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
 msgid "Restart"
 msgstr "重新啟動"
 
@@ -5494,8 +5503,7 @@ msgid "Reuse my password for privileged tasks"
 msgstr "重用我的密碼以執行特權任務"
 
 #: pkg/shell/index.html:159
-msgid ""
-"Reuse my password for privileged tasks and to connect to other machines"
+msgid "Reuse my password for privileged tasks and to connect to other machines"
 msgstr "重用我的密碼以執行特權任務並連接到其他計算機"
 
 #: pkg/users/index.html:94
@@ -5616,10 +5624,11 @@ msgstr "週六"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:523
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "儲存"
 
@@ -5672,8 +5681,8 @@ msgstr "選擇"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with "
-"{{#strong}}{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with {{#strong}}"
+"{{host}}{{/strong}}"
 msgstr "選擇您要與之同步的用戶 {{#strong}}{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
@@ -5695,8 +5704,8 @@ msgid "Serial Console"
 msgstr "串行控制台"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
 msgid "Server"
 msgstr "伺服器"
 
@@ -5873,15 +5882,14 @@ msgstr "關機"
 
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/diskAdd.jsx:167
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
+#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
+#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
+#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
 msgid "Size"
 msgstr "大小"
 
@@ -5959,10 +5967,10 @@ msgstr "其他一些程序目前正在使用包管理器，請稍候..."
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:504
 #: pkg/machines/components/nicEdit.jsx:141
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "來源"
 
@@ -5970,10 +5978,10 @@ msgstr "來源"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "來源路徑"
 
@@ -6015,8 +6023,8 @@ msgid "Stable"
 msgstr "穩定"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
+#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
 msgid "Start"
 msgstr "開始"
 
@@ -6053,8 +6061,8 @@ msgid "Startup"
 msgstr "啟動"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
 #: pkg/systemd/init.js:285
 msgid "State"
@@ -6082,8 +6090,8 @@ msgid "Sticky"
 msgstr "黏"
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
+#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
 #: pkg/systemd/init.js:542
 msgid "Stop"
 msgstr "停止"
@@ -6328,8 +6336,8 @@ msgstr "唐鑰匙服務器"
 msgid "Target"
 msgstr "目標"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
 msgid "Target Path"
 msgstr "目標路徑"
 
@@ -6449,9 +6457,10 @@ msgstr "帳戶'$0'將在下次登錄時被迫更改密碼"
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
-msgstr "主機的真實性 {{#strong}}{{host}}{{/strong}} 無法建立。您確定要繼續連接嗎？"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
+msgstr ""
+"主機的真實性 {{#strong}}{{host}}{{/strong}} 無法建立。您確定要繼續連接嗎？"
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
@@ -6482,8 +6491,7 @@ msgid ""
 msgstr "登錄會話和系統服務正在使用文件系統。繼續進行將阻止這些。"
 
 #: pkg/storaged/dialog.jsx:1014
-msgid ""
-"The filesystem is in use by login sessions. Proceeding will stop these."
+msgid "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr "登錄會話正在使用文件系統。繼續進行將阻止這些。"
 
 #: pkg/storaged/dialog.jsx:1016
@@ -6492,8 +6500,7 @@ msgid ""
 msgstr "文件系統正由系統服務使用。繼續進行將阻止這些。"
 
 #: pkg/docker/util.js:631
-msgid ""
-"The following containers depend on this image and will become unusable."
+msgid "The following containers depend on this image and will become unusable."
 msgstr "以下容器依賴於此圖像並將變得不可用。"
 
 #: pkg/sosreport/index.html:51
@@ -6501,7 +6508,9 @@ msgid ""
 "The generated archive contains data considered sensitive and its content "
 "should be reviewed by the originating organization before being passed to "
 "any third party."
-msgstr "生成的存檔包含被視為敏感的數據，其內容應在發送給任何第三方之前由原始組織審核。"
+msgstr ""
+"生成的存檔包含被視為敏感的數據，其內容應在發送給任何第三方之前由原始組織審"
+"核。"
 
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
@@ -6509,8 +6518,8 @@ msgid ""
 "in use. Unless this machine was recently replaced, it is likely that someone "
 "is trying to attack your connection to this machine."
 msgstr ""
-"關鍵 {{#strong}}{{host}}{{/strong}} "
-"與之前使用的密鑰不匹配。除非最近更換了這台機器，否則有人可能會試圖攻擊您與此機器的連接。"
+"關鍵 {{#strong}}{{host}}{{/strong}} 與之前使用的密鑰不匹配。除非最近更換了這"
+"台機器，否則有人可能會試圖攻擊您與此機器的連接。"
 
 #: pkg/users/authorized-keys.js:124
 msgid "The key you provided was not valid."
@@ -6626,8 +6635,7 @@ msgstr "用戶名只能包含來自az，數字，點，短劃線和下劃線的�
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible "
-"$0)"
+"The web browser configuration prevents Cockpit from running (inaccessible $0)"
 msgstr "Web瀏覽器配置可防止Cockpit運行（無法訪問） $0）"
 
 #: pkg/shell/active-pages-dialog.jsx:58
@@ -6676,7 +6684,8 @@ msgstr "此設備無法在此處管理。"
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
-msgstr "此設備具有當前正在使用的文件系統。 Proceeding將卸載其上的所有文件系統。"
+msgstr ""
+"此設備具有當前正在使用的文件系統。 Proceeding將卸載其上的所有文件系統。"
 
 #: pkg/storaged/dialog.jsx:976
 msgid "This device is currently used for RAID devices."
@@ -6792,7 +6801,9 @@ msgid ""
 "This will test kdump settings by crashing the kernel and thereby the system. "
 "Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
-msgstr "這將通過崩潰內核以及系統來測試kdump設置。根據設置，系統可能不會自動重啟，並且該過程可能需要一段時間。"
+msgstr ""
+"這將通過崩潰內核以及系統來測試kdump設置。根據設置，系統可能不會自動重啟，並且"
+"該過程可能需要一段時間。"
 
 #: pkg/kdump/kdump-view.jsx:489
 msgid "This will test the kdump configuration by crashing the kernel."
@@ -6823,13 +6834,15 @@ msgstr "計時器"
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
-msgstr "提示：使您的密鑰密碼與您的登錄密碼相匹配，以自動對其他系統進行身份驗證。"
+msgstr ""
+"提示：使您的密鑰密碼與您的登錄密碼相匹配，以自動對其他系統進行身份驗證。"
 
 #: pkg/packagekit/updates.jsx:773
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
-msgstr "要獲得軟件更新，需要使用Red Hat客戶門戶或本地訂閱服務器向Red Hat註冊此系統。"
+msgstr ""
+"要獲得軟件更新，需要使用Red Hat客戶門戶或本地訂閱服務器向Red Hat註冊此系統。"
 
 #: node_modules/registry-image-widgets/views/image-pull.html:4
 msgid "To pull this image:"
@@ -6926,18 +6939,17 @@ msgstr "Tuned沒有運行"
 msgid "Tuned is off"
 msgstr "Tuned已關閉"
 
-#: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
+#: pkg/systemd/hwinfo.jsx:75
 msgid "Type"
 msgstr "類型"
 
@@ -7040,10 +7052,11 @@ msgstr "單位"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/lib/machine-info.js:65 pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/machines/components/vmnetworktab.jsx:139
 #: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
 #: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
+#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "不明"
 
@@ -7256,7 +7269,7 @@ msgstr "使用者名稱"
 msgid "User Password"
 msgstr "用戶密碼"
 
-#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
+#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "使用者名稱"
@@ -7407,7 +7420,7 @@ msgstr "核驗"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
 msgid "Version"
 msgstr "版本"
 
@@ -7415,8 +7428,8 @@ msgstr "版本"
 msgid "Very securely erasing $target"
 msgstr "非常安全地擦除 $target"
 
-#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:39
 #: pkg/machines/hostvmslist.jsx:82
 msgid "Virtual Machines"
 msgstr "虛擬機器"
@@ -7434,11 +7447,10 @@ msgid "Virtualization Service is Available"
 msgstr "虛擬化服務可用"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "音量"
 
@@ -7554,7 +7566,9 @@ msgstr "是"
 msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
-msgstr "你已經連接到了 {{#strong}}{{host}}{{/strong}}, 但是，為了同步用戶，需要具有超級用戶權限的用戶。"
+msgstr ""
+"你已經連接到了 {{#strong}}{{host}}{{/strong}}, 但是，為了同步用戶，需要具有超"
+"級用戶權限的用戶。"
 
 #: pkg/dashboard/list.js:440
 msgid ""
@@ -7589,7 +7603,9 @@ msgstr ""
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
-msgstr "您的瀏覽器將斷開連接，但這不會影響更新過程。您可以在幾分鐘後重新連接以繼續觀察進度。"
+msgstr ""
+"您的瀏覽器將斷開連接，但這不會影響更新過程。您可以在幾分鐘後重新連接以繼續觀"
+"察進度。"
 
 #: pkg/packagekit/updates.jsx:865
 msgid ""
@@ -7625,8 +7641,12 @@ msgstr "[二進制數據]"
 msgid "[no data]"
 msgstr "[沒有數據]"
 
-#: pkg/machines/components/networks/network.jsx:59
+#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
+msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
+msgstr ""
+
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "活性"
@@ -7757,8 +7777,8 @@ msgstr ""
 msgid "idle"
 msgstr "閒"
 
-#: pkg/machines/components/networks/network.jsx:59
 #: pkg/machines/components/storagePools/storagePool.jsx:70
+#: pkg/machines/components/networks/network.jsx:59
 msgid "inactive"
 msgstr "待用"
 
@@ -7794,9 +7814,9 @@ msgstr "網絡"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs dump target未格式化為server：path"
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "否"
@@ -7961,9 +7981,9 @@ msgid ""
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "是"
@@ -7973,5 +7993,5 @@ msgid ""
 "{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
 "count: {{ condition.generation }}"
 msgstr ""
-"{{ condition.message }}。時間戳： {{ condition.lastTransitionTime }} 錯誤計數： {{ "
-"condition.generation }}"
+"{{ condition.message }}。時間戳： {{ condition.lastTransitionTime }} 錯誤計"
+"數： {{ condition.generation }}"


### PR DESCRIPTION
A lot of translatable strings got dropped with the kubernetes and ovirt
removals. Clean these up so that translators who only look at the .po
files don't do unnecessary work.