### PR TITLE
bridge: Handle ENOBUFS in packet channel

### DIFF
--- a/src/bridge/cockpitpacketchannel.c
+++ b/src/bridge/cockpitpacketchannel.c
@@ -278,7 +278,7 @@ dispatch_output (gint fd,
 
       if (ret < 0)
         {
-          if (errno == EAGAIN && errno == EINTR)
+          if (errno == EAGAIN || errno == EINTR || errno == ENOBUFS)
             {
               break;
             }


### PR DESCRIPTION
On some architectures at least, send(2) can fail with `ENOBUFS` on
congestion. Accept that as a transient error condition as well.

Also fix the broken check for EAGAIN/EINTR.

Fixes #12414