### PR TITLE
machines: do not add a new pool entry into the global state with 'Started' signal

### DIFF
--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -1160,11 +1160,11 @@ function startEventMonitorStoragePools(connectionName, dispatch) {
 
             switch (eventType) {
             case Enum.VIR_STORAGE_POOL_EVENT_DEFINED:
-            case Enum.VIR_STORAGE_POOL_EVENT_STARTED:
             case Enum.VIR_STORAGE_POOL_EVENT_CREATED:
                 dispatch(getStoragePool({ connectionName, id:objPath }));
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_STOPPED:
+            case Enum.VIR_STORAGE_POOL_EVENT_STARTED:
                 dispatch(getStoragePool({ connectionName, id:objPath, updateOnly: true }));
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_UNDEFINED:


### PR DESCRIPTION
This could lead to race conditions, where a pool gets added twice.

This probably fixes the StoragePools test flake.
See here: https://209.132.184.41:8493/logs/pull-12331-20190722-144646-ccefb0d2-cockpit-project-cockpit-verify-fedora-30/log.html#229