### PR TITLE
bots: Add naughty for libvirt CAP_SYS_RAWIO denial on Debian

### DIFF
--- a/bots/naughty/debian-testing/12250-apparmor-libvirt-rawio
+++ b/bots/naughty/debian-testing/12250-apparmor-libvirt-rawio
@@ -1,0 +1,1 @@
+Error: audit: type=1400 audit(*): apparmor="DENIED" operation="capable" profile="/usr/sbin/libvirtd" * comm="libvirt_parthel" * capname="sys_rawio"


### PR DESCRIPTION
Known issue #12250
Downstream bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931470