### PR TITLE
 bots: Enable passing test branch in test name

### DIFF
--- a/bots/tests-invoke
+++ b/bots/tests-invoke
@@ -52,10 +52,14 @@ def main():
     name = os.environ.get("TEST_NAME", "tests")
     revision = os.environ.get("TEST_REVISION")
     test_project = os.environ.get("TEST_PROJECT")
+    # branch name when explicitly given in the test status
+    # e.g. PR opened against master for test `rhel-8-0@cockpit-project/cockpit/rhel-8.0`
+    # TEST_BRANCH would be `rhel-8.0`
+    test_branch = os.environ.get("TEST_BRANCH")
 
     try:
         task = PullTask(name, revision, opts.context, opts.rebase, opts.remote,
-                        test_project=test_project, html_logs=opts.html_logs)
+                        test_project=test_project, test_branch=test_branch, html_logs=opts.html_logs)
         ret = task.run(opts)
     except RuntimeError as ex:
         ret = str(ex)
@@ -66,13 +70,14 @@ def main():
     return 0
 
 class PullTask(object):
-    def __init__(self, name, revision, context, base, remote, test_project, html_logs):
+    def __init__(self, name, revision, context, base, remote, test_project, test_branch, html_logs):
         self.name = name
         self.revision = revision
         self.context = context
         self.base = base
         self.remote = remote
         self.test_project = test_project
+        self.test_branch = test_branch
         self.html_logs = html_logs
 
         self.sink = None
@@ -104,7 +109,7 @@ class PullTask(object):
         api = github.GitHub()
 
         # build a unique file name for this test run
