### PR TITLE
Searching with keywords

### DIFF
--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -186,6 +186,42 @@ $ cockpit-bridge --packages
         <listitem><para>The relative path to the HTML file within the package that implements
           the menu item or tool.</para></listitem>
       </varlistentry>
+      <varlistentry>
+        <term>keywords</term>
+        <listitem><para>Keywords that describe the page and which are used for searching.
+          These keywords should be lowercase. Keywords is a list containing keyword
+          items as described below. Page label is prepended as first keyword
+          in the first keyword item.
+        </para></listitem>
+      </varlistentry>
+    </variablelist>
+
+    <para>Keyword items are registered using JSON objects that have the
+      following properties:</para>
+
+    <variablelist>
+      <varlistentry>
+        <term>matches</term>
+        <listitem><para>List of keywords to be matched.</para></listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>goto</term>
+        <listitem><para>Optional path that is used for all keywords in this item.
+          When this argument starts with slash, then it is used as pathname, otherwise
+          it is used as hash. Defining <code>goto:"page_hash"</code> in page with <code>path:"/page_path"</code>
+          would redirect to <code>/page_path#page_hash</code>, while <code>goto:"/page_path"</code>
+          would redirect to <code>/page_path</code> ignoring default page path.</para></listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>weight</term>
+        <listitem><para>How much keywords are prioritized over others. Default is 3.
+          </para></listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>translate</term>
+        <listitem><para><code>false</code> when keywords should not be localized. Default is <code>true</code>.
+        </para></listitem>
+      </varlistentry>
     </variablelist>
 
     <para>An example manifest.json with some optional properties set:</para>

--- a/pkg/apps/manifest.json.in
+++ b/pkg/apps/manifest.json.in
@@ -6,7 +6,12 @@
 
     "tools": {
         "index": {
-            "label": "Applications"
+            "label": "Applications",
+            "keywords": [
+                {
+                    "matches": ["plugin", "apps", "addon", "add-on", "install", "extension"]
+                }
+            ]
         }
     },
 

--- a/pkg/kdump/manifest.json.in
+++ b/pkg/kdump/manifest.json.in
@@ -6,7 +6,12 @@
 
     "tools": {
         "index": {
-            "label": "Kernel Dump"
+            "label": "Kernel Dump",
+            "keywords": [
+                {
+                    "matches": ["kdump", "crash"]
+                }
+            ]
         }
     },
     "content-security-policy": "img-src 'self' data:"

--- a/pkg/machines/manifest.json.in
+++ b/pkg/machines/manifest.json.in
@@ -8,7 +8,12 @@
      "vms": {
         "label": "Virtual Machines",
         "path": "index.html",
-        "order": 60
+        "order": 60,
+        "keywords": [
+            {
+                "matches": ["iso", "pxe", "qcow2", "libvirt", "vm", "qemu"]
+            }
+        ]
      }
   },
   "content-security-policy": "img-src 'self' data:; frame-src 'self' data:"

--- a/pkg/networkmanager/manifest.json.in
+++ b/pkg/networkmanager/manifest.json.in
@@ -8,7 +8,16 @@
     "menu": {
         "index": {
             "label": "Networking",
-            "order": 40
+            "order": 40,
+            "keywords": [
+                {
+                    "matches": ["network", "inteface", "bridge", "vlan", "bond", "team", "port", "mac", "ipv4", "ipv6"]
+                },
+                {
+                    "matches": ["firewall", "zone", "tcp", "udp"],
+                    "goto": "/network/firewall"
+                }
+            ]
         }
     },
 

--- a/pkg/packagekit/manifest.json.in
+++ b/pkg/packagekit/manifest.json.in
@@ -8,7 +8,12 @@
 
     "tools": {
         "index": {
-            "label": "Software Updates"
+            "label": "Software Updates",
+            "keywords": [
+                {
+                    "matches": ["package", "packagekit", "dnf", "yum", "apt-get", "security"]
+                }
+            ]
         }
     },
 

