### PR TITLE
tls: Move data reading/writing into Connection

### DIFF
--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -38,6 +38,8 @@ connection_new (int client_fd)
 
   con = callocx (1, sizeof (Connection));
   con->client_fd = client_fd;
+  con->buf_client.connection = con;
+  con->buf_ws.connection = con;
 
   debug ("new connection on fd %i", con->client_fd);
   return con;

--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -19,10 +19,13 @@
 
 #include "connection.h"
 
+#include <assert.h>
 #include <err.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/socket.h>
 
 #include "common/cockpitmemory.h"
 
@@ -61,4 +64,136 @@ connection_free (Connection *c)
     close (c->ws_fd);
 
   free (c);
+}
+
+/**
+ * connection_read; Read a data block from source
+ *
+ * Buffer must be empty for this.
+ * Returns SUCCESS, CLOSED, FATAL, or RETRY.
+ */
+ConnectionResult
+connection_read (Connection *c, DataSource source)
+{
+  int r;
+  struct ConnectionBuffer *buf = source == CLIENT ? &c->buf_client : &c->buf_ws;
+  int fd = source == CLIENT ? c->client_fd : c->ws_fd;
+
+  assert (buf->length == 0);
+  assert (buf->offset == 0);
+
+  if (c->is_tls && source == CLIENT)
+    {
+      r = gnutls_record_recv (c->session, buf->data, sizeof (buf->data));
+      if (r == 0)
+        {
+          debug ("client fd %i closed the TLS connection", fd);
+          do
+            {
+              r = gnutls_bye (c->session, GNUTLS_SHUT_WR);
+            } while (r == GNUTLS_E_AGAIN || r == GNUTLS_E_INTERRUPTED);
+          return CLOSED;
+        }
+      if (r < 0)
+        {
+          if (r == GNUTLS_E_AGAIN || r == GNUTLS_E_INTERRUPTED)
+            {
+              debug ("reading from client fd %i TLS connection: %s; RETRY", fd, gnutls_strerror (r));
+              return RETRY;
+            }
+          warnx ("reading from client fd %i TLS connection failed: %s", fd, gnutls_strerror (r));
+          return FATAL;
+        }
+      debug ("read %i bytes from client fd %i TLS connection", r, fd);
+    }
+  else
+    {
+      r = recv (fd, buf->data, sizeof (buf->data), MSG_DONTWAIT);
+      if (r == 0)
+      {
+        debug ("fd %i has closed the connection", fd);
+        return CLOSED;
+      }
+      if (r < 0)
+        {
+          if (errno == EAGAIN || errno == EINTR)
+            {
+              debug ("reading from fd %i: %m; RETRY", fd);
+              return RETRY;
+            }
+          warn ("reading from fd %i failed", fd);
+          return FATAL;
+        }
+      debug ("read %i bytes from fd %i", r, fd);
+    }
+
+  buf->length = r;
+  return SUCCESS;
+}
+
+/**
+ * connection_write: Write a previously read data block from source to the
+ * other peer
+ *
+ * Buffer must be non-empty for this. This may do a partial write, in which
+ * case multiple calls are necessary.
+ * Returns SUCCESS, PARTIAL, FATAL, or RETRY.
+ */
+ConnectionResult
+connection_write (Connection *c, DataSource source)
+{
+  int r;
+  ssize_t size;
+  struct ConnectionBuffer *buf = source == CLIENT ? &c->buf_client : &c->buf_ws;
+  /* write the buffer to the *other* peer */
+  int fd = source == CLIENT ? c->ws_fd : c->client_fd;
+
+  assert (buf->length > 0);
+  assert (buf->offset < buf->length);
+  size = buf->length - buf->offset;
+
+  if (c->is_tls && source == WS)
+    {
+      r = gnutls_record_send (c->session, buf->data + buf->offset, size);
+      if (r == 0) /* Should Not Happen™, as data_size > 0 */
+        return FATAL;
+      if (r < 0)
+        {
+          if (r == GNUTLS_E_AGAIN || r == GNUTLS_E_INTERRUPTED)
+            {
+              debug ("writing to client fd %i TLS connection: %s; RETRY", fd, gnutls_strerror (r));
+              return RETRY;
+            }
+          warnx ("writing to client fd %i TLS connection failed: %s", fd, gnutls_strerror (r));
+          return FATAL;
+        }
+
+      debug ("wrote %i bytes out of %zi to TLS connection client fd %i", r, size, fd);
+    }
+  else
+  {
+    r = send (fd, buf->data + buf->offset, size, 0);
+    if (r == 0) /* Should Not Happen™, as data_size > 0 */
+      return FATAL;
+    if (r < 0)
+      {
+        if (errno == EAGAIN || errno == EINTR)
+          {
+            debug ("writing to fd %i: %m; RETRY", fd);
+            return RETRY;
+          }
+        warn ("writing to fd %i failed", fd);
+        return FATAL;
+      }
+    debug ("wrote %i bytes out of %zi to fd %i", r, size, fd);
+  }
+
+  assert (r <= size);
+  buf->offset += r;
+  if (buf->offset < buf->length)
+    return PARTIAL;
+
+  /* all written, reset indexes */
+  buf->offset = buf->length = 0;
+  return SUCCESS;
 }

