### PR TITLE
networkmanager: add Modem, OpenVPN and WiFi interface handlers

### DIFF
--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -107,19 +107,31 @@
       <div class="panel-heading">
         <h2 class="panel-title" translatable="yes">Interfaces</h2>
         <div class="panel-actions">
-          <button translatable="yes" id="networking-add-bond" class="btn btn-default network-privileged">Add Bond</button>
           <button translatable="yes" id="networking-add-team" class="btn btn-default network-privileged">Add Team</button>
-          <button translatable="yes" id="networking-add-bridge" class="btn btn-default network-privileged">Add Bridge</button>
-          <button translatable="yes" id="networking-add-vlan" class="btn btn-default network-privileged">Add VLAN</button>
+          <div class="btn-group dropdown interface-type">
+            <button id="networking-add-new" class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+              <span translatable="yes">Add new</span>
+              <div class="caret"></div>
+            </button>
+              <ul class="dropdown-menu left-offset-75-menu">
+                <li><a tabindex="0" id="networking-add-wifi" translatable="yes">WiFi</a></li>
+                <li><a tabindex="0" id="networking-add-modem" translatable="yes">Mobile Broadband</a></li>
+                <li><a tabindex="0" id="networking-add-openvpn" translatable="yes">OpenVPN</a></li>
+                <li><a tabindex="0" id="networking-add-bond" translatable="yes">Bond</a></li>
+                <li><a tabindex="0" id="networking-add-bridge" translatable="yes">Bridge</a></li>
+                <li><a tabindex="0" id="networking-add-vlan" translatable="yes">VLAN</a></li>
+              </ul>
+          </div>
         </div>
       </div>
       <table class="table table-hover">
         <thead>
           <tr>
             <th translatable="yes">Name</th>
+            <th translatable="yes">Interface</th>
+            <th translatable="yes">Type</th>
             <th translatable="yes">IP Address</th>
-            <th translatable="yes" class="networking-speed">Sending</th>
-            <th translatable="yes" class="networking-speed">Receiving</th>
+            <th translatable="yes" class="networking-speed">Status: (Sending/Receiving)</th>
           </tr>
         </thead>
         <tbody>
@@ -135,9 +147,10 @@
         <thead>
           <tr>
             <th translatable="yes">Name</th>
+            <th translatable="yes">Interface</th>
+            <th translatable="yes">Type</th>
             <th translatable="yes">IP Address</th>
-            <th translatable="yes" class="networking-speed">Sending</th>
-            <th translatable="yes" class="networking-speed">Receiving</th>
+            <th translatable="yes" class="networking-speed">Status: (Sending/Receiving)</th>
           </tr>
         </thead>
         <tbody>
@@ -150,6 +163,33 @@
       <div class="panel-body" id="networking-log" role="rowgroup"></div>
     </div>
   </div>
+
+  <script id="network-general-settings-template" type="x-template/mustache">
+    <form class="ct-form">
+      <label class="control-label" for="network-general-settings-name-input" translatable="yes">Name</label>
+      <input id="network-general-settings-name-input" class="form-control" type="text"
+             value="{{name}}"/>
+
+      <label class="checkbox-inline">
+        <input id="network-general-settings-autoconnect" type="checkbox" checked="false">
+        <span translatable="yes">Automatically connect to this network when it is available</span>
+      </label>
+
+      <div>
+        <span translatable="yes">Connection priority for auto connect</span>
+        <input id="network-autoconnect-priority-input" type="number" min="0"/>
+      </div>
+
+      <label class="checkbox-inline hidden-vpn">
+        <input id="network-general-settings-autovpn" type="checkbox" checked="false"/>
+        <span translatable="yes">Automatically connect to VPN when using this connection</span>
+        <select id="network-general-settings-autovpn-select">
+          <option selected disabled hidden>Select VPN</option>
+          {{! the rather complex dropdown-select will be created dynamically via jquery }}
+        </select>
+      </label>
+    </form>
+  </script>
 
   <script id="network-vlan-settings-template" type="x-template/mustache">
     <form class="ct-form">
@@ -380,6 +420,167 @@
     </form>
   </script>
 
+  <script id="network-modem-settings-template" type="x-template/mustache">
+    <form class="ct-form">
+      <label class="control-label" for="network-modem-settings-device-select" translatable="yes">Device</label>
+      <div id="network-modem-settings-device-select">
+        {{! the rather complex dropdown-select will be created dynamically via jquery }}
+      </div>
+
+      <label class="control-label" for="network-modem-settings-username-input" translatable="yes">Username</label>
+      <input id="network-modem-settings-username-input" class="form-control network-number-field ct-form-relax"
+             type="text" value="{{username_input}}"/>
+
+      <label class="control-label" for="network-modem-settings-password-input" translatable="yes">Password</label>
+      <input id="network-modem-settings-password-input" class="form-control network-number-field ct-form-relax"
+             type="password" value="{{password_input}}"/>
+
+      <label class="checkbox-inline">
+        <input id="network-modem-settings-password-toggle" type="checkbox" checked="false"/>
+        <span translatable="yes">Show password</span>
+      </label>
+
+      <label class="control-label" for="network-modem-settings-number-input" translatable="yes">Phone number</label>
+      <input id="network-modem-settings-number-input" class="form-control network-number-field ct-form-relax"
+             type="tel" value="{{number_input}}"/>
+
+      <label class="control-label" for="network-modem-settings-apn-input" translatable="yes">APN Name</label>
+      <input id="network-modem-settings-apn-input" class="form-control network-number-field ct-form-relax"
+             type="text" value="{{apn_input}}"/>
+
+      <label class="control-label" for="network-modem-settings-sim-input" translatable="yes">SIM Pin</label>
+      <input id="network-modem-settings-sim-input" class="form-control network-number-field ct-form-relax"
+             type="text" value="{{sim_input}}"/>
+    </form>
+  </script>
+
+  <script id="network-openvpn-settings-template" type="x-template/mustache">
+    <form class="ct-form">
+      <label class="control-label" for="network-openvpn-settings-gateway-input" translatable="yes">Gateway</label>
+      <input id="network-openvpn-settings-gateway-input" class="form-control network-number-field ct-form-relax"
+             type="text" value="{{gateway_input}}"/>
+
+     <label class="control-label" for="network-openvpn-settings-auth" translatable="yes">Authentication</label>
+     <span translatable="yes">Certificates (TLS)</span>
+
+     <label class="control-label" for="network-openvpn-settings-cert-file" translatable="yes">CA Certificate</label>
+     <input id="network-openvpn-settings-cert-file" type="file"/>
+     </label>
+
+     <label class="control-label" for="network-openvpn-settings-dev-cert-file" translatable="yes">Device Certificate</label>
+     <input id="network-openvpn-settings-dev-cert-file" type="file"/>
+
+     <label class="control-label" for="network-openvpn-settings-dev-key-file" translatable="yes">Device private key</label>
+     <input id="network-openvpn-settings-dev-key-file" type="file"/>
+
+     <label class="checkbox-inline">
+       <input id="network-openvpn-settings-config-toggle" type="checkbox" checked="false"/>
+       <span translatable="yes">Import a saved VPN configuration</span>
+     </label>
+
+     <label class="control-label" for="network-openvpn-settings-ovpn-file" translatable="yes">Import (.ovpn)</label>
+     <input id="network-openvpn-settings-ovpn-file" type="file"/>
+    </form>
+  </script>
+
+  <script id="network-wifi-settings-template" type="x-template/mustache">
+    <form class="ct-form">
+      <label class="control-label" for="network-wifi-settings-ssid-input" translatable="yes">SSID</label>
+      <input id="network-wifi-settings-ssid-input" class="form-control network-number-field ct-form-relax"
+             type="text" value="{{ssid_input}}"/>
+
+     <label class="control-label" for="network-wifi-settings-mode-select" translatable="yes">Mode</label>
+     <div id="network-wifi-settings-mode-select">
+       {{! the rather complex dropdown-select will be created dynamically via jquery }}
+     </div>
+
+     <label class="control-label" for="network-wifi-settings-band-select" translatable="yes">Band</label>
+     <div id="network-wifi-settings-band-select">
+       {{! the rather complex dropdown-select will be created dynamically via jquery }}
+     </div>
+
+     <label class="control-label" for="network-wifi-settings-channel-select" translatable="yes">Channel</label>
+     <div id="network-wifi-settings-channel-select">
+       {{! the rather complex dropdown-select will be created dynamically via jquery }}
+     </div>
+
+     <label class="control-label" for="network-wifi-settings-device-select" translatable="yes">Device</label>
+     <div id="network-wifi-settings-device-select">
+       {{! the rather complex dropdown-select will be created dynamically via jquery }}
+     </div>
+
+     <label class="control-label" for="network-wifi-settings-security-select" translatable="yes">Security</label>
+     <div id="network-wifi-settings-security-select">
+       {{! the rather complex dropdown-select will be created dynamically via jquery }}
+     </div>
+
+     <label class="control-label hidden-ps" for="security-personal-password-input" translatable="yes">Password</label>
+     <input class="hidden-ps" id="security-personal-password-input" type="password" value="{{personal_password}}">
+
+     <label class="checkbox-inline hidden-ps">
+       <input id="security-personal-password-toggle" type="checkbox" checked="false"/>
+       <span translatable="yes">Show password</span>
+     </label>
+
+     <label class="control-label hidden-ep hidden-type" for="security-eap-auth-select" translatable="yes">Authentication</label>
+     <div class="hidden-ep hidden-type" id="security-eap-auth-select">
+       {{! the rather complex dropdown-select will be created dynamically via jquery }}
+     </div>
+
+     <label class="control-label hidden-ep hidden-tls" for="security-tls-identity" translatable="yes">Identity</label>
+     <input class="hidden-ep hidden-tls" id="security-tls-identity" type="text" value="{{tls_identity_input}}">
+
+     <label class="control-label hidden-ep hidden-peap" for="security-peap-identity" translatable="yes">Anonymous identity</label>
+     <input class="hidden-ep hidden-peap" id="security-peap-identity" type="text" value="{{peap_identity_input}}">
+
+     <label class="control-label hidden-ep" for="security-eap-domain" translatable="yes">Domain</label>
+     <input class="hidden-ep" id="security-eap-domain" type="text" value="{{eap_domain_input}}">
+
+     <label class="control-label hidden-ep" for="security-eap-cert-file" translatable="yes">CA certificate</label>
+     <input class="hidden-ep" id="security-eap-cert-file" type="file"/>
+
+     <label class="checkbox-inline hidden-ep">
+       <input id="security-eap-cert-toggle" type="checkbox" checked="false"/>
+       <span translatable="yes">No CA certificate is required</span>
+     </label>
+
+     <label class="control-label hidden-ep hidden-tls" for="security-tls-user-cert-file" translatable="yes">User certificate</label>
+     <input class="hidden-ep hidden-tls" id="security-tls-user-cert-file" type="file"/>
+
+     <label class="control-label hidden-ep hidden-tls" for="security-tls-user-private-key-file" translatable="yes">User private key</label>
+     <input class="hidden-ep hidden-tls" id="security-tls-user-private-key-file" type="file"/>
+
+     <label class="control-label hidden-ep hidden-tls" for="security-tls-private-key-password" translatable="yes">User key password</label>
+     <input class="hidden-ep hidden-tls" id="security-tls-private-key-password" type="password" value="{{tls_key_password_input}}">
+
+     <label class="checkbox-inline hidden-ep hidden-tls">
+       <input id="security-tls-key-password-toggle" type="checkbox" checked="false">
+       <span translatable="yes">Show password</span>
+     </label>
+
+     <label class="control-label hidden-ep hidden-peap" for="security-peap-version-select" translatable="yes">PEAP version</label>
+     <div class="hidden-ep hidden-peap" id="security-peap-version-select">
+       {{! the rather complex dropdown-select will be created dynamically via jquery }}
+     </div>
+
+     <label class="control-label hidden-ep hidden-peap" for="security-peap-inner-auth-select" translatable="yes">Inner authentication</label>
+     <div class="hidden-ep hidden-peap" id="security-peap-inner-auth-select">
+       {{! the rather complex dropdown-select will be created dynamically via jquery }}
+     </div>
+
+     <label class="control-label hidden-ep hidden-peap" for="security-peap-username" translatable="yes">Username</label>
+     <input class="hidden-ep hidden-peap" id="security-peap-username" type="text" value="{{peap_username_input}}">
+
+     <label class="control-label hidden-ep hidden-peap" for="security-peap-password" translatable="yes">Password</label>
+     <input class="hidden-ep hidden-peap" id="security-peap-password" type="password" value="{{peap_password_input}}">
+
+     <label class="checkbox-inline hidden-ep hidden-peap">
+       <input id="security-peap-password-toggle" type="checkbox" checked="false">
+       <span translatable="yes">Show password</span>
+     </label>
+    </form>
+  </script>
+
   <div id="network-interface" class="container-fluid" hidden>
     <ol class="breadcrumb">
       <li><a tabindex="0" translatable="yes">Networking</a></li>