--- a/pkg/selinux/manifest.json.in
+++ b/pkg/selinux/manifest.json.in
@@ -6,7 +6,12 @@
 
     "tools": {
         "setroubleshoot": {
-            "label": "SELinux"
+            "label": "SELinux",
+            "keywords": [
+                {
+                    "matches": ["setroubleshoot", "semanage", "avc"]
+                }
+            ]
         }
     }
 }

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -511,6 +511,7 @@ function Index() {
     $(document).on("click", "a[href]", function(ev) {
         var a = this;
         if (!a.host || window.location.host === a.host) {
+            document.getElementById("filter-menus").value = "";
             self.jump(a.getAttribute('href'));
             ev.preventDefault();
         }
@@ -940,8 +941,20 @@ function CompiledComponents() {
                     label: cockpit.gettext(info.label) || prop,
                     order: info.order === undefined ? 1000 : info.order,
                     icon: info.icon,
-                    wants: info.wants
+                    wants: info.wants,
+                    keywords: info.keywords || [{ matches: [] }],
+                    keyword: { score: -1 }
                 };
+
+                // Always first keyword should be page name
+                item.keywords[0].matches.unshift(item.label.toLowerCase());
+
+                // Keywords from manifest have different defaults than are usual
+                item.keywords.forEach(i => {
+                    i.weight = i.weight || 3;
+                    i.translate = i.translate === undefined ? true : i.translate;
+                });
+
                 if (info.path)
                     item.path = info.path.replace(/\.html$/, "");
                 else

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -359,6 +359,10 @@
                         </ul>
                     </div>
                 </div>
+                <div class="has-feedback search" id="menu-search">
+                    <input id="filter-menus" class="form-control" type="search" placeholder="Type to search..." translate="placeholder">
+                    <span class="fa fa-search form-control-feedback"></span>
+                </div>
 
                 <nav id="host-apps" class="host-apps">
                     <ul class="list-group" id="sidebar-menu">

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -114,6 +114,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
 
     /* Navigation */
     var ready = false;
+    var filter_timer = null;
     function on_ready() {
         ready = true;
         index.ready();
@@ -123,6 +124,69 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
         for (const m of machines.list)
             index.preload_frames(m, m.manifests);
     }
+
+    // Click on active menu item (when using arrows to navigate through menu)
+    function clickActiveItem() {
+        const cur = document.activeElement;
+        if (cur.nodeName === "INPUT") {
+            const el = document.querySelector("#host-apps li:first-of-type > a");
+            if (el)
+                el.click();
+        } else {
+            cur.click();
+        }
+    }
+
+    // Move focus to next item in menu (when using arrows to navigate through menu)
+    // With arguments it is possible to change direction
+    function focusNextItem(nth_of_type, sibling) {
+        const cur = document.activeElement;
+        if (cur.nodeName === "INPUT") {
+            const item = document.querySelector("#host-apps li:" + nth_of_type + " > a");
+            if (item)
+                item.focus();
+        } else {
+            const next = cur.parentNode[sibling];
+            if (next)
+                next.children[0].focus();
+            else
+                document.getElementById("filter-menus").focus();
+        }
+    }
+
+    function navigate_apps(ev) {
+        if (ev.keyCode === 13) // Enter
+            clickActiveItem();
+        else if (ev.keyCode === 40) // Arrow Down
+            focusNextItem("first-of-type", "nextSibling");
+        else if (ev.keyCode === 38) // Arrow Up
+            focusNextItem("last-of-type", "previousSibling");
+        else if (ev.keyCode === 27) { // Escape - clean selection
+            document.getElementById("filter-menus").value = "";
+            update_sidebar();
+            document.getElementById("filter-menus").focus();
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    function on_filter_menus_changed(ev) {
+        if (!navigate_apps(ev)) {
+            if (filter_timer)
+                window.clearTimeout(filter_timer);
+
+            filter_timer = window.setTimeout(function () {
+                if (document.getElementById("filter-menus") === document.activeElement)
+                    update_sidebar();
+                filter_timer = null;
+            }, 250);
+        }
+    }
+
+    document.getElementById("host-apps").addEventListener("keyup", navigate_apps);
+    document.getElementById("filter-menus").addEventListener("keyup", on_filter_menus_changed);
+    document.getElementById("filter-menus").addEventListener("change", on_filter_menus_changed);
 
     /* When the machine list is ready we start processing navigation */
     $(machines)
@@ -290,6 +354,18 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     }
 
     function update_sidebar(machine, state, compiled) {
+        if (!state)
+            state = index.retrieve_state();
+
+        if (!machine)
+            machine = machines.lookup(state.host);
+
+        if (!compiled)
+            compiled = compile(machine);
+
+        var term = document.getElementById("filter-menus").value
+                .toLowerCase();
+
         function links(component) {
             var active = state.component === component.path;
             var listItem;
@@ -308,6 +384,30 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                     return 'fa fa-info-circle';
             }
 
+            function mark_text(text, term) {
+                const b = text.toLowerCase().indexOf(term);
+                const e = b + term.length;
+                return (text.substring(0, b) + "<mark>" + text.substring(b, e) + "</mark>" + text.substring(e, text.length));
+            }
+
+            let label_text = document.createElement("span");
+            label_text.append(component.label);
+            // When this label was matched, we want to show why
+            if (component.keyword.keyword) {
+                const k = component.keyword.keyword;
+                if (k === component.label.toLowerCase()) {
+                    label_text.innerHTML = mark_text(component.label, term);
+                } else {
+                    const container = document.createElement("span");
+                    container.append(label_text);
+                    const contains = document.createElement("div");
+                    contains.className = "hint";
+                    contains.innerHTML = _("Contains") + ": " + mark_text(k, term);
+                    container.append(contains);
+                    label_text = container;
+                }
+            }
+
             if (status && status.type) {
                 label = $("<span>",
                           {
@@ -316,14 +416,23 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                           }).append(
                     $("<div class='pull-right'>").append(
                         $('<span>', { class: icon_class_for_type(status.type) })),
-                    component.label);
+                    label_text);
             } else
-                label = $("<span>").text(component.label);
+                label = label_text;
+
+            let path = component.path;
+            let hash = component.hash;
+            if (component.keyword.goto) {
+                if (component.keyword.goto[0] === "/")
+                    path = component.keyword.goto.substr(1);
+                else
+                    hash = component.keyword.goto;
+            }
 
             listItem = $("<li class='list-group-item'>")
                     .toggleClass("active", active)
                     .append($("<a>")
-                            .attr("href", index.href({ host: machine.address, component: component.path, hash: component.hash }))
+                            .attr("href", index.href({ host: machine.address, component: path, hash: hash }))
                             .append(label));
 
             if (active)
@@ -332,13 +441,90 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
             return listItem;
         }
 
-        var menu = compiled.ordered("menu").map(links);
+        function keyword_relevance(current_best, item) {
+            const translate = item.translate || false;
+            const weight = item.weight || 0;
+            let score;
+            let _m = "";
+            let best = { score: -1 };
+            item.matches.forEach(m => {
+                if (translate)
+                    _m = _(m);
+                score = -1;
+                // Best score when starts in translate language
+                if (translate && _m.indexOf(term) == 0)
+                    score = 4 + weight;
+                // Second best score when starts in English
+                else if (m.indexOf(term) == 0)
+                    score = 3 + weight;
+                // Substring consider only when at least 3 letters were used
+                else if (term.length >= 3) {
+                    if (translate && _m.indexOf(term) >= 0)
+                        score = 2 + weight;
+                    else if (m.indexOf(term) >= 0)
+                        score = 1 + weight;
+                }
+                if (score > best.score) {
+                    best = { keyword: m, score: score };
+                }
+            });
+            if (best.score > current_best.score) {
+                current_best = { keyword: best.keyword, score: best.score, goto: item.goto || null };
+            }
+            return current_best;
+        }
+
+        function keyword_filter(item) {
+            item.keyword = { score:-1 };
+            if (!term)
+                return true;
+            const best_keyword = item.keywords.reduce(keyword_relevance, { score:-1 });
+            if (best_keyword.score > -1) {
+                item.keyword = best_keyword;
+                return true;
+            }
+            return false;
+        }
+
+        var menu = compiled.ordered("menu")
+                .filter(keyword_filter)
+                .sort((a, b) => b.keyword.score - a.keyword.score)
+                .map(links);
         $("#sidebar-menu").empty()
                 .append(menu);
 
-        var tools = compiled.ordered("tools").map(links);
-        $("#sidebar-tools").empty()
-                .append(tools);
+        var tools = compiled.ordered("tools")
+                .filter(keyword_filter)
+                .sort((a, b) => { return b.keyword.score - a.keyword.score })
+                .map(links);
+        $("#sidebar-tools").empty();
+
+        if (term !== "") {
+            $("#sidebar-menu").append(tools);
+            const clear_button = document.createElement("button");
+            clear_button.textContent = _("Clear Search");
+            clear_button.className = "link-button hint";
+            clear_button.onclick = function() {
+                document.getElementById("filter-menus").value = "";
+                update_sidebar(machine, state, compiled);
+            };
+            const container = document.createElement("div");
+            container.className = "non-menu-item";
+            container.append(clear_button);
+            $("#sidebar-tools").append(container);
+        } else {
+            $("#sidebar-tools").append(tools);
+        }
+
+        if (!menu.length && !tools.length) {
+            const group = document.createElement("li");
+            group.className = "list-group-item disabled";
+            const text = document.createElement("span");
+            text.className = "non-menu-item";
+            text.append(document.createTextNode(_("No results found")));
+            group.append(text);
+            document.getElementById("sidebar-menu").innerHTML = group.outerHTML;
+        }
 
         $("#machine-avatar").attr("src", machine && machine.avatar ? encodeURI(machine.avatar)
             : "../shell/images/server-small.png");

--- a/pkg/shell/switcher.less
+++ b/pkg/shell/switcher.less
@@ -29,6 +29,40 @@
     z-index: 2;
     opacity: 1;
 
+    mark {
+        padding-left: 0;
+        padding-right: 0;
+        font-weight: bold;
+    }
+
+    > .search {
+        margin: 0.5rem 1rem;
+
+        > input {
+            border: none;
+        }
+
+        > span {
+            color: var(--color-subtle-copy);
+            margin: 0.5rem;
+        }
+
+        &:after {
+            content: "";
+            position: absolute;
+            margin: 0 0.5rem;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            height: 1px;
+            background: var(--color-border);
+        }
+    }
+
+    .hint {
+        font-size: var(--pf-global--FontSize--xs);
+    }
+
     .list-group {
         border: none;
         margin: 0.5rem 0;
@@ -46,6 +80,11 @@
                 left: 1.5rem;
             }
         }
+    }
+
+    .non-menu-item {
+        display: flex;
+        justify-content: center;
     }
 
     .list-group-item {
@@ -87,10 +126,20 @@
         }
     }
 
