### PR TITLE
eslintrc: Set "root" to true

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "browser": true,
         "es6": true

--- a/bots/README.md
+++ b/bots/README.md
@@ -44,6 +44,13 @@ tests-scan tool:
 
     $ bots/tests-scan -vd
 
+#### Note on eslintrc interaction
+
+As eslint looks for additional configurations, eslintrc.(json|yaml) files, in
+parent directories, it is recommended to have `"root": true` in the eslint
+configuration of any project which is using eslint and is tested through
+cockpit-bots.
+
 ## Integration with GitHub
 
 A number of machines are watching our GitHub repository and are


### PR DESCRIPTION
Eslint shimmies up directories looking for more eslintrcs. As
make-checkout now clones projects in a subdirectory, this can result in
some strange interactions.

Each subproject using eslint should enable this as well.

https://eslint.org/docs/user-guide/configuring