### PR TITLE
 systemd: Highlight failed services

### DIFF
--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -431,3 +431,15 @@ body {
     margin: 0px;
     white-space: pre-wrap;
 }
+
+.fa-info-circle {
+    color: var(--pf-global--info-color--100);
+}
+
+.fa-exclamation-triangle {
+    color: var(--pf-global--warning-color--100);
+}
+
+.fa-exclamation-circle {
+    color: var(--pf-global--danger-color--100);
+}

--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -33,6 +33,8 @@ import * as service from "service.js";
 import { shutdown } from "./shutdown.js";
 import host_keys_script from "raw-loader!./ssh-list-host-keys.sh";
 
+import { PageStatusNotifications } from "./page-status.jsx";
+
 import "form-layout.less";
 
 /* These add themselves to jQuery so just including is enough */
@@ -569,6 +571,13 @@ PageServer.prototype = {
         // Only link from graphs to available pages
         set_page_link("#link-disk", "storage", _("Disk I/O"));
         set_page_link("#link-network", "network", _("Network Traffic"));
+
+        function toggle_health_label(visible) {
+            $('label[for="page_status_notifications"]').toggle(visible);
+        }
+
+        ReactDOM.render(React.createElement(PageStatusNotifications, { toggle_label: toggle_health_label }),
+                        document.getElementById('page_status_notifications'));
     },
 
     enter: function() {

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -160,6 +160,10 @@
                     <span class="pficon pficon-info"></span>
                     <span translate>Enable stored metrics…</span>
                 </a>
+
+                <label class="control-label" for="page_status_notifications" translatable="yes">System Health</label>
+                <div id="page_status_notifications">
+                </div>
             </form>
         </div>
 

--- a/pkg/systemd/manifest.json.in
+++ b/pkg/systemd/manifest.json.in
@@ -27,7 +27,7 @@
         }
     },
 
-    "preload": [ "index" ],
+    "preload": [ "index", "services" ],
 
     "content-security-policy": "img-src 'self' data:"
 }

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+
+import React from "react";
+import { page_status } from "notifications";
+
+function icon_class_for_type(type) {
+    if (type == "error")
+        return 'fa fa-exclamation-circle';
+    else if (type == "warning")
+        return 'fa fa-exclamation-triangle';
+    else
+        return 'fa fa-info-circle';
+}
+
+export class PageStatusNotifications extends React.Component {
+    constructor() {
+        super();
+        this.state = { };
+        this.on_page_status_changed = () => this.setState({ });
+    }
+
+    componentDidMount() {
+        page_status.addEventListener("changed", this.on_page_status_changed);
+    }
+
+    componentWillUnmount() {
+        page_status.removeEventListener("changed", this.on_page_status_changed);
+    }
+
+    render() {
+        // Just this one for now
+        const page = "system/services";
+        const status = page_status.get(page);
+        if (status && status.type && status.title) {
+            this.props.toggle_label(true);
+            const jump = () => cockpit.jump("/" + page);
+            return (
+                <span>
+                    <span className={icon_class_for_type(status.type)} /> <a onClick={jump}>{status.title}</a>
+                </span>);
+        } else {
+            this.props.toggle_label(false);
+            return null;
+        }
+    }
+}

