### PR TITLE
machines: introduce check for VM memory to be above allowed minimum

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -526,13 +526,7 @@ class CreateVmModal extends React.Component {
                                         os: osEntry[0].shortId
                                     });
                                 }
-                            }, ex => {
-                                console.log("osinfo-detect command failed: ", ex.message);
-                                this.setState({
-                                    vendor: NOT_SPECIFIED,
-                                    os: OTHER_OS_SHORT_ID,
-                                });
-                            });
+                            }, ex => console.log("osinfo-detect command failed: ", ex.message));
                 };
                 this.typingTimeout = setTimeout(() => onOsAutodetect(value), 250);
             }

--- a/pkg/machines/getOSList.py
+++ b/pkg/machines/getOSList.py
@@ -26,6 +26,14 @@ for i in range(oses.get_length()):
     osObj['releaseDate'] = os.get_release_date_string() or ""
     osObj['eolDate'] = os.get_eol_date_string() or ""
     osObj['codename'] = os.get_codename() or ""
+    osObj['recommendedResources'] = {}
+    recommendedResources = os.get_recommended_resources()
+    if recommendedResources.get_length():
+        osObj['recommendedResources']['ram'] = recommendedResources.get_nth(0).get_ram()
+    osObj['minimumResources'] = {}
+    minimumResources = os.get_minimum_resources()
+    if minimumResources.get_length():
+        osObj['minimumResources']['ram'] = minimumResources.get_nth(0).get_ram()
 
     res.append(osObj)
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1328,6 +1328,12 @@ class TestMachines(NetworkCase):
         # memory
         checkDialogFormValidationTest(TestMachines.VmDialog(self, storage_size=1, memory_size=0), {"Memory": "Memory must not be 0"})
 
+        # memory
+        checkDialogFormValidationTest(TestMachines.VmDialog(self, storage_size=1,
+                                                            os_vendor=config.FEDORA_VENDOR,
+                                                            os_name=config.FEDORA_28,
+                                                            memory_size=256, memory_size_unit='MiB'), {"Memory": "minimum memory requirement of 1024 MiB"})
+
         # start vm
         checkDialogFormValidationTest(TestMachines.VmDialog(self, storage_size=1,
                                                             os_vendor=config.NOVELL_VENDOR,
@@ -1345,12 +1351,13 @@ class TestMachines(NetworkCase):
         createTest(TestMachines.VmDialog(self, sourceType='url',
                                          location=config.VALID_URL,
                                          storage_size=1,
+                                         memory_size=512, memory_size_unit='MiB',
                                          os_vendor=config.MICROSOFT_VENDOR,
                                          os_name=config.MICROSOFT_VISTA))
 
         createTest(TestMachines.VmDialog(self, sourceType='url',
                                          location=config.VALID_URL,
-                                         memory_size=256, memory_size_unit='MiB',
+                                         memory_size=512, memory_size_unit='MiB',
                                          storage_size=100, storage_size_unit='MiB',
                                          os_vendor=config.MICROSOFT_VENDOR,
                                          os_name=config.MICROSOFT_XP_OS,
@@ -1737,6 +1744,9 @@ class TestMachines(NetworkCase):
         REDHAT_VENDOR = 'Red Hat, Inc'
         REDHAT_RHEL_4_7_FILTERED_OS = 'Red Hat Enterprise Linux 4.9'
 
+        FEDORA_VENDOR = 'Fedora Project'
+        FEDORA_28 = 'Fedora 28'
+
         MANDRIVA_FILTERED_VENDOR = 'Mandriva'
         MANDRIVA_2011_FILTERED_OS = 'Mandriva Linux 2011'
 
@@ -1947,7 +1957,7 @@ class TestMachines(NetworkCase):
             b.click(".modal-footer button:contains(Create)")
 
             for error, error_msg in errors.items():
-                error_location = ".modal-body label:contains('{0}') + div.form-group.has-error span p".format(error)
+                error_location = ".modal-body label:contains('{0}') + div.form-group.has-error span.help-block".format(error)
                 b.wait_visible(error_location)
                 if (error_msg):
                     b.wait_in_text(error_location, error_msg)


### PR DESCRIPTION
Also add a helpblock indicating the suggested memory if an operating
system was detected but the selected memory is less than recommended.

Ideally we would like to prefill the memory values with the suggested
ram size from libosinfo, but this should be part of bigger refactoring of
the 'Create VM' dialog.

The text-danger class was removed from the memory helpblock because it
created extra spacing between the helpblocks.
The red color for failed validation comes from the wrapper formgroup
element anyway.