### PR TITLE
build: don't delete test/ directories in autogen

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -414,7 +414,7 @@ dist-hook:: $(WEBPACK_PACKAGES:%=dist/%/manifest.json)
 	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 
 DIST_TAR_MAIN = tar --format=posix -cf - "$(distdir)"
-DIST_TAR_CACHE = tar --format=posix -cf - --transform="flags=r;s|^\./||" --transform="flags=r;s|^|$(distdir)/|" \
+DIST_TAR_CACHE = tar --format=posix -cf - --transform="flags=r;s|^\./||" --transform="flags=r;s|^|$(distdir)/|" --exclude test \
 	"$(srcdir)/node_modules" "$(srcdir)/package.json"
 
 DIST_ARCHIVES = \

--- a/autogen.sh
+++ b/autogen.sh
@@ -47,8 +47,6 @@ npm prune
 # npm install is flaky, so give it a few tries
 npm install || { sleep 30; npm install; } || { sleep 30; npm install; }
 
-find node_modules -name test | xargs rm -rf
-
 rm -rf autom4te.cache
 
 autoreconf -f -i -I tools


### PR DESCRIPTION
autogen.sh contains an unsafe invocation of find|xargs to iterate over
the node_modules and delete all test directories that it finds (with the
goal of reducing the size of the cache tarball by removing unit tests).

This is a pretty strange thing to do to the node_modules directory,
particularly when you contemplate incremental invocations of 'npm
install'.  The same effect can be accomplished by using tar --exclude
when creating the tarball.  Do that instead.