### PR TITLE
machines: handle pools which don't support CreateVol API in add disk dialog

### DIFF
--- a/pkg/lib/cockpit-components-select.jsx
+++ b/pkg/lib/cockpit-components-select.jsx
@@ -92,6 +92,7 @@ Select.propTypes = {
  * Expected properties:
  *  - data (required), will be passed to the select's onChange callback
  *  - disabled (optional): whether or not the entry is disabled.
+ *  - title (optional): acts as a tooltip to the option entry
  * Example: <SelectEntry data="foo">Some entry</SelectEntry>
  */
 export class SelectEntry extends React.Component {
@@ -99,6 +100,7 @@ export class SelectEntry extends React.Component {
         const value = (this.props.children !== undefined) ? this.props.children : textForUndefined;
         return (
             <option key={value} disabled={this.props.disabled}
+                title={this.props.title}
                 data-value={value} value={this.props.data}>
                 {value}
             </option>
@@ -108,6 +110,8 @@ export class SelectEntry extends React.Component {
 
 SelectEntry.propTypes = {
     data: PropTypes.any.isRequired,
+    disabled: PropTypes.bool,
+    title: PropTypes.string,
 };
 
 /* Divider

--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -203,12 +203,12 @@ const PoolRow = ({ idPrefix, onValueChanged, storagePoolName, vmStoragePools }) 
                            onChange={value => onValueChanged('storagePoolName', value)}
                            initial={storagePoolName || _("No Storage Pools available")}
                            extraClass="form-control">
-                {vmStoragePools.length > 0 ? vmStoragePools.map(pool => pool.name)
-                        .sort((a, b) => a.localeCompare(b))
-                        .map(poolName => {
+                {vmStoragePools.length > 0 ? vmStoragePools
+                        .sort((a, b) => a.name.localeCompare(b.name))
+                        .map(pool => {
                             return (
-                                <Select.SelectEntry data={poolName} key={poolName}>
-                                    {poolName}
+                                <Select.SelectEntry disabled={pool.disabled} title={pool.disabled ? _("This pool type does not support Storage Volume creation") : null} data={pool.name} key={pool.name}>
+                                    {pool.name}
                                 </Select.SelectEntry>
                             );
                         })
@@ -265,6 +265,7 @@ class PerformanceOptions extends React.Component {
 
 const CreateNewDisk = ({ idPrefix, onValueChanged, dialogValues, vmStoragePools, provider, vm }) => {
     const storagePool = vmStoragePools.find(pool => pool.name == dialogValues.storagePoolName);
+    const poolTypesNotSupportingVolumeCreation = ['iscsi', 'iscsi-direct', 'gluster', 'mpath'];
 
     return (
         <React.Fragment>
@@ -272,7 +273,7 @@ const CreateNewDisk = ({ idPrefix, onValueChanged, dialogValues, vmStoragePools,
             <PoolRow idPrefix={idPrefix}
                      storagePoolName={dialogValues.storagePoolName}
                      onValueChanged={onValueChanged}
-                     vmStoragePools={vmStoragePools} />
+                     vmStoragePools={vmStoragePools.map(pool => ({ ...pool, disabled: poolTypesNotSupportingVolumeCreation.includes(pool.type) }))} />
             {storagePool &&
             <React.Fragment>
                 <hr />


### PR DESCRIPTION
Show them in the dropdown list but disable the pools for which the
CreateVol API is not supported.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1731849