### PR TITLE
spec: Avoid file dependency in cockpit-docker

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -609,8 +609,7 @@ bastion hosts, and a basic dashboard.
 Summary: Cockpit user interface for Docker containers
 Requires: cockpit-bridge >= %{required_base}
 Requires: cockpit-shell >= %{required_base}
-Requires: /usr/bin/docker
-Requires: /usr/lib/systemd/system/docker.service
+Requires: (docker or moby-engine)
 Requires: %{__python3}
 
 %description -n cockpit-docker


### PR DESCRIPTION
Fedora Packaging Guidelines allow dependencies only on files/directories
from /usr/bin, /usr/sbin and /etc directories[0], so replace the
docker.service dependency with the package alternatives that provide it
in current Fedora.

[0] https://docs.fedoraproject.org/en-US/packaging-guidelines/#_file_and_directory_dependencies

https://bugzilla.redhat.com/show_bug.cgi?id=1731686