### PR TITLE
shell: Page status notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bootstrap-datepicker": "1.9.0",
     "c3": "0.4.23",
     "d3": "3.5.17",
+    "deep-equal": "1.0.1",
     "jquery": "3.4.1",
     "jquery-flot": "0.8.3",
     "js-sha1": "0.6.0",

--- a/pkg/lib/notifications.js
+++ b/pkg/lib/notifications.js
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* NOTIFICATIONS
+
+A page can broadcast notifications to the rest of Cockpit.  For
+example, the "Software Updates" page can send out a notification when
+it detects that software updates are available.  The shell will then
+highlight the menu entry for "Software Updates" and the "System"
+overview page will also mention it in its "Operating System" section.
+
+The details are all still experimental and subject to change.
+
+As a first step, there are only simple "page status" notifications.
+When we address "event" style notifications, page status notifications
+might become a special case of them.  Or not.
+
+A page status is either null, or a JSON value with the following
+fields:
+
+ - type (string, optional)
+
+ If specified, one of "info", "warning", "error".  The shell will put
+ an appropriate icon next to the navigation entry for this page, for
+ example.
+
+ Omitting 'type' means that the page has no special status and is the
+ same as using "null" as the whole status value.  This can be used to
+ broadcast values in the 'details' field to other pages without
+ forcing an icon into the navigation menu.
+
+ - title (string, optional)
+
+ A short, human readable, localized description of the status,
+ suitable for a tooltip.
+
+ - details (JSON value, optional)
+
+ An arbitrary value.  The "System" overview page might monitor a
+ couple of pages for their status and it will use 'details' to display
+ a richer version of the status than possible with just type and
+ title.
+
+Usage:
+
+ import { page_status } from "notifications";
+
+ - page_status.set_own(STATUS)
+
+ Sets the status of the page making the call, completely overwriting
+ the current status.  For example,
+
+    page_status.set_own({
+      type: "info",
+      title: _("Software updates available"),
+      details: {
+        num_updates: 10,
+        num_security_updates: 5
+      }
+    });
+
+    page_status.set_own({
+      type: null
+      title: _("System is up to date"),
+      details: {
+        last_check: 81236457
+      }
+    });
+
+ Calling this function with the same STATUS value multiple times is
+ cheap: only the first call will actually broadcast the new status.
+
+ - page_status.get(PAGE, [HOST])
+
+ Retrieves the current status of page PAGE of HOST.  When HOST is
+ omitted, it defaults to the default host of the calling page.
+
+ PAGE is the same string that Cockpit uses in its URLs to identify a
+ page, such as "system/terminal" or "storage".
+
+ Until the page_status object is fully initialized (see 'valid'
+ below), this function will return 'undefined'.
+
+ - page_status.addEventListener("changed", event => { ... })
+
+ The "changed" event is emitted whenever any page status changes.
+
+ - page_status.valid
+
+ The page_status objects needs to initialize itself asynchronously and
+ 'valid' is false until this is done.  When 'valid' changes to true, a
+ "changed" event is emitted.
+
+*/
+
+import cockpit from "cockpit";
+import deep_equal from "deep-equal";
+
+class PageStatus {
+    constructor() {
+        cockpit.event_target(this);
+        window.addEventListener("storage", event => {
+            if (event.key == "cockpit:page_status") {
+                this.dispatchEvent("changed");
+            }
+        });
+
+        this.cur_own = null;
+
+        this.valid = false;
+        cockpit.transport.wait(() => {
+            this.valid = true;
+            this.dispatchEvent("changed");
+        });
+    }
+
+    get(page, host) {
+        let page_status;
+
+        if (!this.valid)
+            return undefined;
+
+        if (host === undefined)
+            host = cockpit.transport.host;
+
+        try {
+            page_status = JSON.parse(sessionStorage.getItem("cockpit:page_status"));
+        } catch {
+            return null;
+        }
+
+        if (page_status && page_status[host])
+            return page_status[host][page] || null;
+        return null;
+    }
+
+    set_own(status) {
+        if (!deep_equal(status, this.cur_own)) {
+            this.cur_own = status;
+            cockpit.transport.control("notify", { page_status: status });
+        }
+    }
+}
+
+export const page_status = new PageStatus();

--- a/pkg/playground/manifest.json.in
+++ b/pkg/playground/manifest.json.in
@@ -23,6 +23,12 @@
         },
         "preloaded": {
             "label": "Preloaded"
+        },
+        "notifications": {
+            "label": "Notifications"
+        },
+        "notifications-receiver": {
+            "label": "Notifications Receiver"
         }
     },
     "preload": [ "preloaded" ],

--- a/pkg/playground/notifications-receiver.html
+++ b/pkg/playground/notifications-receiver.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Notifications Receiver</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="../base1/cockpit.js"></script>
+    <script src="notifications-receiver.js"></script>
+</head>
+
+<body>
+  <h1>Notifications Receiver</h1>
+
+  <span id="received-type"></span> / <span id="received-title"></span>
+
+</body>
+
+</html>

