### PR TITLE
naughty: Close 11579: podman PullImage varlink API broken on fedora-29 when the tag specified does not exist

### DIFF
--- a/bots/naughty/fedora-29/11579-podman-pull-non-existing-tag-crash-no-coredump-available
+++ b/bots/naughty/fedora-29/11579-podman-pull-non-existing-tag-crash-no-coredump-available
@@ -1,7 +1,0 @@
-# testDownloadImage (__main__.TestApplication)
-*
-Traceback (most recent call last):
-  File *, line *, in testDownloadImage
-    dialog.openDialog() \
-  File *, line *, in expectDownloadErrorForNonExistingTag
-*

--- a/bots/naughty/fedora-29/11579-podman-pull-nonexisting-tag-crash
+++ b/bots/naughty/fedora-29/11579-podman-pull-nonexisting-tag-crash
@@ -1,3 +1,0 @@
-# testDownloadImage (__main__.TestApplication)*
-*
-*process * (podman) of user 0 dumped core.

--- a/bots/naughty/fedora-30/11579-podman-pull-non-existing-tag-crash-no-coredump-available
+++ b/bots/naughty/fedora-30/11579-podman-pull-non-existing-tag-crash-no-coredump-available
@@ -1,7 +1,0 @@
-# testDownloadImage (__main__.TestApplication)
-*
-Traceback (most recent call last):
-  File *, line *, in testDownloadImage
-    dialog.openDialog() \
-  File *, line *, in expectDownloadErrorForNonExistingTag
-*

--- a/bots/naughty/fedora-30/11579-podman-pull-nonexisting-tag-crash
+++ b/bots/naughty/fedora-30/11579-podman-pull-nonexisting-tag-crash
@@ -1,3 +1,0 @@
-# testDownloadImage (__main__.TestApplication)*
-*
-*process * (podman) of user 0 dumped core.


### PR DESCRIPTION
Known issue which has not occurred in 28 days

podman PullImage varlink API broken on fedora-29 when the tag specified does not exist

Fixes #11579