-    /* Fade start and end of the host menu to indicate more content is available */
+    .disabled {
+        color: var(--color-subtle-copy);
+        font-size: var(--pf-global--FontSize--sm);
 
-    &:before,
-    &:after {
+        &:focus,
+        &:hover {
+            background-color: initial;
+            cursor: default;
+        }
+    }
+
+    /* Fade end of the host menu to indicate more content is available */
+
+    &::after {
         content: '';
         display: block;
         position: absolute;
@@ -101,14 +150,6 @@
         z-index: 2;
         /* Accomodate scrollbars with margin (IE11 needs 18px; rest are less) */
         margin-right: 18px;
-    }
-
-    &:before {
-        background: var(--color-ct-nav-cover-up);
-        top: 4rem; // Move down by the same size as the dropdown
-    }
-
-    &:after {
         background: var(--color-ct-nav-cover-down);
         bottom: 0;
         height: 4rem;

--- a/pkg/sosreport/manifest.json.in
+++ b/pkg/sosreport/manifest.json.in
@@ -6,7 +6,12 @@
 
     "tools": {
         "index": {
-            "label": "Diagnostic Reports"
+            "label": "Diagnostic Reports",
+            "keywords": [
+                {
+                    "matches": ["sos"]
+                }
+            ]
         }
     }
 }

--- a/pkg/storaged/manifest.json.in
+++ b/pkg/storaged/manifest.json.in
@@ -8,7 +8,12 @@
     "menu": {
         "index": {
             "label": "Storage",
-            "order": 30
+            "order": 30,
+            "keywords": [
+                {
+                    "matches": ["filesystem", "nfs", "raid", "volume", "disk", "vdo", "iscsi", "drive", "mount", "unmount", "udisks", "mkfs", "format", "fstab"]
+                }
+            ]
         }
     },
 

--- a/pkg/systemd/manifest.json.in
+++ b/pkg/systemd/manifest.json.in
@@ -9,21 +9,53 @@
     "menu": {
         "index": {
             "label": "System",
-            "order": 10
+            "order": 10,
+            "keywords": [
+                {
+                    "matches": ["time", "date", "restart", "shut", "domain", "machine", "operating system", "os", "asset tag", "ssh", "power", "version", "host"]
+                },
+                {
+                    "matches": ["hardware", "mitigation", "pci", "memory", "cpu", "bios", "ram", "dimm", "serial"],
+                    "goto": "/system/hwinfo"
+                }
+            ]
         },
         "services": {
             "label": "Services",
-            "order": 100
+            "order": 100,
+            "keywords": [
+                {
+                    "matches": ["service", "systemd", "target", "socket", "timer", "path", "unit", "systemctl"]
+                },
+                {
+                    "matches": ["boot", "mask", "unmask", "restart", "enable", "disable"],
+                    "weight": 1
+                }
+            ]
         },
         "logs": {
             "label": "Logs",
-            "order": 20
+            "order": 20,
+            "keywords": [
+                {
+                    "matches": ["journal", "warning", "error", "debug"]
+                },
+                {
+                    "matches": ["abrt", "crash", "coredump"],
+                    "goto": "?tag=abrt-notification"
+                }
+            ]
         }
     },
 
     "tools": {
         "terminal": {
-            "label": "Terminal"
+            "label": "Terminal",
+            "keywords": [
+                {
+                    "matches": ["console", "command", "bash", "shell"]
+                }
+            ]
         }
     },
 

--- a/pkg/users/manifest.json.in
+++ b/pkg/users/manifest.json.in
@@ -7,7 +7,12 @@
     "menu": {
         "index": {
             "label": "Accounts",
-            "order": 70
+            "order": 70,
+            "keywords": [
+                {
+                    "matches": ["user", "password", "useradd", "passwd", "username", "login", "access", "roles", "ssh", "keys"]
+                }
+            ]
         }
     }
 }

