### PR TITLE
WIPPOC - Notifications about failed services

### DIFF
--- a/pkg/lib/notifications.js
+++ b/pkg/lib/notifications.js
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+
+class PageStatus {
+    constructor() {
+        cockpit.event_target(this);
+        window.addEventListener("storage", event => {
+            if (event.key == "cockpit:page_status")
+                this.dispatchEvent("changed");
+        });
+    }
+
+    get(page, host) {
+        let page_status;
+        if (host === undefined)
+            host = cockpit.transport.host;
+
+        try {
+            page_status = JSON.parse(sessionStorage.getItem("cockpit:page_status"));
+        } catch {
+            return null;
+        }
+
+        if (page_status && page_status[host])
+            return page_status[host][page] || null;
+        return null;
+    }
+
+    set_own(status) {
+        cockpit.transport.control("notify", { "page_status": status });
+    }
+}
+
+export const page_status = new PageStatus();

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -423,6 +423,9 @@ function Router(index) {
             } else if (control.command == "oops") {
                 index.show_oops();
                 return;
+            } else if (control.command == "notify") {
+                index.handle_notifications(source.default_host, control.notify);
+                return;
 
             /* Only control messages with a channel are forwardable */
             } else if (control.channel === undefined && !forward_command) {

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -302,11 +302,14 @@ function Router(index) {
     }
 
     function register(child) {
-        var host;
+        var host, page;
         var name = child.name || "";
-        if (name.indexOf("cockpit1:") === 0)
-            host = name.substring(9).split("/")[0];
-        if (!name || !host) {
+        if (name.indexOf("cockpit1:") === 0) {
+            var parts = name.substring(9).split("/");
+            host = parts[0];
+            page = parts.slice(1).join("/");
+        }
+        if (!name || !host || !page) {
             console.warn("invalid child window name", child, name);
             return;
         }
@@ -318,6 +321,7 @@ function Router(index) {
             window: child,
             channel_seed: seed,
             default_host: host,
+            page: page,
             inited: false,
         };
         source_by_seed[seed] = source;
@@ -424,7 +428,8 @@ function Router(index) {
                 index.show_oops();
                 return;
             } else if (control.command == "notify") {
-                index.handle_notifications(source.default_host, control.notify);
+                console.log("notify", control);
+                index.handle_notifications(source.default_host, source.page, control);
                 return;
 
             /* Only control messages with a channel are forwardable */

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -30,12 +30,21 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     if (!index_options)
         index_options = {};
 
+    var page_status = { };
+    sessionStorage.removeItem("cockpit:page_status");
+
     index_options.navigate = function (state, sidebar) {
         return navigate(state, sidebar);
     };
     index_options.handle_notifications = function (host, page, data) {
-        if (data.page_status)
-            machines.overlay(host, { "page_status": { [page]: data.page_status } });
+        if (data.page_status !== undefined) {
+            if (!page_status[host])
+                page_status[host] = { };
+            page_status[host][page] = data.page_status;
+            sessionStorage.setItem("cockpit:page_status", JSON.stringify(page_status));
+            // Just for triggering an "updated" event
+            machines.overlay(host, { });
+        }
     };
     var index = base_index.new_index_from_proto(index_options);
 
@@ -275,8 +284,8 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
             var status = null;
             var label;
 
-            if (machine.page_status)
-                status = machine.page_status[component.path];
+            if (page_status[machine.key])
+                status = page_status[machine.key][component.path];
 
             function icon_class_for_level(level) {
                 if (level == "error")

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -33,9 +33,9 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     index_options.navigate = function (state, sidebar) {
         return navigate(state, sidebar);
     };
-    index_options.handle_notifications = function (host, data) {
+    index_options.handle_notifications = function (host, page, data) {
         if (data.page_status)
-            machines.overlay(host, { "page_status": { [data.page_status.path]: data.page_status.status } });
+            machines.overlay(host, { "page_status": { [page]: data.page_status } });
     };
     var index = base_index.new_index_from_proto(index_options);
 

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -287,10 +287,10 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
             if (page_status[machine.key])
                 status = page_status[machine.key][component.path];
 
-            function icon_class_for_level(level) {
-                if (level == "error")
+            function icon_class_for_type(type) {
+                if (type == "error")
                     return 'fa fa-exclamation-circle';
-                else if (level == "warning")
+                else if (type == "warning")
                     return 'fa fa-exclamation-triangle';
                 else
                     return 'fa fa-info-circle';
@@ -303,7 +303,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                           }).append(component.label,
                                     " ",
                                     $("<span>",
-                                      { 'class': icon_class_for_level(status.level)
+                                      { 'class': icon_class_for_type(status.type)
                                       }));
             } else
                 label = $("<span>").text(component.label);

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -273,20 +273,36 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
             var active = state.component === component.path;
             var listItem;
             var status = null;
+            var label;
 
             if (machine.page_status)
                 status = machine.page_status[component.path];
 
+            function icon_class_for_level(level) {
+                if (level == "error")
+                    return 'fa fa-exclamation-circle';
+                else if (level == "warning")
+                    return 'fa fa-exclamation-triangle';
+                else
+                    return 'fa fa-info-circle';
+            }
+
             if (status)
-                status = " (" + status + ")";
+                label = $("<span>").append(component.label,
+                                           " ",
+                                           $("<span>",
+                                             { 'data-toggle': 'tooltip',
+                                               'title': status.description,
+                                               'class': icon_class_for_level(status.level)
+                                             }));
             else
-                status = "";
+                label = $("<span>").text(component.label);
 
             listItem = $("<li class='list-group-item'>")
                     .toggleClass("active", active)
                     .append($("<a>")
                             .attr("href", index.href({ host: machine.address, component: component.path, hash: component.hash }))
-                            .append($("<span>").text(component.label + status)));
+                            .append(label));
 
             if (active)
                 listItem.find('a').attr("aria-current", "page");

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -296,15 +296,16 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                     return 'fa fa-info-circle';
             }
 
-            if (status)
-                label = $("<span>").append(component.label,
-                                           " ",
-                                           $("<span>",
-                                             { 'data-toggle': 'tooltip',
-                                               'title': status.description,
-                                               'class': icon_class_for_level(status.level)
-                                             }));
-            else
+            if (status) {
+                label = $("<span>",
+                          { 'data-toggle': 'tooltip',
+                            'title': status.description
+                          }).append(component.label,
+                                    " ",
+                                    $("<span>",
+                                      { 'class': icon_class_for_level(status.level)
+                                      }));
+            } else
                 label = $("<span>").text(component.label);
 
             listItem = $("<li class='list-group-item'>")

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -33,6 +33,10 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     index_options.navigate = function (state, sidebar) {
         return navigate(state, sidebar);
     };
+    index_options.handle_notifications = function (host, data) {
+        if (data.page_status)
+            machines.overlay(host, { "page_status": { [data.page_status.path]: data.page_status.status } });
+    };
     var index = base_index.new_index_from_proto(index_options);
 
     /* Restarts */
@@ -268,12 +272,21 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
         function links(component) {
             var active = state.component === component.path;
             var listItem;
+            var status = null;
+
+            if (machine.page_status)
+                status = machine.page_status[component.path];
+
+            if (status)
+                status = " (" + status + ")";
+            else
+                status = "";
 
             listItem = $("<li class='list-group-item'>")
                     .toggleClass("active", active)
                     .append($("<a>")
                             .attr("href", index.href({ host: machine.address, component: component.path, hash: component.hash }))
-                            .append($("<span>").text(component.label)));
+                            .append($("<span>").text(component.label + status)));
 
             if (active)
                 listItem.find('a').attr("aria-current", "page");

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -986,3 +986,15 @@ It is less bad than using !important, at least.
         }
     }
 }
+
+#sidebar-menu .fa-info-circle {
+    color: var(--pf-global--info-color--100);
+}
+
+#sidebar-menu .fa-exclamation-triangle {
+    color: var(--pf-global--warning-color--100);
+}
+
+#sidebar-menu .fa-exclamation-circle {
+    color: var(--pf-global--error-color--100);
+}

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -470,7 +470,8 @@ PageServer.prototype = {
 
         // if cockpit component "page" is available, set element content to a link to it, otherwise just text
         function set_page_link(element_sel, page, text) {
-            if (cockpit.manifests[page]) {
+            var pkg = page.split("/")[0];
+            if (cockpit.manifests[pkg]) {
                 var link = document.createElement("a");
                 link.innerHTML = text;
                 link.tabIndex = 0;

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -31,6 +31,7 @@ import { install_dialog } from "cockpit-components-install-dialog.jsx";
 import * as plot from "plot.js";
 import * as service from "service.js";
 import { shutdown } from "./shutdown.js";
+import { page_status } from "notifications";
 import host_keys_script from "raw-loader!./ssh-list-host-keys.sh";
 
 import "form-layout.less";
@@ -567,24 +568,18 @@ PageServer.prototype = {
         });
 
         function refresh_service_failures() {
-            var page_status = JSON.parse(sessionStorage.getItem("cockpit:page_status"));
-            if (page_status && page_status[cockpit.transport.host]) {
-                $("#system_information_service_failures").empty();
-                var services_status = page_status[cockpit.transport.host]["system/services"];
-                if (services_status) {
-                    $("#system_information_service_failures")
-                            .append(services_status.details.map(u => $('<div>').append(
-                                $('<a>', { 'data-goto-service': u }).text(u),
-                                " has failed")));
-                }
+            var services_status = page_status.get("system/services");
+            $("#system_information_service_failures").empty();
+            if (services_status) {
+                $("#system_information_service_failures")
+                        .append(services_status.details.map(u => $('<div>').append(
+                            $('<a>', { 'data-goto-service': u }).text(u),
+                            " has failed")));
             }
         }
 
         refresh_service_failures();
-        window.addEventListener("storage", event => {
-            if (event.key == "cockpit:page_status")
-                refresh_service_failures();
-        });
+        page_status.addEventListener("changed", refresh_service_failures);
 
         // Only link from graphs to available pages
         set_page_link("#link-disk", "storage", _("Disk I/O"));

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -569,13 +569,14 @@ PageServer.prototype = {
         function refresh_service_failures() {
             var page_status = JSON.parse(sessionStorage.getItem("cockpit:page_status"));
             if (page_status && page_status[cockpit.transport.host]) {
+                $("#system_information_service_failures").empty();
                 var services_status = page_status[cockpit.transport.host]["system/services"];
-                console.log("ST", services_status);
-                if (services_status)
-                    set_page_link("#system_information_service_failures", "system/services",
-                                  services_status.description);
-                else
-                    $("#system_information_service_failures").text("");
+                if (services_status) {
+                    $("#system_information_service_failures")
+                            .append(services_status.details.map(u => $('<div>').append(
+                                $('<a>', { 'data-goto-service': u }).text(u),
+                                " has failed")));
+                }
             }
         }
 

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -565,6 +565,25 @@ PageServer.prototype = {
             refresh_os_updates_state();
         });
 
+        function refresh_service_failures() {
+            var page_status = JSON.parse(sessionStorage.getItem("cockpit:page_status"));
+            if (page_status && page_status[cockpit.transport.host]) {
+                var services_status = page_status[cockpit.transport.host]["system/services"];
+                console.log("ST", services_status);
+                if (services_status)
+                    set_page_link("#system_information_service_failures", "system/services",
+                                  services_status.description);
+                else
+                    $("#system_information_service_failures").text("");
+            }
+        }
+
+        refresh_service_failures();
+        window.addEventListener("storage", event => {
+            if (event.key == "cockpit:page_status")
+                refresh_service_failures();
+        });
+
         // Only link from graphs to available pages
         set_page_link("#link-disk", "storage", _("Disk I/O"));
         set_page_link("#link-network", "network", _("Network Traffic"));

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -103,6 +103,10 @@
                     <span id="system_information_updates_text"></span>
                 </div>
 
+                <div role="group" class="system-information-updates">
+                    <span id="system_information_service_failures"></span>
+                </div>
+
                 <label class="control-label" for="system-ssh-keys-link" translatable="yes">Secure Shell Keys</label>
                 <a tabindex="0" id="system-ssh-keys-link" translatable="yes" data-toggle="modal"
                    data-target="#system_information_ssh_keys">Show fingerprints</a>

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -103,8 +103,7 @@
                     <span id="system_information_updates_text"></span>
                 </div>
 
-                <div role="group" class="system-information-updates">
-                    <span id="system_information_service_failures"></span>
+                <div id="system_information_service_failures">
                 </div>
 
                 <label class="control-label" for="system-ssh-keys-link" translatable="yes">Secure Shell Keys</label>

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -576,6 +576,11 @@ $(function() {
             update_all();
         });
 
+        $(systemd_manager).on("Reloading", function(event, reloading) {
+            if (!reloading)
+                update_all();
+        });
+
         $('#services-dropdown').on('change', render);
 
         update_all();

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -420,14 +420,7 @@ $(function() {
                         "description": cockpit.format(_("$0 services have failed to start"), n_failed)
                     };
                 }
-                cockpit.transport.control("notify",
-                                          { "notify":
-                                            { "page_status":
-                                              { "path": "system/services",
-                                                "status": status
-                                              }
-                                            }
-                                          });
+                cockpit.transport.control("notify", { "page_status": status });
             }
         }
 

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -8,6 +8,7 @@ import ReactDOM from 'react-dom';
 import { ServiceTabs } from "./services.jsx";
 import { ServiceDetails, ServiceTemplate } from "./service-details.jsx";
 import { journal } from "journal";
+import { page_status } from "notifications";
 import "patterns";
 import "bootstrap-datepicker/dist/js/bootstrap-datepicker";
 
@@ -424,15 +425,18 @@ $(function() {
             render_tabs();
             if (old_failed === null || !set_equal(failed, old_failed)) {
                 console.log("FAILED", failed);
-                let status = null;
                 if (failed.size > 0) {
-                    status = {
-                        "level": "warning",
-                        "description": cockpit.format(_("$0 services have failed"), failed.size),
+                    page_status.set_own({
+                        "type": "warning",
+                        "description": cockpit.format(cockpit.ngettext("$0 service has failed",
+                                                                       "$0 services have failed",
+                                                                       failed.size),
+                                                      failed.size),
                         "details": [...failed]
-                    };
+                    });
+                } else {
+                    page_status.set_own(null);
                 }
-                cockpit.transport.control("notify", { "page_status": status });
             }
         }
 

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -380,11 +380,18 @@ $(function() {
             render();
         }
 
-        ReactDOM.render(
-            React.createElement(ServiceTabs, {
-                onChange: tab_changed,
-            }),
-            document.getElementById("services-filter"));
+        let tab_warnings = { };
+
+        function render_tabs() {
+            ReactDOM.render(
+                React.createElement(ServiceTabs, {
+                    onChange: tab_changed,
+                    warnings: tab_warnings,
+                }),
+                document.getElementById("services-filter"));
+        }
+
+        render_tabs();
 
         $("#services-text-filter").on("input", render);
         $(document).on("click", "#clear-all-filters", clear_filters);
@@ -394,12 +401,16 @@ $(function() {
         function process_failed_units() {
             let old_some_failed = some_failed;
             some_failed = false;
+            tab_warnings = { };
             for (let p in units_by_path) {
-                if (units_by_path[p].ActiveState == "failed") {
+                let u = units_by_path[p];
+                if (u.ActiveState == "failed" && u.LoadState !== "masked") {
                     some_failed = true;
-                    break;
+                    tab_warnings[u.Id.substr(u.Id.lastIndexOf('.') + 1)] = true;
                 }
             }
+
+            render_tabs();
             if (some_failed != old_some_failed) {
                 console.log("SOME FAILED", some_failed);
                 cockpit.transport.control("notify",

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -282,8 +282,19 @@ $(function() {
                     .toLowerCase();
             var current_type_filter = parseInt($('#services-dropdown').val());
 
-            function cmp_path(a, b) { return units_by_path[a].Id.localeCompare(units_by_path[b].Id) }
-            var sorted_keys = Object.keys(units_by_path).sort(cmp_path);
+            function cmp_units(a, b) {
+                let unit_a = units_by_path[a];
+                let unit_b = units_by_path[b];
+                let failed_a = unit_a.ActiveState == "failed" ? 1 : 0;
+                let failed_b = unit_b.ActiveState == "failed" ? 1 : 0;
+
+                if (failed_a != failed_b)
+                    return failed_b - failed_a;
+                else
+                    return unit_a.Id.localeCompare(unit_b.Id);
+            }
+
+            var sorted_keys = Object.keys(units_by_path).sort(cmp_units);
             var units = [ ];
             var header = {
                 Description: _("Description"),

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -415,7 +415,7 @@ $(function() {
             tab_warnings = { };
             for (let p in units_by_path) {
                 let u = units_by_path[p];
-                if (u.ActiveState == "failed" && u.LoadState !== "masked") {
+                if (u.ActiveState == "failed") {
                     failed.add(u.Id);
                     tab_warnings[u.Id.substr(u.Id.lastIndexOf('.') + 1)] = true;
                 }

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -396,28 +396,35 @@ $(function() {
         $("#services-text-filter").on("input", render);
         $(document).on("click", "#clear-all-filters", clear_filters);
 
-        let some_failed = false;
+        let n_failed = null;
 
         function process_failed_units() {
-            let old_some_failed = some_failed;
-            some_failed = false;
+            let old_n_failed = n_failed;
+            n_failed = 0;
             tab_warnings = { };
             for (let p in units_by_path) {
                 let u = units_by_path[p];
                 if (u.ActiveState == "failed" && u.LoadState !== "masked") {
-                    some_failed = true;
+                    n_failed += 1;
                     tab_warnings[u.Id.substr(u.Id.lastIndexOf('.') + 1)] = true;
                 }
             }
 
             render_tabs();
-            if (some_failed != old_some_failed) {
-                console.log("SOME FAILED", some_failed);
+            if (old_n_failed === null || n_failed != old_n_failed) {
+                console.log("FAILED", n_failed);
+                let status = null;
+                if (n_failed) {
+                    status = {
+                        "level": "warning",
+                        "description": cockpit.format(_("$0 services have failed to start"), n_failed)
+                    };
+                }
                 cockpit.transport.control("notify",
                                           { "notify":
                                             { "page_status":
                                               { "path": "system/services",
-                                                "status": some_failed ? "warning" : null
+                                                "status": status
                                               }
                                             }
                                           });

--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -755,6 +755,9 @@ $(function() {
     function update() {
         var path = cockpit.location.path;
 
+        if (!systemd_manager.valid)
+            return;
+
         if (path.length === 0) {
             show_unit(null);
             $("#services").show();
@@ -771,6 +774,7 @@ $(function() {
     }
 
     $(cockpit).on("locationchanged", update);
+    $(cockpit).on("visibilitychange", update);
 
     $('#service-navigate-home').on("click", function() {
         cockpit.location.go('/');

--- a/pkg/systemd/manifest.json.in
+++ b/pkg/systemd/manifest.json.in
@@ -27,7 +27,7 @@
         }
     },
 
-    "preload": [ "index" ],
+    "preload": [ "index", "services" ],
 
     "content-security-policy": "img-src 'self' data:"
 }

--- a/pkg/systemd/service-details.jsx
+++ b/pkg/systemd/service-details.jsx
@@ -264,9 +264,11 @@ export class ServiceDetails extends React.Component {
         }
     }
 
-    unitAction(method) {
+    unitAction(method, extra_args) {
+        if (extra_args === undefined)
+            extra_args = [ "fail" ];
         this.setState({ waitsAction: true });
-        this.props.systemdManager.call(method, [ this.props.unit.Names[0], "fail" ])
+        this.props.systemdManager.call(method, [ this.props.unit.Names[0] ].concat(extra_args))
                 .fail(error => this.setState({ error: error.toString() }))
                 .finally(() => this.setState({ waitsAction: false }));
     }
@@ -323,6 +325,7 @@ export class ServiceDetails extends React.Component {
                     <span className="pficon pficon-error-circle-o status-icon" />
                     <span className="status">{ _("Failed to start") }</span>
                     <button className="btn btn-default action-button" onClick={() => this.unitAction("StartUnit") }>{ _("Start Service") }</button>
+                    <button className="btn btn-default action-button" onClick={() => this.unitAction("ResetFailedUnit", [ ]) }>{ _("Clear \"Failed\" Status") }</button>
                 </div>
             );
         }

--- a/pkg/systemd/services.css
+++ b/pkg/systemd/services.css
@@ -211,3 +211,15 @@ table.systemd-unit-relationship-table td:first-child {
 .service-unit-description {
   width: 40%;
 }
+
+.fa-info-circle {
+    color: var(--pf-global--info-color--100);
+}
+
+.fa-exclamation-triangle {
+    color: var(--pf-global--warning-color--100);
+}
+
+.fa-exclamation-circle {
+    color: var(--pf-global--error-color--100);
+}

--- a/pkg/systemd/services.jsx
+++ b/pkg/systemd/services.jsx
@@ -37,7 +37,7 @@ export class ServiceTabs extends React.Component {
 
         function title(label, tag) {
             if (warnings[tag])
-                return <span>{label} <span className="pficon pficon-warning-triangle-o" /></span>;
+                return <span>{label} <span className="fa fa-exclamation-triangle" /></span>;
             else
                 return label;
         }

--- a/pkg/systemd/services.jsx
+++ b/pkg/systemd/services.jsx
@@ -33,13 +33,22 @@ const _ = cockpit.gettext;
  */
 export class ServiceTabs extends React.Component {
     render() {
+        let { warnings } = this.props;
+
+        function title(label, tag) {
+            if (warnings[tag])
+                return <span>{label} <span className="pficon pficon-warning-triangle-o" /></span>;
+            else
+                return label;
+        }
+
         return (
             <Tabs defaultActiveKey=".service$" id="service-tabs" onSelect={this.props.onChange}>
-                <Tab eventKey=".service$" title={ _("System Services") } />
-                <Tab eventKey=".target$" title={ _("Targets") } />
-                <Tab eventKey=".socket$" title={ _("Sockets") } />
-                <Tab eventKey=".timer$" title={ _("Timers") } />
-                <Tab eventKey=".path$" title={ _("Paths") } />
+                <Tab eventKey=".service$" title={ title(_("System Services"), "service") } />
+                <Tab eventKey=".target$" title={ title(_("Targets"), "target") } />
+                <Tab eventKey=".socket$" title={ title(_("Sockets"), "socket") } />
+                <Tab eventKey=".timer$" title={ title(_("Timers"), "timer") } />
+                <Tab eventKey=".path$" title={ title(_("Paths"), "path") } />
             </Tabs>
         );
     }


### PR DESCRIPTION
Some brain dump:

This is for "state" things that reflect the state of the system and not "events", which are about things that just happened. We might later say that a service that has just failed is event worth of a notification, and then the Service page would need to make another API call in addition to distributing the state like here.

- [x] Sort failed services at the the top of the list
- [x] Preload the services page after login
- [x] Put warning icons on services/timers/targets etc tabs
- [x] Proper icon and tooltip for page status
- [x] Don't persist page status via the Machines thing (i.e. don't use `machine.overlay`)
- [x] Put info about failed services on System page
- [x] Put list of failed services on the System page
- [x] Reusable API
- [x] #12505
- [x] #12534 
- [x] #12585

Demo: https://www.youtube.com/watch?v=d8PbufSwQVI