### PR TITLE
tools: support string "author" fields in package.json files

### DIFF
--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -107,7 +107,15 @@ def module_copyright(moddir):
         # fall back to package.json's author
         try:
             with open(os.path.join(moddir, 'package.json')) as f:
-                copyrights.add(' ' + json.load(f)['author']['name'])
+                author = json.load(f)['author']
+
+                # `author` can be either a string or a dict
+                # https://flaviocopes.com/package-json/#author
+                if isinstance(author, dict):
+                    author = author['name']
+                assert isinstance(author, str)
+
+                copyrights.add(' ' + author)
         except (IOError, KeyError):
             pass
 


### PR DESCRIPTION
As per https://flaviocopes.com/package-json/#author it's possible to
list the author either as a dict (with 'name', 'email', etc. fields) or
as a string.  We only supported the dict format, but now one of our
packages is using the string format, so support that one too.