### PR TITLE
hwinfo: Never show 'undefined' in HW field

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -750,7 +750,16 @@ PageServer.prototype = {
         hardware_text.tooltip({ title: _("Click to see system hardware information"), placement: "bottom" });
         machine_info.dmi_info()
                 .done(function(fields) {
-                    hardware_text.text(fields.sys_vendor + " " + fields.product_name);
+                    let vendor = fields.sys_vendor;
+                    let name = fields.product_name;
+                    if (!vendor || !name) {
+                        vendor = fields.board_vendor;
+                        name = fields.board_name;
+                    }
+                    if (!vendor || !name)
+                        hardware_text.text(_("Details"));
+                    else
+                        hardware_text.text(vendor + " " + name);
                     var present = !!(fields.product_serial || fields.chassis_serial);
                     asset_tag_text.text(fields.product_serial || fields.chassis_serial);
                     asset_tag_text.toggle(present);

--- a/pkg/systemd/hw-detect.js
+++ b/pkg/systemd/hw-detect.js
@@ -23,6 +23,8 @@ import * as machine_info from "machine-info.js";
 const InfoDMIKey = {
     version: "product_version",
     name: "product_name",
+    alt_version: "board_vendor",
+    alt_name: "board_name",
     type: "chassis_type_str",
     bios_vendor: "bios_vendor",
     bios_version: "bios_version",

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -57,6 +57,10 @@ class SystemInfo extends React.Component {
 
     render() {
         let info = this.props.info;
+        if ((!info.name || !info.version) && info.alt_name && info.alt_version) {
+            info.name = info.alt_name;
+            info.version = info.alt_version;
+        }
         let onSecurityClick = this.props.onSecurityClick;
 
         let mitigations = this.state.allowed ? (<a role="link" onClick={onSecurityClick}>{ _("Mitigations") }</a>)

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -436,7 +436,7 @@ class TestSystemInfo(MachineCase):
             return
 
         b.logout()
-        self.machine.execute("mount -t tmpfs none /sys/class/dmi")
+        self.machine.execute("mount -t tmpfs none /sys/class/dmi/id")
         self.login_and_go("/system")
         b.wait_present('#system_information_hardware_text')
         # asset tag should be hidden
@@ -455,7 +455,22 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text(pci_selector + heading_selector, "PCI")
         b.wait_in_text(pci_selector + ' .listing-ct', "0000:00:00.0")
 
-        self.machine.execute("umount /sys/class/dmi")
+        # Check also variants when only some fields are present
+        m.write("/sys/class/dmi/id/chassis_type", "10")
+        b.go("/system")
+        b.enter_page('/system')
+        b.wait_text('#system_information_hardware_text', "Details")
+
+        m.write("/sys/class/dmi/id/board_vendor", "VENDOR")
+        m.write("/sys/class/dmi/id/board_name", "NAME")
+        b.reload()
+        b.enter_page('/system')
+        b.wait_in_text('#system_information_hardware_text', "VENDOR NAME")
+        b.click("#system_information_hardware_text")
+        b.enter_page("/system/hwinfo")
+        b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(1) tr:nth-of-type(2) td', "NAME")
+        b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(1) tr:nth-of-type(3) td', "VENDOR")
+        self.machine.execute("umount /sys/class/dmi/id")
 
         # Memory details should be shown for generic QEMU memory
         # demidecode not available on certain images


### PR DESCRIPTION
When `sys_vendor` is undefined try `board_vendor`.
When `product_name` is undefined try `board_name`.
When either of vendor or name is not defined by neither of those
options, then just show `Details`.

Fixes #12593