### PR TITLE
tls: Make writes non-blocking

### DIFF
--- a/src/tls/connection.h
+++ b/src/tls/connection.h
@@ -24,7 +24,7 @@
 #include "wsinstance.h"
 
 typedef enum { CLIENT, WS } DataSource;
-typedef enum { SUCCESS, PARTIAL, CLOSED, RETRY, FATAL } ConnectionResult;
+typedef enum { SUCCESS, PARTIAL, CLOSED, RETRY, FATAL, FULL } ConnectionResult;
 
 typedef struct Connection Connection;
 
@@ -32,7 +32,6 @@ typedef struct Connection Connection;
 struct ConnectionBuffer {
   char data[256 * 1024];
   size_t length;
-  size_t offset; /* for partial writes */
   Connection *connection;
 };
 

--- a/src/tls/connection.h
+++ b/src/tls/connection.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <sys/epoll.h>
 
 #include "wsinstance.h"
 
@@ -32,6 +33,7 @@ typedef struct Connection Connection;
 struct ConnectionBuffer {
   char data[256 * 1024];
   size_t length;
+  struct epoll_event epoll_ev;
   Connection *connection;
 };
 


### PR DESCRIPTION
Stop writing back a read block to the peer in a loop. This may lead to
deadlocks with full buffers and block all other connections.
    
Instead, decouple reading and writing, and flip the epoll between
EPOLLIN and EPOLLOUT, i. e. wait until the receiver is ready for
writing.

 - [x] PR #12492
