### PR TITLE
shell: Display message when websocket fails early

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -13,7 +13,7 @@
     <script src="../*/po.js"></script>
   </head>
   <body hidden>
-    <div class="area-ct-layout">
+    <div id="main" class="area-ct-layout">
         <nav id="topnav" class="navbar navbar-default navbar-pf navbar-pf-vertical area-ct-navbar" role="navigation">
           <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
@@ -386,6 +386,22 @@
           </div>
         </div>
 
+    </div>
+
+    <div id="early-failure" class="blank-slate-pf" role="alertdialog" hidden>
+      <div class="blank-slate-pf-icon">
+        <i class="fa fa-exclamation-circle"></i>
+      </div>
+      <h1 translate>Connection failed</h1>
+      <p>
+        <span translate>There was an unexpected error while connecting to the machine.</span><br>
+        <span translate>Messages related to the failure might be found in the journal:</span><br>
+        <code>journalctl -u cockpit</code>
+      </p>
+      <p id="safari-cert-help" hidden>
+        <span translate>Safari users need to import and trust the certificate of the self-signing CA:</span><br>
+        <a download>ca.cer</a>
+      </p>
     </div>
 
     <script src="index.js"></script>

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -156,6 +156,18 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     });
 
     function show_disconnected() {
+        if (!ready) {
+            const ca_cert_url = window.sessionStorage.getItem("CACertUrl");
+            if (window.navigator.userAgent.indexOf("Safari") >= 0 && ca_cert_url) {
+                $("#safari-cert-help a").attr("href", ca_cert_url);
+                $("#safari-cert-help").show();
+            }
+            $("#early-failure").show();
+            $("#main").hide();
+            $("body").show();
+            return;
+        }
+
         var current_frame = index.current_frame();
 
         if (current_frame)

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -658,7 +658,6 @@ function Transport() {
     /* The channel/control arguments is used by filters, and auto-populated if necessary */
     self.send_data = function send_data(data, channel, control) {
         if (!ws) {
-            console.log("transport closed, dropped message: ", data);
             return false;
         }
 

--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -335,6 +335,32 @@ cockpit_certificate_locate_gerror (GError **error)
   return path;
 }
 
+gchar *
+cockpit_certificate_locate_selfsign_ca ()
+{
+  g_autofree gchar *cert_path = NULL;
+  g_autofree gchar *base = NULL;
+  gchar *ca_path = NULL;
+
+  cert_path = cockpit_certificate_locate_gerror (NULL);
+  if (cert_path)
+    {
+      base = g_path_get_basename (cert_path);
+      if (g_strcmp0 (base, "0-self-signed.cert") == 0)
+        {
+          g_autofree gchar *dir = g_path_get_dirname (cert_path);
+          ca_path = g_build_filename (dir, "0-self-signed-ca.pem", NULL);
+          if (!g_file_test (ca_path, G_FILE_TEST_EXISTS))
+            {
+              g_free (ca_path);
+              ca_path = NULL;
+            }
+        }
+    }
+
+  return ca_path;
+}
+
 static gint
 tls_certificate_count (GTlsCertificate *cert)
 {

--- a/src/ws/cockpitcertificate.h
+++ b/src/ws/cockpitcertificate.h
@@ -26,6 +26,7 @@
 G_BEGIN_DECLS
 
 gchar *             cockpit_certificate_locate_gerror      (GError **error);
+gchar *             cockpit_certificate_locate_selfsign_ca (void);
 
 gchar *             cockpit_certificate_create_selfsigned  (GError **error);
 

--- a/src/ws/cockpithandlers.h
+++ b/src/ws/cockpithandlers.h
@@ -71,4 +71,10 @@ gboolean       cockpit_handler_ping              (CockpitWebServer *server,
                                                   CockpitWebResponse *response,
                                                   CockpitHandlerData *ws);
 
+gboolean       cockpit_handler_ca_cert           (CockpitWebServer *server,
+                                                  const gchar *path,
+                                                  GHashTable *headers,
+                                                  CockpitWebResponse *response,
+                                                  CockpitHandlerData *ws);
+
 #endif /* __COCKPIT_HANDLERS_H__ */

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -764,6 +764,10 @@
          */
         if (url_root)
             localStorage.setItem('url-root', url_root);
+
+        var ca_cert_url = environment["CACertUrl"];
+        if (ca_cert_url)
+            window.sessionStorage.setItem('CACertUrl', ca_cert_url);
     }
 
     function run(response) {

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -263,6 +263,8 @@ main (int argc,
                     G_CALLBACK (cockpit_handler_root), &data);
   g_signal_connect (server, "handle-resource::/apple-touch-icon.png",
                     G_CALLBACK (cockpit_handler_root), &data);
+  g_signal_connect (server, "handle-resource::/ca.cer",
+                    G_CALLBACK (cockpit_handler_ca_cert), &data);
 
   /* The fallback handler for everything else */
   g_signal_connect (server, "handle-resource",

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -130,6 +130,9 @@ class Browser:
         self.cdp.invoke("Page.navigate", url=href)
         self.expect_load()
 
+    def set_user_agent(self, ua):
+        self.cdp.invoke("Emulation.setUserAgentOverride", userAgent=ua)
+
     def reload(self, ignore_cache=False):
         self.switch_to_top()
         self.wait_js_cond("ph_select('iframe.container-frame').every(function (e) { return e.getAttribute('data-loaded'); })")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -529,6 +529,23 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
         self.assertIn("HTTP/1.1 301 Moved Permanently", m.execute("curl --silent --head http://172.27.0.15:9091"))
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9091"))
 
+    @skipImage("Starting on Atomic is weird", "fedora-atomic")
+    @skipImage("Implemented in #12493", "rhel-8-0-distropkg")
+    def testCaCert(self):
+        m = self.machine
+
+        m.start_cockpit()
+        # Really start Cockpit to make sure it has generated all its certificates.
+        m.execute("systemctl start cockpit")
+
+        # Start without a CA certificate.
+        m.execute("rm -f /etc/cockpit/ws-certs.d/0-self-signed-ca.pem")
+        m.execute("! curl -sfS http://localhost:9090/ca.cer")
+
+        # Now make one up and check that is is served.
+        m.write("/etc/cockpit/ws-certs.d/0-self-signed-ca.pem", "FAKE CERT FOR TESTING\n")
+        self.assertEqual(m.execute("curl -sfS http://localhost:9090/ca.cer"), "FAKE CERT FOR TESTING\n")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -343,6 +343,56 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_not_visible("#login")
         b.wait_not_visible("#login-details")
 
+    @skipImage("Starting on Atomic is weird", "fedora-atomic")
+    @skipImage("Added in PR #12493", "rhel-8-0-distropkg")
+    def testFailingWebsocket(self, safari=False, cacert=False):
+        m = self.machine
+        b = self.browser
+
+        # Cause cockpit-ws to reject WebSocket connections
+        m.write("/etc/cockpit/cockpit.conf", "[WebService]\nOrigins=foo.bar.com\n")
+        self.allow_journal_messages("received request from bad Origin: .*",
+                                    "Received invalid handshake request from the client")
+        self.allow_browser_errors(".*")
+
+        m.start_cockpit()
+        # Really start Cockpit to make sure it has generated all its certificates.
+        m.execute("systemctl start cockpit")
+
+        if safari:
+            b.set_user_agent("Safari/300")
+        else:
+            b.set_user_agent("GenericBrowser/300")
+
+        if cacert:
+            m.write("/etc/cockpit/ws-certs.d/0-self-signed-ca.pem", "FAKE CERT FOR TESTING\n")
+        else:
+            m.execute("rm -f /etc/cockpit/ws-certs.d/0-self-signed-ca.pem")
+
+        # Log in.
+        b.open("/system")
+        b.wait_visible("#login")
+        b.set_val('#login-user-input', "admin")
+        b.set_val('#login-password-input', "foobar")
+        b.click('#login-button')
+        b.expect_load()
+        b.wait_present("#content")
+
+        b.wait_visible("#early-failure")
+        if safari and cacert:
+            b.wait_visible("#safari-cert-help")
+        else:
+            b.wait_not_visible("#safari-cert-help")
+
+    @skipImage("Starting on Atomic is weird", "fedora-atomic")
+    @skipImage("Added in PR #12493", "rhel-8-0-distropkg")
+    def testFailingWebsocketSafari(self):
+        self.testFailingWebsocket(safari=True, cacert=True)
+
+    @skipImage("Starting on Atomic is weird", "fedora-atomic")
+    @skipImage("Added in PR #12493", "rhel-8-0-distropkg")
+    def testFailingWebsocketSafariNoCA(self):
+        self.testFailingWebsocket(safari=True, cacert=False)
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
It is possible to misconfigure Cockpit or a proxy so that websockets
connection can not be established.  Show a error message in this case
instead of a blank page.