@@ -454,6 +655,30 @@
         <tbody>
         </tbody>
       </table>
+    </div>
+  </div>
+
+  <div class="modal" id="network-general-settings-dialog"
+       tabindex="-1" role="dialog"
+       data-backdrop="static">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" translatable="yes">General Settings</h4>
+        </div>
+        <div class="modal-body">
+          <div id="network-general-settings-body">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <div class="alert alert-danger dialog-error" id="network-general-settings-error">
+            <i class="fa fa-exclamation-triangle"></i>
+            <span></span>
+          </div>
+          <button class="btn btn-default" translatable="yes" id="network-general-settings-cancel">Cancel</button>
+          <button class="btn btn-primary" translatable="yes" id="network-general-settings-apply">Apply</button>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -668,6 +893,78 @@
           </div>
           <button class="btn btn-default" translatable="yes" id="network-mac-settings-cancel">Cancel</button>
           <button class="btn btn-primary" translatable="yes" id="network-mac-settings-apply">Apply</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal" id="network-modem-settings-dialog"
+       tabindex="-1" role="dialog"
+       data-backdrop="static">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" translatable="yes">Mobile Broadband</h4>
+        </div>
+        <div class="modal-body">
+          <div id="network-modem-settings-body">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <div class="alert alert-danger dialog-error" id="network-modem-settings-error">
+            <i class="fa fa-exclamation-triangle"></i>
+            <span></span>
+          </div>
+          <button class="btn btn-default" translatable="yes" id="network-modem-settings-cancel">Cancel</button>
+          <button class="btn btn-primary" translatable="yes" id="network-modem-settings-apply">Apply</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal" id="network-openvpn-settings-dialog"
+       tabindex="-1" role="dialog"
+       data-backdrop="static">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" translatable="yes">OpenVPN</h4>
+        </div>
+        <div class="modal-body">
+          <div id="network-openvpn-settings-body">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <div class="alert alert-danger dialog-error" id="network-openvpn-settings-error">
+            <i class="fa fa-exclamation-triangle"></i>
+            <span></span>
+          </div>
+          <button class="btn btn-default" translatable="yes" id="network-openvpn-settings-cancel">Cancel</button>
+          <button class="btn btn-primary" translatable="yes" id="network-openvpn-settings-apply">Apply</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal" id="network-wifi-settings-dialog"
+       tabindex="-1" role="dialog"
+       data-backdrop="static">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" translatable="yes">WiFi</h4>
+        </div>
+        <div class="modal-body">
+          <div id="network-wifi-settings-body">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <div class="alert alert-danger dialog-error" id="network-wifi-settings-error">
+            <i class="fa fa-exclamation-triangle"></i>
+            <span></span>
+          </div>
+          <button class="btn btn-default" translatable="yes" id="network-wifi-settings-cancel">Cancel</button>
+          <button class="btn btn-primary" translatable="yes" id="network-wifi-settings-apply">Apply</button>
         </div>
       </div>
     </div>

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -604,6 +604,9 @@ function NetworkManagerModel() {
                 timestamp:      get("connection", "timestamp", 0),
                 id:             get("connection", "id", _("Unknown")),
                 autoconnect:    get("connection", "autoconnect", true),
+                autoconnect_priority:
+                                get("connection", "autoconnect-priority", 0),
+                secondaries:    get("connection", "secondaries"),
                 autoconnect_slaves:
                                 get("connection", "autoconnect-slaves", -1),
                 slave_type:     get("connection", "slave-type"),
@@ -619,6 +622,35 @@ function NetworkManagerModel() {
         if (settings["802-3-ethernet"]) {
             result.ethernet = { mtu: get("802-3-ethernet", "mtu"),
                                 assigned_mac_address: get("802-3-ethernet", "assigned-mac-address")
+            };
+        }
+
+        if (settings["802-11-wireless"]) {
+            result.wifi = { ssid: get("802-11-wireless", "ssid", []),
+                            mode: get("802-11-wireless", "mode"),
+                            band: get("802-11-wireless", "band"),
+                            channel: get("802-11-wireless", "channel", 0)
+            };
+        }
+
+        if (settings["802-11-wireless-security"]) {
+            result.wifi_security = { key_mgmt: get("802-11-wireless-security", "key-mgmt"),
+                                     psk: get("802-11-wireless-security", "psk")
+            };
+        }
+
+        if (settings["802-1x"]) {
+            result.wifi_1x = { eap: get("802-1x", "eap", []),
+                               identity: get("802-1x", "identity"),
+                               anonymous_identity: get("802-1x", "anonymous-identity"),
+                               domain_suffix_match: get("802-1x", "domain-suffix-match"),
+                               ca_cert: get("802-1x", "ca-cert"),
+                               client_cert: get("802-1x", "client-cert"),
+                               private_key: get("802-1x", "private-key"),
+                               private_key_password: get("802-1x", "private-key-password"),
+                               phase1_peapver: get("802-1x", "phase1-peapver"),
+                               phase2_autheap: get("802-1x", "phase2-autheap", "none"),
+                               password: get("802-1x", "password")
             };
         }
 
@@ -675,6 +707,15 @@ function NetworkManagerModel() {
             };
         }
 
+        if (settings["gsm"]) {
+            result.modem = { username:  get("gsm", "username"),
+                             password:  get("gsm", "password"),
+                             number:    get("gsm", "number"),
+                             apn:       get("gsm", "apn"),
+                             pin:       get("gsm", "pin")
+            };
+        }
+
         return result;
     }
 
