### PR TITLE
firewall: Move "default" zone text outside of icon

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -122,7 +122,7 @@ function ZoneRow(props) {
 
     let columns = [
         { name: props.zone.name, header: true },
-        <React.Fragment>{ props.zone.id === firewall.defaultZone ? <span className="fa fa-check">default</span> : '' }</React.Fragment>,
+        <React.Fragment>{ props.zone.id === firewall.defaultZone ? <React.Fragment><span className="fa fa-check" /> default</React.Fragment> : '' }</React.Fragment>,
         <React.Fragment>{ props.zone.interfaces.length > 0 ? props.zone.interfaces.join(', ') : '*' }</React.Fragment>,
         <React.Fragment>{ props.zone.source.length > 0 ? props.zone.source.join(', ') : '*' }</React.Fragment>,
         deleteButton,


### PR DESCRIPTION
The default zone text is included inside the icon, which makes it use the FontAwesome icon font, which doesn't have coverage for letters, which means it falls back to a default font (sometimes even a serif font). Therefore, text should be outside of elements with an icon class.