### PR TITLE
containers: Use /entrypoint for unit-tests/exec

### DIFF
--- a/containers/unit-tests/exec
+++ b/containers/unit-tests/exec
@@ -43,4 +43,4 @@ if test $# -eq 0; then
 fi
 
 set -ex
-exec docker exec ${args} -- "${id}" "$@"
+exec docker exec ${args} -- "${id}" /entrypoint "$@"


### PR DESCRIPTION
`docker exec` ignores /entrypoint, but we want to make sure our shell
ends up running as the right architecture, so explicitly add it to all
of our commandlines.