### PR TITLE
bots: Correct extra whitespace in action check in run-queue

### DIFF
--- a/bots/run-queue
+++ b/bots/run-queue
@@ -63,7 +63,7 @@ def consume_webhook_queue(channel, amqp):
     elif event == 'issues':
         action = request['action']
         # scan for opened, body changes (edited), and the bots label
-        if action in ['opened',' labeled'] or (action == 'edited' and 'body' in request.get('changes', {})):
+        if action in ['opened', 'labeled'] or (action == 'edited' and 'body' in request.get('changes', {})):
             issue = request['issue']
             cmd = ['bots/issue-scan', '--issue-data', json.dumps(issue), '--amqp', amqp]
     else:


### PR DESCRIPTION
This should be the cause of the image refreshes failing to trigger.