### PR TITLE
services: Redesign details page

### DIFF
--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -333,25 +333,6 @@ body {
     color: red;
 }
 
-.service-action-btn {
-    margin-left: 10px;
-}
-
-.service-action-btn ul {
-    right: 0px;
-    left: auto;
-    min-width: 0;
-    text-align: left;
-}
-
-.service-panel span {
-    font-weight: bold;
-}
-
-.service-panel table {
-    width: 100%;
-}
-
 .service-template input {
     width: 50em;
 }

--- a/pkg/systemd/service-details.css
+++ b/pkg/systemd/service-details.css
@@ -1,0 +1,131 @@
+#service-details {
+    padding-bottom: 2.5rem;
+}
+
+.service-top-panel {
+    padding-bottom: 1.25rem;
+    display: flex;
+    align-items: baseline;
+}
+
+.service-top-panel > .service-name {
+    margin: 0 1.5rem 0 0;
+}
+
+.service-top-panel .onoff-ct {
+    vertical-align: text-bottom;
+}
+
+/* Make the kebab wrapper and button flex to parents for proper alignment */
+.service-top-panel .dropdown-kebab-pf,
+.service-top-panel .dropdown-kebab-pf > .dropdown-toggle {
+    display: flex;
+}
+
+/* Remove unnecessary margin */
+.service-top-panel .dropdown-kebab-pf > .dropdown-toggle {
+    margin: 0;
+}
+
+/* Use up to 13rem width for the kebab space (including menu) */
+.service-top-panel .dropdown-kebab-pf {
+    flex: auto;
+    max-width: 13rem;
+}
+
+/* Bump up the z-index to menu's z-index + 1 */
+.service-top-panel .dropdown-kebab-pf > .dropdown-toggle[aria-expanded=true] {
+    position: relative;
+    z-index: 1001;
+}
+
+/* Recreate the ^ menu pointer, but under the button itself */
+.service-top-panel .dropdown-kebab-pf > .dropdown-toggle[aria-expanded=true]:before,
+.service-top-panel .dropdown-kebab-pf > .dropdown-toggle[aria-expanded=true]:after {
+    border: 10px solid var(--pf-global--BorderColor--200);
+    border-top-width: 0;
+    border-right: 10px solid transparent;
+    border-left: 10px solid transparent;
+    content: "";
+    display: inline-block;
+    position: absolute;
+    bottom: -0.5rem;
+    /* Start element at 50% width */
+    left: 50%;
+    /* Bump element to the left ½ its width */
+    transform: translateX(-50%);
+}
+
+/* Recolor inner triangle and bump down a pixel to overlap */
+.service-top-panel .dropdown-kebab-pf > .dropdown-toggle[aria-expanded=true]:after {
+    border-bottom-color: var(--pf-global--BackgroundColor--100);
+    bottom: calc(-0.5rem - 1px);
+}
+
+/* Turn off PF3 kebab menu's ^ caret */
+.service-top-panel .dropdown-kebab-pf > .dropdown-menu::before,
+.service-top-panel .dropdown-kebab-pf > .dropdown-menu::after {
+    display: none;
+}
+
+/* Reposition kebab menu */
+.service-top-panel .dropdown-kebab-pf > .dropdown-menu {
+    left: auto;
+    right: 0;
+    margin: 0 -0.5rem;
+    min-width: calc(100% + 1rem);
+    top: calc(100% + 0.5rem);
+}
+
+.action-button {
+    margin-left: 2rem;
+}
+
+#service-details .ct-form > :not(hr) {
+    line-height: 1.5rem;
+    row-gap: normal;
+}
+
+.ct-form .closer-lines {
+    margin: 0;
+}
+
+.status-icon::before {
+    color: inherit;
+}
+
+.status-icon {
+    padding-right: 0.5rem;
+    color: var(--pf-global--icon--Color--light);
+}
+
+.status-icon.spinner.spinner-xs {
+    height: 1rem;
+    width: 1rem;
+    margin-right: 0.5rem;
+}
+
+.status-running > .status-icon,
+.status-enabled > .status-icon {
+    /* mid-way between PF4 success-100 & 200; then rounded to AA contrast */
+    color: #6da000;
+}
+
+.status-failed > .status-icon,
+.status-failed > .status,
+.control-label.failed {
+    color: var(--pf-global--danger-color--200);
+}
+
+.side-note {
+    color: var(--pf-global--Color--300);
+    padding-left: 1em;
+}
+
+.font-xs {
+    font-size: var(--pf-global--FontSize--xs);
+}
+
+.list-group-item {
+    border: none;
+}

