### PR TITLE
tls: Survive when getting events for removed connections

### DIFF
--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -486,7 +486,12 @@ handle_connection_data (int fd)
   char buffer[1024 * 1024];
 
   con = get_fd_connection (fd, &src);
-  assert (con);
+  if (con == NULL)
+    {
+      debug ("no connection for fd %i, ignoring", fd);
+      return;
+    }
+
   debug ("%s connection fd %i has data from %s; ws %s",
          con->is_tls ? "TLS" : "unencrypted", con->client_fd,
          src == WS ? "ws" : "client",


### PR DESCRIPTION
When a cockpit-ws process exits that still has connections open,
cockpit-tls gets a SIGCHLD and also events on all its connections.
When cockpit-tls processes the SIGCHLD before the epoll events, it
fails to find a Connection for the fd of the event (because they have
all been removed during SIGCHLD handling).