### PR TITLE
shell: Remove overview `overflow: hidden`

### DIFF
--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -672,7 +672,6 @@ thead.credential-lock.credential-unlocked > *:last-child {
 @media (max-width: 991px) {
     #server .info-table-ct-container {
         padding: 0 0 20px;
-        overflow: hidden;
 
         th,
         td:first-child {


### PR DESCRIPTION
Overflow was previously used for containing floats. Since then, we
switched to grid-based layout, so it is no longer needed.

In fact, overflow of hidden was truncating the shutdown selector.

Fixes #12309
Closes #12330