### PR TITLE
networkmanager: add priority and vpn for auto-connect

### DIFF
--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -107,19 +107,28 @@
       <div class="panel-heading">
         <h2 class="panel-title" translatable="yes">Interfaces</h2>
         <div class="panel-actions">
-          <button translatable="yes" id="networking-add-bond" class="btn btn-default network-privileged">Add Bond</button>
           <button translatable="yes" id="networking-add-team" class="btn btn-default network-privileged">Add Team</button>
-          <button translatable="yes" id="networking-add-bridge" class="btn btn-default network-privileged">Add Bridge</button>
-          <button translatable="yes" id="networking-add-vlan" class="btn btn-default network-privileged">Add VLAN</button>
+          <div class="btn-group dropdown interface-type">
+            <button id="networking-add-new" class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+              <span translatable="yes">Add new</span>
+              <div class="caret"></div>
+            </button>
+              <ul class="dropdown-menu">
+                <li><a tabindex="0" id="networking-add-bond" translatable="yes">Bond</a></li>
+                <li><a tabindex="0" id="networking-add-bridge" translatable="yes">Bridge</a></li>
+                <li><a tabindex="0" id="networking-add-vlan" translatable="yes">VLAN</a></li>
+              </ul>
+          </div>
         </div>
       </div>
       <table class="table table-hover">
         <thead>
           <tr>
             <th translatable="yes">Name</th>
+            <th translatable="yes">Interface</th>
+            <th translatable="yes">Type</th>
             <th translatable="yes">IP Address</th>
-            <th translatable="yes" class="networking-speed">Sending</th>
-            <th translatable="yes" class="networking-speed">Receiving</th>
+            <th translatable="yes" class="networking-speed">Status: (Sending/Receiving)</th>
           </tr>
         </thead>
         <tbody>
@@ -135,9 +144,10 @@
         <thead>
           <tr>
             <th translatable="yes">Name</th>
+            <th translatable="yes">Interface</th>
+            <th translatable="yes">Type</th>
             <th translatable="yes">IP Address</th>
-            <th translatable="yes" class="networking-speed">Sending</th>
-            <th translatable="yes" class="networking-speed">Receiving</th>
+            <th translatable="yes" class="networking-speed">Status: (Sending/Receiving)</th>
           </tr>
         </thead>
         <tbody>
@@ -150,6 +160,33 @@
       <div class="panel-body" id="networking-log" role="rowgroup"></div>
     </div>
   </div>
+
+  <script id="network-general-settings-template" type="x-template/mustache">
+    <form class="ct-form">
+      <label class="control-label" for="network-general-settings-name-input" translatable="yes">Name</label>
+      <input id="network-general-settings-name-input" class="form-control" type="text"
+             value="{{name}}"/>
+
+      <label class="checkbox-inline">
+        <input id="network-general-settings-autoconnect" type="checkbox" checked="false">
+        <span translatable="yes">Automatically connect to this network when it is available</span>
+      </label>
+
+      <div>
+        <span translatable="yes">Connection priority for auto connect</span>
+        <input id="network-autoconnect-priority-input" type="number" min="0"/>
+      </div>
+
+      <label class="checkbox-inline hidden-vpn">
+        <input id="network-general-settings-autovpn" type="checkbox" checked="false"/>
+        <span translatable="yes">Automatically connect to VPN when using this connection</span>
+        <select id="network-general-settings-autovpn-select">
+          <option selected disabled hidden>Select VPN</option>
+          {{! the rather complex dropdown-select will be created dynamically via jquery }}
+        </select>
+      </label>
+    </form>
+  </script>
 
   <script id="network-vlan-settings-template" type="x-template/mustache">
     <form class="ct-form">
@@ -454,6 +491,30 @@
         <tbody>
         </tbody>
       </table>
