### PR TITLE
cockpituous-release: Don't upload to ubuntu ppa

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -42,6 +42,5 @@ job release-bodhi F30
 # Upload documentation
 job bots/release-guide dist/guide cockpit-project/cockpit-project.github.io
 
-# Create and publish a Debian repository and Ubuntu PPA
+# Create and publish a Debian repository
 job release-dsc
-job release-ubuntu-ppa


### PR DESCRIPTION
This PPA hasn't existed for a while now and uploading failed.