### PR TITLE
bots: Fix image-prune --checkout-only

### DIFF
--- a/bots/image-prune
+++ b/bots/image-prune
@@ -143,11 +143,7 @@ def prune_images(force, dryrun, quiet=False, open_pull_requests=True, offline=Fa
             continue
 
         target = os.readlink(path)
-        if not os.path.isabs(target):
-            targets.add(os.path.join(testvm.IMAGES_DIR, target))
-            targets.add(os.path.join(testvm.get_images_data_dir(), target))
-        else:
-            targets.add(target)
+        targets.add(target)
 
     expiry_threshold = now - IMAGE_EXPIRE * 86400
     for filename in os.listdir(testvm.get_images_data_dir()):


### PR DESCRIPTION
The `targets` set is supposed to contain file names without path. That's
what our bots/images/<name> symlinks point to and what get_image_links()
returns.

However, the targets from the current checkout were added as full paths.
When running with `--checkout-only` this would then cause  all current
images to be removed, as the plain file name was never found after
commit d12fe778a1c9cf (that commit was correct for the other cases,
though).