### PR TITLE
bots: Distinguish context only when repo is different to PR target

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -113,9 +113,7 @@ class PullTask(object):
         api = github.GitHub()
 
         # build a unique file name for this test run
-        id_context = self.context
-        if self.test_project:  # disambiguate when running several external projects
-            id_context = self.test_project + "-" + id_context
+        id_context = "-".join([self.test_project, self.context])
         identifier = "-".join([
             self.name.replace("/", "-"),
             self.github_revision[0:8],
@@ -126,7 +124,7 @@ class PullTask(object):
 
         # build a globally unique test context for GitHub statuses
         github_context = self.context
-        if self.test_project:  # disambiguate tests for external projects
+        if self.test_project != api.repo :  # disambiguate test name for foreign project tests
             github_context += "@" + self.test_project
 
         self.github_status_data = {


### PR DESCRIPTION
I have question about this and I am opening this PR to discuss it.

The test project (for now) in the tests-invoke is used just for building up name for publishing. I am not sure what this all affects, I've changed it in this PR to always use project name. If this has unwanted effect then I am ready to change it to `if self.test_project != "cockpit-project/cockpit`.

@Gundersanne @martinpitt 