### PR TITLE
networkmanager: Ensure that endianess is always set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ depcomp
 /test/testlib.pyc
 /test/*.rpm
 /test/files/cockpit_test_bridge*
-/test/run
 /test/kdc
 /cockpit-askpass
 /cockpit-session

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2316,7 +2316,7 @@ PageNetworkInterface.prototype = {
                 firewall.disable().then(() => renderFirewallState());
         }
 
-        firewall.addEventListener('changed', function () {
+        function onFirewallChanged() {
             if (!firewall.installed) {
                 $('#networking-firewall').hide();
                 return;
@@ -2331,7 +2331,10 @@ PageNetworkInterface.prototype = {
             var summary = cockpit.format(cockpit.ngettext('$0 Active Rule', '$0 Active Rules', n), n.toString());
 
             $('#networking-firewall-summary').text(summary);
-        });
+        }
+
+        firewall.addEventListener('changed', onFirewallChanged);
+        onFirewallChanged();
 
         $(window).on('resize', function () {
             self.rx_plot.resize();

--- a/pkg/networkmanager/test-utils.js
+++ b/pkg/networkmanager/test-utils.js
@@ -150,6 +150,12 @@ QUnit.test("ip4_from_text empty", function (assert) {
     assert.strictEqual(utils.ip4_from_text("", true), 0);
 });
 
+QUnit.test("ip4_to/from_text invalid byteorder", function (assert) {
+    utils.set_byteorder(undefined);
+    assert.throws(function() { utils.ip4_from_text("1.2.3.4") });
+    assert.throws(function() { utils.ip4_to_text(0x01020304) });
+});
+
 QUnit.test("ip4_prefix_from_text", function (assert) {
     var checks = [
         "0.0.0.0",

--- a/pkg/networkmanager/utils.js
+++ b/pkg/networkmanager/utils.js
@@ -67,11 +67,13 @@ function bytes_from_nm32(num) {
             bytes[i] = num & 0xFF;
             num = num >>> 8;
         }
-    } else {
+    } else if (byteorder == "le") {
         for (i = 0; i < 4; i++) {
             bytes[i] = num & 0xFF;
             num = num >>> 8;
         }
+    } else {
+        throw new Error("byteorder is unset or has invalid value " + JSON.stringify(byteorder));
     }
     return bytes;
 }
@@ -114,10 +116,12 @@ export function ip4_from_text(text, empty_is_zero) {
         for (i = 0; i < 4; i++) {
             shift(bytes[i]);
         }
-    } else {
+    } else if (byteorder == "le") {
         for (i = 3; i >= 0; i--) {
             shift(bytes[i]);
         }
+    } else {
+        throw new Error("byteorder is unset or has invalid value " + JSON.stringify(byteorder));
     }
 
     return num;

--- a/test/run
+++ b/test/run
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# This is the expected entry point for Cockpit CI; will be called without
+# arguments but with an appropriate $TEST_OS, and optionally $TEST_SCENARIO
+
+set -eu
+
+TEST_SCENARIO=${TEST_SCENARIO:-verify}
+case $TEST_SCENARIO in
+    verify)
+        test/image-prepare --verbose $TEST_OS
+        test/verify/run-tests --jobs ${TEST_JOBS:-1}
+        ;;
+    avocado)
+        test/image-prepare --verbose $TEST_OS
+        test/avocado/run-tests --quick --tests
+        ;;
+    selenium-*)
+        test/image-prepare --verbose $TEST_OS
+        test/avocado/run-tests --quick --selenium-tests --browser ${TEST_SCENARIO#*-}
+        ;;
+    container-kubernetes)
+        test/image-prepare --containers --verbose $TEST_OS
+        test/image-prepare --containers --verbose --install-only openshift
+        test/containers/run-tests --container kubernetes
+        ;;
+    container-*)
+        test/image-prepare --containers --verbose $TEST_OS
+        test/containers/run-tests --container ${TEST_SCENARIO#*-}
+        ;;
+    *)
+        echo "Unknown test scenario: $TEST_SCENARIO"
+        exit 1
+esac

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -119,7 +119,7 @@ if [ -z "${PYTHON_STYLE_CHECKER-}" ]; then
     echo "ok 7 pycodestyle test # SKIP pycodestyle not installed"
 else
     # FIXME: Fix code for the warnings and re-enable them
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md,test/run) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"


### PR DESCRIPTION
Initializing the endianess in parallel meant that a lot of IP addresses
in the UI got rendered with `byteorder === undefined`, and thus being in
reverse order on big-endian machines.

Make these errors apparent also on LE machines by asserting that the
value is set correctly. In the UI, initialize byte order first and defer
everything else until that finished, via a new "preinit" promise.

Fixes #6041
https://bugzilla.redhat.com/show_bug.cgi?id=1728213

Cherry-picked from master commit e3002502.