### PR TITLE
networkmanager: Ensure that endianess is always set

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2316,7 +2316,7 @@ PageNetworkInterface.prototype = {
                 firewall.disable().then(() => renderFirewallState());
         }
 
-        firewall.addEventListener('changed', function () {
+        function onFirewallChanged() {
             if (!firewall.installed) {
                 $('#networking-firewall').hide();
                 return;
@@ -2331,7 +2331,10 @@ PageNetworkInterface.prototype = {
             var summary = cockpit.format(cockpit.ngettext('$0 Active Rule', '$0 Active Rules', n), n.toString());
 
             $('#networking-firewall-summary').text(summary);
-        });
+        }
+
+        firewall.addEventListener('changed', onFirewallChanged);
+        onFirewallChanged();
 
         $(window).on('resize', function () {
             self.rx_plot.resize();

--- a/pkg/networkmanager/test-utils.js
+++ b/pkg/networkmanager/test-utils.js
@@ -150,6 +150,12 @@ QUnit.test("ip4_from_text empty", function (assert) {
     assert.strictEqual(utils.ip4_from_text("", true), 0);
 });
 
+QUnit.test("ip4_to/from_text invalid byteorder", function (assert) {
+    utils.set_byteorder(undefined);
+    assert.throws(function() { utils.ip4_from_text("1.2.3.4") });
+    assert.throws(function() { utils.ip4_to_text(0x01020304) });
+});
+
 QUnit.test("ip4_prefix_from_text", function (assert) {
     var checks = [
         "0.0.0.0",

--- a/pkg/networkmanager/utils.js
+++ b/pkg/networkmanager/utils.js
@@ -67,11 +67,13 @@ function bytes_from_nm32(num) {
             bytes[i] = num & 0xFF;
             num = num >>> 8;
         }
-    } else {
+    } else if (byteorder == "le") {
         for (i = 0; i < 4; i++) {
             bytes[i] = num & 0xFF;
             num = num >>> 8;
         }
+    } else {
+        throw new Error("byteorder is unset or has invalid value " + JSON.stringify(byteorder));
     }
     return bytes;
 }
@@ -114,10 +116,12 @@ export function ip4_from_text(text, empty_is_zero) {
         for (i = 0; i < 4; i++) {
             shift(bytes[i]);
         }
-    } else {
+    } else if (byteorder == "le") {
         for (i = 3; i >= 0; i--) {
             shift(bytes[i]);
         }
+    } else {
+        throw new Error("byteorder is unset or has invalid value " + JSON.stringify(byteorder));
     }
 
     return num;


### PR DESCRIPTION
Initializing the endianess in parallel meant that a lot of IP addresses
in the UI got rendered with `byteorder === undefined`, and thus being in
reverse order on big-endian machines.

Make these errors apparent also on LE machines by asserting that the
value is set correctly. In the UI, initialize byte order first and defer
everything else until that finished, via a new "preinit" promise.

https://bugzilla.redhat.com/show_bug.cgi?id=1728213