### PR TITLE
bots: Use virtio-net instead of rtl8139 network cards for our VMs

### DIFF
--- a/bots/machine/machine_core/cli.py
+++ b/bots/machine/machine_core/cli.py
@@ -26,7 +26,7 @@ def cmd_cli():
     parser.add_argument("image", help="Image name")
     args = parser.parse_args()
 
-    network = machine_virtual.VirtNetwork(0)
+    network = machine_virtual.VirtNetwork(0, image=args.image)
     machine = machine_virtual.VirtMachine(image=args.image, networking=network.host(), memory_mb=args.memory)
     machine.start()
     machine.wait_boot()

--- a/bots/vm-run
+++ b/bots/vm-run
@@ -98,7 +98,7 @@ try:
         memory = 4096
 
     graphics = args.graphics or 'windows' in args.image
-    network = testvm.VirtNetwork(0, bridge=bridge)
+    network = testvm.VirtNetwork(0, bridge=bridge, image=args.image)
 
     machine = testvm.VirtMachine(verbose=args.verbose, image=args.image, maintain=args.maintain,
                                  networking=network.host(restrict=args.no_network),

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -636,7 +636,7 @@ class MachineCase(unittest.TestCase):
             if not machine_class:
                 machine_class = testvm.VirtMachine
             if not self.network:
-                network = testvm.VirtNetwork()
+                network = testvm.VirtNetwork(image=image)
                 self.addCleanup(lambda: network.kill())
                 self.network = network
             networking = self.network.host(restrict=True, forward=forward)

--- a/test/selenium/run-tests
+++ b/test/selenium/run-tests
@@ -351,8 +351,9 @@ def main():
 
     opts = parser.parse_args()
 
-    network = testvm.VirtNetwork()
     image = BASE_IMAGE
+    # When Windows in use, we need rtl8139, for anything else we want virtio-net-pci
+    network = testvm.VirtNetwork(image="windows-10" if "edge" in opts.browser else image)
     machine = None
     test_timeout = 300
     testsuite = None

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -35,7 +35,7 @@ class TestImageCustomize(unittest.TestCase):
 
     def checkBoot(self, image):
         with testvm.Timeout(seconds=300, error_message="Timed out waiting for image to run"):
-            network = testvm.VirtNetwork(0)
+            network = testvm.VirtNetwork(0, image=image)
             machine = testvm.VirtMachine(image=image, networking=network.host(), memory_mb=512)
             machine.start()
             machine.wait_boot()


### PR DESCRIPTION
All our images support virtio-net now, but e. g. Debian cloud images
don't support the ancient rtl8139 any more. Let's use virtio which is
faster.

Pass the image to VirtNetwork(), so that it can decide which image
supports which virtual hardware.