### PR TITLE
containers: don't use xz --extreme for unit-tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -420,13 +420,16 @@ DIST_ARCHIVES = \
 	cockpit-$(VERSION).tar.xz \
 	cockpit-cache-$(VERSION).tar.xz
 
+# used from containers/unit-tests/run.sh
+XZ_COMPRESS_FLAGS = --extreme
+
 dist-gzip: distdir
 	$(DIST_TAR_MAIN) | GZIP=$(GZIP_ENV) gzip -c > $(distdir).tar.gz
 	$(DIST_TAR_CACHE) | GZIP=$(GZIP_ENV) gzip -c > cockpit-cache-$(VERSION).tar.gz
 	find "$(distdir)" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "$(distdir)"
 dist-xz: distdir
-	$(DIST_TAR_MAIN) | xz -ec > $(distdir).tar.xz
-	$(DIST_TAR_CACHE) | xz -ec > cockpit-cache-$(VERSION).tar.xz
+	$(DIST_TAR_MAIN) | xz $(XZ_COMPRESS_FLAGS) > $(distdir).tar.xz
+	$(DIST_TAR_CACHE) | xz $(XZ_COMPRESS_FLAGS) > cockpit-cache-$(VERSION).tar.xz
 	find "$(distdir)" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "$(distdir)"
 
 distcheck-hook::

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -55,7 +55,7 @@ python3 -c "import fcntl, os; map(lambda fd: fcntl.fcntl(fd, fcntl.F_SETFL, fcnt
 
 if dpkg-architecture --is amd64; then
     # run distcheck on main arch
-    make distcheck 2>&1
+    make XZ_COMPRESS_FLAGS='-0' distcheck 2>&1
 else
     # on i386, validate that "distclean" does not remove too much
     make dist-gzip


### PR DESCRIPTION
In the course of 'make distcheck', we end up building two tarballs,
twice (for a total of 4) and compressing them with 'xz --extreme', which
is really slow.

We can substantially speed things up using -0.  This is actually even
faster than gzip, but let's leave the i386 gzip case in place anyway,
because it tests a different path.

Measured locally on my unloaded laptop, this results in a speedup of a
bit over 2m30s, which is a ~30% improvement on a unit-tests run (ie:
`containers/unit-tests/start`).  On Semaphore, under load, the change is
probably even larger.

Closes #12289