### PR TITLE
selinux: Inform user that reading of system mods failed

### DIFF
--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -141,6 +141,8 @@ export class Modifications extends React.Component {
 
     render() {
         let emptyRow = null;
+        let fail_message = this.props.permitted ? _("No System Modifications") : _("The logged in user is not permitted to view system modifications");
+        fail_message = this.props.failed ? _("Error running semanage to discover system modifications") : fail_message;
         if (this.props.entries === null) {
             emptyRow = <thead className={"listing-ct-empty"}>
                 <tr className="modification-row">
@@ -155,7 +157,7 @@ export class Modifications extends React.Component {
             emptyRow = <thead className={"listing-ct-empty"}>
                 <tr className="modification-row">
                     <td>
-                        { this.props.permitted ? _("No System Modifications") : _("The logged in user is not permitted to view system modifications") }
+                        { fail_message }
                     </td>
                 </tr>
             </thead>;

--- a/pkg/selinux/selinux-client.js
+++ b/pkg/selinux/selinux-client.js
@@ -36,6 +36,7 @@ var status = {
     shell: "",
     modifications: null,
     permitted: true,
+    failed: false,
 };
 
 /* initializes the selinux status updating, returns initial status
@@ -48,6 +49,7 @@ var status = {
  *   - shell:           Output of `semanage export`
  *   - modifications:   List of all local modifications in selinux policy
  *   - permitted:       Set to false if user is not allowed to see local modifications
+ *   - failed:          Reading of modifications failed in unexpected way
  * errorMessage:    optional, if getting the status failed, here will be additional info
  *
  * Since we're screenscraping we need to run this in LC_ALL=C mode
@@ -153,11 +155,12 @@ export function init(statusChangedCallback) {
                     statusChangedCallback(status, undefined);
                 })
                 .catch(e => {
+                    status.modifications = [];
                     if (e.message.indexOf("ValueError:") >= 0) {
                         status.permitted = false;
-                        status.modifications = [];
                         statusChangedCallback(status, undefined);
                     } else {
+                        status.failed = true;
                         statusChangedCallback(status, e.message);
                     }
                 });

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -460,6 +460,7 @@ export class SETroubleshootPage extends React.Component {
                 permitted={ this.props.selinuxStatus.permitted }
                 shell={ this.props.selinuxStatus.shell }
                 entries={ this.props.selinuxStatus.modifications }
+                failed={ this.props.selinuxStatus.failed }
             />
         );
 


### PR DESCRIPTION
@garrett reported in  #12284 that `semanage` failes on his system. There is not much we can do about broken systems. However we can at least stop the spinner with message `Loading sys mods` and show that it failed. There is opened always alert message that shows more info.

@garrett can you verify that on your system it shows "Failed to load system modifications"? I've created some artificial crash but it would be great if you could ack that it also catches your problem. Thanks.

Fixes  #12284