### PR TITLE
naughty: Close 11917: SELinux: avc:  denied  { getattr } comm="iscsid"

### DIFF
--- a/bots/naughty/rhel-7/11917-selinux-getattr-iscsid
+++ b/bots/naughty/rhel-7/11917-selinux-getattr-iscsid
@@ -1,1 +1,0 @@
-Error: type=1400 * avc:  denied  { getattr } * comm="iscsid"


### PR DESCRIPTION
Known issue which has not occurred in 23 days

SELinux: avc:  denied  { getattr } comm="iscsid"

Fixes #11917