### PR TITLE
system: Fix graph tick labels

### DIFF
--- a/pkg/lib/plot.css
+++ b/pkg/lib/plot.css
@@ -1,6 +1,6 @@
 .plot-unit {
     display:      inline-block;
-    min-width:    1.5rem;
+    min-width:    2rem;
     font-size:    var(--pf-global--FontSize--xs);
     text-align:   right;
     color:        var(--color-gray-9);
@@ -12,7 +12,7 @@
 }
 
 .flot-y-axis .flot-tick-label {
-    width: 1.5rem;
+    width: 2rem;
     margin-right: 0.5rem;
 }
 

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -234,6 +234,16 @@ PageServer.prototype = {
         return null;
     },
 
+    relayout: function() {
+        var self = this;
+        if (self.cpu_plot) {
+            self.cpu_plot.resize();
+            self.memory_plot.resize();
+            self.network_plot.resize();
+            self.disk_plot.resize();
+        }
+    },
+
     setup: function() {
         var self = this;
         update_hostname_privileged();
@@ -557,6 +567,7 @@ PageServer.prototype = {
         machine_id.read()
                 .done(function(content) {
                     $("#system_machine_id").text(content);
+                    self.relayout();
                 })
                 .fail(function(ex) {
                     console.error("Error reading machine id", ex);
@@ -722,12 +733,7 @@ PageServer.prototype = {
 
         self.plot_controls.reset([ self.cpu_plot, self.memory_plot, self.network_plot, self.disk_plot ]);
 
-        $(window).on('resize.server', function() {
-            self.cpu_plot.resize();
-            self.memory_plot.resize();
-            self.network_plot.resize();
-            self.disk_plot.resize();
-        });
+        $(window).on('resize.server', () => { self.relayout() });
 
         let asset_tag_text = $("#system_information_asset_tag_text");
         let hardware_text = $("#system_information_hardware_text");
@@ -739,6 +745,7 @@ PageServer.prototype = {
                     asset_tag_text.text(fields.product_serial || fields.chassis_serial);
                     asset_tag_text.toggle(present);
                     asset_tag_text.prev().toggle(present);
+                    self.relayout();
                 })
                 .fail(function(ex) {
                     debug("couldn't read dmi info: " + ex);


### PR DESCRIPTION
The tick labels of the y-axis were frequently overlapping the graph
itself, for two reasons:

 - There was not enough space for very long labels like "0.500".

 - One needs to call plot.resize() explicitly whenever the size of a
   graph has changed.  This doesn't always happen, such as when then
   column with the graphs gets narrower because the info column gets
   wider when the machine id is inserted into it.