--- a/po/manifest2po
+++ b/po/manifest2po
@@ -95,6 +95,17 @@ function process_manifest(manifest) {
         process_menu(manifest.tools);
 }
 
+function process_keywords(keywords) {
+    keywords.forEach(v => {
+        v.matches.forEach(keyword =>
+            push({
+                msgid: keyword,
+                locations: [ filename ]
+            })
+        );
+    });
+}
+
 function process_menu(menu) {
     for (var m in menu) {
         if (menu[m].label) {
@@ -103,6 +114,8 @@ function process_menu(menu) {
                 locations: [ filename ]
             });
         }
+        if (menu[m].keywords)
+            process_keywords(menu[m].keywords);
     }
 }
 

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -401,6 +401,118 @@ OnCalendar=daily
 
         self.allow_restart_journal_messages()
 
+    @skipImage("Searching implemented in #12579", "rhel-8-1-distropkg")
+    def testMenuSearch(self):
+        b = self.browser
+        m = self.machine
+
+        # On Ubuntu and Debian we would need to generate locales - just ignore it
+        self.allow_journal_messages("invalid or unusable locale: de_DE.UTF-8")
+
+        self.login_and_go()
+
+        # Check that some page disappears and some stay
+        b.focus("#filter-menus")
+        b.set_val("#filter-menus", "se")
+        b.wait_not_present("#sidebar-menu > li > a > span:contains('Logs')")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Services')")
+        b.wait_text("#sidebar-menu > li > a > span:contains('Services') mark", "Se")
+
+        b.focus("#filter-menus")
+        b.set_val("#filter-menus", "")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Logs')")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Services')")
+
+        # Check that any substring work
+        b.focus("#filter-menus")
+        b.set_val("#filter-menus", "CoUN")
+        b.wait_not_present("#sidebar-menu > li > a > span:contains('System')")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Accounts')")
+        b.wait_text("#sidebar-menu > li > a > span:contains('Accounts') mark", "coun")
+
+        # Check it can also search by keywords
+        b.focus("#filter-menus")
+        b.set_val("#filter-menus", "systemd")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Services')")
+        b.wait_text("#sidebar-menu > li > a > span:contains('Services')", "ServicesContains: systemd")
+        b.wait_text("#sidebar-menu > li > a > span:contains('Services') div mark", "systemd")
+
+        # Check that enter activates first result
+        b.focus("#filter-menus")
+        b.set_val("#filter-menus", "logs")
+        b.wait_not_present("#sidebar-menu > li > a > span:contains('Services')")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Logs')")
+        b.focus("#filter-menus")
+        b.key_press("\r")
+        b.enter_page("/system/logs")
+        b.wait_visible("#journal")
+
+        # Visited page, search should be cleaned up
+        b.switch_to_top()
+        b.wait_val("#filter-menus", "")
+
+        # Check that escape cleans the search
+        b.set_val("#filter-menus", "logs")
+        b.wait_not_present("#sidebar-menu > li > a > span:contains('Services')")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Logs')")
+        b.focus("#filter-menus")
+        b.key_press(chr(27)) # escape
+        b.wait_val("#filter-menus", "")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Services')")
+
+        # Check that clicking on `Clear Search` cleans the search
+        b.set_val("#filter-menus", "logs")
+        b.wait_not_present("#sidebar-menu > li > a > span:contains('Services')")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Logs')")
+        b.click("button:contains('Clear Search')")
+        b.wait_val("#filter-menus", "")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Services')")
+        b.wait_not_present("button:contains('Clear Search')")
+
+        # Check that arrows navigate the menu
+        b.focus("#filter-menus")
+        b.set_val("#filter-menus", "s")
+        b.wait_not_present("#sidebar-menu > li > a > span:contains('Logs')")
+        b.key_press(chr(40), use_ord=True) # arrow down
+        b.key_press(chr(40), use_ord=True) # arrow down
+        b.key_press("\r")
+        if (m.image == "fedora-atomic"):
+            b.enter_page("/users")
+        else:
+            b.enter_page("/storage")
+
+        # Check we jump into subpage when defined in manifest
+        b.switch_to_top()
+        b.focus("#filter-menus")
+        b.set_val("#filter-menus", "firew")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Networking')")
+        b.wait_not_present("#sidebar-menu > li > a > span:contains('System')")
+        b.click("#sidebar-menu > li > a > span:contains('Networking')")
+        b.enter_page("/network/firewall")
+
+        # Search internationalized menu
+        b.switch_to_top()
+        b.click("#content-user-name")
+        b.click(".display-language-menu a")
+        b.wait_popup('display-language')
+        b.set_val("#display-language select", "de-de")
+        b.click("#display-language-select-button")
+        b.expect_load()
+        # HACK: work around language switching in Chrome not working in current session (issue #8160)
+        b.reload(ignore_cache=True)
+        b.wait_present("#content")
+        b.go("/system")
+        b.enter_page("/system")
+        b.wait_in_text("#server", "Neustarten")
+
+        b.switch_to_top()
+        b.wait_present("#sidebar-menu > li > a > span:contains('Dienste')")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Protokolle')")
+        b.set_val("#filter-menus", "dien")
+        b.wait_not_present("#sidebar-menu > li > a > span:contains('Protokolle')")
+        b.wait_present("#sidebar-menu > li > a > span:contains('Dienste')")
+        b.wait_text("#sidebar-menu > li > a > span:contains('Dienste') mark", "Dien")
+
     @skipImage("Preloading implemented in #12534", "rhel-8-1-distropkg")
     def testShellPreload(self):
         b = self.browser


### PR DESCRIPTION
Uses page name and keywords to search. Later on pages will also provide what they contain (like names of services or names of users). Also works with translated pages names and translated keywords. Navigable with arrows, possible to visit page with enter and clean the search with escape.

![general](https://user-images.githubusercontent.com/12330670/65314709-217e9800-db97-11e9-8e6f-8831b588599c.png)

TODOs:
- [x] Case insensitive
- [x] Only search substrings when term longer than 2 characters
- [x] Keep track of relevance
- [x] Show why something matches
- [x] Keyboard navigation
- [x] improve the no string language
- [x] Write proper keywords for every page
- [x] tests
- [x] document `keywords` in manifest
- [x] Jump to subpages directly
- [x] Usability review
- [ ] Design review

Followups:
- [ ] Use also info from pages - Can be found [here](https://github.com/marusak/cockpit/tree/keywords_with_service)
- [ ] hotkey for searching
