### PR TITLE
naughty: Close 11671: SELinux is preventing chronyd from sendto access on the unix_dgram_socket

### DIFF
--- a/bots/naughty/rhel-atomic/11671-selinux-chronyd-sendto
+++ b/bots/naughty/rhel-atomic/11671-selinux-chronyd-sendto
@@ -1,1 +1,0 @@
-Error: type=1400 audit(*): avc:  denied  { sendto } for  pid=* comm="chronyd" * tclass=unix_dgram_socket


### PR DESCRIPTION
Known issue which has not occurred in 25 days

SELinux is preventing chronyd from sendto access on the unix_dgram_socket

Fixes #11671