### PR TITLE
Stop defining Python source code encodings

### DIFF
--- a/bots/example-task
+++ b/bots/example-task
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/github-info
+++ b/bots/github-info
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/image-download
+++ b/bots/image-download
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/image-prune
+++ b/bots/image-prune
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/image-trigger
+++ b/bots/image-trigger
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/images/scripts/atomic.bootstrap
+++ b/bots/images/scripts/atomic.bootstrap
@@ -1,5 +1,4 @@
 #! /bin/bash
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/images/scripts/continuous-atomic.bootstrap
+++ b/bots/images/scripts/continuous-atomic.bootstrap
@@ -1,5 +1,4 @@
 #! /bin/bash
-# -*- coding: utf-8 -*-
 
 set -e
 

--- a/bots/images/scripts/continuous-atomic.install
+++ b/bots/images/scripts/continuous-atomic.install
@@ -1,5 +1,4 @@
 #! /bin/bash
-# -*- coding: utf-8 -*-
 
 set -e
 

--- a/bots/images/scripts/fedora-atomic.bootstrap
+++ b/bots/images/scripts/fedora-atomic.bootstrap
@@ -1,5 +1,4 @@
 #! /bin/bash
-# -*- coding: utf-8 -*-
 
 set -e
 

--- a/bots/images/scripts/fedora-atomic.install
+++ b/bots/images/scripts/fedora-atomic.install
@@ -1,5 +1,4 @@
 #! /bin/bash
-# -*- coding: utf-8 -*-
 
 set -e
 

--- a/bots/images/scripts/fedora-atomic.setup
+++ b/bots/images/scripts/fedora-atomic.setup
@@ -1,5 +1,4 @@
 #!/bin/bash
-# -*- coding: utf-8 -*-
 
 set -ex
 

--- a/bots/images/scripts/lib/atomic.setup
+++ b/bots/images/scripts/lib/atomic.setup
@@ -1,5 +1,4 @@
 #!/bin/bash
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/images/scripts/lib/docker-images.setup
+++ b/bots/images/scripts/lib/docker-images.setup
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -ex
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/images/scripts/lib/zero-disk.setup
+++ b/bots/images/scripts/lib/zero-disk.setup
@@ -1,5 +1,4 @@
 #!/bin/bash
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/images/scripts/rhel-atomic.bootstrap
+++ b/bots/images/scripts/rhel-atomic.bootstrap
@@ -1,5 +1,4 @@
 #! /bin/bash
-# -*- coding: utf-8 -*-
 
 set -e
 

--- a/bots/images/scripts/rhel-atomic.install
+++ b/bots/images/scripts/rhel-atomic.install
@@ -1,5 +1,4 @@
 #! /bin/bash
-# -*- coding: utf-8 -*-
 
 set -e
 

--- a/bots/images/scripts/rhel-atomic.setup
+++ b/bots/images/scripts/rhel-atomic.setup
@@ -1,5 +1,4 @@
 #!/bin/bash
-# -*- coding: utf-8 -*-
 
 set -e
 

--- a/bots/issue-scan
+++ b/bots/issue-scan
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/learn-tests
+++ b/bots/learn-tests
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/learn-trigger
+++ b/bots/learn-trigger
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/machine/machine_core/cli.py
+++ b/bots/machine/machine_core/cli.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/bots/machine/machine_core/constants.py
+++ b/bots/machine/machine_core/constants.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/bots/machine/machine_core/directories.py
+++ b/bots/machine/machine_core/directories.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2019 Red Hat, Inc.

--- a/bots/machine/machine_core/exceptions.py
+++ b/bots/machine/machine_core/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/bots/machine/machine_core/machine.py
+++ b/bots/machine/machine_core/machine.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/bots/machine/machine_core/machine_virtual.py
+++ b/bots/machine/machine_core/machine_virtual.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/bots/machine/machine_core/ssh_connection.py
+++ b/bots/machine/machine_core/ssh_connection.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/bots/machine/machine_core/testvm.py
+++ b/bots/machine/machine_core/testvm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/bots/machine/machine_core/timeout.py
+++ b/bots/machine/machine_core/timeout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/bots/machine/make-cloud-init-iso
+++ b/bots/machine/make-cloud-init-iso
@@ -1,5 +1,4 @@
 #! /bin/bash
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/machine/testvm.py
+++ b/bots/machine/testvm.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3 -u
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/make-checkout
+++ b/bots/make-checkout
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/naughty-prune
+++ b/bots/naughty-prune
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/naughty-trigger
+++ b/bots/naughty-trigger
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/npm-trigger
+++ b/bots/npm-trigger
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/npm-update
+++ b/bots/npm-update
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/po-refresh
+++ b/bots/po-refresh
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/po-trigger
+++ b/bots/po-trigger
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/task/__init__.py
+++ b/bots/task/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/task/cache.py
+++ b/bots/task/cache.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/task/github.py
+++ b/bots/task/github.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/task/sink.py
+++ b/bots/task/sink.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/task/test-cache
+++ b/bots/task/test-cache
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/task/test-checklist
+++ b/bots/task/test-checklist
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/task/test-github
+++ b/bots/task/test-github
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/task/test-task
+++ b/bots/task/test-task
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/tests-data
+++ b/bots/tests-data
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/bots/tests-score
+++ b/bots/tests-score
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/avocado/checklogin-basic.py
+++ b/test/avocado/checklogin-basic.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/avocado/checklogin-raw.py
+++ b/test/avocado/checklogin-raw.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/avocado/example-check-foo.py
+++ b/test/avocado/example-check-foo.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/avocado/notworking-checkrealms-basic.py
+++ b/test/avocado/notworking-checkrealms-basic.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/avocado/testlib_avocado/cockpit.py
+++ b/test/avocado/testlib_avocado/cockpit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.

--- a/test/avocado/testlib_avocado/exceptions.py
+++ b/test/avocado/testlib_avocado/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/test/avocado/testlib_avocado/libdisc.py
+++ b/test/avocado/testlib_avocado/libdisc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.

--- a/test/avocado/testlib_avocado/libnetwork.py
+++ b/test/avocado/testlib_avocado/libnetwork.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.

--- a/test/avocado/testlib_avocado/timeoutlib.py
+++ b/test/avocado/testlib_avocado/timeoutlib.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import fcntl
 import glob
 import json

--- a/test/common/tap.py
+++ b/test/common/tap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-active-pages
+++ b/test/verify/check-active-pages
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -1,5 +1,4 @@
 #! /usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-checkpoints
+++ b/test/verify/check-networking-checkpoints
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-mac
+++ b/test/verify/check-networking-mac
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-mtu
+++ b/test/verify/check-networking-mtu
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-other
+++ b/test/verify/check-networking-other
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-settings
+++ b/test/verify/check-networking-settings
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-unmanaged
+++ b/test/verify/check-networking-unmanaged
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networking-vlan
+++ b/test/verify/check-networking-vlan
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-roles
+++ b/test/verify/check-roles
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-ignored
+++ b/test/verify/check-storage-ignored
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-raid1
+++ b/test/verify/check-storage-raid1
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-scaling
+++ b/test/verify/check-storage-scaling
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-tuned
+++ b/test/verify/check-tuned
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.
 #

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2013 Red Hat, Inc.

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2017 Red Hat, Inc.

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2017 Red Hat, Inc.

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2015 Red Hat, Inc.


### PR DESCRIPTION
This is not needed in python3 as utf-8 is default python encoding...

and remove one more nitpick that @martinpitt can find in my PRs :)