@@ -720,12 +761,14 @@ function NetworkManagerModel() {
 
         set("connection", "id", 's', settings.connection.id);
         set("connection", "autoconnect", 'b', settings.connection.autoconnect);
+        set("connection", "autoconnect-priority", 'i', settings.connection.autoconnect_priority);
         set("connection", "autoconnect-slaves", 'i', settings.connection.autoconnect_slaves);
         set("connection", "uuid", 's', settings.connection.uuid);
         set("connection", "interface-name", 's', settings.connection.interface_name);
         set("connection", "type", 's', settings.connection.type);
         set("connection", "slave-type", 's', settings.connection.slave_type);
         set("connection", "master", 's', settings.connection.master);
+        set("connection", "secondaries", 'as', settings.connection.secondaries);
 
         if (settings.ipv4)
             set_ip("ipv4", 'aau', ip4_address_to_nm, 'aau', ip4_route_to_nm, 'au', utils.ip4_from_text);
@@ -789,16 +832,89 @@ function NetworkManagerModel() {
         } else
             delete result["802-3-ethernet"];
 
+        if (settings.wifi) {
+            set("802-11-wireless", "ssid", 'ay', settings.wifi.ssid);
+            set("802-11-wireless", "mode", 's', settings.wifi.mode);
+            set("802-11-wireless", "band", 's', settings.wifi.band);
+            set("802-11-wireless", "channel", 'u', settings.wifi.channel);
+            // delete band and channel if wireless mode: Automatic
+            if (!settings.wifi.band) {
+                delete result["802-11-wireless"].band;
+                delete result["802-11-wireless"].channel;
+            }
+        } else
+            delete result["802-11-wireless"];
+
+        if (settings.wifi_security) {
+            set("802-11-wireless-security", "key-mgmt", 's', settings.wifi_security.key_mgmt);
+            set("802-11-wireless-security", "psk", 's', settings.wifi_security.psk);
+            // delete wifi_security options if security: None
+            if (!settings.wifi_security.key_mgmt)
+                delete result["802-11-wireless-security"];
+        } else
+            delete result["802-11-wireless-security"];
+
+        if (settings.wifi_1x && settings.wifi_security.key_mgmt === "wpa-eap") {
+            delete result["802-11-wireless-security"].psk;
+            set("802-1x", "eap", 'as', settings.wifi_1x.eap);
+            set("802-1x", "identity", 's', settings.wifi_1x.identity);
+            set("802-1x", "anonymous-identity", 's', settings.wifi_1x.anonymous_identity);
+            set("802-1x", "domain-suffix-match", 's', settings.wifi_1x.domain_suffix_match);
+            set("802-1x", "ca-cert", 'ay', settings.wifi_1x.ca_cert);
+            set("802-1x", "client-cert", 'ay', settings.wifi_1x.client_cert);
+            set("802-1x", "private-key", 'ay', settings.wifi_1x.private_key);
+            set("802-1x", "private-key-password", 's', settings.wifi_1x.private_key_password);
+            set("802-1x", "phase1-peapver", 's', settings.wifi_1x.phase1_peapver);
+            set("802-1x", "phase2-autheap", 's', settings.wifi_1x.phase2_autheap);
+            set("802-1x", "password", 's', settings.wifi_1x.password);
+            // delete peapver if version: Automatic
+            if (!settings.wifi_1x.phase1_peapver || settings.wifi_1x.eap[0] === "tls")
+                delete result["802-1x"]["phase1-peapver"];
+            // delete prop if settings not required
+            if (!settings.wifi_1x.phase2_autheap || settings.wifi_1x.eap[0] === "tls")
+                delete result["802-1x"]["phase2-autheap"];
+            if (!settings.wifi_1x.anonymous_identity || settings.wifi_1x.eap[0] === "tls")
+                delete result["802-1x"]["anonymous-identity"];
+            if (settings.wifi_1x.eap[0] === "tls")
+                delete result["802-1x"]["password"];
+            if (!settings.wifi_1x.domain_suffix_match)
+                delete result["802-1x"]["domain-suffix-match"];
+            if (!settings.wifi_1x.client_cert || settings.wifi_1x.eap[0] === "peap")
+                delete result["802-1x"]["client-cert"];
+            if (!settings.wifi_1x.private_key || settings.wifi_1x.eap[0] === "peap")
+                delete result["802-1x"]["private-key"];
+            if (!settings.wifi_1x.private_key_password || settings.wifi_1x.eap[0] === "peap")
+                delete result["802-1x"]["private-key-password"];
+            if ($('#security-eap-cert-toggle').prop('checked'))
+                delete result["802-1x"]["ca-cert"];
+        } else
+            delete result["802-1x"];
+
+        if (settings.modem) {
+            set("gsm", "username", 's', settings.modem.username);
+            set("gsm", "password", 's', settings.modem.password);
+            set("gsm", "number", 's', settings.modem.number);
+            set("gsm", "apn", 's', settings.modem.apn);
+            set("gsm", "pin", 's', settings.modem.pin);
+            if (!settings.modem.username)
+                delete result["gsm"].username;
+            if (!settings.modem.password)
+                delete result["gsm"].password;
+            if (!settings.modem.pin)
+                delete result["gsm"].pin;
+        } else
+            delete result["gsm"];
+
         return result;
     }
 
     function device_type_to_symbol(type) {
         // This returns a string that is suitable for the connection.type field of
-        // Connection.Settings, except for "ethernet".
+        // Connection.Settings, except for "ethernet" and "wifi".
         switch (type) {
         case 0: return 'unknown';
         case 1: return 'ethernet'; // 802-3-ethernet
-        case 2: return '802-11-wireless';
+        case 2: return 'wifi'; // 802-11-wireless
         case 3: return 'unused1';
         case 4: return 'unused2';
         case 5: return 'bluetooth';
@@ -1041,7 +1157,7 @@ function NetworkManagerModel() {
 
     var type_ActiveConnection = {
         interfaces: [
-            "org.freedesktop.NetworkManager.Connection.Active"
+            "org.freedesktop.NetworkManager.Connection.Active",
         ],
 
         props: {
@@ -1063,7 +1179,9 @@ function NetworkManagerModel() {
     var type_Device = {
         interfaces: [
             "org.freedesktop.NetworkManager.Device",
+            "org.freedesktop.NetworkManager.Device.Wireless",
             "org.freedesktop.NetworkManager.Device.Wired",
+            "org.freedesktop.NetworkManager.Device.Modem",
             "org.freedesktop.NetworkManager.Device.Bond",
             "org.freedesktop.NetworkManager.Device.Team",
             "org.freedesktop.NetworkManager.Device.Bridge",
@@ -1219,6 +1337,26 @@ function NetworkManagerModel() {
                     dfd.reject(e);
                 }
                 return dfd.promise();
+            },
+            list_connections: function() {
+                var dfd = $.Deferred();
+                try {
+                    call_object_method(this,
+                                       'org.freedesktop.NetworkManager.Settings',
+                                       'ListConnection')
+                            .done(function (path) {
+                                dfd.resolve(get_object(path, type_Connection));
+                            })
+                            .fail(function (error) {
+                                dfd.reject(error);
+                            });
+                } catch (e) {
+                    dfd.reject(e);
+                }
+                return dfd.promise();
+                /*    return call_object_method(this,
+                                              'org.freedesktop.NetworkManager.Settings',
+                                              'ListConnections'); */
             }
         },
 
@@ -1249,6 +1387,12 @@ function NetworkManagerModel() {
                                 add_to_interface(con.Settings.bridge.interface_name);
                             if (con.Settings.vlan)
                                 add_to_interface(con.Settings.vlan.interface_name);
+                            if (con.Settings.modem)
+                                add_to_interface(con.Settings.modem.interface_name);
+                            if (con.Settings.wifi)
+                                add_to_interface(con.Settings.wifi.interface_name);
+                            if (con.Settings.vpn)
+                                add_to_interface(con.Settings.vpn.interface_name);
                         }
                     });
                 }
@@ -1588,6 +1732,12 @@ function complete_settings(settings, device) {
     if (device.DeviceType == 'ethernet') {
         settings.connection.type = '802-3-ethernet';
         settings.ethernet = { };
+    } else if (device.DeviceType == 'wifi') {
+        settings.connection.type = '802-11-wireless';
+        settings.wifi = { };
+    } else if (device.DeviceType == 'modem') {
+        settings.connection.type = 'gsm';
+        settings.modem = { };
     } else {
         // The remaining types are identical between Device and Settings, see
         // device_type_to_symbol.
@@ -1638,6 +1788,9 @@ PageNetworking.prototype = {
         var self = this;
 
         update_network_privileged();
+        $("#networking-add-wifi").syn_click(self.model, $.proxy(this, "add_wifi"));
+        $("#networking-add-modem").syn_click(self.model, $.proxy(this, "add_modem"));
+        $("#networking-add-openvpn").syn_click(self.model, $.proxy(this, "add_openvpn"));
         $("#networking-add-bond").syn_click(self.model, $.proxy(this, "add_bond"));
         $("#networking-add-team").syn_click(self.model, $.proxy(this, "add_team"));
         $("#networking-add-bridge").syn_click(self.model, $.proxy(this, "add_bridge"));
@@ -1734,8 +1887,8 @@ PageNetworking.prototype = {
                 var tx = samples[1][0];
                 var row = $('#networking-interfaces tr[data-sample-id="' + encodeURIComponent(iface) + '"]');
                 if (rx !== undefined && tx !== undefined && row.length > 0) {
-                    row.find('td:nth-child(3)').text(cockpit.format_bits_per_sec(tx * 8));
-                    row.find('td:nth-child(4)').text(cockpit.format_bits_per_sec(rx * 8));
+                    row.find('td:nth-child(5)').text("on: (" + cockpit.format_bits_per_sec(tx * 8) +
+                        " / " + cockpit.format_bits_per_sec(rx * 8) + ")");
                 }
             }
         }
@@ -1807,11 +1960,14 @@ PageNetworking.prototype = {
             var row = $('<tr>', { "data-interface": encodeURIComponent(iface.Name),
                                   "data-sample-id": show_traffic ? encodeURIComponent(iface.Name) : null
             })
-                    .append($('<td>').text(iface.Name),
+                    .append($('<td>').text((iface.MainConnection && iface.MainConnection.Settings)
+                        ? iface.MainConnection.Settings.connection.id : null),
+                            $('<td>').text(iface.Name),
+                            $('<td>').text(dev ? dev.DeviceType : null),
                             $('<td>').html(render_active_connection(dev, false, true)),
                             (show_traffic
-                                ? [ $('<td>').text(""), $('<td>').text("") ]
-                                : $('<td colspan="2">').text(device_state_text(dev))));
+                                ? $('<td>').text("")
+                                : $('<td>').text("off: " + device_state_text(dev))));
 
             if (!dev || dev.Managed) {
                 managed_tbody.append(row.click(function () {
@@ -1843,6 +1999,8 @@ PageNetworking.prototype = {
                 connection: {
                     id: iface,
                     autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
                     type: "bond",
                     uuid: uuid,
                     interface_name: iface
@@ -1877,6 +2035,8 @@ PageNetworking.prototype = {
                 connection: {
                     id: iface,
                     autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
                     type: "team",
                     uuid: uuid,
                     interface_name: iface
@@ -1909,6 +2069,8 @@ PageNetworking.prototype = {
                 connection: {
                     id: iface,
                     autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
                     type: "bridge",
                     uuid: uuid,
                     interface_name: iface
@@ -1941,6 +2103,8 @@ PageNetworking.prototype = {
                 connection: {
                     id: "",
                     autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
                     type: "vlan",
                     uuid: uuid,
                     interface_name: ""
@@ -1952,13 +2116,255 @@ PageNetworking.prototype = {
             };
 
         $('#network-vlan-settings-dialog').modal('show');
-    }
+    },
 
+    add_modem: function () {
+        var i, iface, uuid;
+
+        for (i = 0; i < 100; i++) {
+            iface = "modem" + i;
+            if (!this.model.find_interface(iface))
+                break;
+        }
+        uuid = generate_uuid();
+
+        PageNetworkModemSettings.model = this.model;
+        PageNetworkModemSettings.done = null;
+        PageNetworkModemSettings.connection = null;
+        PageNetworkModemSettings.apply_settings = settings_applier(this.model);
+        PageNetworkModemSettings.ghost_settings =
+            {
+                connection: {
+                    id: iface,
+                    autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
+                    type: "gsm",
+                    uuid: uuid,
+                    interface_name: ""
+                },
+                modem: {
+                    username: "",
+                    password: "",
+                    number: "",
+                    apn: "",
+                    pin: ""
+                }
+            };
+
+        $('#network-modem-settings-dialog').modal('show');
+    },
+
+    add_openvpn: function () {
+        var i, iface, uuid;
+
+        for (i = 0; i < 100; i++) {
+            iface = "vpn" + i;
+            if (!this.model.find_interface(iface))
+                break;
+        }
+        uuid = generate_uuid();
+
+        PageNetworkOpenVPNSettings.model = this.model;
+        PageNetworkOpenVPNSettings.done = null;
+        PageNetworkOpenVPNSettings.connection = null;
+        PageNetworkOpenVPNSettings.apply_settings = settings_applier(this.model);
+        PageNetworkOpenVPNSettings.ghost_settings =
+            {
+                connection: {
+                    id: iface,
+                    autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
+                    type: "vpn",
+                    uuid: uuid,
+                    interface_name: iface
+                },
+                vpn: {
+                    auth: "SHA256",
+                    cipher: "AES-256-GCM",
+                    connection_type: "password-tls",
+                    dev: "tun",
+                    mssfix: "1450",
+                    password_flags: "1",
+                    remote: [],
+                    remote_cert_tls: "server",
+                    reneg_sec: "0",
+                    ta_dir: "1",
+                    tun_mtu: "1500",
+                    service_type: "org.freedesktop.NetworkManager.openvpn"
+                }
+            };
+
+        $('#network-openvpn-settings-dialog').modal('show');
+    },
+
+    add_wifi: function () {
+        var i, iface, uuid;
+
+        for (i = 0; i < 100; i++) {
+            iface = "wifi" + i;
+            if (!this.model.find_interface(iface))
+                break;
+        }
+        uuid = generate_uuid();
+
+        PageNetworkWiFiSettings.model = this.model;
+        PageNetworkWiFiSettings.done = null;
+        PageNetworkWiFiSettings.connection = null;
+        PageNetworkWiFiSettings.apply_settings = settings_applier(this.model);
+        PageNetworkWiFiSettings.ghost_settings =
+            {
+                connection: {
+                    id: iface,
+                    autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
+                    type: "802-11-wireless",
+                    uuid: uuid,
+                    interface_name: ""
+                },
+                wifi: {
+                    ssid: [],
+                    mode: "",
+                    band: "",
+                    channel: 0
+                },
+                wifi_security: {
+                    key_mgmt: "",
+                    psk: ""
+                },
+                wifi_1x: {
+                    eap: [],
+                    identity: "",
+                    anonymous_identity: "",
+                    domain_suffix_match: "",
+                    ca_cert: [],
+                    client_cert: [],
+                    private_key: [],
+                    private_key_password: "",
+                    phase1_peapver: "",
+                    phase2_autheap: "",
+                    password: ""
+                }
+            };
+
+        $('#network-wifi-settings-dialog').modal('show');
+    }
 };
 
 function PageNetworking(model) {
     this._init(model);
 }
+
+var wifi_mode_choices =
+    [
+        { choice: 'infrastructure', title: _("Client") },
+        { choice: 'ap', title: _("Hotspot") }
+    ];
+
+var wifi_band_choices =
+    [
+        { choice: '', title: _("Automatic") },
+        { choice: 'a', title: _("A (5GHz)") },
+        { choice: 'bg', title: _("B-G (2.4GHz)") }
+    ];
+
+var wifi_bg_channel_choices =
+    [
+        { choice: 0, title: _("Default") },
+        { choice: 1, title: _("1 (2412 MHz)") },
+        { choice: 2, title: _("2 (2417 MHz)") },
+        { choice: 3, title: _("3 (2422 MHz)") },
+        { choice: 4, title: _("4 (2427 MHz)") },
+        { choice: 5, title: _("5 (2432 MHz)") },
+        { choice: 6, title: _("6 (2437 MHz)") },
+        { choice: 7, title: _("7 (2442 MHz)") },
+        { choice: 8, title: _("8 (2447 MHz)") },
+        { choice: 9, title: _("9 (2452 MHz)") },
+        { choice: 10, title: _("10 (2457 MHz)") },
+        { choice: 11, title: _("11 (2462 MHz)") },
+        { choice: 12, title: _("12 (2467 MHz)") },
+        { choice: 13, title: _("13 (2472 MHz)") },
+        { choice: 14, title: _("14 (2484 MHz)") }
+    ];
+
+var wifi_a_channel_choices =
+    [
+        { choice: 0, title: _("Default") },
+        { choice: 7, title: _("7 (5035 MHz)") },
+        { choice: 8, title: _("8 (5040 MHz)") },
+        { choice: 9, title: _("9 (5045 MHz)") },
+        { choice: 11, title: _("11 (5055 MHz)") },
+        { choice: 12, title: _("12 (5060 MHz)") },
+        { choice: 16, title: _("16 (5080 MHz)") },
+        { choice: 34, title: _("34 (5170 MHz)") },
+        { choice: 36, title: _("36 (5180 MHz)") },
+        { choice: 38, title: _("38 (5190 MHz)") },
+        { choice: 40, title: _("40 (5200 MHz)") },
+        { choice: 42, title: _("42 (5210 MHz)") },
+        { choice: 44, title: _("44 (5220 MHz)") },
+        { choice: 46, title: _("46 (5230 MHz)") },
+        { choice: 48, title: _("48 (5240 MHz)") },
+        { choice: 50, title: _("50 (5250 MHz)") },
+        { choice: 52, title: _("52 (5260 MHz)") },
+        { choice: 56, title: _("56 (5280 MHz)") },
+        { choice: 58, title: _("58 (5290 MHz)") },
+        { choice: 60, title: _("60 (5300 MHz)") },
+        { choice: 64, title: _("64 (5320 MHz)") },
+        { choice: 100, title: _("100 (5500 MHz)") },
+        { choice: 104, title: _("104 (5520 MHz)") },
+        { choice: 108, title: _("108 (5540 MHz)") },
+        { choice: 112, title: _("112 (5560 MHz)") },
+        { choice: 116, title: _("116 (5580 MHz)") },
+        { choice: 120, title: _("120 (5600 MHz)") },
+        { choice: 124, title: _("124 (5620 MHz)") },
+        { choice: 128, title: _("128 (5640 MHz)") },
+        { choice: 132, title: _("132 (5660 MHz)") },
+        { choice: 136, title: _("136 (5680 MHz)") },
+        { choice: 140, title: _("140 (5700 MHz)") },
+        { choice: 149, title: _("149 (5745 MHz)") },
+        { choice: 152, title: _("152 (5760 MHz)") },
+        { choice: 153, title: _("153 (5765 MHz)") },
+        { choice: 157, title: _("157 (5785 MHz)") },
+        { choice: 160, title: _("160 (5800 MHz)") },
+        { choice: 161, title: _("161 (5805 MHz)") },
+        { choice: 165, title: _("165 (5825 MHz)") },
+        { choice: 183, title: _("183 (4915 MHz)") },
+        { choice: 184, title: _("184 (4920 MHz)") },
+        { choice: 185, title: _("185 (4925 MHz)") },
+        { choice: 187, title: _("187 (4935 MHz)") },
+        { choice: 188, title: _("188 (4945 MHz)") },
+        { choice: 192, title: _("192 (4960 MHz)") },
+        { choice: 196, title: _("196 (4980 MHz)") },
+    ];
+
+var wifi_security_choices =
+    [
+        { choice: '', title: _("None") },
+        { choice: 'wpa-psk', title: _("WPA & WPA2 Personal") },
+        { choice: 'wpa-eap', title: _("WPA & WPA2 Enterprise") }
+    ];
+
+var wifi_eap_auth_choices =
+    [
+        { choice: 'tls', title: _("TLS") },
+        { choice: 'peap', title: _("Protected EAP (PEAP)") }
+    ];
+
+var wifi_peap_version_choices =
+    [
+        { choice: '', title: _("Automatic") },
+        { choice: '0', title: _("Version 0") },
+        { choice: '1', title: _("Version 1") }
+    ];
+
+var wifi_peap_inner_auth_choices =
+    [
+        { choice: 'mschapv2', title: _("MSHAPv2") },
+        { choice: 'md5', title: _("MD5") },
+        { choice: 'gtc', title: _("GTC") }
+    ];
 
 var ipv4_method_choices =
     [
@@ -2526,6 +2932,12 @@ PageNetworkInterface.prototype = {
                 desc = _("VLAN");
             } else if (dev.DeviceType == 'bridge') {
                 desc = _("Bridge");
+            } else if (dev.DeviceType == 'modem') {
+                desc = _("Modem");
+            } else if (dev.DeviceType == 'wifi') {
+                desc = _("WiFi");
+            } else if (dev.DeviceType == 'vpn') {
+                desc = _("OpenVPN");
             } else
                 desc = cockpit.format(_("Unknown \"$0\""), dev.DeviceType);
         } else if (iface) {
@@ -2538,6 +2950,12 @@ PageNetworkInterface.prototype = {
                 desc = _("VLAN");
             else if (cs.type == "bridge")
                 desc = _("Bridge");
+            else if (cs.type == "modem")
+                desc = _("Modem");
+            else if (cs.type == "wifi")
+                desc = _("WiFi");
+            else if (cs.type == "vpn")
+                desc = _("OpenVPN");
             else if (cs.type)
                 desc = cockpit.format(_("Unknown \"$0\""), cs.type);
             else
@@ -2593,8 +3011,24 @@ PageNetworkInterface.prototype = {
         var is_deletable = (iface && !dev) || (dev && (dev.DeviceType == 'bond' ||
                                                        dev.DeviceType == 'team' ||
                                                        dev.DeviceType == 'vlan' ||
-                                                       dev.DeviceType == 'bridge'));
+                                                       dev.DeviceType == 'bridge' ||
+                                                       dev.DeviceType == 'modem' ||
+                                                       dev.DeviceType == 'wifi' ||
+                                                       dev.DeviceType == 'vpn'));
         $('#network-interface-delete').toggle(is_deletable && managed);
+
+        function render_interface_section_separator(title) {
+            return $('<td class="network-interface-separator" colspan="100%">').text(title);
+        }
+
+        function render_interface_type_row() {
+            if (dev) {
+                return $('<tr>').append(
+                    $('<td>').text(_("Type")),
+                    $('<td>').append(self.connection_settings.connection.id +
+                        " | " + dev.Interface, " | ", dev.DeviceType));
+            }
+        }
 
         function render_carrier_status_row() {
             if (dev && dev.Carrier !== undefined) {
@@ -2627,6 +3061,14 @@ PageNetworkInterface.prototype = {
                     render_active_connection(dev, true, false),
                     " ",
                     state ? $('<span>').text(state) : null));
+        }
+
+        function render_general_information_row() {
+            return [ render_interface_section_separator("General Information"),
+                render_interface_type_row(),
+                render_carrier_status_row(),
+                render_active_status_row(),
+            ];
         }
 
         function render_connection_settings_rows(con, settings) {
@@ -2674,6 +3116,10 @@ PageNetworkInterface.prototype = {
                 return parts;
             }
 
+            function configure_general_settings() {
+                self.show_dialog(PageNetworkGeneralSettings, '#network-general-settings-dialog');
+            }
+
             function configure_ip_settings(topic) {
                 PageNetworkIpSettings.topic = topic;
                 self.show_dialog(PageNetworkIpSettings, '#network-ip-settings-dialog');
@@ -2708,22 +3154,12 @@ PageNetworkInterface.prototype = {
                 self.show_dialog(PageNetworkMtuSettings, '#network-mtu-settings-dialog');
             }
 
-            function render_autoconnect_row() {
-                if (settings.connection.autoconnect !== undefined) {
-                    return (
-                        $('<tr>').append(
-                            $('<td>').text(_("General")),
-                            $('<td class="networking-controls">').append(
-                                $('<label>').append(
-                                    $('<input type="checkbox">')
-                                            .prop('checked', settings.connection.autoconnect)
-                                            .change(function () {
-                                                settings.connection.autoconnect = $(this).prop('checked');
-                                                settings_applier(self.model, self.dev, con)(settings);
-                                            }),
-                                    $('<span>').text(_("Connect automatically")))))
-                    );
-                }
+            function configure_modem_settings() {
+                self.show_dialog(PageNetworkModemSettings, '#network-modem-settings-dialog');
+            }
+
+            function configure_wifi_settings() {
+                self.show_dialog(PageNetworkWiFiSettings, '#network-wifi-settings-dialog');
             }
 
             function render_settings_row(title, rows, configure) {
@@ -2744,6 +3180,35 @@ PageNetworkInterface.prototype = {
                         $('<a tabindex="0" class="network-privileged">')
                                 .append(link_text)
                                 .syn_click(self.model, function () { configure() })));
+            }
+
+            function render_general_settings_row() {
+                var parts = [];
+                var rows = [];
+                var options = settings.connection;
+
+                if (!options)
+                    return null;
+
+                parts.push("Auto-connection: " +
+                     (options.autoconnect ? "Enabled" : "Disabled"));
+
+                if (options.autoconnect)
+                    parts.push("(Priority: " + (options.autoconnect_priority >= 0
+                        ? options.autoconnect_priority : "None") + ")");
+
+                if (parts.length > 0)
+                    rows.push(parts.join(" "));
+
+                if (options.type != "vpn") {
+                    var vpn_name = $('#network-general-settings-autovpn-select')
+                            .children('option:selected')
+                            .text() || "Enabled";
+                    rows.push("Auto-selected VPN: " +
+                        (options.secondaries ? vpn_name : "None"));
+                }
+
+                return render_settings_row(_("General"), rows, configure_general_settings);
             }
 
             function render_ip_settings_row(topic, title) {
@@ -2919,17 +3384,59 @@ PageNetworkInterface.prototype = {
                                            configure_vlan_settings);
             }
 
-            return [ render_master(),
-                render_autoconnect_row(),
-                render_ip_settings_row("ipv4", _("IPv4")),
-                render_ip_settings_row("ipv6", _("IPv6")),
+            function render_modem_settings_row() {
+                var rows = [ ];
+                var options = settings.modem;
+
+                if (!options)
+                    return null;
+
+                function add_row(fmt, args) {
+                    rows.push(cockpit.format(fmt, args));
+                }
+
+                add_row(_("APN: $apn"), options);
+                add_row(_("Phone number: $number"), options);
+
+                return render_settings_row(_("Modem"), rows, configure_modem_settings);
+            }
+
+            function render_wifi_settings_row() {
+                var parts = [ ];
+                var rows = [ ];
+                var options = settings.wifi;
+                var security_options = settings.wifi_security;
+
+                if (!options)
+                    return null;
+
+                rows.push(_("SSID: " + (options.ssid ? atob(options.ssid) : "Not defined")));
+                parts.push(choice_title(wifi_mode_choices, options.mode, "Not configured"));
+                parts.push(choice_title(wifi_band_choices, options.band, "Automatic"));
+
+                if (parts.length > 0)
+                    rows.push(parts.join(", "));
+
+                rows.push(choice_title(wifi_security_choices, security_options
+                    ? security_options.key_mgmt : null, "Security disabled"));
+
+                return render_settings_row(_("WiFi"), rows, configure_wifi_settings);
+            }
+
+            return [ render_interface_section_separator("Settings"),
+                render_master(),
+                render_general_settings_row(),
                 render_mtu_settings_row(),
                 render_vlan_settings_row(),
                 render_bridge_settings_row(),
                 render_bridge_port_settings_row(),
                 render_bond_settings_row(),
                 render_team_settings_row(),
-                render_team_port_settings_row()
+                render_team_port_settings_row(),
+                render_modem_settings_row(),
+                render_wifi_settings_row(),
+                render_ip_settings_row("ipv4", _("IPv4")),
+                render_ip_settings_row("ipv6", _("IPv6")),
             ];
         }
 
@@ -2973,8 +3480,7 @@ PageNetworkInterface.prototype = {
 
         $('#network-interface-settings')
                 .empty()
-                .append(render_active_status_row())
-                .append(render_carrier_status_row())
+                .append(render_general_information_row())
                 .append(render_connection_settings_rows(self.main_connection, self.connection_settings));
         update_network_privileged();
 
@@ -3181,6 +3687,150 @@ function connection_devices(con) {
         con.Interfaces.forEach(function (iface) { if (iface.Device) devices.push(iface.Device); });
 
     return devices;
+}
+
+PageNetworkGeneralSettings.prototype = {
+    _init: function () {
+        this.id = "network-general-settings-dialog";
+        this.general_settings_template = $("#network-general-settings-template").html();
+        mustache.parse(this.general_settings_template);
+    },
+
+    setup: function () {
+        $('#network-general-settings-cancel').click($.proxy(this, "cancel"));
+        $('#network-general-settings-apply').click($.proxy(this, "apply"));
+    },
+
+    enter: function () {
+        $('#network-general-settings-error').hide();
+        this.settings = PageNetworkGeneralSettings.ghost_settings || PageNetworkGeneralSettings.connection.copy_settings();
+        this.update();
+    },
+
+    show: function() {
+    },
+
+    leave: function() {
+    },
+
+    update: function() {
+        var self = this;
+        var options = self.settings.connection;
+        var vpn_choices = [];
+        var name_input, priority_btn, priority_input, autovpn_btn, autovpn_select;
+
+        function set_vpn_connections(data) {
+            var lines = data.split("\n");
+
+            lines.forEach(function(line, index) {
+                var dict = {};
+                var values = line.split(':');
+
+                if (values[1] === "vpn") {
+                    dict.name = values[0];
+                    dict.uuid = values[2];
+                    vpn_choices.push(dict);
+                }
+            });
+        }
+
+        function vpn_connections_handler() {
+            var process = cockpit.spawn(["nmcli", "-g", "name,type,uuid", "con"]);
+            process.stream(function(data) {
+                set_vpn_connections(data);
+                vpn_choices.forEach(function(item, index, arr) {
+                    if (autovpn_select.find('option[value="' + arr[index].uuid + '"]').length == 0)
+                        autovpn_select.append(new Option(arr[index].name, arr[index].uuid));
+                });
+                if (options.secondaries) {
+                    autovpn_btn.prop('checked', true);
+                    autovpn_select.val(options.secondaries[0]);
+                } else
+                    autovpn_btn.prop('checked', false);
+            });
+        }
+
+        function change() {
+            options.id = name_input.val();
+            options.autoconnect = priority_btn.prop('checked');
+            options.autoconnect_priority = options.autoconnect ? parseInt(priority_input.val()) : 0;
+            options.secondaries = [];
+            if (autovpn_btn.prop('checked') && autovpn_select.val() !== undefined)
+                options.secondaries.push(autovpn_select.val());
+        }
+
+        var body = $(mustache.render(self.general_settings_template, { name: options.id }));
+        name_input = body.find('#network-general-settings-name-input');
+        name_input.change(change);
+        priority_btn = body.find('#network-general-settings-autoconnect');
+        priority_btn.change(change);
+        priority_input = body.find('#network-autoconnect-priority-input');
+        priority_input.change(change);
+        autovpn_btn = body.find('#network-general-settings-autovpn');
+        autovpn_btn.change(change);
+        autovpn_select = body.find('#network-general-settings-autovpn-select');
+        autovpn_select.change(change);
+
+        $('#network-general-settings-body').html(body);
+        priority_btn.prop('checked', options.autoconnect);
+        priority_input.val(options.autoconnect_priority);
+
+        if (options.type !== "vpn") {
+            vpn_connections_handler();
+            $('.hidden-vpn').show();
+        } else
+            $('.hidden-vpn').hide();
+
+        priority_input.focus(function () {
+            priority_btn.prop('checked', true);
+        });
+
+        autovpn_select.focus(function () {
+            autovpn_btn.prop('checked', true);
+        });
+    },
+
+    cancel: function() {
+        $('#network-general-settings-dialog').modal('hide');
+    },
+
+    apply: function() {
+        var self = this;
+        var model = PageNetworkGeneralSettings.model;
+
+        function show_error(error) {
+            show_dialog_error('#network-general-settings-error', error);
+        }
+
+        if (self.settings.connection.autoconnect_priority < 0) {
+            show_error(_("Please select a value that is no less than 0"));
+            return;
+        }
+
+        if (self.settings.connection.type !== "vpn" &&
+            $('#network-general-settings-autovpn').prop('checked') &&
+            !self.settings.connection.secondaries) {
+            show_error(_("Disable or select VPN connection"));
+            return;
+        }
+
+        function modify () {
+            return PageNetworkGeneralSettings.apply_settings(self.settings)
+                    .then(function () {
+                        $('#network-general-settings-dialog').modal('hide');
+                        if (PageNetworkGeneralSettings.done)
+                            return PageNetworkGeneralSettings.done();
+                    })
+                    .fail(show_error);
+        }
+
+        with_settings_checkpoint(model, modify,
+                                 { devices: connection_devices(PageNetworkGeneralSettings.connection) });
+    }
+};
+
+function PageNetworkGeneralSettings() {
+    this._init();
 }
 
 PageNetworkIpSettings.prototype = {
@@ -4651,6 +5301,719 @@ function PageNetworkMacSettings() {
     this._init();
 }
 
+PageNetworkModemSettings.prototype = {
+    _init: function () {
+        this.id = "network-modem-settings-dialog";
+        this.modem_settings_template = $("#network-modem-settings-template").html();
+        mustache.parse(this.modem_settings_template);
+    },
+
+    setup: function () {
+        $('#network-modem-settings-cancel').click($.proxy(this, "cancel"));
+        $('#network-modem-settings-apply').click($.proxy(this, "apply"));
+    },
+
+    enter: function () {
+        $('#network-modem-settings-error').hide();
+        this.settings = PageNetworkModemSettings.ghost_settings || PageNetworkModemSettings.connection.copy_settings();
+        this.update();
+    },
+
+    show: function() {
+    },
+
+    leave: function() {
+    },
+
+    update: function() {
+        var self = this;
+        var options = self.settings.modem;
+        var connection = self.settings.connection;
+        var username_input, password_input, number_input;
+        var apn_input, pin_input, device_btn;
+
+        var device_choices = [];
+        PageNetworkModemSettings.model.list_interfaces().forEach(function (i) {
+            if (!i.Device)
+                device_choices.push({ title: "Not detected", choice: "" });
+            else if (is_interesting_interface(i) && i.Device && i.Device.DeviceType === "modem")
+                device_choices.push({ title: i.Name, choice: i.Device.Interface });
+        });
+
+        function choicebox(env, subenv, choices, klass) {
+            var btn = select_btn(
+                function (choice) {
+                    if (env)
+                        env[subenv] = choice;
+                    change();
+                },
+                choices, klass);
+            select_btn_select(btn, choices[0].choice);
+            return btn;
+        }
+
+        function change() {
+            connection.interface_name = select_btn_selected(device_btn);
+            options.username = username_input.val();
+            options.password = password_input.val();
+            options.number = number_input.val();
+            options.apn = apn_input.val();
+            options.pin = pin_input.val();
+        }
+
+        var body = $(mustache.render(self.modem_settings_template, options));
+
+        body.find('#network-modem-settings-device-select').replaceWith(
+            device_btn = choicebox(connection, "interface_name", device_choices));
+        username_input = body.find('#network-modem-settings-username-input');
+        username_input.change(change);
+        password_input = body.find('#network-modem-settings-password-input');
+        password_input.change(change);
+        number_input = body.find('#network-modem-settings-number-input');
+        number_input.change(change);
+        apn_input = body.find('#network-modem-settings-apn-input');
+        apn_input.change(change);
+        pin_input = body.find('#network-modem-settings-pin-input');
+        pin_input.change(change);
+
+        $('#network-modem-settings-body').html(body);
+
+        // hide password by default
+        $('#network-modem-settings-password-toggle').prop('checked', false);
+
+        $('#network-modem-settings-password-toggle').click(function() {
+            if (password_input.attr("type") == "password")
+                password_input.attr('type', "text");
+            else
+                password_input.attr('type', "password");
+        });
+        change();
+    },
+
+    cancel: function() {
+        $('#network-modem-settings-dialog').modal('hide');
+    },
+
+    apply: function() {
+        var self = this;
+        var model = PageNetworkModemSettings.model;
+
+        function show_error(error) {
+            show_dialog_error('#network-modem-settings-error', error);
+        }
+
+        if (!self.settings.connection.interface_name) {
+            show_error(_("Device is not set: Check if modem adapter is recognized"));
+            return;
+        }
+
+        function modify () {
+            return PageNetworkModemSettings.apply_settings(self.settings)
+                    .then(function () {
+                        $('#network-modem-settings-dialog').modal('hide');
+                        if (PageNetworkModemSettings.done)
+                            return PageNetworkModemSettings.done();
+                    })
+                    .fail(show_error);
+        }
+
+        with_settings_checkpoint(model, modify,
+                                 { devices: connection_devices(PageNetworkModemSettings.connection) });
+    }
+};
+
+function PageNetworkModemSettings() {
+    this._init();
+}
+
+PageNetworkOpenVPNSettings.prototype = {
+    _init: function () {
+        this.id = "network-openvpn-settings-dialog";
+        this.openvpn_settings_template = $("#network-openvpn-settings-template").html();
+        mustache.parse(this.openvpn_settings_template);
+    },
+
+    setup: function () {
+        $('#network-openvpn-settings-cancel').click($.proxy(this, "cancel"));
+        $('#network-openvpn-settings-apply').click($.proxy(this, "apply"));
+    },
+
+    enter: function () {
+        $('#network-openvpn-settings-error').hide();
+        this.settings = PageNetworkOpenVPNSettings.ghost_settings || PageNetworkOpenVPNSettings.connection.copy_settings();
+        this.update();
+    },
+
+    show: function() {
+    },
+
+    leave: function() {
+    },
+
+    update: function() {
+        var self = this;
+        var options = self.settings.vpn;
+        var pwd, gateway_input, import_config_btn;
+        var ca_cert_file, dev_cert_file, dev_key_file, ovpn_file;
+        var no_extension = /\.[^/.]+$/;
+        var process = cockpit.spawn(["pwd"]);
+        process.stream(function(data) {
+            pwd = data;
+        });
+
+        function get_prop(input, prop) {
+            return input.match(new RegExp(prop + '\\s(\\w+)'))[1];
+        }
+
+        function parse_props(input) {
+            options.dev = get_prop(input, "dev");
+            options.proto = get_prop(input, "proto");
+            options.resolv_retry = get_prop(input, "resolv-retry");
+            options.tun_mtu = get_prop(input, "tun-mtu");
+            options.mssfix = get_prop(input, "mssfix");
+            options.remote_cert_tls = get_prop(input, "remote-cert-tls");
+            options.verb = get_prop(input, "verb");
+            options.reneg_sec = get_prop(input, "reneg-sec");
+            options.sndbuf = get_prop(input, "sndbuf");
+            options.rcvbuf = get_prop(input, "rcvbuf");
+            options.cipher = get_prop(input, "cipher");
+            options.auth = get_prop(input, "auth");
+            options.key_direction = get_prop(input, "key-direction");
+        }
+
+        function parse_remote(input) {
+            // saved configuration may have multiple remote lines
+            input.match(/[^\r\n]+/g).forEach(function(line) {
+                if (line.match(/\bremote \b/)) {
+                    line = line.replace("remote ", "");
+                    options.remote.push(line.replace(" ", ":"));
+                }
+            });
+        }
+
+        function get_content_from_tag(tag, input) {
+            var reg = new RegExp("<" + tag + ">[\\s\\S]*?<\\/" + tag + ">");
+            var str = reg.exec(input) ? reg.exec(input).toString() : null;
+
+            if (!str)
+                return null;
+
+            str = str.substring(str.indexOf("\n") + 1);
+            return str.substring(str.lastIndexOf("\n") + 1, -1);
+        }
+
+        function read_file_content(file, callback) {
+            var reader = new FileReader();
+            reader.onload = callback;
+            reader.readAsText(file);
+        }
+
+        function save_file(id, blob, prop) {
+            if (!blob)
+                return null;
+
+            cockpit.script("echo \"" + blob + "\" > " + id, { err: "ignore" })
+                    .done(function () {
+                        options[prop] = (pwd + "/" + id).replace(/\r?\n|\r/g, "");
+                    });
+        }
+
+        var body = $(mustache.render(self.openvpn_settings_template, options));
+
+        gateway_input = body.find('#network-openvpn-settings-gateway-input');
+        gateway_input.change(function() {
+            var data = gateway_input.val()
+                    .replace(",", "\n")
+                    .trim();
+            parse_remote(data);
+        });
+        import_config_btn = body.find('#network-openvpn-settings-config-toggle');
+        import_config_btn.on('change', function() {
+            gateway_input.prop('disabled', !gateway_input.prop('disabled'));
+            ca_cert_file.prop('disabled', !ca_cert_file.prop('disabled'));
+            dev_cert_file.prop('disabled', !dev_cert_file.prop('disabled'));
+            dev_key_file.prop('disabled', !dev_key_file.prop('disabled'));
+            ovpn_file.prop('disabled', !ovpn_file.prop('disabled'));
+        });
+        ca_cert_file = body.find('#network-openvpn-settings-cert-file');
+        ca_cert_file.on('change', function(e) {
+            if (!this.files[0])
+                return null;
+            var filename = this.files[0].name.replace(no_extension, "");
+            read_file_content(this.files[0], function(e) {
+                save_file(filename + "-ca.pem", e.target.result, "ca");
+                self.settings.connection.id = filename;
+            });
+        });
+        dev_cert_file = body.find('#network-openvpn-settings-dev-cert-file');
+        dev_cert_file.on('change', function(e) {
+            if (!this.files[0])
+                return null;
+            var filename = this.files[0].name.replace(no_extension, "");
+            read_file_content(this.files[0], function(e) {
+                save_file(filename + "-cert.pem", e.target.result, "cert");
+            });
+        });
+        dev_key_file = body.find('#network-openvpn-settings-dev-key-file');
+        dev_key_file.on('change', function(e) {
+            if (!this.files[0])
+                return null;
+            var filename = this.files[0].name.replace(no_extension, "");
+            read_file_content(this.files[0], function(e) {
+                save_file(filename + "-key.pem", e.target.result, "key");
+            });
+        });
+        ovpn_file = body.find('#network-openvpn-settings-ovpn-file');
+        ovpn_file.on('change', function(e) {
+            if (!this.files[0])
+                return null;
+            var filename = this.files[0].name.replace(no_extension, "");
+            read_file_content(this.files[0], function(e) {
+                save_file(filename + "-ca.pem", get_content_from_tag("ca", e.target.result),
+                          "ca");
+                save_file(filename + "-cert.pem", get_content_from_tag("cert", e.target.result),
+                          "cert");
+                save_file(filename + "-key.pem", get_content_from_tag("key", e.target.result),
+                          "key");
+                save_file(filename + "-tls-auth.pem", get_content_from_tag("tls-auth", e.target.result),
+                          "ta");
+                self.settings.connection.id = filename;
+                parse_remote(e.target.result);
+                parse_props(e.target.result);
+            });
+        });
+
+        $('#network-openvpn-settings-body').html(body);
+
+        import_config_btn.prop('checked', false);
+        ovpn_file.prop('disabled', true);
+    },
+
+    cancel: function() {
+        $('#network-openvpn-settings-dialog').modal('hide');
+    },
+
+    apply: function() {
+        var self = this;
+        var options = self.settings.vpn;
+        var vpn_props = [
+            { line: "+vpn.data auth=", prop: "auth" },
+            { line: "+vpn.data ca=", prop: "ca" },
+            { line: "+vpn.data cert=", prop: "cert" },
+            { line: "+vpn.data cipher=", prop: "cipher" },
+            { line: "+vpn.data dev=", prop: "dev" },
+            { line: "+vpn.data key=", prop: "key" },
+            { line: "+vpn.data key-direction=", prop: "key_direction" },
+            { line: "+vpn.data mssfix=", prop: "mssfix" },
+            { line: "+vpn.data port=", prop: "port" },
+            { line: "+vpn.data proto=", prop: "proto" },
+            { line: "+vpn.data rcvbuf=", prop: "rcvbuf" },
+            { line: "+vpn.data remote-cert-tls=", prop: "remote_cert_tls" },
+            { line: "+vpn.data reneg-sec=", prop: "reneg_sec" },
+            { line: "+vpn.data resolv-retry=", prop: "resolv_retry" },
+            { line: "+vpn.data sndbuf=", prop: "sndbuf" },
+            { line: "+vpn.data ta=", prop: "ta" },
+            { line: "+vpn.data tun-mtu=", prop: "tun_mtu" },
+        ];
+
+        function add_vpn_connection() {
+            var cmd = [
+                "nmcli connection add \\",
+                "connection.id " + self.settings.connection.id + " \\",
+                "connection.interface-name " + self.settings.connection.interface_name + " \\",
+                "connection.type vpn \\",
+                "vpn-type openvpn \\",
+                "connection.autoconnect off \\",
+                "connection.permissions \"user:$USER\" \\",
+                "ipv4.dns-search \"\" \\",
+                "ipv4.method auto \\",
+                "ipv4.never-default true \\",
+                "ipv6.dns-search \"\" \\",
+                "ipv6.method auto \\",
+                "ipv6.never-default true \\",
+                "+vpn.data connection-type=password-tls \\",
+                "+vpn.data username=${USER} \\",
+                "+vpn.data password-flags=1 \\",
+            ];
+
+            options.remote.forEach(function(item) {
+                cmd.push("+vpn.data remote=" + item + " \\");
+            });
+
+            vpn_props.forEach(function(item) {
+                if (options[item.prop])
+                    cmd.push(item.line + options[item.prop] + " \\");
+            });
+
+            cmd.push("+vpn.data service-type=org.freedesktop.NetworkManager.openvpn");
+            cmd = cmd.join("\n");
+
+            cockpit.script(cmd, { err: "ignore" })
+                    .fail(function () {
+                        show_error("Connection has not been established");
+                    });
+        }
+
+        function show_error(error) {
+            show_dialog_error('#network-openvpn-settings-error', error);
+        }
+
+        // show warning if network-manager-openvpn is not installed
+        cockpit.script("test -f /usr/lib*/NetworkManager/nm-openvpn-service",
+                       { err: "ignore" })
+                .done(function () {
+                    add_vpn_connection();
+                    $('#network-openvpn-settings-dialog').modal('hide');
+                })
+                .fail(function () {
+                    show_error("`network-manager-openvpn` is not installed");
+                });
+    }
+};
+
+function PageNetworkOpenVPNSettings() {
+    this._init();
+}
+
+PageNetworkWiFiSettings.prototype = {
+    _init: function () {
+        this.id = "network-wifi-settings-dialog";
+        this.wifi_settings_template = $("#network-wifi-settings-template").html();
+        mustache.parse(this.wifi_settings_template);
+    },
+
+    setup: function () {
+        $('#network-wifi-settings-cancel').click($.proxy(this, "cancel"));
+        $('#network-wifi-settings-apply').click($.proxy(this, "apply"));
+    },
+
+    enter: function () {
+        $('#network-wifi-settings-error').hide();
+        this.settings = PageNetworkWiFiSettings.ghost_settings || PageNetworkWiFiSettings.connection.copy_settings();
+        this.update();
+    },
+
+    show: function() {
+    },
+
+    leave: function() {
+    },
+
+    update: function() {
+        var self = this;
+        var connection = self.settings.connection;
+        var options = self.settings.wifi;
+        var security_options = self.settings.wifi_security;
+        var auth_options = self.settings.wifi_1x;
+        var ssid_input, personal_password_input, tls_identity_input, tls_key_password_input,
+            peap_identity_input, eap_domain_input, peap_username_input, peap_password_input;
+        var mode_btn, band_btn, channel_btn, device_btn, security_btn, eap_auth_btn,
+            peap_version_btn, peap_inner_auth_btn;
+        var eap_cert_file, tls_user_cert_file, tls_user_private_key_file;
+
+        var pwd;
+        var no_extension = /\.[^/.]+$/;
+        var process = cockpit.spawn(["pwd"]);
+        process.stream(function(data) {
+            pwd = data;
+        });
+
+        var device_choices = [];
+        PageNetworkWiFiSettings.model.list_interfaces().forEach(function (i) {
+            if (!i.Device)
+                device_choices.push({ title: "Not detected", choice: "" });
+            else if (is_interesting_interface(i) && i.Device && i.Device.DeviceType === "wifi")
+                device_choices.push({ title: i.Name, choice: i.Device.Interface });
+        });
+
+        function search_choices(array, value) {
+            for (var i = 0; i < array.length; i++) {
+                if (array[i].choice === value)
+                    return true;
+            }
+        }
+
+        function choicebox(env, subenv, choices, klass) {
+            var btn = select_btn(
+                function (choice) {
+                    if (env)
+                        env[subenv] = choice;
+                    change();
+                },
+                choices, klass);
+            if (env) {
+                select_btn_select(btn, search_choices(choices, env[subenv])
+                    ? env[subenv] : choices[0].choice);
+            }
+            return btn;
+        }
+
+        function channel_block_handler() {
+            switch (select_btn_selected(band_btn)) {
+            case 'a':
+                channel_btn.replaceWith(channel_btn = choicebox(
+                    options, "channel", wifi_a_channel_choices));
+                break;
+            case 'bg':
+                channel_btn.replaceWith(channel_btn = choicebox(
+                    options, "channel", wifi_bg_channel_choices));
+                break;
+            default:
+                channel_btn.replaceWith(channel_btn = choicebox(
+                    options, "channel", [{ choice: 0, title: _("Default") }]));
+                break;
+            }
+        }
+
+        function restore_wifi_security(value) {
+            if (!security_options) {
+                self.settings["wifi_security"] = {
+                    key_mgmt : value,
+                    psk : ""
+                };
+                security_options = self.settings.wifi_security;
+                change(); // in case of password managers
+            }
+        }
+
+        function restore_wifi_1x() {
+            if (!auth_options) {
+                self.settings["wifi_1x"] = {
+                    eap: [],
+                    identity: "",
+                    anonymous_identity: "",
+                    domain_suffix_match: "",
+                    ca_cert: [],
+                    client_cert: [],
+                    private_key: [],
+                    phase1_peapver: "",
+                    phase2_autheap: "",
+                    password: ""
+                };
+                auth_options = self.settings.wifi_1x;
+                change(); // in case of password managers
+            }
+        }
+
+        function security_block_handler() {
+            var value = select_btn_selected(security_btn);
+
+            switch (value) {
+            case "wpa-psk":
+                $('.hidden-ps').show();
+                $('.hidden-ep').hide();
+                restore_wifi_security();
+                break;
+            case "wpa-eap":
+                $('.hidden-ps').hide();
+                $('.hidden-type').show();
+                restore_wifi_security();
+                restore_wifi_1x();
+                security_auth_block_handler();
+                break;
+            default:
+                $('.hidden-ps').hide();
+                $('.hidden-ep').hide();
+                break;
+            }
+        }
+
+        function security_auth_block_handler() {
+            if (select_btn_selected(eap_auth_btn) === "tls") {
+                $('.hidden-ep').show();
+                $('.hidden-peap').hide();
+            } else if (select_btn_selected(eap_auth_btn) === "peap") {
+                $('.hidden-ep').show();
+                $('.hidden-tls').hide();
+            }
+        }
+
+        function toggle_password(container) {
+            if (container.attr("type") == "password")
+                container.attr('type', "text");
+            else
+                container.attr('type', "password");
+        }
+
+        function read_file_content(file, callback) {
+            var reader = new FileReader();
+            reader.onload = callback;
+            reader.readAsText(file);
+        }
+
+        function save_file(id, blob, prop) {
+            if (!blob)
+                return null;
+
+            cockpit.script("echo \"" + blob + "\" > " + id, { err: "ignore" })
+                    .done(function () {
+                        var temp = (pwd + "/" + id).replace(/\r?\n|\r/g, "");
+                        auth_options[prop] = btoa(temp);
+                    });
+        }
+
+        function change() {
+            options.ssid = btoa(ssid_input.val());
+            options.mode = select_btn_selected(mode_btn);
+            options.band = select_btn_selected(band_btn);
+            options.channel = parseInt(select_btn_selected(channel_btn), 10);
+            connection.interface_name = select_btn_selected(device_btn);
+
+            if (security_options) {
+                security_options.key_mgmt = select_btn_selected(security_btn);
+                security_options.psk = personal_password_input.val();
+            }
+            if (auth_options) {
+                auth_options.eap = [];
+                auth_options.eap.push(select_btn_selected(eap_auth_btn));
+                auth_options.anonymous_identity = peap_identity_input.val();
+                auth_options.domain_suffix_match = eap_domain_input.val();
+                auth_options.phase1_peapver = select_btn_selected(peap_version_btn);
+                auth_options.phase2_autheap = select_btn_selected(peap_inner_auth_btn);
+                auth_options.identity = auth_options.eap[0] === "tls"
+                    ? tls_identity_input.val() : peap_username_input.val();
+                auth_options.private_key_password = tls_key_password_input.val();
+                auth_options.password = peap_password_input.val();
+            }
+        }
+
+        var render_options = { ssid_input: options.ssid ? atob(options.ssid) : "" };
+        if (auth_options) {
+            render_options.tls_identity_input = auth_options.identity;
+            render_options.peap_identity_input = auth_options.anonymous_identity;
+            render_options.eap_domain_input = auth_options.domain_suffix_match;
+            render_options.peap_username_input = auth_options.identity;
+        }
+
+        var body = $(mustache.render(self.wifi_settings_template, render_options));
+
+        ssid_input = body.find('#network-wifi-settings-ssid-input');
+        ssid_input.change(change);
+        body.find('#network-wifi-settings-mode-select').replaceWith(
+            mode_btn = choicebox(options, "mode", wifi_mode_choices));
+        body.find('#network-wifi-settings-band-select').replaceWith(
+            band_btn = choicebox(options, "band", wifi_band_choices));
+        body.find('#network-wifi-settings-channel-select').replaceWith(
+            channel_btn = choicebox(options, "channel", [{ choice: 0, title: _("Default") }]));
+        body.find('#network-wifi-settings-device-select').replaceWith(
+            device_btn = choicebox(connection, "interface_name", device_choices));
+        body.find('#network-wifi-settings-security-select').replaceWith(
+            security_btn = choicebox(security_options, "key_mgmt", wifi_security_choices));
+        personal_password_input = body.find('#security-personal-password-input');
+        personal_password_input.change(change);
+        body.find('#security-eap-auth-select').replaceWith(eap_auth_btn = choicebox(
+            auth_options, "eap", wifi_eap_auth_choices, "hidden-ep hidden-type"));
+        tls_identity_input = body.find('#security-tls-identity');
+        tls_identity_input.change(change);
+        tls_key_password_input = body.find('#security-tls-private-key-password');
+        tls_key_password_input.change(change);
+        peap_identity_input = body.find('#security-peap-identity');
+        peap_identity_input.change(change);
+        eap_domain_input = body.find('#security-eap-domain');
+        eap_domain_input.change(change);
+        body.find('#security-peap-version-select').replaceWith(peap_version_btn = choicebox(
+            auth_options, "phase1_peapver", wifi_peap_version_choices, "hidden-ep hidden-peap"));
+        body.find('#security-peap-inner-auth-select').replaceWith(peap_inner_auth_btn = choicebox(
+            auth_options, "phase2_autheap", wifi_peap_inner_auth_choices, "hidden-ep hidden-peap"));
+        peap_username_input = body.find('#security-peap-username');
+        peap_username_input.change(change);
+        peap_password_input = body.find('#security-peap-password');
+        peap_password_input.change(change);
+        eap_cert_file = body.find('#security-eap-cert-file');
+        eap_cert_file.on('change', function(e) {
+            if (!this.files[0])
+                return null;
+            var filename = this.files[0].name.replace(no_extension, "");
+            read_file_content(this.files[0], function(e) {
+                save_file(filename + "-ca.pem", e.target.result, "ca_cert");
+            });
+        });
+        tls_user_cert_file = body.find('#security-tls-user-cert-file');
+        tls_user_cert_file.on('change', function(e) {
+            if (!this.files[0])
+                return null;
+            var filename = this.files[0].name.replace(no_extension, "");
+            read_file_content(this.files[0], function(e) {
+                save_file(filename + "-dev.pem", e.target.result, "client_cert");
+            });
+        });
+        tls_user_private_key_file = body.find('#security-tls-user-private-key-file');
+        tls_user_private_key_file.on('change', function(e) {
+            if (!this.files[0])
+                return null;
+            var filename = this.files[0].name.replace(no_extension, "");
+            read_file_content(this.files[0], function(e) {
+                save_file(filename + "-key.key", e.target.result, "private_key");
+            });
+        });
+
+        band_btn.on('click', 'li', channel_block_handler);
+        security_btn.on('click', 'li', security_block_handler);
+        eap_auth_btn.on('click', 'li', security_auth_block_handler);
+
+        body.find('#security-personal-password-toggle').click(function() {
+            toggle_password(personal_password_input);
+        });
+        body.find('#security-tls-key-password-toggle').click(function() {
+            toggle_password(tls_key_password_input);
+        });
+        body.find('#security-peap-password-toggle').click(function() {
+            toggle_password(peap_password_input);
+        });
+
+        $('#network-wifi-settings-body').html(body);
+
+        channel_block_handler();
+        security_block_handler();
+
+        $('#security-personal-password-toggle').prop('checked', false);
+        $('#security-eap-cert-toggle').prop('checked', false);
+        $('#security-tls-key-password-toggle').prop('checked', false);
+        $('#security-peap-password-toggle').prop('checked', false);
+    },
+
+    cancel: function() {
+        $('#network-wifi-settings-dialog').modal('hide');
+    },
+
+    apply: function() {
+        var self = this;
+        var security_options = self.settings.wifi_security;
+        var model = PageNetworkWiFiSettings.model;
+
+        function show_error(error) {
+            show_dialog_error('#network-wifi-settings-error', error);
+        }
+
+        if (security_options && security_options.key_mgmt === "wpa-psk" && !security_options.psk) {
+            show_error(_("Password field cannot be empty!"));
+            return;
+        }
+
+        if (!self.settings.connection.interface_name) {
+            show_error(_("Device is not set: Check if network adapter is recognized"));
+            return;
+        }
+
+        function modify () {
+            return PageNetworkWiFiSettings.apply_settings(self.settings)
+                    .then(function () {
+                        $('#network-wifi-settings-dialog').modal('hide');
+                        if (PageNetworkWiFiSettings.done)
+                            return PageNetworkWiFiSettings.done();
+                    })
+                    .fail(show_error);
+        }
+
+        with_settings_checkpoint(model, modify,
+                                 { devices: connection_devices(PageNetworkWiFiSettings.connection) });
+    }
+};
+
+function PageNetworkWiFiSettings() {
+    this._init();
+}
+
 /* INITIALIZATION AND NAVIGATION
  *
  * The code above still uses the legacy 'Page' abstraction for both
@@ -4721,6 +6084,7 @@ function init() {
         interface_page = new PageNetworkInterface(model);
         interface_page.setup();
 
+        dialog_setup(new PageNetworkGeneralSettings());
         dialog_setup(new PageNetworkIpSettings());
         dialog_setup(new PageNetworkBondSettings());
         dialog_setup(new PageNetworkTeamSettings());
@@ -4730,6 +6094,9 @@ function init() {
         dialog_setup(new PageNetworkVlanSettings());
         dialog_setup(new PageNetworkMtuSettings());
         dialog_setup(new PageNetworkMacSettings());
+        dialog_setup(new PageNetworkModemSettings());
+        dialog_setup(new PageNetworkOpenVPNSettings());
+        dialog_setup(new PageNetworkWiFiSettings());
 
         $(cockpit).on("locationchanged", navigate);
         navigate();

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1157,7 +1157,7 @@ function NetworkManagerModel() {
 
     var type_ActiveConnection = {
         interfaces: [
-            "org.freedesktop.NetworkManager.Connection.Active",
+            "org.freedesktop.NetworkManager.Connection.Active"
         ],
 
         props: {
@@ -1337,26 +1337,6 @@ function NetworkManagerModel() {
                     dfd.reject(e);
                 }
                 return dfd.promise();
-            },
-            list_connections: function() {
-                var dfd = $.Deferred();
-                try {
-                    call_object_method(this,
-                                       'org.freedesktop.NetworkManager.Settings',
-                                       'ListConnection')
-                            .done(function (path) {
-                                dfd.resolve(get_object(path, type_Connection));
-                            })
-                            .fail(function (error) {
-                                dfd.reject(error);
-                            });
-                } catch (e) {
-                    dfd.reject(e);
-                }
-                return dfd.promise();
-                /*    return call_object_method(this,
-                                              'org.freedesktop.NetworkManager.Settings',
-                                              'ListConnections'); */
             }
         },
 
@@ -5334,11 +5314,12 @@ PageNetworkModemSettings.prototype = {
 
         var device_choices = [];
         PageNetworkModemSettings.model.list_interfaces().forEach(function (i) {
-            if (!i.Device)
-                device_choices.push({ title: "Not detected", choice: "" });
-            else if (is_interesting_interface(i) && i.Device && i.Device.DeviceType === "modem")
+            if (is_interesting_interface(i) && i.Device && i.Device.DeviceType === "modem")
                 device_choices.push({ title: i.Name, choice: i.Device.Interface });
         });
+
+        if (device_choices.length == 0)
+            device_choices.push({ title: "Not detected", choice: "" });
 
         function choicebox(env, subenv, choices, klass) {
             var btn = select_btn(
@@ -5720,11 +5701,12 @@ PageNetworkWiFiSettings.prototype = {
 
         var device_choices = [];
         PageNetworkWiFiSettings.model.list_interfaces().forEach(function (i) {
-            if (!i.Device)
-                device_choices.push({ title: "Not detected", choice: "" });
-            else if (is_interesting_interface(i) && i.Device && i.Device.DeviceType === "wifi")
+            if (is_interesting_interface(i) && i.Device && i.Device.DeviceType === "wifi")
                 device_choices.push({ title: i.Name, choice: i.Device.Interface });
         });
+
+        if (device_choices.length == 0)
+            device_choices.push({ title: "Not detected", choice: "" });
 
         function search_choices(array, value) {
             for (var i = 0; i < array.length; i++) {

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -44,6 +44,12 @@
     margin-right: 4px;
 }
 
+.network-interface-separator {
+    font-weight: bold;
+    background: #F4F4F4;
+    border: 1px solid #d1d1d1;
+}
+
 /* Fix padding for network graph controls */
 
 #networking-graph-toolbar,
@@ -58,8 +64,12 @@
     height: 120px;
 }
 
+#networking-interfaces {
+    min-height: 300px;
+}
+
 th.networking-speed {
-    width: 20%;
+    width: 30%;
 }
 
 th.networking-spacer {
@@ -118,6 +128,32 @@ span.inverted-switchbox {
     min-width: 150px;
 }
 
+#network-general-settings-dialog input[type=number] {
+    width: 5em;
+    margin-left: 0.5em;
+}
+
+#network-general-settings-autoconnect-priority {
+    margin-left: 17px;
+}
+
+#network-general-settings-dialog select {
+    margin-left: 0.5em;
+}
+
+#network-wifi-settings-dialog input {
+    width: 100%;
+}
+
+#network-wifi-settings-dialog input[type=checkbox] {
+    width: auto;
+}
+
+#network-wifi-settings-dialog .control-label {
+    min-width: 11em;
+    text-align: left;
+}
+
 #network-mtu-settings-dialog label {
     font-weight: normal;
 }
@@ -136,6 +172,22 @@ span.inverted-switchbox {
 
 #network-mac-settings-dialog label {
     font-weight: normal;
+}
+
+#network-modem-settings-dialog input {
+    width: 100%;
+}
+
+#network-modem-settings-dialog input[type=checkbox] {
+    width: auto;
+}
+
+#network-openvpn-settings-dialog input[type=text] {
+    width: 20em;
+}
+
+#network-modem-settings-dialog input[type=checkbox] {
+    width: auto;
 }
 
 #testing-connection-curtain {
@@ -371,4 +423,8 @@ form.horizontal fieldset {
 
 .add-zone-interfaces > label.radio {
     margin: 0;
+}
+
+.left-offset-75-menu {
+    left: -75px;
 }

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -186,10 +186,6 @@ span.inverted-switchbox {
     width: 20em;
 }
 
-#network-modem-settings-dialog input[type=checkbox] {
-    width: auto;
-}
-
 #testing-connection-curtain {
     z-index: 2000;
 }


### PR DESCRIPTION
Patch changes:
  * General:
    - moved "Add ..." buttons to dropdown list "Add new"
    - improved "Interfaces" summary table
    - unified general settings dialog UI
    - added new general settings (conn ID, aut-connect priority, auto-connect vpn)
  * added modem settings dialog
  * added OpenVPN settings dialog
  * added Wifi settings dialog:
    - enabled security options ("none", "wpa-psk", "wpa-eap"(TLS and PEAP))

Here is the doc with screenshots: [changes.pdf](https://cloud.3mdeb.com/index.php/s/554bytDo5wTszWZ)