--- a/pkg/systemd/service-details.jsx
+++ b/pkg/systemd/service-details.jsx
@@ -1,0 +1,517 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import moment from "moment";
+import PropTypes from "prop-types";
+import { Button, Modal, OverlayTrigger, Tooltip, DropdownKebab, MenuItem } from 'patternfly-react';
+
+import cockpit from "cockpit";
+import { OnOffSwitch } from "cockpit-components-onoff.jsx";
+
+import './service-details.css';
+
+const _ = cockpit.gettext;
+
+/*
+ * React template for instantiating service templates
+ * Required props:
+ *  - template:
+ *      Name of the template
+ *  - instantiateCallback
+ *      Method for calling unit file methods like `EnableUnitFiles`
+ */
+export class ServiceTemplate extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            inputText: "",
+        };
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(e) {
+        this.setState({ inputText: e.target.value });
+    }
+
+    render() {
+        return (
+            <div className="panel panel-default">
+                <div className="list-group">
+                    <div className="list-group-item">
+                        { cockpit.format(_("$0 Template"), this.props.template) }
+                    </div>
+                    <div className="list-group-item">
+                        <input type="text" onChange={ this.handleChange } />
+                        <button onClick={() => this.props.instantiateCallback(this.state.inputText)}>{ _("Instantiate") }</button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+ServiceTemplate.propTypes = {
+    template: PropTypes.string.isRequired,
+    instantiateCallback: PropTypes.func.isRequired,
+};
+/*
+ * Note:
+<p translatable="yes">This unit is not designed to be enabled explicitly.</p>
+    Error:
+    error.toString()
+*/
+
+/*
+ * React template for showing basic dialog for confirming action
+ * Required props:
+ *  - title
+ *     Title of the dialog
+ *  - message
+ *     Message in the dialog
+ *  - close
+ *     Action to be executed when Cancel button is selected.
+ * Optional props:
+ *  - confirmText
+ *     Text of the button for confirming the action
+ *  - confirmAction
+ *     Action to be executed when the action is confirmed
+ */
+class ServiceConfirmDialog extends React.Component {
+    render() {
+        return (
+            <Modal show>
+                <Modal.Header>
+                    <Modal.Title>{this.props.title}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {this.props.message}
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button bsStyle='default' className='btn-cancel' onClick={this.props.close}>
+                        { _("Cancel") }
+                    </Button>
+                    { this.props.confirmText && this.props.confirmAction &&
+                        <Button bsStyle='danger' onClick={this.props.confirmAction}>
+                            {this.props.confirmText}
+                        </Button>
+                    }
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+ServiceConfirmDialog.propTypes = {
+    title: PropTypes.string.isRequired,
+    message: PropTypes.string.isRequired,
+    close: PropTypes.func.isRequired,
+    confirmText: PropTypes.string,
+    confirmAction: PropTypes.func,
+};
+
+/*
+ * React template for showing possible service action (in a kebab menu)
+ * Required props:
+ *  - masked
+ *     Unit is masked
+ *  - active
+ *     Unit is active (running)
+ *  - enabled
+ *     Unit is enabled
+ *  - isStatic
+ *     Unit is static
+ *  - actionCallback
+ *      Method for calling unit methods like `UnitStart`
+ *  - fileActionCallback
+ *      Method for calling unit file methods like `EnableUnitFiles`
+ *  - disabled
+ *      Button is disabled
+ */
+class ServiceActions extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            dialogMaskedOpened: false,
+        };
+    }
+
+    render() {
+        let actions = [];
+
+        // If masked, only show unmasking and nothing else
+        if (this.props.masked) {
+            actions.push(
+                <MenuItem key="unmask" onClick={() => this.props.fileActionCallback("UnmaskUnitFiles", undefined)}>{ _("Allow running (unmask)") }</MenuItem>
+            );
+        } else { // All cases when not masked
+            // Only show stop when running but not enabled
+            if (this.props.active && !this.props.enabled) {
+                actions.push(
+                    <MenuItem key="stop" onClick={() => this.props.actionCallback("StopUnit")}>{ _("Stop") }</MenuItem>,
+                );
+            }
+            if (!this.props.isStatic && (this.props.enabled || this.props.active)) {
+                if (actions.length > 0) {
+                    actions.push(
+                        <MenuItem key="divider1" divider />
+                    );
+                }
+                if (this.props.active) {
+                    actions.push(
+                        <MenuItem key="restart" onClick={() => this.props.actionCallback("RestartUnit")}>{ _("Restart") }</MenuItem>
+                    );
+                } else {
+                    actions.push(
+                        <MenuItem key="start" onClick={() => this.props.actionCallback("StartUnit")}>{ _("Start") }</MenuItem>
+                    );
+                }
+
+                actions.push(
+                    <MenuItem key="reload" onClick={() => this.props.actionCallback("ReloadUnit")}>{ _("Reload") }</MenuItem>
+                );
+            }
+
+            if (actions.length > 0) {
+                actions.push(
+                    <MenuItem key="divider2" divider />
+                );
+            }
+
+            actions.push(
+                <MenuItem key="mask" onClick={() => this.setState({ dialogMaskedOpened: true }) }>{ _("Disallow running (mask)") }</MenuItem>
+            );
+        }
+
+        return (
+            <React.Fragment>
+                { this.state.dialogMaskedOpened &&
+                    <ServiceConfirmDialog title={ _("Mask Service") }
+                                          message={ _("Masking service prevents all dependant units from running. This can have bigger impact than anticipated. Please confirm that you want to mask this unit.")}
+                                          close={() => this.setState({ dialogMaskedOpened: false }) }
+                                          confirmText={ _("Mask Service") }
+                                          confirmAction={() => { this.props.fileActionCallback("MaskUnitFiles", false); this.setState({ dialogMaskedOpened: false }) }} />
+                }
+                <DropdownKebab id="service-actions" title={ _("Additional actions") } className={this.props.disabled ? "disabled" : "" }>
+                    {actions}
+                </DropdownKebab>
+            </React.Fragment>
+        );
+    }
+}
+ServiceActions.propTypes = {
+    masked: PropTypes.bool.isRequired,
+    active: PropTypes.bool.isRequired,
+    enabled: PropTypes.bool.isRequired,
+    isStatic: PropTypes.bool.isRequired,
+    actionCallback: PropTypes.func.isRequired,
+    fileActionCallback: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
+};
+
+/*
+ * React template for a service details
+ * Shows current status and informations about the service.
+ * Enables user to control this unit like starting, enabling, etc. the service.
+ * Required props:
+ *  -  unit
+ *      Unit as returned from systemd dbus API
+ *  -  permitted
+ *      True if user can control this unit
+ *  -  systemdManager
+ *      Callback for displaying errors
+ *  -  isValid
+ *      Method for finding if unit is valid
+ * Optional props:
+ *  -  originTemplate
+ *      Template name, from which this unit has been initialized
+ */
+export class ServiceDetails extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            waitsAction: false,
+            waitsFileAction: false,
+            note: "",
+            error: "",
+        };
+
+        this.onOnOffSwitch = this.onOnOffSwitch.bind(this);
+        this.unitAction = this.unitAction.bind(this);
+        this.unitFileAction = this.unitFileAction.bind(this);
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+        // Don't update when only actions resolved, wait until API triggers some redrawing
+        if ((nextState.waitsAction === false && this.state.waitsAction === true) ||
+            (nextState.waitsFileAction === false && this.state.waitsFileAction === true))
+            return false;
+        return true;
+    }
+
+    onOnOffSwitch() {
+        if (this.props.unit.UnitFileState === "enabled") {
+            this.unitFileAction("DisableUnitFiles", undefined);
+            if (this.props.unit.ActiveState === "active" || this.props.unit.ActiveState === "activating")
+                this.unitAction("StopUnit");
+        } else {
+            this.unitFileAction("EnableUnitFiles", false);
+            if (this.props.unit.ActiveState !== "active" && this.props.unit.ActiveState !== "activating")
+                this.unitAction("StartUnit");
+        }
+    }
+
+    unitAction(method) {
+        this.setState({ waitsAction: true });
+        this.props.systemdManager.call(method, [ this.props.unit.Names[0], "fail" ])
+                .fail(error => this.setState({ error: error.toString() }))
+                .finally(() => this.setState({ waitsAction: false }));
+    }
+
+    unitFileAction(method, force) {
+        this.setState({ waitsFileAction: true });
+        let args = [ [ this.props.unit.Names[0] ], false ];
+        if (force !== undefined)
+            args.push(force == "true");
+        this.props.systemdManager.call(method, args)
+                .then(results => {
+                    if (results.length == 2 && !results[0])
+                        this.setState({ note:_("This unit is not designed to be enabled explicitly.") });
+                    this.props.systemdManager.Reload()
+                            .then(() => this.setState({ waitsFileAction: false }));
+                })
+                .fail(error => {
+                    this.setState({ error: error.toString(),
+                                    waitsFileAction: false });
+                });
+    }
+
+    render() {
+        let active = this.props.unit.ActiveState === "active" || this.props.unit.ActiveState === "activating";
+        let enabled = this.props.unit.UnitFileState === "enabled";
+        let isStatic = this.props.unit.UnitFileState !== "disabled" && !enabled;
+        let failed = this.props.unit.ActiveState === "failed";
+        let masked = this.props.unit.LoadState === "masked";
+
+        let status = [];
+
+        if (masked) {
+            status.push(
+                <div key="masked" className="status-masked">
+                    <span className="fa fa-ban status-icon" />
+                    <span className="status">{ _("Masked") }</span>
+                    <span className="side-note font-xs">{ _("Forbidden from running") }</span>
+                </div>
+            );
+        }
+
+        if (!enabled && !active && !masked && !isStatic) {
+            status.push(
+                <div key="disabled" className="status-disabled">
+                    <span className="pficon pficon-off status-icon" />
+                    <span className="status">{ _("Disabled") }</span>
+                </div>
+            );
+        }
+
+        if (failed) {
+            status.push(
+                <div key="failed" className="status-failed">
+                    <span className="pficon pficon-error-circle-o status-icon" />
+                    <span className="status">{ _("Failed to start") }</span>
+                    <button className="btn btn-default action-button" onClick={() => this.props.actionCallback("StartUnit") }>{ _("Start Service") }</button>
+                </div>
+            );
+        }
+
+        if (!status.length) {
+            if (active) {
+                status.push(
+                    <div key="running" className="status-running">
+                        <span className="pficon pficon-on-running status-icon" />
+                        <span className="status">{ _("Running") }</span>
+                        <span className="side-note font-xs">{ _("Active since ") + moment(this.props.unit.ActiveEnterTimestamp / 1000).format('LLL') }</span>
+                    </div>
+                );
+            } else {
+                status.push(
+                    <div key="stopped" className="status-stopped">
+                        <span className="pficon pficon-off status-icon" />
+                        <span className="status">{ _("Not running") }</span>
+                    </div>
+                );
+            }
+        }
+
+        if (isStatic && !masked) {
+            status.unshift(
+                <div key="static" className="status-static">
+                    <span className="pficon pficon-asleep status-icon" />
+                    <span className="status">{ _("Static") }</span>
+                    { this.props.unit.WantedBy && this.props.unit.WantedBy.length > 0 &&
+                        <React.Fragment>
+                            <span className="side-note font-xs">{ _("Required by ") }</span>
+                            <ul className="comma-list">
+                                {this.props.unit.WantedBy.map(unit => <li className="font-xs" key={unit}><a href={"#/" + unit}>{unit}</a></li>)}
+                            </ul>
+                        </React.Fragment>
+                    }
+                </div>
+            );
+        }
+
+        if (!this.props.permitted) {
+            status.unshift(
+                <div key="readonly" className="status-readonly">
+                    <span className="fa fa-user status-icon" />
+                    <span className="status">{ _("Read-only") }</span>
+                    <span className="side-note font-xs">{ _("Requires administration access to edit") }</span>
+                </div>
+            );
+        }
+
+        if (enabled) {
+            status.push(
+                <div key="enabled" className="status-enabled">
+                    <span className="pficon pficon-ok status-icon" />
+                    <span className="status">{ _("Automatically starts") }</span>
+                </div>
+            );
+        }
+
+        /* If there is some ongoing action just show spinner */
+        if (this.state.waitsAction || this.state.waitsFileAction) {
+            status = [
+                <div key="updating" className="status-updating">
+                    <span className="spinner spinner-inline spinner-xs status-icon" />
+                    <span className="status">{ _("Updating status...") }</span>
+                </div>
+            ];
+        }
+
+        let tooltipMessage = enabled ? _("Stop and Disable") : _("Start and Enable");
+        let hasLoadError = this.props.unit.LoadState !== "loaded" && this.props.unit.LoadState !== "masked";
+        let loadError = this.props.unit.LoadError ? this.props.unit.LoadError[1] : null;
+        let relationships = [
+            { Name: _("Requires"), Units: this.props.unit.Requires },
+            { Name: _("Requisite"), Units: this.props.unit.Requisite },
+            { Name: _("Wants"), Units: this.props.unit.Wants },
+            { Name: _("Binds To"), Units: this.props.unit.BindsTo },
+            { Name: _("Part Of"), Units: this.props.unit.PartOf },
+            { Name: _("Required By"), Units: this.props.unit.RequiredBy },
+            { Name: _("Requisite Of"), Units: this.props.unit.RequisiteOf },
+            { Name: _("Wanted By"), Units: this.props.unit.WantedBy },
+            { Name: _("Bound By"), Units: this.props.unit.BoundBy },
+            { Name: _("Consists Of"), Units: this.props.unit.ConsistsOf },
+            { Name: _("Conflicts"), Units: this.props.unit.Conflicts },
+            { Name: _("Conflicted By"), Units: this.props.unit.ConflictedBy },
+            { Name: _("Before"), Units: this.props.unit.Before },
+            { Name: _("After"), Units: this.props.unit.After },
+            { Name: _("On Failure"), Units: this.props.unit.OnFailure },
+            { Name: _("Triggers"), Units: this.props.unit.Triggers },
+            { Name: _("Triggered By"), Units: this.props.unit.TriggeredBy },
+            { Name: _("Propagates Reload To"), Units: this.props.unit.PropagatesReloadTo },
+            { Name: _("Reload Propagated From"), Units: this.props.unit.ReloadPropagatedFrom },
+            { Name: _("Joins Namespace Of"), Units: this.props.unit.JoinsNamespaceOf }
+        ];
+
+        let conditions = this.props.unit.Conditions;
+        let notMetConditions = [];
+        if (conditions)
+            conditions.map(condition => {
+                if (condition[4] < 0)
+                    notMetConditions.push(cockpit.format(_("Condition $0=$1 was not met"), condition[0], condition[3]));
+            });
+
+        return (
+            <React.Fragment>
+                { (this.state.note || this.state.error) &&
+                    <ServiceConfirmDialog title={ this.state.error ? _("Error") : _("Note") }
+                                          message={ this.state.error || this.state.note }
+                                          close={ () => this.setState(this.state.error ? { error:"" } : { note:"" }) }
+                    />
+                }
+                { hasLoadError
+                    ? <div className="alert alert-danger">
+                        <span className="pficon pficon-error-circle-o" />
+                        <strong>{this.props.unit.LoadState}</strong>
+                        {loadError}
+                    </div>
+                    : <React.Fragment>
+                        <div className="service-top-panel">
+                            <h2 className="service-name">{this.props.unit.Description}</h2>
+                            { this.props.permitted &&
+                                <React.Fragment>
+                                    { !masked && !isStatic &&
+                                        <OverlayTrigger overlay={ <Tooltip id="switch-unit-state">{ tooltipMessage }</Tooltip> } placement='right'>
+                                            <span>
+                                                <OnOffSwitch state={enabled} disabled={this.state.waitsAction || this.state.waitsFileAction} onChange={this.onOnOffSwitch} />
+                                            </span>
+                                        </OverlayTrigger>
+                                    }
+                                    <ServiceActions { ...{ active, enabled, isStatic, masked } } actionCallback={this.unitAction} fileActionCallback={this.unitFileAction} disabled={this.state.waitsAction || this.state.waitsFileAction} />
+                                </React.Fragment>
+                            }
+                        </div>
+                        <form className="ct-form">
+                            <label className="control-label" htmlFor="statuses">{ _("Status") }</label>
+                            <div id="statuses" className="ct-validation-wrapper">
+                                { status }
+                            </div>
+                            <hr />
+                            <label className="control-label" htmlFor="path">{ _("Path") }</label>
+                            <span id="path">{this.props.unit.FragmentPath}</span>
+                            <hr />
+                            { this.props.originTemplate &&
+                                <React.Fragment>
+                                    <label className="control-label" />
+                                    <span>{_("This unit is an instanced from ")}<a href={"#/" + this.props.originTemplate}>{this.props.originTemplate}</a>{ _(" template.")}</span>
+                                </React.Fragment>
+                            }
+                            { notMetConditions.length > 0 &&
+                                <React.Fragment>
+                                    <label className="control-label failed" htmlFor="condition">{ _("Condition failed") }</label>
+                                    <div id="condition" className="ct-validation-wrapper">
+                                        {notMetConditions.map(cond => <div key={cond.split(' ').join('')}>{cond}</div>)}
+                                    </div>
+                                </React.Fragment>
+                            }
+                            <hr />
+                            {relationships.map(rel =>
+                                rel.Units && rel.Units.length > 0 &&
+                                    <React.Fragment key={rel.Name.split().join("")}>
+                                        <label className="control-label closer-lines" htmlFor={rel.Name}>{rel.Name}</label>
+                                        <ul id={rel.Name.split(" ").join("")} className="comma-list closer-lines">
+                                            {rel.Units.map(unit => <li key={unit}><a href={"#/" + unit} className={this.props.isValid(unit) ? "" : "disabled"}>{unit}</a></li>)}
+                                        </ul>
+                                    </React.Fragment>
+                            )}
+                        </form>
+                    </React.Fragment>
+                }
+            </React.Fragment>
+        );
+    }
+}
+ServiceDetails.propTypes = {
+    unit: PropTypes.object.isRequired,
+    originTemplate: PropTypes.string,
+    permitted: PropTypes.bool.isRequired,
+    systemdManager: PropTypes.object.isRequired,
+    isValid: PropTypes.func.isRequired,
+};

