### PR TITLE
naughty: Close 8875: RHEL, Centos: SELinux is preventing /usr/lib/systemd/systemd-machined from 'search' accesses

### DIFF
--- a/bots/naughty/rhel-7/8875-selinux-systemd-machine-search
+++ b/bots/naughty/rhel-7/8875-selinux-systemd-machine-search
@@ -1,1 +1,0 @@
-Error: type=1400 audit*: avc:  denied  { search } for  pid=* comm="systemd-machine" name="*" dev="proc" ino=* scontext=system_u:system_r:systemd_machined_t:* tcontext=system_u:system_r:svirt_tcg_t:*


### PR DESCRIPTION
Known issue which has not occurred in 23 days

RHEL, Centos: SELinux is preventing /usr/lib/systemd/systemd-machined from 'search' accesses

Fixes #8875