### PR TITLE
firewall: Only reload firewall when adding custom services

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -21,6 +21,7 @@ import cockpit from "cockpit";
 import React from "react";
 import ReactDOM from "react-dom";
 import {
+    Alert,
     Button,
     ListView,
     Modal,
@@ -226,8 +227,7 @@ class AddServicesModal extends React.Component {
     save() {
         let p;
         if (this.state.custom) {
-            p = firewall.createService(this.state.custom_id, this.state.custom_name, this.createPorts())
-                    .then(firewall.enableService(this.state.zones, this.state.custom_id));
+            p = firewall.createService(this.state.custom_id, this.state.custom_name, this.createPorts(), this.state.zones);
         } else {
             p = firewall.addServices(this.state.zones, [...this.state.selected]);
         }
@@ -555,6 +555,11 @@ class AddServicesModal extends React.Component {
                 <Modal.Footer>
                     {
                         this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />
+                    }
+                    { !this.state.custom ||
+                        <Alert type="warning">
+                            { _("Adding custom ports will reload firewalld. A reload will result in the loss of any runtime-only configuration!")}
+                        </Alert>
                     }
                     <Button bsStyle='default' className='btn-cancel' onClick={this.props.close}>
                         {_("Cancel")}

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -140,6 +140,11 @@ class TestFirewall(NetworkCase):
         b.wait_in_text("#zones-listing", "Public")
         b.wait_in_text("#zones-listing", "default")
 
+        # add a service to the runtime configuration via the cli, after all the
+        # operations it should still be there, indicating no reload took place
+        m.execute("firewall-cmd --add-service=http")
+        b.wait_present("tr[data-row-id='http']")
+
         # click on the "Add Services" button
         b.wait_present("caption #add-services-button:enabled")
         b.click("caption #add-services-button")
@@ -194,6 +199,9 @@ class TestFirewall(NetworkCase):
         b.click("#add-services-dialog .modal-footer .btn-cancel")
         b.wait_not_present("#cockpit_modal_dialog")
 
+        # should still be here
+        b.wait_present("tr[data-row-id='http']")
+
         # Service without name should appear in the dialog
         m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload")
         b.click("caption #add-services-button")
@@ -236,7 +244,7 @@ class TestFirewall(NetworkCase):
         # remove service while the dialog is open
         m.execute("firewall-cmd --remove-service=pop3")
         b.click("#remove-services-dialog button.btn-primary")
-        b.wait_in_text("#remove-services-dialog div.alert", "org.fedoraproject.FirewallD1.Exception: NOT_ENABLED: 'pop3' not in 'public'")
+        b.wait_in_text("#remove-services-dialog div.alert-danger", "org.fedoraproject.FirewallD1.Exception: NOT_ENABLED: 'pop3' not in 'public'")
 
     @skipImage("Custom ports were introduced in #11420", "rhel-8-0-distropkg")
     def testAddCustomServices(self):
@@ -246,6 +254,11 @@ class TestFirewall(NetworkCase):
         self.login_and_go("/network/firewall")
         b.wait_in_text("#zones-listing", "Public")
         b.wait_in_text("#zones-listing", "default")
+
+        # add a service to the runtime configuration via the cli, after all the
+        # operations it should be removed, indicating a reload took place
+        m.execute("firewall-cmd --add-service=http")
+        b.wait_present("tr[data-row-id='http']")
 
         def open_dialog():
             b.wait_present("caption #add-services-button:enabled")
@@ -328,7 +341,10 @@ class TestFirewall(NetworkCase):
         open_dialog()
         set_field("#udp-ports", "19834", "19834")
         b.click("#add-services-dialog button.btn-primary")
-        b.wait_in_text("#add-services-dialog div.alert", "org.fedoraproject.FirewallD1.Exception: NAME_CONFLICT: new_service(): 'custom--19834'")
+        b.wait_in_text("#add-services-dialog div.alert-danger", "org.fedoraproject.FirewallD1.Exception: NAME_CONFLICT: new_service(): 'custom--19834'")
+
+        # should have been removed in the reload
+        b.wait_not_present("tr[data-row-id='http']")
 
 
     @skipImage("Zones were introduced in #11745", "rhel-8-0-distropkg")
@@ -360,7 +376,7 @@ class TestFirewall(NetworkCase):
             b.click("#add-zone-dialog .modal-footer button.btn-primary:enabled")
 
             if error:
-                b.wait_in_text("#add-zone-dialog div.alert", error)
+                b.wait_in_text("#add-zone-dialog div.alert-danger", error)
                 b.click("#add-zone-dialog .modal-footer button.btn-cancel")
                 b.wait_not_present("#add-zone-dialog")
                 return


### PR DESCRIPTION
Add a warning as well that adding a custom service will reload
firewalld, resulting in a loss of runtime-only configuration.

This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1725094 as
well.