### PR TITLE
tests: Introduce `test/run` script for Cockpit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ depcomp
 /test/testlib.pyc
 /test/*.rpm
 /test/files/cockpit_test_bridge*
-/test/run
 /test/kdc
 /cockpit-askpass
 /cockpit-session

--- a/test/run
+++ b/test/run
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# This is the expected entry point for Cockpit CI; will be called without
+# arguments but with an appropriate $TEST_OS, and optionally $TEST_SCENARIO
+
+set -eu
+
+TEST_SCENARIO=${TEST_SCENARIO:-verify}
+case $TEST_SCENARIO in
+    verify)
+        test/image-prepare --verbose $TEST_OS
+        test/verify/run-tests --jobs ${TEST_JOBS:-1}
+        ;;
+    avocado)
+        test/image-prepare --verbose $TEST_OS
+        test/avocado/run-tests --quick --tests
+        ;;
+    selenium-*)
+        test/image-prepare --verbose $TEST_OS
+        test/avocado/run-tests --quick --selenium-tests --browser ${TEST_SCENARIO#*-}
+        ;;
+    container-kubernetes)
+        test/image-prepare --containers --verbose $TEST_OS
+        test/image-prepare --containers --verbose --install-only openshift
+        test/containers/run-tests --container kubernetes
+        ;;
+    container-*)
+        test/image-prepare --containers --verbose $TEST_OS
+        test/containers/run-tests --container ${TEST_SCENARIO#*-}
+        ;;
+    *)
+        echo "Unknown test scenario: $TEST_SCENARIO"
+        exit 1
+esac

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -119,7 +119,7 @@ if [ -z "${PYTHON_STYLE_CHECKER-}" ]; then
     echo "ok 7 pycodestyle test # SKIP pycodestyle not installed"
 else
     # FIXME: Fix code for the warnings and re-enable them
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md,test/run) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"


### PR DESCRIPTION
External projects use this script to run tests. Let's do the same in
Cockpit so `tests/invoke` does not have to differentiate between cockpit
and external projects.

This is not yet used. It is going to be enabled a bit later on, see #12367 