### PR TITLE
ws: Include CA in sscg generated certificates

### DIFF
--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -199,13 +199,12 @@ sscg_make_dummy_cert (const gchar *key_file,
                       const gchar *ca_file,
                       GError **error)
 {
-  gboolean ret = FALSE;
   gint exit_status;
-  gchar *stderr_str = NULL;
-  gchar *command_line = NULL;
-  gchar *cn = get_common_name ();
-  gchar *machine_id = get_machine_id ();
-  gchar *org;
+  g_autofree gchar *stderr_str = NULL;
+  g_autofree gchar *command_line = NULL;
+  g_autofree gchar *cn = get_common_name ();
+  g_autofree gchar *machine_id = get_machine_id ();
+  const gchar *org = NULL;
 
   if (machine_id)
     org = machine_id;
@@ -237,30 +236,23 @@ sscg_make_dummy_cert (const gchar *key_file,
       g_info ("Error generating temporary dummy cert using sscg, "
               "falling back to openssl");
       g_clear_error (error);
-      goto out;
+      return FALSE;
     }
 
-  ret = TRUE;
-
-out:
-  g_free (stderr_str);
-  g_free (command_line);
-  g_free (machine_id);
-  g_free (cn);
-  return ret;
+  return TRUE;
 }
 
 gchar *
 cockpit_certificate_create_selfsigned (GError **error)
 {
-  gchar *dir = NULL;
-  gchar *cert_path = NULL;
-  gchar *ca_path = NULL;
-  gchar *tmp_key = NULL;
-  gchar *tmp_pem = NULL;
-  gchar *cert_data = NULL;
-  gchar *pem_data = NULL;
-  gchar *key_data = NULL;
+  g_autofree gchar *dir = NULL;
+  g_autofree gchar *cert_path = NULL;
+  g_autofree gchar *ca_path = NULL;
+  g_autofree gchar *tmp_key = NULL;
+  g_autofree gchar *tmp_pem = NULL;
+  g_autofree gchar *cert_data = NULL;
+  g_autofree gchar *pem_data = NULL;
+  g_autofree gchar *key_data = NULL;
   gchar *ret = NULL;
 
   dir = g_build_filename (cockpit_conf_get_dirs ()[0], "cockpit", "ws-certs.d", NULL);
@@ -321,20 +313,12 @@ cockpit_certificate_create_selfsigned (GError **error)
   cert_path = NULL;
 
 out:
-  g_free (cert_path);
-  g_free (ca_path);
   cockpit_memory_clear (key_data, -1);
-  g_free (key_data);
-  g_free (pem_data);
   cockpit_memory_clear (cert_data, -1);
-  g_free (cert_data);
   if (tmp_key)
     g_unlink (tmp_key);
   if (tmp_pem)
     g_unlink (tmp_pem);
-  g_free (tmp_key);
-  g_free (tmp_pem);
-  g_free (dir);
   return ret;
 }
 

--- a/src/ws/test-remotectlcertificate.c
+++ b/src/ws/test-remotectlcertificate.c
@@ -102,7 +102,7 @@ setup (TestCase *tc,
   if (fix->ensure)
     {
       cockpit_expect_info ("Generating temporary certificate*");
-      cockpit_expect_info ("Error generating temporary dummy cert using sscg, falling back to openssl*");
+      cockpit_expect_info ("Error generating temporary dummy cert using sscg:*; falling back to openssl*");
       g_ptr_array_add (ptr, "--ensure");
     }
   g_ptr_array_add (ptr, "--user");

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -232,6 +232,27 @@ class TestConnection(MachineCase):
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --head http://127.0.0.1:9090"))
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --head http://172.27.0.15:9090"))
 
+    @skipImage("Fixed in PR #12530", "rhel-8-0-distropkg")
+    def testSSCG(self):
+        m = self.machine
+
+        m.start_cockpit(tls=True)
+        output = m.execute("openssl s_client -connect 172.27.0.15:9090 2>&1")
+        self.assertIn("DONE", output)
+        self.assertRegex(output, "0 s:.*CN *=")
+        self.assertRegex(output, "i:.*CN *=")
+
+        # on OSes without sscg we expect a self-signed certificate
+        if m.image in ["debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1804"]:
+            # no intermediate
+            self.assertNotRegex(output, "i:.*OU *= *ca-")
+            # no second certificate
+            self.assertNotIn("\n1 s", output)
+        else:
+            # has intermediate
+            self.assertRegex(output, "i:.*OU *= *ca-")
+            self.assertRegex(output, "1 s:.*CN *= *")
+
     def testConfigOrigins(self):
         m = self.machine
         m.execute(


### PR DESCRIPTION
Our TLS certificate files should contain the entire certificate chain
with the intermediate CAs, not just the top-level cert:

  https://cockpit-project.org/guide/latest/https.html#https-certificates

So for sscg, append the CA to the .cert file. Also keep the separate
file, as it's useful for importing into browsers or other places.

Fixes #12499