### PR TITLE
lib/page: Fix kebab menu pointers

### DIFF
--- a/pkg/lib/page.css
+++ b/pkg/lib/page.css
@@ -59,9 +59,16 @@ a.disabled:hover {
 /* Limit dropdown menus to 90% of the viewport size */
 .dropdown-menu {
     height: auto;
-    overflow-x: hidden;
+    overflow-y: auto;
     max-height: 90vh;
 }
+
+/* Allow kebab menus to have a ^ with overflowing */
+/* Note: This means kebab menus cannot be _too_ long */
+.dropdown-kebab-pf > .dropdown-menu {
+    overflow: visible;
+}
+
 /* Align these buttons more nicely */
 .btn.fa-minus,
 .btn.fa-plus {


### PR DESCRIPTION
Overflowing truncates the kebab menu tails.

We need to choose to scroll for _many_ menu items or allow (pseudo-)elements to visually "escape" the `.dropdown-menu` container.

In the case of most dropdowns, they don't need children to display outside of their boundaries. For kebabs, however, they do. And the kebab menus also _should_ be short in the # of items anyway.