### PR TITLE
bots: Fix typo in cockpit-project naming

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -178,7 +178,7 @@ class PullTask(object):
             # explicit request for html logs
             status["link"] = "log.html"
             status["extras"] = [ "https://raw.githubusercontent.com/cockpit-project/cockpit/master/bots/task/log.html" ]
-        elif self.test_project != "cockpit/cockpit-project":
+        elif self.test_project != "cockpit-project/cockpit":
             # third-party project, link directly to text log
             status["link"] = "log"
         else:


### PR DESCRIPTION
Fedora-30 in https://github.com/cockpit-project/cockpit/pull/12331 does not produce `.html` logs. Now it should. I'll run it here to check if it really fixes it.

And sorry for such stupid mistake :(