### PR TITLE
build: Split out library without external dependencies

### DIFF
--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -89,6 +89,7 @@ libcockpit_bridge_a_CFLAGS = \
 libcockpit_bridge_LIBS = \
 	libcockpit-bridge.a \
 	libcockpit-common.a \
+	libcockpit-common-nodeps.a \
 	libwebsocket.a \
 	$(COCKPIT_BRIDGE_LIBS) \
 	$(NULL)
@@ -305,6 +306,7 @@ libcockpit_pcp_a_CFLAGS = \
 libcockpit_pcp_LIBS = \
 	libcockpit-pcp.a \
 	libcockpit-common.a \
+	libcockpit-common-nodeps.a \
 	$(COCKPIT_PCP_LIBS) \
 	$(NULL)
 

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -21,24 +21,41 @@ EXTRA_DIST += \
 	$(test_locale_PO) \
 	$(NULL)
 
-noinst_LIBRARIES += libcockpit-common.a
+noinst_LIBRARIES += libcockpit-common-nodeps.a
 
-libcockpit_common_a_SOURCES = \
+# Code that has no dependencies other than libc
+libcockpit_common_nodeps_a_SOURCES = \
 	src/common/cockpitauthorize.c \
 	src/common/cockpitauthorize.h \
 	src/common/cockpitbase64.c \
 	src/common/cockpitbase64.h \
+	src/common/cockpitconf.h \
+	src/common/cockpitconf.c \
+	src/common/cockpitframe.c \
+	src/common/cockpitframe.h \
+	src/common/cockpithex.c \
+	src/common/cockpithex.h \
+	src/common/cockpitmemory.c \
+	src/common/cockpitmemory.h \
+	src/common/cockpitwebcertificate.h \
+	src/common/cockpitwebcertificate.c \
+	$(NULL)
+
+libcockpit_common_nodeps_a_CFLAGS = \
+	-fPIC \
+	$(NULL)
+
+noinst_LIBRARIES += libcockpit-common.a
+
+# Code that has other dependencies, like glib or libsystemd
+libcockpit_common_a_SOURCES = \
 	src/common/cockpitchannel.c \
 	src/common/cockpitchannel.h \
 	src/common/cockpiterror.h src/common/cockpiterror.c \
 	src/common/cockpitflow.c \
 	src/common/cockpitflow.h \
-	src/common/cockpitframe.c \
-	src/common/cockpitframe.h \
 	src/common/cockpithash.c \
 	src/common/cockpithash.h \
-	src/common/cockpithex.c \
-	src/common/cockpithex.h \
 	src/common/cockpitjson.c \
 	src/common/cockpitjson.h \
 	src/common/cockpitlog.h src/common/cockpitlog.c \
@@ -48,8 +65,6 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitloopback.h \
 	src/common/cockpitmachinesjson.c \
 	src/common/cockpitmachinesjson.h \
-	src/common/cockpitmemory.c \
-	src/common/cockpitmemory.h \
 	src/common/cockpitpipe.c \
 	src/common/cockpitpipe.h \
 	src/common/cockpitpipetransport.c \
@@ -70,8 +85,6 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitunixsignal.h \
 	src/common/cockpitversion.c \
 	src/common/cockpitversion.h \
-	src/common/cockpitwebcertificate.h \
-	src/common/cockpitwebcertificate.c \
 	src/common/cockpitwebfilter.h \
 	src/common/cockpitwebfilter.c \
 	src/common/cockpitwebinject.h \
@@ -80,8 +93,6 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitwebresponse.c \
 	src/common/cockpitwebserver.h \
 	src/common/cockpitwebserver.c \
-	src/common/cockpitconf.h \
-	src/common/cockpitconf.c \
 	$(NULL)
 
 nodist_libcockpit_common_a_SOURCES = \
@@ -96,6 +107,7 @@ libcockpit_common_a_CFLAGS = \
 
 libcockpit_common_a_LIBS = \
 	libcockpit-common.a \
+	libcockpit-common-nodeps.a \
 	libwebsocket.a \
 	$(COCKPIT_LIBS) \
 	$(NULL)
@@ -124,24 +136,12 @@ COCKPIT_CHECKS = \
 	$(NULL)
 
 test_authorize_CFLAGS = $(libcockpit_common_a_CFLAGS)
-test_authorize_SOURCES = \
-	src/common/cockpitauthorize.c \
-	src/common/cockpitauthorize.h \
-	src/common/cockpitbase64.c \
-	src/common/cockpitbase64.h \
-	src/common/cockpitmemory.c \
-	src/common/cockpitmemory.h \
-	src/common/test-authorize.c \
-	$(NULL)
-test_authorize_LDADD = libretest.a
+test_authorize_SOURCES = src/common/test-authorize.c
+test_authorize_LDADD = libcockpit-common-nodeps.a libretest.a
 
 test_base64_CFLAGS = $(COCKPIT_SESSION_CFLAGS)
-test_base64_SOURCES = \
-	src/common/test-base64.c \
-	src/common/cockpitbase64.h \
-	src/common/cockpitbase64.c \
-	$(NULL)
-test_base64_LDADD = libretest.a
+test_base64_SOURCES = src/common/test-base64.c
+test_base64_LDADD = libcockpit-common-nodeps.a libretest.a
 
 test_channel_SOURCES = \
 	src/common/test-channel.c \

--- a/src/common/cockpitmemory.c
+++ b/src/common/cockpitmemory.c
@@ -76,7 +76,7 @@ abort_errno (const char *msg)
   abort ();
 }
 
-void*
+void *
 mallocx (size_t size)
 {
   void *r = malloc (size);
@@ -85,7 +85,7 @@ mallocx (size_t size)
   return r;
 }
 