+    </div>
+  </div>
+
+  <div class="modal" id="network-general-settings-dialog"
+       tabindex="-1" role="dialog"
+       data-backdrop="static">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" translatable="yes">General Settings</h4>
+        </div>
+        <div class="modal-body">
+          <div id="network-general-settings-body">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <div class="alert alert-danger dialog-error" id="network-general-settings-error">
+            <i class="fa fa-exclamation-triangle"></i>
+            <span></span>
+          </div>
+          <button class="btn btn-default" translatable="yes" id="network-general-settings-cancel">Cancel</button>
+          <button class="btn btn-primary" translatable="yes" id="network-general-settings-apply">Apply</button>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -604,6 +604,9 @@ function NetworkManagerModel() {
                 timestamp:      get("connection", "timestamp", 0),
                 id:             get("connection", "id", _("Unknown")),
                 autoconnect:    get("connection", "autoconnect", true),
+                autoconnect_priority:
+                                get("connection", "autoconnect-priority", 0),
+                secondaries:    get("connection", "secondaries"),
                 autoconnect_slaves:
                                 get("connection", "autoconnect-slaves", -1),
                 slave_type:     get("connection", "slave-type"),
@@ -720,12 +723,14 @@ function NetworkManagerModel() {
 
         set("connection", "id", 's', settings.connection.id);
         set("connection", "autoconnect", 'b', settings.connection.autoconnect);
+        set("connection", "autoconnect-priority", 'i', settings.connection.autoconnect_priority);
         set("connection", "autoconnect-slaves", 'i', settings.connection.autoconnect_slaves);
         set("connection", "uuid", 's', settings.connection.uuid);
         set("connection", "interface-name", 's', settings.connection.interface_name);
         set("connection", "type", 's', settings.connection.type);
         set("connection", "slave-type", 's', settings.connection.slave_type);
         set("connection", "master", 's', settings.connection.master);
+        set("connection", "secondaries", 'as', settings.connection.secondaries);
 
         if (settings.ipv4)
             set_ip("ipv4", 'aau', ip4_address_to_nm, 'aau', ip4_route_to_nm, 'au', utils.ip4_from_text);
@@ -1734,8 +1739,8 @@ PageNetworking.prototype = {
                 var tx = samples[1][0];
                 var row = $('#networking-interfaces tr[data-sample-id="' + encodeURIComponent(iface) + '"]');
                 if (rx !== undefined && tx !== undefined && row.length > 0) {
-                    row.find('td:nth-child(3)').text(cockpit.format_bits_per_sec(tx * 8));
-                    row.find('td:nth-child(4)').text(cockpit.format_bits_per_sec(rx * 8));
+                    row.find('td:nth-child(5)').text("on: (" + cockpit.format_bits_per_sec(tx * 8) +
+                        " / " + cockpit.format_bits_per_sec(rx * 8) + ")");
                 }
             }
         }
@@ -1807,11 +1812,14 @@ PageNetworking.prototype = {
             var row = $('<tr>', { "data-interface": encodeURIComponent(iface.Name),
                                   "data-sample-id": show_traffic ? encodeURIComponent(iface.Name) : null
             })
-                    .append($('<td>').text(iface.Name),
+                    .append($('<td>').text((iface.MainConnection && iface.MainConnection.Settings)
+                        ? iface.MainConnection.Settings.connection.id : null),
+                            $('<td>').text(iface.Name),
+                            $('<td>').text(dev ? dev.DeviceType : null),
                             $('<td>').html(render_active_connection(dev, false, true)),
                             (show_traffic
-                                ? [ $('<td>').text(""), $('<td>').text("") ]
-                                : $('<td colspan="2">').text(device_state_text(dev))));
+                                ? $('<td>').text("")
+                                : $('<td>').text("off: " + device_state_text(dev))));
 
             if (!dev || dev.Managed) {
                 managed_tbody.append(row.click(function () {
@@ -1843,6 +1851,8 @@ PageNetworking.prototype = {
                 connection: {
                     id: iface,
                     autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
                     type: "bond",
                     uuid: uuid,
                     interface_name: iface
@@ -1877,6 +1887,8 @@ PageNetworking.prototype = {
                 connection: {
                     id: iface,
                     autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
                     type: "team",
                     uuid: uuid,
                     interface_name: iface
@@ -1909,6 +1921,8 @@ PageNetworking.prototype = {
                 connection: {
                     id: iface,
                     autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
                     type: "bridge",
                     uuid: uuid,
                     interface_name: iface
@@ -1941,6 +1955,8 @@ PageNetworking.prototype = {
                 connection: {
                     id: "",
                     autoconnect: true,
+                    autoconnect_priority: 0,
+                    secondaries: [],
                     type: "vlan",
                     uuid: uuid,
                     interface_name: ""
@@ -2596,6 +2612,19 @@ PageNetworkInterface.prototype = {
                                                        dev.DeviceType == 'bridge'));
         $('#network-interface-delete').toggle(is_deletable && managed);
 
+        function render_interface_section_separator(title) {
+            return $('<td class="network-interface-separator" colspan="100%">').text(title);
+        }
+
+        function render_interface_type_row() {
+            if (dev) {
+                return $('<tr>').append(
+                    $('<td>').text(_("Type")),
+                    $('<td>').append(self.connection_settings.connection.id +
+                        " | " + dev.Interface, " | ", dev.DeviceType));
+            }
+        }
+
         function render_carrier_status_row() {
             if (dev && dev.Carrier !== undefined) {
                 return $('<tr>').append(
@@ -2627,6 +2656,14 @@ PageNetworkInterface.prototype = {
                     render_active_connection(dev, true, false),
                     " ",
                     state ? $('<span>').text(state) : null));
+        }
+
+        function render_general_information_row() {
+            return [ render_interface_section_separator("General Information"),
+                render_interface_type_row(),
+                render_carrier_status_row(),
+                render_active_status_row(),
+            ];
         }
 
         function render_connection_settings_rows(con, settings) {
@@ -2674,6 +2711,10 @@ PageNetworkInterface.prototype = {
                 return parts;
             }
 
+            function configure_general_settings() {
+                self.show_dialog(PageNetworkGeneralSettings, '#network-general-settings-dialog');
+            }
+
             function configure_ip_settings(topic) {
                 PageNetworkIpSettings.topic = topic;
                 self.show_dialog(PageNetworkIpSettings, '#network-ip-settings-dialog');
@@ -2708,24 +2749,6 @@ PageNetworkInterface.prototype = {
                 self.show_dialog(PageNetworkMtuSettings, '#network-mtu-settings-dialog');
             }
 
-            function render_autoconnect_row() {
-                if (settings.connection.autoconnect !== undefined) {
-                    return (
-                        $('<tr>').append(
-                            $('<td>').text(_("General")),
-                            $('<td class="networking-controls">').append(
-                                $('<label>').append(
-                                    $('<input type="checkbox">')
-                                            .prop('checked', settings.connection.autoconnect)
-                                            .change(function () {
-                                                settings.connection.autoconnect = $(this).prop('checked');
-                                                settings_applier(self.model, self.dev, con)(settings);
-                                            }),
-                                    $('<span>').text(_("Connect automatically")))))
-                    );
-                }
-            }
-
             function render_settings_row(title, rows, configure) {
                 var link_text = [ ];
                 for (var i = 0; i < rows.length; i++) {
@@ -2744,6 +2767,35 @@ PageNetworkInterface.prototype = {
                         $('<a tabindex="0" class="network-privileged">')
                                 .append(link_text)
                                 .syn_click(self.model, function () { configure() })));
+            }
+
+            function render_general_settings_row() {
+                var parts = [];
+                var rows = [];
+                var options = settings.connection;
+
+                if (!options)
+                    return null;
+
+                parts.push("Auto-connection: " +
+                     (options.autoconnect ? "Enabled" : "Disabled"));
+
+                if (options.autoconnect)
+                    parts.push("(Priority: " + (options.autoconnect_priority >= 0
+                        ? options.autoconnect_priority : "None") + ")");
+
+                if (parts.length > 0)
+                    rows.push(parts.join(" "));
+
+                if (options.type != "vpn") {
+                    var vpn_name = $('#network-general-settings-autovpn-select')
+                            .children('option:selected')
+                            .text() || "Enabled";
+                    rows.push("Auto-selected VPN: " +
+                        (options.secondaries ? vpn_name : "None"));
+                }
+
+                return render_settings_row(_("General"), rows, configure_general_settings);
             }
 
             function render_ip_settings_row(topic, title) {
@@ -2919,17 +2971,18 @@ PageNetworkInterface.prototype = {
                                            configure_vlan_settings);
             }
 
-            return [ render_master(),
-                render_autoconnect_row(),
-                render_ip_settings_row("ipv4", _("IPv4")),
-                render_ip_settings_row("ipv6", _("IPv6")),
+            return [ render_interface_section_separator("Settings"),
+                render_master(),
+                render_general_settings_row(),
                 render_mtu_settings_row(),
                 render_vlan_settings_row(),
                 render_bridge_settings_row(),
                 render_bridge_port_settings_row(),
                 render_bond_settings_row(),
                 render_team_settings_row(),
-                render_team_port_settings_row()
+                render_team_port_settings_row(),
+                render_ip_settings_row("ipv4", _("IPv4")),
+                render_ip_settings_row("ipv6", _("IPv6"))
             ];
         }
 
@@ -2973,8 +3026,7 @@ PageNetworkInterface.prototype = {
 
         $('#network-interface-settings')
                 .empty()
-                .append(render_active_status_row())
-                .append(render_carrier_status_row())
+                .append(render_general_information_row())
                 .append(render_connection_settings_rows(self.main_connection, self.connection_settings));
         update_network_privileged();
 
@@ -3181,6 +3233,150 @@ function connection_devices(con) {
         con.Interfaces.forEach(function (iface) { if (iface.Device) devices.push(iface.Device); });
 
     return devices;
+}
+
+PageNetworkGeneralSettings.prototype = {
+    _init: function () {
+        this.id = "network-general-settings-dialog";
+        this.general_settings_template = $("#network-general-settings-template").html();
+        mustache.parse(this.general_settings_template);
+    },
+
+    setup: function () {
+        $('#network-general-settings-cancel').click($.proxy(this, "cancel"));
+        $('#network-general-settings-apply').click($.proxy(this, "apply"));
+    },
+
+    enter: function () {
+        $('#network-general-settings-error').hide();
+        this.settings = PageNetworkGeneralSettings.ghost_settings || PageNetworkGeneralSettings.connection.copy_settings();
+        this.update();
+    },
+
+    show: function() {
+    },
+
+    leave: function() {
+    },
+
+    update: function() {
+        var self = this;
+        var options = self.settings.connection;
+        var vpn_choices = [];
+        var name_input, priority_btn, priority_input, autovpn_btn, autovpn_select;
+
+        function set_vpn_connections(data) {
+            var lines = data.split("\n");
+
+            lines.forEach(function(line, index) {
+                var dict = {};
+                var values = line.split(':');
+
+                if (values[1] === "vpn") {
+                    dict.name = values[0];
+                    dict.uuid = values[2];
+                    vpn_choices.push(dict);
+                }
+            });
+        }
+
+        function vpn_connections_handler() {
+            var process = cockpit.spawn(["nmcli", "-g", "name,type,uuid", "con"]);
+            process.stream(function(data) {
+                set_vpn_connections(data);
+                vpn_choices.forEach(function(item, index, arr) {
+                    if (autovpn_select.find('option[value="' + arr[index].uuid + '"]').length == 0)
+                        autovpn_select.append(new Option(arr[index].name, arr[index].uuid));
+                });
+                if (options.secondaries) {
+                    autovpn_btn.prop('checked', true);
+                    autovpn_select.val(options.secondaries[0]);
+                } else
+                    autovpn_btn.prop('checked', false);
+            });
+        }
+
+        function change() {
+            options.id = name_input.val();
+            options.autoconnect = priority_btn.prop('checked');
+            options.autoconnect_priority = options.autoconnect ? parseInt(priority_input.val()) : 0;
+            options.secondaries = [];
+            if (autovpn_btn.prop('checked') && autovpn_select.val() !== undefined)
+                options.secondaries.push(autovpn_select.val());
+        }
+
+        var body = $(mustache.render(self.general_settings_template, { name: options.id }));
+        name_input = body.find('#network-general-settings-name-input');
+        name_input.change(change);
+        priority_btn = body.find('#network-general-settings-autoconnect');
+        priority_btn.change(change);
+        priority_input = body.find('#network-autoconnect-priority-input');
+        priority_input.change(change);
+        autovpn_btn = body.find('#network-general-settings-autovpn');
+        autovpn_btn.change(change);
+        autovpn_select = body.find('#network-general-settings-autovpn-select');
+        autovpn_select.change(change);
+
+        $('#network-general-settings-body').html(body);
+        priority_btn.prop('checked', options.autoconnect);
+        priority_input.val(options.autoconnect_priority);
+
+        if (options.type !== "vpn") {
+            vpn_connections_handler();
+            $('.hidden-vpn').show();
+        } else
+            $('.hidden-vpn').hide();
+
+        priority_input.focus(function () {
+            priority_btn.prop('checked', true);
+        });
+
+        autovpn_select.focus(function () {
+            autovpn_btn.prop('checked', true);
+        });
+    },
+
+    cancel: function() {
+        $('#network-general-settings-dialog').modal('hide');
+    },
+
+    apply: function() {
+        var self = this;
+        var model = PageNetworkGeneralSettings.model;
+
+        function show_error(error) {
+            show_dialog_error('#network-general-settings-error', error);
+        }
+
+        if (self.settings.connection.autoconnect_priority < 0) {
+            show_error(_("Please select a value that is no less than 0"));
+            return;
+        }
+
+        if (self.settings.connection.type !== "vpn" &&
+            $('#network-general-settings-autovpn').prop('checked') &&
+            !self.settings.connection.secondaries) {
+            show_error(_("Disable or select VPN connection"));
+            return;
+        }
+
+        function modify () {
+            return PageNetworkGeneralSettings.apply_settings(self.settings)
+                    .then(function () {
+                        $('#network-general-settings-dialog').modal('hide');
+                        if (PageNetworkGeneralSettings.done)
+                            return PageNetworkGeneralSettings.done();
+                    })
+                    .fail(show_error);
+        }
+
+        with_settings_checkpoint(model, modify,
+                                 { devices: connection_devices(PageNetworkGeneralSettings.connection) });
+    }
+};
+
+function PageNetworkGeneralSettings() {
+    this._init();
 }
 
 PageNetworkIpSettings.prototype = {
@@ -4721,6 +4917,7 @@ function init() {
         interface_page = new PageNetworkInterface(model);
         interface_page.setup();
 
+        dialog_setup(new PageNetworkGeneralSettings());
         dialog_setup(new PageNetworkIpSettings());
         dialog_setup(new PageNetworkBondSettings());
         dialog_setup(new PageNetworkTeamSettings());

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -44,6 +44,12 @@
     margin-right: 4px;
 }
 
+.network-interface-separator {
+    font-weight: bold;
+    background: #F4F4F4;
+    border: 1px solid #d1d1d1;
+}
+
 /* Fix padding for network graph controls */
 
 #networking-graph-toolbar,
@@ -58,8 +64,12 @@
     height: 120px;
 }
 
+#networking-interfaces {
+    min-height: 300px;
+}
+
 th.networking-speed {
-    width: 20%;
+    width: 30%;
 }
 
 th.networking-spacer {
@@ -116,6 +126,19 @@ span.inverted-switchbox {
 
 .bootstrap-select {
     min-width: 150px;
+}
+
+#network-general-settings-dialog input[type=number] {
+    width: 5em;
+    margin-left: 0.5em;
+}
+
+#network-general-settings-autoconnect-priority {
+    margin-left: 17px;
+}
+
+#network-general-settings-dialog select {
+    margin-left: 0.5em;
 }
 
 #network-mtu-settings-dialog label {


### PR DESCRIPTION
Patch changes:
    - moved "Add ..." buttons to dropdown list "Add new"
    - improved "Interfaces" summary table
    - unified general settings dialog UI (General page)
    - added new general settings (conn ID, auto-connect priority, auto-connect vpn)