-        id_context = "-".join([self.test_project, self.context])
+        id_context = "-".join([self.test_project, self.test_branch or "", self.context])
         identifier = "-".join([
             self.name.replace("/", "-"),
             self.revision[0:8],
@@ -115,7 +120,9 @@ class PullTask(object):
 
         # build a globally unique test context for GitHub statuses
         github_context = self.context
-        if self.test_project != api.repo :  # disambiguate test name for foreign project tests
+        if self.test_branch:
+            github_context += "@" + self.test_project + "/" + self.test_branch
+        elif self.test_project != api.repo :  # disambiguate test name for foreign project tests
             github_context += "@" + self.test_project
 
         self.github_status_data = {

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -82,10 +82,13 @@ def main():
     try:
         policy = testmap.tests_for_project(opts.repo)
         if opts.context:
+            short_contexts = []
+            for context in opts.context:
+                short_contexts.append(context.split("@")[0])
             policy = {}
             for (branch, contexts) in testmap.tests_for_project(opts.repo).items():
                 branch_context = []
-                for context in opts.context:
+                for context in short_contexts:
                     if context in contexts:
                         branch_context.append(context)
                 if branch_context:
@@ -145,7 +148,8 @@ def tests_invoke(priority, name, number, revision, ref, context, base, repo, bot
     checkout = "PRIORITY={priority:04d} bots/make-checkout --verbose"
     cmd = "TEST_PROJECT={repo} TEST_NAME={name}-{current} TEST_REVISION={revision} bots/tests-invoke --pull-number={pull_number} "
     if base:
-        cmd += " --rebase={base}"
+        if base != ref:
+            cmd += " --rebase={base}"
         checkout += " --base={base}"
 
     checkout += " --repo={repo}"
@@ -306,37 +310,12 @@ def cockpit_tasks(api, update, branch_contexts, repo, pull_data, pull_number, sh
 
         labels = labels_of_pull(pull)
 
-        # Do we have any statuses for this commit?
-        have = len(statuses.keys()) > 0
-
         baseline = distributed_queue.BASELINE_PRIORITY
         # amqp automatically prioritizes on age
         if not amqp:
             # modify the baseline slightly to favor older pull requests, so that we don't
             # end up with a bunch of half tested pull requests
             baseline += 1.0 - (min(100000, float(number)) / 100000)
-
-        for context in contexts:
-            status = statuses.get(context, None)
-
-            # Only create new status for requests that have none
-            if not status:
-                if have or (base not in branch_contexts or context not in branch_contexts[base]):
-                    continue
-                status = { }
-
-            # For unmarked and untested status, user must be in whitelist
-            # Not this only applies to this specific commit. A new status
-            # will apply if the user pushes a new commit.
-            if login not in whitelist and status.get("description", github.NO_TESTING) == github.NO_TESTING:
-                priority = github.NO_TESTING
-                changes = { "description": github.NO_TESTING, "context": context, "state": "pending" }
-            else:
-                (priority, changes) = prioritize(status, title, labels, baseline, context, number)
-            if not update or update_status(api, revision, context, status, changes):
-                results.append((priority, "pull-%d" % number, number, revision, "pull/%d/head" % number, context, base, repo, None))
-
-        # if a cockpit repo PR changes bots/, also trigger all external tests against this cockpit PR
 
         def trigger_externals():
             if repo != "cockpit-project/cockpit":  # already a non-cockpit project
@@ -346,7 +325,7 @@ def cockpit_tasks(api, update, branch_contexts, repo, pull_data, pull_number, sh
             if LABEL_TEST_EXTERNAL in labels:  # already checked before?
                 return True
 
-            if not have:
+            if not statuses:
                 # this is the first time tests-scan looks at a PR, so determine if it changes bots/
                 with urllib.request.urlopen(pull["patch_url"]) as f:
                     # enough to look at the git commit header, it lists all changed files
@@ -358,22 +337,76 @@ def cockpit_tasks(api, update, branch_contexts, repo, pull_data, pull_number, sh
 
             return False
 
-        if trigger_externals():
+        def get_externals():
+            result = []
             for proj_repo in testmap.projects():
                 if proj_repo == "cockpit-project/cockpit":
                     continue
                 for context in testmap.tests_for_project(proj_repo).get("master", []):
-                    repo_context = context + "@" + proj_repo
+                    result.append(context + "@" + proj_repo)
+            return result
 
-                    status = statuses.get(repo_context, {})
-                    if login not in whitelist and status.get("description", github.NO_TESTING) == github.NO_TESTING:
-                        priority = github.NO_TESTING
-                        changes = { "description": github.NO_TESTING, "context": repo_context, "state": "pending" }
-                    else:
-                        (priority, changes) = prioritize(status, title, labels, baseline, repo_context, number)
-                    if not update or update_status(api, revision, repo_context, status, changes):
-                        # don't specify a ref to check out; make-source already checks out project master
-                        results.append((priority, "pull-%d" % number, number, revision, "", context, base, proj_repo, "pull/%s/head" % number))
+        def is_valid_context(context):
+            (os_scenario, _, repo_branch) = context.partition("@")
+            if repo_branch:
+                repo_branch = "/".join(repo_branch.split("/")[:2])
+                repo_contexts = testmap.tests_for_project(repo_branch).values()
+                return os_scenario in set(itertools.chain(*repo_contexts))
+            else:
+                return os_scenario in contexts
+
+        # Create list of statuses to process
+        todos = {}
+        for status in statuses: # Firstly add all valid contexts that already exist in github
+            if is_valid_context(status):
+                todos[status] = statuses[status]
+        if not statuses: # If none defined in github add basic set of contexts
+            for context in branch_contexts.get(base, contexts):
+                todos[context] = {}
+        if trigger_externals():
+            for context in get_externals():
+                if context not in todos:
+                    todos[context] = {}
+
+        for context in todos:
+            # Get correct project and branch. Ones from test name have priority
+            project = repo
+            branch = base
+            (os_scenario, _, repo_branch) = context.partition("@")
+            repo_branch = repo_branch.split("/")
+            if len(repo_branch) == 2:
+                project = "/".join(repo_branch)
+                branch = "master"
+            elif len(repo_branch) == 3:
+                project = "/".join(repo_branch[:2])
+                branch = repo_branch[2]
+
+            ref = "pull/%d/head" % number
+
+            # For unmarked and untested status, user must be in whitelist
+            # Not this only applies to this specific commit. A new status
+            # will apply if the user pushes a new commit.
+            status = todos[context]
+            if login not in whitelist and status.get("description", github.NO_TESTING) == github.NO_TESTING:
+                priority = github.NO_TESTING
+                changes = { "description": github.NO_TESTING, "context": context, "state": "pending" }
+            else:
+                (priority, changes) = prioritize(status, title, labels, baseline, context, number)
+            if not update or update_status(api, revision, context, status, changes):
+                checkout_ref = ref
+                if project != repo:
+                    checkout_ref = "master"
+                if base != branch:
+                    checkout_ref = branch
+                results.append((priority,
+                                "pull-%d" % number,
+                                number,
+                                revision,
+                                checkout_ref,
+                                os_scenario,
+                                branch,
+                                project,
+                                ref if project != repo or base != branch else None))
 
     return results
 

--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -110,20 +110,21 @@ def main():
     return 0
 
 # Prepare a human readable output
-def tests_human(priority, name, number, revision, ref, context, base, repo, bots_ref):
+def tests_human(priority, name, number, revision, ref, context, base, original_base, repo, bots_ref):
     if not priority:
         return
     try:
         priority = int(priority)
     except (ValueError, TypeError):
         pass
-    return "{name:11} {context:25} {revision:10} {priority:2}{repo}{bots_ref}".format(
+    return "{name:11} {context:25} {revision:10} {priority:2}{repo}{bots_ref}{branches}".format(
         priority=priority,
         revision=revision[0:7],
         context=context,
         name=name,
         repo=repo and "  (%s)" % repo or "",
         bots_ref=bots_ref and (" [bots@%s]" % bots_ref) or "",
+        branches=base != original_base and ("   {%s...%s}" % (original_base, base)) or ""
     )
 
 def is_internal_context(context):
@@ -133,7 +134,7 @@ def is_internal_context(context):
     return False
 
 # Prepare a test invocation command
-def tests_invoke(priority, name, number, revision, ref, context, base, repo, bots_ref, options):
+def tests_invoke(priority, name, number, revision, ref, context, base, original_base, repo, bots_ref, options):
     if not options.amqp and not redhat_network() and is_internal_context(context):
         return ''
 
@@ -166,6 +167,10 @@ def tests_invoke(priority, name, number, revision, ref, context, base, repo, bot
     if repo in REPO_EXTRA_INVOKE_OPTIONS:
         cmd += " " + " ".join(REPO_EXTRA_INVOKE_OPTIONS[repo])
 
+    # Let tests-invoke know that we are triggering different branch - it needs to post correct status
+    if base != original_base:
+        cmd = "TEST_BRANCH={base} " + cmd
+
     cmd += " {context}"
     if bots_ref:
         # we are checking the external repo on a cockpit PR, so stay on the project's master
@@ -187,8 +192,8 @@ def tests_invoke(priority, name, number, revision, ref, context, base, repo, bot
         repo=pipes.quote(repo),
     )
 
-def queue_test(priority, name, number, revision, ref, context, base, repo, bots_ref, channel, options):
-    command = tests_invoke(priority, name, number, revision, ref, context, base, repo, bots_ref, options)
+def queue_test(priority, name, number, revision, ref, context, base, original_base, repo, bots_ref, channel, options):
+    command = tests_invoke(priority, name, number, revision, ref, context, base, original_base, repo, bots_ref, options)
     if command:
         if priority > distributed_queue.MAX_PRIORITY:
             priority = distributed_queue.MAX_PRIORITY
@@ -405,6 +410,7 @@ def cockpit_tasks(api, update, branch_contexts, repo, pull_data, pull_number, sh
                                 checkout_ref,
                                 os_scenario,
                                 branch,
+                                base,
                                 project,
                                 ref if project != repo or base != branch else None))
 


### PR DESCRIPTION
While on it, unify how we deal with statuses and contexts.
Now it works something like this:
1) Get all existing statuses from github and verify them
2) If there are no valid statuses get the default ones
3) Of change in bots/ append all external contexts
4) Go through all generated contexts:
4.1) If test name contains project (and branch) use those instead of
default ones

Other things work the same.

**This is in testing, opening PR to see how bots deal with it. Failing to prepare tests is expected.**

There is still one thing I work on - the fact that image-refresh is opened against master, but we want to test it in stable branch. We need to do:
1) Checkout the stable branch
2) Pick bots from correct ref

I think we don't do this anywhere, so make-checkout needs to be edited as well
(If we test PR opened against stable branch we checkout the PR and then pick bots from master, and when testing external project we checkout master and then pick both from ref). It seems that firstly doing `make-checkout` and then rebasing in `tests-invoke` causes some problems.