### PR TITLE
systemd: Fix template instance link

### DIFF
--- a/pkg/systemd/service-details.jsx
+++ b/pkg/systemd/service-details.jsx
@@ -480,7 +480,7 @@ export class ServiceDetails extends React.Component {
                             { this.props.originTemplate &&
                                 <React.Fragment>
                                     <label className="control-label" />
-                                    <span>{_("This unit is an instanced from ")}<a href={"#/" + this.props.originTemplate}>{this.props.originTemplate}</a>{ _(" template.")}</span>
+                                    <span>{_("Instance of template: ")}<a href={"#/" + this.props.originTemplate}>{this.props.originTemplate}</a></span>
                                 </React.Fragment>
                             }
                             { notMetConditions.length > 0 &&

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -244,7 +244,7 @@ Unit=test.service
         b.click("#service-details button")
         b.wait_text(".service-name", "Test Template for param-f/o/o")
         self.check_service_details(["Static", "Not running"], ["Disallow running (mask)"], True, onoff=False)
-        b.wait_in_text("#service-details", "This unit is an instanced from test-template@.service template.")
+        b.wait_in_text("#service-details", "Instance of template: test-template@.service")
         b.click("#service-details .ct-form a:contains('test-template@.service')")
         b.wait_visible("#service-details input")
 


### PR DESCRIPTION
"is an instanced from" is ungrammatical, and one can't concatenate parts
of a sentence like this, as it's not translatable.