### PR TITLE
fix "input is not a number" error in machines tests

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -814,3 +814,6 @@ CreateVmAction.propTypes = {
     providerName: PropTypes.string.isRequired,
     systemInfo: PropTypes.object.isRequired,
 };
+CreateVmAction.defaultProps = {
+    nodeMaxMemory: 1048576, // 1GiB
+};


### PR DESCRIPTION
Example: https://logs-https-cockpit.apps.ci.centos.org/logs/pull-12068-20190714-155252-187e2b57-verify-fedora-30/log.html#204

@KKoukiou : Can you please check if this makes sense? I. e. do we actually have a test that tries an invalid number, or is that pointing out some race condition?