### PR TITLE
containers: use 'podman' or 'sudo docker' in unit-tests scripts

### DIFF
--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -9,6 +9,10 @@ It assumes that the Cockpit source git checkout is available in `/source`. It
 will not modify that directory or take uncommitted changes into account, but it
 will re-use an already existing `node_modules/` directory.
 
+The scripts can use either podman (preferred) or docker. If you use docker, you
+need to run all commands as root. With podman the containers work as either user
+or root.
+
 ## Building
 
 The `build` script will build the `cockpit/unit-tests` and
@@ -29,17 +33,17 @@ to modify its behaviour:
 
 Some examples:
 
-    $ sudo ./start           # run the unit tests on amd64
+    $ ./start           # run the unit tests on amd64
 
-    $ sudo ./start CC=clang  # run the unit tests on amd64, compiled with clang
+    $ ./start CC=clang  # run the unit tests on amd64, compiled with clang
 
-    $ sudo ./start :i386     # run the unit tests on i386
+    $ ./start :i386     # run the unit tests on i386
 
 ## Debugging tests
 
 For interactive debugging, run a shell in the container:
 
-    $ sudo ./start shell     # start an interactive shell on i386
+    $ ./start shell     # start an interactive shell on i386
 
 You will find the cockpit source tree (from the host) mounted at `/source` in
 the container.
@@ -52,9 +56,9 @@ will checkout and build the source, but not run any tests.
 
 You can also attach to another container using the provided `exec` script.  For example:
 
-    $ sudo ./exec uname -a   # run a command as the "builder" user
+    $ ./exec uname -a   # run a command as the "builder" user
 
-    $ sudo ./exec --root     # start a shell as root
+    $ ./exec --root     # start a shell as root
 
 ## More Info
 

--- a/containers/unit-tests/build
+++ b/containers/unit-tests/build
@@ -2,7 +2,12 @@
 
 dir=$(dirname "$0")
 
-docker build --build-arg debian_arch=amd64 --build-arg personality=linux64 -t cockpit/unit-tests ${dir}
-docker tag  cockpit/unit-tests:latest docker.io/cockpit/unit-tests:latest
-docker build --build-arg debian_arch=i386 --build-arg personality=linux32 -t cockpit/unit-tests:i386 ${dir}
-docker tag  cockpit/unit-tests:i386 docker.io/cockpit/unit-tests:i386
+if test -z "${docker:=$(which podman || which docker || true)}"; then
+  echo 'Neither podman nor docker are installed'
+  exit 1
+fi
+
+$docker build --build-arg debian_arch=amd64 --build-arg personality=linux64 -t cockpit/unit-tests ${dir}
+$docker tag  cockpit/unit-tests:latest docker.io/cockpit/unit-tests:latest
+$docker build --build-arg debian_arch=i386 --build-arg personality=linux32 -t cockpit/unit-tests:i386 ${dir}
+$docker tag  cockpit/unit-tests:i386 docker.io/cockpit/unit-tests:i386

--- a/containers/unit-tests/exec
+++ b/containers/unit-tests/exec
@@ -10,6 +10,8 @@ id=''
 
 while test $# -gt 0; do
   case "$1" in
+    --docker) docker="docker";;
+    --podman) docker="podman";;
     --root) args="$args -uroot";;
     --id=*) id="${1#--id=}";;
     -it) args="$args -it"; defaultargs='';;
@@ -20,8 +22,13 @@ while test $# -gt 0; do
   shift
 done
 
+if test -z "${docker:=$(which podman || which docker || true)}"; then
+  echo 'Neither podman nor docker are installed'
+  exit 1
+fi
+
 if [ -z "$id" ]; then
-  id="$(docker ps -qf "${filter}")"
+  id="$(${docker} ps -qf "${filter}")"
 
   if checkargs 2 $id; then :
   elif checkargs 1 $id; then
@@ -30,7 +37,7 @@ if [ -z "$id" ]; then
   else
     echo 'More than one running cockpit-unit/tests container:'
     echo
-    docker ps -f "${filter}" | sed -e 's/^/  /'
+    ${docker} ps -f "${filter}" | sed -e 's/^/  /'
     echo
     echo 'Use --id= to specify which one.'
     exit 1
@@ -42,5 +49,6 @@ if test $# -eq 0; then
   set -- $defaultcmd
 fi
 
+
 set -ex
-exec docker exec ${args} -- "${id}" /entrypoint "$@"
+exec ${docker} exec ${args} -- "${id}" /entrypoint "$@"

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -7,6 +7,8 @@ cmd=''
 
 while test $# -gt 0; do
   case "$1" in
+    --docker) docker="docker";;
+    --podman) docker="podman";;
     CC=*) ccarg="--env=$1";;
     shell) flags=-it; cmd=/bin/bash;;
     :*) image=cockpit/unit-tests"$1";;
@@ -15,6 +17,11 @@ while test $# -gt 0; do
   shift
 done
 
+if test -z "${docker:=$(which podman || which docker || true)}"; then
+  echo 'Neither podman nor docker are installed'
+  exit 1
+fi
+
 set -ex
-exec docker run --shm-size=512M --volume "${top_srcdir}":/source:ro \
+exec ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro \
        ${ccarg:+"$ccarg"} $flags -- "$image" $cmd


### PR DESCRIPTION
Detect if we have podman installed and use that in preference to docker.
If we have only docker, make sure to run it under sudo.

This commit is a little bit ugly, particularly in the 'exec' script: we
can end up running sudo more than once for the normal case where we
detect the ID.  I have some weird ideas about how to work around that,
but they're pretty evil.

The sed thing is also pretty nasty.

...