--- a/pkg/systemd/services.css
+++ b/pkg/systemd/services.css
@@ -9,11 +9,12 @@
 }
 
 .comma-list > li {
-  display: inline;
+  display: inline-block;
 }
 
 .comma-list > li:not(:last-child):after {
   content: ",";
+  margin-right: 0.5em;
 }
 
 table.systemd-unit-relationship-table td:first-child {

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -79,108 +79,6 @@
     </div>
   </div>
 
-  <script id="action-btn-tmpl"  type="x-template/mustache">
-    {{#primary-id}}
-    <div class="btn-group service-action-btn" id="{{primary-id}}">
-        <button data-action="{{primary-action.action}}" data-container="body" class="btn btn-default">{{primary-action.title}}</button>
-    </div>
-    {{/primary-id}}
-    <div class="btn-group service-action-btn" id="{{id}}">
-      <button data-action="{{def.action}}" data-container="body" class="btn btn-default">{{def.title}}</button>
-      <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-        <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu" role="menu">
-        {{#actions}}
-        <li class="presentation">
-          <a tabindex="0" data-action="{{action}}" role="menuitem">{{title}}</a>
-        </li>
-        {{/actions}}
-      </ul>
-    </div>
-  </script>
-
-  <script id="service-unit-tmpl" type="x-template/mustache">
-    <div class="panel panel-default service-panel">
-      <div class="panel-heading">{{Unit.Description}}</div>
-      <div class="list-group">
-        <div class="list-group-item">
-          {{#HasLoadError}}
-            <div class="alert alert-danger">
-              <span class="pficon pficon-error-circle-o"></span>
-              <strong>{{Unit.LoadState}}</strong> {{LoadError}}
-            </div>
-          {{/HasLoadError}}
-          <table class="form-table-ct">
-            <tr><td class="top-right" translate>Status</td><td><span>{{Unit.ActiveState}}</span> ({{Unit.LoadState}}) {{{UnitButton}}}</td></tr>
-            {{#Since}}
-              <tr><td class="top-right" translate>Running Since</td><td>{{Since}}</td></tr>
-            {{/Since}}
-            <tr><td class="top-right" translate>Automatic Startup</td><td>{{Unit.UnitFileState}} {{{FileButton}}}</td></tr>
-            <tr><td class="top-right" translate>Path</td><td>{{Unit.FragmentPath}}</td></tr>
-          </table>
-        </div>
-        {{#TemplateDescription}}
-        <div class="list-group-item">
-          <table>
-            <tr>
-              <td>{{{.}}}</td>
-            </tr>
-          </table>
-        </div>
-        {{/TemplateDescription}}
-        {{#NotMetConditions.length}}
-        <div class="list-group-item cond-fail">
-          <table>
-            <tr>
-              <td>
-                <span translate>Condition failed</span>
-                <ul>
-                {{#NotMetConditions}}
-                  <li>{{.}}</li>
-                {{/NotMetConditions}}
-               </ul>
-             </td>
-             <td></td>
-            </tr>
-          </table>
-        </div>
-        {{/NotMetConditions.length}}
-        <div class="list-group-item">
-          <table class="form-table-ct systemd-unit-relationship-table">
-          {{#Relationships}}
-          {{#Units.length}}
-            <tr>
-              <td class="top-right">{{Name}}</td>
-              <td>
-                <ul class="comma-list">
-                {{#Units}}
-                  <li><a {{#disabled}}class="disabled"{{/disabled}} href='#/{{Id}}'>{{Id}}</a></li>
-                {{/Units}}
-                </ul>
-              </td>
-              <td></td>
-            </tr>
-          {{/Units.length}}
-          {{/Relationships}}
-          </table>
-        </div>
-      </div>
-    </div>
-  </script>
-
-  <script id="service-template-tmpl" type="x-template/mustache">
-    <div class="panel panel-default service-template">
-      <div class="panel-heading">{{Description}}</div>
-      <div class="list-group">
-        <div class="list-group-item">
-          <input/>
-          <button translatable="yes">Instantiate</button>
-        </div>
-      </div>
-    </div>
-  </script>
-
   <script id="service-empty-tmpl" type="x-template/mustache">
     <div id="empty-search" class="blank-slate-pf blank-screen">
       <h1 translate>No Matching Results</h1>
@@ -325,12 +223,11 @@
       <li class="active"></li>
     </ol>
 
-    <div id="service-valid">
-      <div id="service-unit"></div>
-      <div class="panel panel-default cockpit-log-panel" id="service-log-box" role="table" aria-describedby="service-log-box-heading">
+    <div id="service-details"></div>
+
+    <div class="panel panel-default cockpit-log-panel" id="service-log-box" role="table" aria-describedby="service-log-box-heading" hidden>
         <div class="panel-heading" id="service-log-box-heading" translatable="yes">Service Logs</div>
         <div class="panel-body" id="service-log" role="rowgroup"></div>
-      </div>
     </div>
 
     <div id="service-template">
@@ -340,42 +237,6 @@
       <div id="service-error-message"></div>
     </div>
 
-  </div>
-
-  <div class="modal" id="service-no-install-info-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translatable="yes">Note</h4>
-        </div>
-        <div class="modal-body">
-          <p translatable="yes">This unit is not designed to be enabled explicitly.</p>
-        </div>
-        <div class="modal-footer">
-          <button class="btn btn-primary" data-dismiss="modal" translatable="yes">Close</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="modal" id="service-error-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translatable="yes">Error</h4>
-        </div>
-        <div class="modal-body">
-          <p id="service-error-dialog-message"></p>
-        </div>
-        <div class="modal-footer">
-          <button class="btn btn-primary" data-dismiss="modal" translatable="yes">Close</button>
-        </div>
-      </div>
-    </div>
   </div>
 
   <div class="modal" id="timer-dialog"

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -61,6 +61,17 @@ function ph_has_val (sel, val)
     return ph_val(sel) == val;
 }
 
+function ph_collected_text_is (sel, val)
+{
+    var els = ph_select(sel);
+    var rest = els.map(el => {
+        if (el.textContent === undefined)
+            throw sel + " can not have text";
+        return el.textContent.replace(/\xa0/g, " ")
+    }).join("");
+    return rest === val;
+}
+
 function ph_text (sel)
 {
     var el = ph_find(sel);

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -387,6 +387,9 @@ class Browser:
         self.wait_visible(selector)
         self.wait_js_func('!ph_in_text', selector, text)
 
+    def wait_collected_text(self, selector, text):
+        self.wait_js_func('ph_collected_text_is', selector, text)
+
     def wait_text(self, selector, text):
         self.wait_visible(selector)
         self.wait_js_func('ph_text_is', selector, text)

--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -138,10 +138,17 @@ systemctl daemon-reload""")
         assert_stopped(True)
         b.click("#networking-nm-crashed a")
         b.enter_page("/system/services")
-        b.wait_in_text("#service-unit", "NetworkManager.service")
-        b.click("button[data-action='StartUnit']")
-        b.wait_in_text("#service-unit", "active")
-        b.wait_present("button[data-action='StopUnit']")
+        if m.image in ["rhel-8-0-distropkg"]: # Changed in #12265
+            b.wait_in_text("#service-unit", "NetworkManager.service")
+            b.click("button[data-action='StartUnit']")
+            b.wait_in_text("#service-unit", "active")
+            b.wait_present("button[data-action='StopUnit']")
+        else:
+            b.wait_text(".service-name", "Network Manager")
+            b.click(".service-top-panel .dropdown-kebab-pf button")
+            b.click(".service-top-panel .dropdown-menu a:contains('Start')")
+            b.wait_in_text("#statuses", "Running")
+
         # networking page should notice start from Services page
         b.go("/network")
         b.enter_page("/network")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -71,11 +71,18 @@ OnCalendar=daily
         b.enter_page("/system/services")
         b.reload()
         b.enter_page("/system/services")
-        b.wait_text("#service-unit .panel-heading", "Test Service")
+        if m.image in ["rhel-8-0-distropkg"]: # Changed in #12265
+            b.wait_text("#service-unit .panel-heading", "Test Service")
+        else:
+            b.wait_text(".service-name", "Test Service")
+
 
         m.restart_cockpit()
         b.relogin("/system/services")
-        b.wait_text("#service-unit .panel-heading", "Test Service")
+        if m.image in ["rhel-8-0-distropkg"]: # Changed in #12265
+            b.wait_text("#service-unit .panel-heading", "Test Service")
+        else:
+            b.wait_text(".service-name", "Test Service")
 
         # check that navigating away and back preserves place
         b.switch_to_top()
@@ -85,10 +92,11 @@ OnCalendar=daily
         b.switch_to_top()
         b.click("a[href='/system/services']")
         b.enter_page("/system/services")
-        b.wait_present("#service-unit .panel-heading")
-        b.wait_visible("#service-unit")
         b.wait_present("ol.breadcrumb")
-        b.wait_text("#service-unit .panel-heading", "Test Service")
+        if m.image in ["rhel-8-0-distropkg"]: # Changed in #12265
+            b.wait_text("#service-unit .panel-heading", "Test Service")
+        else:
+            b.wait_text(".service-name", "Test Service")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname === "/system/services"')
         b.wait_js_cond('window.location.hash === "#/test.service"')
@@ -100,9 +108,10 @@ OnCalendar=daily
         b.enter_page("/system/services")
         if m.image in ["rhel-8-0-distropkg"]:
             b.wait_present("#services-list-enabled")
+            b.wait_not_visible("#service-unit")
         else:
             b.wait_present("#services-list")
-        b.wait_not_visible("#service-unit")
+            b.wait_not_visible("#service-details")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname === "/system/services"')
         b.wait_js_cond('window.location.hash === ""')

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -176,9 +176,15 @@ class TestRealms(MachineCase):
         b.password = 'foobarfoo'
 
         self.login_and_go('/system/services#/systemd-tmpfiles-clean.timer', user='admin@cockpit.lan')
-        b.wait_in_text('#service-unit', "active")
-        b.click('#service-unit-primary-action button[data-action="StopUnit"]')
-        b.wait_in_text('#service-unit', "inactive")
+        if m.image in ["rhel-8-0-distropkg"]: # Changed in #12265
+            b.wait_in_text('#service-unit', "active")
+            b.click('#service-unit-primary-action button[data-action="StopUnit"]')
+            b.wait_in_text('#service-unit', "inactive")
+        else:
+            b.wait_in_text("#statuses", "Running")
+            b.click(".service-top-panel .dropdown-kebab-pf button")
+            b.click(".service-top-panel .dropdown-menu a:contains('Stop')")
+            b.wait_in_text("#statuses", "Not running")
         b.logout()
         b.password = orig_password
         m.execute("chown -R admin /home/admin")
@@ -318,9 +324,17 @@ class TestRealms(MachineCase):
         # should be able to run admin operations
         b.go('/system/services#/systemd-tmpfiles-clean.timer')
         b.enter_page('/system/services')
-        b.wait_in_text('#service-unit', "active")
-        b.click('#service-unit-primary-action button[data-action="StopUnit"]')
-        b.wait_in_text('#service-unit', "inactive")
+
+
+        if m.image in ["rhel-8-0-distropkg"]: # Changed in #12265
+            b.wait_in_text('#service-unit', "active")
+            b.click('#service-unit-primary-action button[data-action="StopUnit"]')
+            b.wait_in_text('#service-unit', "inactive")
+        else:
+            b.wait_in_text("#statuses", "Running")
+            b.click(".service-top-panel .dropdown-kebab-pf button")
+            b.click(".service-top-panel .dropdown-menu a:contains('Stop')")
+            b.wait_in_text("#statuses", "Not running")
 
         b.go('/system')
         b.enter_page('/system')

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -39,6 +39,30 @@ class TestServices(MachineCase):
         else:
             self.browser.click('#services-filter li:nth-child({0}) a'.format(n))
 
+    def wait_onoff(self, val):
+        self.browser.wait_present(".service-top-panel .onoff-ct input" + (":checked" if val else ":not(:checked)"))
+
+    def toggle_onoff(self):
+        self.browser.click(".service-top-panel .onoff-ct input")
+
+    def do_action(self, action):
+        self.browser.click(".service-top-panel .dropdown-kebab-pf button")
+        self.browser.click(".service-top-panel .dropdown-menu a:contains('{0}')".format(action))
+
+    def check_service_details(self, statuses, actions, enabled, onoff=True, kebab=True):
+        self.browser.wait_collected_text("#statuses .status", "".join(statuses))
+        if onoff:
+            self.wait_onoff(enabled)
+        else:
+            self.browser.wait_not_present(".service-top-panel .onoff-ct")
+        if kebab:
+            self.browser.click(".service-top-panel .dropdown-kebab-pf button")
+            self.browser.wait_text(".service-top-panel .dropdown-menu", "".join(actions))
+            # Click away to close the dropdown-menu
+            self.browser.click(".service-top-panel .dropdown-kebab-pf button")
+        else:
+            self.browser.wait_not_present(".service-top-panel .dropdown-kebab-pf")
+
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -73,6 +97,9 @@ Description=Failing Test Service
 
 [Service]
 ExecStart=/usr/bin/false
+
+[Install]
+WantedBy=default.target
 """)
         m.write("/etc/systemd/system/test-template@.service",
                 """
@@ -110,7 +137,6 @@ Unit=test.service
             return 'tr[data-goto-unit="%s"]' % service
 
         def wait_service_state(service, state):
-            b.wait_present(svc_sel(service))
             b.wait_in_text(svc_sel(service), state)
 
         def wait_service_in_panel(service, title):
@@ -130,10 +156,6 @@ Unit=test.service
         wait_service_state("test.service", "inactive")
         wait_service_state("test.service", "inactive")
 
-        unit_primary_action_btn = '#service-unit-primary-action'
-        unit_action_btn = '#service-unit-action'
-        file_action_btn = '#service-file-action'
-
         # Selects Timer tab
         self.pick_tab(4)
         b.wait_present(svc_sel('test.timer'))
@@ -152,74 +174,71 @@ Unit=test.service
         b.wait_in_text(svc_sel('test-onboot.timer'), "unknown")  # last trigger
         m.execute("systemctl stop test-onboot.timer")
 
+        if m.image in ["rhel-8-0-distropkg"]: # Changed in #12265
+            return
+
         # Selects Services tab
-        if self.machine.image in ["rhel-8-0-distropkg"]: # Changed in #12349
-            self.pick_tab(2)
-        else:
-            self.pick_tab(1)
-        b.wait_present(svc_sel('test.service'))
+        self.pick_tab(1)
+
+        # Check test.service and then start it
         b.click(svc_sel("test.service"))
-        b.wait_in_text('#service-valid', "inactive")
-        b.wait_action_btn(unit_primary_action_btn, "Start")
-        b.wait_action_btn(unit_action_btn, "Restart")
-        b.click_action_btn(unit_action_btn)
-        b.wait_in_text('#service-valid', "active")
-        b.wait_action_btn(unit_primary_action_btn, "Stop")
-        b.wait_action_btn(unit_action_btn, "Restart")
+        self.check_service_details(["Not running", "Automatically starts"], ["Start", "Reload", "Disallow running (mask)"], True)
+        self.do_action("Start")
+        self.check_service_details(["Running", "Automatically starts"], ["Restart", "Reload", "Disallow running (mask)"], True)
         b.wait_in_text('#service-log', "START")
         b.wait_in_text('#service-log', "WORKING")
 
+        # Stop and disable and back again
+        self.toggle_onoff()
+        self.check_service_details(["Disabled"], ["Disallow running (mask)"], False)
+        self.toggle_onoff()
+        self.check_service_details(["Running", "Automatically starts"], ["Restart", "Reload", "Disallow running (mask)"], True)
+
+        # Check without permissions
         self.allow_authorize_journal_messages()
         b.relogin('/system/services#/test.service', authorized=False)
-        b.wait_present('#service-unit')
-        b.wait_present('#service-unit-primary-action>button.disabled')
-        b.wait_present('#service-unit-action>button:nth-of-type(1).disabled')
-        b.wait_present('#service-unit-action>button:nth-of-type(2).disabled')
-        b.wait_present('#service-file-action>button:nth-of-type(1).disabled')
-        b.wait_present('#service-file-action>button:nth-of-type(2).disabled')
+        self.check_service_details(["Read-only", "Running", "Automatically starts"], [], False, onoff=False, kebab=False)
+
         b.relogin('/system/services#/test.service', authorized=True)
-        b.wait_present('#service-unit')
 
-        b.wait_in_text('#service-valid', "enabled")
-        b.wait_action_btn(file_action_btn, "Disable")
-        b.click_action_btn(file_action_btn)
-        b.wait_in_text('#service-valid', "disabled")
-        b.wait_action_btn(file_action_btn, "Enable")
+        self.toggle_onoff() # later on we need some disabled test
+        self.check_service_details(["Disabled"], ["Disallow running (mask)"], False)
 
+        # Check service that fails to start
         b.go("#/")
-        b.wait_in_text("#services", "test-fail.service")
-        b.wait_visible(svc_sel("test-fail.service"))
         b.click(svc_sel("test-fail.service"))
-        b.wait_in_text('#service-valid', "inactive")
-        b.wait_action_btn(unit_primary_action_btn, "Start")
-        b.click_action_btn(unit_primary_action_btn)
-        b.wait_in_text('#service-valid', "failed")
-
+        self.check_service_details(["Disabled"], ["Disallow running (mask)"], False)
+        self.toggle_onoff()
+        self.check_service_details(["Failed to start", "Automatically starts"], ["Start", "Reload", "Disallow running (mask)"], True)
+        b.wait_visible(".action-button:contains('Start Service')")
         b.go("#/")
         b.wait_in_text("#services", "test-fail.service")
         wait_service_state("test-fail.service", "failed")
 
+        # Check static service
+        b.click(svc_sel("systemd-halt.service"))
+        self.check_service_details(["Static", "Not running"], ["Disallow running (mask)"], True, onoff=False)
+
+        # Mask and unmask
+        self.do_action("Disallow running (mask)")
+        b.click(".modal-dialog .btn-danger")
+        self.check_service_details(["Masked"], ["Allow running (unmask)"], False, onoff=False)
+        self.do_action("Allow running (unmask)")
+        self.check_service_details(["Static", "Not running"], ["Disallow running (mask)"], True, onoff=False)
+
+
         # Instantiate a template
-        b.wait_in_text("#services", "test-template@.service")
-        b.wait_visible(svc_sel("test-template@.service"))
+        b.go("#/")
         b.click(svc_sel("test-template@.service"))
-        b.wait_visible('#service-template')
-        b.set_val("#service-template input", "//param-f//o//o//")
-        b.click("#service-template button")
-        b.wait_visible("#service-valid")
-        b.wait_text("#service-unit .panel-heading", "Test Template for param-f/o/o")
-        b.wait_text("#service-valid a[data-goto-unit]", "test-template@.service")
-        b.click("#service-valid a[data-goto-unit]")
-        b.wait_visible("#service-template")
-
-        self.allow_journal_messages("Failed to get realtime timestamp: Cannot assign requested address")
-
-        # Test searching and filtering
-        if m.image in ["rhel-8-0-distropkg"]: # Introduced in #11241
-            return
+        b.set_input_text("#service-details input", "//param-f//o//o//")
+        b.click("#service-details button")
+        b.wait_text(".service-name", "Test Template for param-f/o/o")
+        self.check_service_details(["Static", "Not running"], ["Disallow running (mask)"], True, onoff=False)
+        b.wait_in_text("#service-details", "This unit is an instanced from test-template@.service template.")
+        b.click("#service-details .ct-form a:contains('test-template@.service')")
+        b.wait_visible("#service-details input")
 
         def wait_service_present(service):
-            b.wait_present(svc_sel(service))
             b.wait_visible(svc_sel(service))
 
         def wait_service_not_present(service):
@@ -249,12 +268,14 @@ Unit=test.service
         init_filter_state()
         b.select_from_dropdown("#services-dropdown", "Static")
         wait_service_not_present("test.service")
-        wait_service_present("test-fail.service")
+        wait_service_not_present("test-fail.service")
+        wait_service_present("systemd-halt.service")
 
         # Select only disabled services
         b.select_from_dropdown("#services-dropdown", "Disabled")
         wait_service_present("test.service")
         wait_service_not_present("test-fail.service")
+        wait_service_not_present("systemd-halt.service")
 
         # Check filtering and selecting together - empty state
         b.set_input_text("#services-text-filter", "failing")
@@ -265,6 +286,7 @@ Unit=test.service
         b.click("#clear-all-filters")
         wait_service_present("test.service")
         wait_service_present("test-fail.service")
+        wait_service_present("systemd-halt.service")
         self.assertEqual(b.val("#services-text-filter"), "")
         self.assertEqual(b.val("#services-dropdown"), "0")
 
@@ -583,6 +605,7 @@ WantedBy=default.target
         m.execute("timedatectl set-ntp on")
         self.allow_restart_journal_messages()
 
+    @skipImage("Reworked in #12265", "rhel-8-0-distropkg")
     def testConditions(self):
         m = self.machine
         b = self.browser
@@ -615,31 +638,25 @@ WantedBy=multi-user.target
         def svc_sel(service):
             return 'tr[data-goto-unit="%s"]' % service
 
-        unit_primary_action_btn = '#service-unit-primary-action'
-
         # Selects Services tab
         if self.machine.image in ["rhel-8-0-distropkg"]: # Changed in #12349
             self.pick_tab(2)
         else:
             self.pick_tab(1)
-        b.wait_present(svc_sel('condtest.service'))
-        b.click(svc_sel("condtest.service"))
-        b.wait_in_text('#service-valid', "inactive")
-        b.wait_action_btn(unit_primary_action_btn, "Start")
-        b.click_action_btn(unit_primary_action_btn)
 
-        b.wait_in_text("#service-unit div.cond-fail", "ConditionDirectoryNotEmpty")
+        b.wait_in_text(svc_sel("condtest.service"), "Enabled")
+        b.click(svc_sel("condtest.service"))
+        self.check_service_details(["Not running", "Automatically starts"], ["Start", "Reload", "Disallow running (mask)"], True)
+        self.do_action("Start")
+        b.wait_text("#condition", "Condition ConditionDirectoryNotEmpty=/var/tmp/empty was not met")
 
         # If the condition succeeds the message disappears
         m.execute("touch /var/tmp/empty/non-empty")
+        self.do_action("Start")
+        self.check_service_details(["Running", "Automatically starts"], ["Restart", "Reload", "Disallow running (mask)"], True)
+        b.wait_not_present("#condition")
 
-        b.wait_in_text('#service-valid', "inactive")
-        b.wait_action_btn(unit_primary_action_btn, "Start")
-        b.click_action_btn(unit_primary_action_btn)
-        b.wait_in_text('#service-valid', "active")
-
-        b.wait_not_present("#service-unit div.cond-fail")
-
+    @skipImage("Reworked in #12265", "rhel-8-0-distropkg")
     def testRelationships(self):
         m = self.machine
         b = self.browser
@@ -682,15 +699,8 @@ ExecStart=/bin/sh -c "while true; do sleep 5; done"
         def svc_sel(service):
             return 'tr[data-goto-unit="%s"]' % service
 
-        def rel_sel(reltype):
-            return "table.systemd-unit-relationship-table tr:has(td:contains('%s'))" % reltype
-
-        def wait_relationship(reltype, service):
-            b.wait_present(rel_sel(reltype))
-            b.wait_in_text(rel_sel(reltype), service)
-
-        def click_relationship(reltype, service):
-            b.click(rel_sel(reltype) + (" a:contains('%s')" % service))
+        def rel_sel(reltype, service):
+            return "#{0} a:contains('{1}')".format("".join(reltype.split(" ")), service)
 
         # services page
         self.login_and_go("/system/services")
@@ -699,29 +709,29 @@ ExecStart=/bin/sh -c "while true; do sleep 5; done"
 
         # service a
         b.wait_js_cond('window.location.hash === "#/test-a.service"')
-        wait_relationship("Before", "test-b.service")
-        wait_relationship("Conflicts", "test-c.service")
-        click_relationship("Before", "test-b.service")
+        b.wait_visible(rel_sel("Before", "test-b.service"))
+        b.wait_visible(rel_sel("Conflicts", "test-c.service"))
+        b.click(rel_sel("Before", "test-b.service"))
 
         # service b
         b.wait_js_cond('window.location.hash === "#/test-b.service"')
-        wait_relationship("After", "test-a.service")
-        click_relationship("After", "test-a.service")
+        b.wait_visible(rel_sel("After", "test-a.service"))
+        b.click(rel_sel("After", "test-a.service"))
 
         # service a
         b.wait_js_cond('window.location.hash === "#/test-a.service"')
-        wait_relationship("Conflicts", "test-c.service")
-        click_relationship("Conflicts", "test-c.service")
+        b.wait_visible(rel_sel("Conflicts", "test-c.service"))
+        b.click(rel_sel("Conflicts", "test-c.service"))
 
         # service c
         b.wait_js_cond('window.location.hash === "#/test-c.service"')
-        wait_relationship("Conflicts", "test-a.service")
-        wait_relationship("Part Of", "test-b.service")
-        click_relationship("Part Of", "test-b.service")
+        b.wait_visible(rel_sel("Conflicts", "test-a.service"))
+        b.wait_visible(rel_sel("Part Of", "test-b.service"))
+        b.click(rel_sel("Part Of", "test-b.service"))
 
         # service b
         b.wait_js_cond('window.location.hash === "#/test-b.service"')
-        wait_relationship("After", "test-a.service")
+        b.wait_visible(rel_sel("After", "test-a.service"))
 
     def testNotFound(self):
         m = self.machine
@@ -744,16 +754,14 @@ ExecStart=/bin/true
         def svc_sel(service):
             return 'tr[data-goto-unit="%s"]' % service
 
-        def rel_link_sel(service):
-            return "table.systemd-unit-relationship-table a:contains('%s')" % service
-
         b.wait_present(svc_sel("test.service"))
         b.wait_not_present(svc_sel("not-found.service"))
 
         b.click(svc_sel("test.service"))
         b.wait_js_cond('window.location.hash === "#/test.service"')
-        b.wait_present(rel_link_sel("not-found.service"))
-        b.wait_attr(rel_link_sel("not-found.service"), "class", "disabled")
+
+        if m.image != "rhel-8-0-distropkg": # Changed in #12265
+            b.wait_attr("#Requires a:contains('not-found.service')", "class", "disabled")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Redesign and rewrite (part of) service details into react. (Only the panel marked with red is in React as I wanted to make as little changes as possible, moving other things into React should be follow ups).
Follows [this](https://raw.githubusercontent.com/cockpit-project/cockpit-design/master/services/service-details.png) design.

No need for code review, I plan to polish that anyway. Firstly I would like to get design review by @garrett as he created the design. Can you please take a look, thanks. If you have some small styling fixes feel free to push them here (ideally as separate commit(s)). Also @andreasn if you have time I would like to hear your feedback as well, it is different to use it than to see mock-up and you can maybe find some rough edges that could be fixed. Thanks. 

Only functional change that is missing and I know of is not showing `vendor` related stuff. Still havn't found reasonable way of getting this info.

![screenservices](https://user-images.githubusercontent.com/12330670/60886024-2ea31080-a251-11e9-8540-7373a63ee927.png)

TODO:

- [ ] Implement `vendor` stuff
- [x] Use ct-form-layout instead of form-table-ct
- [x] Tooltip for on-off switch
- [x] Accessibility review
   - [x] Keyboard arrows are unpredictable (pressing down skipped the second menu item)
- [x] When kebab menu is opened the dropdown does not have arrow. #12290
- [x] Write proper message when masking service.
- [x] Previously in the list of relationships unit possibly could be disabled if does not exist. Is this possible? (runits)
- [x] Tests
- Browser compatibility
   - [x] Firefox
   - [x] Chrome
   - [x] Epiphany (WebKit)
   - [x] Edge
- [x] Fix delay when clicking