### PR TITLE
bots: Ack AMQP message on failed tasks in run-queue

### DIFF
--- a/bots/run-queue
+++ b/bots/run-queue
@@ -111,8 +111,8 @@ def main():
         while p.poll() is None:
             q.connection.process_data_events()
             time.sleep(3)
-        if p.returncode in [0, 2]:
-            channel.basic_ack(delivery_tag)
+
+        channel.basic_ack(delivery_tag)
 
     return 0
 


### PR DESCRIPTION
Tasks that fail should still be acked. Only when an exception is thrown
the message should not be acked, as that indiciates an error somewhere
in the task.