-char*
+char *
 strdupx (const char *s)
 {
   char *r = strdup (s);
@@ -94,7 +94,7 @@ strdupx (const char *s)
   return r;
 }
 
-char*
+char *
 strndupx (const char *s,
          size_t n)
 {
@@ -122,7 +122,7 @@ asprintfx (char **strp,
   return r;
 }
 
-void*
+void *
 reallocx (void *ptr,
           size_t size)
 {
@@ -134,7 +134,7 @@ reallocx (void *ptr,
 
 /* this is like reallocarray(3), but this does not yet exist everywhere; plus
  * abort() on ENOMEM */
-void*
+void *
 reallocarrayx (void *ptr,
                size_t nmemb,
                size_t size)

--- a/src/common/cockpitmemory.h
+++ b/src/common/cockpitmemory.h
@@ -26,20 +26,20 @@ void     cockpit_memory_clear            (void *data,
                                           ssize_t length);
 
 /* variants of glibc functions that abort() on ENOMEM */
-void*    mallocx                         (size_t size);
-char*    strdupx                         (const char *s);
+void *   mallocx                         (size_t size);
+char *   strdupx                         (const char *s);
 
-char*    strndupx                        (const char *s,
+char *   strndupx                        (const char *s,
                                           size_t n);
 
 __attribute__((__format__ (__printf__, 2, 3)))
 int      asprintfx                       (char **strp,
                                           const char *fmt, ...);
 
-void*    reallocx                        (void *ptr,
+void *   reallocx                        (void *ptr,
                                           size_t size);
 
-void*    reallocarrayx                   (void *ptr,
+void *   reallocarrayx                   (void *ptr,
                                           size_t nmemb,
                                           size_t size);
 

--- a/src/ssh/Makefile-ssh.am
+++ b/src/ssh/Makefile-ssh.am
@@ -8,8 +8,6 @@ libcockpit_ssh_a_SOURCES = \
 	src/ssh/cockpitsshoptions.h \
 	src/ssh/cockpitsshrelay.h \
 	src/ssh/cockpitsshrelay.c \
-	src/common/cockpitauthorize.c \
-	src/common/cockpitauthorize.h \
 	$(NULL)
 
 if !HAVE_SSH_SESSION_HAS_KNOWN_HOSTS_ENTRY
@@ -30,6 +28,7 @@ libcockpit_ssh_a_CFLAGS = \
 libcockpit_ssh_LIBS = \
 	libcockpit-ssh.a \
 	libcockpit-common.a \
+	libcockpit-common-nodeps.a \
 	$(COCKPIT_SSH_SESSION_LIBS) \
 	$(NULL)
 

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -94,6 +94,7 @@ libcockpit_ws_a_CFLAGS = \
 libcockpit_ws_LIBS = \
 	libcockpit-ws.a \
 	libcockpit-common.a \
+	libcockpit-common-nodeps.a \
 	libwebsocket.a \
 	$(COCKPIT_WS_LIBS) \
 	$(NULL)
@@ -118,19 +119,14 @@ sbin_PROGRAMS += remotectl
 libexec_PROGRAMS += cockpit-ws cockpit-session
 
 cockpit_session_SOURCES = \
-	src/common/cockpitauthorize.c \
-	src/common/cockpitauthorize.h \
-	src/common/cockpitbase64.c \
-	src/common/cockpitbase64.h \
-	src/common/cockpitframe.c \
-	src/common/cockpitframe.h \
-	src/common/cockpitmemory.c \
-	src/common/cockpitmemory.h \
 	src/ws/session-utils.c \
 	src/ws/session-utils.h \
 	src/ws/session.c \
 	$(NULL)
-cockpit_session_LDADD = $(COCKPIT_SESSION_LIBS)
+cockpit_session_LDADD = \
+	libcockpit-common-nodeps.a \
+	$(COCKPIT_SESSION_LIBS) \
+	$(NULL)
 
 cockpit_ws_SOURCES =					\
 	src/ws/main.c					\
@@ -161,6 +157,7 @@ remotectl_CFLAGS = \
 
 remotectl_LDADD = \
 	libcockpit-common.a \
+	libcockpit-common-nodeps.a \
 	$(COCKPIT_LIBS) \
 	$(NULL)
 
@@ -365,6 +362,7 @@ test_remotectlcertificate_SOURCES = \
 	$(NULL)
 test_remotectlcertificate_LDADD = \
 	libcockpit-common.a \
+	libcockpit-common-nodeps.a \
 	$(COCKPIT_LIBS) \
 	$(NULL)
 
@@ -390,17 +388,8 @@ mock_echo_SOURCES = src/ws/mock-echo.c
 mock_echo_CFLAGS = $(COCKPIT_WS_CFLAGS)
 mock_echo_LDADD = $(COCKPIT_WS_LIBS)
 
-mock_auth_command_SOURCES = \
-	src/common/cockpitauthorize.c \
-	src/common/cockpitauthorize.h \
-	src/common/cockpitbase64.c \
-	src/common/cockpitbase64.h \
-	src/common/cockpitframe.c \
-	src/common/cockpitframe.h \
-	src/common/cockpitmemory.c \
-	src/common/cockpitmemory.h \
-	src/ws/mock-auth-command.c \
-	$(NULL)
+mock_auth_command_SOURCES = src/ws/mock-auth-command.c
+mock_auth_command_LDADD = libcockpit-common-nodeps.a
 
 noinst_PROGRAMS += \
 	$(WS_CHECKS) \


### PR DESCRIPTION
Some parts of libcockpit-common.a don't have any dependencies other than
libc. We need this subset for security critical/minimal bits like
cockpit-session, and for various tests.

Instead of building these sources up to four times, build them into a
libcockpit-common-nodeps.a and use it where needed.
