### PR TITLE
machines: fix setting of volume format when adding new disks to VMs

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -138,9 +138,19 @@ const VolumeName = ({ idPrefix, volumeName, onValueChanged }) => {
 
 const VolumeDetails = ({ idPrefix, size, unit, diskFileFormat, storagePoolType, onValueChanged }) => {
     let formatRow;
+    let validVolumeFormats;
 
     // For the valid volume format types for different pool types see https://libvirt.org/storage.html
-    if (['dir', 'fs', 'netfs', 'gluster', 'vstorage'].indexOf(storagePoolType) > -1) {
+    if (['disk'].indexOf(storagePoolType) > -1) {
+        validVolumeFormats = [
+            'none', 'linux', 'fat16', 'fat32', 'linux-swap', 'linux-lvm',
+            'linux-raid', 'extended'
+        ];
+    } else if (['dir', 'fs', 'netfs', 'gluster', 'vstorage'].indexOf(storagePoolType) > -1) {
+        validVolumeFormats = ['qcow2', 'raw'];
+    }
+
+    if (validVolumeFormats) {
         formatRow = (
             <React.Fragment>
                 <label className='control-label' htmlFor={`${idPrefix}-fileformat`}>
@@ -150,12 +160,7 @@ const VolumeDetails = ({ idPrefix, size, unit, diskFileFormat, storagePoolType, 
                     onChange={value => onValueChanged('diskFileFormat', value)}
                     initial={diskFileFormat}
                     extraClass='form-control ct-form-split'>
-                    <Select.SelectEntry data='qcow2' key='qcow2'>
-                        {_("qcow2")}
-                    </Select.SelectEntry>
-                    <Select.SelectEntry data='raw' key='raw'>
-                        {_("raw")}
-                    </Select.SelectEntry>
+                    { validVolumeFormats.map(format => <Select.SelectEntry data={format} key={format}>{format}</Select.SelectEntry>) }
                 </Select.Select>
             </React.Fragment>
         );
@@ -381,8 +386,13 @@ class AddDiskModalBody extends React.Component {
 
     getDefaultVolumeFormat(pool) {
         // For the valid volume format types for different pool types see https://libvirt.org/storage.html
+        if (['disk'].indexOf(pool.type) > -1)
+            return 'none';
+
         if (['dir', 'fs', 'netfs', 'gluster', 'vstorage'].indexOf(pool.type) > -1)
             return 'qcow2';
+
+        return undefined;
     }
 
     get initialState() {

--- a/pkg/machines/libvirt-virsh.js
+++ b/pkg/machines/libvirt-virsh.js
@@ -330,7 +330,8 @@ LIBVIRT_PROVIDER = {
                 .then((volPath) => {
                     let scope = permanent ? '--config' : '';
                     scope = scope + (hotplug ? ' --live' : '');
-                    const command = `virsh ${connection} attach-disk ${vmName} --driver qemu --subdriver ${format} ${volPath.trim()} ${target} ${scope}`;
+                    const subdriver = (format && ['qcow2', 'raw'].includes(format)) ? `--subdriver ${format}` : '';
+                    const command = `virsh ${connection} attach-disk ${vmName} --driver qemu ${subdriver} ${volPath.trim()} ${target} ${scope}`;
 
                     logDebug('ATTACH_DISK command: ', command);
                     return cockpit.script(command, null, { err: "message", environ: ['LC_ALL=en_US.UTF-8'] });

--- a/pkg/machines/xmlCreator.js
+++ b/pkg/machines/xmlCreator.js
@@ -7,7 +7,7 @@ export function getDiskXML(poolName, volumeName, format, target, cacheMode) {
 
     var driverElem = doc.createElement('driver');
     driverElem.setAttribute('name', 'qemu');
-    if (format)
+    if (format && ['qcow2', 'raw'].includes(format))
         driverElem.setAttribute('type', format);
     if (cacheMode)
         driverElem.setAttribute('cache', cacheMode);
@@ -45,9 +45,11 @@ export function getVolumeXML(volumeName, size, format, target) {
 
     var targetElem = doc.createElement('target');
 
-    var formatElem = doc.createElement('format');
-    formatElem.setAttribute('type', format);
-    targetElem.appendChild(formatElem);
+    if (format) {
+        var formatElem = doc.createElement('format');
+        formatElem.setAttribute('type', format);
+        targetElem.appendChild(formatElem);
+    }
 
     volElem.appendChild(targetElem);
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -601,6 +601,7 @@ class TestMachines(NetworkCase):
                 use_existing_volume=False,
                 expected_target='vda', permanent=False, cache_mode=None,
                 verify=True, pool_type=None,
+                volume_format=None,
             ):
                 print(pool_name, volume_name)
                 self.test_obj = test_obj
@@ -615,6 +616,7 @@ class TestMachines(NetworkCase):
                 self.cache_mode = cache_mode
                 self.verify = verify
                 self.pool_type = pool_type
+                self.volume_format = volume_format
 
             def execute(self):
                 self.open()
@@ -649,9 +651,8 @@ class TestMachines(NetworkCase):
                     b.set_input_text("#vm-{0}-disks-adddisk-new-size".format(self.vm_name), str(self.volume_size))
                     b.select_from_dropdown("#vm-{0}-disks-adddisk-new-unit".format(self.vm_name), self.volume_size_unit)
 
-                    # Switch between format types to ensure availability
-                    b.select_from_dropdown("#vm-{0}-disks-adddisk-new-diskfileformat".format(self.vm_name), "raw") # verify content of the dropdown box
-                    b.select_from_dropdown("#vm-{0}-disks-adddisk-new-diskfileformat".format(self.vm_name), "qcow2") # and switch it back
+                    if self.volume_format:
+                        b.select_from_dropdown("#vm-{0}-disks-adddisk-new-diskfileformat".format(self.vm_name), self.volume_format)
 
                     # Configure persistency - by default the check box in unchecked for running VMs
                     if self.permanent:
@@ -686,16 +687,26 @@ class TestMachines(NetworkCase):
                 b.wait_in_text("#vm-{0}-disks-{1}-device".format(self.vm_name, self.expected_target), "disk")
 
                 # Detect volume format
-                detect_format_cmd = "virsh dumpxml {0} | xmllint --xpath '/domain/devices/disk[@type=\"{1}\"]/driver[@type=\"qcow2\"]' -"
+                detect_format_cmd = "virsh vol-dumpxml {0} {1} | xmllint --xpath '/volume/target/format' -".format(self.volume_name, self.pool_name)
 
                 if self.test_obj.provider == "libvirt-dbus":
                     b.wait_in_text('#vm-{0}-disks-{1}-source-volume'.format(self.vm_name, self.expected_target), self.volume_name)
                     if self.cache_mode:
                         b.wait_in_text("#vm-{0}-disks-{1}-cache".format(self.vm_name, self.expected_target), self.cache_mode)
-                    m.execute(detect_format_cmd.format(self.vm_name, "volume"))
+                    # Guess by the name of the pool it's format to avoid passing more parameters
+                    if self.pool_type == 'iscsi':
+                        expected_format = 'unknown'
+                    else:
+                        expected_format = 'qcow2'
+                    self.test_obj.assertEqual(
+                        m.execute(detect_format_cmd).rstrip(),
+                        '<format type="{0}"/>'.format(self.volume_format or expected_format)
+                    )
                 else:
-                    b.wait_in_text('#vm-{0}-disks-{1}-source-file'.format(self.vm_name, self.expected_target), self.volume_name)
-                    m.execute(detect_format_cmd.format(self.vm_name, "file"))
+                    if self.pool_type == 'disk':
+                        b.wait_in_text('#vm-{0}-disks-{1}-source-device'.format(self.vm_name, self.expected_target), self.volume_name)
+                    else:
+                        b.wait_in_text('#vm-{0}-disks-{1}-source-file'.format(self.vm_name, self.expected_target), self.volume_name)
 
                 return self
 
@@ -824,6 +835,7 @@ class TestMachines(NetworkCase):
             VMAddDiskDialog(
                 self,
                 pool_name='iscsi-pool',
+                pool_type='iscsi',
                 volume_name='unit:0:0:0',
                 expected_target='vdi',
                 use_existing_volume='True',
@@ -865,6 +877,25 @@ class TestMachines(NetworkCase):
             b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
             # Check that usage information can't be fetched since the pool is inactive
             b.wait_not_present("#vm-subVmTest1-disks-vdd-used")
+
+        prepareDisk(self.machine)
+        cmds = [
+            "virsh pool-define-as disk-pool disk - - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 - /tmp/poolDiskImages",
+            "virsh pool-build disk-pool --overwrite",
+            "virsh pool-start disk-pool",
+        ]
+        self.machine.execute(" && ".join(cmds))
+        partition = str(self.machine.execute("readlink -f /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 | cut -d '/' -f 3").strip()) + "1"
+        VMAddDiskDialog(
+            self,
+            pool_name='disk-pool',
+            pool_type='disk',
+            volume_name=partition,
+            volume_size=10,
+            volume_size_unit='MiB',
+            expected_target='vdc',
+            volume_format='none',
+        ).execute()
 
     def testVmNICs(self):
         b = self.browser


### PR DESCRIPTION
Don't try to set the disk driver type to something which is neither of
qcow2 or raw.
Volumes on some pool types, can have different format types though.
In that case, just omit settings the disk driver type, and let QEMU
autoset the default.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1732303