### PR TITLE
bots: Fix image rebuilds in pull requests

### DIFF
--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -178,7 +178,8 @@ def output_task(command, issue, verbose):
     checkout = "PRIORITY={priority:04d} "
     cmd = "bots/{name} --verbose --issue='{issue}' {context}"
 
-    if "pull_request" in issue:
+    # direct API scan gets the full information (first case), while --issue-data only gets the info["pull_request"] parts; cover both
+    if "pull_request" in issue or "commits" in issue:
         checkout += "bots/make-checkout --verbose pull/{issue}/head && "
 
     if verbose:


### PR DESCRIPTION
When calling issue-scan with `--issue-data` for PRs, they only get the
`..["pull_request"]` portion and thus testing if that has a
`pull_request` key fails.

As a quick fix, check if the data has a "commits" key, which matches
that case and lets issue-scan accept both formats.

This should eventually be cleaned up by passing the full info to
issue-scan.