### PR TITLE
machines: make Operating System input mandatory field when creating new VMs

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -121,10 +121,7 @@ function validateParams(vmParams) {
         validationFailed['vmName'] = _("Name should not be empty");
     }
 
-    // If we select installation media from URL force the user to select
-    // OS, since virt-install will not detect the OS, in case we don't choose
-    // to start the guest immediately.
-    if (vmParams.os == undefined && vmParams.sourceType == URL_SOURCE && !vmParams.startVm)
+    if (vmParams.os == undefined)
         validationFailed['os'] = _("You need to select the most closely matching Operating System");
 
     let source = vmParams.source ? vmParams.source.trim() : null;

--- a/test/selenium/selenium-machines-basic.py
+++ b/test/selenium/selenium-machines-basic.py
@@ -131,7 +131,7 @@ class MachinesBasicTestSuite(MachinesLib):
 
         for i in range(20):
             self.create_vm_by_ui(
-                connection='session', name='test{}'.format(i), source=iso_source, mem_unit='M', storage=1, storage_unit='M')
+                connection='session', name='test{}'.format(i), source=iso_source, mem=128, mem_unit='M', storage=50, storage_unit='M')
             self.vm_stop_list.append('test{}'.format(i))
 
     def testCreateVMWithISO(self):
@@ -140,7 +140,7 @@ class MachinesBasicTestSuite(MachinesLib):
 
         self.machine.execute('sudo touch {}'.format(iso))
 
