### PR TITLE
storage: Use standard $PATH when checking for mount.nfs

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -422,7 +422,11 @@ function init_model(callback) {
     }
 
     function enable_nfs_features() {
-        return cockpit.spawn([ "which", "mount.nfs" ], { err: "ignore" }).then(
+        // mount.nfs might be in */sbin but that ins't always in
+        // $PATH, such as when connecting from CentOS to another
+        // machine via SSH as non-root.
+        let std_path = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+        return cockpit.spawn([ "which", "mount.nfs" ], { err: "message", environ: [ std_path ] }).then(
             function () {
                 client.features.nfs = true;
                 client.nfs.start();


### PR DESCRIPTION
Fixes #12268