### PR TITLE
Revert "bots: Put ssh control socket into our VM temp dir instead of /tmp"

### DIFF
--- a/bots/machine/machine_core/ssh_connection.py
+++ b/bots/machine/machine_core/ssh_connection.py
@@ -27,7 +27,6 @@ import sys
 
 from . import exceptions
 from . import timeout as timeoutlib
-from .directories import get_temp_dir
 
 
 class SSHConnection(object):
@@ -136,7 +135,7 @@ class SSHConnection(object):
     def _start_ssh_master(self):
         self._kill_ssh_master()
 
-        control = os.path.join(get_temp_dir(), "ssh-%h-%p-%r-" + str(os.getpid()))
+        control = os.path.join(tempfile.gettempdir(), "ssh-%h-%p-%r-" + str(os.getpid()))
 
         cmd = [
             "ssh",


### PR DESCRIPTION
Apparently this broke the selenium tests.

This reverts commit 45d4fa0311753ebac5b1e41b47dc0cb4711ba6b3.