### PR TITLE
networking: Activate a connection after clearing master/slave fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ depcomp
 /test/testlib.pyc
 /test/*.rpm
 /test/files/cockpit_test_bridge*
-/test/run
 /test/kdc
 /cockpit-askpass
 /cockpit-session

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -3046,8 +3046,8 @@ PageNetworkInterface.prototype = {
                                                         with_checkpoint(
                                                             self.model,
                                                             function () {
-                                                                return slave_con.delete_()
-                                                                        .fail(show_unexpected_error);
+                                                                return (free_slave_connection(slave_con)
+                                                                        .fail(show_unexpected_error));
                                                             },
                                                             {
                                                                 devices: dev ? [ dev ] : [ ],
@@ -3477,7 +3477,7 @@ function free_slave_connection(con) {
         delete cs.master;
         delete con.Settings.team_port;
         delete con.Settings.bridge_port;
-        return con.apply_settings(con.Settings);
+        return con.apply_settings(con.Settings).then(() => { con.activate(null, null) });
     }
 }
 

--- a/test/run
+++ b/test/run
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# This is the expected entry point for Cockpit CI; will be called without
+# arguments but with an appropriate $TEST_OS, and optionally $TEST_SCENARIO
+
+set -eu
+
+TEST_SCENARIO=${TEST_SCENARIO:-verify}
+case $TEST_SCENARIO in
+    verify)
+        test/image-prepare --verbose $TEST_OS
+        test/verify/run-tests --jobs ${TEST_JOBS:-1}
+        ;;
+    avocado)
+        test/image-prepare --verbose $TEST_OS
+        test/avocado/run-tests --quick --tests
+        ;;
+    selenium-*)
+        test/image-prepare --verbose $TEST_OS
+        test/avocado/run-tests --quick --selenium-tests --browser ${TEST_SCENARIO#*-}
+        ;;
+    container-kubernetes)
+        test/image-prepare --containers --verbose $TEST_OS
+        test/image-prepare --containers --verbose --install-only openshift
+        test/containers/run-tests --container kubernetes
+        ;;
+    container-*)
+        test/image-prepare --containers --verbose $TEST_OS
+        test/containers/run-tests --container ${TEST_SCENARIO#*-}
+        ;;
+    *)
+        echo "Unknown test scenario: $TEST_SCENARIO"
+        exit 1
+esac

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -89,6 +89,12 @@ class TestNetworking(NetworkCase):
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tbond']")
 
+        # Check that the former members are displayed and both On
+        # Fixed in PR #12400
+        if m.image not in ["rhel-8-0-distropkg"]:
+            self.wait_for_iface(iface1)
+            self.wait_for_iface(iface2)
+
         # Due to above reload
         self.allow_journal_messages(".*Connection reset by peer.*",
                                     "connection unexpectedly closed by peer")

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -65,6 +65,12 @@ class TestNetworking(NetworkCase):
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tbridge']")
 
+        # Check that the former members are displayed and both On
+        # Fixed in PR #12400
+        if m.image not in ["rhel-8-0-distropkg"]:
+            self.wait_for_iface(iface1)
+            self.wait_for_iface(iface2)
+
     def testBridgeActive(self):
         b = self.browser
 

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -87,6 +87,12 @@ class TestNetworking(NetworkCase):
         b.wait_visible("#networking")
         b.wait_not_present("#networking-interfaces tr[data-interface='tteam']")
 
+        # Check that the former members are displayed and both On
+        # Fixed in PR #12400
+        if m.image not in ["rhel-8-0-distropkg"]:
+            self.wait_for_iface(iface1)
+            self.wait_for_iface(iface2)
+
         # Due to above reload
         self.allow_journal_messages(".*Connection reset by peer.*",
                                     "connection unexpectedly closed by peer")

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -119,7 +119,7 @@ if [ -z "${PYTHON_STYLE_CHECKER-}" ]; then
     echo "ok 7 pycodestyle test # SKIP pycodestyle not installed"
 else
     # FIXME: Fix code for the warnings and re-enable them
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md,test/run) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"


### PR DESCRIPTION
This seems to be necessary to have NetworkManager act on those
changes.

This also causes the former slaves to be active after deleting a
bond (etc).  This used to be the case in the unknown past but recently
NM would deactivate them with a reason of "dependency-failed".  See
https://bugzilla.redhat.com/show_bug.cgi?id=1724163