--- a/pkg/systemd/services.css
+++ b/pkg/systemd/services.css
@@ -211,3 +211,7 @@ table.systemd-unit-relationship-table td:first-child {
 .service-unit-description {
   width: 40%;
 }
+
+.fa-exclamation-triangle {
+    color: var(--pf-global--warning-color--100);
+}

--- a/pkg/systemd/services.jsx
+++ b/pkg/systemd/services.jsx
@@ -33,13 +33,22 @@ const _ = cockpit.gettext;
  */
 export class ServiceTabs extends React.Component {
     render() {
+        const { warnings } = this.props;
+
+        function title(label, tag) {
+            if (warnings[tag])
+                return <span>{label} <span className="fa fa-exclamation-triangle" /></span>;
+            else
+                return label;
+        }
+
         return (
             <Tabs defaultActiveKey=".service$" id="service-tabs" onSelect={this.props.onChange}>
-                <Tab eventKey=".service$" title={ _("System Services") } />
-                <Tab eventKey=".target$" title={ _("Targets") } />
-                <Tab eventKey=".socket$" title={ _("Sockets") } />
-                <Tab eventKey=".timer$" title={ _("Timers") } />
-                <Tab eventKey=".path$" title={ _("Paths") } />
+                <Tab eventKey=".service$" title={ title(_("System Services"), "service") } />
+                <Tab eventKey=".target$" title={ title(_("Targets"), "target") } />
+                <Tab eventKey=".socket$" title={ title(_("Sockets"), "socket") } />
+                <Tab eventKey=".timer$" title={ title(_("Timers"), "timer") } />
+                <Tab eventKey=".path$" title={ title(_("Paths"), "path") } />
             </Tabs>
         );
     }

--- a/test/verify/check-active-pages
+++ b/test/verify/check-active-pages
@@ -30,10 +30,11 @@ class TestActivePages(MachineCase):
         self.login_and_go("/system")
 
         # Preloading of playground/preloaded only happens with #12534
-        if m.image in [ "rhel-8-0-distropkg" ]:
+        if m.image in [ "rhel-8-1-distropkg" ]:
             n_extra_preloaded = 0
         else:
-            n_extra_preloaded = 1
+            # playground/preloaded and system/services
+            n_extra_preloaded = 2
 
         b.wait_present("#server")
 

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -836,6 +836,68 @@ WantedBy=default.target
         b.click(".modal-dialog .btn-danger")
         self.check_service_details(["Masked"], ["Allow running (unmask)"], False, onoff=False)
 
+    @skipImage("Implemented in #12585", "rhel-8-1-distropkg")
+    def testNotifyFailed(self):
+        m = self.machine
+        b = self.browser
+
+        m.write("/etc/systemd/system/test-fail.service",
+                """
+[Unit]
+Description=Failing Test Service
+
+[Service]
+ExecStart=/usr/bin/false
+""")
+
+        m.execute("systemctl daemon-reload")
+        self.machine.execute("systemctl start default.target")
+        self.machine.execute("systemctl reset-failed")
+
+        self.login_and_go("/system/services")
+
+        def svc_sel(service):
+            return 'tr[data-goto-unit="%s"]' % service
+
+        # Start test-fail
+        m.execute("systemctl start test-fail")
+
+        # Test-fail should be at the top, and have failed
+        b.wait_present('tr:nth-child(1)[data-goto-unit="test-fail.service"]')
+        b.wait_present('tr[data-goto-unit="test-fail.service"] td:contains("failed")')
+
+        # Services tab should have icon
+        b.wait_present('a:contains("System Services") .fa-exclamation-triangle')
+
+        # Nav link should have icon
+        b.switch_to_top()
+        b.wait_present('a[href="/system/services"] .fa-exclamation-triangle')
+
+        # System page should have notification
+        b.click('#host-apps a[href="/system"]')
+        b.enter_page('/system')
+        b.wait_present('#page_status_notifications:contains("1 service has failed")')
+
+        # Clear test-fail
+        m.execute("systemctl reset-failed test-fail")
+
+        # Test-fail should not be at the top
+        b.switch_to_top()
+        b.click('#host-apps a[href="/system/services"]')
+        b.enter_page('/system/services')
+        b.wait_not_present('tr:nth-child(1)[data-goto-unit="test-fail.service"]')
+
+        # Services tab should not have icon
+        b.wait_not_present('a:contains("System Services") .fa-exclamation-triangle')
+
+        # Nav link should not have icon
+        b.switch_to_top()
+        b.wait_not_present('a[href="/system/services"] .fa-exclamation-triangle')
+
+        # System page should not have notification
+        b.click('#host-apps a[href="/system"]')
+        b.enter_page('/system')
+        b.wait_not_present('#page_status_notifications:contains("1 service has failed")')
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
 - Move them to the top of the list.
 - Put a warning icon into section header when it has a failed unit.
 - List them on the host overview page.
 - Set the page status to "warning" if there are failed units.

Screenshot:
![image](https://user-images.githubusercontent.com/3228183/64942112-e74c8800-d870-11e9-9720-7a663e86231a.png)
