### PR TITLE
Typofix "Kofferraum"

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -4017,7 +4017,7 @@ msgstr "Einhängestelle"
 
 #: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
 msgid "Mount at boot"
-msgstr "Am Kofferraum montieren"
+msgstr "Beim starten einhängen"
 
 #: pkg/docker/index.html:521
 msgid "Mount container volumes"


### PR DESCRIPTION
Change
msgstr "Am Kofferraum montieren"
to
msgstr "Beim starten einhängen"

Kofferraum is a cars trunk :)