### PR TITLE
tls: Write client certificate to runtime directory

### DIFF
--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -62,7 +62,7 @@ Code layout
    process for a particular client side certificate (or no certificate),
    together with a Unix socket that is connected to it.
  * A `Server` (in `server.[hc]`) object represents the cockpit-tls logic. It is
-   usually a singleton, and mostly split out into a separate object so that it
-   can be properly unit tested. It maintains a list of `Connection` and
-   `WsInstance` objects according to incoming requests.
- * `main.c` does the CLI option parsing and instantiation of a `Server` object.
+   a singleton (not instantiated), and mostly split out into a separate object
+   so that it can be properly unit tested. It maintains a list of `Connection`
+   and `WsInstance` objects according to incoming requests.
+ * `main.c` does the CLI option parsing and runs `Server`.

--- a/src/tls/test-wsinstance.c
+++ b/src/tls/test-wsinstance.c
@@ -221,6 +221,11 @@ static const TestFixture fixture_https_cert = {
 static void
 test_https_cert (TestCase *tc, gconstpointer data)
 {
+  const TestFixture *fixture = data;
+  g_autofree char *cert_file_path = NULL;
+  g_autofree char *cert_file = NULL;
+  g_autofree char *expected_pem = NULL;
+
   gnutls_datum_t crt = { .size = 0 };
 
   g_assert_cmpuint (tc->ws->peer_cert.size, >, 0);
@@ -243,6 +248,12 @@ test_https_cert (TestCase *tc, gconstpointer data)
   /* modified crt should not match */
   crt.data[0]++;
   g_assert (!ws_instance_has_peer_cert (tc->ws, &crt));
+
+  /* writes expected certificate file */
+  cert_file_path = g_strdup_printf ("%s/ws.%u.crt", tc->state_dir, tc->ws->pid);
+  g_assert (g_file_get_contents (cert_file_path, &cert_file, NULL, NULL));
+  g_assert (g_file_get_contents (fixture->cert_pem, &expected_pem, NULL, NULL));
+  g_assert_cmpstr (g_strchomp (cert_file), ==, g_strchomp (expected_pem));
 
   gnutls_free (crt.data);
 }

--- a/src/tls/wsinstance.c
+++ b/src/tls/wsinstance.c
@@ -117,7 +117,6 @@ ws_instance_new (const char *ws_path,
   WsInstance *ws;
   int fd;
   pid_t pid;
-  static unsigned long ws_socket_id = 0; /* generate unique Unix socket names */
   static char pid_str[20];
 
   ws = callocx (1, sizeof (WsInstance));
@@ -127,9 +126,7 @@ ws_instance_new (const char *ws_path,
   if (fd < 0)
     err (1, "failed to create cockpit-ws socket");
   ws->socket.sun_family = AF_UNIX;
-  /* Generate unique Unix socket name; theoretical wrap-around on ULONG_MAX */
-  assert (++ws_socket_id > 0);
-  snprintf_checked (ws->socket.sun_path, sizeof (ws->socket.sun_path), "%s/ws.%lu.sock", state_dir, ws_socket_id);
+  snprintf_checked (ws->socket.sun_path, sizeof (ws->socket.sun_path), "%s/ws.%i.sock", state_dir, fd);
   unlink (ws->socket.sun_path);
   if (bind (fd, (const struct sockaddr *) &ws->socket, sizeof (ws->socket)) < 0)
     err (1, "failed to bind cockpit-ws socket %s", ws->socket.sun_path);

--- a/src/tls/wsinstance.h
+++ b/src/tls/wsinstance.h
@@ -28,8 +28,10 @@ enum WsInstanceMode { WS_INSTANCE_HTTP, WS_INSTANCE_HTTP_REDIRECT, WS_INSTANCE_H
 
 /* a single cockpit-ws child process */
 typedef struct WsInstance {
+  const char *state_dir;
   gnutls_datum_t peer_cert;      /* DER format */
   gnutls_datum_t peer_cert_info; /* human readable string */
+  char *peer_cert_file;
   struct sockaddr_un socket;
   pid_t pid;
   struct WsInstance *next;


### PR DESCRIPTION
These get written into `$RUNTIME_DIRECTORY/ws.<ws_pid>.crt`, so that
authentication programs like cockpit-session can find it via their
parent pid (which is cockpit-ws). This is a property that a
hacked/malicious cockpit-ws cannot forge, other than losing the link to
the certificate by quitting itself.

This functionality is not yet accessible, so only unit-test this.
