### PR TITLE
bots: Stop testing obsolete rhel-7* images on master

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -76,13 +76,10 @@ TRIGGERS = {
         "verify/ubuntu-stable"
     ],
     "openshift": [
-        "verify/rhel-7-6",
-        "verify/rhel-7-7",
+        # FIXME: need to test a rhel-7.x branch here, once we can
     ],
     "ipa": [
         "verify/fedora-30",
-        "verify/rhel-7-6",
-        "verify/rhel-7-6-distropkg",
         "verify/ubuntu-1804",
         "verify/debian-stable"
     ],


### PR DESCRIPTION
master does not support RHEL 7 builds any more, so don't trigger these
tests on openshift or ipa images any more.