### PR TITLE
sytemd: Dial down checking for available software updates

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -756,7 +756,9 @@ class OsUpdates extends React.Component {
                 .catch(ex => {
                     this.state.errorMessages.push(ex.message);
                     this.setState({ state: "updateError" });
-                });
+                })
+                // tell the System page to refresh its "Available Updates" status
+                .finally(() => window.sessionStorage.removeItem("last_sw_update_check"));
     }
 
     renderContent() {
@@ -892,6 +894,8 @@ class OsUpdates extends React.Component {
         PK.cancellableTransaction("RefreshCache", [true], data => this.setState({ loadPercent: data.percentage }))
                 .then(() => {
                     this.setState({ timeSinceRefresh: 0 });
+                    // tell the System page to refresh its "Available Updates" status
+                    window.sessionStorage.removeItem("last_sw_update_check");
                     this.loadUpdates();
                 })
                 .catch(this.handleLoadError);

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -506,8 +506,18 @@ PageServer.prototype = {
 
         function check_for_updates() {
             var os_updates = { };
-            self.os_updates = null;
 
+            // skip update check when becoming invisible
+            if (document.visibilityState != "visible")
+                return;
+            const lastCheck = window.sessionStorage.getItem("last_sw_update_check");
+            // check at most once per hour, as this is expensive on embedded machines
+            // this gets reset on applying software updates updates
+            if (self.os_updates && lastCheck && Date.now() - lastCheck < 3600000)
+                return;
+            window.sessionStorage.setItem("last_sw_update_check", Date.now());
+
+            self.os_updates = null;
             packagekit.cancellableTransaction(
                 "GetUpdates", [0],
                 function(data) {


### PR DESCRIPTION
The PackageKit `GetUpdates()` call is apparently fairly expensive on
embedded systems like the RasPi (taking several seconds, as opposed to ~
0.3 s on laptop/server class hardware).

Now check at most once per hour, and after refreshing package indexes or
applying updates on the Software Updates page. Remember the state
through a sessionStorage variable.

This is a trade-off: This will now present out of date information if
software updates are being applied outside of Cockpit, or in the
Terminal.

Fixes #12413