-        self.create_vm_by_ui(connection='session', name=name, source=iso, mem_unit='M', storage_unit='M')
+        self.create_vm_by_ui(connection='session', name=name, source=iso, mem=128, mem_unit='M', storage=50, storage_unit='M')
         self.vm_stop_list.append(name)
 
     @skipIf(os.environ.get('URLSOURCE') is None,

--- a/test/selenium/testlib_avocado/machineslib.py
+++ b/test/selenium/testlib_avocado/machineslib.py
@@ -4,6 +4,7 @@ import secrets
 from time import sleep
 from .timeoutlib import wait
 from .seleniumlib import SeleniumTest, clickable, text_in, invisible
+from selenium.webdriver.common.keys import Keys
 
 
 SPICE_XML = """
@@ -200,7 +201,7 @@ class MachinesLib(SeleniumTest):
                         name='default',
                         source_type='file',
                         source='/var/lib/libvirt/images/cirros.qcow2',
-                        operating_system=None,
+                        operating_system='CirrOS',
                         mem=1,
                         mem_unit='G',
                         storage=10,
@@ -234,7 +235,7 @@ class MachinesLib(SeleniumTest):
                     break
 
         if operating_system is not None:
-            self.send_keys(self.wait_css("label:contains('Operating System') + div > div > div > input"), operating_system)
+            self.send_keys(self.wait_css("label[for=os-select] + div > div > div > input"), operating_system + Keys.ARROW_DOWN + Keys.ENTER)
 
         if mem_unit == 'M':
             self.select_by_text(self.wait_css('#memory-size-unit-select'), 'MiB')

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1321,8 +1321,7 @@ class TestMachines(NetworkCase):
 
         createTest(TestMachines.VmDialog(self, sourceType='url',
                                          location=config.VALID_URL,
-                                         storage_size=1,
-                                         os_name=config.CIRROS))
+                                         storage_size=1))
 
         # test just the DIALOG CREATION and cancel
         print("    *\n    * validation errors and ui info/warn messages expected:\n    * ")
@@ -1376,10 +1375,10 @@ class TestMachines(NetworkCase):
                                                             os_name=config.FEDORA_28, start_vm=True),
                                       {"Source": "Installation Source should not be empty"})
 
-        # disallow empty OS in case of URL installation media and start_vm=False
+        # disallow empty OS
         checkDialogFormValidationTest(TestMachines.VmDialog(self, sourceType='url', location=config.VALID_URL,
                                                             storage_size=100, storage_size_unit='MiB',
-                                                            start_vm=False),
+                                                            start_vm=False, os_name=None),
                                       {"Operating System": "You need to select the most closely matching Operating System"})
 
         # try to CREATE few machines
@@ -1400,13 +1399,11 @@ class TestMachines(NetworkCase):
                                          location=config.VALID_URL,
                                          memory_size=256, memory_size_unit='MiB',
                                          storage_size=100, storage_size_unit='MiB',
-                                         os_name=config.CIRROS,
                                          start_vm=False))
         createTest(TestMachines.VmDialog(self, sourceType='file',
                                          location=config.NOVELL_MOCKUP_ISO_PATH,
                                          memory_size=256, memory_size_unit='MiB',
                                          storage_pool="No Storage",
-                                         os_name=config.CIRROS,
                                          start_vm=False,
                                          connection='session'))
 
@@ -1416,7 +1413,6 @@ class TestMachines(NetworkCase):
                                          location=config.NOVELL_MOCKUP_ISO_PATH,
                                          memory_size=256, memory_size_unit='MiB',
                                          storage_size=100000, storage_size_unit='GiB',
-                                         os_name=config.CIRROS,
                                          start_vm=False))
 
         # Try setting the memory to value bigger than it's available on the OS
@@ -1432,7 +1428,6 @@ class TestMachines(NetworkCase):
         createTest(TestMachines.VmDialog(self, sourceType='disk_image',
                                          location=config.VALID_DISK_IMAGE_PATH,
                                          memory_size=256, memory_size_unit='MiB',
-                                         os_name=config.CIRROS,
                                          start_vm=False))
 
         # Recreate the image the previous test just deleted to reuse it
@@ -1448,7 +1443,6 @@ class TestMachines(NetworkCase):
         createTest(TestMachines.VmDialog(self, sourceType='disk_image',
                                          location=config.VALID_DISK_IMAGE_PATH,
                                          memory_size=256, memory_size_unit='MiB',
-                                         os_name=config.CIRROS,
                                          start_vm=True))
         # End of tests for import existing disk as installation option
 
@@ -1469,7 +1463,6 @@ class TestMachines(NetworkCase):
         createTest(TestMachines.VmDialog(self, sourceType='file',
                                          location=config.NOVELL_MOCKUP_ISO_PATH,
                                          memory_size=256, memory_size_unit='MiB',
-                                         os_name=config.CIRROS,
                                          storage_pool="tmpPool",
                                          storage_volume="vmTmpDestination.qcow2",
                                          start_vm=True,))
@@ -1478,7 +1471,6 @@ class TestMachines(NetworkCase):
         createTest(TestMachines.VmDialog(self, sourceType='file',
                                          location=config.NOVELL_MOCKUP_ISO_PATH,
                                          memory_size=256, memory_size_unit='MiB',
-                                         os_name=config.CIRROS,
                                          storage_pool="No Storage",
                                          start_vm=True,))
 
@@ -1623,7 +1615,6 @@ class TestMachines(NetworkCase):
                                              location="Virtual Network pxe-nat: NAT",
                                              memory_size=256, memory_size_unit='MiB',
                                              storage_pool="No Storage",
-                                             os_name=config.CIRROS,
                                              start_vm=True, delete=False))
 
             # We don't want to use start_vm == False because if we get a seperate install phase
@@ -1678,7 +1669,6 @@ class TestMachines(NetworkCase):
                                              location="Host Device {0}: macvtap".format(iface),
                                              memory_size=256, memory_size_unit='MiB',
                                              storage_pool="No Storage",
-                                             os_name=config.CIRROS,
                                              start_vm=False))
 
             # When switching from PXE mode to anything else make sure that the source input is empty
@@ -1686,7 +1676,7 @@ class TestMachines(NetworkCase):
                                                                 sourceType='pxe',
                                                                 location="Host Device {0}: macvtap".format(iface),
                                                                 sourceTypeSecondChoice='url',
-                                                                os_name=config.CIRROS, start_vm=False),
+                                                                start_vm=False),
                                           {"Source": "Installation Source should not be empty"})
 
         # When switching between no pxe installation modes with the source already set
@@ -1760,7 +1750,7 @@ class TestMachines(NetworkCase):
                      sourceType='file', sourceTypeSecondChoice=None, location='',
                      memory_size=256, memory_size_unit='MiB',
                      storage_size=None, storage_size_unit='GiB',
-                     os_name=None,
+                     os_name='CirrOS',
                      storage_pool='Create New Volume', storage_volume='',
                      start_vm=False,
                      delete=True,
@@ -1816,7 +1806,7 @@ class TestMachines(NetworkCase):
         def checkOsFiltered(self):
             b = self.browser
 
-            b.focus("label:contains('Operating System') + div > div > div > input")
+            b.focus("label[for=os-select] + div > div > div > input")
             b.key_press(self.os_name)
             b.key_press("\t")
             try:


### PR DESCRIPTION
When possible, the OS is auto-detected. However, for PXE boots, or in
cases where libosinfo didn't manage to return some result, the user
should insert the Operating System information, because without that,
they will end up with guest that severely underperforms.