### PR TITLE
bots: Put ssh control socket into our VM temp dir instead of /tmp

### DIFF
--- a/bots/machine/machine_core/ssh_connection.py
+++ b/bots/machine/machine_core/ssh_connection.py
@@ -27,6 +27,7 @@ import sys
 
 from . import exceptions
 from . import timeout as timeoutlib
+from .directories import get_temp_dir
 
 
 class SSHConnection(object):
@@ -135,7 +136,7 @@ class SSHConnection(object):
     def _start_ssh_master(self):
         self._kill_ssh_master()
 
-        control = os.path.join(tempfile.gettempdir(), "ssh-%h-%p-%r-" + str(os.getpid()))
+        control = os.path.join(get_temp_dir(), "ssh-%h-%p-%r-" + str(os.getpid()))
 
         cmd = [
             "ssh",


### PR DESCRIPTION
When running our tests or other VM operations in toolbox, ssh'ing via
the connection sharing socket does not work: connect() just gets a
`ECONNREFUSED`. There is something about podman's/toolbox'es /tmp that
it doesn't like.

Place the socket in our own VM temp dir, which works fine and is
harmless for CI and non-toolbox use.