### PR TITLE
services: Use PF tabs

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -3,6 +3,9 @@ import { mustache } from "mustache";
 
 import cockpit from "cockpit";
 import moment from "moment";
+import React from "react";
+import ReactDOM from 'react-dom';
+import { ServiceTabs } from "./services.jsx";
 import { journal } from "journal";
 import "patterns";
 import "bootstrap-datepicker/dist/js/bootstrap-datepicker";
@@ -147,6 +150,7 @@ $(function() {
 
     var units_by_path = { };
     var path_by_id = { };
+    var pattern = ".service$";
 
     function ensure_units() {
         if (!units_initialized) {
@@ -268,7 +272,6 @@ $(function() {
 
         function render_now() {
             $("#loading-fallback").hide();
-            var pattern = $('#services-filter li.active').attr('data-pattern');
             var current_text_filter = $('#services-text-filter').val()
                     .toLowerCase();
             var current_type_filter = parseInt($('#services-dropdown').val());
@@ -339,6 +342,17 @@ $(function() {
             $('#services-dropdown').val(0);
             render();
         }
+
+        function tab_changed(new_tab) {
+            pattern = new_tab;
+            render();
+        }
+
+        ReactDOM.render(
+            React.createElement(ServiceTabs, {
+                onChange: tab_changed,
+            }),
+            document.getElementById("services-filter"));
 
         $("#services-text-filter").on("input", render);
         $(document).on("click", "#clear-all-filters", clear_filters);
@@ -487,16 +501,6 @@ $(function() {
 
         $(systemd_manager).on("UnitFilesChanged", function(event) {
             update_all();
-        });
-
-        $('#services-filter li').on('click', function() {
-            $('#services-filter li')
-                    .removeClass('active')
-                    .removeAttr('aria-current');
-            $(this)
-                    .addClass('active')
-                    .attr('aria-current', true);
-            render();
         });
 
         $('#services-dropdown').on('change', render);

--- a/pkg/systemd/services.css
+++ b/pkg/systemd/services.css
@@ -40,13 +40,6 @@ table.systemd-unit-relationship-table td:first-child {
   align-items: start;
 }
 
-#services .nav-tabs > li:not([tabindex]),
-#services .nav-tabs:before,
-#services .nav-tabs:after {
-  /* Hide odd non-tabs */
-  display: none;
-}
-
 .content-header-extra.with-navtabs {
   padding-bottom: 0;
 }

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -52,13 +52,7 @@
 
   <div id="services">
     <div class="content-header-extra with-navtabs">
-      <ul class="nav nav-tabs" id="services-filter">
-        <li tabindex="0" data-pattern="\.target$"><a tabindex="0" translatable="yes">Targets</a></li>
-        <li class="active" aria-current=true tabindex="0" data-pattern="\.service$"><a tabindex="0" translatable="yes">System Services</a></li>
-        <li tabindex="0" data-pattern="\.socket$"><a tabindex="0" translatable="yes">Sockets</a></li>
-        <li tabindex="0" data-pattern="\.timer$"><a tabindex="0" translatable="yes">Timers</a><li>
-        <li tabindex="0" data-pattern="\.path$"><a tabindex="0" translatable="yes">Paths</a><li>
-      </ul>
+      <div id="services-filter"></div>
 
       <div class="content-header-actions">
         <button id="create-timer" data-toggle="#timer-dialog" data-target="#timer-dialog" class="btn btn-primary" translate>Create Timer</button>

--- a/pkg/systemd/services.jsx
+++ b/pkg/systemd/services.jsx
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Tabs, Tab } from 'patternfly-react';
+
+import cockpit from "cockpit";
+
+const _ = cockpit.gettext;
+
+/*
+ * React component showing services tabs
+ * Required props:
+ *  - onChange:
+ *      When different tab is selected this callback is called
+ */
+export class ServiceTabs extends React.Component {
+    render() {
+        return (
+            <Tabs defaultActiveKey=".service$" id="service-tabs" onSelect={this.props.onChange}>
+                <Tab eventKey=".target$" title={ _("Targets") } />
+                <Tab eventKey=".service$" title={ _("System Services") } />
+                <Tab eventKey=".socket$" title={ _("Sockets") } />
+                <Tab eventKey=".timer$" title={ _("Timers") } />
+                <Tab eventKey=".path$" title={ _("Paths") } />
+            </Tabs>
+        );
+    }
+}
+
+ServiceTabs.propTypes = {
+    onChange: PropTypes.func.isRequired,
+};

--- a/pkg/systemd/services.jsx
+++ b/pkg/systemd/services.jsx
@@ -35,8 +35,8 @@ export class ServiceTabs extends React.Component {
     render() {
         return (
             <Tabs defaultActiveKey=".service$" id="service-tabs" onSelect={this.props.onChange}>
-                <Tab eventKey=".target$" title={ _("Targets") } />
                 <Tab eventKey=".service$" title={ _("System Services") } />
+                <Tab eventKey=".target$" title={ _("Targets") } />
                 <Tab eventKey=".socket$" title={ _("Sockets") } />
                 <Tab eventKey=".timer$" title={ _("Timers") } />
                 <Tab eventKey=".path$" title={ _("Paths") } />

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -159,7 +159,7 @@ OnCalendar=daily
         if m.image in ["rhel-8-0-distropkg"]:
             b.click('#services-filter button[data-pattern=\'\\\.timer\$\']')
         else:
-            b.click('#services-filter li[data-pattern=\'\\\.timer\$\']')
+            b.click('#services-filter li:nth-child(4) a')
         # HACK: the timers' next run/last trigger (col 3/4) don't always get filled (issue #9439)
         # b.wait_in_text("tr[data-goto-unit='test\.timer'] td:nth-child(3)", "morgen um")
 
@@ -306,7 +306,7 @@ OnCalendar=daily
         if m.image in ["rhel-8-0-distropkg"]:
             b.click('#services-filter button[data-pattern=\'\\\.timer\$\']')
         else:
-            b.click('#services-filter li[data-pattern=\'\\\.timer\$\']')
+            b.click('#services-filter li:nth-child(4) a')
         # HACK: the timers' next run/last trigger (col 3/4) don't always get filled (issue #9439)
         # b.wait_in_text('tr[data-goto-unit=\'test\.timer\'] td:nth-child(3)', 'morgen um')
 

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -153,7 +153,10 @@ Unit=test.service
         m.execute("systemctl stop test-onboot.timer")
 
         # Selects Services tab
-        self.pick_tab(2)
+        if self.machine.image in ["rhel-8-0-distropkg"]: # Changed in #12349
+            self.pick_tab(2)
+        else:
+            self.pick_tab(1)
         b.wait_present(svc_sel('test.service'))
         b.click(svc_sel("test.service"))
         b.wait_in_text('#service-valid', "inactive")
@@ -615,7 +618,10 @@ WantedBy=multi-user.target
         unit_primary_action_btn = '#service-unit-primary-action'
 
         # Selects Services tab
-        self.pick_tab(2)
+        if self.machine.image in ["rhel-8-0-distropkg"]: # Changed in #12349
+            self.pick_tab(2)
+        else:
+            self.pick_tab(1)
         b.wait_present(svc_sel('condtest.service'))
         b.click(svc_sel("condtest.service"))
         b.wait_in_text('#service-valid', "inactive")

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -33,6 +33,12 @@ class TestServices(MachineCase):
         # we don't race with the boot process
         self.machine.execute("systemctl start default.target")
 
+    def pick_tab(self, n):
+        if self.machine.image in ["rhel-8-0-distropkg"]: # Changed in #12349
+            self.browser.click('#services-filter :nth-child({0})'.format(n))
+        else:
+            self.browser.click('#services-filter li:nth-child({0}) a'.format(n))
+
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -129,7 +135,7 @@ Unit=test.service
         file_action_btn = '#service-file-action'
 
         # Selects Timer tab
-        b.click('#services-filter :nth-child(4)')
+        self.pick_tab(4)
         b.wait_present(svc_sel('test.timer'))
         b.wait_text(svc_sel('test.timer') + ' td:nth-child(3)', '')  # next run
         b.wait_text(svc_sel('test.timer') + ' td:nth-child(4)', '')  # last trigger
@@ -147,7 +153,7 @@ Unit=test.service
         m.execute("systemctl stop test-onboot.timer")
 
         # Selects Services tab
-        b.click('#services-filter :nth-child(2)')
+        self.pick_tab(2)
         b.wait_present(svc_sel('test.service'))
         b.click(svc_sel("test.service"))
         b.wait_in_text('#service-valid', "inactive")
@@ -324,7 +330,7 @@ WantedBy=default.target
         self.login_and_go("/system/services")
         if m.image not in ["rhel-8-0-distropkg"]: # Introduced in #11280
             b.wait_not_visible("#loading-fallback")
-        b.click('#services-filter :nth-child(4)')
+        self.pick_tab(4)
         b.wait_visible("#create-timer")
         b.click('#create-timer')
         b.wait_popup("timer-dialog")
@@ -609,7 +615,7 @@ WantedBy=multi-user.target
         unit_primary_action_btn = '#service-unit-primary-action'
 
         # Selects Services tab
-        b.click('#services-filter :nth-child(2)')
+        self.pick_tab(2)
         b.wait_present(svc_sel('condtest.service'))
         b.click(svc_sel("condtest.service"))
         b.wait_in_text('#service-valid', "inactive")


### PR DESCRIPTION
This change makes the tabs accessible. Also it moves a small bit of services page into React. Upon this can be build and other parts of services page can be moved into React. This is gonna conflict with #12265, but both conflicts are going to be easy to resolve, so does not matter which lands first.