### PR TITLE
logs: Show empty message when no logs available

### DIFF
--- a/pkg/lib/journal.css
+++ b/pkg/lib/journal.css
@@ -81,6 +81,14 @@
     min-width: 24px;
 }
 
+.empty-message {
+    width: 100%;
+    color: var(--pf-global--Color--200);
+    display: block;
+    padding: 0.5rem 1rem;
+    text-align: center;
+}
+
 .cockpit-log-warning > .fa-times-circle-o {
     color: var(--pf-global--danger-color--200);
 }

--- a/pkg/lib/journal.js
+++ b/pkg/lib/journal.js
@@ -560,10 +560,12 @@ journal.logbox = function logbox(match, max_entries) {
             renderer.prepend(entries[i]);
         }
         renderer.prepend_flush();
-        if (entries.length > 0)
-            box.removeAttribute("hidden");
-        else
-            box.setAttribute("hidden", "hidden");
+        if (entries.length === 0) {
+            let empty_message = document.createElement("span");
+            empty_message.textContent = "No log entries";
+            empty_message.setAttribute("class", "empty-message");
+            box.appendChild(empty_message);
+        }
     }
 
     render();

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -259,6 +259,10 @@ Unit=test.service
         self.assertEqual(b.val("#services-text-filter"), "")
         self.assertEqual(b.val("#services-dropdown"), "0")
 
+        # Check that journalbox shows empty state
+        b.click(svc_sel("systemd-halt.service"))
+        b.wait_text('#service-log', "No log entries")
+
     def testApi(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
Fixes #12328

Tests are going to conflict with #12265, but then I rebase either one lands second.

![Screenshot from 2019-07-15 10-58-06](https://user-images.githubusercontent.com/12330670/61212662-3e17d300-a703-11e9-935c-ad41c5969f47.png)
