### PR TITLE
bots: Assign repo first in run-queue

### DIFF
--- a/bots/run-queue
+++ b/bots/run-queue
@@ -43,6 +43,7 @@ def consume_webhook_queue(channel, amqp):
     body = json.loads(body)
     event = body['event']
     request = body['request']
+    repo = None
     if event == 'pull_request':
         pull_request = request['pull_request']
         # scan for possible checkboxes and the bots label


### PR DESCRIPTION
Assign the repo first, then check if it's been overwritten.