### PR TITLE
tests: skip slow tests under valgrind

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -302,6 +302,7 @@ valgrind-suppressions: $(VALGRIND_SUPPRESSIONS)
 check-memory: valgrind-suppressions
 	$(MAKE) LOG_FLAGS="valgrind $(VALGRIND_ARGS)" \
 	        HTML_LOG_FLAGS="valgrind $(VALGRIND_ARGS)" \
+		COCKPIT_SKIP_SLOW_TESTS=1 \
 		$(AM_MAKEFLAGS) check TESTS="$(filter-out tools/% bots/%,$(TESTS))"
 recheck-memory: valgrind-suppressions
 	$(MAKE) LOG_FLAGS="-- valgrind $(VALGRIND_ARGS)" \

--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -731,3 +731,15 @@ cockpit_test_reset_warnings (void)
       orig_g_debug = NULL;
     }
 }
+
+gboolean
+cockpit_test_skip_slow (void)
+{
+  if (g_getenv ("COCKPIT_SKIP_SLOW_TESTS"))
+    {
+      g_test_skip ("Skipping slow tests");
+      return TRUE;
+    }
+
+  return FALSE;
+}

--- a/src/common/cockpittest.h
+++ b/src/common/cockpittest.h
@@ -114,6 +114,8 @@ GInetAddress *  cockpit_test_find_non_loopback_address (void);
 void             cockpit_test_allow_warnings           (void);
 void             cockpit_test_reset_warnings           (void);
 
+gboolean         cockpit_test_skip_slow                (void);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_TEST_H__ */

--- a/src/ssh/test-sshbridge.c
+++ b/src/ssh/test-sshbridge.c
@@ -602,6 +602,13 @@ test_echo_large (TestCase *tc,
   GBytes *sent;
   JsonObject *init = NULL;
 
+  /* HACK: TODO: find out exactly why this test is so slow under Valgrind */
+  if (cockpit_test_skip_slow ())
+    {
+      tc->closed = TRUE;
+      return;
+    }
+
   do_fixture_auth (tc->transport, data);
   init = wait_until_transport_init (tc->transport, NULL);
 


### PR DESCRIPTION
Add a mechanism for skipping slow tests when requested by an environment
variable (which we set, by default, when running tests under valgrind).

Use this new API from the /ssh-bridge/echo-large test.  For some reason,
it's extremely slow under valgrind, particularly on i386 — slow enough
that we're regularly hitting the alarm() timeout of 120 seconds on
semaphore.