### PR TITLE
tls: Reject invalid client TLS certificates

### DIFF
--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -247,6 +247,7 @@ EXTRA_DIST += \
 	src/bridge/mock-pmda.c \
 	src/bridge/mock-pmns \
 	src/bridge/mock-client.crt \
+	src/bridge/mock-client-expired.crt \
 	src/bridge/mock-client.key \
 	src/bridge/mock-server.crt \
 	src/bridge/mock-server.key \

--- a/src/bridge/mock-client-expired.crt
+++ b/src/bridge/mock-client-expired.crt
@@ -1,0 +1,20 @@
+# openssl req -new -key mock-client.key -out /tmp/csr -subj /CN=localhost
+# openssl x509 -in /tmp/csr -out mock-client-expired.crt -req -signkey mock-client.key -days -1
+
+-----BEGIN CERTIFICATE-----
+MIICrzCCAZcCFAGtgLnu2BwwUG+YvCCuhXGpNegaMA0GCSqGSIb3DQEBCwUAMBQx
+EjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xOTA4MTIxMjEyNDZaFw0xOTA4MTExMjEy
+NDZaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBAPJdatNQeTf24mhQ2s1Lbj7jqxbCzguuy19YohOtoLnIRH/RchGo
+IJRs7VzkgqWP6l9B1piJBNz6qLW/JT0NJlB5XmAr82POXBZo+JrvqwyD8Sv5cN+1
+7tNIj/623AgOiunYDI6dEyc2bzJ1Nj8sLRag6cOmXIXDIude5HjHy8LHFAv+2PNJ
+T9DxgNcEw2mKMbjJVIak033S6AWe93gPWM4KgXmfXj8aFBZPQLSbZTpUetJhmxDs
+Hg1H3JdW4irWqw1uUiWG1UxY1nT7AlenM2Z3X1SgAJA3fm7GxTHBIqv3aB1NPdmM
+t7GfYIZzgcObAqvIk10PXJno8VK7Lv0ry90CAwEAATANBgkqhkiG9w0BAQsFAAOC
+AQEAOaC9LBIVwxIaAXVi+iiPsl8+tKWWg1UsnqUn80Ws9+FWxygT4fN+n9xYsy+e
+rUw6W9UFdu4CjzF1Ngq0IJfFSh9GqVJNdue9jz4duut0jh6p7zJqqs/u9QEmaUyS
+VZUglrvARltxa71QKUCewIyKg/kP0cs2ARiEeOBB6feqiX+YQR3wuhj/tQW9QcrQ
+9P1EkZ4OYfLxourzrd2SrotuX1Z4aRIVpYUk+0FGQAwXczjcCiMscFhUkWyM6ie4
+yi+TZn00MYWaSxMJHXhIMl3n/Q3ITDmZ1aSgNRdaGgtHTBgmYdHsuMNeQCrajvvm
+HFUO8AJy4dQXHmymW2UvybymTg==
+-----END CERTIFICATE-----


### PR DESCRIPTION
cockpit-tls is supposed to not validate the trust of client
certificates, this is delegated to sssd. However, it should still reject
expired, unsafe, or otherwise invalid certificates. Add a custom peer
certificate verify function for this.

The unit test needs some tweaking to work with TLS 1.3 and earlier. The
former uses a reduced handshake so that `gnutls_handshake()` on the
client side does not fail on a failing certificate validation, only on
the first I/O operation. See
https://nikmav.blogspot.com/2018/05/gnutls-and-tls-13.html for details.