### PR TITLE
bots: Fix printing in inspect-queue

### DIFF
--- a/bots/inspect-queue
+++ b/bots/inspect-queue
@@ -42,7 +42,7 @@ def main():
             for i in range(message_count):
                 method_frame, header_frame, body = q.channel.basic_get(queue=queue)
                 if method_frame:
-                    print(body)
+                    print(body.decode())
 
         print('public queue:')
         print_queue('public')


### PR DESCRIPTION
The AMQP queue contains binary data. Decode it to avoid prefixing
everything with `b''`.