### PR TITLE
cockpit-tls: use eventfd from SIGCHLD handler

### DIFF
--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -486,6 +486,11 @@ test_ws_idle (TestCase *tc, gconstpointer data)
 
   /* ws process should disappear after idle wait */
   sleep (3);
+
+  /* run the mainloop to collect the zombie */
+  while (server_poll_event (0))
+    ;
+
   /* process is gone */
   g_assert_cmpint (waitpid (0, NULL, WNOHANG), ==, -1);
   g_assert_cmpint (errno, ==, ECHILD);


### PR DESCRIPTION
We shouldn't be making unsafe calls from a unix signal handler, so
instead of handling the exit immediately use an eventfd to signal the
mainloop to handle it on the next iteration.