### PR TITLE
tools: Prevent flash of text while loading fonts

### DIFF
--- a/tools/patternfly.sed
+++ b/tools/patternfly.sed
@@ -1,6 +1,6 @@
 s/src: url(.*eot[^'"]*['"]);$//
-s/src: url.*glyphicons-halflings-regular.woff.*/src: url('fonts\/glyphicons.woff') format('woff');/
-s/src: url.*fontawesome-webfont.woff.*/src: url('fonts\/fontawesome.woff?v=4.2.0') format('woff');/
-s/src: url.*PatternFlyIcons-webfont.woff.*/src: url('fonts\/patternfly.woff') format('woff');/
-s/src:.*url.*OpenSans-\([^'"]*\).woff.*/src: url('..\/..\/static\/fonts\/OpenSans-\1.woff') format('woff');/
-s/src:.*url.*RedHat\([a-zA-Z]\+-[^.]*\).*/src: url('..\/..\/static\/fonts\/RedHat\1.woff2') format('woff2');/
+s/src: url.*glyphicons-halflings-regular.woff.*/font-display: block;\n  src: url('fonts\/glyphicons.woff') format('woff');/
+s/src: url.*fontawesome-webfont.woff.*/font-display: block;\n  src: url('fonts\/fontawesome.woff?v=4.2.0') format('woff');/
+s/src: url.*PatternFlyIcons-webfont.woff.*/font-display: block;\n  src: url('fonts\/patternfly.woff') format('woff');/
+s/src:.*url.*OpenSans-\([^'"]*\).woff.*/font-display: block;\n  src: url('..\/..\/static\/fonts\/OpenSans-\1.woff') format('woff');/
+s/src:.*url.*RedHat\([a-zA-Z]\+-[^.]*\).*/font-display: block;\n  src: url('..\/..\/static\/fonts\/RedHat\1.woff2') format('woff2');/


### PR DESCRIPTION
A little bit of CSS is injected into the font files, as to prevent displaying the text until the font has loaded.

Ordinarily, this can be considered a not-so-great practice for document websites, but for apps, it is (arguably) less jarring than showing the text with the improper font and then re-rendering the text with a new font. This is especially the case for icons.

End result? Delaying the text rendering until the appropriate font is available makes the UI feel a bit less jump and a bit more more polished.

This affects initial loads. After the first load, the font should be cached.

More information available @ https://css-tricks.com/almanac/properties/f/font-display/