--- a/src/tls/connection.h
+++ b/src/tls/connection.h
@@ -26,15 +26,18 @@
 typedef enum { CLIENT, WS } DataSource;
 typedef enum { SUCCESS, PARTIAL, CLOSED, RETRY, FATAL } ConnectionResult;
 
+typedef struct Connection Connection;
+
 /* hold a block of read data that is being written */
 struct ConnectionBuffer {
   char data[256 * 1024];
   size_t length;
   size_t offset; /* for partial writes */
+  Connection *connection;
 };
 
 /* a single TCP connection between the client (browser) and cockpit-tls */
-typedef struct Connection {
+struct Connection {
   int client_fd;
   bool is_tls;
   gnutls_session_t session;
@@ -43,7 +46,7 @@ typedef struct Connection {
   struct ConnectionBuffer buf_client;
   struct ConnectionBuffer buf_ws;
   struct Connection *next;
-} Connection;
+};
 
 Connection* connection_new (int client_fd);
 void connection_set_tls_session (Connection *c, gnutls_session_t session);

--- a/src/tls/connection.h
+++ b/src/tls/connection.h
@@ -23,6 +23,16 @@
 
 #include "wsinstance.h"
 
+typedef enum { CLIENT, WS } DataSource;
+typedef enum { SUCCESS, PARTIAL, CLOSED, RETRY, FATAL } ConnectionResult;
+
+/* hold a block of read data that is being written */
+struct ConnectionBuffer {
+  char data[256 * 1024];
+  size_t length;
+  size_t offset; /* for partial writes */
+};
+
 /* a single TCP connection between the client (browser) and cockpit-tls */
 typedef struct Connection {
   int client_fd;
@@ -30,9 +40,13 @@ typedef struct Connection {
   gnutls_session_t session;
   WsInstance *ws;
   int ws_fd;
+  struct ConnectionBuffer buf_client;
+  struct ConnectionBuffer buf_ws;
   struct Connection *next;
 } Connection;
 
 Connection* connection_new (int client_fd);
 void connection_set_tls_session (Connection *c, gnutls_session_t session);
 void connection_free (Connection *c);
+ConnectionResult connection_read (Connection *c, DataSource source);
+ConnectionResult connection_write (Connection *c, DataSource source);

--- a/src/tls/test-connection.c
+++ b/src/tls/test-connection.c
@@ -43,6 +43,9 @@ test_no_ws (void)
   c = connection_new (fd);
   g_assert (c);
   g_assert_cmpint (c->client_fd, ==, fd);
+  /* back references from buffer to connection */
+  g_assert (c->buf_client.connection == c);
+  g_assert (c->buf_ws.connection == c);
 
   /* other fields are clear */
   g_assert (!c->is_tls);

--- a/src/tls/test-connection.c
+++ b/src/tls/test-connection.c
@@ -21,6 +21,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/socket.h>
 
 #include "connection.h"
 #include "common/cockpittest.h"
@@ -94,6 +95,67 @@ test_tls_session (void)
   connection_free (c);
 }
 
+static void
+test_read_write (void)
+{
+  int client_fds[2];
+  int ws_fds[2];
+  char buffer[10];
+  const char *msg = "hello";
+  const size_t msglen = strlen (msg);
+  Connection *c;
+
+  g_assert_cmpint (socketpair (AF_UNIX, SOCK_STREAM, 0, client_fds), ==, 0);
+  g_assert_cmpint (socketpair (AF_UNIX, SOCK_STREAM, 0, ws_fds), ==, 0);
+  c = connection_new (client_fds[0]);
+  g_assert (c);
+  c->ws_fd = ws_fds[0];
+
+  /* client → ws */
+  g_assert_cmpint (connection_read (c, CLIENT), ==, RETRY);
+  g_assert_cmpint (c->buf_client.length, ==, 0);
+  g_assert_cmpint (send (client_fds[1], msg, msglen, 0), ==, msglen);
+  g_assert_cmpint (connection_read (c, CLIENT), ==, SUCCESS);
+  g_assert_cmpint (c->buf_client.length, ==, msglen);
+  g_assert_cmpint (c->buf_ws.length, ==, 0);
+
+  g_assert_cmpint (connection_write (c, CLIENT), ==, SUCCESS);
+  g_assert_cmpint (c->buf_client.length, ==, 0);
+  g_assert_cmpint (c->buf_client.offset, ==, 0);
+
+  g_assert_cmpint (recv (ws_fds[1], buffer, sizeof (buffer), 0), ==, msglen);
+  buffer[msglen] = '\0';
+  g_assert_cmpstr (buffer, ==, msg);
+
+  g_assert_cmpint (connection_read (c, CLIENT), ==, RETRY);
+
+  /* ws → client */
+  g_assert_cmpint (connection_read (c, WS), ==, RETRY);
+
+  g_assert_cmpint (send (ws_fds[1], msg, msglen, 0), ==, msglen);
+  g_assert_cmpint (connection_read (c, WS), ==, SUCCESS);
+  g_assert_cmpint (c->buf_ws.length, ==, msglen);
+  g_assert_cmpint (c->buf_client.length, ==, 0);
+
+  g_assert_cmpint (connection_write (c, WS), ==, SUCCESS);
+  g_assert_cmpint (c->buf_ws.length, ==, 0);
+
+  bzero (buffer, sizeof (buffer));
+  g_assert_cmpint (recv (client_fds[1], buffer, sizeof (buffer), 0), ==, msglen);
+  buffer[msglen] = '\0';
+  g_assert_cmpstr (buffer, ==, msg);
+
+  g_assert_cmpint (connection_read (c, WS), ==, RETRY);
+
+  /* EOF detection */
+  close (client_fds[1]);
+  g_assert_cmpint (connection_read (c, CLIENT), ==, CLOSED);
+  close (ws_fds[1]);
+  g_assert_cmpint (connection_read (c, WS), ==, CLOSED);
+
+  connection_free (c);
+}
+
 int
 main (int argc,
       char *argv[])
@@ -103,6 +165,7 @@ main (int argc,
   g_test_add_func ("/connection/no-ws", test_no_ws);
   g_test_add_func ("/connection/with-ws", test_with_ws);
   g_test_add_func ("/connection/tls-session", test_tls_session);
+  g_test_add_func ("/connection/read-write", test_read_write);
 
   return g_test_run ();
 }


### PR DESCRIPTION
Also move from a single global data buffer in Server to a per-connection
buffer pair (once for each data direction).

This paves the way for asynchronous write handling in the server, and
makes the data housekeeping easier to audit and unit-test.