### PR TITLE
package.json: remove @babel/polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "description": "Cockpit isn't a Node package, these are devel time deps, not needed to build tarball either",
   "private": true,
   "dependencies": {
-    "@babel/polyfill": "7.4.4",
     "@patternfly/react-console": "1.11.3",
     "@redhat/redhat-font": "git+https://github.com/RedHatOfficial/RedHatFont.git#2.2.0",
     "bootstrap": "3.4.1",


### PR DESCRIPTION
This package was giving a very large deprecation warning when running
npm, and it looks like nothing is actually using it anymore, so let's
remove it.

Closes #12300