### PR TITLE
networking: Activate a connection after clearing master/slave fields

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -3058,8 +3058,8 @@ PageNetworkInterface.prototype = {
                                                         with_checkpoint(
                                                             self.model,
                                                             function () {
-                                                                return slave_con.delete_()
-                                                                        .fail(show_unexpected_error);
+                                                                return (free_slave_connection(slave_con)
+                                                                        .fail(show_unexpected_error));
                                                             },
                                                             {
                                                                 devices: dev ? [ dev ] : [ ],
@@ -3489,7 +3489,7 @@ function free_slave_connection(con) {
         delete cs.master;
         delete con.Settings.team_port;
         delete con.Settings.bridge_port;
-        return con.apply_settings(con.Settings);
+        return con.apply_settings(con.Settings).then(() => { con.activate(null, null) });
     }
 }
 

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -88,6 +88,12 @@ class TestNetworking(NetworkCase):
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tbond']")
 
+        # Check that the former members are displayed and both On
+        # Fixed in PR #12400
+        if m.image not in ["rhel-8-0-distropkg"]:
+            self.wait_for_iface(iface1)
+            self.wait_for_iface(iface2)
+
         # Due to above reload
         self.allow_journal_messages(".*Connection reset by peer.*",
                                     "connection unexpectedly closed by peer")

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -64,6 +64,12 @@ class TestNetworking(NetworkCase):
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tbridge']")
 
+        # Check that the former members are displayed and both On
+        # Fixed in PR #12400
+        if m.image not in ["rhel-8-0-distropkg"]:
+            self.wait_for_iface(iface1)
+            self.wait_for_iface(iface2)
+
     def testBridgeActive(self):
         b = self.browser
 

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -81,6 +81,12 @@ class TestNetworking(NetworkCase):
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tteam']")
 
+        # Check that the former members are displayed and both On
+        # Fixed in PR #12400
+        if m.image not in ["rhel-8-0-distropkg"]:
+            self.wait_for_iface(iface1)
+            self.wait_for_iface(iface2)
+
         # Due to above reload
         self.allow_journal_messages(".*Connection reset by peer.*",
                                     "connection unexpectedly closed by peer")


### PR DESCRIPTION
This seems to be necessary to have NetworkManager act on those
changes.

This also causes the former slaves to be active after deleting a
bond (etc).  This used to be the case in the unknown past but recently
NM would deactivate them with a reason of "dependency-failed".  See
https://bugzilla.redhat.com/show_bug.cgi?id=1724163

- [x] add a test to check that former slaves are active