### PR TITLE
po: Generate translations from manifests again

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -65,7 +65,7 @@ po/POTFILES.js.in:
 	( cd $(srcdir) && find src/base1/ $(TRANSLATE) -name '*.js' -o -name '*.jsx' ) > $@
 po/POTFILES.manifest.in:
 	$(MKDIR_P) $(notdir $@)
-	( cd $(srcdir) && find $(TRANSLATE) -name 'manifest.json' ) > $@
+	( cd $(srcdir) && find $(TRANSLATE) -name 'manifest.json.in' ) > $@
 po/POTFILES.pre.in: prepare-po
 	$(MKDIR_P) $(notdir $@)
 	( cd tmp/ && find . -type f ) > $@

--- a/po/manifest2po
+++ b/po/manifest2po
@@ -67,14 +67,17 @@ function step() {
         return;
     }
 
-    if (path.basename(filename) != "manifest.json")
+    if (path.basename(filename) != "manifest.json.in")
         return step();
 
     fs.readFile(filename, { encoding: "utf-8"}, function(err, data) {
         if (err)
             fatal(err.message);
 
-        process_manifest(JSON.parse(data));
+        // There are variables which when not substituted can cause JSON.parse to fail
+        // Dummy replace them. None variable is going to be translated anyway
+        safe_data = data.replace(/\@.+?\@/gi, 1);
+        process_manifest(JSON.parse(safe_data));
 
         return step();
     });


### PR DESCRIPTION
This stopped working when `manifest.json` was moved into
`manifest.json.in`. We do not generate any translations from manifests
now. Most of menu items are translated, but only thanks to the fact that
those strings appear on other places as well.
For example `Docker Containers` do not appear anywhere and therefore
cannot be translated now.