### PR TITLE
bots: Add naughty for libvirt CAP_SYS_RAWIO denial to Ubuntu images

### DIFF
--- a/bots/naughty/ubuntu-1804/12250-apparmor-libvirt-rawio
+++ b/bots/naughty/ubuntu-1804/12250-apparmor-libvirt-rawio
@@ -1,0 +1,1 @@
+Error: audit: type=1400 audit(*): apparmor="DENIED" operation="capable" profile="/usr/sbin/libvirtd" * comm="libvirt_parthel" * capname="sys_rawio"

--- a/bots/naughty/ubuntu-stable/12250-apparmor-libvirt-rawio
+++ b/bots/naughty/ubuntu-stable/12250-apparmor-libvirt-rawio
@@ -1,0 +1,1 @@
+Error: audit: type=1400 audit(*): apparmor="DENIED" operation="capable" profile="/usr/sbin/libvirtd" * comm="libvirt_parthel" * capname="sys_rawio"


### PR DESCRIPTION
Known issue #12250 affects the Ubuntu images as well.