### PR TITLE
machines: when fetching storage pools refresh them first if they are active

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -264,6 +264,8 @@ class PerformanceOptions extends React.Component {
 }
 
 const CreateNewDisk = ({ idPrefix, onValueChanged, dialogValues, vmStoragePools, provider, vm }) => {
+    const storagePool = vmStoragePools.find(pool => pool.name == dialogValues.storagePoolName);
+
     return (
         <React.Fragment>
             <hr />
@@ -271,7 +273,7 @@ const CreateNewDisk = ({ idPrefix, onValueChanged, dialogValues, vmStoragePools,
                      storagePoolName={dialogValues.storagePoolName}
                      onValueChanged={onValueChanged}
                      vmStoragePools={vmStoragePools} />
-            {vmStoragePools.length > 0 &&
+            {storagePool &&
             <React.Fragment>
                 <hr />
                 <VolumeName idPrefix={idPrefix}
@@ -281,7 +283,7 @@ const CreateNewDisk = ({ idPrefix, onValueChanged, dialogValues, vmStoragePools,
                                size={dialogValues.size}
                                unit={dialogValues.unit}
                                diskFileFormat={dialogValues.diskFileFormat}
-                               storagePoolType={vmStoragePools.find(pool => pool.name == dialogValues.storagePoolName).type}
+                               storagePoolType={storagePool.type}
                                onValueChanged={onValueChanged} />
                 <hr />
                 <PermanentChange idPrefix={idPrefix}

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -460,12 +460,20 @@ LIBVIRT_DBUS_PROVIDER = {
         connectionName,
     }) {
         return dispatch => {
-            call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListStoragePools', [0], TIMEOUT)
+            return call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListStoragePools', [0], TIMEOUT)
                     .then(objPaths => {
                         // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
                         // https://github.com/cockpit-project/cockpit/issues/10956
                         // eslint-disable-next-line cockpit/no-cockpit-all
-                        return cockpit.all(objPaths[0].map((path) => dispatch(getStoragePool({ connectionName, id:path }))));
+                        return cockpit.all(objPaths[0].map(path => {
+                            return call(connectionName, path, 'org.freedesktop.DBus.Properties', 'Get', ['org.libvirt.StoragePool', 'Active'], TIMEOUT)
+                                    .then(active => {
+                                        if (active[0].v)
+                                            return storagePoolRefresh(connectionName, path);
+                                        else
+                                            return dispatch(getStoragePool({ connectionName, id:path }));
+                                    });
+                        }));
                     })
                     .fail(ex => console.warn('GET_ALL_STORAGE_POOLS action failed:', JSON.stringify(ex)));
         };

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -665,7 +665,8 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         m.execute("virsh vol-create-as myPoolTwo VolumeOne --capacity 1G --format qcow2")
         m.execute("virsh vol-create-as myPoolTwo VolumeTwo --capacity 1G --format qcow2")
-        wait(lambda: all(volume in m.execute("virsh vol-list myPoolTwo") for volume in ["VolumeOne", "VolumeTwo"]))
+        m.execute("virsh vol-create-as myPoolTwo VolumeThree --capacity 1G --format qcow2")
+        wait(lambda: all(volume in m.execute("virsh vol-list myPoolTwo") for volume in ["VolumeOne", "VolumeTwo", "VolumeThree"]))
 
         connectionName = m.execute("virsh uri | head -1 | cut -d/ -f4").strip()
 
@@ -720,7 +721,17 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_present("#pool-myPoolTwo-{0}-volume-VolumeOne-name".format(connectionName))
         b.wait_in_text("#pool-myPoolTwo-{0}-volume-VolumeOne-name".format(connectionName), "VolumeOne")
         b.wait_in_text("#pool-myPoolTwo-{0}-volume-VolumeTwo-name".format(connectionName), "VolumeTwo")
+        b.wait_in_text("#pool-myPoolTwo-{0}-volume-VolumeThree-name".format(connectionName), "VolumeThree")
         b.wait_not_present("#storage-volumes-delete")
+
+        # Delete a volume from terminal and verify that refresh worked by reloading the browser page
+        m.execute("rm -f /mnt/vm_two/VolumeThree")
+        b.wait_present("#pool-myPoolTwo-{0}-volume-VolumeThree-name".format(connectionName))
+        b.reload()
+        b.enter_page('/machines')
+        b.click("tbody tr[data-row-id=pool-myPoolTwo-{0}] th".format(connectionName)) # click on the row header
+        b.click("#pool-myPoolTwo-{0}-storage-volumes".format(connectionName)) # open the "Storage Volumes" subtab
+        b.wait_not_present("#pool-myPoolTwo-{0}-volume-VolumeThree-name".format(connectionName))
 
         # Delete Storage Volume that is not used by any VM
         b.wait_present("tbody tr[data-row-id=pool-myPoolTwo-{0}-volume-VolumeTwo] input[type=checkbox]".format(connectionName))


### PR DESCRIPTION
This commit calls the poolRefresh API everytime when fetching the list storage
pools. This will trigger the refresh event to get emited, which will
call the GET_STORAGE_POOL for each refreshed pool.
Inactive pools don't have events, so call directly the GET_STORAGE_POOL
method for those.

This commit will allow the user to refresh pool data by reloading the browser page.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1680293