--- a/pkg/playground/notifications-receiver.js
+++ b/pkg/playground/notifications-receiver.js
@@ -1,0 +1,24 @@
+import { page_status } from "notifications";
+
+function id(sel) {
+    return document.getElementById(sel);
+}
+
+function update() {
+    const status = page_status.get("playground/notifications");
+
+    if (status) {
+        id("received-type").innerText = status.type;
+        id("received-title").innerText = status.title;
+    } else if (status !== undefined) {
+        id("received-type").innerText = "-";
+        id("received-title").innerText = "-";
+    }
+}
+
+function init () {
+    page_status.addEventListener("changed", update);
+    update();
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/pkg/playground/notifications.html
+++ b/pkg/playground/notifications.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Notifications</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="../base1/cockpit.js"></script>
+    <script src="notifications.js"></script>
+</head>
+
+<body>
+  <h1>Notifications</h1>
+
+  <label>Type <input id="type"></label>
+  <label>Title <input id="title"></label>
+  <button id="set-status">Set Page Status</button>
+  <button id="clear-status">Clear Page Status</button>
+</body>
+
+</html>

--- a/pkg/playground/notifications.js
+++ b/pkg/playground/notifications.js
@@ -1,0 +1,19 @@
+import cockpit from "cockpit";
+import { page_status } from "notifications";
+
+function id(sel) {
+    return document.getElementById(sel);
+}
+
+function init () {
+    id("set-status").onclick = event => {
+        page_status.set_own({ type: id("type").value, title: id("title").value });
+    };
+
+    id("clear-status").onclick = event => {
+        page_status.set_own(null);
+    };
+}
+
+cockpit.transport.wait(() => true);
+document.addEventListener("DOMContentLoaded", init);

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -302,11 +302,14 @@ function Router(index) {
     }
 
     function register(child) {
-        var host;
+        var host, page;
         var name = child.name || "";
-        if (name.indexOf("cockpit1:") === 0)
-            host = name.substring(9).split("/")[0];
-        if (!name || !host) {
+        if (name.indexOf("cockpit1:") === 0) {
+            var parts = name.substring(9).split("/");
+            host = parts[0];
+            page = parts.slice(1).join("/");
+        }
+        if (!name || !host || !page) {
             console.warn("invalid child window name", child, name);
             return;
         }
@@ -318,6 +321,7 @@ function Router(index) {
             window: child,
             channel_seed: seed,
             default_host: host,
+            page: page,
             inited: false,
         };
         source_by_seed[seed] = source;
@@ -422,6 +426,9 @@ function Router(index) {
                 return;
             } else if (control.command == "oops") {
                 index.show_oops();
+                return;
+            } else if (control.command == "notify") {
+                index.handle_notifications(source.default_host, source.page, control);
                 return;
 
             /* Only control messages with a channel are forwardable */

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -986,3 +986,15 @@ It is less bad than using !important, at least.
         }
     }
 }
+
+#host-apps .fa-info-circle {
+    color: var(--pf-global--info-color--100);
+}
+
+#host-apps .fa-exclamation-triangle {
+    color: var(--pf-global--warning-color--100);
+}
+
+#host-apps .fa-exclamation-circle {
+    color: var(--pf-global--danger-color--100);
+}

--- a/src/base1/test-http.js
+++ b/src/base1/test-http.js
@@ -49,6 +49,12 @@ QUnit.test("simple request", function (assert) {
                         },
                         preloaded: {
                             label: "Preloaded"
+                        },
+                        notifications: {
+                            label: "Notifications"
+                        },
+                        'notifications-receiver': {
+                            label: "Notifications Receiver"
                         }
                     },
                     preload: ["preloaded"],

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -544,6 +544,37 @@ OnCalendar=daily
         mem_used = meminfo['MemTotal'] - meminfo['MemAvailable']
         b.wait_js_func("ph_flot_data_plateau", "#plot_pmcd", mem_used * 0.95, mem_used * 1.05, 15, "mem")
 
+    @skipImage("Implemented in #12598", "rhel-8-0-distropkg")
+    def testPageStatus(self):
+        b = self.browser
+
+        self.login_and_go("/playground/notifications")
+
+        b.set_input_text("#type", "info")
+        b.set_input_text("#title", "My Little Page Status")
+        b.click("#set-status")
+
+        b.switch_to_top()
+        b.wait_present("#host-apps a[href='/playground/notifications'] span.fa-info-circle")
+        b.wait_present("#host-apps a[href='/playground/notifications'] span[title='My Little Page Status']")
+
+        b.click("#host-apps a[href='/playground/notifications-receiver']")
+        b.enter_page("/playground/notifications-receiver")
+        b.wait_text("#received-type", "info")
+        b.wait_text("#received-title", "My Little Page Status")
+
+        b.switch_to_top()
+        b.click("#host-apps a[href='/playground/notifications']")
+        b.enter_page("/playground/notifications")
+        b.click("#clear-status")
+
+        b.switch_to_top()
+        b.wait_not_present("#host-apps a[href='/playground/notifications'] span.fa")
+
+        b.click("#host-apps a[href='/playground/notifications-receiver']")
+        b.enter_page("/playground/notifications-receiver")
+        b.wait_text("#received-type", "-")
+        b.wait_text("#received-title", "-")
 
 if __name__ == '__main__':
     test_main()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,12 @@ var info = {
         "playground/preloaded": [
             "playground/preloaded.js",
         ],
+        "playground/notifications": [
+            "playground/notifications.js",
+        ],
+        "playground/notifications-receiver": [
+            "playground/notifications-receiver.js",
+        ],
 
         "realmd/domain": [
             "realmd/operation.js",
@@ -182,6 +188,8 @@ var info = {
         "playground/test.html",
         "playground/translate.html",
         "playground/preloaded.html",
+        "playground/notifications.html",
+        "playground/notifications-receiver.html",
 
         "selinux/setroubleshoot.html",
 


### PR DESCRIPTION
- [x] Tests
- [x] API docs

Enhancements:
- [x] A page status type that does not result in an icon in the navigation section.  For example, "System is up to date" is a useful page status for /updates, but we don't need an icon for that.
- [x] The API should catch setting a page status that doesn't actually change anything, and not send an actual message to the shell. This will allow pages to just 'render' their page status, when rendering their top React component.
