### PR TITLE
naughty: Close 12250: apparmor denies sys_rawio capability from libvirtd which happens when using scsi disks

### DIFF
--- a/bots/naughty/debian-stable/12250-apparmor-libvirt-rawio
+++ b/bots/naughty/debian-stable/12250-apparmor-libvirt-rawio
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): apparmor="DENIED" operation="capable" profile="/usr/sbin/libvirtd" * comm="libvirt_parthel" * capname="sys_rawio"

--- a/bots/naughty/debian-testing/12250-apparmor-libvirt-rawio
+++ b/bots/naughty/debian-testing/12250-apparmor-libvirt-rawio
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): apparmor="DENIED" operation="capable" profile="/usr/sbin/libvirtd" * comm="libvirt_parthel" * capname="sys_rawio"

--- a/bots/naughty/ubuntu-1804/12250-apparmor-libvirt-rawio
+++ b/bots/naughty/ubuntu-1804/12250-apparmor-libvirt-rawio
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): apparmor="DENIED" operation="capable" profile="/usr/sbin/libvirtd" * comm="libvirt_parthel" * capname="sys_rawio"

--- a/bots/naughty/ubuntu-stable/12250-apparmor-libvirt-rawio
+++ b/bots/naughty/ubuntu-stable/12250-apparmor-libvirt-rawio
@@ -1,1 +1,0 @@
-Error: audit: type=1400 audit(*): apparmor="DENIED" operation="capable" profile="/usr/sbin/libvirtd" * comm="libvirt_parthel" * capname="sys_rawio"


### PR DESCRIPTION
Known issue which has not occurred in 25 days

apparmor denies sys_rawio capability from libvirtd which happens when using scsi disks

Fixes #12250