### PR TITLE
po: Fix file reading in manifest2po

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 08:58+0200\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "PO-Revision-Date: 2018-05-03 04:56+0000\n"
 "Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
 "Language-Team: Catalan\n"
 "Language: ca\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -49,7 +49,7 @@ msgid_plural "$0 Packages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/init.js:395 pkg/systemd/init.js:749
+#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "Plantilla $0"
 
@@ -128,10 +128,10 @@ msgstr ""
 "ho, cerqueu-ho a GNOME Software o executeu el següent:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
-#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
+#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
+#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr ""
 
@@ -143,7 +143,7 @@ msgstr ""
 msgid "$0 killed with signal $1"
 msgstr "$0 es va matar amb el senyal $1"
 
-#: pkg/selinux/setroubleshoot-view.jsx:429
+#: pkg/selinux/setroubleshoot-view.jsx:439
 msgid "$0 occurrence"
 msgid_plural "$1 occurrences"
 msgstr[0] "$0 ocurrència"
@@ -185,7 +185,7 @@ msgid_plural "$1 security fixes"
 msgstr[0] "$1 correcció de seguretat"
 msgstr[1] "$1 correccions de seguretat"
 
-#: pkg/networkmanager/interfaces.js:2757
+#: pkg/networkmanager/interfaces.js:2769
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -201,11 +201,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${desc} de ${size}"
 
-#: pkg/networkmanager/firewall.jsx:549
+#: pkg/networkmanager/firewall.jsx:574
 msgid "(Optional)"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
+#: pkg/networkmanager/firewall.jsx:499 pkg/networkmanager/firewall.jsx:648
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(predeterminat)"
@@ -244,7 +244,7 @@ msgstr "1 dia"
 msgid "1 hour"
 msgstr "1 hora"
 
-#: pkg/systemd/host.js:1669
+#: pkg/systemd/host.js:1686
 msgid "1 min"
 msgstr "1 min"
 
@@ -254,11 +254,11 @@ msgstr "1 min"
 msgid "1 week"
 msgstr "1 setmana"
 
-#: pkg/systemd/services.html:273
+#: pkg/systemd/services.html:165
 msgid "10th"
 msgstr "10è"
 
-#: pkg/systemd/services.html:274
+#: pkg/systemd/services.html:166
 msgid "11th"
 msgstr "11è"
 
@@ -266,19 +266,19 @@ msgstr "11è"
 msgid "128 KiB"
 msgstr "128 KiB"
 
-#: pkg/systemd/services.html:275
+#: pkg/systemd/services.html:167
 msgid "12th"
 msgstr "12è"
 
-#: pkg/systemd/services.html:276
+#: pkg/systemd/services.html:168
 msgid "13th"
 msgstr "13è"
 
-#: pkg/systemd/services.html:277
+#: pkg/systemd/services.html:169
 msgid "14th"
 msgstr "14è"
 
-#: pkg/systemd/services.html:278
+#: pkg/systemd/services.html:170
 msgid "15th"
 msgstr "15è"
 
@@ -286,23 +286,23 @@ msgstr "15è"
 msgid "16 KiB"
 msgstr "16 KiB"
 
-#: pkg/systemd/services.html:279
+#: pkg/systemd/services.html:171
 msgid "16th"
 msgstr "16è"
 
-#: pkg/systemd/services.html:280
+#: pkg/systemd/services.html:172
 msgid "17th"
 msgstr "17è"
 
-#: pkg/systemd/services.html:281
+#: pkg/systemd/services.html:173
 msgid "18th"
 msgstr "18è"
 
-#: pkg/systemd/services.html:282
+#: pkg/systemd/services.html:174
 msgid "19th"
 msgstr "19è"
 
-#: pkg/systemd/services.html:264
+#: pkg/systemd/services.html:156
 msgid "1st"
 msgstr "1r"
 
@@ -310,7 +310,7 @@ msgstr "1r"
 msgid "2 MiB"
 msgstr "2 MiB"
 
-#: pkg/systemd/host.js:1668
+#: pkg/systemd/host.js:1685
 msgid "2 min"
 msgstr "2 min"
 
@@ -318,59 +318,59 @@ msgstr "2 min"
 msgid "20 Minutes"
 msgstr "20 minuts"
 
-#: pkg/systemd/services.html:283
+#: pkg/systemd/services.html:175
 msgid "20th"
 msgstr "20è"
 
-#: pkg/systemd/services.html:284
+#: pkg/systemd/services.html:176
 msgid "21st"
 msgstr "21è"
 
-#: pkg/systemd/services.html:285
+#: pkg/systemd/services.html:177
 msgid "22nd"
 msgstr "22è"
 
-#: pkg/systemd/services.html:286
+#: pkg/systemd/services.html:178
 msgid "23rd"
 msgstr "23è"
 
-#: pkg/systemd/services.html:287
+#: pkg/systemd/services.html:179
 msgid "24th"
 msgstr "24è"
 
-#: pkg/systemd/services.html:288
+#: pkg/systemd/services.html:180
 msgid "25th"
 msgstr "25è"
 
-#: pkg/systemd/services.html:289
+#: pkg/systemd/services.html:181
 msgid "26th"
 msgstr "26è"
 
-#: pkg/systemd/services.html:290
+#: pkg/systemd/services.html:182
 msgid "27th"
 msgstr "27è"
 
-#: pkg/systemd/services.html:291
+#: pkg/systemd/services.html:183
 msgid "28th"
 msgstr "28è"
 
-#: pkg/systemd/services.html:292
+#: pkg/systemd/services.html:184
 msgid "29th"
 msgstr "29è"
 
-#: pkg/systemd/services.html:265
+#: pkg/systemd/services.html:157
 msgid "2nd"
 msgstr "2n"
 
-#: pkg/systemd/host.js:1667
+#: pkg/systemd/host.js:1684
 msgid "3 min"
 msgstr "3 min"
 
-#: pkg/systemd/services.html:293
+#: pkg/systemd/services.html:185
 msgid "30th"
 msgstr "30è"
 
-#: pkg/systemd/services.html:294
+#: pkg/systemd/services.html:186
 msgid "31st"
 msgstr "31è"
 
@@ -378,7 +378,7 @@ msgstr "31è"
 msgid "32 KiB"
 msgstr "32 KiB"
 
-#: pkg/systemd/services.html:266
+#: pkg/systemd/services.html:158
 msgid "3rd"
 msgstr "3r"
 
@@ -386,7 +386,7 @@ msgstr "3r"
 msgid "4 KiB"
 msgstr "4 KiB"
 
-#: pkg/systemd/host.js:1666
+#: pkg/systemd/host.js:1683
 msgid "4 min"
 msgstr "4 min"
 
@@ -394,7 +394,7 @@ msgstr "4 min"
 msgid "40 Minutes"
 msgstr "40 minuts"
 
-#: pkg/systemd/services.html:267
+#: pkg/systemd/services.html:159
 msgid "4th"
 msgstr "4t"
 
@@ -402,7 +402,7 @@ msgstr "4t"
 msgid "5 Minutes"
 msgstr "5 minuts"
 
-#: pkg/systemd/host.js:1665
+#: pkg/systemd/host.js:1682
 msgid "5 min"
 msgstr "5 min"
 
@@ -416,7 +416,7 @@ msgstr "5 minuts"
 msgid "512 KiB"
 msgstr "512 KiB"
 
-#: pkg/systemd/services.html:268
+#: pkg/systemd/services.html:160
 msgid "5th"
 msgstr "5è"
 
@@ -434,11 +434,11 @@ msgstr "60 minuts"
 msgid "64 KiB"
 msgstr "64 KiB"
 
-#: pkg/systemd/services.html:269
+#: pkg/systemd/services.html:161
 msgid "6th"
 msgstr "6è"
 
-#: pkg/systemd/services.html:270
+#: pkg/systemd/services.html:162
 msgid "7th"
 msgstr "7è"
 
@@ -446,19 +446,19 @@ msgstr "7è"
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1987
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:1995
+#: pkg/networkmanager/interfaces.js:2004
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
-#: pkg/systemd/services.html:271
+#: pkg/systemd/services.html:163
 msgid "8th"
 msgstr "8è"
 
-#: pkg/systemd/services.html:272
+#: pkg/systemd/services.html:164
 msgid "9th"
 msgstr "9è"
 
@@ -483,15 +483,15 @@ msgstr ""
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1986
+#: pkg/networkmanager/interfaces.js:1995
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2786
+#: pkg/networkmanager/interfaces.js:2798
 msgid "ARP Monitoring"
 msgstr "Monitoratge ARP"
 
-#: pkg/networkmanager/interfaces.js:2007
+#: pkg/networkmanager/interfaces.js:2016
 msgid "ARP Ping"
 msgstr "Ping ARP"
 
@@ -499,6 +499,10 @@ msgstr "Ping ARP"
 #: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Quant a Cockpit"
+
+#: pkg/lib/machine-info.js:251
+msgid "Absent"
+msgstr ""
 
 #: pkg/users/index.html:104 pkg/users/index.html:190
 msgid "Access"
@@ -520,7 +524,7 @@ msgstr "Ajusts dels comptes"
 msgid "Account not available or cannot be edited."
 msgstr "El compte no està disponible o no es pot editar."
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Comptes"
 
@@ -529,8 +533,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Comptes"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:170
 #: pkg/machines/components/networks/network.jsx:148
+#: pkg/machines/components/storagePools/storagePool.jsx:170
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Activa"
@@ -539,11 +543,11 @@ msgstr "Activa"
 msgid "Activating $target"
 msgstr "S'està activant $target"
 
-#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
+#: pkg/networkmanager/interfaces.js:847 pkg/networkmanager/interfaces.js:2010
 msgid "Active"
 msgstr "Activa"
 
-#: pkg/networkmanager/interfaces.js:1975 pkg/networkmanager/interfaces.js:1992
+#: pkg/networkmanager/interfaces.js:1984 pkg/networkmanager/interfaces.js:2001
 msgid "Active Backup"
 msgstr "Còpia de seguretat activa"
 
@@ -555,27 +559,31 @@ msgstr "Pàgines actives"
 msgid "Active since"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/systemd/service-details.jsx:352
+msgid "Active since "
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:954
 msgid "Active zones"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1980
+#: pkg/networkmanager/interfaces.js:1989
 msgid "Adaptive load balancing"
 msgstr "Balanceig de càrrega adaptativa"
 
-#: pkg/networkmanager/interfaces.js:1979
+#: pkg/networkmanager/interfaces.js:1988
 msgid "Adaptive transmit load balancing"
 msgstr "Balanceig de càrrega de transmissió adaptativa"
 
-#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
+#: pkg/machines/components/diskAdd.jsx:600 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
+#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Afegeix"
 
-#: pkg/networkmanager/interfaces.js:3103
+#: pkg/networkmanager/interfaces.js:3115
 msgid "Add $0"
 msgstr "Afegeix $0"
 
@@ -591,7 +599,7 @@ msgstr "Afegeix un enllaç"
 msgid "Add Bridge"
 msgstr "Afegeix un pont"
 
-#: pkg/machines/components/diskAdd.jsx:360
+#: pkg/machines/components/diskAdd.jsx:368
 msgid "Add Disk"
 msgstr ""
 
@@ -607,12 +615,12 @@ msgstr ""
 msgid "Add Machine to Dashboard"
 msgstr "Afegeix la màquina al tauler de control"
 
-#: pkg/networkmanager/firewall.jsx:457
+#: pkg/networkmanager/firewall.jsx:482
 msgid "Add Ports"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
-#: pkg/networkmanager/firewall.jsx:886
+#: pkg/networkmanager/firewall.jsx:482 pkg/networkmanager/firewall.jsx:904
+#: pkg/networkmanager/firewall.jsx:916
 msgid "Add Services"
 msgstr "Afegeix serveis"
 
@@ -628,8 +636,8 @@ msgstr "Afegeix un equip"
 msgid "Add VLAN"
 msgstr "Afegeix una VLAN"
 
-#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
-#: pkg/networkmanager/firewall.jsx:891
+#: pkg/networkmanager/firewall.jsx:730 pkg/networkmanager/firewall.jsx:910
+#: pkg/networkmanager/firewall.jsx:921
 msgid "Add Zone"
 msgstr ""
 
@@ -641,7 +649,7 @@ msgstr "Afegeix un portal iSCSI"
 msgid "Add key"
 msgstr "Afegeix una clau"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add ports to the following zones:"
 msgstr ""
 
@@ -649,18 +657,24 @@ msgstr ""
 msgid "Add public key"
 msgstr "Afegeix una clau pública"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add services to following zones:"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:776
+#: pkg/networkmanager/firewall.jsx:806
 msgid "Add zone"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3102
+#: pkg/networkmanager/interfaces.js:3114
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:586
+msgid ""
+"Adding custom ports will reload firewalld. A reload will result in the loss "
+"of any runtime-only configuration!"
 msgstr ""
 
 #: pkg/users/authorized-keys.js:113
@@ -675,11 +689,11 @@ msgstr "S'està afegint el volum físic a $target"
 msgid "Additional"
 msgstr "Addicional"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2668
 msgid "Additional DNS $val"
 msgstr "DNS addicional $val"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Additional DNS Search Domains $val"
 msgstr "Dominis de cerca DNS addicionals $val"
 
@@ -687,7 +701,11 @@ msgstr "Dominis de cerca DNS addicionals $val"
 msgid "Additional Storage"
 msgstr "Emmagatzematge addicional"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/systemd/service-details.jsx:209
+msgid "Additional actions"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2663
 msgid "Additional address $val"
 msgstr "Adreça addicional $val"
 
@@ -703,7 +721,7 @@ msgstr ""
 msgid "Address"
 msgstr "Adreça"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/networkmanager/interfaces.js:2663
 msgid "Address $val"
 msgstr "Adreça $val"
 
@@ -715,11 +733,18 @@ msgstr ""
 msgid "Address is not a valid URL"
 msgstr ""
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:60
+#: pkg/machines/components/networks/createNetworkDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:88
+#: pkg/machines/components/networks/createNetworkDialog.jsx:95
+msgid "Address not within subnet"
+msgstr ""
+
 #: pkg/machines/components/desktopConsole.jsx:153
 msgid "Address:"
 msgstr "Adreça:"
 
-#: pkg/networkmanager/interfaces.js:3309
+#: pkg/networkmanager/interfaces.js:3321
 msgid "Addresses"
 msgstr "Adreces"
 
@@ -735,7 +760,7 @@ msgstr "Contrasenya de l'administrador"
 msgid "Advanced TCA"
 msgstr ""
 
-#: pkg/systemd/services.html:455 pkg/systemd/init.js:730
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "Després"
 
@@ -746,8 +771,8 @@ msgid ""
 "settings and the list of trusted CAs may change."
 msgstr ""
 
-#: pkg/systemd/services.html:446 pkg/systemd/services.html:450
-#: pkg/systemd/init.js:1073
+#: pkg/systemd/services.html:301 pkg/systemd/services.html:305
+#: pkg/systemd/init.js:902
 msgid "After system boot"
 msgstr "Després de l'arrencada del sistema"
 
@@ -755,7 +780,7 @@ msgstr "Després de l'arrencada del sistema"
 msgid "Alert and above"
 msgstr ""
 
-#: pkg/systemd/services.html:71 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
 msgid "All"
 msgstr "Tots"
 
@@ -769,11 +794,15 @@ msgid ""
 "storage pool."
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:751
+#: pkg/systemd/service-details.jsx:159
+msgid "Allow running (unmask)"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:781
 msgid "Allowed Addresses"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:967
 msgid "Allowed Services"
 msgstr "Serveis permesos"
 
@@ -789,12 +818,16 @@ msgstr ""
 msgid "Annotations"
 msgstr "Anotacions"
 
+#: pkg/lib/cockpit-components-modifications.jsx:82
+msgid "Ansible Playbook"
+msgstr ""
+
 #: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr ""
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Aplicacions"
 
@@ -802,10 +835,10 @@ msgstr "Aplicacions"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
-#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
-#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
-#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
+#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
+#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
+#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
+#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
 msgid "Apply"
 msgstr "Aplica"
 
@@ -817,11 +850,11 @@ msgstr "Aplica totes les actualitzacions"
 msgid "Apply security updates"
 msgstr "Aplica les actualitzacions de seguretat"
 
-#: pkg/selinux/setroubleshoot-view.jsx:112
+#: pkg/selinux/setroubleshoot-view.jsx:113
 msgid "Apply this solution"
 msgstr "Aplica aquesta solució"
 
-#: pkg/selinux/setroubleshoot-view.jsx:87
+#: pkg/selinux/setroubleshoot-view.jsx:88
 msgid "Applying solution..."
 msgstr "S'està aplicant la solució..."
 
@@ -845,25 +878,25 @@ msgstr "Etiqueta de recurs"
 msgid "At least $0 disks are needed."
 msgstr "Com a mínim es necessiten $0 discs."
 
-#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
-#: pkg/storaged/vgroup-details.jsx:57
+#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
+#: pkg/storaged/vgroups-panel.jsx:63
 msgid "At least one disk is needed."
 msgstr "Com a mínim es necessita un disc."
 
-#: pkg/systemd/services.html:451
+#: pkg/systemd/services.html:306
 msgid "At specific time"
 msgstr "A l'instant específic"
 
-#: pkg/selinux/setroubleshoot-view.jsx:414
+#: pkg/selinux/setroubleshoot-view.jsx:424
 msgid "Audit log"
 msgstr "Registre d'auditoria"
 
-#: pkg/networkmanager/interfaces.js:830
+#: pkg/networkmanager/interfaces.js:839
 msgid "Authenticating"
 msgstr "S'està autenticant"
 
-#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
+#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
 msgid "Authentication"
 msgstr "Autenticació"
 
@@ -899,22 +932,23 @@ msgstr "Autor"
 msgid "Authorized Public SSH Keys"
 msgstr "Claus SSH públiques autoritzades"
 
-#: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
-#: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
-#: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:338
+#: pkg/networkmanager/index.html:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:176
+#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:2771
+#: pkg/networkmanager/interfaces.js:3329 pkg/networkmanager/interfaces.js:3333
+#: pkg/networkmanager/interfaces.js:3339 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automàtic"
 
-#: pkg/networkmanager/interfaces.js:1966
+#: pkg/networkmanager/interfaces.js:1975
 msgid "Automatic (DHCP only)"
 msgstr "Automàtica, tan sols DHCP"
 
-#: pkg/networkmanager/interfaces.js:1956
+#: pkg/networkmanager/interfaces.js:1965
 msgid "Automatic (DHCP)"
 msgstr "Automàtica (DHCP)"
 
-#: pkg/systemd/services.html:125 pkg/systemd/init.js:286
+#: pkg/systemd/init.js:295
 msgid "Automatic Startup"
 msgstr ""
 
@@ -926,6 +960,10 @@ msgstr "Actualitzacions automàtiques"
 msgid "Automatically start libvirt on boot"
 msgstr "Inicia automàticament libvirt amb l'arrencada"
 
+#: pkg/systemd/service-details.jsx:396
+msgid "Automatically starts"
+msgstr ""
+
 #: pkg/systemd/index.html:389
 msgid "Automatically using NTP"
 msgstr "Automàticament mitjançant NTP"
@@ -934,8 +972,12 @@ msgstr "Automàticament mitjançant NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Automàticament mitjançant servidors NTP específics"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/lib/cockpit-components-modifications.jsx:71
+msgid "Automation Script"
+msgstr ""
+
 #: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:69
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
@@ -946,7 +988,7 @@ msgstr ""
 msgid "Available"
 msgstr "Disponible"
 
-#: pkg/packagekit/updates.jsx:822
+#: pkg/packagekit/updates.jsx:824
 msgid "Available Updates"
 msgstr "Actualitzacions disponibles"
 
@@ -986,11 +1028,11 @@ msgstr "S'han passat dades dolentes al mecanisme del passwd1"
 msgid "Balancer"
 msgstr "Eina de balanceig"
 
-#: pkg/systemd/init.js:729
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr ""
 
-#: pkg/systemd/init.js:720
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr ""
 
@@ -1018,8 +1060,8 @@ msgstr "Dispositiu de blocs per al sistema de fitxers"
 msgid "Blocked"
 msgstr "Bloquejat"
 
-#: pkg/networkmanager/interfaces.js:2510 pkg/networkmanager/interfaces.js:2522
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
+#: pkg/networkmanager/interfaces.js:2803
 msgid "Bond"
 msgstr "Enllaç"
 
@@ -1036,12 +1078,12 @@ msgstr ""
 msgid "Boot order settings could not be saved"
 msgstr ""
 
-#: pkg/systemd/init.js:725
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2528 pkg/networkmanager/interfaces.js:2540
+#: pkg/networkmanager/interfaces.js:2880
 msgid "Bridge"
 msgstr "Pont"
 
@@ -1053,19 +1095,19 @@ msgstr "Ajusts del port del pont"
 msgid "Bridge Settings"
 msgstr "Ajusts del pont"
 
-#: pkg/networkmanager/interfaces.js:2889
+#: pkg/networkmanager/interfaces.js:2901
 msgid "Bridge port"
 msgstr "Port del pont"
 
-#: pkg/networkmanager/interfaces.js:1977 pkg/networkmanager/interfaces.js:1994
+#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
 msgid "Broadcast"
 msgstr "Difusió"
 
-#: pkg/networkmanager/interfaces.js:2804 pkg/networkmanager/interfaces.js:2838
+#: pkg/networkmanager/interfaces.js:2816 pkg/networkmanager/interfaces.js:2850
 msgid "Broken configuration"
 msgstr "Configuració trencada"
 
-#: pkg/systemd/host.js:498
+#: pkg/systemd/host.js:508
 msgid "Bug Fix Updates Available"
 msgstr "Hi ha disponibles actualitzacions de correcció d'errors"
 
@@ -1100,7 +1142,7 @@ msgstr ""
 msgid "CPU Security Toggles"
 msgstr ""
 
-#: pkg/systemd/host.js:1548
+#: pkg/systemd/host.js:1565
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Estat de la CPU"
@@ -1117,12 +1159,12 @@ msgstr "Prioritat de CPU"
 msgid "CPU usage:"
 msgstr "Ús de la CPU:"
 
+#: pkg/machines/components/diskAdd.jsx:251
 #: pkg/machines/components/vmDiskColumns.jsx:75
-#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
-#: pkg/systemd/index.html:252 pkg/systemd/host.js:1679
+#: pkg/systemd/index.html:252 pkg/systemd/host.js:1696
 msgid "Cached"
 msgstr "Emmagatzemat temporalment"
 
@@ -1141,39 +1183,41 @@ msgstr "No es pot carregar la imatge"
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
+#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90
-#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
-#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
-#: pkg/users/index.html:356 pkg/users/index.html:413
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
+#: pkg/systemd/index.html:487 pkg/systemd/services.html:377
+#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
+#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
+#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
+#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/diskAdd.jsx:597
+#: pkg/machines/components/networks/createNetworkDialog.jsx:486
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
+#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/vcpuModal.jsx:232
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
-#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
-#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
-#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
-#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
-#: pkg/packagekit/updates.jsx:179
+#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
+#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "No es pot connectar a una màquina desconeguda"
 
@@ -1189,7 +1233,7 @@ msgstr "No es pot planificar un esdeveniment del passat"
 msgid "Capacity"
 msgstr "Capacitat"
 
-#: pkg/networkmanager/interfaces.js:2590
+#: pkg/networkmanager/interfaces.js:2602
 msgid "Carrier"
 msgstr "Portadora"
 
@@ -1235,18 +1279,18 @@ msgstr "Canvia els límits dels recursos"
 msgid "Change resources limits"
 msgstr "Canvia els límits dels recursos"
 
-#: pkg/networkmanager/interfaces.js:3153
+#: pkg/networkmanager/interfaces.js:3165
 msgid "Change the settings"
 msgstr "Canvia els ajusts"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
+#: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
-#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3152
+#: pkg/networkmanager/interfaces.js:3164
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1260,7 +1304,7 @@ msgstr "Comprova si hi ha actualitzacions"
 msgid "Checking $target"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:834
+#: pkg/networkmanager/interfaces.js:843
 msgid "Checking IP"
 msgstr "S'està comprovant la IP"
 
@@ -1280,12 +1324,16 @@ msgstr "Comprovació per si hi ha aplicacions noves"
 msgid "Checking for public keys"
 msgstr "S'està comprovant si hi ha claus públiques"
 
-#: pkg/systemd/host.js:517
+#: pkg/systemd/host.js:537
 msgid "Checking for updates…"
 msgstr "Comprovació per si hi ha actualitzacions..."
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:142
 msgid "Checking installed software"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
+msgid "Choose an operating system"
 msgstr ""
 
 #: pkg/shell/index.html:117 pkg/shell/simple.html:85
@@ -1296,7 +1344,7 @@ msgstr "Seleccioneu l'idioma per utilitzar amb l'aplicació"
 msgid "Chunk Size"
 msgstr "Mida del tros"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "Class"
 msgstr "Classe"
 
@@ -1304,11 +1352,15 @@ msgstr "Classe"
 msgid "Cleaning up for $target"
 msgstr "Neteja de $target"
 
-#: pkg/systemd/services.html:194
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
+
+#: pkg/systemd/services.html:86
 msgid "Clear All Filters"
 msgstr ""
 
-#: pkg/systemd/host.js:734
+#: pkg/systemd/host.js:750
 msgid "Click to see system hardware information"
 msgstr "Feu clic per veure la informació del maquinari del sistema"
 
@@ -1321,16 +1373,14 @@ msgstr ""
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
-#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
-#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
-#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
-#: pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
+#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
+#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
+#: pkg/systemd/index.html:278 pkg/users/index.html:45 pkg/apps/utils.jsx:108
+#: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
 #: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
-#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Tanca"
 
@@ -1352,7 +1402,7 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit no ha pogut contactar amb l'amfitrió indicat."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1412,10 +1462,10 @@ msgstr "Cockpit no ha pogut contactar amb {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
+"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
+"sync_link}}.{{/can_sync}} For more authentication options and "
+"troubleshooting support please upgrade cockpit-ws to a newer version."
 msgstr ""
 
 #: pkg/lib/machine-change-auth.html:9
@@ -1451,12 +1501,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Ús combinat de $0 nucli de CPU"
 msgstr[1] "Ús combinat de $0 nuclis de CPU"
 
-#: pkg/networkmanager/firewall.jsx:529
+#: pkg/networkmanager/firewall.jsx:554
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
-#: pkg/docker/index.html:708 pkg/systemd/services.html:427
+#: pkg/docker/index.html:708 pkg/systemd/services.html:282
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1504,8 +1554,8 @@ msgstr "Compatible amb els sistemes moderns i els discs durs > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Comprimeix els estavellaments per estalviar espai"
 
-#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
-#: pkg/kdump/kdump-view.jsx:156
+#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
+#: pkg/storaged/vdos-panel.jsx:81
 msgid "Compression"
 msgstr "Compressió"
 
@@ -1513,15 +1563,15 @@ msgstr "Compressió"
 msgid "Computer OU"
 msgstr "OU de l'ordinador"
 
-#: pkg/systemd/init.js:692
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr ""
 
-#: pkg/systemd/services.html:143
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "Ha fallat la condició"
 
-#: pkg/networkmanager/interfaces.js:2725
+#: pkg/networkmanager/interfaces.js:2737
 msgid "Configure"
 msgstr "Configura"
 
@@ -1529,11 +1579,11 @@ msgstr "Configura"
 msgid "Configure storage..."
 msgstr "Configura l'emmagatzematge..."
 
-#: pkg/networkmanager/interfaces.js:828
+#: pkg/networkmanager/interfaces.js:837
 msgid "Configuring"
 msgstr "S'està configurant"
 
-#: pkg/networkmanager/interfaces.js:832
+#: pkg/networkmanager/interfaces.js:841
 msgid "Configuring IP"
 msgstr "S'està configurant la IP"
 
@@ -1554,11 +1604,11 @@ msgstr ""
 msgid "Confirm removal with passphrase"
 msgstr ""
 
-#: pkg/systemd/init.js:728
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr ""
 
-#: pkg/systemd/init.js:727
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr ""
 
@@ -1566,7 +1616,7 @@ msgstr ""
 msgid "Connect"
 msgstr "Connecta"
 
-#: pkg/networkmanager/interfaces.js:2712
+#: pkg/networkmanager/interfaces.js:2724
 msgid "Connect automatically"
 msgstr "Connecta automàticament"
 
@@ -1595,7 +1645,7 @@ msgstr ""
 msgid "Connecting to Docker"
 msgstr "S'està connectant a Docker"
 
-#: pkg/selinux/setroubleshoot-view.jsx:371
+#: pkg/selinux/setroubleshoot-view.jsx:381
 msgid "Connecting to SETroubleshoot daemon..."
 msgstr "S'està connectant al dimoni de SETroubleshoot..."
 
@@ -1603,14 +1653,14 @@ msgstr "S'està connectant al dimoni de SETroubleshoot..."
 msgid "Connecting to Virtualization Service"
 msgstr "Connexió al servei de virtualització"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "S'està connectant a la màquina"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
+#: pkg/machines/components/networks/createNetworkDialog.jsx:106
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Connexió"
@@ -1627,7 +1677,7 @@ msgstr "La connexió ha excedit el temps."
 msgid "Connection will be lost"
 msgstr "Es perdrà la connexió"
 
-#: pkg/systemd/init.js:726
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr ""
 
@@ -1705,6 +1755,10 @@ msgstr "Convertible"
 msgid "Copy"
 msgstr ""
 
+#: pkg/lib/cockpit-components-modifications.jsx:106
+msgid "Copy to clipboard"
+msgstr ""
+
 #: pkg/machines/components/vcpuModal.jsx:209
 msgid "Cores per socket"
 msgstr ""
@@ -1729,7 +1783,7 @@ msgstr "No s'han pogut canviar els grups de l'usuari"
 msgid "Couldn't change user password"
 msgstr "No s'ha pogut canviar la contrasenya de l'usuari"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "No s'ha pogut connectar a la màquina"
 
@@ -1758,11 +1812,12 @@ msgid "Crash system"
 msgstr ""
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
-#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
-#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
+#: pkg/machines/components/networks/createNetworkDialog.jsx:491
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
+#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
+#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
+#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
 msgid "Create"
 msgstr "Crea"
 
@@ -1770,7 +1825,7 @@ msgstr "Crea"
 msgid "Create Logical Volume"
 msgstr "Crea un volum lògic"
 
-#: pkg/machines/components/diskAdd.jsx:515
+#: pkg/machines/components/diskAdd.jsx:552
 msgid "Create New"
 msgstr ""
 
@@ -1802,7 +1857,7 @@ msgstr "Crea l'informe"
 msgid "Create Snapshot"
 msgstr "Crea una instantània"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr ""
 
@@ -1810,11 +1865,11 @@ msgstr ""
 msgid "Create Thin Volume"
 msgstr "Crea un volum disgregat"
 
-#: pkg/systemd/services.html:64
+#: pkg/systemd/services.html:58
 msgid "Create Timer"
 msgstr "Crea un temporitzador"
 
-#: pkg/systemd/services.html:393
+#: pkg/systemd/services.html:248
 msgid "Create Timers"
 msgstr "Crea temporitzadors"
 
@@ -1822,9 +1877,14 @@ msgstr "Crea temporitzadors"
 msgid "Create VDO Device"
 msgstr "Crea un dispositiu VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "Crea la MV"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
+#: pkg/machines/components/networks/createNetworkDialog.jsx:525
+msgid "Create Virtual Network"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:53
 msgid "Create Volume Group"
@@ -1834,8 +1894,8 @@ msgstr "Crea un grup de volums"
 msgid "Create diagnostic report"
 msgstr "Crea l'informe de diagnòstic"
 
-#: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
-#: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
+#: pkg/networkmanager/interfaces.js:3834 pkg/networkmanager/interfaces.js:4033
+#: pkg/networkmanager/interfaces.js:4287 pkg/networkmanager/interfaces.js:4492
 msgid "Create it"
 msgstr "Crea-ho"
 
@@ -1872,25 +1932,25 @@ msgstr "S'està creant la partició $target"
 msgid "Creating snapshot of $target"
 msgstr "S'està creant una instantània de $target"
 
-#: pkg/networkmanager/interfaces.js:4479
+#: pkg/networkmanager/interfaces.js:4491
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3821
+#: pkg/networkmanager/interfaces.js:3833
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4274
+#: pkg/networkmanager/interfaces.js:4286
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4020
+#: pkg/networkmanager/interfaces.js:4032
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1900,7 +1960,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "S'està creant el grup de volums $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr ""
 
@@ -1928,7 +1988,7 @@ msgstr "Arrencada actual"
 msgid "Custom"
 msgstr "Personalitzat"
 
-#: pkg/networkmanager/firewall.jsx:523
+#: pkg/networkmanager/firewall.jsx:548
 msgid "Custom Ports"
 msgstr ""
 
@@ -1936,11 +1996,11 @@ msgstr ""
 msgid "Custom encryption options"
 msgstr "Opcions personalitzades de xifrat"
 
-#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
+#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
 msgid "Custom mount options"
 msgstr "Opcions personalitzades de muntatge"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:748
 msgid "Custom zones"
 msgstr ""
 
@@ -1953,19 +2013,19 @@ msgstr ""
 msgid "DISK IS FAILING"
 msgstr "EL DISC ESTÀ FALLANT"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3328
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2668
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3320
+#: pkg/networkmanager/interfaces.js:3332
 msgid "DNS Search Domains"
 msgstr "Dominis de cerca DNS"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2671
 msgid "DNS Search Domains $val"
 msgstr "Dominis de cerca DNS $val"
 
@@ -1981,13 +2041,13 @@ msgstr "Tauler de control"
 msgid "Data Used"
 msgstr "Dades utilitzades"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:165
 #: pkg/machines/components/networks/network.jsx:144
+#: pkg/machines/components/storagePools/storagePool.jsx:165
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Desactiva"
 
-#: pkg/networkmanager/interfaces.js:840
+#: pkg/networkmanager/interfaces.js:849
 msgid "Deactivating"
 msgstr "S'està desactivant"
 
@@ -2015,26 +2075,27 @@ msgstr "Retard"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/docker/containers-view.jsx:202
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
+#: pkg/docker/details.js:292 pkg/docker/util.js:641
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
 #: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Suprimeix"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2447 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Suprimeix $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
 msgstr ""
 
@@ -2043,11 +2104,10 @@ msgid "Delete Files"
 msgstr "Suprimeix els fitxers"
 
 #: pkg/machines/components/networks/networkDelete.jsx:92
-#, fuzzy
 msgid "Delete Network $0"
-msgstr "Suprimeix $0"
+msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:217
 msgid "Delete Storage Pool $0"
 msgstr ""
 
@@ -2055,7 +2115,7 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr "Suprimeix els fitxers d'emmagatzematge associats:"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:170
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
 
@@ -2063,7 +2123,7 @@ msgstr ""
 msgid "Deleting $target"
 msgstr "S'està suprimint $target"
 
-#: pkg/networkmanager/interfaces.js:2434
+#: pkg/networkmanager/interfaces.js:2446
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2077,7 +2137,7 @@ msgstr "La supressió d'un dispositiu RAID n'esborrarà totes les dades."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Si suprimiu un dispositiu VDO, s'esborraran totes les dades."
 
-#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
+#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
 msgid "Deleting a container will erase all data in it."
 msgstr "La supressió d'un contenidor n'esborrarà totes les dades."
 
@@ -2093,7 +2153,7 @@ msgstr "La supressió d'una partició n'esborrarà totes les dades."
 msgid "Deleting a volume group will erase all data on it."
 msgstr "La supressió d'un grup de volums n'esborrarà totes les dades."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:174
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
@@ -2103,15 +2163,25 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "S'està suprimint el grup de volums $target"
 
-#: pkg/systemd/services.html:413
+#: pkg/systemd/services.html:268
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
 msgid "Description"
 msgstr "Descripció"
+
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Escriptori"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:151
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:187
+msgid ""
+"Detach the disks using this pool from any VMs before attempting deletion."
+msgstr ""
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2119,13 +2189,14 @@ msgstr ""
 
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:383
+#: pkg/systemd/host.js:762
 msgid "Details"
 msgstr "Detalls"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:169
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2138,6 +2209,10 @@ msgstr "Fitxer de dispositiu"
 #: pkg/storaged/content-views.jsx:551
 msgid "Device is read-only"
 msgstr "El dispositiu és de només lectura"
+
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
@@ -2156,10 +2231,6 @@ msgstr "Directori"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "No es pot escriure al directori $0 o bé no existeix."
 
-#: pkg/systemd/init.js:571
-msgid "Disable"
-msgstr "Inhabilita"
-
 #: pkg/systemd/hwinfo.jsx:191
 msgid "Disable simultaneous multithreading"
 msgstr ""
@@ -2168,17 +2239,21 @@ msgstr ""
 msgid "Disable tuned"
 msgstr "Inhabilita tuned"
 
-#: pkg/systemd/services.html:73 pkg/networkmanager/interfaces.js:1960
-#: pkg/systemd/init.js:213
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "Inhabilitat"
+
+#: pkg/systemd/service-details.jsx:192
+msgid "Disallow running (mask)"
+msgstr ""
 
 #: pkg/machines/components/serialConsole.jsx:136
 msgid "Disconnect"
 msgstr "Desconnecta"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "Desconnectat"
 
@@ -2194,15 +2269,15 @@ msgstr "Disc"
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr ""
 
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:549
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:569
 msgid "Disk I/O"
 msgstr "E/S de disc"
 
-#: pkg/machines/components/diskAdd.jsx:489
+#: pkg/machines/components/diskAdd.jsx:525
 msgid "Disk failed to be attached"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Disk failed to be created"
 msgstr ""
 
@@ -2214,9 +2289,9 @@ msgstr "El disc està bé"
 msgid "Disk passphrase"
 msgstr ""
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
-#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
+#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
 msgid "Disks"
 msgstr "Discs"
 
@@ -2228,6 +2303,10 @@ msgstr ""
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Idioma de visualització"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2266,8 +2345,8 @@ msgstr "Nom de l'administrador del domini"
 msgid "Domain Administrator Password"
 msgstr "Contrasenya de l'administrador del domini"
 
-#: pkg/systemd/services.html:483 pkg/systemd/services.html:487
-#: pkg/systemd/init.js:1256
+#: pkg/systemd/services.html:338 pkg/systemd/services.html:342
+#: pkg/systemd/init.js:1085
 msgid "Don't Repeat"
 msgstr "No repeteixis"
 
@@ -2320,6 +2399,10 @@ msgstr "Unitat"
 msgid "Drives"
 msgstr "Unitats"
 
+#: pkg/lib/machine-info.js:244
+msgid "Dual Rank"
+msgstr ""
+
 #: pkg/docker/run.js:348
 msgid "Duplicate alias"
 msgstr "Àlies duplicat"
@@ -2328,7 +2411,7 @@ msgstr "Àlies duplicat"
 msgid "Duplicate port"
 msgstr "Port duplicat"
 
-#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
+#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
 #: pkg/storaged/nfs-details.jsx:306
 msgid "Edit"
 msgstr "Edita"
@@ -2376,14 +2459,6 @@ msgstr "S'està buidant $target"
 msgid "Emulated Machine"
 msgstr ""
 
-#: pkg/systemd/init.js:569
-msgid "Enable"
-msgstr "Habilita"
-
-#: pkg/systemd/init.js:570
-msgid "Enable Forcefully"
-msgstr "Habilita-ho forçosament"
-
 #: pkg/networkmanager/index.html:50
 msgid "Enable Service"
 msgstr ""
@@ -2392,7 +2467,7 @@ msgstr ""
 msgid "Enable stored metrics…"
 msgstr ""
 
-#: pkg/systemd/services.html:72 pkg/systemd/init.js:210
+#: pkg/systemd/services.html:66 pkg/systemd/init.js:215
 msgid "Enabled"
 msgstr "Habilitat"
 
@@ -2433,11 +2508,20 @@ msgstr "Xifratge"
 msgid "Encryption Options"
 msgstr "Opcions de xifrat"
 
-#: pkg/selinux/setroubleshoot-view.jsx:299
-msgid "Enforce policy:"
-msgstr "Aplica la política:"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:252
+msgid "End"
+msgstr ""
 
-#: pkg/systemd/host.js:500
+#: pkg/machines/components/networks/createNetworkDialog.jsx:63
+#: pkg/machines/components/networks/createNetworkDialog.jsx:91
+msgid "End should not be empty"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Enforcing"
+msgstr ""
+
+#: pkg/systemd/host.js:510
 msgid "Enhancement Updates Available"
 msgstr ""
 
@@ -2451,7 +2535,7 @@ msgid ""
 "time you reconnect to this machine"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:754
+#: pkg/networkmanager/firewall.jsx:784
 msgid "Entire subnet"
 msgstr ""
 
@@ -2486,9 +2570,9 @@ msgid "Errata:"
 msgstr "Fe d'errates:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
 #: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Error"
 
@@ -2503,6 +2587,10 @@ msgstr "Error en carregar els usuaris: {{perm_failed}}"
 #: pkg/docker/util.js:507
 msgid "Error message from Docker:"
 msgstr "Missatge d'error de Docker:"
+
+#: pkg/lib/cockpit-components-modifications.jsx:145
+msgid "Error running semanage to discover system modifications"
+msgstr ""
 
 #: pkg/users/authorized-keys.js:121
 msgid "Error saving authorized keys: "
@@ -2524,7 +2612,7 @@ msgstr "MAC d'ethernet"
 msgid "Ethernet MTU"
 msgstr "MTU d'ethernet"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:2015
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2532,11 +2620,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Tot"
 
-#: pkg/networkmanager/firewall.jsx:536
+#: pkg/networkmanager/firewall.jsx:561
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:544
+#: pkg/networkmanager/firewall.jsx:569
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
@@ -2544,11 +2632,11 @@ msgstr ""
 msgid "Excellent password"
 msgstr "Contrasenya excel·lent"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
-msgid "Existing Disk Image"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -2572,7 +2660,7 @@ msgstr "Partició estesa"
 msgid "FAILED"
 msgstr "FALLAT"
 
-#: pkg/networkmanager/interfaces.js:842
+#: pkg/networkmanager/interfaces.js:851
 msgid "Failed"
 msgstr "Ha fallat"
 
@@ -2580,20 +2668,19 @@ msgstr "Ha fallat"
 msgid "Failed to add machine: $0"
 msgstr "No s'ha pogut afegir la màquina: $0"
 
-#: pkg/networkmanager/firewall.jsx:237
-#, fuzzy
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add port"
-msgstr "Ha fallat el canvi de contrasenya"
+msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:679
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
+#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
 msgid "Failed to change password"
 msgstr "Ha fallat el canvi de contrasenya"
 
@@ -2625,8 +2712,12 @@ msgstr ""
 msgid "Failed to load authorized keys."
 msgstr "Ha fallat la càrrega de les claus autoritzades."
 
-#: pkg/networkmanager/firewall.jsx:591
+#: pkg/networkmanager/firewall.jsx:621
 msgid "Failed to remove service"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:340
+msgid "Failed to start"
 msgstr ""
 
 #: pkg/docker/containers.js:60
@@ -2654,7 +2745,7 @@ msgstr "Fitxer"
 msgid "Filesystem"
 msgstr "Sistema de fitxers"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr ""
 
@@ -2670,24 +2761,24 @@ msgstr "Nom del sistema de fitxers"
 msgid "Filesystems"
 msgstr "Sistemes de fitxers"
 
-#: pkg/networkmanager/firewall.jsx:491
+#: pkg/networkmanager/firewall.jsx:516
 msgid "Filter Services"
 msgstr "Filtra els serveis"
 
-#: pkg/systemd/services.html:68
+#: pkg/systemd/services.html:62
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
+#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
 msgid "Fingerprint"
 msgstr "Empremta"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
+#: pkg/networkmanager/firewall.jsx:945 pkg/networkmanager/firewall.jsx:948
 msgid "Firewall"
 msgstr "Tallafoc"
 
-#: pkg/networkmanager/firewall.jsx:863
+#: pkg/networkmanager/firewall.jsx:893
 msgid "Firewall is not available"
 msgstr "El tallafoc no està disponible"
 
@@ -2697,6 +2788,10 @@ msgstr "Segueix el dipòsit docker"
 
 #: pkg/storaged/vdos-panel.jsx:88
 msgid "For legacy applications only. Reduces performance."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:322
+msgid "Forbidden from running"
 msgstr ""
 
 #: pkg/users/index.html:122
@@ -2723,9 +2818,10 @@ msgstr "Obliga el canvi de contrasenya"
 msgid "Force remove passphrase in $0"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
-#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:157
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
+#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
+#: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formata"
 
@@ -2747,11 +2843,15 @@ msgstr ""
 "La formatació d'un dispositiu d'emmagatzematge eliminarà totes les dades "
 "contingudes."
 
-#: pkg/networkmanager/interfaces.js:2861
+#: pkg/machines/components/networks/createNetworkDialog.jsx:147
+msgid "Forward Mode"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2873
 msgid "Forward delay $forward_delay"
 msgstr "Retard del reenviament $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:50
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2770,7 +2870,7 @@ msgid ""
 "another physical volume."
 msgstr ""
 
-#: pkg/systemd/services.html:239
+#: pkg/systemd/services.html:131
 msgid "Friday"
 msgstr "Divendres"
 
@@ -2791,7 +2891,7 @@ msgid "Gateway:"
 msgstr "Passarel·la:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2703 pkg/systemd/logs.js:486
+#: pkg/networkmanager/interfaces.js:2715 pkg/systemd/logs.js:486
 msgid "General"
 msgstr "General"
 
@@ -2803,11 +2903,11 @@ msgstr "S'està generant l'informe"
 msgid "Get new image"
 msgstr "Obtén una imatge nova"
 
+#: pkg/machines/components/diskAdd.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
-#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
 
@@ -2859,7 +2959,7 @@ msgstr "Fes créixer per agafar tot l'espai"
 msgid "Hair Pin mode"
 msgstr "Mode hairpin"
 
-#: pkg/networkmanager/interfaces.js:2887
+#: pkg/networkmanager/interfaces.js:2899
 msgid "Hairpin mode"
 msgstr "Mode hairpin"
 
@@ -2880,22 +2980,22 @@ msgstr "Disc dur"
 msgid "Hardware"
 msgstr "Maquinari"
 
-#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:261
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:270
 msgid "Hardware Information"
 msgstr "Informació del maquinari"
 
-#: pkg/networkmanager/interfaces.js:2863
+#: pkg/networkmanager/interfaces.js:2875
 msgid "Hello time $hello_time"
 msgstr "Hello time $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "Amfitrió"
 
@@ -2904,7 +3004,7 @@ msgid "Host Device"
 msgstr ""
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Nom d'amfitrió"
 
@@ -2916,25 +3016,29 @@ msgstr "La clau d'amfitrió és incorrecta"
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr ""
 
-#: pkg/systemd/services.html:499
+#: pkg/systemd/services.html:354
 msgid "Hour : Minute"
 msgstr "hora : minut"
 
-#: pkg/systemd/init.js:1332 pkg/systemd/init.js:1361
+#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
 msgid "Hour needs to be a number between 0-23"
 msgstr "L'hora ha de ser un nombre entre 0-23"
 
-#: pkg/systemd/services.html:465
+#: pkg/systemd/services.html:320
 msgid "Hours"
 msgstr "Hores"
 
-#: pkg/systemd/index.html:238 pkg/systemd/host.js:1582
+#: pkg/systemd/index.html:238 pkg/systemd/host.js:1599
 msgid "I/O Wait"
 msgstr "Espera d'E/S"
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "ID"
+msgstr ""
 
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
 #: pkg/machines/components/vmnetworktab.jsx:133
@@ -2945,11 +3049,15 @@ msgstr "Adreça IP"
 msgid "IP Address:"
 msgstr "Adreça IP:"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:197
+msgid "IP Configuration"
+msgstr ""
+
 #: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "Longitud del prefix IP:"
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:955
 msgid "IP Range"
 msgstr ""
 
@@ -2957,7 +3065,7 @@ msgstr ""
 msgid "IP Settings"
 msgstr "Ajusts de la IP"
 
-#: pkg/networkmanager/interfaces.js:2912
+#: pkg/networkmanager/interfaces.js:2924
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -2965,11 +3073,27 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+msgid "IPv4 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:45
+msgid "IPv4 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3371
 msgid "IPv4 Settings"
 msgstr "Ajusts d'IPv4"
 
-#: pkg/networkmanager/interfaces.js:2913
+#: pkg/machines/components/networks/createNetworkDialog.jsx:213
+msgid "IPv4 and IPv6"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:207
+msgid "IPv4 only"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2925
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -2977,15 +3101,27 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+msgid "IPv6 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:73
+msgid "IPv6 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3371
 msgid "IPv6 Settings"
 msgstr "Ajusts d'IPv6"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:210
+msgid "IPv6 only"
+msgstr ""
 
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
 
-#: pkg/networkmanager/interfaces.js:2904
+#: pkg/networkmanager/interfaces.js:2916
 msgid "Id $id"
 msgstr "Id. $id"
 
@@ -3002,7 +3138,7 @@ msgstr "Identificador"
 msgid "If tang-show-keys is not available, run the following:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1969 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1978 pkg/packagekit/updates.jsx:496
 msgid "Ignore"
 msgstr "Ignora"
 
@@ -3062,17 +3198,22 @@ msgstr "Les imatges poden ser recuperades per usuaris o grups autenticats"
 #: node_modules/registry-image-widgets/views/imagestream-body.html:25
 #: node_modules/registry-image-widgets/views/imagestream-body.html:26
 msgid "Images may only be pulled by specific users or groups"
-msgstr "Les imatges només poden ser recuperades per usuaris o grups específics"
+msgstr ""
+"Les imatges només poden ser recuperades per usuaris o grups específics"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Inicia automàticament la MV"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "En sincronització"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3083,11 +3224,11 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Per sincronitzar els usuaris, cal que inicieu la sessió a {{#strong}}{{host}}"
-"{{/strong}}."
+"Per sincronitzar els usuaris, cal que inicieu la sessió a "
+"{{#strong}}{{host}}{{/strong}}."
 
-#: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
-#: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
+#: pkg/networkmanager/interfaces.js:833 pkg/networkmanager/interfaces.js:1426
+#: pkg/networkmanager/interfaces.js:1433 pkg/networkmanager/interfaces.js:2618
 msgid "Inactive"
 msgstr "Inactiu"
 
@@ -3095,7 +3236,7 @@ msgstr "Inactiu"
 msgid "Inactive volume"
 msgstr "Volum inactiu"
 
-#: pkg/networkmanager/firewall.jsx:732
+#: pkg/networkmanager/firewall.jsx:762
 msgid "Included services"
 msgstr ""
 
@@ -3119,21 +3260,21 @@ msgstr ""
 msgid "Initializing..."
 msgstr "S'està inicialitzant..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/machines/components/vm/vmActions.jsx:98
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/machines/components/vm/vmActions.jsx:98
 msgid "Install"
 msgstr "Instal·la"
 
-#: pkg/packagekit/updates.jsx:806
+#: pkg/packagekit/updates.jsx:808
 msgid "Install All Updates"
 msgstr "Instal·la totes les actualitzacions"
 
@@ -3141,7 +3282,7 @@ msgstr "Instal·la totes les actualitzacions"
 msgid "Install NFS Support"
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:806 pkg/packagekit/updates.jsx:812
+#: pkg/packagekit/updates.jsx:808 pkg/packagekit/updates.jsx:814
 msgid "Install Security Updates"
 msgstr "Instal·la les actualitzacions de seguretat"
 
@@ -3153,20 +3294,20 @@ msgstr ""
 msgid "Install VDO support"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:379
+#: pkg/selinux/setroubleshoot-view.jsx:389
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr ""
 "Instal·leu setroubleshoot-server per resoldre els esdeveniments de SELinux."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Origen d'instal·lació"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Tipus d'origen d'instal·lació"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "L'origen d'instal·lació no pot estar en blanc"
 
@@ -3183,17 +3324,21 @@ msgstr "S'està instal·lant"
 msgid "Installing $0"
 msgstr ""
 
-#: pkg/systemd/services.html:184
+#: pkg/systemd/service-details.jsx:487
+msgid "Instance of template: "
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:62
 msgid "Instantiate"
 msgstr "Instancia"
 
-#: pkg/machines/components/nicEdit.jsx:123
+#: pkg/machines/components/nicEdit.jsx:132
 msgid "Interface Type"
 msgstr ""
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:767 pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/interfaces.js:2998
 msgid "Interfaces"
 msgstr "Interfícies"
 
@@ -3205,19 +3350,39 @@ msgstr ""
 msgid "Internal error"
 msgstr "Error intern"
 
-#: pkg/networkmanager/utils.js:88 pkg/networkmanager/utils.js:171
+#: pkg/machines/components/networks/createNetworkDialog.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:58
+#: pkg/machines/components/networks/createNetworkDialog.jsx:65
+msgid "Invalid IPv4 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:52
+msgid "Invalid IPv4 mask or prefix length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:75
+#: pkg/machines/components/networks/createNetworkDialog.jsx:86
+#: pkg/machines/components/networks/createNetworkDialog.jsx:93
+msgid "Invalid IPv6 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:80
+msgid "Invalid IPv6 prefix"
+msgstr ""
+
+#: pkg/networkmanager/utils.js:90 pkg/networkmanager/utils.js:175
 msgid "Invalid address $0"
 msgstr "Adreça no vàlida $0"
 
-#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "Format de data no vàlid"
 
-#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "Format no vàlid de la data i l'hora"
 
-#: pkg/systemd/init.js:1367
+#: pkg/systemd/init.js:1196
 msgid "Invalid date format."
 msgstr "Format de data no vàlid."
 
@@ -3229,7 +3394,7 @@ msgstr "Data de venciment no vàlida"
 msgid "Invalid file permissions"
 msgstr "Permisos de fitxer no vàlids"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "nom de fitxer no vàlid"
 
@@ -3245,7 +3410,7 @@ msgstr "Mètrica no vàlida $0"
 msgid "Invalid number of days"
 msgstr "Nombre de dies no vàlid"
 
-#: pkg/systemd/init.js:1314
+#: pkg/systemd/init.js:1143
 msgid "Invalid number."
 msgstr "Número no vàlid."
 
@@ -3253,7 +3418,7 @@ msgstr "Número no vàlid."
 msgid "Invalid port"
 msgstr "Port no vàlid"
 
-#: pkg/networkmanager/firewall.jsx:335
+#: pkg/networkmanager/firewall.jsx:360
 msgid "Invalid port number"
 msgstr ""
 
@@ -3261,15 +3426,15 @@ msgstr ""
 msgid "Invalid prefix $0"
 msgstr "Prefix no vàlid $0"
 
-#: pkg/networkmanager/utils.js:132
+#: pkg/networkmanager/utils.js:136
 msgid "Invalid prefix or netmask $0"
 msgstr "Prefix o màscara de xarxa no vàlid $0"
 
-#: pkg/networkmanager/firewall.jsx:362
+#: pkg/networkmanager/firewall.jsx:387
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "Format d'hora no vàlid"
 
@@ -3313,7 +3478,7 @@ msgstr "Uneix-te a un domini"
 msgid "Joining this domain is not supported"
 msgstr "La unió a aquest domini no està admesa"
 
-#: pkg/systemd/init.js:736
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr ""
 
@@ -3348,11 +3513,11 @@ msgstr ""
 msgid "Kerberos Ticket"
 msgstr "Tiquet de Kerberos"
 
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1583
+#: pkg/systemd/index.html:234 pkg/systemd/host.js:1600
 msgid "Kernel"
 msgstr "Kernel"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "Bolcat del kernel"
 
@@ -3384,6 +3549,10 @@ msgstr ""
 msgid "LACP Key"
 msgstr "Clau LACP"
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
+msgid "LVM Volume Group"
+msgstr ""
+
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Etiquetes"
@@ -3404,7 +3573,7 @@ msgstr "Els últims 7 dies"
 msgid "Last Login"
 msgstr "Últim inici de sessió"
 
-#: pkg/systemd/init.js:284
+#: pkg/systemd/init.js:293
 msgid "Last Trigger"
 msgstr "Últim disparador"
 
@@ -3439,6 +3608,7 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
+""
 msgstr ""
 "Deixeu-ho en blanc per connectar a aquesta màquina amb "
 "l'usuari{{#default_user}} ({{default_user}}){{/default_user}}, que ha "
@@ -3465,7 +3635,7 @@ msgstr "Observació de l'enllaç"
 msgid "Link down delay"
 msgstr "Retard del baixament de l'enllaç"
 
-#: pkg/networkmanager/interfaces.js:1957 pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1966 pkg/networkmanager/interfaces.js:1976
 msgid "Link local"
 msgstr "Enllaç local"
 
@@ -3485,7 +3655,7 @@ msgstr "Enllaços"
 msgid "Links:"
 msgstr "Enllaços:"
 
-#: pkg/networkmanager/interfaces.js:1993
+#: pkg/networkmanager/interfaces.js:2002
 msgid "Load Balancing"
 msgstr "Balanceig de càrrega"
 
@@ -3505,9 +3675,13 @@ msgstr "Ha fallat la càrrega de les actualitzacions disponibles"
 msgid "Loading available updates, please wait..."
 msgstr "S'estan carregant les actualitzacions disponibles, espereu..."
 
-#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
-#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
-#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
+#: pkg/lib/cockpit-components-modifications.jsx:151
+msgid "Loading system modifications..."
+msgstr ""
+
+#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:367
+#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
+#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
 msgid "Loading..."
 msgstr "S'està carregant..."
 
@@ -3523,7 +3697,7 @@ msgstr "Discs locals"
 msgid "Local Filesystem"
 msgstr "Sistema de fitxers local"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr ""
 
@@ -3623,7 +3797,7 @@ msgstr ""
 msgid "Logout Successful"
 msgstr "S'ha tancat la sessió amb èxit"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Registres"
 
@@ -3651,15 +3825,15 @@ msgstr "Adreça MAC"
 msgid "MAC Address:"
 msgstr "Adreça MAC:"
 
-#: pkg/networkmanager/interfaces.js:1985
+#: pkg/networkmanager/interfaces.js:1994
 msgid "MII (Recommended)"
 msgstr "MII (recomanat)"
 
-#: pkg/networkmanager/interfaces.js:2761
+#: pkg/networkmanager/interfaces.js:2773
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4545
+#: pkg/networkmanager/interfaces.js:4557
 msgid "MTU must be a positive number"
 msgstr "El valor de la MTU ha de ser un nombre positiu"
 
@@ -3667,7 +3841,7 @@ msgstr "El valor de la MTU ha de ser un nombre positiu"
 msgid "Mac"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:160
+#: pkg/machines/components/nicEdit.jsx:169
 msgid "Mac Address"
 msgstr ""
 
@@ -3679,7 +3853,7 @@ msgstr "Id. de màquina"
 msgid "Machine SSH Key Fingerprints"
 msgstr "Empremtes de les claus SSH de la màquina"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "Màquines"
 
@@ -3691,7 +3865,7 @@ msgstr ""
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
+#: pkg/networkmanager/interfaces.js:1967 pkg/networkmanager/interfaces.js:1977
 msgid "Manual"
 msgstr "Manual"
 
@@ -3711,15 +3885,30 @@ msgstr ""
 msgid "Marking $target as faulty"
 msgstr "S'està ficant $target com a defectuós"
 
-#: pkg/systemd/init.js:574
-msgid "Mask"
-msgstr "Emmascara"
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
+msgid "Mask Service"
+msgstr ""
 
-#: pkg/systemd/init.js:575
-msgid "Mask Forcefully"
-msgstr "Emmascara-ho forçosament"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:293
+msgid "Mask or Prefix Length"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2767
+#: pkg/machines/components/networks/createNetworkDialog.jsx:50
+msgid "Mask or Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:321
+msgid "Masked"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:200
+msgid ""
+"Masking service prevents all dependant units from running. This can have "
+"bigger impact than anticipated. Please confirm that you want to mask this "
+"unit."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2779
 msgid "Master"
 msgstr "Màster"
 
@@ -3735,7 +3924,7 @@ msgstr ""
 msgid "Maximum memory could not be saved"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2865
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Maximum message age $max_age"
 msgstr "Envelliment màxim del missatge $max_age"
 
@@ -3756,18 +3945,22 @@ msgstr "Membre del dispositiu RAID $0"
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
-#: pkg/machines/components/vmOverviewTab.jsx:74
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
+#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "Memòria"
 
-#: pkg/systemd/host.js:1641
+#: pkg/systemd/host.js:1658
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Memòria"
 
 #: pkg/systemd/index.html:205
 msgid "Memory & Swap"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Memory Technology"
 msgstr ""
 
 #: pkg/machines/components/vm/memoryModal.jsx:103
@@ -3779,10 +3972,9 @@ msgstr ""
 msgid "Memory limit"
 msgstr "Límit de memòria"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
-#, fuzzy
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
-msgstr "Ús de la memòria: "
+msgstr ""
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
@@ -3806,10 +3998,10 @@ msgid "Metadata Used"
 msgstr "Metadades utilitzades"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
+#: pkg/machines/components/diskAdd.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
-#: pkg/machines/components/memorySelectRow.jsx:43
-#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -3821,11 +4013,11 @@ msgstr "Mini PC"
 msgid "Mini Tower"
 msgstr "Mini torre"
 
-#: pkg/systemd/init.js:1338 pkg/systemd/init.js:1347 pkg/systemd/init.js:1356
+#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
 msgid "Minute needs to be a number between 0-59"
 msgstr "El minut ha de ser un nombre entre 0-59"
 
-#: pkg/systemd/services.html:464
+#: pkg/systemd/services.html:319
 msgid "Minutes"
 msgstr "Minuts"
 
@@ -3837,7 +4029,7 @@ msgstr ""
 msgid "Mode"
 msgstr "Mode"
 
-#: pkg/machines/components/nicEdit.jsx:54 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
 msgid "Model"
 msgstr "Model"
 
@@ -3850,7 +4042,7 @@ msgstr "Tipus de model"
 msgid "Modifying $target"
 msgstr "S'està modificant $target"
 
-#: pkg/systemd/services.html:235
+#: pkg/systemd/services.html:127
 msgid "Monday"
 msgstr "Dilluns"
 
@@ -3879,23 +4071,23 @@ msgstr "Més informació"
 msgid "More details"
 msgstr "Més detalls"
 
-#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
-#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
+#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
+#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
 msgid "Mount"
 msgstr "Munta"
 
-#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
-#: pkg/storaged/format-dialog.jsx:81
+#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
+#: pkg/storaged/nfs-details.jsx:172
 msgid "Mount Options"
 msgstr "Opcions de muntatge"
 
-#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/format-dialog.jsx:71
+#: pkg/storaged/nfs-panel.jsx:102
 msgid "Mount Point"
 msgstr "Punt de muntatge"
 
-#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
+#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
 msgid "Mount at boot"
 msgstr "Munta a l'arrencada"
 
@@ -3915,7 +4107,7 @@ msgstr "El punt de muntatge no pot estar en blanc."
 msgid "Mount point must start with \"/\"."
 msgstr "El punt de muntatge ha de començar amb «/»."
 
-#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
+#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
 msgid "Mount read only"
 msgstr "Munta només de lectura"
 
@@ -3955,11 +4147,11 @@ msgstr ""
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2008
+#: pkg/networkmanager/interfaces.js:2017
 msgid "NSNA Ping"
 msgstr "Ping NSNA"
 
-#: pkg/systemd/host.js:1514
+#: pkg/systemd/host.js:1531
 msgid "NTP Server"
 msgstr "Servidor NTP"
 
@@ -3970,22 +4162,24 @@ msgstr "Servidor NTP"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
+#: pkg/machines/components/diskAdd.jsx:126
+#: pkg/machines/components/networks/createNetworkDialog.jsx:122
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
-#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
-#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
+#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
+#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
 #: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
-#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "Nom"
 
@@ -4018,7 +4212,8 @@ msgid "Name cannot contain whitespace."
 msgstr "El nom no pot contenir l'espai en blanc."
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:41
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "El nom no pot estar en blanc"
 
@@ -4026,7 +4221,7 @@ msgstr "El nom no pot estar en blanc"
 msgid "Name: "
 msgstr ""
 
-#: pkg/systemd/host.js:1348
+#: pkg/systemd/host.js:1365
 msgid "Need at least one NTP server"
 msgstr "Com a mínim es necessita un servidor NTP"
 
@@ -4046,11 +4241,15 @@ msgstr ""
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+msgid "Network Boot is available only when using System connection"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr ""
 
@@ -4058,11 +4257,11 @@ msgstr ""
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr ""
 
-#: pkg/systemd/host.js:550
+#: pkg/systemd/host.js:570
 msgid "Network Traffic"
 msgstr "Trànsit de xarxa"
 
@@ -4070,7 +4269,7 @@ msgstr "Trànsit de xarxa"
 msgid "Network devices and graphs require NetworkManager."
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:232
+#: pkg/machines/components/nicEdit.jsx:245
 msgid "Network interface settings could not be saved"
 msgstr ""
 
@@ -4079,11 +4278,11 @@ msgid "NetworkManager is not running."
 msgstr ""
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:914
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Xarxa"
 
-#: pkg/networkmanager/interfaces.js:1625 pkg/networkmanager/interfaces.js:2207
+#: pkg/networkmanager/interfaces.js:1634 pkg/networkmanager/interfaces.js:2216
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Xarxa"
@@ -4092,8 +4291,8 @@ msgstr "Xarxa"
 msgid "Networking Logs"
 msgstr "Registres de la xarxa"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/networks/networkList.jsx:46
+#: pkg/machines/components/networks/networkList.jsx:45
+#: pkg/machines/components/networks/networkList.jsx:49
 msgid "Networks"
 msgstr "Xarxes"
 
@@ -4125,7 +4324,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/users/local.js:139 pkg/lib/credentials.js:237
+#: pkg/lib/credentials.js:237 pkg/users/local.js:139
 msgid "New password was not accepted"
 msgstr "No s'ha acceptat la nova contrasenya"
 
@@ -4133,16 +4332,16 @@ msgstr "No s'ha acceptat la nova contrasenya"
 msgid "Next"
 msgstr "Següent"
 
-#: pkg/systemd/init.js:283
+#: pkg/systemd/init.js:292
 msgid "Next Run"
 msgstr "Següent execució"
 
-#: pkg/systemd/index.html:226 pkg/systemd/host.js:1585
+#: pkg/systemd/index.html:226 pkg/systemd/host.js:1602
 msgid "Nice"
 msgstr "Nice"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2606
 msgid "No"
 msgstr "No"
 
@@ -4158,7 +4357,7 @@ msgstr "Sense sistema de fitxers"
 msgid "No Logical Volumes"
 msgstr "Sense volums lògics"
 
-#: pkg/systemd/services.html:192
+#: pkg/systemd/services.html:84
 msgid "No Matching Results"
 msgstr ""
 
@@ -4166,12 +4365,16 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Cap emmagatzematge NFS preparat"
 
-#: pkg/selinux/setroubleshoot-view.jsx:365
+#: pkg/machines/components/nicEdit.jsx:118
+msgid "No Network Devices"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
 msgstr "Sense alertes de SELinux."
 
-#: pkg/machines/components/diskAdd.jsx:204
-#: pkg/machines/components/diskAdd.jsx:216
+#: pkg/machines/components/diskAdd.jsx:209
+#: pkg/machines/components/diskAdd.jsx:221
 msgid "No Storage Pools available"
 msgstr ""
 
@@ -4179,15 +4382,19 @@ msgstr ""
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr ""
 
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "No System Modifications"
+msgstr ""
+
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
 msgstr "No hi ha cap MV en execució o definida en aquest amfitrió"
 
-#: pkg/machines/components/nicEdit.jsx:110
+#: pkg/machines/components/nicEdit.jsx:116
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:926
+#: pkg/networkmanager/firewall.jsx:956
 msgid "No active zones"
 msgstr ""
 
@@ -4215,7 +4422,7 @@ msgstr ""
 msgid "No boot device found"
 msgstr "No s'ha trobat cap dispositiu d'arrencada"
 
-#: pkg/networkmanager/interfaces.js:1419
+#: pkg/networkmanager/interfaces.js:1428
 msgid "No carrier"
 msgstr "Sense portadora"
 
@@ -4239,7 +4446,7 @@ msgstr "Sense contenidors"
 msgid "No containers that match the current filter"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:729
+#: pkg/networkmanager/firewall.jsx:759
 msgid "No description available"
 msgstr ""
 
@@ -4247,9 +4454,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "No s'ha proporcionat cap descripció."
 
-#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
-#: pkg/storaged/vgroup-details.jsx:54
+#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
+#: pkg/storaged/vgroups-panel.jsx:60
 msgid "No disks are available."
 msgstr "No hi ha disponible cap disc."
 
@@ -4319,7 +4526,7 @@ msgstr ""
 msgid "No network interfaces defined for this VM"
 msgstr "No s'ha definit cap interfície de xarxa per aquesta MV"
 
-#: pkg/machines/components/networks/networkList.jsx:48
+#: pkg/machines/components/networks/networkList.jsx:51
 msgid "No network is defined on this host"
 msgstr ""
 
@@ -4327,7 +4534,7 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:939
+#: pkg/networkmanager/firewall.jsx:969
 msgid "No open ports"
 msgstr ""
 
@@ -4384,8 +4591,9 @@ msgid "No volume groups created"
 msgstr "Cap grup de volums creat"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
 #: pkg/kdump/kdump-view.jsx:419
+#: pkg/machines/components/networks/createNetworkDialog.jsx:204
+#: pkg/networkmanager/firewall.jsx:764 pkg/tuned/dialog.js:231
 msgid "None"
 msgstr "Cap"
 
@@ -4409,7 +4617,7 @@ msgstr "No s'autoritza l'accés Docker en aquest sistema"
 msgid "Not authorized to upload-report"
 msgstr "No autoritzat per pujar l'informe"
 
-#: pkg/networkmanager/interfaces.js:822
+#: pkg/networkmanager/interfaces.js:831
 msgid "Not available"
 msgstr "No disponible"
 
@@ -4433,7 +4641,7 @@ msgstr "No muntat"
 msgid "Not permitted to perform this action."
 msgstr "No es permet realitzar aquesta acció."
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "No s'està executant"
 
@@ -4445,7 +4653,7 @@ msgstr "No sincronitzat"
 msgid "Not yet synced"
 msgstr "Encara no sincronitzat"
 
-#: pkg/systemd/services.html:357
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr "Nota"
 
@@ -4457,21 +4665,13 @@ msgstr ""
 msgid "Notice and above"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
-msgid "OS Vendor"
-msgstr ""
-
-#: pkg/selinux/setroubleshoot-view.jsx:394
+#: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
 msgstr "S'ha produït $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:389
+#: pkg/selinux/setroubleshoot-view.jsx:399
 msgid "Occurred between $0 and $1"
 msgstr "S'ha produït entre $0 i $1"
-
-#: pkg/lib/patterns.js:246
-msgid "Off"
-msgstr "Off"
 
 #: pkg/lib/cockpit-components-dialog.jsx:194
 msgid "Ok"
@@ -4485,19 +4685,15 @@ msgstr "Contrasenya antiga"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/users/local.js:86 pkg/lib/credentials.js:218
+#: pkg/lib/credentials.js:218 pkg/users/local.js:86
 msgid "Old password not accepted"
 msgstr "Contrasenya antiga no acceptada"
-
-#: pkg/lib/patterns.js:246
-msgid "On"
-msgstr "On"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:7
 msgid "On Build"
 msgstr "Amb la construcció"
 
-#: pkg/docker/index.html:549 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr "Amb la fallada"
 
@@ -4535,7 +4731,7 @@ msgstr "Només s'utilitzen $0 de $1."
 msgid "Only Emergency"
 msgstr "Només emergències"
 
-#: pkg/systemd/init.js:1288
+#: pkg/systemd/init.js:1117
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "Només es permeten lletres, números, : , _ , . , @ , -."
 
@@ -4552,7 +4748,7 @@ msgid "Open"
 msgstr ""
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "Sistema operatiu"
 
@@ -4562,9 +4758,8 @@ msgstr "L'operació '$operation' en $target"
 
 #: pkg/machines/components/storagePools/storagePool.jsx:175
 #: pkg/machines/components/storagePools/storagePool.jsx:180
-#, fuzzy
 msgid "Operation is in progress"
-msgstr "Inici de sessió d'oVirt en progrés"
+msgstr ""
 
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
@@ -4596,9 +4791,9 @@ msgstr "Altres dispositius"
 msgid "Other Options"
 msgstr "Altres opcions"
 
-#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
+#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/networks/network.jsx:72
+#: pkg/machines/components/vm/vm.jsx:47
 msgid "Overview"
 msgstr "Visió de conjunt"
 
@@ -4606,7 +4801,7 @@ msgstr "Visió de conjunt"
 msgid "Overwrite existing data with zeros"
 msgstr "Sobreescriu les dades existents amb zeros"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "PCI"
 msgstr "PCI"
 
@@ -4614,7 +4809,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "Informació dels paquets"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "PackageKit s'ha estavellat."
 
@@ -4626,19 +4821,23 @@ msgstr "PackageKit no està instal·lat"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit ha informat un codi d'error $0"
 
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "Paquets"
+
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "Pare"
 
-#: pkg/networkmanager/interfaces.js:2903
+#: pkg/networkmanager/interfaces.js:2915
 msgid "Parent $parent"
 msgstr "Pare $parent"
 
-#: pkg/systemd/init.js:721
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1465
+#: pkg/networkmanager/interfaces.js:1474
 msgid "Part of "
 msgstr "Part de"
 
@@ -4654,7 +4853,7 @@ msgstr "Partició de $0"
 msgid "Partitioning"
 msgstr "Particionatge"
 
-#: pkg/networkmanager/interfaces.js:2000
+#: pkg/networkmanager/interfaces.js:2009
 msgid "Passive"
 msgstr "Passiu"
 
@@ -4678,10 +4877,10 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Les contrasenyes no coincideixen"
 
-#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
-#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
+#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
+#: pkg/users/index.html:173 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "Contrasenya"
@@ -4719,7 +4918,8 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Enganxeu aquí el contingut del fitxer de la vostra clau SSH pública"
 
-#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "Camí"
 
@@ -4727,7 +4927,7 @@ msgstr "Camí"
 msgid "Path cost"
 msgstr "Cost del camí"
 
-#: pkg/networkmanager/interfaces.js:2885
+#: pkg/networkmanager/interfaces.js:2897
 msgid "Path cost $path_cost"
 msgstr "Cost del camí $path_cost"
 
@@ -4735,7 +4935,7 @@ msgstr "Cost del camí $path_cost"
 msgid "Path on Server"
 msgstr "Camí al servidor"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr ""
 
@@ -4747,7 +4947,7 @@ msgstr "El camí al servidor no pot estar en blanc."
 msgid "Path on server must start with \"/\"."
 msgstr "El camí al servidor ha de començar amb «/»."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "Camí al fitxer ISO al sistema de fitxers de l'amfitrió"
 
@@ -4755,7 +4955,7 @@ msgstr "Camí al fitxer ISO al sistema de fitxers de l'amfitrió"
 msgid "Path to file"
 msgstr "Camí al fitxer"
 
-#: pkg/systemd/services.html:60
+#: pkg/systemd/services.jsx:42
 msgid "Paths"
 msgstr "Camins"
 
@@ -4771,7 +4971,7 @@ msgstr "Perfil de rendiment"
 msgid "Peripheral Chassis"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3630
+#: pkg/networkmanager/interfaces.js:3642
 msgid "Permanent"
 msgstr "Permanent"
 
@@ -4779,12 +4979,16 @@ msgstr "Permanent"
 msgid "Permission denied"
 msgstr "Permís denegat"
 
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Permissive"
+msgstr ""
+
 #: pkg/machines/components/diskAdd.jsx:110
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
 #: pkg/machines/components/networks/networkOverviewTab.jsx:83
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:66
 msgid "Persistent"
 msgstr ""
 
@@ -4792,7 +4996,7 @@ msgstr ""
 msgid "Physical"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr ""
 
@@ -4804,7 +5008,7 @@ msgstr "Volum físic"
 msgid "Physical Volumes"
 msgstr "Volums físics"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -4828,9 +5032,9 @@ msgstr "Objectiu de ping"
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/details.js:290 pkg/docker/util.js:612
-#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
+#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Si us plau, confirmeu la supressió de $0"
@@ -4839,19 +5043,19 @@ msgstr "Si us plau, confirmeu la supressió de $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Si us plau, confirmeu la supressió forçada de $0"
 
-#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
+#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
 msgid "Please confirm stopping of $0"
 msgstr "Confirmeu l'aturada de $0"
 
-#: pkg/machines/components/diskAdd.jsx:447
+#: pkg/machines/components/diskAdd.jsx:483
 msgid "Please enter new volume name"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:450
+#: pkg/machines/components/diskAdd.jsx:486
 msgid "Please enter new volume size"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:864
+#: pkg/networkmanager/firewall.jsx:894
 msgid "Please install the $0 package"
 msgstr ""
 
@@ -4871,14 +5075,15 @@ msgstr ""
 msgid "Please try another term"
 msgstr "Si us plau, proveu un altre terme"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Plug"
 msgstr ""
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/deleteDialog.jsx:53
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
+#: pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Agrupació"
 
@@ -4894,6 +5099,11 @@ msgstr "Agrupació per als volums disgregats"
 msgid "Pool for thinly provisioned volumes"
 msgstr ""
 
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
+msgid "Pool's volumes are used by VMs "
+msgstr ""
+
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
@@ -4903,7 +5113,7 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#: pkg/networkmanager/firewall.jsx:339
+#: pkg/networkmanager/firewall.jsx:364
 msgid "Port number and type do not match"
 msgstr ""
 
@@ -4914,7 +5124,7 @@ msgstr "Portable"
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
+#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2998
 msgid "Ports"
 msgstr "Ports"
 
@@ -4934,29 +5144,37 @@ msgstr ""
 msgid "Prefix"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/machines/components/networks/createNetworkDialog.jsx:337
+msgid "Prefix Length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:78
+msgid "Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length"
 msgstr "Longitud del prefix"
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr "Longitud del prefix o Màscara de xarxa"
 
-#: pkg/networkmanager/interfaces.js:826
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:835
 msgid "Preparing"
 msgstr "S'està preparant"
 
-#: pkg/networkmanager/interfaces.js:3631
+#: pkg/lib/machine-info.js:251
+msgid "Present"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3643
 msgid "Preserve"
 msgstr "Preserva"
-
-#: pkg/systemd/init.js:572
-msgid "Preset"
-msgstr "Preajusta"
-
-#: pkg/systemd/init.js:573
-msgid "Preset Forcefully"
-msgstr "Preajusta-ho forçosament"
 
 #: pkg/systemd/index.html:295
 msgid "Pretty Host Name"
@@ -4975,7 +5193,7 @@ msgstr "Principal"
 msgid "Priority"
 msgstr "Prioritat"
 
-#: pkg/networkmanager/interfaces.js:2859 pkg/networkmanager/interfaces.js:2883
+#: pkg/networkmanager/interfaces.js:2871 pkg/networkmanager/interfaces.js:2895
 msgid "Priority $priority"
 msgstr "Prioritat $priority"
 
@@ -5024,7 +5242,7 @@ msgstr "Per mitjà del temps d'espera de ssh-add"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Per mitjà del temps d'espera de ssh-keygen"
 
-#: pkg/systemd/init.js:734
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr ""
 
@@ -5034,7 +5252,7 @@ msgstr ""
 msgid "Protocol"
 msgstr "Protocol"
 
-#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
+#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
 msgid "Public Key"
 msgstr "Clau pública"
 
@@ -5045,14 +5263,6 @@ msgstr ""
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Propòsit"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr ""
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
@@ -5114,7 +5324,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "Dispositiu RAID"
 
-#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
+#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
 msgid "RAID Device $0"
 msgstr "Dispositiu RAID $0"
 
@@ -5134,24 +5344,36 @@ msgstr "Membre RAID"
 msgid "Rack Mount Chassis"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3632
+#: pkg/networkmanager/interfaces.js:3644
 msgid "Random"
 msgstr "Aleatòria"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:789
 msgid "Range"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:370
+#: pkg/networkmanager/firewall.jsx:395
 msgid "Range must be strictly ordered"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Rank"
 msgstr ""
 
 #: pkg/kdump/kdump-view.jsx:388
 msgid "Raw to a device"
 msgstr ""
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:386
+msgid "Read-only"
 msgstr ""
 
 #: pkg/docker/index.html:365
@@ -5187,7 +5409,7 @@ msgstr ""
 msgid "Real Host Name"
 msgstr "Nom d'amfitrió real"
 
-#: pkg/systemd/host.js:1020
+#: pkg/systemd/host.js:1037
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
@@ -5195,7 +5417,7 @@ msgstr ""
 "El nom d'amfitrió real només pot contenir caràcters en minúscules, dígits, "
 "guions i punts (amb subdominis poblats)"
 
-#: pkg/systemd/host.js:1021
+#: pkg/systemd/host.js:1038
 msgid "Real host name must be 64 characters or less"
 msgstr "El nom d'amfitrió real pot tenir com a molt 64 caràcters"
 
@@ -5217,7 +5439,7 @@ msgstr "Recent"
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Torna a connectar"
@@ -5250,19 +5472,19 @@ msgstr "Es nega a connectar. La clau d'amfitrió no coincideix"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Es nega a connectar. La clau d'amfitrió és desconeguda"
 
-#: pkg/packagekit/updates.jsx:777
+#: pkg/packagekit/updates.jsx:779
 msgid "Register…"
 msgstr "Registra..."
 
-#: pkg/systemd/init.js:546
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Recarrega"
 
-#: pkg/systemd/init.js:735
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "URL remot"
 
@@ -5283,13 +5505,13 @@ msgstr "Disc extraïble"
 msgid "Removals:"
 msgstr ""
 
+#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
-#: pkg/apps/application.jsx:109
+#: pkg/storaged/nfs-details.jsx:308
 msgid "Remove"
 msgstr "Suprimeix"
 
-#: pkg/networkmanager/interfaces.js:3055
+#: pkg/networkmanager/interfaces.js:3067
 msgid "Remove $0"
 msgstr "Suprimeix $0"
 
@@ -5313,11 +5535,11 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:631
+#: pkg/networkmanager/firewall.jsx:661
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:610
+#: pkg/networkmanager/firewall.jsx:640
 msgid "Remove service from zones"
 msgstr ""
 
@@ -5333,7 +5555,7 @@ msgstr ""
 msgid "Removing $target from RAID Device"
 msgstr "S'està eliminant $target  del dispositiu RAID"
 
-#: pkg/networkmanager/interfaces.js:3054
+#: pkg/networkmanager/interfaces.js:3066
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5364,23 +5586,23 @@ msgstr "S'està reanomenant $target"
 msgid "Repairing $target"
 msgstr ""
 
-#: pkg/systemd/services.html:489
+#: pkg/systemd/services.html:344
 msgid "Repeat Daily"
 msgstr "Repeteix diàriament"
 
-#: pkg/systemd/services.html:488
+#: pkg/systemd/services.html:343
 msgid "Repeat Hourly"
 msgstr "Repeteix cada hora"
 
-#: pkg/systemd/services.html:491
+#: pkg/systemd/services.html:346
 msgid "Repeat Monthly"
 msgstr "Repeteix cada mes"
 
-#: pkg/systemd/services.html:490
+#: pkg/systemd/services.html:345
 msgid "Repeat Weekly"
 msgstr "Repeteix cada setmana"
 
-#: pkg/systemd/services.html:492
+#: pkg/systemd/services.html:347
 msgid "Repeat Yearly"
 msgstr "Repeteix cada any"
 
@@ -5418,19 +5640,27 @@ msgstr "Requereix el canvi de la contrasenya cada $0 dies"
 msgid "Require password change on $0"
 msgstr "Requereix el canvi de la contrasenya el $0"
 
-#: pkg/systemd/init.js:722
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr ""
 
-#: pkg/systemd/init.js:717
+#: pkg/systemd/service-details.jsx:372
+msgid "Required by "
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr ""
 
-#: pkg/systemd/init.js:718
+#: pkg/systemd/service-details.jsx:387
+msgid "Requires administration access to edit"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr ""
 
-#: pkg/systemd/init.js:723
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr ""
 
@@ -5466,8 +5696,9 @@ msgstr ""
 
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
-#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
+#: pkg/machines/components/vm/vmActions.jsx:42
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Reinicia"
 
@@ -5487,7 +5718,7 @@ msgstr "Reinicia la política:"
 msgid "Restart Recommended"
 msgstr "Reinici recomanat"
 
-#: pkg/packagekit/updates.jsx:864
+#: pkg/packagekit/updates.jsx:866
 msgid "Restarting"
 msgstr "S'està reiniciant"
 
@@ -5508,7 +5739,8 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Reutilitza la meva contrasenya per a les tasques privilegiades"
 
 #: pkg/shell/index.html:159
-msgid "Reuse my password for privileged tasks and to connect to other machines"
+msgid ""
+"Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Reutilitza la meva contrasenya per a les tasques privilegiades i per "
 "connectar a altres màquines"
@@ -5517,7 +5749,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Rols"
 
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1983 pkg/networkmanager/interfaces.js:2000
 msgid "Round Robin"
 msgstr "Round Robin"
 
@@ -5529,12 +5761,12 @@ msgstr ""
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3337
 msgid "Routes"
 msgstr "Encaminaments"
 
 #: pkg/docker/index.html:253 pkg/docker/index.html:566
-#: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
+#: pkg/systemd/services.html:296 pkg/machines/components/vm/vmActions.jsx:91
 msgid "Run"
 msgstr "Executa"
 
@@ -5555,19 +5787,19 @@ msgstr ""
 msgid "Runner"
 msgstr "Runner"
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr "En execució"
 
-#: pkg/systemd/services.html:123
-msgid "Running Since"
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:364
+#: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
 msgstr "Errors de control d'accés de SELinux"
 
-#: pkg/selinux/setroubleshoot-view.jsx:297
+#: pkg/selinux/setroubleshoot-view.jsx:301
 msgid "SELinux Policy"
 msgstr "Política de SELinux"
 
@@ -5575,15 +5807,15 @@ msgstr "Política de SELinux"
 msgid "SELinux Troubleshoot"
 msgstr "Solució de problema de SELinux"
 
-#: pkg/selinux/setroubleshoot-view.jsx:356
+#: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "SELinux is disabled on the system"
 msgstr "SELinux no està inhabilitat al sistema"
 
-#: pkg/selinux/setroubleshoot-view.jsx:284
+#: pkg/selinux/setroubleshoot-view.jsx:285
 msgid "SELinux is disabled on the system."
 msgstr "SELinux no està inhabilitat al sistema."
 
-#: pkg/selinux/setroubleshoot-view.jsx:276
+#: pkg/selinux/setroubleshoot-view.jsx:277
 msgid "SELinux system status is unknown."
 msgstr "Es desconeix l'estat del sistema SELinux."
 
@@ -5623,7 +5855,7 @@ msgstr "Envelliment màxim del missatge STP"
 msgid "STP Priority"
 msgstr "Prioritat STP"
 
-#: pkg/systemd/services.html:240
+#: pkg/systemd/services.html:132
 msgid "Saturday"
 msgstr "Dissabte"
 
@@ -5631,11 +5863,10 @@ msgstr "Dissabte"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
-#: pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Desa"
 
@@ -5661,8 +5892,8 @@ msgstr ""
 msgid "Sealed-case PC"
 msgstr ""
 
-#: pkg/systemd/services.html:459 pkg/systemd/services.html:463
-#: pkg/systemd/init.js:1076
+#: pkg/systemd/services.html:314 pkg/systemd/services.html:318
+#: pkg/systemd/init.js:905
 msgid "Seconds"
 msgstr "segons"
 
@@ -5678,7 +5909,7 @@ msgstr "S'està eliminant de forma segura $target"
 msgid "Security"
 msgstr "Seguretat"
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:506
 msgid "Security Updates Available"
 msgstr ""
 
@@ -5688,8 +5919,8 @@ msgstr "Selecciona"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with "
+"{{#strong}}{{host}}{{/strong}}"
 msgstr ""
 "Seleccioneu els usuaris que vulgueu que estiguin sincronitzats amb "
 "{{#strong}}{{host}}{{/strong}}"
@@ -5712,8 +5943,8 @@ msgstr "Enviament"
 msgid "Serial Console"
 msgstr "Consola sèrie"
 
-#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
-#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
+#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
+#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
 msgid "Server"
 msgstr "Servidor"
 
@@ -5745,12 +5976,12 @@ msgstr "El servidor ha tancat la connexió."
 msgid "Servers"
 msgstr "Servidors"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:968
 #: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Servei"
 
-#: pkg/systemd/services.html:337
+#: pkg/systemd/services.html:229
 msgid "Service Logs"
 msgstr "Registres del servei"
 
@@ -5774,15 +6005,16 @@ msgstr "El servei està aturat"
 msgid "Service is stopping"
 msgstr "El servei s'està aturant"
 
-#: pkg/systemd/services.html:399
+#: pkg/systemd/services.html:254
 msgid "Service name"
 msgstr "Nom del servei"
 
-#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:222
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Serveis"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sessió"
@@ -5791,7 +6023,11 @@ msgstr "Sessió"
 msgid "Set"
 msgstr "Estableix"
 
-#: pkg/systemd/host.js:764
+#: pkg/machines/components/networks/createNetworkDialog.jsx:231
+msgid "Set DHCP Range"
+msgstr ""
+
+#: pkg/systemd/host.js:781
 msgid "Set Host name"
 msgstr "Estableix el nom d'amfitrió"
 
@@ -5815,7 +6051,7 @@ msgstr "Estableix a"
 msgid "Set up"
 msgstr "Configurat"
 
-#: pkg/selinux/setroubleshoot-view.jsx:293
+#: pkg/selinux/setroubleshoot-view.jsx:294
 msgid ""
 "Setting deviates from the configured state and will revert on the next boot."
 msgstr ""
@@ -5836,15 +6072,19 @@ msgstr "Gravetat"
 msgid "Severity:"
 msgstr "Gravetat:"
 
-#: pkg/networkmanager/interfaces.js:1959
+#: pkg/networkmanager/interfaces.js:1968
 msgid "Shared"
 msgstr "Compartida"
+
+#: pkg/lib/cockpit-components-modifications.jsx:78
+msgid "Shell Script"
+msgstr ""
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Show Performance Options"
 msgstr ""
 
@@ -5885,16 +6125,21 @@ msgstr ""
 msgid "Shut Down"
 msgstr "Apaga"
 
+#: pkg/lib/machine-info.js:242
+msgid "Single Rank"
+msgstr ""
+
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
+#: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
-#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
-#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
-#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
+#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
+#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
+#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
+#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:259
 msgid "Size"
 msgstr "Mida"
 
@@ -5918,7 +6163,7 @@ msgstr "La mida ha de ser un número"
 msgid "Size must be at least $0"
 msgstr "La mida com a mínim ha de ser $0"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "Slot"
 msgstr "Ranura"
 
@@ -5926,11 +6171,11 @@ msgstr "Ranura"
 msgid "Slot $0"
 msgstr ""
 
-#: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
+#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:40
 msgid "Sockets"
 msgstr "Sockets"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Actualitzacions"
 
@@ -5950,15 +6195,15 @@ msgctxt "storage"
 msgid "Solid-State Disk"
 msgstr "Disc d'estat sòlid"
 
-#: pkg/selinux/setroubleshoot-view.jsx:95
+#: pkg/selinux/setroubleshoot-view.jsx:96
 msgid "Solution applied successfully"
 msgstr "S'ha aplicat la solució amb èxit"
 
-#: pkg/selinux/setroubleshoot-view.jsx:102
+#: pkg/selinux/setroubleshoot-view.jsx:103
 msgid "Solution failed"
 msgstr "Ha fallat la solució"
 
-#: pkg/selinux/setroubleshoot-view.jsx:409
+#: pkg/selinux/setroubleshoot-view.jsx:419
 msgid "Solutions"
 msgstr "Solucions"
 
@@ -5967,25 +6212,26 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:709
+#: pkg/networkmanager/firewall.jsx:739
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:141
+#: pkg/machines/components/diskAdd.jsx:541
+#: pkg/machines/components/nicEdit.jsx:150
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
-#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Origen"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
 msgid "Source Format"
 msgstr ""
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr ""
 
@@ -5993,12 +6239,16 @@ msgstr ""
 msgid "Source URL"
 msgstr "URL d'origen"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
+msgid "Source Volume Group"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr ""
 
@@ -6006,7 +6256,7 @@ msgstr ""
 msgid "Space-saving Computer"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2857
+#: pkg/networkmanager/interfaces.js:2869
 msgid "Spanning Tree Protocol"
 msgstr "STP (Spanning Tree Protocol)"
 
@@ -6022,13 +6272,18 @@ msgstr "Recanvi"
 msgid "Specific Time"
 msgstr "Instant concret"
 
-#: pkg/networkmanager/interfaces.js:3633
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Speed"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3645
 msgid "Stable"
 msgstr "Estable"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
-#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
+#: pkg/machines/components/networks/createNetworkDialog.jsx:237
+#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Inicia"
 
@@ -6040,16 +6295,25 @@ msgstr "Inicia Docker"
 msgid "Start Multipath"
 msgstr "Inicia el multicamí"
 
-#: pkg/networkmanager/index.html:44
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:411
+msgid "Start and Enable"
 msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:105
 msgid "Start libvirt"
 msgstr "Inicia libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:84
+msgid "Start should not be empty"
 msgstr ""
 
 #: pkg/storaged/jobs-panel.jsx:59
@@ -6060,15 +6324,15 @@ msgstr "S'està iniciant el dispositiu RAID $target"
 msgid "Starting swapspace $target"
 msgstr "S'està iniciant l'espai d'intercanvi $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr ""
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/init.js:285
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "Estat"
 
@@ -6076,11 +6340,12 @@ msgstr "Estat"
 msgid "State:"
 msgstr "Estat:"
 
-#: pkg/systemd/services.html:74 pkg/systemd/init.js:207
+#: pkg/systemd/services.html:68 pkg/systemd/init.js:212
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr "Estàtic"
 
-#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "Estat"
 
@@ -6093,15 +6358,19 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
-#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
-#: pkg/systemd/init.js:542
+#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Atura"
 
 #: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Atura el dispositiu"
+
+#: pkg/systemd/service-details.jsx:411
+msgid "Stop and Disable"
+msgstr ""
 
 #: pkg/storaged/nfs-details.jsx:259
 msgid "Stop and Unmount"
@@ -6132,8 +6401,8 @@ msgid "Stopping swapspace $target"
 msgstr "S'està aturant l'espai d'intercanvi $target"
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Emmagatzematge"
 
@@ -6149,11 +6418,11 @@ msgstr ""
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr ""
 
@@ -6177,6 +6446,10 @@ msgstr ""
 #: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Agrupació d'emmagatzematge"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
+msgid "Storage size must not be 0"
+msgstr ""
 
 #: pkg/systemd/index.html:155
 msgid "Store Metrics"
@@ -6206,7 +6479,7 @@ msgstr ""
 msgid "Summary"
 msgstr "Resum"
 
-#: pkg/systemd/services.html:241
+#: pkg/systemd/services.html:133
 msgid "Sunday"
 msgstr "Diumenge"
 
@@ -6227,31 +6500,31 @@ msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "Espai d'intercanvi"
 
-#: pkg/systemd/index.html:248 pkg/systemd/host.js:1692
+#: pkg/systemd/index.html:248 pkg/systemd/host.js:1709
 msgid "Swap Used"
 msgstr "Intercanvi utilitzat"
 
-#: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
+#: pkg/networkmanager/interfaces.js:2504 pkg/networkmanager/interfaces.js:3051
 msgid "Switch off $0"
 msgstr "Apaga $0"
 
-#: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
+#: pkg/networkmanager/interfaces.js:2479 pkg/networkmanager/interfaces.js:3039
 msgid "Switch on $0"
 msgstr "Engega $0"
 
-#: pkg/networkmanager/interfaces.js:2491
+#: pkg/networkmanager/interfaces.js:2503
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3038
+#: pkg/networkmanager/interfaces.js:3050
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2466 pkg/networkmanager/interfaces.js:3026
+#: pkg/networkmanager/interfaces.js:2478 pkg/networkmanager/interfaces.js:3038
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6277,20 +6550,26 @@ msgstr "Sincronitzat amb {{Server}}"
 msgid "Synchronizing RAID Device $target"
 msgstr "Sincronització del dispositiu RAID $target"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:260
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "Sistema"
 
-#: pkg/systemd/hwinfo.jsx:264
+#: pkg/systemd/hwinfo.jsx:273
 msgid "System Information"
 msgstr "Informació del sistema"
 
-#: pkg/systemd/host.js:480
+#: pkg/selinux/setroubleshoot-view.jsx:467
+msgid "System Modifications"
+msgstr ""
+
+#: pkg/systemd/host.js:490
 msgid "System Not Registered"
 msgstr ""
 
-#: pkg/systemd/services.html:57
+#: pkg/systemd/services.jsx:38
 msgid "System Services"
 msgstr "Serveis del sistema"
 
@@ -6298,16 +6577,16 @@ msgstr "Serveis del sistema"
 msgid "System Time"
 msgstr "Hora del sistema"
 
-#: pkg/systemd/host.js:486
+#: pkg/systemd/host.js:496
 msgid "System Up To Date"
 msgstr "El sistema està actualitzat"
 
-#: pkg/packagekit/updates.jsx:876
+#: pkg/packagekit/updates.jsx:878
 msgid "System is up to date"
 msgstr "El sistema està al dia"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:968
 msgid "TCP"
 msgstr "TCP"
 
@@ -6335,25 +6614,25 @@ msgstr ""
 msgid "Target"
 msgstr "Objectiu"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr ""
 
-#: pkg/systemd/services.html:56
+#: pkg/systemd/services.jsx:39
 msgid "Targets"
 msgstr "Objectius"
 
-#: pkg/networkmanager/interfaces.js:2512 pkg/networkmanager/interfaces.js:2524
-#: pkg/networkmanager/interfaces.js:2814
+#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
+#: pkg/networkmanager/interfaces.js:2826
 msgid "Team"
 msgstr "Equip"
 
-#: pkg/networkmanager/interfaces.js:2842
+#: pkg/networkmanager/interfaces.js:2854
 msgid "Team Port"
 msgstr "Port de l'equip"
 
@@ -6365,7 +6644,7 @@ msgstr "Ajusts del port de l'equip"
 msgid "Team Settings"
 msgstr "Ajusts de l'equip"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -6409,8 +6688,8 @@ msgstr ""
 msgid "The RAID device must be running in order to remove disks."
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:80
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:84
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:125
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:129
 msgid "The Storage Pool could not be deleted"
 msgstr ""
 
@@ -6458,15 +6737,15 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
+" Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
 msgstr "La informació recopilada s'emmagatzemarà localment al sistema."
 
-#: pkg/selinux/setroubleshoot-view.jsx:291
+#: pkg/selinux/setroubleshoot-view.jsx:292
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 
@@ -6482,7 +6761,7 @@ msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr ""
 
@@ -6493,7 +6772,8 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1014
-msgid "The filesystem is in use by login sessions. Proceeding will stop these."
+msgid ""
+"The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1016
@@ -6502,7 +6782,8 @@ msgid ""
 msgstr ""
 
 #: pkg/docker/util.js:631
-msgid "The following containers depend on this image and will become unusable."
+msgid ""
+"The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/sosreport/index.html:51
@@ -6537,7 +6818,11 @@ msgstr ""
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "No es pot treure l'últim volum físic d'un grup de volums."
 
-#: pkg/shell/indexes.js:407
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "The logged in user is not permitted to view system modifications"
+msgstr ""
+
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "La màquina s'està reiniciant"
 
@@ -6565,6 +6850,15 @@ msgstr ""
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
+msgid "The selected Operating System has minimum memory requirement of $0 $1"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+msgid ""
+"The selected Operating System has minimum storage size requirement of $0 $1"
+msgstr ""
+
 #: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
@@ -6581,7 +6875,7 @@ msgstr ""
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 
-#: pkg/systemd/init.js:922
+#: pkg/systemd/init.js:751
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "A l'usuari <b>$0</b> no se li permet crear temporitzadors"
 
@@ -6591,10 +6885,6 @@ msgstr ""
 
 #: pkg/systemd/host.js:70
 msgid "The user <b>$0</b> is not permitted to change the system time"
-msgstr ""
-
-#: pkg/systemd/init.js:614
-msgid "The user <b>$0</b> is not permitted to enable or disable services"
 msgstr ""
 
 #: pkg/dashboard/list.js:223
@@ -6613,7 +6903,7 @@ msgstr "A l'usuari <b>$0</b> no se li permet modificar els comptes"
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "A l'usuari <b>$0</b> no se li permet modificar els noms d'amfitrions"
 
-#: pkg/networkmanager/interfaces.js:1516
+#: pkg/networkmanager/interfaces.js:1525
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "A l'usuari <b>$0</b> no se li permet modificar els ajusts de xarxa"
 
@@ -6626,10 +6916,6 @@ msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr ""
 "A l'usuari <b>$0</b> no se li permet apagar o reiniciar aquest servidor."
 
-#: pkg/systemd/init.js:606 pkg/systemd/init.js:610
-msgid "The user <b>$0</b> is not permitted to start or stop services"
-msgstr ""
-
 #: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
@@ -6640,7 +6926,8 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible $0)"
+"The web browser configuration prevents Cockpit from running (inaccessible "
+"$0)"
 msgstr ""
 "La configuració del navegador web impedeix que s'executi Cockpit "
 "(inaccessible $0)"
@@ -6681,7 +6968,7 @@ msgstr ""
 msgid "This VDO device does not use all of its backing device."
 msgstr ""
 
-#: pkg/systemd/init.js:1371
+#: pkg/systemd/init.js:1200
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -6689,7 +6976,7 @@ msgstr ""
 "Aquest dia no existeix en tots els mesos.<br> El temporitzador només "
 "s'executarà en aquells mesos que en tinguin 31."
 
-#: pkg/networkmanager/interfaces.js:2624
+#: pkg/networkmanager/interfaces.js:2636
 msgid "This device cannot be managed here."
 msgstr "Aquest dispositiu no es pot gestionar aquí."
 
@@ -6727,7 +7014,7 @@ msgstr ""
 msgid "This disk cannot be removed while the device is recovering."
 msgstr "Aquest disc no es pot treure quan s'està recuperant el dispositiu."
 
-#: pkg/systemd/init.js:1283 pkg/systemd/init.js:1297 pkg/systemd/init.js:1306
+#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
 msgid "This field cannot be empty."
 msgstr "Aquest camp no pot estar en blanc."
 
@@ -6756,7 +7043,11 @@ msgstr "Aquest paquet no és compatible amb aquesta versió de Cockpit"
 msgid "This package requires Cockpit version %s or later"
 msgstr "Aquest paquet requereix la versió %s, o posterior, de Cockpit"
 
-#: pkg/packagekit/updates.jsx:772
+#: pkg/machines/components/diskAdd.jsx:215
+msgid "This pool type does not support Storage Volume creation"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:774
 msgid "This system is not registered"
 msgstr "Aquest sistema no està registrat"
 
@@ -6776,11 +7067,7 @@ msgstr ""
 "Aquesta eina recopilarà la configuració i la informació de diagnòstic "
 "d'aquest sistema per a l'ús amb el diagnòstic de problemes amb el sistema."
 
-#: pkg/systemd/init.js:685
-msgid "This unit is an instance of the $0 template."
-msgstr "Aquesta unitat és una instància de la plantilla $0."
-
-#: pkg/systemd/services.html:360
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Aquesta unitat no està dissenyada per estar explícitament activada."
 
@@ -6796,7 +7083,7 @@ msgstr ""
 "Aquesta versió de cockpit-ws no és compatible amb la connexió a un amfitrió "
 "amb un usuari o port alternatius"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr ""
 
@@ -6808,7 +7095,7 @@ msgstr ""
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr "Aquest navegador web és massa antic per executar Cockpit (falta $0)"
 
-#: pkg/packagekit/updates.jsx:832
+#: pkg/packagekit/updates.jsx:834
 msgid "This web console will be updated."
 msgstr ""
 
@@ -6830,7 +7117,7 @@ msgstr "Això provarà la configuració de kdump en fer estavellar el kernel."
 msgid "Threads per core"
 msgstr ""
 
-#: pkg/systemd/services.html:238
+#: pkg/systemd/services.html:130
 msgid "Thursday"
 msgstr "Dijous"
 
@@ -6842,7 +7129,7 @@ msgstr ""
 msgid "Time Zone"
 msgstr "Zona horària"
 
-#: pkg/systemd/services.html:59
+#: pkg/systemd/services.jsx:41
 msgid "Timers"
 msgstr "Temporitzadors"
 
@@ -6855,7 +7142,7 @@ msgstr ""
 "contrasenya d'inici de sessió per autenticar automàticament contra altres "
 "sistemes."
 
-#: pkg/packagekit/updates.jsx:773
+#: pkg/packagekit/updates.jsx:775
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
@@ -6900,15 +7187,19 @@ msgstr ""
 msgid "Tower"
 msgstr "Torre"
 
-#: pkg/systemd/init.js:733
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr ""
 
-#: pkg/systemd/init.js:732
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "Disparadors"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Soluciona el problema"
@@ -6917,7 +7208,7 @@ msgstr "Soluciona el problema"
 msgid "Trust key"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:705
+#: pkg/networkmanager/firewall.jsx:735
 msgid "Trust level"
 msgstr ""
 
@@ -6937,7 +7228,7 @@ msgstr "Intenta tornar a connectar"
 msgid "Trying to synchronize with {{Server}}"
 msgstr "S'està intentant la sincronització amb {{Server}}"
 
-#: pkg/systemd/services.html:236
+#: pkg/systemd/services.html:128
 msgid "Tuesday"
 msgstr "Dimarts"
 
@@ -6961,17 +7252,19 @@ msgstr "Tuned no s'està executant"
 msgid "Tuned is off"
 msgstr "Tuned no està aturat"
 
-#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
+#: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
-#: pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/vmnetworktab.jsx:114
+#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/systemd/hwinfo.jsx:259
 msgid "Type"
 msgstr "Tipus"
 
@@ -6987,11 +7280,11 @@ msgstr "Teclegeu una contrasenya"
 msgid "Type to filter…"
 msgstr "Teclegeu per filtrar..."
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:968
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "URL"
 
@@ -7003,7 +7296,7 @@ msgstr "UUID"
 msgid "Unable to apply settings: $0"
 msgstr "No es poden aplicar els ajusts: $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:119
+#: pkg/selinux/setroubleshoot-view.jsx:120
 msgid "Unable to apply this solution automatically"
 msgstr "No es pot aplicar automàticament aquesta solució"
 
@@ -7015,8 +7308,8 @@ msgstr "No es pot connectar a aquesta adreça"
 msgid "Unable to delete root account"
 msgstr "No es pot suprimir el compte de root"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Unable to get alert details."
 msgstr "No es poden obtenir els detalls de l'alerta."
 
@@ -7057,11 +7350,15 @@ msgid "Unavailable"
 msgstr "No disponible"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Error inesperat"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+#: pkg/machines/components/networks/createNetworkDialog.jsx:128
+msgid "Unique Network Name"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr ""
 
@@ -7073,15 +7370,15 @@ msgstr ""
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
+#: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
 #: pkg/machines/components/vmnetworktab.jsx:139
-#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
-#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1076
+#: pkg/networkmanager/interfaces.js:2544 pkg/networkmanager/interfaces.js:2546
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
-#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
+#: pkg/networkmanager/interfaces.js:2530 pkg/networkmanager/interfaces.js:2542
 msgid "Unknown \"$0\""
 msgstr "\"$0\" desconegut"
 
@@ -7097,7 +7394,7 @@ msgstr "Aplicació desconeguda"
 msgid "Unknown Host Key"
 msgstr "Clau desconeguda d'amfitrió"
 
-#: pkg/networkmanager/interfaces.js:2640
+#: pkg/networkmanager/interfaces.js:2652
 msgid "Unknown configuration"
 msgstr "Configuració desconeguda"
 
@@ -7105,7 +7402,7 @@ msgstr "Configuració desconeguda"
 msgid "Unknown host name"
 msgstr "Nom d'amfitrió desconegut"
 
-#: pkg/networkmanager/firewall.jsx:333
+#: pkg/networkmanager/firewall.jsx:358
 msgid "Unknown service name"
 msgstr ""
 
@@ -7146,10 +7443,6 @@ msgstr ""
 msgid "Unmanaged Interfaces"
 msgstr "Interfícies sense gestionar"
 
-#: pkg/systemd/init.js:576
-msgid "Unmask"
-msgstr "Desemmascara"
-
 #: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
 msgid "Unmount"
 msgstr "Desmunta"
@@ -7162,7 +7455,7 @@ msgstr "S'està desmuntat $target"
 msgid "Unnamed"
 msgstr "Sense nom"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Unplug"
 msgstr ""
 
@@ -7200,11 +7493,11 @@ msgstr "Amfitrió no fiable"
 msgid "Up since $0"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -7229,7 +7522,7 @@ msgid "Updated packages may require a restart to take effect."
 msgstr ""
 "Els paquets actualitzats poden requerir un reinici perquè tinguin efecte."
 
-#: pkg/systemd/host.js:502
+#: pkg/systemd/host.js:512
 msgid "Updates Available"
 msgstr "Actualitzacions disponibles"
 
@@ -7237,11 +7530,15 @@ msgstr "Actualitzacions disponibles"
 msgid "Updating"
 msgstr "S'està actualitzant"
 
+#: pkg/systemd/service-details.jsx:406
+msgid "Updating status..."
+msgstr ""
+
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Ús"
 
-#: pkg/systemd/host.js:1613
+#: pkg/systemd/host.js:1630
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] "Ús de $0 nucli de CPU"
@@ -7251,7 +7548,7 @@ msgstr[1] "Ús de $0 nuclis de CPU"
 msgid "Use 512 Byte emulation"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:524
+#: pkg/machines/components/diskAdd.jsx:561
 msgid "Use Existing"
 msgstr ""
 
@@ -7263,7 +7560,7 @@ msgstr "Utilitza les següents claus per autenticar contra altres sistemes"
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
-#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1678
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1695
 msgid "Used"
 msgstr "Utilitzat"
 
@@ -7277,7 +7574,7 @@ msgstr "Utilitzat pels contenidors"
 
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1601
 msgid "User"
 msgstr "Usuari"
 
@@ -7290,7 +7587,7 @@ msgstr "Nom d'usuari"
 msgid "User Password"
 msgstr "Contrasenya d'usuari"
 
-#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
+#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nom d'usuari"
@@ -7340,8 +7637,8 @@ msgstr ""
 msgid "VDO support not installed"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
-#: pkg/networkmanager/interfaces.js:2906
+#: pkg/networkmanager/interfaces.js:2526 pkg/networkmanager/interfaces.js:2538
+#: pkg/networkmanager/interfaces.js:2918
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7369,7 +7666,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -7422,7 +7719,7 @@ msgid "Validating key"
 msgstr "S'està validant la clau"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:250
 msgid "Vendor"
 msgstr "Fabricant"
 
@@ -7439,7 +7736,7 @@ msgid "Verifying"
 msgstr "S'està verificant"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
 msgid "Version"
 msgstr "Versió"
 
@@ -7447,14 +7744,22 @@ msgstr "Versió"
 msgid "Very securely erasing $target"
 msgstr "S'està eliminant de forma molt segura $target"
 
+#: pkg/lib/cockpit-components-modifications.jsx:173
+msgid "View automation script"
+msgstr ""
+
+#: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/components/networks/networkList.jsx:39
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Màquines virtuals"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:422
+msgid "Virtual Network failed to be created"
 msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:80
@@ -7465,11 +7770,12 @@ msgstr "El servei de virtualització  (libvirt) no està actiu"
 msgid "Virtualization Service is Available"
 msgstr "El servei de virtualització està disponible"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
+#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
+#: pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Volum"
 
@@ -7480,6 +7786,14 @@ msgstr "Grup de volums"
 #: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Grup de volums $0"
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
+msgid "Volume Group name"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+msgid "Volume Group name should not be empty"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:113
 msgid "Volume Groups"
@@ -7502,12 +7816,12 @@ msgstr ""
 msgid "WWPN"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:836
+#: pkg/networkmanager/interfaces.js:845
 msgid "Waiting"
 msgstr "S'està esperant"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Waiting for details..."
 msgstr "S'estan esperant els detalls..."
 
@@ -7520,11 +7834,11 @@ msgstr ""
 msgid "Waiting for other software management operations to finish"
 msgstr ""
 
-#: pkg/systemd/init.js:724
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr ""
 
-#: pkg/systemd/init.js:719
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr ""
 
@@ -7536,7 +7850,7 @@ msgstr ""
 msgid "Web Console for Linux servers"
 msgstr ""
 
-#: pkg/systemd/services.html:237
+#: pkg/systemd/services.html:129
 msgid "Wednesday"
 msgstr "Dimecres"
 
@@ -7544,7 +7858,7 @@ msgstr "Dimecres"
 msgid "Wednesdays"
 msgstr ""
 
-#: pkg/systemd/services.html:466
+#: pkg/systemd/services.html:321
 msgid "Weeks"
 msgstr "Setmanes"
 
@@ -7572,11 +7886,11 @@ msgstr "Escriptura"
 msgid "Wrong user name or password"
 msgstr "Contrasenya o nom d'usuari incorrecte"
 
-#: pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1985
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2605
 msgid "Yes"
 msgstr "Sí"
 
@@ -7593,8 +7907,8 @@ msgstr ""
 "Actualment esteu connectat directament a aquest servidor. No el podeu "
 "suprimir."
 
-#: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
+#: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
+#: pkg/networkmanager/firewall.jsx:903 pkg/networkmanager/firewall.jsx:909
 msgid "You are not authorized to modify the firewall."
 msgstr ""
 
@@ -7615,18 +7929,17 @@ msgstr ""
 msgid "You must wait longer to change your password"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
-msgid ""
-"You need to select the most closely matching OS vendor and Operating System"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
+msgid "You need to select the most closely matching Operating System"
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:834
+#: pkg/packagekit/updates.jsx:836
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:865
+#: pkg/packagekit/updates.jsx:867
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
@@ -7642,11 +7955,11 @@ msgstr "La vostra sessió ha estat finalitzada."
 msgid "Your session has expired. Please log in again."
 msgstr "La vostra sessió ha vençut. Si us plau, torneu a iniciar la sessió."
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:955
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:968
 msgid "Zones"
 msgstr ""
 
@@ -7662,12 +7975,8 @@ msgstr "[dades binàries]"
 msgid "[no data]"
 msgstr "[sense dades]"
 
-#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
-msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
-msgstr ""
-
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "actiu"
@@ -7758,7 +8067,7 @@ msgstr "ethernet"
 msgid "every day"
 msgstr "cada dia"
 
-#: pkg/systemd/host.js:886
+#: pkg/systemd/host.js:903
 msgid "failed to list ssh host keys: $0"
 msgstr "no s'han pogut llistar les claus d'amfitrions ssh: $0"
 
@@ -7774,11 +8083,11 @@ msgstr ""
 msgid "hostdev"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr ""
 
@@ -7786,11 +8095,11 @@ msgstr ""
 msgid "iSCSI Targets"
 msgstr "Destinacions iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:83
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -7798,8 +8107,8 @@ msgstr ""
 msgid "idle"
 msgstr "ociós"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 msgid "inactive"
 msgstr "inactiu"
 
@@ -7835,9 +8144,9 @@ msgstr "xarxa"
 msgid "nfs dump target isn't formated as server:path"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "no"
@@ -7848,7 +8157,7 @@ msgstr "no"
 msgid "none"
 msgstr "cap"
 
-#: pkg/systemd/host.js:691
+#: pkg/systemd/host.js:712
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] "de $0 nucli de CPU"
@@ -7857,14 +8166,6 @@ msgstr[1] "de $0 nuclis de CPU"
 #: pkg/machines/helpers.js:190
 msgid "paused"
 msgstr "pausa"
-
-#: pkg/machines/components/diskAdd.jsx:154
-msgid "qcow2"
-msgstr ""
-
-#: pkg/machines/components/diskAdd.jsx:157
-msgid "raw"
-msgstr ""
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -7914,7 +8215,7 @@ msgstr "apagat"
 msgid "shutdown"
 msgstr "apaga"
 
-#: pkg/selinux/setroubleshoot-view.jsx:123
+#: pkg/selinux/setroubleshoot-view.jsx:124
 msgid "solution details"
 msgstr "detalls de la solució"
 
@@ -7955,7 +8256,7 @@ msgid "undefined"
 msgstr "indefinit"
 
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:249 pkg/systemd/init.js:263
+#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
 msgid "unknown"
 msgstr "desconegut"
 
@@ -7995,15 +8296,15 @@ msgstr "valor"
 msgid "vhostuser"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "sí"
@@ -8015,1122 +8316,3 @@ msgid ""
 msgstr ""
 "{{ condition.message }}. Marca temporal: {{ condition.lastTransitionTime }} "
 "Nombre d'errors: {{ condition.generation }}"
-
-#~ msgid " 1\"Do you want to delete the following Nodes?"
-#~ msgstr " 1\"Voleu suprimir els següents nodes?"
-
-#~ msgid "$0% Free"
-#~ msgid_plural "$0% Free"
-#~ msgstr[0] "$0% lliure"
-#~ msgstr[1] "$0% lliures"
-
-#~ msgid "$0% Used"
-#~ msgid_plural "$0% Used"
-#~ msgstr[0] "$0% utilitzat"
-#~ msgstr[1] "$0% utilitzats"
-
-#~ msgid "Access Modes"
-#~ msgstr "Modes d'accés"
-
-#~ msgid "Access denied"
-#~ msgstr "Accés denegat"
-
-#~ msgid "Action"
-#~ msgstr "Acció"
-
-#~ msgid "Activation Key"
-#~ msgstr "Clau d'activació"
-
-#~ msgid "Actual"
-#~ msgstr "Real"
-
-#~ msgid "Add Cluster Node"
-#~ msgstr "Afegeix un node de clúster"
-
-#~ msgid "Add Group"
-#~ msgstr "Afegeix un grup"
-
-#~ msgid "Add Kubernetes Node"
-#~ msgstr "Afegeix un node Kubernetes"
-
-#~ msgid "Add Member"
-#~ msgstr "Afegeix un membre"
-
-#~ msgid "Add Membership"
-#~ msgstr "Afegeix una pertinença"
-
-#~ msgid "Add New Cluster"
-#~ msgstr "Afegeix un clúster nou"
-
-#~ msgid "Add New User"
-#~ msgstr "Afegeix un usuari nou"
-
-#~ msgid "Add Role"
-#~ msgstr "Afegeix un rol"
-
-#~ msgid "Add User"
-#~ msgstr "Afegeix un usuari"
-
-#~ msgid "Add membership"
-#~ msgstr "Afegeix una pertinença"
-
-#~ msgid "Adjust"
-#~ msgstr "Ajusta"
-
-#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-#~ msgstr "Ajusta el volum persistent '{{ item.metadata.name }}'"
-
-#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
-#~ msgstr "Ajusta el controlador de replicació {{ item.metadata.name }}"
-
-#~ msgid "Adjust Route"
-#~ msgstr "Ajusta la ruta"
-
-#~ msgid "Adjust Service"
-#~ msgstr "Ajusta el servei"
-
-#~ msgid "Admin"
-#~ msgstr "Administrador"
-
-#~ msgid "All Projects"
-#~ msgstr "Tots els projectes"
-
-#~ msgid "All Types"
-#~ msgstr "Tots els tipus"
-
-#~ msgid "All images"
-#~ msgstr "Totes les imatges"
-
-#~ msgid "All in use"
-#~ msgstr "Tots en ús"
-
-#~ msgid "All running"
-#~ msgstr "Tot en execució"
-
-#~ msgid "All running virtual machines will be turned off."
-#~ msgstr "S'apagaran totes les màquines virtuals."
-
-#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
-#~ msgstr ""
-#~ "Anònim: permet que tots els usuaris no autenticats recuperin imatges"
-
-#~ msgid "Automatically selected host"
-#~ msgstr "Amfitrió seleccionat automàticament"
-
-#~ msgid "Azure"
-#~ msgstr "Azure"
-
-#~ msgid "Base Template"
-#~ msgstr "Plantilla base"
-
-#~ msgid "Base template"
-#~ msgstr "Plantilla base"
-
-#~ msgid "Base template:"
-#~ msgstr "Plantilla base:"
-
-#~ msgid "Boot ID"
-#~ msgstr "Id. d'arrencada"
-
-#~ msgid "CPU Utilization: $0%"
-#~ msgstr "Utilització de la CPU: $0%"
-
-#~ msgid "CREATE VM action failed"
-#~ msgstr "Ha fallat l'acció CREATE VM"
-
-#~ msgid "Change User"
-#~ msgstr "Canvia l'usuari"
-
-#~ msgid "Change image stream"
-#~ msgstr "Canvia el flux d'imatges"
-
-#~ msgid "Change project"
-#~ msgstr "Canvia el projecte"
-
-#~ msgid "Claim"
-#~ msgstr "Reclama"
-
-#~ msgid "Claim Name"
-#~ msgstr "Nom de la reclamació"
-
-#~ msgid "Client Certificate"
-#~ msgstr "Certificat de client"
-
-#~ msgid "Cluster"
-#~ msgstr "Clúster"
-
-#~ msgid "Cluster Templates"
-#~ msgstr "Plantilles de clúster"
-
-#~ msgid "Cluster Virtual Machines"
-#~ msgstr "Màquines virtuals del clúster"
-
-#~ msgid "Configuration"
-#~ msgstr "Configuració"
-
-#~ msgid "Configure Flannel networking"
-#~ msgstr "Configura la xarxa Flannel"
-
-#~ msgid "Configure Kubelet and Proxy"
-#~ msgstr "Configura Kubelet i el servidor intermediari"
-
-#~ msgid "Confirm migration"
-#~ msgstr "Confirmació de la migració"
-
-#~ msgid "Confirm reload:"
-#~ msgstr "Confirmació de la recàrrega:"
-
-#~ msgid "Confirm save:"
-#~ msgstr "Confirmació del desament:"
-
-#~ msgid "Connect to oVirt Engine"
-#~ msgstr "Connecta't al motor d'oVirt"
-
-#~ msgid "Connecting..."
-#~ msgstr "S'està connectant..."
-
-#~ msgid "Connection Error: $0"
-#~ msgstr "Error de connexió: $0"
-
-#~ msgid "Connection Settings"
-#~ msgstr "Ajusts de la connexió"
-
-#~ msgid "Container ID"
-#~ msgstr "Id. de contenidor"
-
-#~ msgid "Container Runtime Version"
-#~ msgstr "Versió de l'entorn d'execució del contenidor"
-
-#~ msgid "Could not list services"
-#~ msgstr "No s'han pogut llistar els serveis"
-
-#~ msgid "Couldn't connect to server"
-#~ msgstr "No s'ha pogut connectar al servidor"
-
-#~ msgid "Couldn't find running API server"
-#~ msgstr "No s'ha pogut trobar el servidor de l'API en execució"
-
-#~ msgid ""
-#~ "Couldn't get system subscription status. Please ensure subscription-"
-#~ "manager is installed."
-#~ msgstr ""
-#~ "No s'ha pogut obtenir l'estat de subscripció del sistema. Assegureu-vos "
-#~ "que subscription-manager estigui instal·lat."
-
-#~ msgid "Create New VM"
-#~ msgstr "Crea una MV nova"
-
-#~ msgid "Create empty image stream"
-#~ msgstr "Crea un flux d'imatges buit"
-
-#~ msgid "Create image stream"
-#~ msgstr "Crea un flux d'imatges"
-
-#~ msgid "Custom URL"
-#~ msgstr "URL personalitzat"
-
-#~ msgid "DNS Policy"
-#~ msgstr "Política del DNS"
-
-#~ msgid "Delete '{{ name }}'"
-#~ msgstr "Suprimeix '{{ name }}'"
-
-#~ msgid "Delete Node"
-#~ msgstr "Suprimeix el node"
-
-#~ msgid "Delete Persistent Volume"
-#~ msgstr "Suprimeix el volum persistent"
-
-#~ msgid "Delete Persistent Volume Claim"
-#~ msgstr "Suprimeix la reclamació del volum persistent"
-
-#~ msgid "Delete Project"
-#~ msgstr "Suprimeix el projecte"
-
-#~ msgid "Delete Selected"
-#~ msgstr "Suprimeix la selecció"
-
-#~ msgid "Delete image stream"
-#~ msgstr "Suprimeix el flux d'imatges"
-
-#~ msgid "Delete {{ item.kind }}"
-#~ msgstr "Suprimeix {{ item.kind }}"
-
-#~ msgid "Deploy"
-#~ msgstr "Desplega"
-
-#~ msgid "Deploy Application"
-#~ msgstr "Desplega l'aplicació"
-
-#~ msgid "Deployment Causes"
-#~ msgstr "Causes del desplegament"
-
-#~ msgid "Deployment Config"
-#~ msgstr "Configuració de desplegament"
-
-#~ msgid "Deployment Configs"
-#~ msgstr "Configuracions de desplegaments"
-
-#~ msgid "Description:"
-#~ msgstr "Descripció:"
-
-#~ msgid "Disk Utilization: $0%"
-#~ msgstr "Utilització del disc: $0%"
-
-#~ msgid "Display name"
-#~ msgstr "Nom a mostrar"
-
-#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-#~ msgstr "Voleu afegir el rol '{{ fields.displayRole }}'?"
-
-#~ msgid ""
-#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
-#~ "metadata.name}}' image stream?"
-#~ msgstr ""
-#~ "Voleu suprimir el flux d'imatges '{{stream.metadata.namespace}}/{{stream."
-#~ "metadata.name}}'?"
-
-#~ msgid ""
-#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-#~ msgstr "Voleu suprimir el volum persistent '{{item.metadata.name}}'?"
-
-#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-#~ msgstr "Voleu suprimir {{ item.kind }} '{{item.metadata.name}}'?"
-
-#~ msgid "Do you want to delete this Node?"
-#~ msgstr "Voleu suprimir aquest node?"
-
-#~ msgid ""
-#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
-#~ msgstr ""
-#~ "Voleu suprimir la imatge etiquetada com a '{{stream.metadata.namespace}}/"
-#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
-
-#~ msgid ""
-#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
-#~ "{{ fields.member.metadata.name }}?"
-#~ msgstr ""
-#~ "Voleu suprimir el rol '{{ fields.displayRole }}' del membre {{ fields."
-#~ "member.metadata.name }}?"
-
-#~ msgid "Don't pull images automatically"
-#~ msgstr "No recuperis automàticament les imatges"
-
-#~ msgid "Driver"
-#~ msgstr "Controlador"
-
-#~ msgid "Edit the vdsm.conf"
-#~ msgstr "Edita el fitxer vdsm.conf"
-
-#~ msgid "Empty Directory"
-#~ msgstr "Directori buit"
-
-#~ msgid "Endpoint"
-#~ msgstr "Extrem"
-
-#~ msgid "Endpoint Name"
-#~ msgstr "Nom de l'extrem"
-
-#~ msgid "Endpoints"
-#~ msgstr "Extrems"
-
-#~ msgid "Ends"
-#~ msgstr "Acaba"
-
-#~ msgid "Enter New VM name"
-#~ msgstr "Introduïu el nom de la nova MV"
-
-#~ msgid "Error getting certificate details: $0"
-#~ msgstr "Error en obtenir els detalls del certificat: $0"
-
-#~ msgid "Error writing kubectl config"
-#~ msgstr "Error en escriure la configuració de kubectl"
-
-#~ msgid "FQDN"
-#~ msgstr "FQDN"
-
-#~ msgid "Fibre Channel"
-#~ msgstr "Fibre Channel"
-
-#~ msgid "Filesystem Type"
-#~ msgstr "Tipus de sistema de fitxers"
-
-#~ msgid "Flex"
-#~ msgstr "Flex"
-
-#~ msgid "Flocker"
-#~ msgstr "Flocker"
-
-#~ msgid "GCE Persistent Disk"
-#~ msgstr "Disc persistent GCE"
-
-#~ msgid "Git Repository"
-#~ msgstr "Dipòsit git"
-
-#~ msgid "Gluster FS"
-#~ msgstr "Gluster FS"
-
-#~ msgid "GlusterFS"
-#~ msgstr "GlusterFS"
-
-#~ msgid "Group Members"
-#~ msgstr "Membres del grup"
-
-#~ msgid "Group or Project"
-#~ msgstr "Grup o projecte"
-
-#~ msgid "Groups"
-#~ msgstr "Grups"
-
-#~ msgid "HA"
-#~ msgstr "HA"
-
-#~ msgid "HA:"
-#~ msgstr "HA:"
-
-#~ msgid "Host Path"
-#~ msgstr "Camí a l'amfitrió"
-
-#~ msgid "Host to Maintenance"
-#~ msgstr "Amfitrió a manteniment"
-
-#~ msgid "IP"
-#~ msgstr "IP"
-
-#~ msgid "ISCSI"
-#~ msgstr "ISCSI"
-
-#~ msgid "Identities"
-#~ msgstr "Identitats"
-
-#~ msgid "Identity"
-#~ msgstr "Identitat"
-
-#~ msgid "Image ID"
-#~ msgstr "Id. d'imatge"
-
-#~ msgid "Image Name"
-#~ msgstr "Nom de la imatge"
-
-#~ msgid "Image Registry"
-#~ msgstr "Registre d'imatges"
-
-#~ msgid "Image Stream"
-#~ msgstr "Flux d'imatges"
-
-#~ msgid "Image commands"
-#~ msgstr "Ordres de la imatge"
-
-#~ msgid "Images by project"
-#~ msgstr "Imatges per projecte"
-
-#~ msgid "Installed products"
-#~ msgstr "Productes instal·lats"
-
-#~ msgid "Interface"
-#~ msgstr "Interfície"
-
-#~ msgid "Invalid credentials"
-#~ msgstr "Credencials no vàlides"
-
-#~ msgid "Kernel Version"
-#~ msgstr "Versió del kernel"
-
-#~ msgid "Key Ring Path"
-#~ msgstr "Camí a l'anell de claus"
-
-#~ msgid "Kubelet Version"
-#~ msgstr "Versió de Kubelet"
-
-#~ msgid "Kubernetes Cluster"
-#~ msgstr "Clúster Kubernetes"
-
-#~ msgid "Last Heartbeat"
-#~ msgstr "Últim batec"
-
-#~ msgid "Last Status Change"
-#~ msgstr "Últim canvi d'estat"
-
-#~ msgid "Latest Version"
-#~ msgstr "Última versió"
-
-#~ msgid "Loading data ..."
-#~ msgstr "S'estan carregant les dades..."
-
-#~ msgid "Logical Unit Number"
-#~ msgstr "Número de la unitat lògica"
-
-#~ msgid "Login"
-#~ msgstr "Usuari"
-
-#~ msgid "Login commands"
-#~ msgstr "Ordres d'inici de sessió"
-
-#~ msgid "Login/password or activation key required to register."
-#~ msgstr ""
-#~ "Per registrar es requereix un usuari/contrasenya o una clau d'activació."
-
-#~ msgid "MIGRATE action failed"
-#~ msgstr "Ha fallat l'acció MIGRATE"
-
-#~ msgid "Manifest"
-#~ msgstr "Manifest"
-
-#~ msgid "Medium"
-#~ msgstr "Mitjà"
-
-#~ msgid "Member of"
-#~ msgstr "Membre de"
-
-#~ msgid "Members"
-#~ msgstr "Membres"
-
-#~ msgid "Membership"
-#~ msgstr "Pertinença"
-
-#~ msgid "Memory Utilization: $0%"
-#~ msgstr "Utilització de la memòria:  $0%"
-
-#~ msgid "Message"
-#~ msgstr "Missatge"
-
-#~ msgid "Migrate To:"
-#~ msgstr "Migra a:"
-
-#~ msgid "Modify"
-#~ msgstr "Modifica"
-
-#~ msgid "Monitors"
-#~ msgstr "Monitors"
-
-#~ msgid "Mount Location"
-#~ msgstr "Ubicació del muntatge"
-
-#~ msgid "NFS"
-#~ msgstr "NFS"
-
-#~ msgid "Namespace"
-#~ msgstr "Espai de noms"
-
-#~ msgid "Namespace cannot be empty."
-#~ msgstr "L'espai de noms no pot estar en blanc."
-
-#~ msgid "New Group"
-#~ msgstr "Grup nou"
-
-#~ msgid "New Project"
-#~ msgstr "Projecte nou"
-
-#~ msgid "New image stream"
-#~ msgstr "Flux d'imatges nou"
-
-#~ msgid "New project"
-#~ msgstr "Projecte nou"
-
-#~ msgid "No VM found in oVirt."
-#~ msgstr "No s'ha trobat cap MV a oVirt."
-
-#~ msgid "No installed products on the system."
-#~ msgstr "No hi ha cap producte instal·lat al sistema."
-
-#~ msgid ""
-#~ "No metadata file was selected. Please select a Kubernetes metadata file."
-#~ msgstr ""
-#~ "Sense seleccionar el fitxer de metadades. Si us plau, seleccioneu un "
-#~ "fitxer de metadades del Kubernetes."
-
-#~ msgid "No nodes in cluster"
-#~ msgstr "Cap node al clúster"
-
-#~ msgid "No users are present."
-#~ msgstr "No hi ha usuaris presents."
-
-#~ msgid "No volumes are present."
-#~ msgstr "No hi ha volums presents."
-
-#~ msgid "No volumes in use"
-#~ msgstr "Sense volums en ús"
-
-#~ msgid "Node"
-#~ msgstr "Node"
-
-#~ msgid "Nodes"
-#~ msgstr "Nodes"
-
-#~ msgid "Nodes are the machines that run your containers."
-#~ msgstr "Els nodes són les màquines que executen els vostres contenidors."
-
-#~ msgid "Not a valid number of replicas"
-#~ msgstr "No és un nombre vàlid de rèpliques"
-
-#~ msgid "Not a valid value for Host"
-#~ msgstr "No és un valor vàlid per a l'amfitrió"
-
-#~ msgid "Not deployed"
-#~ msgstr "No desplegat"
-
-#~ msgid "OS"
-#~ msgstr "SO"
-
-#~ msgid "OS Type:"
-#~ msgstr "Tipus de SO:"
-
-#~ msgid "OS Versions"
-#~ msgstr "Versions del SO"
-
-#~ msgid "Optimized for:"
-#~ msgstr "Optimitzat per:"
-
-#~ msgid "Organization"
-#~ msgstr "Organització"
-
-#~ msgid "Pending Volume Claims"
-#~ msgstr "Reclamacions de volums pendents"
-
-#~ msgid "Persistent Volumes"
-#~ msgstr "Volums persistents"
-
-#~ msgid "Phase"
-#~ msgstr "Fase"
-
-#~ msgid "Please confirm, the host shall be switched to maintenance mode."
-#~ msgstr "Confirmeu que l'amfitrió s'ha de canviar al mode de manteniment."
-
-#~ msgid "Please create another namespace for $0 \"$1\""
-#~ msgstr "Si us plau, creeu un altre espai de noms per a $0 \"$1\""
-
-#~ msgid "Please provide a GlusterFS volume name"
-#~ msgstr "Si us plau, proporcioneu un nom de volum GlusterFS"
-
-#~ msgid "Please provide a username"
-#~ msgstr "Si us plau, proporcioneu un nom d'usuari vàlid"
-
-#~ msgid "Please provide a valid NFS server"
-#~ msgstr "Si us plau, proporcioneu un servidor NFS vàlid"
-
-#~ msgid "Please provide a valid address"
-#~ msgstr "Si us plau, proporcioneu una adreça vàlida"
-
-#~ msgid "Please provide a valid filesystem type"
-#~ msgstr "Si us plau, proporcioneu un tipus de sistema de fitxers vàlid"
-
-#~ msgid "Please provide a valid interface"
-#~ msgstr "Proporcioneu una interfície vàlida"
-
-#~ msgid "Please provide a valid logical unit number"
-#~ msgstr "Si us plau, proporcioneu un nombre vàlid d'unitat lògica"
-
-#~ msgid "Please provide a valid name"
-#~ msgstr "Si us plau, proporcioneu un nom vàlid"
-
-#~ msgid "Please provide a valid namespace."
-#~ msgstr "Si us plau, proporcioneu un espai de noms vàlid."
-
-#~ msgid "Please provide a valid path"
-#~ msgstr "Si us plau, proporcioneu un camí vàlid"
-
-#~ msgid "Please provide a valid storage capacity."
-#~ msgstr "Si us plau, proporcioneu una capacitat d'emmagatzematge vàlida."
-
-#~ msgid "Please provide a valid target"
-#~ msgstr "Si us plau, proporcioneu un objectiu vàlid"
-
-#~ msgid ""
-#~ "Please provide fully qualified domain name and port of the oVirt engine."
-#~ msgstr ""
-#~ "Proporcioneu el nom de domini plenament qualificat i el port del motor "
-#~ "oVirt."
-
-#~ msgid ""
-#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-#~ "port (443 by default)"
-#~ msgstr ""
-#~ "Proporcioneu el nom de domini plenament qualificat d'un motor oVirt vàlid "
-#~ "i el port (443 per defecte)."
-
-#~ msgid "Please select a valid access mode"
-#~ msgstr "Si us plau, seleccioneu un mode d'accés vàlid"
-
-#~ msgid "Please select a valid endpoint"
-#~ msgstr "Si us plau, seleccioneu un extrem vàlid"
-
-#~ msgid "Please select a valid policy option."
-#~ msgstr "Si us plau, seleccioneu una opció de política vàlida."
-
-#~ msgid "Please type an address"
-#~ msgstr "Si us plau, teclegeu una adreça"
-
-#~ msgid "Please wait till VMs list is loaded from the server."
-#~ msgstr "Espereu fins que la llista de MV es carregui del servidor."
-
-#~ msgid "Please wait till list of templates is loaded from the server."
-#~ msgstr "Espereu fins que la llista de plantilles es carregui del servidor."
-
-#~ msgid "Pod"
-#~ msgstr "Pod"
-
-#~ msgid "Pods"
-#~ msgstr "Pods"
-
-#~ msgid "Pool Name"
-#~ msgstr "Nom de l'agrupació"
-
-#~ msgid "Populate"
-#~ msgstr "Pobla"
-
-#~ msgid "Private: Allow only specific users or groups to pull images"
-#~ msgstr ""
-#~ "Privat: permet que només els usuaris o grups específics recuperin imatges"
-
-#~ msgid "Product ID"
-#~ msgstr "Id. del producte"
-
-#~ msgid "Product name"
-#~ msgstr "Nom del producte"
-
-#~ msgid "Project"
-#~ msgstr "Projecte"
-
-#~ msgid "Project Members"
-#~ msgstr "Membres del projecte"
-
-#~ msgid "Project access policy allows anonymous users to pull images."
-#~ msgstr ""
-#~ "La política d'accés de projecte permet que els usuaris anònims recuperin "
-#~ "imatges."
-
-#~ msgid "Project access policy allows any authenticated user to pull images."
-#~ msgstr ""
-#~ "La política d'accés públic permet que qualsevol usuari o grup autenticat "
-#~ "recuperi imatges."
-
-#~ msgid "Project:"
-#~ msgstr "Projecte:"
-
-#~ msgid "Projects"
-#~ msgstr "Projectes"
-
-#~ msgid "Proxy"
-#~ msgstr "Servidor intermediari"
-
-#~ msgid "Proxy Version"
-#~ msgstr "Versió del servidor intermediari"
-
-#~ msgid "Pull an image:"
-#~ msgstr "Recupera una imatge:"
-
-#~ msgid "Pull from"
-#~ msgstr "Recupera de"
-
-#~ msgid "Pull specific tags from another image repository"
-#~ msgstr "Recupera les etiquetes específiques d'un altre dipòsit d'imatges"
-
-#~ msgid "Qualified Name"
-#~ msgstr "Nom qualificat"
-
-#~ msgid "REBOOT action failed"
-#~ msgstr "Ha fallat l'acció REBOOT"
-
-#~ msgid "Rados Block Device"
-#~ msgstr "Dispositiu de blocs rados"
-
-#~ msgid "Read Only"
-#~ msgstr "Tan sols lectura"
-
-#~ msgid "Read and write from a single node"
-#~ msgstr "Lectura i escriptura d'un sol node"
-
-#~ msgid "Read and write from multiple nodes"
-#~ msgstr "Lectura i escriptura de diversos nodes"
-
-#~ msgid "Read only from multiple nodes"
-#~ msgstr "Només lectura de diversos nodes"
-
-#~ msgid "Reason"
-#~ msgstr "Motiu"
-
-#~ msgid "Recycle"
-#~ msgstr "Recicla"
-
-#~ msgid "Register"
-#~ msgstr "Registra"
-
-#~ msgid "Register New Volume"
-#~ msgstr "Registra un volum nou"
-
-#~ msgid "Register Persistent Volume"
-#~ msgstr "Registra un volum persistent"
-
-#~ msgid "Register oVirt"
-#~ msgstr "Registra l'oVirt"
-
-#~ msgid "Register system"
-#~ msgstr "Registra el sistema"
-
-#~ msgid "Registering oVirt to Cockpit"
-#~ msgstr "Registrament d'oVirt a Cockpit"
-
-#~ msgid "Remove Group"
-#~ msgstr "Suprimeix el grup"
-
-#~ msgid "Remove Member"
-#~ msgstr "Suprimeix el membre"
-
-#~ msgid "Remove Role"
-#~ msgstr "Suprimeix el rol"
-
-#~ msgid "Remove User"
-#~ msgstr "Suprimeix l'usuari"
-
-#~ msgid "Remove image tag"
-#~ msgstr "Suprimeix l'etiqueta de la imatge"
-
-#~ msgid "Remove membership"
-#~ msgstr "Suprimeix la pertinença"
-
-#~ msgid "Replicas"
-#~ msgstr "Rèpliques"
-
-#~ msgid "Replication Controller"
-#~ msgstr "Controlador de replicació"
-
-#~ msgid "Replication Controllers"
-#~ msgstr "Controladors de replicació"
-
-#~ msgid "Repository URL"
-#~ msgstr "URl del dipòsit"
-
-#~ msgid "Requests"
-#~ msgstr "Peticions"
-
-#~ msgid "Requires Authentication"
-#~ msgstr "Requereix autenticació"
-
-#~ msgid "Restart Count"
-#~ msgstr "Reinicia el compte"
-
-#~ msgid "Retrieving subscription status..."
-#~ msgstr "S'està recuperant l'estat de la subscripció..."
-
-#~ msgid "Revision"
-#~ msgstr "Revisió"
-
-#~ msgid "Role"
-#~ msgstr "Rol"
-
-#~ msgid "Run Here"
-#~ msgstr "Executa-ho aquí"
-
-#~ msgid "Running Since:"
-#~ msgstr "En execució des de:"
-
-#~ msgid "SHUTDOWN action failed"
-#~ msgstr "Ha fallat l'acció SHUTDOWN"
-
-#~ msgid "START action failed"
-#~ msgstr "Ha fallat l'acció START"
-
-#~ msgid "SUSPEND action failed"
-#~ msgstr "Ha fallat l'acció SUSPEND"
-
-#~ msgid "Scheduling Disabled"
-#~ msgstr "Planificació inhabilitada"
-
-#~ msgid "Secret"
-#~ msgstr "Secret"
-
-#~ msgid "Secret File"
-#~ msgstr "Fitxer secret"
-
-#~ msgid "Secret Name"
-#~ msgstr "Nom secret"
-
-#~ msgid "Secret Volume"
-#~ msgstr "Volum secret"
-
-#~ msgid "Select Manifest File..."
-#~ msgstr "Selecciona el fitxer del manifest..."
-
-#~ msgid "Select an object to see more details."
-#~ msgstr "Seleccioneu un objecte per veure'n més detalls. "
-
-#~ msgid "Service Account"
-#~ msgstr "Compte del servei"
-
-#~ msgid "Share Name"
-#~ msgstr "Nom de compartició"
-
-#~ msgid "Shared: Allow any authenticated user to pull images"
-#~ msgstr "Compartit: permet que qualsevol usuari autenticat recuperi imatges"
-
-#~ msgid "Shell"
-#~ msgstr "Shell"
-
-#~ msgid "Show all Containers"
-#~ msgstr "Mostra tots els contenidors"
-
-#~ msgid "Show all Deployment Configs"
-#~ msgstr "Mostra totes les configuracions de desplegament"
-
-#~ msgid "Show all Nodes"
-#~ msgstr "Mostra tots els nodes"
-
-#~ msgid "Show all Persistent Volumes"
-#~ msgstr "Mostra tots els volums persistents"
-
-#~ msgid "Show all Pods"
-#~ msgstr "Mostra tots els pods"
-
-#~ msgid "Show all Projects"
-#~ msgstr "Mostra tots els projectes"
-
-#~ msgid "Show all Replication Controllers"
-#~ msgstr "Mostra tots els controladors de replicació"
-
-#~ msgid "Show all Routes"
-#~ msgstr "Mostra tots els encaminaments"
-
-#~ msgid "Show all Services"
-#~ msgstr "Mostra tots els serveis"
-
-#~ msgid "Show all image streams"
-#~ msgstr "Mostra tots els fluxos d'imatges"
-
-#~ msgid "Since"
-#~ msgstr "Des de"
-
-#~ msgid "Skip Certificate Verification"
-#~ msgstr "Omet la verificació del certificat"
-
-#~ msgid "Starts"
-#~ msgstr "Comença"
-
-#~ msgid "Status: $0"
-#~ msgstr "Estat: $0"
-
-#~ msgid "Status: System isn't registered"
-#~ msgstr "Estat: el sistema no està registrat"
-
-#~ msgid "Strategy"
-#~ msgstr "Estratègia"
-
-#~ msgid "Subscriptions"
-#~ msgstr "Subscripcions"
-
-#~ msgid "Suspend"
-#~ msgstr "Suspèn"
-
-#~ msgid "Switch Host to Maintenance"
-#~ msgstr "Canvia l'amfitrió a manteniment"
-
-#~ msgid "Switching host to maintenance mode failed. Received error: "
-#~ msgstr "Ha fallat el canvi de l'amfitrió a manteniment. Error rebut: "
-
-#~ msgid "Switching host to maintenance mode in progress ..."
-#~ msgstr "Canvi de l'amfitrió a manteniment en progrés..."
-
-#~ msgid "TLS Termination"
-#~ msgstr "Finalització TLS"
-
-#~ msgid "Template"
-#~ msgstr "Plantilla"
-
-#~ msgid "Templates"
-#~ msgstr "Plantilles"
-
-#~ msgid "Templates of $0 cluster"
-#~ msgstr "Plantilles de clúster $0"
-
-#~ msgid "The address contains invalid characters"
-#~ msgstr "L'adreça conté caràcters no vàlids"
-
-#~ msgid "The container '{{ target }}' does not exist."
-#~ msgstr "El contenidor '{{ target }}' no existeix."
-
-#~ msgid "The deployment config '{{ target }}' does not exist."
-#~ msgstr "La configuració del desplegament '{{ target }}' no existeix."
-
-#~ msgid "The group '{{ groupName }}' does not exist."
-#~ msgstr "El grup '{{ groupName }}' no existeix."
-
-#~ msgid "The maximum number of replicas is 128"
-#~ msgstr "El nombre màxim de rèpliques és 128"
-
-#~ msgid "The name contains invalid characters"
-#~ msgstr "El nom conté caràcters no vàlids"
-
-#~ msgid "The node '{{ target }}' does not exist."
-#~ msgstr "El node '{{ target }}' no existeix."
-
-#~ msgid "The node doesn't have enough disk space"
-#~ msgstr "El node no té prou espai lliure al disc"
-
-#~ msgid "The node doesn't have enough free memory"
-#~ msgstr "El node no té prou memòria lliure al disc"
-
-#~ msgid "The persistent volume '{{ target }}' does not exist."
-#~ msgstr "El volum persistent '{{ target }}' no existeix."
-
-#~ msgid "The pod '{{ target }}' does not exist."
-#~ msgstr "El pod '{{ target }}' no existeix."
-
-#~ msgid "The project '{{ projName }}' does not exist."
-#~ msgstr "El projecte '{{ projName }}' no existeix."
-
-#~ msgid "The replication controller '{{ target }}' does not exist."
-#~ msgstr "El controlador de replicació '{{ target }}' no existeix."
-
-#~ msgid "The route '{{ target }}' does not exist."
-#~ msgstr "L'encaminament '{{ target }}' no existeix."
-
-#~ msgid "The selected file is not a valid Kubernetes application manifest."
-#~ msgstr ""
-#~ "El fitxer seleccionat no és un manifest d'aplicació Kubernetes vàlid."
-
-#~ msgid "The server uses a certificate signed by an unknown authority."
-#~ msgstr ""
-#~ "El servidor utilitza un certificat signat per una autoritat desconeguda."
-
-#~ msgid "The service '{{ target }}' does not exist."
-#~ msgstr "El servei '{{ target }}' no existeix."
-
-#~ msgid "The user '{{ userName }}' does not exist."
-#~ msgstr "L'usuari '{{ userName }}' no existeix."
-
-#~ msgid ""
-#~ "This option is for single node testing only – local storage will not work "
-#~ "in a multi-node cluster"
-#~ msgstr ""
-#~ "Aquesta opció només és per a proves de node únic: l'emmagatzematge local "
-#~ "no funcionarà en un clúster de diversos nodes"
-
-#~ msgid "This virtual machine is not managed by oVirt"
-#~ msgstr "Aquesta màquina virtual no està gestionada per oVirt"
-
-#~ msgid "This volume has not been claimed"
-#~ msgstr "Aquest volum no ha estat reclamat"
-
-#~ msgid "Token"
-#~ msgstr "Testimoni"
-
-#~ msgid "Topology"
-#~ msgstr "Topologia"
-
-#~ msgid "Trust this certificate for this connection"
-#~ msgstr "Confia en aquest certificat per a aquesta connexió"
-
-#~ msgid "Type:"
-#~ msgstr "Tipus:"
-
-#~ msgid "Unable to connect"
-#~ msgstr "No es pot connectar"
-
-#~ msgid "Unable to decode Kubernetes application manifest."
-#~ msgstr "No es pot descodificar el manifest d'aplicació de Kubernetes."
-
-#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
-#~ msgstr "No es pot llegir el fitxer del manifest del Kubernetes. Codi $0."
-
-#~ msgid "Unregister"
-#~ msgstr "Desregistra"
-
-#~ msgid "Unregistering system..."
-#~ msgstr "S'està desregistrant el sistema..."
-
-#~ msgid "Updating $0..."
-#~ msgstr "S'està actualitzant $0..."
-
-#~ msgid "Use proxy server"
-#~ msgstr "Utilitza un servidor intermediari"
-
-#~ msgid "User or Group"
-#~ msgstr "Usuari o grup"
-
-#~ msgid "Users"
-#~ msgstr "Usuaris"
-
-#~ msgid "VDSM"
-#~ msgstr "VDSM"
-
-#~ msgid "VDSM Service Management"
-#~ msgstr "Gestió del servei VDSM"
-
-#~ msgid "VM icon"
-#~ msgstr "Icona de la MV"
-
-#~ msgid "Version num"
-#~ msgstr "Núm. versió"
-
-#~ msgid "Virtual Machines of $0 cluster"
-#~ msgstr "Màquines virtuals del clúster $0"
-
-#~ msgid "Volume ID"
-#~ msgstr "Id. del volum"
-
-#~ msgid "Volume Name"
-#~ msgstr "Nom del volum"
-
-#~ msgid "Volume Type"
-#~ msgstr "Tipus del volum"
-
-#~ msgid "Warning:"
-#~ msgstr "Advertència:"
-
-#~ msgid "Welcome to the Image Registry"
-#~ msgstr "Benvingut al registre d'imatges"
-
-#~ msgid "When"
-#~ msgstr "Quan"
-
-#~ msgid "You can deploy an application to your cluster."
-#~ msgstr "Podeu desplegar una aplicació al vostre clúster."
-
-#~ msgid ""
-#~ "Your login credentials do not give you access to use the docker registry "
-#~ "from the command line."
-#~ msgstr ""
-#~ "Les vostres credencials d'inici de sessió no us donen accés a utilitzar "
-#~ "el registre de docker des de la línia d'ordres."
-
-#~ msgid "connecting"
-#~ msgstr "connectant"
-
-#~ msgid "cores"
-#~ msgstr "nuclis"
-
-#~ msgid "error"
-#~ msgstr "error"
-
-#~ msgid "initializing"
-#~ msgstr "inicialitzant"
-
-#~ msgid "installation failed"
-#~ msgstr "ha fallat la instal·lació"
-
-#~ msgid "installing OS"
-#~ msgstr "instal·lant el SO"
-
-#~ msgid "maintenance"
-#~ msgstr "manteniment"
-
-#~ msgid "oVirt"
-#~ msgstr "oVirt"
-
-#~ msgid "oVirt Host State:"
-#~ msgstr "Estat de l'amfitrió oVirt:"
-
-#~ msgid "pending approval"
-#~ msgstr "pendent d'aprovació"
-
-#~ msgid "pending volume claims"
-#~ msgstr "reclamacions de volums pendents"
-
-#~ msgid "reboot"
-#~ msgstr "reinicia"
-
-#~ msgid "threads"
-#~ msgstr "fils"
-
-#~ msgid "unassigned"
-#~ msgstr "sense assignar"

--- a/po/cs.po
+++ b/po/cs.po
@@ -10,11 +10,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-15 04:42+0000\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-08-08 08:38+0000\n"
+"PO-Revision-Date: 2019-08-15 04:43+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
 "Language-Team: Czech\n"
 "Language: cs\n"
@@ -539,7 +539,7 @@ msgstr "Nastavení účtu"
 msgid "Account not available or cannot be edited."
 msgstr "Účet není k dispozici nebo ho není možné měnit."
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Účty"
 
@@ -575,7 +575,7 @@ msgstr "Aktivní stránky"
 msgid "Active since"
 msgstr "Aktivní od"
 
-#: pkg/systemd/service-details.jsx:336
+#: pkg/systemd/service-details.jsx:352
 msgid "Active since "
 msgstr "Aktivní od"
 
@@ -722,7 +722,7 @@ msgstr "Další DNS domény k prohledávání $val"
 msgid "Additional Storage"
 msgstr "Další úložiště"
 
-#: pkg/systemd/service-details.jsx:198
+#: pkg/systemd/service-details.jsx:209
 msgid "Additional actions"
 msgstr "Další akce"
 
@@ -784,7 +784,7 @@ msgstr "Heslo správce"
 msgid "Advanced TCA"
 msgstr "Pokročilé TCA"
 
-#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:412
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "Později"
 
@@ -824,7 +824,7 @@ msgstr ""
 "Všechna data na vybraných discích budou vymazána a disky budou přidány do "
 "fondu úložiště."
 
-#: pkg/systemd/service-details.jsx:157
+#: pkg/systemd/service-details.jsx:159
 msgid "Allow running (unmask)"
 msgstr "Umožnit spouštění (odmaskovat)"
 
@@ -858,7 +858,7 @@ msgid "Appearance:"
 msgstr "Vzhled:"
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Aplikace"
 
@@ -998,7 +998,7 @@ msgstr "Automatické aktualizace"
 msgid "Automatically start libvirt on boot"
 msgstr "Spouštět libvirt automaticky při startu"
 
-#: pkg/systemd/service-details.jsx:380
+#: pkg/systemd/service-details.jsx:396
 msgid "Automatically starts"
 msgstr "Spouští se automaticky"
 
@@ -1067,11 +1067,11 @@ msgstr "Data předaná mechanizmu passwd1 jsou chybná"
 msgid "Balancer"
 msgstr "Rozkládání zátěže"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr "Před"
 
-#: pkg/systemd/service-details.jsx:402
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr "Spojuje k"
 
@@ -1118,7 +1118,7 @@ msgstr "Pořadí zavádění"
 msgid "Boot order settings could not be saved"
 msgstr "Nastavení pořadí zavádění se nepodařilo uložit"
 
-#: pkg/systemd/service-details.jsx:407
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr "Spojeno"
 
@@ -1240,25 +1240,26 @@ msgstr "Obraz se nedaří smazat"
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:785
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
 #: pkg/machines/components/diskAdd.jsx:597
 #: pkg/machines/components/networks/createNetworkDialog.jsx:486
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:523
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/machines/components/nicEdit.jsx:311 pkg/networkmanager/firewall.jsx:590
-#: pkg/networkmanager/firewall.jsx:658 pkg/networkmanager/firewall.jsx:801
-#: pkg/packagekit/updates.jsx:179 pkg/sosreport/index.js:51
-#: pkg/storaged/dialog.jsx:393 pkg/storaged/jobs-panel.jsx:123
-#: pkg/systemd/hwinfo.jsx:216 pkg/systemd/service-details.jsx:107
+#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
+#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "Storno"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "Nelze se připojit k neznámému stroji"
 
@@ -1325,10 +1326,10 @@ msgstr "Změnit limity prostředků"
 msgid "Change the settings"
 msgstr "Změnit nastavení"
 
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
-#: pkg/machines/components/nicEdit.jsx:287
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Změny se projeví až po vypnutí virt. stroje"
 
@@ -1376,7 +1377,7 @@ msgstr "Zjišťování případných aktualizací…"
 msgid "Checking installed software"
 msgstr "Zjišťuje se nainstalovaný sofware"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:352
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
 msgid "Choose an operating system"
 msgstr "Zvolte operační systém"
 
@@ -1396,6 +1397,10 @@ msgstr "Třída"
 #: pkg/storaged/jobs-panel.jsx:55
 msgid "Cleaning up for $target"
 msgstr "Čištění pro $target"
+
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
 
 #: pkg/systemd/services.html:86
 msgid "Clear All Filters"
@@ -1448,7 +1453,7 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit se nepodařilo daný stroj kontaktovat."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1623,11 +1628,11 @@ msgstr "Komprese"
 msgid "Computer OU"
 msgstr "Organizační jednotka počítače"
 
-#: pkg/systemd/service-details.jsx:426
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr "Podmínka $0=$1 nebyla splněna"
 
-#: pkg/systemd/service-details.jsx:476
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "Podmínka nebyla úspěšná"
 
@@ -1666,11 +1671,11 @@ msgstr "Potvrďte smazání virtuální sítě"
 msgid "Confirm removal with passphrase"
 msgstr "Potvrdit odebrání pomocí heslové fráze"
 
-#: pkg/systemd/service-details.jsx:410
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr "V konfliktu s"
 
-#: pkg/systemd/service-details.jsx:409
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr "Konflikty"
 
@@ -1716,15 +1721,14 @@ msgstr "Připojování k procesu služby SETroubleshoot…"
 msgid "Connecting to Virtualization Service"
 msgstr "Připojuje se ke službě virtualizace"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "Připojování ke stroji"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:699
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
 #: pkg/machines/components/networks/createNetworkDialog.jsx:106
 #: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
@@ -1742,7 +1746,7 @@ msgstr "Překročen časový limit připojení."
 msgid "Connection will be lost"
 msgstr "Spojení bude ztraceno"
 
-#: pkg/systemd/service-details.jsx:408
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr "Sestává se z"
 
@@ -1850,7 +1854,7 @@ msgstr "Nedaří se změnit skupiny uživatele"
 msgid "Couldn't change user password"
 msgstr "Nedaří se změnit heslo uživatele"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "Nedaří se připojit ke stroji"
 
@@ -1879,9 +1883,9 @@ msgid "Crash system"
 msgstr "Zhavarovat systém"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:790
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
 #: pkg/machines/components/networks/createNetworkDialog.jsx:491
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:526
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
 #: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
 #: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
 #: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
@@ -1925,7 +1929,7 @@ msgstr "Vytvořit výkaz"
 msgid "Create Snapshot"
 msgstr "Pořídit zachycený stav"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:560
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "Vytvořit fond úložiště"
 
@@ -1945,7 +1949,7 @@ msgstr "Vytvořit časovače"
 msgid "Create VDO Device"
 msgstr "Vytvořit VDO zařízení"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:832
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "Vytvořit virt. stroj"
 
@@ -2036,7 +2040,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Vytváření skupiny svazků $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:684
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr "Vytvoření virt. stroje $0 se nezdařilo"
 
@@ -2254,6 +2258,10 @@ msgstr "Maže se skupina svazků $target"
 msgid "Description"
 msgstr "Popis"
 
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
+
 # auto translated by TM merge from project: Fedora Websites, version: arm.fedoraproject.org, DocId: po/arm.fedoraproject.org
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2264,6 +2272,8 @@ msgstr "Desktop"
 msgid ""
 "Detach the disks using this pool from any VMs before attempting deletion."
 msgstr ""
+"Před pokusem o smazání odpojte veškeré disky, které využívají tento fond, z "
+"virt. strojů."
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2294,6 +2304,10 @@ msgstr "Soubor představující zařízení"
 msgid "Device is read-only"
 msgstr "Zařízení je pouze pro čtení"
 
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
+
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
 msgstr "Diagnostická hlášení"
@@ -2321,11 +2335,11 @@ msgid "Disable tuned"
 msgstr "Vypnout proces služby tuned"
 
 #: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
-#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:315
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "Vypnuto"
 
-#: pkg/systemd/service-details.jsx:185
+#: pkg/systemd/service-details.jsx:192
 msgid "Disallow running (mask)"
 msgstr "Nepovolit spuštění (maskovat)"
 
@@ -2334,7 +2348,7 @@ msgid "Disconnect"
 msgstr "Odpojit"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "Odpojeno"
 
@@ -2387,6 +2401,10 @@ msgstr "Disky není možné odebrat z $0 virt. strojů"
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Jazyk zobrazení"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2664,7 +2682,7 @@ msgstr "Errata:"
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
 #: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
 #: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/systemd/service-details.jsx:432 pkg/users/local.js:1476
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Chyba"
 
@@ -2725,11 +2743,11 @@ msgstr "Příkaz: 88,2019,nfs,rsync"
 msgid "Excellent password"
 msgstr "Skvělé heslo"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:295
-msgid "Existing Disk Image"
-msgstr "Existující obraz disku"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
+msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:232
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr "Existující obraz disku na souborovém systému hostitele"
 
@@ -2811,7 +2829,7 @@ msgstr "Nepodařilo se nahrát ověřovací klíče."
 msgid "Failed to remove service"
 msgstr "Službu se nepodařilo odbrat"
 
-#: pkg/systemd/service-details.jsx:324
+#: pkg/systemd/service-details.jsx:340
 msgid "Failed to start"
 msgstr "Nepodařilo se spustit"
 
@@ -2842,7 +2860,7 @@ msgstr "Soubor"
 msgid "Filesystem"
 msgstr "Souborový systém"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "Složka v souborovém systému"
 
@@ -2889,7 +2907,7 @@ msgstr "Následuje docker repozitář"
 msgid "For legacy applications only. Reduces performance."
 msgstr "Pouze pro staré aplikace. Snižuje výkon."
 
-#: pkg/systemd/service-details.jsx:306
+#: pkg/systemd/service-details.jsx:322
 msgid "Forbidden from running"
 msgstr "Spuštění zakázáno"
 
@@ -2919,7 +2937,7 @@ msgstr "Vynutit odebrání heslové fráze v $0"
 
 # auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
 #: pkg/machines/components/diskAdd.jsx:157
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:263
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
 #: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
 #: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
@@ -3104,10 +3122,10 @@ msgid "Hide Performance Options"
 msgstr "Předvolby pro výkonnost"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "Počítač"
 
@@ -3117,7 +3135,7 @@ msgstr "Zařízení hostitele"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Název počítače"
 
@@ -3129,7 +3147,7 @@ msgstr "Klíč stroje není správný"
 msgid "Host name should not be changed in a domain"
 msgstr "Název stroje není v doméně možné měnit"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "Hostitele je třeba vyplnit"
 
@@ -3323,15 +3341,19 @@ msgstr ""
 msgid "Images may only be pulled by specific users or groups"
 msgstr "Obrazy mohou být stahovány pouze konkrétními uživateli či skupinami"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:768
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Okamžitě spustit virt. stroj"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "Synchronní"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:240
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3380,11 +3402,11 @@ msgstr "Informace o Docker fondu úložiště nejsou k dispozici."
 msgid "Initializing..."
 msgstr "Inicializace…"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr "Iniciátor"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr "IQN iniciátoru by mělo být vyplněné"
 
@@ -3420,15 +3442,15 @@ msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "Nainstalovat setroubleshoot-server pro řešení potíží s SELinux."
 
 # auto translated by TM merge from project: Fedora Installation Guide, version: f22, DocId: pot/SourceSpoke
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:299
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Zdroj instalace"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:281
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Typ zdroje instalace"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "Zdroj instalace je třeba vyplnit"
 
@@ -3447,7 +3469,7 @@ msgstr "Instaluje se"
 msgid "Installing $0"
 msgstr "Instaluje se $0"
 
-#: pkg/systemd/service-details.jsx:471
+#: pkg/systemd/service-details.jsx:487
 msgid "Instance of template: "
 msgstr "Instance šablony:"
 
@@ -3499,11 +3521,11 @@ msgstr "Neplatná IPv6 předpona"
 msgid "Invalid address $0"
 msgstr "Neplatná adresa $0"
 
-#: pkg/systemd/host.js:1469 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "Neplatný formát data"
 
-#: pkg/systemd/host.js:1465 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "Neplatný formát data a času"
 
@@ -3519,7 +3541,7 @@ msgstr "Neplatné datum skončení platnosti"
 msgid "Invalid file permissions"
 msgstr "Neplatná souborová práva"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "Neplatný název souboru"
 
@@ -3559,7 +3581,7 @@ msgstr "Neplatná předpona nebo maska sítě $0"
 msgid "Invalid range"
 msgstr "Neplatný rozsah"
 
-#: pkg/systemd/host.js:1467 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "Neplatný formát času"
 
@@ -3606,7 +3628,7 @@ msgstr "Připojit se k doméně"
 msgid "Joining this domain is not supported"
 msgstr "Připojení se do této domény není podporováno"
 
-#: pkg/systemd/service-details.jsx:418
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr "Připojuje jmenný prostor od"
 
@@ -3647,7 +3669,7 @@ msgstr "Kerberos tiket"
 msgid "Kernel"
 msgstr "Jádro"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "Výpis paměti jádra"
 
@@ -3679,7 +3701,7 @@ msgstr "Odebrání serveru s klíči může zabránit odemčení $0."
 msgid "LACP Key"
 msgstr "LACP klíč"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:80
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
 msgid "LVM Volume Group"
 msgstr "LVM skupina svazků"
 
@@ -3828,7 +3850,7 @@ msgstr "Místní disky"
 msgid "Local Filesystem"
 msgstr "Místní souborový systém"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr "Místní instalační médium"
 
@@ -3933,7 +3955,7 @@ msgstr "Přihlášení má oprávnění povýšené na úroveň pro správu"
 msgid "Logout Successful"
 msgstr "Odhlášení úspěšné"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Záznamy událostí"
 
@@ -3990,7 +4012,7 @@ msgstr "Identif. stroje"
 msgid "Machine SSH Key Fingerprints"
 msgstr "Otisky SSH klíče stroje"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "Stroje"
 
@@ -4023,7 +4045,7 @@ msgstr "Zkontrolovat ručně s SSH:"
 msgid "Marking $target as faulty"
 msgstr "Označování $target jako vadný"
 
-#: pkg/systemd/service-details.jsx:192 pkg/systemd/service-details.jsx:195
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
 msgid "Mask Service"
 msgstr "Maskovat službu"
 
@@ -4035,11 +4057,11 @@ msgstr "Maska nebo délka předpony"
 msgid "Mask or Prefix Length should not be empty"
 msgstr "Masku nebo délku předpony je třeba vyplnit"
 
-#: pkg/systemd/service-details.jsx:305
+#: pkg/systemd/service-details.jsx:321
 msgid "Masked"
 msgstr "Maskováno"
 
-#: pkg/systemd/service-details.jsx:193
+#: pkg/systemd/service-details.jsx:200
 msgid ""
 "Masking service prevents all dependant units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
@@ -4088,7 +4110,7 @@ msgstr "Člen RAID zařízení $0"
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:390
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
 #: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "Paměť"
@@ -4116,7 +4138,7 @@ msgstr "Paměť se nepodařilo uložit"
 msgid "Memory limit"
 msgstr "Limit paměti"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
 msgstr "Je třeba, aby paměť nebyla 0 (nula)"
 
@@ -4314,11 +4336,11 @@ msgstr "NTP server"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:194
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
 #: pkg/machines/components/diskAdd.jsx:126
 #: pkg/machines/components/networks/createNetworkDialog.jsx:122
 #: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
@@ -4330,8 +4352,8 @@ msgstr "NTP server"
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
 #: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:290
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "Název"
 
@@ -4365,7 +4387,7 @@ msgstr "Název nemůže obsahovat prázdné znaky."
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/networks/createNetworkDialog.jsx:41
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "Název je třeba vyplnit"
 
@@ -4394,16 +4416,16 @@ msgstr "Síť $0 se nepodařilo aktivovat"
 msgid "Network $0 failed to get deactivated"
 msgstr "Síť $0 se nepodařilo deaktivovat"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:293
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr "Zavádění ze sítě (PXE)"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:290
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
 msgid "Network Boot is available only when using System connection"
 msgstr ""
 "Zavedení ze sítě je k dispozici pouze při použití systémových přípojení"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "Síťový souborový systém"
 
@@ -4411,7 +4433,7 @@ msgstr "Síťový souborový systém"
 msgid "Network Interfaces"
 msgstr "Síťová rozhraní"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:246
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr "Síťový výběr nepodporuje PXE."
 
@@ -4433,7 +4455,7 @@ msgstr "NetworkManager není spuštěný."
 
 # auto translated by TM merge from project: Fedora Release Notes, version: f24, DocId: pot/Networking
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:944
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Síť"
 
@@ -4524,7 +4546,7 @@ msgstr "Nejsou nastavená žádná NFS připojení"
 
 #: pkg/machines/components/nicEdit.jsx:118
 msgid "No Network Devices"
-msgstr ""
+msgstr "Žádná síťová zařízení"
 
 #: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
@@ -4800,7 +4822,7 @@ msgstr "Nepřipojeno"
 msgid "Not permitted to perform this action."
 msgstr "Neoprávněni k provedení této akce."
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "Není spuštěné"
 
@@ -4813,7 +4835,7 @@ msgid "Not yet synced"
 msgstr "Doposud nesynchronizováno"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/systemd/service-details.jsx:432
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr "Poznámka"
 
@@ -4853,7 +4875,7 @@ msgstr "Původní heslo nebylo přijato"
 msgid "On Build"
 msgstr "Při sestavování"
 
-#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:413
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr "Při nezdaru"
 
@@ -4914,7 +4936,7 @@ msgid "Open"
 msgstr "Otevřít"
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:343
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "Operační systém"
 
@@ -4977,7 +4999,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "Informace o balíčku"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "PackageKit zhavaroval"
 
@@ -4989,6 +5011,11 @@ msgstr "PackageKit není nainstalovaný"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit ohlásilo chybový kód $0"
 
+# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "Balíčky"
+
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
@@ -4998,7 +5025,7 @@ msgstr "Nadřazené"
 msgid "Parent $parent"
 msgstr "Nadřazené $parent"
 
-#: pkg/systemd/service-details.jsx:403
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr "Součástí"
 
@@ -5091,7 +5118,7 @@ msgstr "Sem vložte obsah veřejné části svého ssh klíče"
 
 # auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/systemd/service-details.jsx:465
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "Popis umístění"
 
@@ -5107,7 +5134,7 @@ msgstr "Náklady trasy $path_cost"
 msgid "Path on Server"
 msgstr "Popis umístění na serveru"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "Umístění v souborovém systému hostitele"
 
@@ -5119,7 +5146,7 @@ msgstr "Popis umístění na serveru je třeba vyplnit."
 msgid "Path on server must start with \"/\"."
 msgstr "Je třeba, aby popis umístění na serveru začínal na „/“."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:223
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "Popis umístění ISO souboru na souborovém systému hostitele"
 
@@ -5171,7 +5198,7 @@ msgstr "Trvalé"
 msgid "Physical"
 msgstr "Fyzické"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr "Fyzické diskové zařízení"
 
@@ -5183,7 +5210,7 @@ msgstr "Fyzický svazek"
 msgid "Physical Volumes"
 msgstr "Fyzické svazky"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr "Fyzické diskové zařízení na hostiteli"
 
@@ -5278,7 +5305,7 @@ msgstr "Fond pro tence poskytované svazky"
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
 msgid "Pool's volumes are used by VMs "
-msgstr ""
+msgstr "Svazky fondu jsou využívány virt. stroji"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/lib/machine-change-port.html:23
@@ -5338,6 +5365,10 @@ msgstr "Délka předpony"
 #: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr "Délka předpony nebo maska sítě"
+
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
 #: pkg/networkmanager/interfaces.js:835
@@ -5422,7 +5453,7 @@ msgstr "Časový limit výzvy prostřednictvím ssh-add překročen"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Časový limit výzvy prostřednictvím ssh-keygen překročen"
 
-#: pkg/systemd/service-details.jsx:416
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr "Propaguje načíst znovu k"
 
@@ -5444,14 +5475,6 @@ msgstr "Veřejný repozitář pro stahování"
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Účel"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "Systémové QEMU/KVM spojení"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "Uživatelské QEMU/KVM spojení"
 
 #: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
@@ -5555,11 +5578,15 @@ msgstr "Rank"
 msgid "Raw to a device"
 msgstr "Neupravované na zařízení"
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr "Zjistit více…"
 
-#: pkg/systemd/service-details.jsx:370
+#: pkg/systemd/service-details.jsx:386
 msgid "Read-only"
 msgstr "Pouze pro čtení"
 
@@ -5627,7 +5654,7 @@ msgstr "Nedávné"
 msgid "Recommended default"
 msgstr "Doporučené výchozí"
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Znovu připojit"
@@ -5664,15 +5691,15 @@ msgstr "Odmítá se připojit. Klíč stroje není znám"
 msgid "Register…"
 msgstr "Zaregistrovat…"
 
-#: pkg/systemd/service-details.jsx:163
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Načíst znovu"
 
-#: pkg/systemd/service-details.jsx:417
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr "Znovu načíst propagováno z"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:271
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "Vzdálená URL adresa"
 
@@ -5835,27 +5862,27 @@ msgstr "Vyžadovat změnu hesla každých $0 dnů"
 msgid "Require password change on $0"
 msgstr "Vyžadovat změnu hesla na $0"
 
-#: pkg/systemd/service-details.jsx:404
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr "Vyžadováno"
 
-#: pkg/systemd/service-details.jsx:356
+#: pkg/systemd/service-details.jsx:372
 msgid "Required by "
 msgstr "Vyžadováno"
 
-#: pkg/systemd/service-details.jsx:399
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr "Vyžaduje"
 
-#: pkg/systemd/service-details.jsx:371
+#: pkg/systemd/service-details.jsx:387
 msgid "Requires administration access to edit"
 msgstr "Pro úpravu jsou vyžadována oprávnění správce systému"
 
-#: pkg/systemd/service-details.jsx:400
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr "Závislost"
 
-#: pkg/systemd/service-details.jsx:405
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr "Závislost pro"
 
@@ -5896,7 +5923,7 @@ msgstr ""
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
 #: pkg/machines/components/vm/vmActions.jsx:42
-#: pkg/systemd/service-details.jsx:167 pkg/systemd/shutdown.js:95
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
 #: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Restartovat"
@@ -5987,9 +6014,13 @@ msgid "Runner"
 msgstr "Spouštěč"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:335
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr "Spuštěné"
+
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
+msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
@@ -6061,11 +6092,10 @@ msgid "Saturdays"
 msgstr "Soboty"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
-#: pkg/systemd/services.html:378
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/machines/components/nicEdit.jsx:314 pkg/storaged/crypto-keyslots.jsx:261
-#: pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Uložit"
 
@@ -6216,10 +6246,11 @@ msgstr "Název služby"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
-#: pkg/networkmanager/firewall.jsx:508
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Služby"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sezení"
@@ -6343,7 +6374,7 @@ msgstr "Single Rank"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:476
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
 #: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
@@ -6388,7 +6419,7 @@ msgstr "Slot $0"
 msgid "Sockets"
 msgstr "Sokety"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Aktualizace software"
 
@@ -6435,9 +6466,9 @@ msgstr "Seřazeno od nejméně po nejvíce důvěryhodné"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
 #: pkg/machines/components/diskAdd.jsx:541
+#: pkg/machines/components/nicEdit.jsx:150
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/nicEdit.jsx:150
 #: pkg/machines/components/vmnetworktab.jsx:148
 msgid "Source"
 msgstr "Zdroj"
@@ -6446,8 +6477,8 @@ msgstr "Zdroj"
 msgid "Source Format"
 msgstr "Zdrojový formát"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:221
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:248
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
@@ -6457,16 +6488,16 @@ msgstr "Popis umístění zdroje"
 msgid "Source URL"
 msgstr "Zdrojová URL adresa"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
 msgid "Source Volume Group"
 msgstr "zdrojová skupina svazků"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:238
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:259
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "Popis umístění zdroje je třeba vyplnit"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "Zdroj by měl začínat na http, ftp nebo nfs protokol"
 
@@ -6501,7 +6532,7 @@ msgstr "Stabilní"
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
 #: pkg/machines/components/networks/createNetworkDialog.jsx:237
 #: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:174
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Spustit"
 
@@ -6513,11 +6544,11 @@ msgstr "Spustit Docker"
 msgid "Start Multipath"
 msgstr "Spustit multipath"
 
-#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:325
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
 msgstr "Spustit službu"
 
-#: pkg/systemd/service-details.jsx:395
+#: pkg/systemd/service-details.jsx:411
 msgid "Start and Enable"
 msgstr "Spustit a zapnout"
 
@@ -6525,7 +6556,7 @@ msgstr "Spustit a zapnout"
 msgid "Start libvirt"
 msgstr "Spustit libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:318
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
 msgstr "Spustit fond při startu hostitele"
 
@@ -6542,7 +6573,7 @@ msgstr "Spouštění RAID zařízení $target"
 msgid "Starting swapspace $target"
 msgstr "Spouštění odkládacího prostoru $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "Při spuštění"
 
@@ -6551,7 +6582,7 @@ msgstr "Při spuštění"
 #: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:259 pkg/systemd/init.js:294
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "Stav"
 
@@ -6561,12 +6592,12 @@ msgid "State:"
 msgstr "Stav:"
 
 #: pkg/systemd/services.html:68 pkg/systemd/init.js:212
-#: pkg/systemd/service-details.jsx:353
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr "Statické"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:460
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "Stav"
 
@@ -6582,7 +6613,7 @@ msgstr "Lepkavé"
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
 #: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
 #: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
-#: pkg/systemd/service-details.jsx:170
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Zastavit"
 
@@ -6590,7 +6621,7 @@ msgstr "Zastavit"
 msgid "Stop Device"
 msgstr "Zastavit zařízení"
 
-#: pkg/systemd/service-details.jsx:395
+#: pkg/systemd/service-details.jsx:411
 msgid "Stop and Disable"
 msgstr "Zastavit a vypnout"
 
@@ -6625,8 +6656,8 @@ msgstr "Zastavování odkládacího prostoru $target"
 
 # auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:439
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Úložiště"
 
@@ -6642,11 +6673,11 @@ msgstr "Fond úložiště $0 se nepodařilo aktivovat"
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr "Fond úložiště $0 se nepodařilo deaktivovat"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr "Název fondu úložiště"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:475
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr "Fond úložiště se nepodařilo uložit"
 
@@ -6671,9 +6702,9 @@ msgstr "Úložiště není na tomto systému možné spravovat."
 msgid "Storage pool"
 msgstr "Fond úložiště"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:172
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
 msgid "Storage size must not be 0"
-msgstr ""
+msgstr "Velikost úložiště nemůže být nula"
 
 #: pkg/systemd/index.html:155
 msgid "Store Metrics"
@@ -6784,8 +6815,10 @@ msgid "Synchronizing RAID Device $target"
 msgstr "Synchronizuje se RAID zařízení $target"
 
 # auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "Systém"
 
@@ -6849,12 +6882,12 @@ msgstr "Tang server s klíči"
 msgid "Target"
 msgstr "Cíl"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "Popis umístění cíle"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "Popis umístění cíle je třeba vyplnit"
 
@@ -6880,7 +6913,7 @@ msgstr "Nastavení portu týmu"
 msgid "Team Settings"
 msgstr "Nastavení týmu"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "Terminál"
 
@@ -6998,7 +7031,7 @@ msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr "Stávající uživatel není oprávněn zobrazovat informace o klíčích."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "Složka na serveru, kterou exportovat"
 
@@ -7069,7 +7102,7 @@ msgstr "Poslední zbývající fyzický svazek skupiny svazků není možné ode
 msgid "The logged in user is not permitted to view system modifications"
 msgstr "Přihlášený uživatel není oprávněn zobrazovat modifikace systému"
 
-#: pkg/shell/indexes.js:407
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "Stroj se restartuje"
 
@@ -7097,14 +7130,14 @@ msgstr "Sken z $time ($type) nenalezl žádné zranitelnosti."
 msgid "The scan from $time ($type) was not successful."
 msgstr "Sken z $time ($type) nebyl úspěšný."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
 msgid "The selected Operating System has minimum memory requirement of $0 $1"
 msgstr "Zvolený operační systém vyžaduje přinejmenším $0 $1 operační paměti"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:178
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid ""
 "The selected Operating System has minimum storage size requirement of $0 $1"
-msgstr ""
+msgstr "Vybraný operační systém vyžaduje velikost úložiště přinejmenším $0 $1"
 
 #: src/ws/login.js:645
 msgid ""
@@ -7320,7 +7353,7 @@ msgstr ""
 "Tento nástroj shromáždí informace o nastavení systému a diagnostice pro "
 "použití při analýze problémů se systémem."
 
-#: pkg/systemd/service-details.jsx:282
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Tato jednotka není navržena k tomu, aby byla výslovně zapnuta."
 
@@ -7336,7 +7369,7 @@ msgstr ""
 "Tato verze cockpit-ws nepodporuje připojování ke stroji pomocí "
 "alternativního uživatele nebo portu"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:469
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr "Tento svazek už je využíván jiným virt. strojem"
 
@@ -7442,16 +7475,20 @@ msgstr "Celková velikost: $0"
 msgid "Tower"
 msgstr "Věž"
 
-#: pkg/systemd/service-details.jsx:415
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr "Spuštěno na základě"
 
-#: pkg/systemd/service-details.jsx:414
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "Spouštěče"
 
 # auto translated by TM merge from project: SETroubleShoot, version: master, DocId: framework/po/setroubleshoot
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Řešit potíže"
@@ -7507,7 +7544,7 @@ msgstr "Tuned je vypnuté"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
@@ -7539,7 +7576,7 @@ msgid "UDP"
 msgstr "UDP"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:288
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "URL"
 
@@ -7607,7 +7644,7 @@ msgid "Unavailable"
 msgstr "Nedostupné"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Neočekávaná chyba"
 
@@ -7615,7 +7652,7 @@ msgstr "Neočekávaná chyba"
 msgid "Unique Network Name"
 msgstr "Doposud nepoužívaný název sítě"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:201
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "Neopakující se název"
 
@@ -7752,11 +7789,11 @@ msgstr "Nedůvěryhodný stroj"
 msgid "Up since $0"
 msgstr "Zapnuto od $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:490
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr "Ve výchozím umístění je k dipozici až $0 $1"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:403
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr "Až $0 $1 k dispozici na tomto stroji"
 
@@ -7790,7 +7827,7 @@ msgstr "Jsou k dispozici aktualizace"
 msgid "Updating"
 msgstr "Aktualizuje se"
 
-#: pkg/systemd/service-details.jsx:390
+#: pkg/systemd/service-details.jsx:406
 msgid "Updating status..."
 msgstr "Aktualizace stavu…"
 
@@ -7933,7 +7970,7 @@ msgstr "Nepodařilo se vynutit vypnutí virt. stroje $0"
 msgid "VM $0 failed to get deleted"
 msgstr "Virt. stroj $0 se nezdařilo smazat"
 
-#: pkg/machines/libvirt-common.js:1308 pkg/machines/hostvmslist.jsx:110
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
 msgid "VM $0 failed to get installed"
 msgstr "Virt. stroj $0 se nezdařilo nainstalovat"
 
@@ -8015,13 +8052,13 @@ msgstr "Verze"
 msgid "Very securely erasing $target"
 msgstr "Velmi jisté vymazávání $target"
 
-#: pkg/lib/cockpit-components-modifications.jsx:174
+#: pkg/lib/cockpit-components-modifications.jsx:173
 msgid "View automation script"
 msgstr "Zobrazit automatizační skript"
 
 #: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Virtuální stroje"
 
@@ -8042,7 +8079,7 @@ msgid "Virtualization Service is Available"
 msgstr "Virtualizační služba je k dispozici"
 
 # auto translated by TM merge from project: anaconda, version: master, DocId: main
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:459
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
@@ -8060,11 +8097,11 @@ msgstr "Skupina oddílů"
 msgid "Volume Group $0"
 msgstr "Skupina svazků $0"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:214
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
 msgid "Volume Group name"
 msgstr "Název skupiny svazků"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:298
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
 msgid "Volume Group name should not be empty"
 msgstr "Název skupiny svazků je třeba vyplnit"
 
@@ -8107,11 +8144,11 @@ msgstr "Čeká se až ostatní programy dokončí použití správy balíčků�
 msgid "Waiting for other software management operations to finish"
 msgstr "Čeká se na dokončení ostatních operací správy balíčků"
 
-#: pkg/systemd/service-details.jsx:406
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr "Vyžadováno"
 
-#: pkg/systemd/service-details.jsx:401
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr "Vyžaduje"
 
@@ -8205,7 +8242,7 @@ msgstr "Nemáte oprávnění spravovat fond úložiště pro Docker."
 msgid "You must wait longer to change your password"
 msgstr "Pro změnu hesla je třeba vyčkat déle"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
 msgid "You need to select the most closely matching Operating System"
 msgstr "Je třeba vybrat co nejvíce odpovídající operační systém"
 
@@ -8367,11 +8404,11 @@ msgstr "zařízení hostitele"
 msgid "hostdev"
 msgstr "zařízení hostitele"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr "IQN iSCSI iniciátoru"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr "iSCSI cíl"
 
@@ -8379,11 +8416,11 @@ msgstr "iSCSI cíl"
 msgid "iSCSI Targets"
 msgstr "iSCSI cíle"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:84
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr "Přímý cíl iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr "IQN název iSCSI cíle"
 
@@ -8588,7 +8625,7 @@ msgstr "hodnota"
 msgid "vhostuser"
 msgstr "uzivatelvirtstroje"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:837
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"

--- a/po/de.po
+++ b/po/de.po
@@ -10,18 +10,19 @@
 # Fabian Affolter <fab@fedoraproject.org>, 2018. #zanata
 # Ludek Janda <ljanda@redhat.com>, 2018. #zanata
 # cockpit <cockpituous@gmail.com>, 2018. #zanata
+# Fabian Affolter <fab@fedoraproject.org>, 2019. #zanata
 # Martin Pitt <mpitt@redhat.com>, 2019. #zanata
 # Stefan Lehmann <stefan.lehmann@mailbox.org>, 2019. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-17 06:21+0000\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-07-16 01:54+0000\n"
-"Last-Translator: Stefan Lehmann <stefan.lehmann@mailbox.org>\n"
+"PO-Revision-Date: 2019-08-19 12:00+0000\n"
+"Last-Translator: Fabian Affolter <fab@fedoraproject.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -50,15 +51,15 @@ msgstr "$0 Dateisystem"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:105
 msgid "$0 Network"
-msgstr ""
+msgstr "$0 Netzwerk"
 
 #: pkg/packagekit/history.jsx:101
 msgid "$0 Package"
 msgid_plural "$0 Packages"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "$0 Paket"
+msgstr[1] "$0 Pakete"
 
-#: pkg/systemd/init.js:395 pkg/systemd/init.js:749
+#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "$0 Template"
 
@@ -152,7 +153,7 @@ msgstr "$0 ist in keinem Repository verfügbar."
 msgid "$0 killed with signal $1"
 msgstr "$0 mit Signal getötet $1"
 
-#: pkg/selinux/setroubleshoot-view.jsx:431
+#: pkg/selinux/setroubleshoot-view.jsx:439
 msgid "$0 occurrence"
 msgid_plural "$1 occurrences"
 msgstr[0] "$0 Auftreten"
@@ -194,7 +195,7 @@ msgid_plural "$1 security fixes"
 msgstr[0] "$1 Sicherheitsupdate"
 msgstr[1] "$1 Sicherheitsupdates"
 
-#: pkg/networkmanager/interfaces.js:2757
+#: pkg/networkmanager/interfaces.js:2769
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -210,11 +211,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:549
+#: pkg/networkmanager/firewall.jsx:574
 msgid "(Optional)"
 msgstr "(optional)"
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
+#: pkg/networkmanager/firewall.jsx:499 pkg/networkmanager/firewall.jsx:648
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(Vorgabe)"
@@ -253,7 +254,7 @@ msgstr "1 Tag"
 msgid "1 hour"
 msgstr "1 Stunde"
 
-#: pkg/systemd/host.js:1669
+#: pkg/systemd/host.js:1686
 msgid "1 min"
 msgstr "1 Minute"
 
@@ -263,11 +264,11 @@ msgstr "1 Minute"
 msgid "1 week"
 msgstr "1 Woche"
 
-#: pkg/systemd/services.html:273
+#: pkg/systemd/services.html:165
 msgid "10th"
 msgstr "10."
 
-#: pkg/systemd/services.html:274
+#: pkg/systemd/services.html:166
 msgid "11th"
 msgstr "11."
 
@@ -275,19 +276,19 @@ msgstr "11."
 msgid "128 KiB"
 msgstr "128 KiB"
 
-#: pkg/systemd/services.html:275
+#: pkg/systemd/services.html:167
 msgid "12th"
 msgstr "12."
 
-#: pkg/systemd/services.html:276
+#: pkg/systemd/services.html:168
 msgid "13th"
 msgstr "13."
 
-#: pkg/systemd/services.html:277
+#: pkg/systemd/services.html:169
 msgid "14th"
 msgstr "14."
 
-#: pkg/systemd/services.html:278
+#: pkg/systemd/services.html:170
 msgid "15th"
 msgstr "15."
 
@@ -295,23 +296,23 @@ msgstr "15."
 msgid "16 KiB"
 msgstr "16 KiB"
 
-#: pkg/systemd/services.html:279
+#: pkg/systemd/services.html:171
 msgid "16th"
 msgstr "16."
 
-#: pkg/systemd/services.html:280
+#: pkg/systemd/services.html:172
 msgid "17th"
 msgstr "17."
 
-#: pkg/systemd/services.html:281
+#: pkg/systemd/services.html:173
 msgid "18th"
 msgstr "18."
 
-#: pkg/systemd/services.html:282
+#: pkg/systemd/services.html:174
 msgid "19th"
 msgstr "19."
 
-#: pkg/systemd/services.html:264
+#: pkg/systemd/services.html:156
 msgid "1st"
 msgstr "1."
 
@@ -319,7 +320,7 @@ msgstr "1."
 msgid "2 MiB"
 msgstr "2 MiB"
 
-#: pkg/systemd/host.js:1668
+#: pkg/systemd/host.js:1685
 msgid "2 min"
 msgstr "2 Minuten"
 
@@ -327,59 +328,59 @@ msgstr "2 Minuten"
 msgid "20 Minutes"
 msgstr "20 Minuten"
 
-#: pkg/systemd/services.html:283
+#: pkg/systemd/services.html:175
 msgid "20th"
 msgstr "20."
 
-#: pkg/systemd/services.html:284
+#: pkg/systemd/services.html:176
 msgid "21st"
 msgstr "21."
 
-#: pkg/systemd/services.html:285
+#: pkg/systemd/services.html:177
 msgid "22nd"
 msgstr "22."
 
-#: pkg/systemd/services.html:286
+#: pkg/systemd/services.html:178
 msgid "23rd"
 msgstr "23."
 
-#: pkg/systemd/services.html:287
+#: pkg/systemd/services.html:179
 msgid "24th"
 msgstr "24."
 
-#: pkg/systemd/services.html:288
+#: pkg/systemd/services.html:180
 msgid "25th"
 msgstr "25."
 
-#: pkg/systemd/services.html:289
+#: pkg/systemd/services.html:181
 msgid "26th"
 msgstr "26."
 
-#: pkg/systemd/services.html:290
+#: pkg/systemd/services.html:182
 msgid "27th"
 msgstr "27."
 
-#: pkg/systemd/services.html:291
+#: pkg/systemd/services.html:183
 msgid "28th"
 msgstr "28."
 
-#: pkg/systemd/services.html:292
+#: pkg/systemd/services.html:184
 msgid "29th"
 msgstr "29."
 
-#: pkg/systemd/services.html:265
+#: pkg/systemd/services.html:157
 msgid "2nd"
 msgstr "2."
 
-#: pkg/systemd/host.js:1667
+#: pkg/systemd/host.js:1684
 msgid "3 min"
 msgstr "3 Minuten"
 
-#: pkg/systemd/services.html:293
+#: pkg/systemd/services.html:185
 msgid "30th"
 msgstr "30."
 
-#: pkg/systemd/services.html:294
+#: pkg/systemd/services.html:186
 msgid "31st"
 msgstr "31."
 
@@ -387,7 +388,7 @@ msgstr "31."
 msgid "32 KiB"
 msgstr "32 KiB"
 
-#: pkg/systemd/services.html:266
+#: pkg/systemd/services.html:158
 msgid "3rd"
 msgstr "3."
 
@@ -395,7 +396,7 @@ msgstr "3."
 msgid "4 KiB"
 msgstr "4 KiB"
 
-#: pkg/systemd/host.js:1666
+#: pkg/systemd/host.js:1683
 msgid "4 min"
 msgstr "4 Minuten"
 
@@ -403,7 +404,7 @@ msgstr "4 Minuten"
 msgid "40 Minutes"
 msgstr "40 Minuten"
 
-#: pkg/systemd/services.html:267
+#: pkg/systemd/services.html:159
 msgid "4th"
 msgstr "4."
 
@@ -411,7 +412,7 @@ msgstr "4."
 msgid "5 Minutes"
 msgstr "5 Minuten"
 
-#: pkg/systemd/host.js:1665
+#: pkg/systemd/host.js:1682
 msgid "5 min"
 msgstr "5 Minuten"
 
@@ -425,7 +426,7 @@ msgstr "5 Minuten"
 msgid "512 KiB"
 msgstr "512 KiB"
 
-#: pkg/systemd/services.html:268
+#: pkg/systemd/services.html:160
 msgid "5th"
 msgstr "5."
 
@@ -443,11 +444,11 @@ msgstr "60 Minuten"
 msgid "64 KiB"
 msgstr "64 KiB"
 
-#: pkg/systemd/services.html:269
+#: pkg/systemd/services.html:161
 msgid "6th"
 msgstr "6."
 
-#: pkg/systemd/services.html:270
+#: pkg/systemd/services.html:162
 msgid "7th"
 msgstr "7."
 
@@ -455,19 +456,19 @@ msgstr "7."
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1987
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:1995
+#: pkg/networkmanager/interfaces.js:2004
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
-#: pkg/systemd/services.html:271
+#: pkg/systemd/services.html:163
 msgid "8th"
 msgstr "8."
 
-#: pkg/systemd/services.html:272
+#: pkg/systemd/services.html:164
 msgid "9th"
 msgstr "9."
 
@@ -496,15 +497,15 @@ msgstr ""
 "Eine Ersatzfestplatte muss zuerst hinzugefügt werden, bevor diese entfernt "
 "werden kann."
 
-#: pkg/networkmanager/interfaces.js:1986
+#: pkg/networkmanager/interfaces.js:1995
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2786
+#: pkg/networkmanager/interfaces.js:2798
 msgid "ARP Monitoring"
 msgstr "ARP-Überwachung"
 
-#: pkg/networkmanager/interfaces.js:2007
+#: pkg/networkmanager/interfaces.js:2016
 msgid "ARP Ping"
 msgstr "ARP-Ping"
 
@@ -512,6 +513,10 @@ msgstr "ARP-Ping"
 #: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Über Cockpit"
+
+#: pkg/lib/machine-info.js:251
+msgid "Absent"
+msgstr ""
 
 #: pkg/users/index.html:104 pkg/users/index.html:190
 msgid "Access"
@@ -533,7 +538,7 @@ msgstr "Kontoeinstellungen"
 msgid "Account not available or cannot be edited."
 msgstr "Konto nicht verfügbar oder Änderungen nicht möglich."
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Konten"
 
@@ -552,11 +557,11 @@ msgstr "Aktivieren"
 msgid "Activating $target"
 msgstr "Aktiviere $target"
 
-#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
+#: pkg/networkmanager/interfaces.js:847 pkg/networkmanager/interfaces.js:2010
 msgid "Active"
 msgstr "Aktiv"
 
-#: pkg/networkmanager/interfaces.js:1975 pkg/networkmanager/interfaces.js:1992
+#: pkg/networkmanager/interfaces.js:1984 pkg/networkmanager/interfaces.js:2001
 msgid "Active Backup"
 msgstr "Aktive Sicherung"
 
@@ -568,27 +573,31 @@ msgstr "Aktive Seiten"
 msgid "Active since"
 msgstr "Aktiv seit"
 
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/systemd/service-details.jsx:352
+msgid "Active since "
+msgstr "Aktiviert seit"
+
+#: pkg/networkmanager/firewall.jsx:954
 msgid "Active zones"
 msgstr "aktive Zonen"
 
-#: pkg/networkmanager/interfaces.js:1980
+#: pkg/networkmanager/interfaces.js:1989
 msgid "Adaptive load balancing"
 msgstr "Adaptives Load Balancing (alb)"
 
-#: pkg/networkmanager/interfaces.js:1979
+#: pkg/networkmanager/interfaces.js:1988
 msgid "Adaptive transmit load balancing"
 msgstr "Adaptives Transmit Load Balancing (tlb)"
 
 #: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/machines/components/diskAdd.jsx:600 pkg/storaged/crypto-keyslots.jsx:228
 #: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
 #: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: pkg/networkmanager/interfaces.js:3103
+#: pkg/networkmanager/interfaces.js:3115
 msgid "Add $0"
 msgstr "$0 hinzufügen"
 
@@ -604,7 +613,7 @@ msgstr "Bündelung hinzufügen"
 msgid "Add Bridge"
 msgstr "Bridge hinzufügen"
 
-#: pkg/machines/components/diskAdd.jsx:360
+#: pkg/machines/components/diskAdd.jsx:368
 msgid "Add Disk"
 msgstr "Datenträger hinzufügen"
 
@@ -620,12 +629,12 @@ msgstr "Schlüssel hinzufügen"
 msgid "Add Machine to Dashboard"
 msgstr "Maschine zum Dashboard hinzufügen"
 
-#: pkg/networkmanager/firewall.jsx:457
+#: pkg/networkmanager/firewall.jsx:482
 msgid "Add Ports"
 msgstr "Ports hinzufügen"
 
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
-#: pkg/networkmanager/firewall.jsx:886
+#: pkg/networkmanager/firewall.jsx:482 pkg/networkmanager/firewall.jsx:904
+#: pkg/networkmanager/firewall.jsx:916
 msgid "Add Services"
 msgstr "Dienste hinzufügen"
 
@@ -641,8 +650,8 @@ msgstr "Team hinzufügen"
 msgid "Add VLAN"
 msgstr "VLAN hinzufügen"
 
-#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
-#: pkg/networkmanager/firewall.jsx:891
+#: pkg/networkmanager/firewall.jsx:730 pkg/networkmanager/firewall.jsx:910
+#: pkg/networkmanager/firewall.jsx:921
 msgid "Add Zone"
 msgstr "Zone hinzufügen"
 
@@ -654,7 +663,7 @@ msgstr "Fügen Sie das iSCSI-Portal hinzu"
 msgid "Add key"
 msgstr "Schlüssel hinzufügen"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add ports to the following zones:"
 msgstr "Ports zu folgenden Zonen hinzufügen"
 
@@ -662,21 +671,27 @@ msgstr "Ports zu folgenden Zonen hinzufügen"
 msgid "Add public key"
 msgstr "Öffentlichen Schlüssel hinzufügen"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add services to following zones:"
 msgstr "Services zu folgenden Zonen hinzufügen"
 
-#: pkg/networkmanager/firewall.jsx:776
+#: pkg/networkmanager/firewall.jsx:806
 msgid "Add zone"
 msgstr "Zone hinzufügen"
 
-#: pkg/networkmanager/interfaces.js:3102
+#: pkg/networkmanager/interfaces.js:3114
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
 msgstr ""
 "Das Hinzufügen von <b>$0</b> wird die Verbindung zum Server unterbrechen und "
 "damit den Zugriff auf die Benutzeroberfläche unmöglich machen."
+
+#: pkg/networkmanager/firewall.jsx:586
+msgid ""
+"Adding custom ports will reload firewalld. A reload will result in the loss "
+"of any runtime-only configuration!"
+msgstr ""
 
 #: pkg/users/authorized-keys.js:113
 msgid "Adding key"
@@ -690,11 +705,11 @@ msgstr "Füge physikalischen Datenträger zu $target hinzu"
 msgid "Additional"
 msgstr "Mehr"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2668
 msgid "Additional DNS $val"
 msgstr "Zusätzliches DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Additional DNS Search Domains $val"
 msgstr "Zusätzliche DNS-Suchdomänen $val"
 
@@ -702,7 +717,11 @@ msgstr "Zusätzliche DNS-Suchdomänen $val"
 msgid "Additional Storage"
 msgstr "Zusätzlicher Speicher"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/systemd/service-details.jsx:209
+msgid "Additional actions"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2663
 msgid "Additional address $val"
 msgstr "Zusätzliche Adresse $val"
 
@@ -718,7 +737,7 @@ msgstr "Zusatzpakete:"
 msgid "Address"
 msgstr "Adresse"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/networkmanager/interfaces.js:2663
 msgid "Address $val"
 msgstr "Adresse $val"
 
@@ -730,11 +749,18 @@ msgstr "Adresse darf nicht leer sein"
 msgid "Address is not a valid URL"
 msgstr "Adresse ist keine gültige URL"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:60
+#: pkg/machines/components/networks/createNetworkDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:88
+#: pkg/machines/components/networks/createNetworkDialog.jsx:95
+msgid "Address not within subnet"
+msgstr ""
+
 #: pkg/machines/components/desktopConsole.jsx:153
 msgid "Address:"
 msgstr "Adresse:"
 
-#: pkg/networkmanager/interfaces.js:3309
+#: pkg/networkmanager/interfaces.js:3321
 msgid "Addresses"
 msgstr "Adressen"
 
@@ -750,7 +776,7 @@ msgstr "Passwort des Administrators"
 msgid "Advanced TCA"
 msgstr "Fortgeschrittenes TCA"
 
-#: pkg/systemd/services.html:455 pkg/systemd/init.js:730
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "Hinten"
 
@@ -765,8 +791,8 @@ msgstr ""
 "z.B. die DNS Auflösungs Einstellungen und die Liste der vertrauenswürdigen "
 "CAs könnte sich ändern."
 
-#: pkg/systemd/services.html:446 pkg/systemd/services.html:450
-#: pkg/systemd/init.js:1073
+#: pkg/systemd/services.html:301 pkg/systemd/services.html:305
+#: pkg/systemd/init.js:902
 msgid "After system boot"
 msgstr "Nach dem Systemstart"
 
@@ -774,7 +800,7 @@ msgstr "Nach dem Systemstart"
 msgid "Alert and above"
 msgstr "Alarm und höher"
 
-#: pkg/systemd/services.html:71 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
 msgid "All"
 msgstr "Alle"
 
@@ -790,11 +816,15 @@ msgstr ""
 "Die ausgewählten Datenträger werden zum Storage Pool hinzugefügt. Dabei "
 "werden sämtliche Daten auf den ausgewählten Datenträgern gelöscht."
 
-#: pkg/networkmanager/firewall.jsx:751
+#: pkg/systemd/service-details.jsx:159
+msgid "Allow running (unmask)"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:781
 msgid "Allowed Addresses"
 msgstr "Erlaubte Adressen"
 
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:967
 msgid "Allowed Services"
 msgstr "Zulässige Dienste"
 
@@ -819,7 +849,7 @@ msgid "Appearance:"
 msgstr "Erscheinungsbild"
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Anwendungen"
 
@@ -875,16 +905,16 @@ msgstr "Mindestens $0 Datenträger sind nötig."
 msgid "At least one disk is needed."
 msgstr "Mindestens ein Datenträger ist nötig."
 
-#: pkg/systemd/services.html:451
+#: pkg/systemd/services.html:306
 msgid "At specific time"
 msgstr "Zu einer bestimmten Zeit"
 
 # translation auto-copied from project Drools Workbench, version 6.0.0, document org.drools/drools-wb-guided-rule-editor-client/org/drools/workbench/screens/guided/rule/client/resources/i18n/Constants, author jdimanos
-#: pkg/selinux/setroubleshoot-view.jsx:416
+#: pkg/selinux/setroubleshoot-view.jsx:424
 msgid "Audit log"
 msgstr "Audit-Protokoll"
 
-#: pkg/networkmanager/interfaces.js:830
+#: pkg/networkmanager/interfaces.js:839
 msgid "Authenticating"
 msgstr "Authentifiziere"
 
@@ -925,22 +955,23 @@ msgstr "Autor"
 msgid "Authorized Public SSH Keys"
 msgstr "Autorisierte öffentliche SSH-Schlüssel"
 
-#: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
-#: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
-#: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:338
+#: pkg/networkmanager/index.html:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:176
+#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:2771
+#: pkg/networkmanager/interfaces.js:3329 pkg/networkmanager/interfaces.js:3333
+#: pkg/networkmanager/interfaces.js:3339 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: pkg/networkmanager/interfaces.js:1966
+#: pkg/networkmanager/interfaces.js:1975
 msgid "Automatic (DHCP only)"
 msgstr "Automatisch (nur DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1956
+#: pkg/networkmanager/interfaces.js:1965
 msgid "Automatic (DHCP)"
 msgstr "Automatisch (DHCP)"
 
-#: pkg/systemd/services.html:125 pkg/systemd/init.js:286
+#: pkg/systemd/init.js:295
 msgid "Automatic Startup"
 msgstr "Autostart"
 
@@ -951,6 +982,10 @@ msgstr "Automatische Updates"
 #: pkg/machines/components/libvirtSlate.jsx:90
 msgid "Automatically start libvirt on boot"
 msgstr "Starten Sie libvirt automatisch beim Booten"
+
+#: pkg/systemd/service-details.jsx:396
+msgid "Automatically starts"
+msgstr ""
 
 #: pkg/systemd/index.html:389
 msgid "Automatically using NTP"
@@ -965,7 +1000,7 @@ msgid "Automation Script"
 msgstr ""
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:86
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:69
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "Autostart"
@@ -976,7 +1011,7 @@ msgstr "Autostart"
 msgid "Available"
 msgstr "Verfügbar"
 
-#: pkg/packagekit/updates.jsx:822
+#: pkg/packagekit/updates.jsx:824
 msgid "Available Updates"
 msgstr "Verfügbare Updates"
 
@@ -1017,11 +1052,11 @@ msgid "Balancer"
 msgstr "Balancer"
 
 # translation auto-copied from project Drools Workbench, version 6.0.0, document org.drools/drools-wb-guided-rule-editor-client/org/drools/workbench/screens/guided/rule/client/resources/i18n/Constants, author jdimanos
-#: pkg/systemd/init.js:729
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr "Bevor"
 
-#: pkg/systemd/init.js:720
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr "Bindet an"
 
@@ -1049,8 +1084,8 @@ msgstr "Gerät für Dateisysteme blockieren"
 msgid "Blocked"
 msgstr "Gesperrt"
 
-#: pkg/networkmanager/interfaces.js:2510 pkg/networkmanager/interfaces.js:2522
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
+#: pkg/networkmanager/interfaces.js:2803
 msgid "Bond"
 msgstr "Bond"
 
@@ -1067,12 +1102,12 @@ msgstr "Boot Reihenfolge"
 msgid "Boot order settings could not be saved"
 msgstr "Boot-Reihenfolge konnte nicht gespeichert werden"
 
-#: pkg/systemd/init.js:725
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr "Gebunden"
 
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2528 pkg/networkmanager/interfaces.js:2540
+#: pkg/networkmanager/interfaces.js:2880
 msgid "Bridge"
 msgstr "Bridge"
 
@@ -1084,19 +1119,19 @@ msgstr "Bridge Port Einstellungen"
 msgid "Bridge Settings"
 msgstr "Bridge Einstellungen"
 
-#: pkg/networkmanager/interfaces.js:2889
+#: pkg/networkmanager/interfaces.js:2901
 msgid "Bridge port"
 msgstr "Bridge-Port"
 
-#: pkg/networkmanager/interfaces.js:1977 pkg/networkmanager/interfaces.js:1994
+#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
 msgid "Broadcast"
 msgstr "Broadcast"
 
-#: pkg/networkmanager/interfaces.js:2804 pkg/networkmanager/interfaces.js:2838
+#: pkg/networkmanager/interfaces.js:2816 pkg/networkmanager/interfaces.js:2850
 msgid "Broken configuration"
 msgstr "Fehlerhafte Konfiguration"
 
-#: pkg/systemd/host.js:498
+#: pkg/systemd/host.js:508
 msgid "Bug Fix Updates Available"
 msgstr "Bug Fix Updates verfügbar"
 
@@ -1132,7 +1167,7 @@ msgstr "Prozessor-Sicherheit"
 msgid "CPU Security Toggles"
 msgstr "Prozessor-Sicherheits-Schalter"
 
-#: pkg/systemd/host.js:1548
+#: pkg/systemd/host.js:1565
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "CPU Status"
@@ -1149,12 +1184,12 @@ msgstr "CPU Priorität"
 msgid "CPU usage:"
 msgstr "CPU auslastung:"
 
-#: pkg/machines/components/diskAdd.jsx:246
+#: pkg/machines/components/diskAdd.jsx:251
 #: pkg/machines/components/vmDiskColumns.jsx:75
 msgid "Cache"
 msgstr "Cache"
 
-#: pkg/systemd/index.html:252 pkg/systemd/host.js:1679
+#: pkg/systemd/index.html:252 pkg/systemd/host.js:1696
 msgid "Cached"
 msgstr "Zwischengespeichert"
 
@@ -1183,29 +1218,31 @@ msgstr "Bild kann nicht geladen werden"
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
 #: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:522
+#: pkg/systemd/index.html:487 pkg/systemd/services.html:377
 #: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:560
+#: pkg/machines/components/diskAdd.jsx:597
+#: pkg/machines/components/networks/createNetworkDialog.jsx:486
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:560 pkg/networkmanager/firewall.jsx:628
-#: pkg/networkmanager/firewall.jsx:771 pkg/packagekit/updates.jsx:179
+#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
+#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
 #: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "Kann nicht zu einer unbekannten Maschine verbinden"
 
@@ -1221,7 +1258,7 @@ msgstr "Vorgang kann nicht für die Vergangenheit geplant werden"
 msgid "Capacity"
 msgstr "Kapazität"
 
-#: pkg/networkmanager/interfaces.js:2590
+#: pkg/networkmanager/interfaces.js:2602
 msgid "Carrier"
 msgstr "Träger"
 
@@ -1267,18 +1304,18 @@ msgstr "Ressourcenlimits anpassen"
 msgid "Change resources limits"
 msgstr "Ressourcenlimits anpassen"
 
-#: pkg/networkmanager/interfaces.js:3153
+#: pkg/networkmanager/interfaces.js:3165
 msgid "Change the settings"
 msgstr "Bridge Port-Einstellungen"
 
-#: pkg/machines/components/nicEdit.jsx:272
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Änderungen werden nach dem Herunterfahren der VM wirksam"
 
-#: pkg/networkmanager/interfaces.js:3152
+#: pkg/networkmanager/interfaces.js:3164
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1294,7 +1331,7 @@ msgstr "Nach Aktualisierungen suchen"
 msgid "Checking $target"
 msgstr "Überprüfung $target"
 
-#: pkg/networkmanager/interfaces.js:834
+#: pkg/networkmanager/interfaces.js:843
 msgid "Checking IP"
 msgstr "IP wird überprüft"
 
@@ -1314,13 +1351,17 @@ msgstr "Nach neuen Anwendungen suchen"
 msgid "Checking for public keys"
 msgstr "Auf öffentliche Schlüssel überprüfen"
 
-#: pkg/systemd/host.js:517
+#: pkg/systemd/host.js:537
 msgid "Checking for updates…"
 msgstr "Nach Updates suchen…"
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:142
 msgid "Checking installed software"
 msgstr "Installierte Software überprüfen"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
+msgid "Choose an operating system"
+msgstr ""
 
 #: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
@@ -1330,7 +1371,7 @@ msgstr "Wählen Sie die in der Applikation zu verwendende Sprache"
 msgid "Chunk Size"
 msgstr "Datenblock Grösse"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "Class"
 msgstr "Klasse"
 
@@ -1338,11 +1379,15 @@ msgstr "Klasse"
 msgid "Cleaning up for $target"
 msgstr "$target wird aufgeräumt"
 
-#: pkg/systemd/services.html:194
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
+
+#: pkg/systemd/services.html:86
 msgid "Clear All Filters"
 msgstr "Alle Filter entfernen"
 
-#: pkg/systemd/host.js:734
+#: pkg/systemd/host.js:750
 msgid "Click to see system hardware information"
 msgstr "Klicken Sie hier, um Informationen zur Systemhardware anzuzeigen"
 
@@ -1362,8 +1407,7 @@ msgstr ""
 #: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
 #: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
 #: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/users/index.html:45 pkg/apps/utils.jsx:108
+#: pkg/systemd/index.html:278 pkg/users/index.html:45 pkg/apps/utils.jsx:108
 #: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
 #: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
 msgid "Close"
@@ -1390,7 +1434,7 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit konnte den angegebenen Host nicht erreichen."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1506,12 +1550,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Kombinierte Verwendung von $0 CPU-Kern"
 msgstr[1] "Kombinierte Verwendung von $0 CPU-Kernen"
 
-#: pkg/networkmanager/firewall.jsx:529
+#: pkg/networkmanager/firewall.jsx:554
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
-#: pkg/docker/index.html:708 pkg/systemd/services.html:427
+#: pkg/docker/index.html:708 pkg/systemd/services.html:282
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1568,15 +1612,15 @@ msgstr "Komprimierung"
 msgid "Computer OU"
 msgstr "Computer OU"
 
-#: pkg/systemd/init.js:692
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr "Bedingung $0=$1 wurde nicht erfüllt"
 
-#: pkg/systemd/services.html:143
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "Bedingung fehlgeschlagen"
 
-#: pkg/networkmanager/interfaces.js:2725
+#: pkg/networkmanager/interfaces.js:2737
 msgid "Configure"
 msgstr "Konfigurieren"
 
@@ -1584,11 +1628,11 @@ msgstr "Konfigurieren"
 msgid "Configure storage..."
 msgstr "Speicher konfigurieren ..."
 
-#: pkg/networkmanager/interfaces.js:828
+#: pkg/networkmanager/interfaces.js:837
 msgid "Configuring"
 msgstr "Konfiguriere"
 
-#: pkg/networkmanager/interfaces.js:832
+#: pkg/networkmanager/interfaces.js:841
 msgid "Configuring IP"
 msgstr "Konfiguriere IP"
 
@@ -1609,11 +1653,11 @@ msgstr "Löschung des virtuellen Netzwerks bestätigen"
 msgid "Confirm removal with passphrase"
 msgstr "Bestätigen Sie das Entfernen mit der Passphrase"
 
-#: pkg/systemd/init.js:728
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr "Konflikt von"
 
-#: pkg/systemd/init.js:727
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr "Konflikte"
 
@@ -1621,7 +1665,7 @@ msgstr "Konflikte"
 msgid "Connect"
 msgstr "Verbinden"
 
-#: pkg/networkmanager/interfaces.js:2712
+#: pkg/networkmanager/interfaces.js:2724
 msgid "Connect automatically"
 msgstr "Verbindung automatisch herstellen"
 
@@ -1653,7 +1697,7 @@ msgstr ""
 msgid "Connecting to Docker"
 msgstr "Verbinde zu Docker"
 
-#: pkg/selinux/setroubleshoot-view.jsx:373
+#: pkg/selinux/setroubleshoot-view.jsx:381
 msgid "Connecting to SETroubleshoot daemon..."
 msgstr "Verbinde zum SETroubleshoot Daemon..."
 
@@ -1661,13 +1705,13 @@ msgstr "Verbinde zum SETroubleshoot Daemon..."
 msgid "Connecting to Virtualization Service"
 msgstr "Verbindung zum Virtualisierungsdienst herstellen"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "Verbindung zur Maschine wird hergestellt"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
+#: pkg/machines/components/networks/createNetworkDialog.jsx:106
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
@@ -1685,7 +1729,7 @@ msgstr "Zeitüberschreitung bei der Verbindung."
 msgid "Connection will be lost"
 msgstr "Verbindung geht verloren"
 
-#: pkg/systemd/init.js:726
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr "Besteht aus"
 
@@ -1791,7 +1835,7 @@ msgstr "Benutzergruppen konnten nicht geändert werden"
 msgid "Couldn't change user password"
 msgstr "Passwort konnte nicht geändert werden"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "Verbindung zur Maschine konnte nicht hergstellt werden"
 
@@ -1820,8 +1864,9 @@ msgid "Crash system"
 msgstr "Crash-System"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
+#: pkg/machines/components/networks/createNetworkDialog.jsx:491
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
 #: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
 #: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
 #: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
@@ -1833,7 +1878,7 @@ msgid "Create Logical Volume"
 msgstr "Logischen Datenträger erstellen"
 
 # translation auto-copied from project Drools Workbench, version 6.0.0, document org.drools/drools-wb-guided-rule-editor-client/org/drools/workbench/screens/guided/rule/client/resources/i18n/Constants, author jdimanos
-#: pkg/machines/components/diskAdd.jsx:515
+#: pkg/machines/components/diskAdd.jsx:552
 msgid "Create New"
 msgstr "Neu erstellen"
 
@@ -1865,7 +1910,7 @@ msgstr "Bericht erzeugen"
 msgid "Create Snapshot"
 msgstr "Snapshot erzeugen"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "Erstellen Sie einen Speicherpool"
 
@@ -1873,11 +1918,11 @@ msgstr "Erstellen Sie einen Speicherpool"
 msgid "Create Thin Volume"
 msgstr "Thin Volume erstellen"
 
-#: pkg/systemd/services.html:64
+#: pkg/systemd/services.html:58
 msgid "Create Timer"
 msgstr "Timer erstellen"
 
-#: pkg/systemd/services.html:393
+#: pkg/systemd/services.html:248
 msgid "Create Timers"
 msgstr "Timer erstellen"
 
@@ -1885,9 +1930,14 @@ msgstr "Timer erstellen"
 msgid "Create VDO Device"
 msgstr "Erstellen Sie ein VDO-Gerät"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "VM erstellen"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
+#: pkg/machines/components/networks/createNetworkDialog.jsx:525
+msgid "Create Virtual Network"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:53
 msgid "Create Volume Group"
@@ -1897,8 +1947,8 @@ msgstr "Datenträgerverbund erstellen"
 msgid "Create diagnostic report"
 msgstr "Diagnosebericht erstellen"
 
-#: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
-#: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
+#: pkg/networkmanager/interfaces.js:3834 pkg/networkmanager/interfaces.js:4033
+#: pkg/networkmanager/interfaces.js:4287 pkg/networkmanager/interfaces.js:4492
 msgid "Create it"
 msgstr "Anlegen"
 
@@ -1935,7 +1985,7 @@ msgstr "Erzeuge Partition $target"
 msgid "Creating snapshot of $target"
 msgstr "Erzeuge Snapshot von $target"
 
-#: pkg/networkmanager/interfaces.js:4479
+#: pkg/networkmanager/interfaces.js:4491
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1943,7 +1993,7 @@ msgstr ""
 "Das Erzeugen dieses VLANs wird die Verbindung zum Server unterbrechen und "
 "damit den Zugriff auf die Benutzeroberfläche unmöglich machen."
 
-#: pkg/networkmanager/interfaces.js:3821
+#: pkg/networkmanager/interfaces.js:3833
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1951,7 +2001,7 @@ msgstr ""
 "Durch das Erstellen dieser Verbindung wird die Verbindung zum Server "
 "unterbrochen und die Verwaltungsbenutzeroberfläche wird nicht verfügbar."
 
-#: pkg/networkmanager/interfaces.js:4274
+#: pkg/networkmanager/interfaces.js:4286
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1960,7 +2010,7 @@ msgstr ""
 "unterbrechen und damit den Zugriff auf die Benutzeroberfläche unmöglich "
 "machen."
 
-#: pkg/networkmanager/interfaces.js:4020
+#: pkg/networkmanager/interfaces.js:4032
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1972,7 +2022,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Erzeuge Datenträgerverbund $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr "Das Erstellen von VM $0 ist fehlgeschlagen"
 
@@ -2000,7 +2050,7 @@ msgstr "Aktueller Boot"
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: pkg/networkmanager/firewall.jsx:523
+#: pkg/networkmanager/firewall.jsx:548
 msgid "Custom Ports"
 msgstr "Eigene Ports"
 
@@ -2012,7 +2062,7 @@ msgstr "Benutzerdefinierte Verschlüsselungsoptionen"
 msgid "Custom mount options"
 msgstr "Kundenspezifische Montageoptionen"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:748
 msgid "Custom zones"
 msgstr "Eigene Zonen"
 
@@ -2025,19 +2075,19 @@ msgstr "DHCP Bereich"
 msgid "DISK IS FAILING"
 msgstr "Datenträger ist FEHLERHAFT"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3328
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2668
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3320
+#: pkg/networkmanager/interfaces.js:3332
 msgid "DNS Search Domains"
 msgstr "DNS Suchdomänen"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2671
 msgid "DNS Search Domains $val"
 msgstr "DNS-Suchdomänen $val"
 
@@ -2059,7 +2109,7 @@ msgstr "Verwendete Daten"
 msgid "Deactivate"
 msgstr "Deaktivieren"
 
-#: pkg/networkmanager/interfaces.js:840
+#: pkg/networkmanager/interfaces.js:849
 msgid "Deactivating"
 msgstr "Wird deaktiviert"
 
@@ -2093,8 +2143,9 @@ msgstr "Verzögerung"
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
 #: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
@@ -2102,11 +2153,11 @@ msgstr "Verzögerung"
 msgid "Delete"
 msgstr "Löschen"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2447 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "$0 löschen"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
 msgstr "Inhalt löschen"
 
@@ -2118,7 +2169,7 @@ msgstr "Dateien löschen"
 msgid "Delete Network $0"
 msgstr "Lösche Netzwerk $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:217
 msgid "Delete Storage Pool $0"
 msgstr "Lösche Speicher-Pool $0"
 
@@ -2126,7 +2177,7 @@ msgstr "Lösche Speicher-Pool $0"
 msgid "Delete associated storage files:"
 msgstr "Verknüpfte Speicherdateien löschen:"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:170
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
 
@@ -2134,7 +2185,7 @@ msgstr ""
 msgid "Deleting $target"
 msgstr "Lösche $target"
 
-#: pkg/networkmanager/interfaces.js:2434
+#: pkg/networkmanager/interfaces.js:2446
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2174,7 +2225,7 @@ msgstr ""
 "Das Löschen eines Datenträgerverbunds löscht alle sich darin befindenden "
 "Daten."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:174
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
@@ -2184,15 +2235,25 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Lösche Datenträgerverbund ätarget"
 
-#: pkg/systemd/services.html:413
+#: pkg/systemd/services.html:268
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
 msgid "Description"
 msgstr "Beschreibung"
+
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Desktop"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:151
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:187
+msgid ""
+"Detach the disks using this pool from any VMs before attempting deletion."
+msgstr ""
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2200,12 +2261,13 @@ msgstr "Abnehmbar"
 
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:745
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:383
+#: pkg/systemd/host.js:762
 msgid "Details"
 msgstr "Details"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:169
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
@@ -2219,6 +2281,10 @@ msgstr "Gerätedatei"
 #: pkg/storaged/content-views.jsx:551
 msgid "Device is read-only"
 msgstr "Gerät ist schreibgeschützt"
+
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
@@ -2237,10 +2303,6 @@ msgstr "Ordner"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "Verzeichnis $0 ist nicht beschreibbar oder existiert nicht."
 
-#: pkg/systemd/init.js:571
-msgid "Disable"
-msgstr "Ausschalten"
-
 #: pkg/systemd/hwinfo.jsx:191
 msgid "Disable simultaneous multithreading"
 msgstr ""
@@ -2249,17 +2311,21 @@ msgstr ""
 msgid "Disable tuned"
 msgstr "Tuned deaktivieren"
 
-#: pkg/systemd/services.html:73 pkg/networkmanager/interfaces.js:1960
-#: pkg/systemd/init.js:213
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "Deaktiviert"
+
+#: pkg/systemd/service-details.jsx:192
+msgid "Disallow running (mask)"
+msgstr ""
 
 #: pkg/machines/components/serialConsole.jsx:136
 msgid "Disconnect"
 msgstr "Verbindung trennen"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "Getrennt"
 
@@ -2277,15 +2343,15 @@ msgstr "Festplatte"
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr ""
 
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:549
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:569
 msgid "Disk I/O"
 msgstr "Festplatten-E/A"
 
-#: pkg/machines/components/diskAdd.jsx:489
+#: pkg/machines/components/diskAdd.jsx:525
 msgid "Disk failed to be attached"
 msgstr "Festplatte konnte nicht angeschlossen werden"
 
-#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Disk failed to be created"
 msgstr "Datenträger konnte nicht erstellt werden"
 
@@ -2311,6 +2377,10 @@ msgstr ""
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Anzeigesprache"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2350,8 +2420,8 @@ msgstr "Name des Domain-Administrators"
 msgid "Domain Administrator Password"
 msgstr "Passwort des Domain-Administrators"
 
-#: pkg/systemd/services.html:483 pkg/systemd/services.html:487
-#: pkg/systemd/init.js:1256
+#: pkg/systemd/services.html:338 pkg/systemd/services.html:342
+#: pkg/systemd/init.js:1085
 msgid "Don't Repeat"
 msgstr "Nicht wiederholen"
 
@@ -2405,6 +2475,10 @@ msgstr "Speichergerät"
 msgid "Drives"
 msgstr "Laufwerke"
 
+#: pkg/lib/machine-info.js:244
+msgid "Dual Rank"
+msgstr ""
+
 #: pkg/docker/run.js:348
 msgid "Duplicate alias"
 msgstr "Alias duplizieren"
@@ -2413,7 +2487,7 @@ msgstr "Alias duplizieren"
 msgid "Duplicate port"
 msgstr "Port duplizieren"
 
-#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
+#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
 #: pkg/storaged/nfs-details.jsx:306
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -2461,14 +2535,6 @@ msgstr "Leere $target"
 msgid "Emulated Machine"
 msgstr ""
 
-#: pkg/systemd/init.js:569
-msgid "Enable"
-msgstr "Einschalten"
-
-#: pkg/systemd/init.js:570
-msgid "Enable Forcefully"
-msgstr "Gewaltsam Einschalten"
-
 #: pkg/networkmanager/index.html:50
 msgid "Enable Service"
 msgstr "Service aktivieren"
@@ -2477,7 +2543,7 @@ msgstr "Service aktivieren"
 msgid "Enable stored metrics…"
 msgstr "Gespeicherte Metriken aktivieren…"
 
-#: pkg/systemd/services.html:72 pkg/systemd/init.js:210
+#: pkg/systemd/services.html:66 pkg/systemd/init.js:215
 msgid "Enabled"
 msgstr "Aktiviert"
 
@@ -2520,11 +2586,20 @@ msgstr "Verschlüsselung"
 msgid "Encryption Options"
 msgstr "Verschlüsselungsoptionen"
 
-#: pkg/selinux/setroubleshoot-view.jsx:300
-msgid "Enforce policy:"
-msgstr "Politik erzwingen:"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:252
+msgid "End"
+msgstr ""
 
-#: pkg/systemd/host.js:500
+#: pkg/machines/components/networks/createNetworkDialog.jsx:63
+#: pkg/machines/components/networks/createNetworkDialog.jsx:91
+msgid "End should not be empty"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Enforcing"
+msgstr ""
+
+#: pkg/systemd/host.js:510
 msgid "Enhancement Updates Available"
 msgstr "Verbesserungsaktualisierungen verfügbar"
 
@@ -2540,7 +2615,7 @@ msgstr ""
 "Wenn Sie hier ein anderes Passwort eingeben, müssen Sie es jedes Mal erneut "
 "eingeben, wenn Sie sich erneut mit diesem System verbinden"
 
-#: pkg/networkmanager/firewall.jsx:754
+#: pkg/networkmanager/firewall.jsx:784
 msgid "Entire subnet"
 msgstr ""
 
@@ -2575,9 +2650,9 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/apps/utils.jsx:100
-#: pkg/storaged/multipath.jsx:57 pkg/storaged/storage-controls.jsx:99
-#: pkg/storaged/storage-controls.jsx:192 pkg/users/local.js:1476
+#: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Fehler"
 
@@ -2617,7 +2692,7 @@ msgstr "Ethernet-MAC"
 msgid "Ethernet MTU"
 msgstr "Ethernet-MTU"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:2015
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2625,11 +2700,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Alles"
 
-#: pkg/networkmanager/firewall.jsx:536
+#: pkg/networkmanager/firewall.jsx:561
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:544
+#: pkg/networkmanager/firewall.jsx:569
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
@@ -2637,11 +2712,11 @@ msgstr ""
 msgid "Excellent password"
 msgstr "Perfektes Passwort!"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
-msgid "Existing Disk Image"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -2665,7 +2740,7 @@ msgstr "Erweiterte Partition"
 msgid "FAILED"
 msgstr "KAPUTT"
 
-#: pkg/networkmanager/interfaces.js:842
+#: pkg/networkmanager/interfaces.js:851
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
@@ -2673,15 +2748,15 @@ msgstr "Fehlgeschlagen"
 msgid "Failed to add machine: $0"
 msgstr "Maschine konnte nicht hinzugefügt werden: $0"
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add port"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:679
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Failed to add zone"
 msgstr ""
 
@@ -2717,8 +2792,12 @@ msgstr ""
 msgid "Failed to load authorized keys."
 msgstr "Fehler beim Laden autorisierter Schlüssel."
 
-#: pkg/networkmanager/firewall.jsx:591
+#: pkg/networkmanager/firewall.jsx:621
 msgid "Failed to remove service"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:340
+msgid "Failed to start"
 msgstr ""
 
 #: pkg/docker/containers.js:60
@@ -2748,7 +2827,7 @@ msgstr "Datei"
 msgid "Filesystem"
 msgstr "Dateisystem"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "Dateisystemverzeichnis"
 
@@ -2764,11 +2843,11 @@ msgstr "Dateisystemname"
 msgid "Filesystems"
 msgstr "Dateisysteme"
 
-#: pkg/networkmanager/firewall.jsx:491
+#: pkg/networkmanager/firewall.jsx:516
 msgid "Filter Services"
 msgstr "Filterdienste"
 
-#: pkg/systemd/services.html:68
+#: pkg/systemd/services.html:62
 msgid "Filter by name or description..."
 msgstr ""
 
@@ -2777,11 +2856,11 @@ msgid "Fingerprint"
 msgstr "Fingerabdruck"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
+#: pkg/networkmanager/firewall.jsx:945 pkg/networkmanager/firewall.jsx:948
 msgid "Firewall"
 msgstr "Firewall"
 
-#: pkg/networkmanager/firewall.jsx:863
+#: pkg/networkmanager/firewall.jsx:893
 msgid "Firewall is not available"
 msgstr "Firewall ist nicht verfügbar"
 
@@ -2791,6 +2870,10 @@ msgstr "Folgt dem Docker-Repo"
 
 #: pkg/storaged/vdos-panel.jsx:88
 msgid "For legacy applications only. Reduces performance."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:322
+msgid "Forbidden from running"
 msgstr ""
 
 #: pkg/users/index.html:122
@@ -2817,8 +2900,8 @@ msgstr "Kennwort ändern"
 msgid "Force remove passphrase in $0"
 msgstr "Entfernen der Passphrase erzwingen $0"
 
-#: pkg/machines/components/diskAdd.jsx:147
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:157
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
 #: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
 #: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
@@ -2842,11 +2925,15 @@ msgid "Formatting a storage device will erase all data on it."
 msgstr ""
 "Das Formatieren eines Speichergeräts löscht alle darauf vorhandenen Daten."
 
-#: pkg/networkmanager/interfaces.js:2861
+#: pkg/machines/components/networks/createNetworkDialog.jsx:147
+msgid "Forward Mode"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2873
 msgid "Forward delay $forward_delay"
 msgstr "Weiterleitungsverzögerung $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:50
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2865,7 +2952,7 @@ msgid ""
 "another physical volume."
 msgstr ""
 
-#: pkg/systemd/services.html:239
+#: pkg/systemd/services.html:131
 msgid "Friday"
 msgstr "Freitag"
 
@@ -2887,7 +2974,7 @@ msgid "Gateway:"
 msgstr "Gateway:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2703 pkg/systemd/logs.js:486
+#: pkg/networkmanager/interfaces.js:2715 pkg/systemd/logs.js:486
 msgid "General"
 msgstr "Allgemein"
 
@@ -2899,7 +2986,7 @@ msgstr "Bericht erstellen"
 msgid "Get new image"
 msgstr "Holen Sie sich ein neues Bild"
 
-#: pkg/machines/components/diskAdd.jsx:186
+#: pkg/machines/components/diskAdd.jsx:191
 #: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
@@ -2955,7 +3042,7 @@ msgstr "Wachsen Sie, um den gesamten Raum einzunehmen"
 msgid "Hair Pin mode"
 msgstr "Hairpin Modus"
 
-#: pkg/networkmanager/interfaces.js:2887
+#: pkg/networkmanager/interfaces.js:2899
 msgid "Hairpin mode"
 msgstr "Hairpin-Modus"
 
@@ -2976,22 +3063,22 @@ msgstr "Festplatte"
 msgid "Hardware"
 msgstr "Hardware"
 
-#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:261
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:270
 msgid "Hardware Information"
 msgstr "Hardware-Informationen"
 
-#: pkg/networkmanager/interfaces.js:2863
+#: pkg/networkmanager/interfaces.js:2875
 msgid "Hello time $hello_time"
 msgstr "Hello-Zeit $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "Host"
 
@@ -3000,7 +3087,7 @@ msgid "Host Device"
 msgstr ""
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Rechnername"
 
@@ -3012,25 +3099,29 @@ msgstr "Hostschlüssel ist falsch"
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "Host sollte nicht leer sein"
 
-#: pkg/systemd/services.html:499
+#: pkg/systemd/services.html:354
 msgid "Hour : Minute"
 msgstr "Stunde : Minute"
 
-#: pkg/systemd/init.js:1332 pkg/systemd/init.js:1361
+#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
 msgid "Hour needs to be a number between 0-23"
 msgstr "Die Stunde muss eine Zahl zwischen 0 und 23 sein"
 
-#: pkg/systemd/services.html:465
+#: pkg/systemd/services.html:320
 msgid "Hours"
 msgstr "Stunde"
 
-#: pkg/systemd/index.html:238 pkg/systemd/host.js:1582
+#: pkg/systemd/index.html:238 pkg/systemd/host.js:1599
 msgid "I/O Wait"
 msgstr "I / O Warten"
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "ID"
+msgstr ""
 
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
 #: pkg/machines/components/vmnetworktab.jsx:133
@@ -3041,11 +3132,15 @@ msgstr "IP-Adresse"
 msgid "IP Address:"
 msgstr "IP-Adresse:"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:197
+msgid "IP Configuration"
+msgstr ""
+
 #: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "IP-Präfixlänge:"
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:955
 msgid "IP Range"
 msgstr ""
 
@@ -3053,7 +3148,7 @@ msgstr ""
 msgid "IP Settings"
 msgstr "IP Einstellungen"
 
-#: pkg/networkmanager/interfaces.js:2912
+#: pkg/networkmanager/interfaces.js:2924
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3061,11 +3156,27 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+msgid "IPv4 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:45
+msgid "IPv4 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3371
 msgid "IPv4 Settings"
 msgstr "IPv4 Einstellungen"
 
-#: pkg/networkmanager/interfaces.js:2913
+#: pkg/machines/components/networks/createNetworkDialog.jsx:213
+msgid "IPv4 and IPv6"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:207
+msgid "IPv4 only"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2925
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3073,15 +3184,27 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+msgid "IPv6 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:73
+msgid "IPv6 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3371
 msgid "IPv6 Settings"
 msgstr "IPv6 Einstellungen"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:210
+msgid "IPv6 only"
+msgstr ""
 
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "ID"
 
-#: pkg/networkmanager/interfaces.js:2904
+#: pkg/networkmanager/interfaces.js:2916
 msgid "Id $id"
 msgstr "ID $id"
 
@@ -3098,7 +3221,7 @@ msgstr "Kennung"
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Wenn Tang-Show-Keys nicht verfügbar sind, führen Sie Folgendes aus:"
 
-#: pkg/networkmanager/interfaces.js:1969 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1978 pkg/packagekit/updates.jsx:496
 msgid "Ignore"
 msgstr "Ignorieren"
 
@@ -3164,15 +3287,19 @@ msgid "Images may only be pulled by specific users or groups"
 msgstr ""
 "Bilder dürfen nur von bestimmten Benutzern oder Gruppen gezogen werden"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Sofort starten Sie die VM"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "Synchron"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3186,8 +3313,8 @@ msgstr ""
 "Um Benutzer zu synchronisieren, müssen Sie sich bei anmelden "
 "{{#strong}}{{host}}{{/strong}}."
 
-#: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
-#: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
+#: pkg/networkmanager/interfaces.js:833 pkg/networkmanager/interfaces.js:1426
+#: pkg/networkmanager/interfaces.js:1433 pkg/networkmanager/interfaces.js:2618
 msgid "Inactive"
 msgstr "Inaktiv"
 
@@ -3195,7 +3322,7 @@ msgstr "Inaktiv"
 msgid "Inactive volume"
 msgstr "Inaktives Volumen"
 
-#: pkg/networkmanager/firewall.jsx:732
+#: pkg/networkmanager/firewall.jsx:762
 msgid "Included services"
 msgstr ""
 
@@ -3219,11 +3346,11 @@ msgstr "Informationen zum Docker-Speicherpool sind nicht verfügbar."
 msgid "Initializing..."
 msgstr "Initialisierung ..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
@@ -3233,7 +3360,7 @@ msgstr ""
 msgid "Install"
 msgstr "Installation"
 
-#: pkg/packagekit/updates.jsx:806
+#: pkg/packagekit/updates.jsx:808
 msgid "Install All Updates"
 msgstr "Installieren Sie alle Updates"
 
@@ -3241,7 +3368,7 @@ msgstr "Installieren Sie alle Updates"
 msgid "Install NFS Support"
 msgstr "Installieren Sie die NFS-Unterstützung"
 
-#: pkg/packagekit/updates.jsx:806 pkg/packagekit/updates.jsx:812
+#: pkg/packagekit/updates.jsx:808 pkg/packagekit/updates.jsx:814
 msgid "Install Security Updates"
 msgstr "Installieren Sie Sicherheitsupdates"
 
@@ -3253,20 +3380,20 @@ msgstr "Software installieren"
 msgid "Install VDO support"
 msgstr "Installieren Sie die VDO-Unterstützung"
 
-#: pkg/selinux/setroubleshoot-view.jsx:381
+#: pkg/selinux/setroubleshoot-view.jsx:389
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr ""
 "Installieren Sie setroubleshoot-server, um SELinux-Ereignisse zu behandeln."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Installationsquelle"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Installationsquellentyp"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "Installationsquelle sollte nicht leer sein"
 
@@ -3284,17 +3411,21 @@ msgstr "Installation wird ausgeführt"
 msgid "Installing $0"
 msgstr "$0 wird installiert"
 
-#: pkg/systemd/services.html:184
+#: pkg/systemd/service-details.jsx:487
+msgid "Instance of template: "
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:62
 msgid "Instantiate"
 msgstr "Instanzieren"
 
-#: pkg/machines/components/nicEdit.jsx:123
+#: pkg/machines/components/nicEdit.jsx:132
 msgid "Interface Type"
 msgstr ""
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:737 pkg/networkmanager/firewall.jsx:925
-#: pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/firewall.jsx:767 pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/interfaces.js:2998
 msgid "Interfaces"
 msgstr "Schnittstellen"
 
@@ -3306,20 +3437,40 @@ msgstr "Interner Fehler: Ungültiger Challenge-Header"
 msgid "Internal error"
 msgstr "Interner Fehler"
 
-#: pkg/networkmanager/utils.js:88 pkg/networkmanager/utils.js:171
+#: pkg/machines/components/networks/createNetworkDialog.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:58
+#: pkg/machines/components/networks/createNetworkDialog.jsx:65
+msgid "Invalid IPv4 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:52
+msgid "Invalid IPv4 mask or prefix length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:75
+#: pkg/machines/components/networks/createNetworkDialog.jsx:86
+#: pkg/machines/components/networks/createNetworkDialog.jsx:93
+msgid "Invalid IPv6 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:80
+msgid "Invalid IPv6 prefix"
+msgstr ""
+
+#: pkg/networkmanager/utils.js:90 pkg/networkmanager/utils.js:175
 #, fuzzy
 msgid "Invalid address $0"
 msgstr "Ungültiger Schlüssel"
 
-#: pkg/systemd/host.js:1452 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "ungültiges Datumsformat"
 
-#: pkg/systemd/host.js:1448 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "Ungültiges Datumsformat und ungültiges Zeitformat"
 
-#: pkg/systemd/init.js:1367
+#: pkg/systemd/init.js:1196
 #, fuzzy
 msgid "Invalid date format."
 msgstr "Ungültiger Port"
@@ -3332,7 +3483,7 @@ msgstr "Ungültiges Ablaufdatum"
 msgid "Invalid file permissions"
 msgstr "Ungültige Dateiberechtigungen"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "Ungültiger Dateiname"
 
@@ -3349,7 +3500,7 @@ msgstr "Ungültiger Schlüssel"
 msgid "Invalid number of days"
 msgstr "Ungültige Anzahl von Tagen"
 
-#: pkg/systemd/init.js:1314
+#: pkg/systemd/init.js:1143
 #, fuzzy
 msgid "Invalid number."
 msgstr "Ungültiger Schlüssel"
@@ -3358,7 +3509,7 @@ msgstr "Ungültiger Schlüssel"
 msgid "Invalid port"
 msgstr "Ungültiger Port"
 
-#: pkg/networkmanager/firewall.jsx:335
+#: pkg/networkmanager/firewall.jsx:360
 msgid "Invalid port number"
 msgstr ""
 
@@ -3367,16 +3518,16 @@ msgstr ""
 msgid "Invalid prefix $0"
 msgstr "Ungültiger Port"
 
-#: pkg/networkmanager/utils.js:132
+#: pkg/networkmanager/utils.js:136
 #, fuzzy
 msgid "Invalid prefix or netmask $0"
 msgstr "Ungültiger Port"
 
-#: pkg/networkmanager/firewall.jsx:362
+#: pkg/networkmanager/firewall.jsx:387
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1450 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
 
@@ -3421,7 +3572,7 @@ msgstr "Einer Domain beitreten"
 msgid "Joining this domain is not supported"
 msgstr "Der Beitritt zu dieser Domain wird nicht unterstützt"
 
-#: pkg/systemd/init.js:736
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr "Tritt dem Namespace Of bei"
 
@@ -3456,11 +3607,11 @@ msgstr "Kerberos-basiertes SSO"
 msgid "Kerberos Ticket"
 msgstr "Kerberos Ticket"
 
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1583
+#: pkg/systemd/index.html:234 pkg/systemd/host.js:1600
 msgid "Kernel"
 msgstr "Kernel"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "Kernel Dump"
 
@@ -3494,6 +3645,10 @@ msgstr ""
 msgid "LACP Key"
 msgstr "LACP Key"
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
+msgid "LVM Volume Group"
+msgstr ""
+
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Bezeichnungen"
@@ -3514,7 +3669,7 @@ msgstr "Letzte 7 Tage"
 msgid "Last Login"
 msgstr "Letzte Anmeldung"
 
-#: pkg/systemd/init.js:284
+#: pkg/systemd/init.js:293
 msgid "Last Trigger"
 msgstr "Letzter Auslöser"
 
@@ -3580,7 +3735,7 @@ msgstr "Link local"
 msgid "Link down delay"
 msgstr "Verzögerung bei der Deaktivierung einer Verbindung"
 
-#: pkg/networkmanager/interfaces.js:1957 pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1966 pkg/networkmanager/interfaces.js:1976
 msgid "Link local"
 msgstr "Link local"
 
@@ -3600,7 +3755,7 @@ msgstr "Links"
 msgid "Links:"
 msgstr "Links:"
 
-#: pkg/networkmanager/interfaces.js:1993
+#: pkg/networkmanager/interfaces.js:2002
 #, fuzzy
 msgid "Load Balancing"
 msgstr "Adaptives Load Balancing (alb)"
@@ -3625,7 +3780,7 @@ msgstr "Verfügbare Updates werden geladen, bitte warten ..."
 msgid "Loading system modifications..."
 msgstr ""
 
-#: pkg/systemd/services.html:84 pkg/kdump/kdump-view.jsx:367
+#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:367
 #: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
 #: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
 msgid "Loading..."
@@ -3645,7 +3800,7 @@ msgstr "$0 Datenträger"
 msgid "Local Filesystem"
 msgstr "Kein Dateisystem"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr ""
 
@@ -3745,7 +3900,7 @@ msgstr "Anmeldung hat Administrator-Rechte"
 msgid "Logout Successful"
 msgstr "Abmeldung erfolgreich"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Protokolle"
 
@@ -3773,15 +3928,15 @@ msgstr "MAC-Adresse"
 msgid "MAC Address:"
 msgstr "MAC-Adresse:"
 
-#: pkg/networkmanager/interfaces.js:1985
+#: pkg/networkmanager/interfaces.js:1994
 msgid "MII (Recommended)"
 msgstr "MII (empfohlen)"
 
-#: pkg/networkmanager/interfaces.js:2761
+#: pkg/networkmanager/interfaces.js:2773
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4545
+#: pkg/networkmanager/interfaces.js:4557
 msgid "MTU must be a positive number"
 msgstr "MTU muss eine positive Zahl sein"
 
@@ -3789,7 +3944,7 @@ msgstr "MTU muss eine positive Zahl sein"
 msgid "Mac"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:160
+#: pkg/machines/components/nicEdit.jsx:169
 msgid "Mac Address"
 msgstr "MAC-Adresse"
 
@@ -3801,7 +3956,7 @@ msgstr "Maschinen-ID"
 msgid "Machine SSH Key Fingerprints"
 msgstr "SSH-Fingerabdrücke auf diesem Rechner"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "Maschinen"
 
@@ -3814,7 +3969,7 @@ msgid "Make sure the key hash from the Tang server matches:"
 msgstr ""
 "Stellen Sie sicher, dass der Schlüsselhash vom Tang-Server übereinstimmt:"
 
-#: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
+#: pkg/networkmanager/interfaces.js:1967 pkg/networkmanager/interfaces.js:1977
 msgid "Manual"
 msgstr "Manuell"
 
@@ -3834,15 +3989,30 @@ msgstr "Manuell mit SSH prüfen: "
 msgid "Marking $target as faulty"
 msgstr "Markiere $target als fehlerhaft"
 
-#: pkg/systemd/init.js:574
-msgid "Mask"
-msgstr "Sperren"
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
+msgid "Mask Service"
+msgstr ""
 
-#: pkg/systemd/init.js:575
-msgid "Mask Forcefully"
-msgstr "Maskieren erzwingen"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:293
+msgid "Mask or Prefix Length"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2767
+#: pkg/machines/components/networks/createNetworkDialog.jsx:50
+msgid "Mask or Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:321
+msgid "Masked"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:200
+msgid ""
+"Masking service prevents all dependant units from running. This can have "
+"bigger impact than anticipated. Please confirm that you want to mask this "
+"unit."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2779
 msgid "Master"
 msgstr "Master"
 
@@ -3858,7 +4028,7 @@ msgstr ""
 msgid "Maximum memory could not be saved"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2865
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Maximum message age $max_age"
 msgstr "Maximales Alter der Nachrichten $max_age"
 
@@ -3881,12 +4051,12 @@ msgstr "Mitglied des RAID-Geräts $0"
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
-#: pkg/machines/components/vmOverviewTab.jsx:74
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
+#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "Speicher"
 
-#: pkg/systemd/host.js:1641
+#: pkg/systemd/host.js:1658
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Speicher"
@@ -3894,6 +4064,10 @@ msgstr "Speicher"
 #: pkg/systemd/index.html:205
 msgid "Memory & Swap"
 msgstr "Speicher & Swap"
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Memory Technology"
+msgstr ""
 
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
@@ -3904,7 +4078,7 @@ msgstr ""
 msgid "Memory limit"
 msgstr "Speicherlimite"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
 msgstr ""
 
@@ -3930,7 +4104,7 @@ msgid "Metadata Used"
 msgstr "Verwendete Metadaten"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
+#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
@@ -3945,11 +4119,11 @@ msgstr "Mini PC"
 msgid "Mini Tower"
 msgstr "Mini Tower"
 
-#: pkg/systemd/init.js:1338 pkg/systemd/init.js:1347 pkg/systemd/init.js:1356
+#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
 msgid "Minute needs to be a number between 0-59"
 msgstr "Minute muss eine Zahl zwischen 0 und 59 sein"
 
-#: pkg/systemd/services.html:464
+#: pkg/systemd/services.html:319
 msgid "Minutes"
 msgstr "Minuten"
 
@@ -3961,7 +4135,7 @@ msgstr ""
 msgid "Mode"
 msgstr "Modus"
 
-#: pkg/machines/components/nicEdit.jsx:54 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
 msgid "Model"
 msgstr "Modell"
 
@@ -3974,7 +4148,7 @@ msgstr "Modelltyp"
 msgid "Modifying $target"
 msgstr "Ändern $target"
 
-#: pkg/systemd/services.html:235
+#: pkg/systemd/services.html:127
 msgid "Monday"
 msgstr "Montag"
 
@@ -4079,11 +4253,11 @@ msgstr "NFS-Unterstützung nicht installiert"
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2008
+#: pkg/networkmanager/interfaces.js:2017
 msgid "NSNA Ping"
 msgstr "NSNA-Ping"
 
-#: pkg/systemd/host.js:1514
+#: pkg/systemd/host.js:1531
 msgid "NTP Server"
 msgstr "NTP Server"
 
@@ -4094,10 +4268,11 @@ msgstr "NTP Server"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
 #: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:122
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
@@ -4109,8 +4284,8 @@ msgstr "NTP Server"
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
 #: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "Name"
 
@@ -4147,7 +4322,8 @@ msgid "Name cannot contain whitespace."
 msgstr "Der Name darf keine Leerzeichen enthalten."
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:41
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "Name sollte nicht leer sein"
 
@@ -4155,7 +4331,7 @@ msgstr "Name sollte nicht leer sein"
 msgid "Name: "
 msgstr ""
 
-#: pkg/systemd/host.js:1348
+#: pkg/systemd/host.js:1365
 msgid "Need at least one NTP server"
 msgstr "Benötigen Sie mindestens einen NTP-Server"
 
@@ -4175,11 +4351,15 @@ msgstr ""
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+msgid "Network Boot is available only when using System connection"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "Netzwerk-Dateisystem"
 
@@ -4187,11 +4367,11 @@ msgstr "Netzwerk-Dateisystem"
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr ""
 
-#: pkg/systemd/host.js:550
+#: pkg/systemd/host.js:570
 msgid "Network Traffic"
 msgstr "Netzwerk-Verkehr"
 
@@ -4199,7 +4379,7 @@ msgstr "Netzwerk-Verkehr"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "Netzwerkgeräte und -diagramme erfordern NetworkManager."
 
-#: pkg/machines/components/nicEdit.jsx:232
+#: pkg/machines/components/nicEdit.jsx:245
 msgid "Network interface settings could not be saved"
 msgstr ""
 
@@ -4208,11 +4388,11 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager wird nicht ausgeführt."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:914
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Netzwerk"
 
-#: pkg/networkmanager/interfaces.js:1625 pkg/networkmanager/interfaces.js:2207
+#: pkg/networkmanager/interfaces.js:1634 pkg/networkmanager/interfaces.js:2216
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Netzwerk"
@@ -4221,8 +4401,8 @@ msgstr "Netzwerk"
 msgid "Networking Logs"
 msgstr "Netzwerk-Logs"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/networks/networkList.jsx:46
+#: pkg/machines/components/networks/networkList.jsx:45
+#: pkg/machines/components/networks/networkList.jsx:49
 msgid "Networks"
 msgstr "Netzwerke"
 
@@ -4262,16 +4442,16 @@ msgstr "Das neue Passwort wurde nicht akzeptiert"
 msgid "Next"
 msgstr "Weiter"
 
-#: pkg/systemd/init.js:283
+#: pkg/systemd/init.js:292
 msgid "Next Run"
 msgstr "Nächster Run"
 
-#: pkg/systemd/index.html:226 pkg/systemd/host.js:1585
+#: pkg/systemd/index.html:226 pkg/systemd/host.js:1602
 msgid "Nice"
 msgstr "Nice-Wert"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2606
 msgid "No"
 msgstr "Nein"
 
@@ -4287,7 +4467,7 @@ msgstr "Kein Dateisystem"
 msgid "No Logical Volumes"
 msgstr "Keine logischen Volumes"
 
-#: pkg/systemd/services.html:192
+#: pkg/systemd/services.html:84
 msgid "No Matching Results"
 msgstr ""
 
@@ -4295,12 +4475,16 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Es sind keine NFS-Mounts eingerichtet"
 
-#: pkg/selinux/setroubleshoot-view.jsx:367
+#: pkg/machines/components/nicEdit.jsx:118
+msgid "No Network Devices"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
 msgstr "Keine SELinux-Alarme"
 
-#: pkg/machines/components/diskAdd.jsx:204
-#: pkg/machines/components/diskAdd.jsx:216
+#: pkg/machines/components/diskAdd.jsx:209
+#: pkg/machines/components/diskAdd.jsx:221
 msgid "No Storage Pools available"
 msgstr ""
 
@@ -4316,11 +4500,11 @@ msgstr ""
 msgid "No VM is running or defined on this host"
 msgstr "Auf diesem Host ist keine VM ausgeführt oder definiert"
 
-#: pkg/machines/components/nicEdit.jsx:110
+#: pkg/machines/components/nicEdit.jsx:116
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:926
+#: pkg/networkmanager/firewall.jsx:956
 msgid "No active zones"
 msgstr ""
 
@@ -4348,7 +4532,7 @@ msgstr "Keine verfügbaren Slots"
 msgid "No boot device found"
 msgstr "Kein Startgerät gefunden"
 
-#: pkg/networkmanager/interfaces.js:1419
+#: pkg/networkmanager/interfaces.js:1428
 msgid "No carrier"
 msgstr "Kein Träger"
 
@@ -4373,7 +4557,7 @@ msgstr "Keine behälter"
 msgid "No containers that match the current filter"
 msgstr "Keine Container, die dem aktuellen Filter entsprechen"
 
-#: pkg/networkmanager/firewall.jsx:729
+#: pkg/networkmanager/firewall.jsx:759
 msgid "No description available"
 msgstr ""
 
@@ -4453,7 +4637,7 @@ msgstr ""
 msgid "No network interfaces defined for this VM"
 msgstr "Keine Netzwerkschnittstellen für diese VM definiert"
 
-#: pkg/machines/components/networks/networkList.jsx:48
+#: pkg/machines/components/networks/networkList.jsx:51
 msgid "No network is defined on this host"
 msgstr ""
 
@@ -4461,7 +4645,7 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:939
+#: pkg/networkmanager/firewall.jsx:969
 msgid "No open ports"
 msgstr "Keine offenen Ports"
 
@@ -4518,8 +4702,9 @@ msgid "No volume groups created"
 msgstr "Keine Datenträgerverbünde erzeugt"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:734
-#: pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
+#: pkg/machines/components/networks/createNetworkDialog.jsx:204
+#: pkg/networkmanager/firewall.jsx:764 pkg/tuned/dialog.js:231
 msgid "None"
 msgstr "Kein"
 
@@ -4543,7 +4728,7 @@ msgstr "Keine Berechtigung, auf diesem System Docker zu verwenden"
 msgid "Not authorized to upload-report"
 msgstr "Keine Berechtigung zum Hochladen von Berichten"
 
-#: pkg/networkmanager/interfaces.js:822
+#: pkg/networkmanager/interfaces.js:831
 msgid "Not available"
 msgstr "Nicht verfügbar"
 
@@ -4567,7 +4752,7 @@ msgstr "Nicht montiert"
 msgid "Not permitted to perform this action."
 msgstr "Diese Aktion darf nicht ausgeführt werden."
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "Läuft nicht"
 
@@ -4579,7 +4764,7 @@ msgstr "Nicht synchronisiert"
 msgid "Not yet synced"
 msgstr "Noch nicht synchronisiert"
 
-#: pkg/systemd/services.html:357
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr "Hinweis"
 
@@ -4591,15 +4776,11 @@ msgstr "Notizbuch"
 msgid "Notice and above"
 msgstr "Hinweis und höher"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
-msgid "OS Vendor"
-msgstr "Betriebssystemanbieter"
-
-#: pkg/selinux/setroubleshoot-view.jsx:396
+#: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
 msgstr "Aufgetreten $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:391
+#: pkg/selinux/setroubleshoot-view.jsx:399
 msgid "Occurred between $0 and $1"
 msgstr "Zwischen aufgetreten $0 und $1"
 
@@ -4623,7 +4804,7 @@ msgstr "Altes Passwort wurde nicht akzeptiert"
 msgid "On Build"
 msgstr "Auf bauen"
 
-#: pkg/docker/index.html:549 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr "Bei einem Ausfall"
 
@@ -4663,7 +4844,7 @@ msgstr "Nur $0 von $1 werden verwendet."
 msgid "Only Emergency"
 msgstr "Nur Notfall"
 
-#: pkg/systemd/init.js:1288
+#: pkg/systemd/init.js:1117
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "Nur Alphabete, Zahlen,:, _,. , @ , - sind erlaubt."
 
@@ -4680,7 +4861,7 @@ msgid "Open"
 msgstr ""
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "Betriebssystem"
 
@@ -4733,7 +4914,7 @@ msgstr "Überblick"
 msgid "Overwrite existing data with zeros"
 msgstr "Vorhandene Daten mit Nullen überschreiben"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "PCI"
 msgstr "PCI"
 
@@ -4741,7 +4922,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "Paket informationen"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "PackageKit ist abgestürzt"
 
@@ -4753,19 +4934,23 @@ msgstr "PackageKit ist nicht installiert"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit hat Fehlercode gemeldet $0"
 
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr ""
+
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "Parent"
 
-#: pkg/networkmanager/interfaces.js:2903
+#: pkg/networkmanager/interfaces.js:2915
 msgid "Parent $parent"
 msgstr "Parent $parent"
 
-#: pkg/systemd/init.js:721
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr "Teil von"
 
-#: pkg/networkmanager/interfaces.js:1465
+#: pkg/networkmanager/interfaces.js:1474
 msgid "Part of "
 msgstr "Teil von"
 
@@ -4781,7 +4966,7 @@ msgstr "Partition von $0"
 msgid "Partitioning"
 msgstr "Partitionierung"
 
-#: pkg/networkmanager/interfaces.js:2000
+#: pkg/networkmanager/interfaces.js:2009
 msgid "Passive"
 msgstr "Passiv"
 
@@ -4850,7 +5035,8 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Fügen Sie hier den Inhalt Ihrer öffentlichen SSH-Schlüsseldatei ein"
 
-#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "Pfad"
 
@@ -4858,7 +5044,7 @@ msgstr "Pfad"
 msgid "Path cost"
 msgstr "Pfadkosten"
 
-#: pkg/networkmanager/interfaces.js:2885
+#: pkg/networkmanager/interfaces.js:2897
 msgid "Path cost $path_cost"
 msgstr "Pfadkosten $path_cost"
 
@@ -4866,7 +5052,7 @@ msgstr "Pfadkosten $path_cost"
 msgid "Path on Server"
 msgstr "Pfad auf dem Server"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "Pfad zum Dateisystem des Hosts"
 
@@ -4878,7 +5064,7 @@ msgstr "Pfad auf dem Server darf nicht leer sein."
 msgid "Path on server must start with \"/\"."
 msgstr "Pfad auf dem Server muss mit \"/\" beginnen."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "Pfad zur ISO-Datei im Dateisystem des Hosts"
 
@@ -4886,7 +5072,7 @@ msgstr "Pfad zur ISO-Datei im Dateisystem des Hosts"
 msgid "Path to file"
 msgstr "Pfad zur Datei"
 
-#: pkg/systemd/services.html:60
+#: pkg/systemd/services.jsx:42
 msgid "Paths"
 msgstr "Pfade"
 
@@ -4902,7 +5088,7 @@ msgstr "Leistungsprofil"
 msgid "Peripheral Chassis"
 msgstr "Peripheriechassis"
 
-#: pkg/networkmanager/interfaces.js:3630
+#: pkg/networkmanager/interfaces.js:3642
 msgid "Permanent"
 msgstr "Permanent"
 
@@ -4910,12 +5096,16 @@ msgstr "Permanent"
 msgid "Permission denied"
 msgstr "Erlaubnis verweigert"
 
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Permissive"
+msgstr ""
+
 #: pkg/machines/components/diskAdd.jsx:110
 msgid "Persistence"
 msgstr ""
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:83
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:66
 msgid "Persistent"
 msgstr ""
 
@@ -4924,7 +5114,7 @@ msgstr ""
 msgid "Physical"
 msgstr "Physisch"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr ""
 
@@ -4936,7 +5126,7 @@ msgstr "Physisches Volumen"
 msgid "Physical Volumes"
 msgstr "Physikalische Volumen"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -4977,15 +5167,15 @@ msgstr "Bitte bestätigen Sie das erzwungene Löschen von $0"
 msgid "Please confirm stopping of $0"
 msgstr "Bitte bestätigen Sie das Stoppen von $0"
 
-#: pkg/machines/components/diskAdd.jsx:447
+#: pkg/machines/components/diskAdd.jsx:483
 msgid "Please enter new volume name"
 msgstr "Bitte geben Sie den neuen Datenträgernamen ein"
 
-#: pkg/machines/components/diskAdd.jsx:450
+#: pkg/machines/components/diskAdd.jsx:486
 msgid "Please enter new volume size"
 msgstr "Bitte geben Sie die neue Volumengröße ein"
 
-#: pkg/networkmanager/firewall.jsx:864
+#: pkg/networkmanager/firewall.jsx:894
 msgid "Please install the $0 package"
 msgstr "Bitte installieren Sie die $0 Paket"
 
@@ -5006,12 +5196,12 @@ msgstr "Starten Sie die virtuelle Maschine, um auf die Konsole zuzugreifen."
 msgid "Please try another term"
 msgstr "Bitte versuchen Sie es mit einem anderen Begriff"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Plug"
 msgstr "Plug"
 
 #: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
+#: pkg/machines/components/diskAdd.jsx:204
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
 #: pkg/storaged/content-views.jsx:133
@@ -5030,6 +5220,11 @@ msgstr "Pool für dünne Mengen"
 msgid "Pool for thinly provisioned volumes"
 msgstr "Pool für dünn bereitgestellte Datenträger"
 
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
+msgid "Pool's volumes are used by VMs "
+msgstr ""
+
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
@@ -5039,7 +5234,7 @@ msgstr "Pool für dünn bereitgestellte Datenträger"
 msgid "Port"
 msgstr "Port"
 
-#: pkg/networkmanager/firewall.jsx:339
+#: pkg/networkmanager/firewall.jsx:364
 msgid "Port number and type do not match"
 msgstr ""
 
@@ -5050,7 +5245,7 @@ msgstr "tragbar"
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
+#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2998
 msgid "Ports"
 msgstr "Ports"
 
@@ -5072,29 +5267,37 @@ msgstr ""
 msgid "Prefix"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/machines/components/networks/createNetworkDialog.jsx:337
+msgid "Prefix Length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:78
+msgid "Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length"
 msgstr "Präfix"
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr "Präfix oder Netzmaske"
 
-#: pkg/networkmanager/interfaces.js:826
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:835
 msgid "Preparing"
 msgstr "Vorbereitung läuft"
 
-#: pkg/networkmanager/interfaces.js:3631
+#: pkg/lib/machine-info.js:251
+msgid "Present"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3643
 msgid "Preserve"
 msgstr "Beibehalten"
-
-#: pkg/systemd/init.js:572
-msgid "Preset"
-msgstr "Voreinstellen"
-
-#: pkg/systemd/init.js:573
-msgid "Preset Forcefully"
-msgstr "Gewaltsam Voreinstellen"
 
 #: pkg/systemd/index.html:295
 msgid "Pretty Host Name"
@@ -5113,7 +5316,7 @@ msgstr "Primär"
 msgid "Priority"
 msgstr "Priorität"
 
-#: pkg/networkmanager/interfaces.js:2859 pkg/networkmanager/interfaces.js:2883
+#: pkg/networkmanager/interfaces.js:2871 pkg/networkmanager/interfaces.js:2895
 msgid "Priority $priority"
 msgstr "Priorität $priority"
 
@@ -5163,7 +5366,7 @@ msgstr "Die Aufforderung über ssh-add ist abgelaufen"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Die Aufforderung über ssh-keygen ist abgelaufen"
 
-#: pkg/systemd/init.js:734
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr "Propagiert reload to"
 
@@ -5184,14 +5387,6 @@ msgstr "Öffentliches Pulling-Repo"
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Verwendungszweck"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "QEMU / KVM-Systemverbindung"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "QEMU / KVM-Benutzerverbindung"
 
 #: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
@@ -5274,24 +5469,36 @@ msgstr "RAID-Mitglied"
 msgid "Rack Mount Chassis"
 msgstr "Rack-Einbaugehäuse"
 
-#: pkg/networkmanager/interfaces.js:3632
+#: pkg/networkmanager/interfaces.js:3644
 msgid "Random"
 msgstr "Zufällig"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:789
 msgid "Range"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:370
+#: pkg/networkmanager/firewall.jsx:395
 msgid "Range must be strictly ordered"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Rank"
 msgstr ""
 
 #: pkg/kdump/kdump-view.jsx:388
 msgid "Raw to a device"
 msgstr "Raw zu einem Gerät"
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:386
+msgid "Read-only"
 msgstr ""
 
 #: pkg/docker/index.html:365
@@ -5328,7 +5535,7 @@ msgstr "Bereiten"
 msgid "Real Host Name"
 msgstr "Echter Rechnername"
 
-#: pkg/systemd/host.js:1020
+#: pkg/systemd/host.js:1037
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
@@ -5336,7 +5543,7 @@ msgstr ""
 "Ein echter Hostname darf nur Kleinbuchstaben, Ziffern, Bindestriche und "
 "Punkte enthalten (mit ausgefüllten Unterdomänen)."
 
-#: pkg/systemd/host.js:1021
+#: pkg/systemd/host.js:1038
 msgid "Real host name must be 64 characters or less"
 msgstr "Der tatsächliche Hostname darf höchstens 64 Zeichen umfassen"
 
@@ -5358,7 +5565,7 @@ msgstr "Zuletzt verwendet"
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Erneut verbinden"
@@ -5392,19 +5599,19 @@ msgstr "Verbindung ablehnen Hostkey stimmt nicht überein"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Verbindung ablehnen Hostkey ist unbekannt"
 
-#: pkg/packagekit/updates.jsx:777
+#: pkg/packagekit/updates.jsx:779
 msgid "Register…"
 msgstr "Registrieren…"
 
-#: pkg/systemd/init.js:546
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Neu Laden"
 
-#: pkg/systemd/init.js:735
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr "Propagiert von neu laden"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "Remote-URL"
 
@@ -5431,7 +5638,7 @@ msgstr "Umzüge:"
 msgid "Remove"
 msgstr "Entfernen"
 
-#: pkg/networkmanager/interfaces.js:3055
+#: pkg/networkmanager/interfaces.js:3067
 #, fuzzy
 msgid "Remove $0"
 msgstr "Entfernen"
@@ -5456,11 +5663,11 @@ msgstr "Passphrase entfernen"
 msgid "Remove passphrase in $0?"
 msgstr "Passphrase entfernen in $0?"
 
-#: pkg/networkmanager/firewall.jsx:631
+#: pkg/networkmanager/firewall.jsx:661
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:610
+#: pkg/networkmanager/firewall.jsx:640
 msgid "Remove service from zones"
 msgstr ""
 
@@ -5476,7 +5683,7 @@ msgstr "Entfernen $0"
 msgid "Removing $target from RAID Device"
 msgstr "Entferne $target vom RAID-Gerät"
 
-#: pkg/networkmanager/interfaces.js:3054
+#: pkg/networkmanager/interfaces.js:3066
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5509,23 +5716,23 @@ msgstr "$target wird umbenannt"
 msgid "Repairing $target"
 msgstr "Reparieren $target"
 
-#: pkg/systemd/services.html:489
+#: pkg/systemd/services.html:344
 msgid "Repeat Daily"
 msgstr "Täglich wiederholen"
 
-#: pkg/systemd/services.html:488
+#: pkg/systemd/services.html:343
 msgid "Repeat Hourly"
 msgstr "Stündlich wiederholen"
 
-#: pkg/systemd/services.html:491
+#: pkg/systemd/services.html:346
 msgid "Repeat Monthly"
 msgstr "Monatlich wiederholen"
 
-#: pkg/systemd/services.html:490
+#: pkg/systemd/services.html:345
 msgid "Repeat Weekly"
 msgstr "Wöchentlich wiederholen"
 
-#: pkg/systemd/services.html:492
+#: pkg/systemd/services.html:347
 msgid "Repeat Yearly"
 msgstr "Jährlich wiederholen"
 
@@ -5564,20 +5771,28 @@ msgstr "Erfordert jedes Mal ein Passwort $0 Tage"
 msgid "Require password change on $0"
 msgstr "Kennwortänderung an erforderlich $0"
 
-#: pkg/systemd/init.js:722
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr "Benötigt von"
 
+#: pkg/systemd/service-details.jsx:372
+msgid "Required by "
+msgstr ""
+
 # translation auto-copied from project RHN Satellite UI, version 5.7, document java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource, author jdimanos
-#: pkg/systemd/init.js:717
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr "Erfordert"
 
-#: pkg/systemd/init.js:718
+#: pkg/systemd/service-details.jsx:387
+msgid "Requires administration access to edit"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr "Requisit"
 
-#: pkg/systemd/init.js:723
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr "Erfordernis von"
 
@@ -5615,8 +5830,9 @@ msgstr ""
 
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/init.js:545
-#: pkg/systemd/shutdown.js:95 pkg/systemd/shutdown.js:96
+#: pkg/machines/components/vm/vmActions.jsx:42
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Neustarten"
 
@@ -5636,7 +5852,7 @@ msgstr "Neustartrichtlinie:"
 msgid "Restart Recommended"
 msgstr "Neustart empfohlen"
 
-#: pkg/packagekit/updates.jsx:864
+#: pkg/packagekit/updates.jsx:866
 msgid "Restarting"
 msgstr "Neustart"
 
@@ -5668,7 +5884,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Rollen"
 
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1983 pkg/networkmanager/interfaces.js:2000
 msgid "Round Robin"
 msgstr "Round Robin"
 
@@ -5680,12 +5896,12 @@ msgstr ""
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3337
 msgid "Routes"
 msgstr "Routen"
 
 #: pkg/docker/index.html:253 pkg/docker/index.html:566
-#: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
+#: pkg/systemd/services.html:296 pkg/machines/components/vm/vmActions.jsx:91
 msgid "Run"
 msgstr "Ausführen"
 
@@ -5706,19 +5922,19 @@ msgstr ""
 msgid "Runner"
 msgstr "Runner"
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr "Läuft"
 
-#: pkg/systemd/services.html:123
-msgid "Running Since"
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:366
+#: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
 msgstr "SELinux-Zugriffssteuerungsfehler"
 
-#: pkg/selinux/setroubleshoot-view.jsx:298
+#: pkg/selinux/setroubleshoot-view.jsx:301
 msgid "SELinux Policy"
 msgstr "SELinux-Richtlinie"
 
@@ -5726,7 +5942,7 @@ msgstr "SELinux-Richtlinie"
 msgid "SELinux Troubleshoot"
 msgstr "SELinux-Problembehandlung"
 
-#: pkg/selinux/setroubleshoot-view.jsx:357
+#: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "SELinux is disabled on the system"
 msgstr "SELinux ist auf dem System deaktiviert"
 
@@ -5774,7 +5990,7 @@ msgstr "STP Maximum Message Age"
 msgid "STP Priority"
 msgstr "STP Priorität"
 
-#: pkg/systemd/services.html:240
+#: pkg/systemd/services.html:132
 msgid "Saturday"
 msgstr "Samstag"
 
@@ -5782,7 +5998,7 @@ msgstr "Samstag"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
 #: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
@@ -5813,8 +6029,8 @@ msgstr ""
 msgid "Sealed-case PC"
 msgstr "PC mit versiegeltem Gehäuse"
 
-#: pkg/systemd/services.html:459 pkg/systemd/services.html:463
-#: pkg/systemd/init.js:1076
+#: pkg/systemd/services.html:314 pkg/systemd/services.html:318
+#: pkg/systemd/init.js:905
 msgid "Seconds"
 msgstr "Sekunden"
 
@@ -5830,7 +6046,7 @@ msgstr "$target wird sicher gelöscht"
 msgid "Security"
 msgstr "Sicherheit"
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:506
 msgid "Security Updates Available"
 msgstr "Sicherheitsupdates verfügbar"
 
@@ -5897,12 +6113,12 @@ msgstr "Der Server hat die Verbindung beendet."
 msgid "Servers"
 msgstr "Server"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:968
 #: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Dienst"
 
-#: pkg/systemd/services.html:337
+#: pkg/systemd/services.html:229
 msgid "Service Logs"
 msgstr "Serviceprotokolle"
 
@@ -5927,15 +6143,16 @@ msgstr "Dienst ist beendet"
 msgid "Service is stopping"
 msgstr "Dienst wird beendet"
 
-#: pkg/systemd/services.html:399
+#: pkg/systemd/services.html:254
 msgid "Service name"
 msgstr "Dienstname"
 
-#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:222
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Dienste"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sitzung"
@@ -5945,7 +6162,11 @@ msgstr "Sitzung"
 msgid "Set"
 msgstr "Einstellen"
 
-#: pkg/systemd/host.js:764
+#: pkg/machines/components/networks/createNetworkDialog.jsx:231
+msgid "Set DHCP Range"
+msgstr ""
+
+#: pkg/systemd/host.js:781
 msgid "Set Host name"
 msgstr "Rechnernamen festlegen"
 
@@ -5993,7 +6214,7 @@ msgstr "Schweregrad"
 msgid "Severity:"
 msgstr "Schwere:"
 
-#: pkg/networkmanager/interfaces.js:1959
+#: pkg/networkmanager/interfaces.js:1968
 msgid "Shared"
 msgstr "Geteilt"
 
@@ -6005,7 +6226,7 @@ msgstr ""
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Show Performance Options"
 msgstr ""
 
@@ -6047,9 +6268,13 @@ msgstr ""
 msgid "Shut Down"
 msgstr "Herunterfahren"
 
+#: pkg/lib/machine-info.js:242
+msgid "Single Rank"
+msgstr ""
+
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/diskAdd.jsx:167
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
+#: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
@@ -6057,7 +6282,7 @@ msgstr "Herunterfahren"
 #: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
 #: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
 #: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36
+#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:259
 msgid "Size"
 msgstr "Größe"
 
@@ -6082,7 +6307,7 @@ msgstr "Größe muss eine Zahl sein"
 msgid "Size must be at least $0"
 msgstr "Größe muss mindestens sein $0"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "Slot"
 msgstr "Slot"
 
@@ -6091,11 +6316,11 @@ msgid "Slot $0"
 msgstr "Slot $0"
 
 # translation auto-copied from project MRG Realtime Reference Guide, version 2.2, document Sockets
-#: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
+#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:40
 msgid "Sockets"
 msgstr "Sockets"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Aktualisierungen"
 
@@ -6124,7 +6349,7 @@ msgstr "Lösung erfolgreich angewendet"
 msgid "Solution failed"
 msgstr "Lösung fehlgeschlagen"
 
-#: pkg/selinux/setroubleshoot-view.jsx:411
+#: pkg/selinux/setroubleshoot-view.jsx:419
 msgid "Solutions"
 msgstr "Lösungen"
 
@@ -6135,23 +6360,24 @@ msgstr ""
 "Ein anderes Programm verwendet derzeit den Paketmanager, bitte warten Sie ..."
 ""
 
-#: pkg/networkmanager/firewall.jsx:709
+#: pkg/networkmanager/firewall.jsx:739
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:504
-#: pkg/machines/components/nicEdit.jsx:141
+#: pkg/machines/components/diskAdd.jsx:541
+#: pkg/machines/components/nicEdit.jsx:150
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
 msgid "Source"
 msgstr "Quelle"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
@@ -6161,12 +6387,16 @@ msgstr "Quellpfad"
 msgid "Source URL"
 msgstr "Quell-URL"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
+msgid "Source Volume Group"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "Quellpfad sollte nicht leer sein"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr ""
 
@@ -6174,7 +6404,7 @@ msgstr ""
 msgid "Space-saving Computer"
 msgstr "Platzsparender Computer"
 
-#: pkg/networkmanager/interfaces.js:2857
+#: pkg/networkmanager/interfaces.js:2869
 msgid "Spanning Tree Protocol"
 msgstr "Spanning Tree Protocol"
 
@@ -6190,13 +6420,18 @@ msgstr "Ersatz"
 msgid "Specific Time"
 msgstr "Bestimmte Zeit"
 
-#: pkg/networkmanager/interfaces.js:3633
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Speed"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3645
 msgid "Stable"
 msgstr "Stabil"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/machines/components/networks/createNetworkDialog.jsx:237
 #: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/init.js:541
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Starten"
 
@@ -6208,17 +6443,26 @@ msgstr "Docker starten"
 msgid "Start Multipath"
 msgstr "Multipath starten"
 
-#: pkg/networkmanager/index.html:44
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
 msgstr "Dienst starten"
+
+#: pkg/systemd/service-details.jsx:411
+msgid "Start and Enable"
+msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:105
 msgid "Start libvirt"
 msgstr "Starten Sie libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
 msgstr "Starten Sie den Pool, wenn der Host bootet"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:84
+msgid "Start should not be empty"
+msgstr ""
 
 #: pkg/storaged/jobs-panel.jsx:59
 msgid "Starting RAID Device $target"
@@ -6228,15 +6472,15 @@ msgstr "Starte RAID-Gerät $target"
 msgid "Starting swapspace $target"
 msgstr "Swapspace wird gestartet $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "Anlaufen"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/init.js:285
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "Status"
 
@@ -6244,11 +6488,12 @@ msgstr "Status"
 msgid "State:"
 msgstr "Status:"
 
-#: pkg/systemd/services.html:74 pkg/systemd/init.js:207
+#: pkg/systemd/services.html:68 pkg/systemd/init.js:212
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr "Statisch"
 
-#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "Status"
 
@@ -6263,13 +6508,17 @@ msgstr "Sticky"
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
 #: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
 #: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
-#: pkg/systemd/init.js:542
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Stoppen"
 
 #: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Gerät anhalten"
+
+#: pkg/systemd/service-details.jsx:411
+msgid "Stop and Disable"
+msgstr ""
 
 #: pkg/storaged/nfs-details.jsx:259
 msgid "Stop and Unmount"
@@ -6301,8 +6550,8 @@ msgid "Stopping swapspace $target"
 msgstr "Swapspace wird angehalten $target"
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Speicher"
 
@@ -6318,11 +6567,11 @@ msgstr ""
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr "Speicherpoolname"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr "Speicherpool konnte nicht erstellt werden"
 
@@ -6346,6 +6595,10 @@ msgstr ""
 #: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Storage Pool"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
+msgid "Storage size must not be 0"
+msgstr ""
 
 #: pkg/systemd/index.html:155
 msgid "Store Metrics"
@@ -6375,7 +6628,7 @@ msgstr "Subnotizbuch"
 msgid "Summary"
 msgstr "Zusammenfassung"
 
-#: pkg/systemd/services.html:241
+#: pkg/systemd/services.html:133
 msgid "Sunday"
 msgstr "Sonntag"
 
@@ -6396,19 +6649,19 @@ msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "Auslagerungsspeicher"
 
-#: pkg/systemd/index.html:248 pkg/systemd/host.js:1692
+#: pkg/systemd/index.html:248 pkg/systemd/host.js:1709
 msgid "Swap Used"
 msgstr "Benutzter Auslagerungsspeicher"
 
-#: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
+#: pkg/networkmanager/interfaces.js:2504 pkg/networkmanager/interfaces.js:3051
 msgid "Switch off $0"
 msgstr "$0 ausschalten"
 
-#: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
+#: pkg/networkmanager/interfaces.js:2479 pkg/networkmanager/interfaces.js:3039
 msgid "Switch on $0"
 msgstr "$0 anschalten"
 
-#: pkg/networkmanager/interfaces.js:2491
+#: pkg/networkmanager/interfaces.js:2503
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6416,7 +6669,7 @@ msgstr ""
 "Das Ausschalten von <b>$0</b> wird die Verbindung zum Server unterbrechen "
 "und damit den Zugriff auf die Benutzeroberfläche unmöglich machen."
 
-#: pkg/networkmanager/interfaces.js:3038
+#: pkg/networkmanager/interfaces.js:3050
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6424,7 +6677,7 @@ msgstr ""
 "Das Ausschalten von <b>$0</b> wird die Verbindung zum Server unterbrechen "
 "und damit den Zugriff auf die Benutzeroberfläche unmöglich machen."
 
-#: pkg/networkmanager/interfaces.js:2466 pkg/networkmanager/interfaces.js:3026
+#: pkg/networkmanager/interfaces.js:2478 pkg/networkmanager/interfaces.js:3038
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6452,24 +6705,26 @@ msgstr "Synchronisiert mit {{Server}}"
 msgid "Synchronizing RAID Device $target"
 msgstr "Synchronisiere RAID-Gerät $target"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:260
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "System"
 
-#: pkg/systemd/hwinfo.jsx:264
+#: pkg/systemd/hwinfo.jsx:273
 msgid "System Information"
 msgstr "Systeminformationen"
 
-#: pkg/selinux/setroubleshoot-view.jsx:459
+#: pkg/selinux/setroubleshoot-view.jsx:467
 msgid "System Modifications"
 msgstr ""
 
-#: pkg/systemd/host.js:480
+#: pkg/systemd/host.js:490
 msgid "System Not Registered"
 msgstr "System nicht registriert"
 
-#: pkg/systemd/services.html:57
+#: pkg/systemd/services.jsx:38
 msgid "System Services"
 msgstr "System Dienste"
 
@@ -6477,17 +6732,17 @@ msgstr "System Dienste"
 msgid "System Time"
 msgstr "Systemzeit"
 
-#: pkg/systemd/host.js:486
+#: pkg/systemd/host.js:496
 msgid "System Up To Date"
 msgstr "System ist auf aktuellem Stand"
 
 # ctx::sourcefile::/systems/SystemEntitlements
-#: pkg/packagekit/updates.jsx:876
+#: pkg/packagekit/updates.jsx:878
 msgid "System is up to date"
 msgstr "System ist aktualisiert"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:968
 msgid "TCP"
 msgstr "TCP"
 
@@ -6516,25 +6771,25 @@ msgstr "Tang Keyserver"
 msgid "Target"
 msgstr "Ziel"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "Zielpfad"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "Zielpfad sollte nicht leer sein"
 
-#: pkg/systemd/services.html:56
+#: pkg/systemd/services.jsx:39
 msgid "Targets"
 msgstr "Ziele"
 
-#: pkg/networkmanager/interfaces.js:2512 pkg/networkmanager/interfaces.js:2524
-#: pkg/networkmanager/interfaces.js:2814
+#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
+#: pkg/networkmanager/interfaces.js:2826
 msgid "Team"
 msgstr "Team"
 
-#: pkg/networkmanager/interfaces.js:2842
+#: pkg/networkmanager/interfaces.js:2854
 msgid "Team Port"
 msgstr "Netzwerk-Team Anschluss"
 
@@ -6548,7 +6803,7 @@ msgstr "Bridge Port Einstellungen"
 msgid "Team Settings"
 msgstr "IP Einstellungen"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -6594,8 +6849,8 @@ msgstr ""
 msgid "The RAID device must be running in order to remove disks."
 msgstr "Das RAID-Gerät muss aktiv sein, um Festplatten entfernen zu können."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:80
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:84
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:125
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:129
 msgid "The Storage Pool could not be deleted"
 msgstr ""
 
@@ -6676,7 +6931,7 @@ msgstr ""
 "Der aktuell angemeldete Benutzer kann keine Informationen zu Schlüsseln "
 "anzeigen."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "Das Verzeichnis auf dem Server, der exportiert wird"
 
@@ -6751,7 +7006,7 @@ msgstr ""
 msgid "The logged in user is not permitted to view system modifications"
 msgstr ""
 
-#: pkg/shell/indexes.js:407
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "Die Maschine startet neu"
 
@@ -6779,6 +7034,15 @@ msgstr "Der Scan von $time ($type) keine Schwachstellen gefunden."
 msgid "The scan from $time ($type) was not successful."
 msgstr "Der Scan von $time ($type) war nicht erfolgreich."
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
+msgid "The selected Operating System has minimum memory requirement of $0 $1"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+msgid ""
+"The selected Operating System has minimum storage size requirement of $0 $1"
+msgstr ""
+
 #: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
@@ -6798,7 +7062,7 @@ msgstr ""
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 
-#: pkg/systemd/init.js:922
+#: pkg/systemd/init.js:751
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "Der Benutzer <b>$0</b> hat keine Rechte zum Anlegen von Timern"
 
@@ -6809,11 +7073,6 @@ msgstr "Der Benutzer <b>$0</b> darf das Profil nicht ändern"
 #: pkg/systemd/host.js:70
 msgid "The user <b>$0</b> is not permitted to change the system time"
 msgstr "Der Benutzer <b>$0</b> darf die Systemzeit nicht ändern"
-
-#: pkg/systemd/init.js:614
-msgid "The user <b>$0</b> is not permitted to enable or disable services"
-msgstr ""
-"Der Benutzer <b>$0</b> darf keine Dienste aktivieren oder deaktivieren"
 
 #: pkg/dashboard/list.js:223
 msgid "The user <b>$0</b> is not permitted to manage servers"
@@ -6831,7 +7090,7 @@ msgstr "Der Benutzer <b>$0</b> hat keine Rechte, Konten zu verändern"
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "Der Benutzer <b>$0</b> hat keine Rechte, Hostnamen zu verändern"
 
-#: pkg/networkmanager/interfaces.js:1516
+#: pkg/networkmanager/interfaces.js:1525
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
 "Der User <b>$0</b> hat keine Rechte, die Netzwerkeinstellungen zu verändern."
@@ -6845,12 +7104,6 @@ msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr ""
 "Der Benutzer <b>$0</b> darf diesen Server nicht herunterfahren oder neu "
 "starten"
-
-#: pkg/systemd/init.js:606 pkg/systemd/init.js:610
-msgid "The user <b>$0</b> is not permitted to start or stop services"
-msgstr ""
-"Der Benutzer <b>$0</b> ist nicht berechtigt, Dienste zu starten oder zu "
-"stoppen"
 
 #: pkg/users/local.js:553
 msgid ""
@@ -6907,7 +7160,7 @@ msgstr ""
 msgid "This VDO device does not use all of its backing device."
 msgstr "Dieses VDO-Gerät verwendet nicht alle seine Hintergrundgeräte."
 
-#: pkg/systemd/init.js:1371
+#: pkg/systemd/init.js:1200
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -6915,7 +7168,7 @@ msgstr ""
 "Dieser Tag ist nicht in allen Monaten vorhanden.<br> Die Aktion wird nur in "
 "Monaten mit 31 Tagen ausgeführt."
 
-#: pkg/networkmanager/interfaces.js:2624
+#: pkg/networkmanager/interfaces.js:2636
 msgid "This device cannot be managed here."
 msgstr "Dieses Gerät kann hier nicht verwaltet werden."
 
@@ -6961,7 +7214,7 @@ msgstr ""
 "Diese Diskette kann nicht entfernt werden, während das Gerät "
 "wiederhergestellt wird."
 
-#: pkg/systemd/init.js:1283 pkg/systemd/init.js:1297 pkg/systemd/init.js:1306
+#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
 msgid "This field cannot be empty."
 msgstr "Dieses Feld darf nicht leer sein."
 
@@ -6990,7 +7243,11 @@ msgstr "Das Paket ist mit dieser Cockpit-Version nicht kompatibel"
 msgid "This package requires Cockpit version %s or later"
 msgstr "Dieses Paket erfordert Cockpit in der Version %s oder höher"
 
-#: pkg/packagekit/updates.jsx:772
+#: pkg/machines/components/diskAdd.jsx:215
+msgid "This pool type does not support Storage Volume creation"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:774
 msgid "This system is not registered"
 msgstr "Dieses System ist nicht registriert"
 
@@ -7010,11 +7267,7 @@ msgstr ""
 "Dieses Tool erfasst Systemkonfigurations- und Diagnoseinformationen von "
 "diesem System, um Probleme mit dem System zu diagnostizieren."
 
-#: pkg/systemd/init.js:685
-msgid "This unit is an instance of the $0 template."
-msgstr "Diese Einheit ist eine Instanz von $0 Vorlage."
-
-#: pkg/systemd/services.html:360
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Dieses Gerät kann nicht explizit aktiviert werden."
 
@@ -7030,7 +7283,7 @@ msgstr ""
 "Das Verbinden zu einem Host mit alternativen Benutzernamen oder auf anderen "
 "Ports wird von dieser Version von cockpit-ws nicht unterstützt"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr ""
 
@@ -7043,7 +7296,7 @@ msgstr ""
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr "Dieser Webbrowser ist zu alt, um Cockpit auszuführen (fehlt) $0)"
 
-#: pkg/packagekit/updates.jsx:832
+#: pkg/packagekit/updates.jsx:834
 msgid "This web console will be updated."
 msgstr "Diese Webkonsole wird aktualisiert."
 
@@ -7066,7 +7319,7 @@ msgstr "Dies wird die kdump-Konfiguration durch einen Kernel-Absturz testen."
 msgid "Threads per core"
 msgstr "Fäden pro Kern"
 
-#: pkg/systemd/services.html:238
+#: pkg/systemd/services.html:130
 msgid "Thursday"
 msgstr "Donnerstag"
 
@@ -7078,7 +7331,7 @@ msgstr ""
 msgid "Time Zone"
 msgstr "Zeitzone"
 
-#: pkg/systemd/services.html:59
+#: pkg/systemd/services.jsx:41
 msgid "Timers"
 msgstr "Timer"
 
@@ -7090,7 +7343,7 @@ msgstr ""
 "Tipp: Wenn Ihr Schlüsselpasswort mit Ihrem Login-Passwort übereinstimmt, "
 "können Sie sich an anderen Systemen automatisiert anmelden."
 
-#: pkg/packagekit/updates.jsx:773
+#: pkg/packagekit/updates.jsx:775
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
@@ -7134,15 +7387,19 @@ msgstr "Gesamtgröße: $0"
 msgid "Tower"
 msgstr "Turm"
 
-#: pkg/systemd/init.js:733
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr "Ausgelöst durch"
 
-#: pkg/systemd/init.js:732
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "Löst aus"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Fehlersuche"
@@ -7151,7 +7408,7 @@ msgstr "Fehlersuche"
 msgid "Trust key"
 msgstr "Schlüssel vertrauen"
 
-#: pkg/networkmanager/firewall.jsx:705
+#: pkg/networkmanager/firewall.jsx:735
 msgid "Trust level"
 msgstr ""
 
@@ -7171,7 +7428,7 @@ msgstr "Versuche neu zu verbinden"
 msgid "Trying to synchronize with {{Server}}"
 msgstr "Versuche mit  {{Server}} zu synchronisieren"
 
-#: pkg/systemd/services.html:236
+#: pkg/systemd/services.html:128
 msgid "Tuesday"
 msgstr "Dienstag"
 
@@ -7196,8 +7453,8 @@ msgid "Tuned is off"
 msgstr "Tuned ist ausgeschaltet"
 
 #: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
@@ -7207,6 +7464,7 @@ msgstr "Tuned ist ausgeschaltet"
 #: pkg/machines/components/vmnetworktab.jsx:114
 #: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
 #: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/systemd/hwinfo.jsx:259
 msgid "Type"
 msgstr "Typ"
 
@@ -7222,11 +7480,11 @@ msgstr "Geben Sie ein Passwort ein"
 msgid "Type to filter…"
 msgstr "Zum Filtern tippen..."
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:968
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "URL"
 
@@ -7292,11 +7550,15 @@ msgid "Unavailable"
 msgstr "Nicht verfügbar"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Unerwarteter Fehler"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+#: pkg/machines/components/networks/createNetworkDialog.jsx:128
+msgid "Unique Network Name"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "Einzigartiger Name"
 
@@ -7308,14 +7570,15 @@ msgstr "Einheit"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/lib/machine-info.js:65 pkg/machines/components/vmnetworktab.jsx:139
-#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
-#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
+#: pkg/machines/components/vmnetworktab.jsx:139
+#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1076
+#: pkg/networkmanager/interfaces.js:2544 pkg/networkmanager/interfaces.js:2546
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
+#: pkg/networkmanager/interfaces.js:2530 pkg/networkmanager/interfaces.js:2542
 msgid "Unknown \"$0\""
 msgstr "Unbekannte \"$0\""
 
@@ -7331,7 +7594,7 @@ msgstr "Unbekannte Anwendung"
 msgid "Unknown Host Key"
 msgstr "Unbekannter Host-Schlüssel"
 
-#: pkg/networkmanager/interfaces.js:2640
+#: pkg/networkmanager/interfaces.js:2652
 msgid "Unknown configuration"
 msgstr "Unbekannte Konfiguration"
 
@@ -7339,7 +7602,7 @@ msgstr "Unbekannte Konfiguration"
 msgid "Unknown host name"
 msgstr "Unbekannter Host-Name"
 
-#: pkg/networkmanager/firewall.jsx:333
+#: pkg/networkmanager/firewall.jsx:358
 msgid "Unknown service name"
 msgstr ""
 
@@ -7380,10 +7643,6 @@ msgstr "Festplatte wird entsperrt ..."
 msgid "Unmanaged Interfaces"
 msgstr "Unverwaltete Schnittstellen"
 
-#: pkg/systemd/init.js:576
-msgid "Unmask"
-msgstr "Freigeben"
-
 #: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
 msgid "Unmount"
 msgstr "Aushängen"
@@ -7396,7 +7655,7 @@ msgstr "$target wird ausgehängt"
 msgid "Unnamed"
 msgstr "Unbennant"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Unplug"
 msgstr "Ziehen Sie den Stecker heraus"
 
@@ -7434,11 +7693,11 @@ msgstr "Nicht vertrauenswürdiger Host"
 msgid "Up since $0"
 msgstr "Up seit $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -7464,7 +7723,7 @@ msgstr ""
 "Aktualisierte Pakete erfordern möglicherweise einen Neustart, um wirksam zu "
 "werden."
 
-#: pkg/systemd/host.js:502
+#: pkg/systemd/host.js:512
 msgid "Updates Available"
 msgstr "Updates verfügbar"
 
@@ -7472,12 +7731,16 @@ msgstr "Updates verfügbar"
 msgid "Updating"
 msgstr "Aktualisiere"
 
+#: pkg/systemd/service-details.jsx:406
+msgid "Updating status..."
+msgstr ""
+
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Verbrauch"
 
-#: pkg/systemd/host.js:1613
+#: pkg/systemd/host.js:1630
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] "Verwendung von $0 CPU-Kern"
@@ -7487,7 +7750,7 @@ msgstr[1] "Verwendung von $0 CPU-Kernen"
 msgid "Use 512 Byte emulation"
 msgstr "Verwenden Sie eine 512-Byte-Emulation"
 
-#: pkg/machines/components/diskAdd.jsx:524
+#: pkg/machines/components/diskAdd.jsx:561
 msgid "Use Existing"
 msgstr "Benutze existierendes"
 
@@ -7500,7 +7763,7 @@ msgstr ""
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
-#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1678
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1695
 msgid "Used"
 msgstr "Benutzt"
 
@@ -7514,7 +7777,7 @@ msgstr "Genutzt von Containern"
 
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1601
 msgid "User"
 msgstr "Benutzer"
 
@@ -7577,8 +7840,8 @@ msgstr "VDO-Sicherungsgeräte können nicht kleiner gemacht werden"
 msgid "VDO support not installed"
 msgstr "VDO-Unterstützung nicht installiert"
 
-#: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
-#: pkg/networkmanager/interfaces.js:2906
+#: pkg/networkmanager/interfaces.js:2526 pkg/networkmanager/interfaces.js:2538
+#: pkg/networkmanager/interfaces.js:2918
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7606,7 +7869,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -7660,7 +7923,7 @@ msgstr "Schlüssel wird überprüft"
 
 # translation auto-copied from project subscription-manager, version 1.9.X, document keys
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:250
 msgid "Vendor"
 msgstr "Anbieter"
 
@@ -7685,18 +7948,22 @@ msgstr "Version"
 msgid "Very securely erasing $target"
 msgstr "$target wird sehr sicher gelöscht"
 
-#: pkg/lib/cockpit-components-modifications.jsx:174
+#: pkg/lib/cockpit-components-modifications.jsx:173
 msgid "View automation script"
 msgstr ""
 
-#: pkg/machines/components/networks/networkList.jsx:39
+#: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Virtuelle Maschinen"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:422
+msgid "Virtual Network failed to be created"
 msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:80
@@ -7707,7 +7974,7 @@ msgstr "Der Virtualisierungsdienst (libvirt) ist nicht aktiv"
 msgid "Virtualization Service is Available"
 msgstr "Der Virtualisierungsdienst ist verfügbar"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
@@ -7723,6 +7990,14 @@ msgstr "Datenträgerverbund"
 #: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Datenträgerverbund $0"
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
+msgid "Volume Group name"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+msgid "Volume Group name should not be empty"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:113
 msgid "Volume Groups"
@@ -7745,7 +8020,7 @@ msgstr "Volumen:"
 msgid "WWPN"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:836
+#: pkg/networkmanager/interfaces.js:845
 msgid "Waiting"
 msgstr "Wartet"
 
@@ -7763,11 +8038,11 @@ msgstr "Warten, bis andere Programme mit dem Paketmanager fertig sind ..."
 msgid "Waiting for other software management operations to finish"
 msgstr "Warten, bis andere Software-Verwaltungsvorgänge abgeschlossen sind"
 
-#: pkg/systemd/init.js:724
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr "Gesucht von"
 
-#: pkg/systemd/init.js:719
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr "Will"
 
@@ -7779,7 +8054,7 @@ msgstr "Warnung und höher"
 msgid "Web Console for Linux servers"
 msgstr "Webkonsole für Linux-Server"
 
-#: pkg/systemd/services.html:237
+#: pkg/systemd/services.html:129
 msgid "Wednesday"
 msgstr "Mittwoch"
 
@@ -7787,7 +8062,7 @@ msgstr "Mittwoch"
 msgid "Wednesdays"
 msgstr ""
 
-#: pkg/systemd/services.html:466
+#: pkg/systemd/services.html:321
 msgid "Weeks"
 msgstr "Wochen"
 
@@ -7815,11 +8090,11 @@ msgstr "Schreiben"
 msgid "Wrong user name or password"
 msgstr "Benutzername oder Passwort falsch"
 
-#: pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1985
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2605
 msgid "Yes"
 msgstr "Ja"
 
@@ -7838,8 +8113,8 @@ msgstr ""
 "Sie sind derzeit direkt mit diesem Server verbunden und können ihn deshalb "
 "nicht löschen."
 
-#: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
+#: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
+#: pkg/networkmanager/firewall.jsx:903 pkg/networkmanager/firewall.jsx:909
 msgid "You are not authorized to modify the firewall."
 msgstr "Sie sind nicht berechtigt, die Firewall zu ändern."
 
@@ -7860,12 +8135,11 @@ msgstr "Sie haben keine Berechtigung, den Docker Storage Pool zu verwalten."
 msgid "You must wait longer to change your password"
 msgstr "Sie müssen länger warten, um Ihr Passwort zu ändern"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
-msgid ""
-"You need to select the most closely matching OS vendor and Operating System"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
+msgid "You need to select the most closely matching Operating System"
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:834
+#: pkg/packagekit/updates.jsx:836
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
@@ -7874,7 +8148,7 @@ msgstr ""
 "jedoch nicht beeinflusst. Sie können die Verbindung in wenigen Augenblicken "
 "wiederherstellen, um den Fortschritt fortzusetzen."
 
-#: pkg/packagekit/updates.jsx:865
+#: pkg/packagekit/updates.jsx:867
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
@@ -7890,11 +8164,11 @@ msgstr "Ihre Sitzung wurde beendet."
 msgid "Your session has expired. Please log in again."
 msgstr "Die Session ist abgelaufen. Bitte neu einloggen."
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:955
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:968
 msgid "Zones"
 msgstr ""
 
@@ -8002,7 +8276,7 @@ msgstr "Ethernet"
 msgid "every day"
 msgstr "jeden Tag"
 
-#: pkg/systemd/host.js:886
+#: pkg/systemd/host.js:903
 msgid "failed to list ssh host keys: $0"
 msgstr "Kann SSH-Hostschlüssel nicht anzeigen: $0"
 
@@ -8019,11 +8293,11 @@ msgstr ""
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr ""
 
@@ -8031,11 +8305,11 @@ msgstr ""
 msgid "iSCSI Targets"
 msgstr "iSCSI Targets"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:83
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -8082,8 +8356,8 @@ msgid "nfs dump target isn't formated as server:path"
 msgstr "Das NFS-Speicherauszugsziel ist nicht als Serverpfad formatiert"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "Nein"
@@ -8094,7 +8368,7 @@ msgstr "Nein"
 msgid "none"
 msgstr "kein"
 
-#: pkg/systemd/host.js:691
+#: pkg/systemd/host.js:712
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] "von $0 CPU-Kern"
@@ -8103,14 +8377,6 @@ msgstr[1] "von $0 CPU-Kernen"
 #: pkg/machines/helpers.js:190
 msgid "paused"
 msgstr "pausiert"
-
-#: pkg/machines/components/diskAdd.jsx:154
-msgid "qcow2"
-msgstr "qcow2"
-
-#: pkg/machines/components/diskAdd.jsx:157
-msgid "raw"
-msgstr "raw"
 
 #: pkg/tuned/change-profile.jsx:42
 #, fuzzy
@@ -8202,7 +8468,7 @@ msgid "undefined"
 msgstr "nicht definiert"
 
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:249 pkg/systemd/init.js:263
+#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
 msgid "unknown"
 msgstr "unbekannt"
 
@@ -8245,15 +8511,15 @@ msgstr "value"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr ""
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "Ja"

--- a/po/es.po
+++ b/po/es.po
@@ -19,14 +19,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 08:58+0200\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "PO-Revision-Date: 2018-12-11 10:57+0000\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Spanish\n"
 "Language: es\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -61,7 +61,7 @@ msgid_plural "$0 Packages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/init.js:395 pkg/systemd/init.js:749
+#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "$0 Plantilla"
 
@@ -140,10 +140,10 @@ msgstr ""
 "en \"GNOME Software\" o ejecuta el siguiente comando:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
-#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
+#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
+#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 esta en uso actualmente"
 
@@ -156,7 +156,7 @@ msgstr "$0 no está disponible en ningún repositorio"
 msgid "$0 killed with signal $1"
 msgstr "$0 terminado con señal $1"
 
-#: pkg/selinux/setroubleshoot-view.jsx:429
+#: pkg/selinux/setroubleshoot-view.jsx:439
 msgid "$0 occurrence"
 msgid_plural "$1 occurrences"
 msgstr[0] "$1 ocurrencia"
@@ -199,7 +199,7 @@ msgid_plural "$1 security fixes"
 msgstr[0] "$1 corrección de seguridad"
 msgstr[1] "$1 correcciones de seguridad"
 
-#: pkg/networkmanager/interfaces.js:2757
+#: pkg/networkmanager/interfaces.js:2769
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -215,11 +215,11 @@ msgstr "${hip}:${hport} → $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:549
+#: pkg/networkmanager/firewall.jsx:574
 msgid "(Optional)"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
+#: pkg/networkmanager/firewall.jsx:499 pkg/networkmanager/firewall.jsx:648
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(predeterminado)"
@@ -258,7 +258,7 @@ msgstr "1 día"
 msgid "1 hour"
 msgstr "1 hora"
 
-#: pkg/systemd/host.js:1669
+#: pkg/systemd/host.js:1686
 msgid "1 min"
 msgstr "1 min"
 
@@ -268,11 +268,11 @@ msgstr "1 min"
 msgid "1 week"
 msgstr "1 semana"
 
-#: pkg/systemd/services.html:273
+#: pkg/systemd/services.html:165
 msgid "10th"
 msgstr "10.º"
 
-#: pkg/systemd/services.html:274
+#: pkg/systemd/services.html:166
 msgid "11th"
 msgstr "11.º"
 
@@ -280,19 +280,19 @@ msgstr "11.º"
 msgid "128 KiB"
 msgstr "128 KiB"
 
-#: pkg/systemd/services.html:275
+#: pkg/systemd/services.html:167
 msgid "12th"
 msgstr "12.º"
 
-#: pkg/systemd/services.html:276
+#: pkg/systemd/services.html:168
 msgid "13th"
 msgstr "13.º"
 
-#: pkg/systemd/services.html:277
+#: pkg/systemd/services.html:169
 msgid "14th"
 msgstr "14.º"
 
-#: pkg/systemd/services.html:278
+#: pkg/systemd/services.html:170
 msgid "15th"
 msgstr "15.º"
 
@@ -300,23 +300,23 @@ msgstr "15.º"
 msgid "16 KiB"
 msgstr "16 KiB"
 
-#: pkg/systemd/services.html:279
+#: pkg/systemd/services.html:171
 msgid "16th"
 msgstr "16.º"
 
-#: pkg/systemd/services.html:280
+#: pkg/systemd/services.html:172
 msgid "17th"
 msgstr "17.º"
 
-#: pkg/systemd/services.html:281
+#: pkg/systemd/services.html:173
 msgid "18th"
 msgstr "18.º"
 
-#: pkg/systemd/services.html:282
+#: pkg/systemd/services.html:174
 msgid "19th"
 msgstr "19.º"
 
-#: pkg/systemd/services.html:264
+#: pkg/systemd/services.html:156
 msgid "1st"
 msgstr "1.º"
 
@@ -324,7 +324,7 @@ msgstr "1.º"
 msgid "2 MiB"
 msgstr "2 MiB"
 
-#: pkg/systemd/host.js:1668
+#: pkg/systemd/host.js:1685
 msgid "2 min"
 msgstr "2 min"
 
@@ -332,59 +332,59 @@ msgstr "2 min"
 msgid "20 Minutes"
 msgstr "20 minutos"
 
-#: pkg/systemd/services.html:283
+#: pkg/systemd/services.html:175
 msgid "20th"
 msgstr "20.º"
 
-#: pkg/systemd/services.html:284
+#: pkg/systemd/services.html:176
 msgid "21st"
 msgstr "21.º"
 
-#: pkg/systemd/services.html:285
+#: pkg/systemd/services.html:177
 msgid "22nd"
 msgstr "22.º"
 
-#: pkg/systemd/services.html:286
+#: pkg/systemd/services.html:178
 msgid "23rd"
 msgstr "23.º"
 
-#: pkg/systemd/services.html:287
+#: pkg/systemd/services.html:179
 msgid "24th"
 msgstr "24.º"
 
-#: pkg/systemd/services.html:288
+#: pkg/systemd/services.html:180
 msgid "25th"
 msgstr "25.º"
 
-#: pkg/systemd/services.html:289
+#: pkg/systemd/services.html:181
 msgid "26th"
 msgstr "26.º"
 
-#: pkg/systemd/services.html:290
+#: pkg/systemd/services.html:182
 msgid "27th"
 msgstr "27.º"
 
-#: pkg/systemd/services.html:291
+#: pkg/systemd/services.html:183
 msgid "28th"
 msgstr "28.º"
 
-#: pkg/systemd/services.html:292
+#: pkg/systemd/services.html:184
 msgid "29th"
 msgstr "29.º"
 
-#: pkg/systemd/services.html:265
+#: pkg/systemd/services.html:157
 msgid "2nd"
 msgstr "2.º"
 
-#: pkg/systemd/host.js:1667
+#: pkg/systemd/host.js:1684
 msgid "3 min"
 msgstr "3 min"
 
-#: pkg/systemd/services.html:293
+#: pkg/systemd/services.html:185
 msgid "30th"
 msgstr "30.º"
 
-#: pkg/systemd/services.html:294
+#: pkg/systemd/services.html:186
 msgid "31st"
 msgstr "31.º"
 
@@ -392,7 +392,7 @@ msgstr "31.º"
 msgid "32 KiB"
 msgstr "32 KiB"
 
-#: pkg/systemd/services.html:266
+#: pkg/systemd/services.html:158
 msgid "3rd"
 msgstr "3.º"
 
@@ -400,7 +400,7 @@ msgstr "3.º"
 msgid "4 KiB"
 msgstr "4 KiB"
 
-#: pkg/systemd/host.js:1666
+#: pkg/systemd/host.js:1683
 msgid "4 min"
 msgstr "4 min"
 
@@ -408,7 +408,7 @@ msgstr "4 min"
 msgid "40 Minutes"
 msgstr "40 minutos"
 
-#: pkg/systemd/services.html:267
+#: pkg/systemd/services.html:159
 msgid "4th"
 msgstr "4.º"
 
@@ -416,7 +416,7 @@ msgstr "4.º"
 msgid "5 Minutes"
 msgstr "5 minutos"
 
-#: pkg/systemd/host.js:1665
+#: pkg/systemd/host.js:1682
 msgid "5 min"
 msgstr "5 min"
 
@@ -430,7 +430,7 @@ msgstr "5 minutos"
 msgid "512 KiB"
 msgstr "512 KiB"
 
-#: pkg/systemd/services.html:268
+#: pkg/systemd/services.html:160
 msgid "5th"
 msgstr "5.º"
 
@@ -448,11 +448,11 @@ msgstr "60 minutos"
 msgid "64 KiB"
 msgstr "64 KiB"
 
-#: pkg/systemd/services.html:269
+#: pkg/systemd/services.html:161
 msgid "6th"
 msgstr "6.º"
 
-#: pkg/systemd/services.html:270
+#: pkg/systemd/services.html:162
 msgid "7th"
 msgstr "7.º"
 
@@ -460,19 +460,19 @@ msgstr "7.º"
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1987
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:1995
+#: pkg/networkmanager/interfaces.js:2004
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
-#: pkg/systemd/services.html:271
+#: pkg/systemd/services.html:163
 msgid "8th"
 msgstr "8.º"
 
-#: pkg/systemd/services.html:272
+#: pkg/systemd/services.html:164
 msgid "9th"
 msgstr "9.º"
 
@@ -481,8 +481,8 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"No se ha instalado una versión compatible de Cockpit en {{#strong}}{{host}}"
-"{{/strong}}."
+"No se ha instalado una versión compatible de Cockpit en "
+"{{#strong}}{{host}}{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:59
 msgid "A disk is needed."
@@ -501,15 +501,15 @@ msgstr ""
 "Un disco de repuesto debe agregarse primero antes de este disco se puede "
 "quitar."
 
-#: pkg/networkmanager/interfaces.js:1986
+#: pkg/networkmanager/interfaces.js:1995
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2786
+#: pkg/networkmanager/interfaces.js:2798
 msgid "ARP Monitoring"
 msgstr "Supervisión ARP"
 
-#: pkg/networkmanager/interfaces.js:2007
+#: pkg/networkmanager/interfaces.js:2016
 msgid "ARP Ping"
 msgstr "Ping ARP"
 
@@ -517,6 +517,10 @@ msgstr "Ping ARP"
 #: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Acerca de Cockpit"
+
+#: pkg/lib/machine-info.js:251
+msgid "Absent"
+msgstr ""
 
 #: pkg/users/index.html:104 pkg/users/index.html:190
 msgid "Access"
@@ -538,7 +542,7 @@ msgstr "Configuración de la cuenta"
 msgid "Account not available or cannot be edited."
 msgstr "La cuenta no está disponible o no se puede modificar."
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Cuentas"
 
@@ -547,8 +551,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Cuentas"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:170
 #: pkg/machines/components/networks/network.jsx:148
+#: pkg/machines/components/storagePools/storagePool.jsx:170
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Activar"
@@ -557,11 +561,11 @@ msgstr "Activar"
 msgid "Activating $target"
 msgstr "Activando $target"
 
-#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
+#: pkg/networkmanager/interfaces.js:847 pkg/networkmanager/interfaces.js:2010
 msgid "Active"
 msgstr "Activo"
 
-#: pkg/networkmanager/interfaces.js:1975 pkg/networkmanager/interfaces.js:1992
+#: pkg/networkmanager/interfaces.js:1984 pkg/networkmanager/interfaces.js:2001
 msgid "Active Backup"
 msgstr "Copia de seguridad activa"
 
@@ -573,27 +577,31 @@ msgstr "Páginas Activas"
 msgid "Active since"
 msgstr "Activo desde"
 
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/systemd/service-details.jsx:352
+msgid "Active since "
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:954
 msgid "Active zones"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1980
+#: pkg/networkmanager/interfaces.js:1989
 msgid "Adaptive load balancing"
 msgstr "Equilibrio de carga adaptativo"
 
-#: pkg/networkmanager/interfaces.js:1979
+#: pkg/networkmanager/interfaces.js:1988
 msgid "Adaptive transmit load balancing"
 msgstr "Equilibrio de carga de transmisión adaptativa"
 
-#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
+#: pkg/machines/components/diskAdd.jsx:600 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
+#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Añadir"
 
-#: pkg/networkmanager/interfaces.js:3103
+#: pkg/networkmanager/interfaces.js:3115
 msgid "Add $0"
 msgstr "Añadir $0"
 
@@ -610,7 +618,7 @@ msgid "Add Bridge"
 msgstr "Añadir puente"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:360
+#: pkg/machines/components/diskAdd.jsx:368
 msgid "Add Disk"
 msgstr "Añadir disco"
 
@@ -627,12 +635,12 @@ msgstr "Añadir clave"
 msgid "Add Machine to Dashboard"
 msgstr "Añadir máquina al tablero"
 
-#: pkg/networkmanager/firewall.jsx:457
+#: pkg/networkmanager/firewall.jsx:482
 msgid "Add Ports"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
-#: pkg/networkmanager/firewall.jsx:886
+#: pkg/networkmanager/firewall.jsx:482 pkg/networkmanager/firewall.jsx:904
+#: pkg/networkmanager/firewall.jsx:916
 msgid "Add Services"
 msgstr "Añadir Servicios"
 
@@ -648,8 +656,8 @@ msgstr "Añadir equipo"
 msgid "Add VLAN"
 msgstr "Añadir VLAN"
 
-#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
-#: pkg/networkmanager/firewall.jsx:891
+#: pkg/networkmanager/firewall.jsx:730 pkg/networkmanager/firewall.jsx:910
+#: pkg/networkmanager/firewall.jsx:921
 msgid "Add Zone"
 msgstr ""
 
@@ -661,7 +669,7 @@ msgstr "Agregar portal iSCSI"
 msgid "Add key"
 msgstr "Añadir clave"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add ports to the following zones:"
 msgstr ""
 
@@ -669,21 +677,27 @@ msgstr ""
 msgid "Add public key"
 msgstr "Añadir clave pública"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add services to following zones:"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:776
+#: pkg/networkmanager/firewall.jsx:806
 msgid "Add zone"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3102
+#: pkg/networkmanager/interfaces.js:3114
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
 msgstr ""
 "Si se añade <b>$0</b> se romperá la conexión con el servidor y se "
 "indisponibilizará el acceso a la IU de administración."
+
+#: pkg/networkmanager/firewall.jsx:586
+msgid ""
+"Adding custom ports will reload firewalld. A reload will result in the loss "
+"of any runtime-only configuration!"
+msgstr ""
 
 #: pkg/users/authorized-keys.js:113
 msgid "Adding key"
@@ -697,11 +711,11 @@ msgstr "Añadiendo volumen físico a $target"
 msgid "Additional"
 msgstr "Adicional"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2668
 msgid "Additional DNS $val"
 msgstr "DNA adicional $val"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Additional DNS Search Domains $val"
 msgstr "Búsqueda de Dominios DNA Adicional $val"
 
@@ -709,7 +723,11 @@ msgstr "Búsqueda de Dominios DNA Adicional $val"
 msgid "Additional Storage"
 msgstr "Almacenamiento Adicional"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/systemd/service-details.jsx:209
+msgid "Additional actions"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2663
 msgid "Additional address $val"
 msgstr "Dirección adicional $val"
 
@@ -726,7 +744,7 @@ msgstr "Paquetes adicionales:"
 msgid "Address"
 msgstr "Dirección"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/networkmanager/interfaces.js:2663
 msgid "Address $val"
 msgstr "Dirección $val"
 
@@ -739,11 +757,18 @@ msgstr "La dirección no puede estar vacía"
 msgid "Address is not a valid URL"
 msgstr "La dirección no es una URL válida"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:60
+#: pkg/machines/components/networks/createNetworkDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:88
+#: pkg/machines/components/networks/createNetworkDialog.jsx:95
+msgid "Address not within subnet"
+msgstr ""
+
 #: pkg/machines/components/desktopConsole.jsx:153
 msgid "Address:"
 msgstr "Dirección:"
 
-#: pkg/networkmanager/interfaces.js:3309
+#: pkg/networkmanager/interfaces.js:3321
 msgid "Addresses"
 msgstr "Dirección"
 
@@ -759,7 +784,7 @@ msgstr "Contraseña de Administrador"
 msgid "Advanced TCA"
 msgstr "TCA avanzado"
 
-#: pkg/systemd/services.html:455 pkg/systemd/init.js:730
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "Después"
 
@@ -770,8 +795,8 @@ msgid ""
 "settings and the list of trusted CAs may change."
 msgstr ""
 
-#: pkg/systemd/services.html:446 pkg/systemd/services.html:450
-#: pkg/systemd/init.js:1073
+#: pkg/systemd/services.html:301 pkg/systemd/services.html:305
+#: pkg/systemd/init.js:902
 msgid "After system boot"
 msgstr "Después de que el sistema arranque"
 
@@ -779,7 +804,7 @@ msgstr "Después de que el sistema arranque"
 msgid "Alert and above"
 msgstr "Alerta y arriba"
 
-#: pkg/systemd/services.html:71 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
 msgid "All"
 msgstr "Todos"
 
@@ -795,11 +820,15 @@ msgstr ""
 "Todos los datos en los discos seleccionados serán borrados y los discos "
 "serán añadidos al pool de almacenamiento."
 
-#: pkg/networkmanager/firewall.jsx:751
+#: pkg/systemd/service-details.jsx:159
+msgid "Allow running (unmask)"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:781
 msgid "Allowed Addresses"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:967
 msgid "Allowed Services"
 msgstr "Servicios Permitidos"
 
@@ -815,12 +844,16 @@ msgstr ""
 msgid "Annotations"
 msgstr "Anotaciones"
 
+#: pkg/lib/cockpit-components-modifications.jsx:82
+msgid "Ansible Playbook"
+msgstr ""
+
 #: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr ""
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Aplicaciones"
 
@@ -828,10 +861,10 @@ msgstr "Aplicaciones"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
-#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
-#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
-#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
+#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
+#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
+#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
+#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -843,11 +876,11 @@ msgstr "Aplicar todas las actualizaciones"
 msgid "Apply security updates"
 msgstr "Aplicar actualizaciones de seguridad"
 
-#: pkg/selinux/setroubleshoot-view.jsx:112
+#: pkg/selinux/setroubleshoot-view.jsx:113
 msgid "Apply this solution"
 msgstr "Aplicar esta solución"
 
-#: pkg/selinux/setroubleshoot-view.jsx:87
+#: pkg/selinux/setroubleshoot-view.jsx:88
 msgid "Applying solution..."
 msgstr "Aplicando solución..."
 
@@ -871,25 +904,25 @@ msgstr "Etiqueta de Propiedad"
 msgid "At least $0 disks are needed."
 msgstr "Se necesitan al menos $0 discos."
 
-#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
-#: pkg/storaged/vgroup-details.jsx:57
+#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
+#: pkg/storaged/vgroups-panel.jsx:63
 msgid "At least one disk is needed."
 msgstr "Se necesita al menos un disco."
 
-#: pkg/systemd/services.html:451
+#: pkg/systemd/services.html:306
 msgid "At specific time"
 msgstr "A hora específica"
 
-#: pkg/selinux/setroubleshoot-view.jsx:414
+#: pkg/selinux/setroubleshoot-view.jsx:424
 msgid "Audit log"
 msgstr "Registro de auditoria"
 
-#: pkg/networkmanager/interfaces.js:830
+#: pkg/networkmanager/interfaces.js:839
 msgid "Authenticating"
 msgstr "Autenticando "
 
-#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
+#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
 msgid "Authentication"
 msgstr "Autenticación"
 
@@ -925,22 +958,23 @@ msgstr "Autor"
 msgid "Authorized Public SSH Keys"
 msgstr "Llaves SSH Públicas Autorizadas"
 
-#: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
-#: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
-#: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:338
+#: pkg/networkmanager/index.html:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:176
+#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:2771
+#: pkg/networkmanager/interfaces.js:3329 pkg/networkmanager/interfaces.js:3333
+#: pkg/networkmanager/interfaces.js:3339 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automático"
 
-#: pkg/networkmanager/interfaces.js:1966
+#: pkg/networkmanager/interfaces.js:1975
 msgid "Automatic (DHCP only)"
 msgstr "Automático (solo DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1956
+#: pkg/networkmanager/interfaces.js:1965
 msgid "Automatic (DHCP)"
 msgstr "Automático (DHCP)"
 
-#: pkg/systemd/services.html:125 pkg/systemd/init.js:286
+#: pkg/systemd/init.js:295
 msgid "Automatic Startup"
 msgstr ""
 
@@ -952,6 +986,10 @@ msgstr "Actualizaciones Automáticas"
 msgid "Automatically start libvirt on boot"
 msgstr "Iniciar automáticamente libvirt en el arranque"
 
+#: pkg/systemd/service-details.jsx:396
+msgid "Automatically starts"
+msgstr ""
+
 #: pkg/systemd/index.html:389
 msgid "Automatically using NTP"
 msgstr "Usando automáticamente NTP"
@@ -960,8 +998,12 @@ msgstr "Usando automáticamente NTP"
 msgid "Automatically using specific NTP servers"
 msgstr "Usando automáticamente servidores NTP específicos"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/lib/cockpit-components-modifications.jsx:71
+msgid "Automation Script"
+msgstr ""
+
 #: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:69
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
@@ -972,7 +1014,7 @@ msgstr ""
 msgid "Available"
 msgstr "Disponible"
 
-#: pkg/packagekit/updates.jsx:822
+#: pkg/packagekit/updates.jsx:824
 msgid "Available Updates"
 msgstr "Actualizaciones Disponibles"
 
@@ -1013,12 +1055,12 @@ msgid "Balancer"
 msgstr "Balanceador"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/systemd/init.js:729
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr "Antes"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/systemd/init.js:720
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr "Asociado a"
 
@@ -1046,8 +1088,8 @@ msgstr "Dispositivo de bloque para sistemas de archivos"
 msgid "Blocked"
 msgstr "Bloqueado"
 
-#: pkg/networkmanager/interfaces.js:2510 pkg/networkmanager/interfaces.js:2522
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
+#: pkg/networkmanager/interfaces.js:2803
 msgid "Bond"
 msgstr "Vínculo"
 
@@ -1064,12 +1106,12 @@ msgstr ""
 msgid "Boot order settings could not be saved"
 msgstr ""
 
-#: pkg/systemd/init.js:725
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr "Obligado por"
 
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2528 pkg/networkmanager/interfaces.js:2540
+#: pkg/networkmanager/interfaces.js:2880
 msgid "Bridge"
 msgstr "Puente"
 
@@ -1081,19 +1123,19 @@ msgstr "Configuración del puerto Bridge"
 msgid "Bridge Settings"
 msgstr "Configuración Bridge"
 
-#: pkg/networkmanager/interfaces.js:2889
+#: pkg/networkmanager/interfaces.js:2901
 msgid "Bridge port"
 msgstr "Puerto bridge"
 
-#: pkg/networkmanager/interfaces.js:1977 pkg/networkmanager/interfaces.js:1994
+#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
 msgid "Broadcast"
 msgstr "Emisión"
 
-#: pkg/networkmanager/interfaces.js:2804 pkg/networkmanager/interfaces.js:2838
+#: pkg/networkmanager/interfaces.js:2816 pkg/networkmanager/interfaces.js:2850
 msgid "Broken configuration"
 msgstr "Configuración rota"
 
-#: pkg/systemd/host.js:498
+#: pkg/systemd/host.js:508
 msgid "Bug Fix Updates Available"
 msgstr "Disponibles Actualizaciones que Corrigen Problemas"
 
@@ -1128,7 +1170,7 @@ msgstr ""
 msgid "CPU Security Toggles"
 msgstr ""
 
-#: pkg/systemd/host.js:1548
+#: pkg/systemd/host.js:1565
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Estado del CPU"
@@ -1145,12 +1187,12 @@ msgstr "Prioridad del CPU"
 msgid "CPU usage:"
 msgstr "Utilización de CPU:"
 
+#: pkg/machines/components/diskAdd.jsx:251
 #: pkg/machines/components/vmDiskColumns.jsx:75
-#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
-#: pkg/systemd/index.html:252 pkg/systemd/host.js:1679
+#: pkg/systemd/index.html:252 pkg/systemd/host.js:1696
 msgid "Cached"
 msgstr "En cache"
 
@@ -1169,39 +1211,41 @@ msgstr "No puede cargar imagen"
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
+#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90
-#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
-#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
-#: pkg/users/index.html:356 pkg/users/index.html:413
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
+#: pkg/systemd/index.html:487 pkg/systemd/services.html:377
+#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
+#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
+#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
+#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/diskAdd.jsx:597
+#: pkg/machines/components/networks/createNetworkDialog.jsx:486
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
+#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/vcpuModal.jsx:232
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
-#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
-#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
-#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
-#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
-#: pkg/packagekit/updates.jsx:179
+#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
+#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "No se puede conectar a una máquina desconocida"
 
@@ -1217,7 +1261,7 @@ msgstr "No puede planificar un evento en el pasado"
 msgid "Capacity"
 msgstr "Capacidad"
 
-#: pkg/networkmanager/interfaces.js:2590
+#: pkg/networkmanager/interfaces.js:2602
 msgid "Carrier"
 msgstr "Transporte"
 
@@ -1264,18 +1308,18 @@ msgstr "Cambiar los límites de recurso"
 msgid "Change resources limits"
 msgstr "Cambiar límites de recursos"
 
-#: pkg/networkmanager/interfaces.js:3153
+#: pkg/networkmanager/interfaces.js:3165
 msgid "Change the settings"
 msgstr "Cambiar los ajustes"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
+#: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
-#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Los cambios entrarán en vigor después de apagar la máquina virtual"
 
-#: pkg/networkmanager/interfaces.js:3152
+#: pkg/networkmanager/interfaces.js:3164
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1291,7 +1335,7 @@ msgstr "Comprobacióin de Actualizaciones"
 msgid "Checking $target"
 msgstr "Comprobando $target"
 
-#: pkg/networkmanager/interfaces.js:834
+#: pkg/networkmanager/interfaces.js:843
 msgid "Checking IP"
 msgstr "Comprobando IP"
 
@@ -1311,7 +1355,7 @@ msgstr "Requisitos para las nuevas aplicaciones"
 msgid "Checking for public keys"
 msgstr "Chequeando llaves públicas"
 
-#: pkg/systemd/host.js:517
+#: pkg/systemd/host.js:537
 msgid "Checking for updates…"
 msgstr "Buscando actualizaciones..."
 
@@ -1319,6 +1363,10 @@ msgstr "Buscando actualizaciones..."
 #: pkg/lib/cockpit-components-install-dialog.jsx:142
 msgid "Checking installed software"
 msgstr "Comprobando el software instalado"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
+msgid "Choose an operating system"
+msgstr ""
 
 #: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
@@ -1328,7 +1376,7 @@ msgstr "Seleccione el idioma del idioma a utilizar en la aplicación"
 msgid "Chunk Size"
 msgstr "Tamaño de la porción"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "Class"
 msgstr "Clase"
 
@@ -1336,11 +1384,15 @@ msgstr "Clase"
 msgid "Cleaning up for $target"
 msgstr "Limpiando por $target"
 
-#: pkg/systemd/services.html:194
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
+
+#: pkg/systemd/services.html:86
 msgid "Clear All Filters"
 msgstr ""
 
-#: pkg/systemd/host.js:734
+#: pkg/systemd/host.js:750
 msgid "Click to see system hardware information"
 msgstr "Pulse para ver información del hardware del sistema"
 
@@ -1355,16 +1407,14 @@ msgstr ""
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
-#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
-#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
-#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
-#: pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
+#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
+#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
+#: pkg/systemd/index.html:278 pkg/users/index.html:45 pkg/apps/utils.jsx:108
+#: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
 #: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
-#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Cerrar"
 
@@ -1388,7 +1438,7 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit no se puede conectar con el host especificado."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1450,15 +1500,16 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
+"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
+"sync_link}}.{{/can_sync}} For more authentication options and "
+"troubleshooting support please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit no pudo ingresar en {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"Puede que desee probar a {{#sync_link}}sincronizar usuarios{{/sync_link}}.{{/"
-"can_sync}} Para obtener más opciones de autenticación y asistencia para "
-"solucionar problemas, actualice cockpit-ws a una versión más reciente."
+"Cockpit no pudo ingresar en {{#strong}}{{host}}{{/strong}}. "
+"{{#can_sync}}Puede que desee probar a {{#sync_link}}sincronizar usuarios{{/"
+"sync_link}}.{{/can_sync}} Para obtener más opciones de autenticación y "
+"asistencia para solucionar problemas, actualice cockpit-ws a una versión más "
+"reciente."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1498,12 +1549,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Uso combinado de núcleo de CPU $0"
 msgstr[1] "Uo combinado de núcleos de CPU $0"
 
-#: pkg/networkmanager/firewall.jsx:529
+#: pkg/networkmanager/firewall.jsx:554
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
-#: pkg/docker/index.html:708 pkg/systemd/services.html:427
+#: pkg/docker/index.html:708 pkg/systemd/services.html:282
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1551,8 +1602,8 @@ msgstr "Compatible con los sistemas modernos y discos duros > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Comprimir volcado de errores para ahorrar espacio"
 
-#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
-#: pkg/kdump/kdump-view.jsx:156
+#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
+#: pkg/storaged/vdos-panel.jsx:81
 msgid "Compression"
 msgstr "Compresión"
 
@@ -1560,15 +1611,15 @@ msgstr "Compresión"
 msgid "Computer OU"
 msgstr "Computadora OU"
 
-#: pkg/systemd/init.js:692
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr "La condición $0=$1 no se cumple"
 
-#: pkg/systemd/services.html:143
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "Condición fallida"
 
-#: pkg/networkmanager/interfaces.js:2725
+#: pkg/networkmanager/interfaces.js:2737
 msgid "Configure"
 msgstr "Configurar"
 
@@ -1576,11 +1627,11 @@ msgstr "Configurar"
 msgid "Configure storage..."
 msgstr "Configurar almacenamiento..."
 
-#: pkg/networkmanager/interfaces.js:828
+#: pkg/networkmanager/interfaces.js:837
 msgid "Configuring"
 msgstr "Configurando"
 
-#: pkg/networkmanager/interfaces.js:832
+#: pkg/networkmanager/interfaces.js:841
 msgid "Configuring IP"
 msgstr "Configurando IP"
 
@@ -1602,12 +1653,12 @@ msgstr ""
 msgid "Confirm removal with passphrase"
 msgstr "Confirmar eliminación con frase de acceso"
 
-#: pkg/systemd/init.js:728
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr "En conflicto por"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/systemd/init.js:727
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr "Conflictos"
 
@@ -1615,7 +1666,7 @@ msgstr "Conflictos"
 msgid "Connect"
 msgstr "Conectar"
 
-#: pkg/networkmanager/interfaces.js:2712
+#: pkg/networkmanager/interfaces.js:2724
 msgid "Connect automatically"
 msgstr "Conectado automáticamente"
 
@@ -1645,7 +1696,7 @@ msgstr ""
 msgid "Connecting to Docker"
 msgstr "Conectando a Docker"
 
-#: pkg/selinux/setroubleshoot-view.jsx:371
+#: pkg/selinux/setroubleshoot-view.jsx:381
 msgid "Connecting to SETroubleshoot daemon..."
 msgstr "Conectando al demonio SETroubleshoot..."
 
@@ -1653,14 +1704,14 @@ msgstr "Conectando al demonio SETroubleshoot..."
 msgid "Connecting to Virtualization Service"
 msgstr "Conectando al Servicio de Virtualización"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "Conectándose a la máquina"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
+#: pkg/machines/components/networks/createNetworkDialog.jsx:106
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Conexión"
@@ -1678,7 +1729,7 @@ msgid "Connection will be lost"
 msgstr "Se perderá la conexión"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.6, DocId: cockpit
-#: pkg/systemd/init.js:726
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr "Consta de"
 
@@ -1756,6 +1807,10 @@ msgstr "Convertible"
 msgid "Copy"
 msgstr ""
 
+#: pkg/lib/cockpit-components-modifications.jsx:106
+msgid "Copy to clipboard"
+msgstr ""
+
 # auto translated by TM merge from project: Cockpit, version: rhel-7.6, DocId: cockpit
 #: pkg/machines/components/vcpuModal.jsx:209
 msgid "Cores per socket"
@@ -1781,7 +1836,7 @@ msgstr "No se pudo cambiar los grupos del usuario"
 msgid "Couldn't change user password"
 msgstr "No se pudo cambiar la contraseña del usuario"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "No se pudo conectar a la máquina"
 
@@ -1810,11 +1865,12 @@ msgid "Crash system"
 msgstr "Error del sistema"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
-#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
-#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
+#: pkg/machines/components/networks/createNetworkDialog.jsx:491
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
+#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
+#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
+#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
 msgid "Create"
 msgstr "Crear"
 
@@ -1823,7 +1879,7 @@ msgid "Create Logical Volume"
 msgstr "Crear un volumen logico"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.6, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:515
+#: pkg/machines/components/diskAdd.jsx:552
 msgid "Create New"
 msgstr "Crear nuevo"
 
@@ -1855,7 +1911,7 @@ msgstr "Crear Reporte"
 msgid "Create Snapshot"
 msgstr "Crear Instantánea"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "Crear grupo de almacenamiento"
 
@@ -1863,11 +1919,11 @@ msgstr "Crear grupo de almacenamiento"
 msgid "Create Thin Volume"
 msgstr "Crear Volumen Delgado"
 
-#: pkg/systemd/services.html:64
+#: pkg/systemd/services.html:58
 msgid "Create Timer"
 msgstr "Crear temporizador"
 
-#: pkg/systemd/services.html:393
+#: pkg/systemd/services.html:248
 msgid "Create Timers"
 msgstr "Crear Temporizadores"
 
@@ -1875,9 +1931,14 @@ msgstr "Crear Temporizadores"
 msgid "Create VDO Device"
 msgstr "Crear Dispositivo VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "Crear VM"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
+#: pkg/machines/components/networks/createNetworkDialog.jsx:525
+msgid "Create Virtual Network"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:53
 msgid "Create Volume Group"
@@ -1887,8 +1948,8 @@ msgstr "Crear un Grupo de Volúmenes"
 msgid "Create diagnostic report"
 msgstr "Crear reporte de diagnóstico"
 
-#: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
-#: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
+#: pkg/networkmanager/interfaces.js:3834 pkg/networkmanager/interfaces.js:4033
+#: pkg/networkmanager/interfaces.js:4287 pkg/networkmanager/interfaces.js:4492
 msgid "Create it"
 msgstr "Crearlo"
 
@@ -1925,7 +1986,7 @@ msgstr "Creando partición $target"
 msgid "Creating snapshot of $target"
 msgstr "Creando una imagne de $target"
 
-#: pkg/networkmanager/interfaces.js:4479
+#: pkg/networkmanager/interfaces.js:4491
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1933,7 +1994,7 @@ msgstr ""
 "La creación de esta VLAN romperá la conexión con el servidor y hará a la "
 "administración de UI no disponible."
 
-#: pkg/networkmanager/interfaces.js:3821
+#: pkg/networkmanager/interfaces.js:3833
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1941,7 +2002,7 @@ msgstr ""
 "La creación de este enlace romperá la conexión con el servidor y hará que la "
 "interfaz de usuario de administración no esté disponible."
 
-#: pkg/networkmanager/interfaces.js:4274
+#: pkg/networkmanager/interfaces.js:4286
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1949,7 +2010,7 @@ msgstr ""
 "La creación de este puente romperá la conexión con el servidor y hará la "
 "administración de UI no disponible."
 
-#: pkg/networkmanager/interfaces.js:4020
+#: pkg/networkmanager/interfaces.js:4032
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1961,7 +2022,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Creando Grupo de Volumen $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr ""
 
@@ -1989,7 +2050,7 @@ msgstr "Arranque actual"
 msgid "Custom"
 msgstr "Personalizar"
 
-#: pkg/networkmanager/firewall.jsx:523
+#: pkg/networkmanager/firewall.jsx:548
 msgid "Custom Ports"
 msgstr ""
 
@@ -1997,11 +2058,11 @@ msgstr ""
 msgid "Custom encryption options"
 msgstr "Opciones de encriptación personalizadas"
 
-#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
+#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
 msgid "Custom mount options"
 msgstr "Opciones de montaje personalizadas"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:748
 msgid "Custom zones"
 msgstr ""
 
@@ -2014,19 +2075,19 @@ msgstr ""
 msgid "DISK IS FAILING"
 msgstr "DISCO ESTÁ FALLANDO"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3328
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2668
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3320
+#: pkg/networkmanager/interfaces.js:3332
 msgid "DNS Search Domains"
 msgstr "Búsqueda Dominios DNS"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2671
 msgid "DNS Search Domains $val"
 msgstr "Buscar Dominios DNS $val"
 
@@ -2042,13 +2103,13 @@ msgstr "Tablero"
 msgid "Data Used"
 msgstr "Datos Usados"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:165
 #: pkg/machines/components/networks/network.jsx:144
+#: pkg/machines/components/storagePools/storagePool.jsx:165
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Desactivar"
 
-#: pkg/networkmanager/interfaces.js:840
+#: pkg/networkmanager/interfaces.js:849
 msgid "Deactivating"
 msgstr "Desactivando"
 
@@ -2076,26 +2137,27 @@ msgstr "Retraso"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/docker/containers-view.jsx:202
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
+#: pkg/docker/details.js:292 pkg/docker/util.js:641
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
 #: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Eliminar"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2447 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Eliminar $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
 msgstr ""
 
@@ -2104,11 +2166,10 @@ msgid "Delete Files"
 msgstr "Borrar Ficheros"
 
 #: pkg/machines/components/networks/networkDelete.jsx:92
-#, fuzzy
 msgid "Delete Network $0"
-msgstr "Eliminar $0"
+msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:217
 msgid "Delete Storage Pool $0"
 msgstr ""
 
@@ -2116,7 +2177,7 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr "Eliminar archivos de almacenamiento asociados:"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:170
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
 
@@ -2124,7 +2185,7 @@ msgstr ""
 msgid "Deleting $target"
 msgstr "Eliminando $target"
 
-#: pkg/networkmanager/interfaces.js:2434
+#: pkg/networkmanager/interfaces.js:2446
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2140,7 +2201,7 @@ msgstr "Eliminar un dispositivo RAID borrará toda la información en el."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Al borrar un dispositivo VDO borrará todos los datos en él."
 
-#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
+#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
 msgid "Deleting a container will erase all data in it."
 msgstr "Eliminar un contenedor eliminara toda la información en él."
 
@@ -2156,7 +2217,7 @@ msgstr "Eliminar una partición borrará toda la información en el."
 msgid "Deleting a volume group will erase all data on it."
 msgstr "Eliminar un grupo de volúmenes borrará toda la información en el."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:174
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
@@ -2166,15 +2227,25 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Borrando Grupo de Volumen $target"
 
-#: pkg/systemd/services.html:413
+#: pkg/systemd/services.html:268
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
 msgid "Description"
 msgstr "Descripción "
+
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Escritorio"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:151
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:187
+msgid ""
+"Detach the disks using this pool from any VMs before attempting deletion."
+msgstr ""
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2182,13 +2253,14 @@ msgstr "Desmontable"
 
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:383
+#: pkg/systemd/host.js:762
 msgid "Details"
 msgstr "Detalles"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:169
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2201,6 +2273,10 @@ msgstr "Fichero de Dispositivo"
 #: pkg/storaged/content-views.jsx:551
 msgid "Device is read-only"
 msgstr "El dispositivo es de sólo lectura"
+
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
@@ -2219,10 +2295,6 @@ msgstr "Directorio"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "El directorio $0 no es editable o no existe."
 
-#: pkg/systemd/init.js:571
-msgid "Disable"
-msgstr "Desabilitar"
-
 #: pkg/systemd/hwinfo.jsx:191
 msgid "Disable simultaneous multithreading"
 msgstr ""
@@ -2231,17 +2303,21 @@ msgstr ""
 msgid "Disable tuned"
 msgstr "Deshabilitar tuned "
 
-#: pkg/systemd/services.html:73 pkg/networkmanager/interfaces.js:1960
-#: pkg/systemd/init.js:213
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "Deshabilitado"
+
+#: pkg/systemd/service-details.jsx:192
+msgid "Disallow running (mask)"
+msgstr ""
 
 #: pkg/machines/components/serialConsole.jsx:136
 msgid "Disconnect"
 msgstr "Desconectar"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "Desconectado"
 
@@ -2257,15 +2333,15 @@ msgstr "Disco"
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr ""
 
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:549
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:569
 msgid "Disk I/O"
 msgstr "Disco I/O"
 
-#: pkg/machines/components/diskAdd.jsx:489
+#: pkg/machines/components/diskAdd.jsx:525
 msgid "Disk failed to be attached"
 msgstr "Disco no se pudo adjuntar"
 
-#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Disk failed to be created"
 msgstr "Disco no se pudo crear"
 
@@ -2278,9 +2354,9 @@ msgstr "Disco está OK"
 msgid "Disk passphrase"
 msgstr "Frase de acceso al disco"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
-#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
+#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
 msgid "Disks"
 msgstr "Discos"
 
@@ -2292,6 +2368,10 @@ msgstr ""
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Mostrar Idioma"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2330,8 +2410,8 @@ msgstr "Nombre del Administrador de Dominio"
 msgid "Domain Administrator Password"
 msgstr "Contraseña del Administrador de Dominio"
 
-#: pkg/systemd/services.html:483 pkg/systemd/services.html:487
-#: pkg/systemd/init.js:1256
+#: pkg/systemd/services.html:338 pkg/systemd/services.html:342
+#: pkg/systemd/init.js:1085
 msgid "Don't Repeat"
 msgstr "No repetir"
 
@@ -2386,6 +2466,10 @@ msgstr "Unidad"
 msgid "Drives"
 msgstr "Discos"
 
+#: pkg/lib/machine-info.js:244
+msgid "Dual Rank"
+msgstr ""
+
 #: pkg/docker/run.js:348
 msgid "Duplicate alias"
 msgstr "Alias duplicado"
@@ -2394,7 +2478,7 @@ msgstr "Alias duplicado"
 msgid "Duplicate port"
 msgstr "Puerto duplicado"
 
-#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
+#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
 #: pkg/storaged/nfs-details.jsx:306
 msgid "Edit"
 msgstr "Editar"
@@ -2442,14 +2526,6 @@ msgstr "Eliminando el contenido de $target"
 msgid "Emulated Machine"
 msgstr ""
 
-#: pkg/systemd/init.js:569
-msgid "Enable"
-msgstr "Habilitar"
-
-#: pkg/systemd/init.js:570
-msgid "Enable Forcefully"
-msgstr "Habilitar pre-ajuste"
-
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/networkmanager/index.html:50
 msgid "Enable Service"
@@ -2459,7 +2535,7 @@ msgstr "Habilitar servicio"
 msgid "Enable stored metrics…"
 msgstr "Habilitar métricas almacenadas ..."
 
-#: pkg/systemd/services.html:72 pkg/systemd/init.js:210
+#: pkg/systemd/services.html:66 pkg/systemd/init.js:215
 msgid "Enabled"
 msgstr "Habilitado"
 
@@ -2502,11 +2578,20 @@ msgstr "Encriptación"
 msgid "Encryption Options"
 msgstr "Opciones de cifrado"
 
-#: pkg/selinux/setroubleshoot-view.jsx:299
-msgid "Enforce policy:"
-msgstr "Aplicar la política:"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:252
+msgid "End"
+msgstr ""
 
-#: pkg/systemd/host.js:500
+#: pkg/machines/components/networks/createNetworkDialog.jsx:63
+#: pkg/machines/components/networks/createNetworkDialog.jsx:91
+msgid "End should not be empty"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Enforcing"
+msgstr ""
+
+#: pkg/systemd/host.js:510
 msgid "Enhancement Updates Available"
 msgstr "Actualizaciones de Mejora Disponibles"
 
@@ -2522,7 +2607,7 @@ msgstr ""
 "Introducir una contraseña diferente aquí significa que necesitará volver a "
 "teclear cada vez que vuelva a esa máquina"
 
-#: pkg/networkmanager/firewall.jsx:754
+#: pkg/networkmanager/firewall.jsx:784
 msgid "Entire subnet"
 msgstr ""
 
@@ -2556,9 +2641,9 @@ msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
 #: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Error"
 
@@ -2573,6 +2658,10 @@ msgstr "Error cargando usuarios: {{perm_failed}}"
 #: pkg/docker/util.js:507
 msgid "Error message from Docker:"
 msgstr "Mensaje de error de Docker:"
+
+#: pkg/lib/cockpit-components-modifications.jsx:145
+msgid "Error running semanage to discover system modifications"
+msgstr ""
 
 #: pkg/users/authorized-keys.js:121
 msgid "Error saving authorized keys: "
@@ -2594,7 +2683,7 @@ msgstr "Ethernet MAC"
 msgid "Ethernet MTU"
 msgstr "Ethernet MTU"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:2015
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2602,11 +2691,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Todo"
 
-#: pkg/networkmanager/firewall.jsx:536
+#: pkg/networkmanager/firewall.jsx:561
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:544
+#: pkg/networkmanager/firewall.jsx:569
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
@@ -2614,11 +2703,11 @@ msgstr ""
 msgid "Excellent password"
 msgstr "Contraseña excelente "
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
-msgid "Existing Disk Image"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -2642,7 +2731,7 @@ msgstr "Partición Extendida"
 msgid "FAILED"
 msgstr "Fallido"
 
-#: pkg/networkmanager/interfaces.js:842
+#: pkg/networkmanager/interfaces.js:851
 msgid "Failed"
 msgstr "Falló"
 
@@ -2650,20 +2739,19 @@ msgstr "Falló"
 msgid "Failed to add machine: $0"
 msgstr "Fallo al agregar maquina: $0"
 
-#: pkg/networkmanager/firewall.jsx:237
-#, fuzzy
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add port"
-msgstr "Error al cambiar contraseña"
+msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:679
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
+#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
 msgid "Failed to change password"
 msgstr "Error al cambiar contraseña"
 
@@ -2695,8 +2783,12 @@ msgstr ""
 msgid "Failed to load authorized keys."
 msgstr "Fallo al cargar llaves autorizadas."
 
-#: pkg/networkmanager/firewall.jsx:591
+#: pkg/networkmanager/firewall.jsx:621
 msgid "Failed to remove service"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:340
+msgid "Failed to start"
 msgstr ""
 
 #: pkg/docker/containers.js:60
@@ -2725,7 +2817,7 @@ msgstr "Archivo"
 msgid "Filesystem"
 msgstr "Sistema de archivos"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "Directorio del sistema de archivos"
 
@@ -2741,24 +2833,24 @@ msgstr "Nombre de Sistema de archivos"
 msgid "Filesystems"
 msgstr "Archivos del sistema"
 
-#: pkg/networkmanager/firewall.jsx:491
+#: pkg/networkmanager/firewall.jsx:516
 msgid "Filter Services"
 msgstr "Filtrar Servicios"
 
-#: pkg/systemd/services.html:68
+#: pkg/systemd/services.html:62
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
+#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
 msgid "Fingerprint"
 msgstr "Fingerprint"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
+#: pkg/networkmanager/firewall.jsx:945 pkg/networkmanager/firewall.jsx:948
 msgid "Firewall"
 msgstr "Cortafuegos"
 
-#: pkg/networkmanager/firewall.jsx:863
+#: pkg/networkmanager/firewall.jsx:893
 msgid "Firewall is not available"
 msgstr "El cortafuegos no está disponible"
 
@@ -2768,6 +2860,10 @@ msgstr "Seguir al repositorio docker"
 
 #: pkg/storaged/vdos-panel.jsx:88
 msgid "For legacy applications only. Reduces performance."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:322
+msgid "Forbidden from running"
 msgstr ""
 
 #: pkg/users/index.html:122
@@ -2794,9 +2890,10 @@ msgstr "Cambio de clave forzado"
 msgid "Force remove passphrase in $0"
 msgstr "Forzar la eliminación de la contraseña en $0"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
-#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:157
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
+#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
+#: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Formato"
 
@@ -2817,11 +2914,15 @@ msgid "Formatting a storage device will erase all data on it."
 msgstr ""
 "Formatear un dispositivo de almacenamiento eliminará todos los datos en el."
 
-#: pkg/networkmanager/interfaces.js:2861
+#: pkg/machines/components/networks/createNetworkDialog.jsx:147
+msgid "Forward Mode"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2873
 msgid "Forward delay $forward_delay"
 msgstr "Retardo del reenvío $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:50
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2840,7 +2941,7 @@ msgid ""
 "another physical volume."
 msgstr ""
 
-#: pkg/systemd/services.html:239
+#: pkg/systemd/services.html:131
 msgid "Friday"
 msgstr "Viernes"
 
@@ -2861,7 +2962,7 @@ msgid "Gateway:"
 msgstr "Pasarela:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2703 pkg/systemd/logs.js:486
+#: pkg/networkmanager/interfaces.js:2715 pkg/systemd/logs.js:486
 msgid "General"
 msgstr "General"
 
@@ -2873,11 +2974,11 @@ msgstr "Generando reporte"
 msgid "Get new image"
 msgstr "Obtener nueva imagen"
 
+#: pkg/machines/components/diskAdd.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
-#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
 
@@ -2929,7 +3030,7 @@ msgstr "Crecer para tomar todo el espacio"
 msgid "Hair Pin mode"
 msgstr "Modo horquilla"
 
-#: pkg/networkmanager/interfaces.js:2887
+#: pkg/networkmanager/interfaces.js:2899
 msgid "Hairpin mode"
 msgstr "Modo horquilla"
 
@@ -2950,22 +3051,22 @@ msgstr "Disco Duro"
 msgid "Hardware"
 msgstr "Hardware"
 
-#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:261
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:270
 msgid "Hardware Information"
 msgstr "Información de Hardware"
 
-#: pkg/networkmanager/interfaces.js:2863
+#: pkg/networkmanager/interfaces.js:2875
 msgid "Hello time $hello_time"
 msgstr "Tiempo de saludo $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "Anfitrión"
 
@@ -2974,7 +3075,7 @@ msgid "Host Device"
 msgstr ""
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Nombre de Host"
 
@@ -2986,25 +3087,29 @@ msgstr "Tecla del Host es incorrecta"
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "El anfitrión no debe estar vacío"
 
-#: pkg/systemd/services.html:499
+#: pkg/systemd/services.html:354
 msgid "Hour : Minute"
 msgstr "Hora : Minuto"
 
-#: pkg/systemd/init.js:1332 pkg/systemd/init.js:1361
+#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
 msgid "Hour needs to be a number between 0-23"
 msgstr "La hora es necesario que sea un número entre 0 y 23"
 
-#: pkg/systemd/services.html:465
+#: pkg/systemd/services.html:320
 msgid "Hours"
 msgstr "Horas"
 
-#: pkg/systemd/index.html:238 pkg/systemd/host.js:1582
+#: pkg/systemd/index.html:238 pkg/systemd/host.js:1599
 msgid "I/O Wait"
 msgstr "Espera de E/S"
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "ID"
+msgstr ""
 
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
 #: pkg/machines/components/vmnetworktab.jsx:133
@@ -3015,11 +3120,15 @@ msgstr "Dirección IP"
 msgid "IP Address:"
 msgstr "Dirección IP:"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:197
+msgid "IP Configuration"
+msgstr ""
+
 #: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "Longitud de Prefijo IP:"
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:955
 msgid "IP Range"
 msgstr ""
 
@@ -3027,7 +3136,7 @@ msgstr ""
 msgid "IP Settings"
 msgstr "Configuración IP"
 
-#: pkg/networkmanager/interfaces.js:2912
+#: pkg/networkmanager/interfaces.js:2924
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3035,11 +3144,27 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+msgid "IPv4 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:45
+msgid "IPv4 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3371
 msgid "IPv4 Settings"
 msgstr "Configuración IPv4"
 
-#: pkg/networkmanager/interfaces.js:2913
+#: pkg/machines/components/networks/createNetworkDialog.jsx:213
+msgid "IPv4 and IPv6"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:207
+msgid "IPv4 only"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2925
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3047,15 +3172,27 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+msgid "IPv6 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:73
+msgid "IPv6 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3371
 msgid "IPv6 Settings"
 msgstr "Configuración IPv6"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:210
+msgid "IPv6 only"
+msgstr ""
 
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
 
-#: pkg/networkmanager/interfaces.js:2904
+#: pkg/networkmanager/interfaces.js:2916
 msgid "Id $id"
 msgstr "Id $id"
 
@@ -3072,7 +3209,7 @@ msgstr "Identificador"
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Si tang-show-keys no está disponible, ejecuta lo siguiente:"
 
-#: pkg/networkmanager/interfaces.js:1969 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1978 pkg/packagekit/updates.jsx:496
 msgid "Ignore"
 msgstr "Ignorar"
 
@@ -3138,15 +3275,19 @@ msgid "Images may only be pulled by specific users or groups"
 msgstr ""
 "Las imágenes sólo ueden ser utilizadas por usuaior o grupos específicos"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Iniciar Inmediatamente VM"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "En Sincronía"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3157,11 +3298,11 @@ msgid ""
 "In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Con el objetivo de sincronizar usuarios, necesita acceder a {{#strong}}"
-"{{host}}{{/strong}}."
+"Con el objetivo de sincronizar usuarios, necesita acceder a "
+"{{#strong}}{{host}}{{/strong}}."
 
-#: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
-#: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
+#: pkg/networkmanager/interfaces.js:833 pkg/networkmanager/interfaces.js:1426
+#: pkg/networkmanager/interfaces.js:1433 pkg/networkmanager/interfaces.js:2618
 msgid "Inactive"
 msgstr "Inactivo"
 
@@ -3169,7 +3310,7 @@ msgstr "Inactivo"
 msgid "Inactive volume"
 msgstr "Volumen inactivo"
 
-#: pkg/networkmanager/firewall.jsx:732
+#: pkg/networkmanager/firewall.jsx:762
 msgid "Included services"
 msgstr ""
 
@@ -3194,21 +3335,21 @@ msgstr ""
 msgid "Initializing..."
 msgstr "Inicializando..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/machines/components/vm/vmActions.jsx:98
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/machines/components/vm/vmActions.jsx:98
 msgid "Install"
 msgstr "Instalar"
 
-#: pkg/packagekit/updates.jsx:806
+#: pkg/packagekit/updates.jsx:808
 msgid "Install All Updates"
 msgstr "Instalar todas las Actualizaciones"
 
@@ -3217,7 +3358,7 @@ msgstr "Instalar todas las Actualizaciones"
 msgid "Install NFS Support"
 msgstr "Instalar soporte para NFS"
 
-#: pkg/packagekit/updates.jsx:806 pkg/packagekit/updates.jsx:812
+#: pkg/packagekit/updates.jsx:808 pkg/packagekit/updates.jsx:814
 msgid "Install Security Updates"
 msgstr "Instalar Actualizaciones de Seguridad"
 
@@ -3231,21 +3372,21 @@ msgstr "Instalar software"
 msgid "Install VDO support"
 msgstr "Instalar soporte VDO"
 
-#: pkg/selinux/setroubleshoot-view.jsx:379
+#: pkg/selinux/setroubleshoot-view.jsx:389
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr ""
 "Instale «setroubleshoot-server» para solucionar problemas con sucesos de "
 "SELinux."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Fuente de la Instalación"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Tipo de Fuente de Instalación"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "La Fuente de Instalación no debería estar vacía"
 
@@ -3263,17 +3404,21 @@ msgstr "Instalando"
 msgid "Installing $0"
 msgstr "Instalando $0"
 
-#: pkg/systemd/services.html:184
+#: pkg/systemd/service-details.jsx:487
+msgid "Instance of template: "
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:62
 msgid "Instantiate"
 msgstr "Instanciar"
 
-#: pkg/machines/components/nicEdit.jsx:123
+#: pkg/machines/components/nicEdit.jsx:132
 msgid "Interface Type"
 msgstr ""
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:767 pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/interfaces.js:2998
 msgid "Interfaces"
 msgstr "Interfaces"
 
@@ -3285,19 +3430,39 @@ msgstr "Error Interno: Encabezado del reto no valido "
 msgid "Internal error"
 msgstr "Error interno"
 
-#: pkg/networkmanager/utils.js:88 pkg/networkmanager/utils.js:171
+#: pkg/machines/components/networks/createNetworkDialog.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:58
+#: pkg/machines/components/networks/createNetworkDialog.jsx:65
+msgid "Invalid IPv4 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:52
+msgid "Invalid IPv4 mask or prefix length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:75
+#: pkg/machines/components/networks/createNetworkDialog.jsx:86
+#: pkg/machines/components/networks/createNetworkDialog.jsx:93
+msgid "Invalid IPv6 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:80
+msgid "Invalid IPv6 prefix"
+msgstr ""
+
+#: pkg/networkmanager/utils.js:90 pkg/networkmanager/utils.js:175
 msgid "Invalid address $0"
 msgstr "La dirección $0 no es válida"
 
-#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "Formato de fecha inválido"
 
-#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "Formato de fecha y formato de hora inválidos "
 
-#: pkg/systemd/init.js:1367
+#: pkg/systemd/init.js:1196
 msgid "Invalid date format."
 msgstr "El formato de fecha no es válido."
 
@@ -3309,7 +3474,7 @@ msgstr "Fecha de expiración invalida"
 msgid "Invalid file permissions"
 msgstr "Permisos de archivo invalidos"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "Nobre de fichero no válido"
 
@@ -3325,7 +3490,7 @@ msgstr "La métrica $0 no es válida"
 msgid "Invalid number of days"
 msgstr "Numero de días incorrecto."
 
-#: pkg/systemd/init.js:1314
+#: pkg/systemd/init.js:1143
 msgid "Invalid number."
 msgstr "El número no es válido."
 
@@ -3333,7 +3498,7 @@ msgstr "El número no es válido."
 msgid "Invalid port"
 msgstr "Puerto invalido"
 
-#: pkg/networkmanager/firewall.jsx:335
+#: pkg/networkmanager/firewall.jsx:360
 msgid "Invalid port number"
 msgstr ""
 
@@ -3341,15 +3506,15 @@ msgstr ""
 msgid "Invalid prefix $0"
 msgstr "El prefijo $0 no es válido"
 
-#: pkg/networkmanager/utils.js:132
+#: pkg/networkmanager/utils.js:136
 msgid "Invalid prefix or netmask $0"
 msgstr "El prefijo o la máscara de red $0 no es válido"
 
-#: pkg/networkmanager/firewall.jsx:362
+#: pkg/networkmanager/firewall.jsx:387
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "Formato de hora inválido"
 
@@ -3393,7 +3558,7 @@ msgstr "Unirse a un dominio"
 msgid "Joining this domain is not supported"
 msgstr "Unirse a este dominio no esta soportado"
 
-#: pkg/systemd/init.js:736
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr "Se une a Namespace de"
 
@@ -3428,11 +3593,11 @@ msgstr "SSO Basado en Kerberos"
 msgid "Kerberos Ticket"
 msgstr "Tiquete Kerberos"
 
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1583
+#: pkg/systemd/index.html:234 pkg/systemd/host.js:1600
 msgid "Kernel"
 msgstr "Kernel"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "Volcado del Kernel"
 
@@ -3467,6 +3632,10 @@ msgstr "La eliminación de Keyserver puede evitar el desbloqueo $0."
 msgid "LACP Key"
 msgstr "Clave de LACP"
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
+msgid "LVM Volume Group"
+msgstr ""
+
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "Viñetas"
@@ -3487,7 +3656,7 @@ msgstr "Ultimos 7 dias"
 msgid "Last Login"
 msgstr "Último inicio de sesión"
 
-#: pkg/systemd/init.js:284
+#: pkg/systemd/init.js:293
 msgid "Last Trigger"
 msgstr "Última ejecución"
 
@@ -3522,6 +3691,7 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
+""
 msgstr ""
 "Déjelo en blanco para conectarse a esta máquina como el usuario actualmente "
 "conectado {{#default_user}} ({{default_user}}){{/default_user}}. Si usted "
@@ -3548,7 +3718,7 @@ msgstr "Enlace para ver"
 msgid "Link down delay"
 msgstr "Desvincular demora"
 
-#: pkg/networkmanager/interfaces.js:1957 pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1966 pkg/networkmanager/interfaces.js:1976
 msgid "Link local"
 msgstr "Enlace local"
 
@@ -3568,7 +3738,7 @@ msgstr "Vinculos"
 msgid "Links:"
 msgstr "Enlaces:"
 
-#: pkg/networkmanager/interfaces.js:1993
+#: pkg/networkmanager/interfaces.js:2002
 msgid "Load Balancing"
 msgstr "Equilibrio de carga"
 
@@ -3588,9 +3758,13 @@ msgstr "Fallo la carga de  las actualizaciones disponibles "
 msgid "Loading available updates, please wait..."
 msgstr "Leyendo actualizaciones disponibles, por favor espere..."
 
-#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
-#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
-#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
+#: pkg/lib/cockpit-components-modifications.jsx:151
+msgid "Loading system modifications..."
+msgstr ""
+
+#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:367
+#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
+#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
 msgid "Loading..."
 msgstr "Cargando..."
 
@@ -3606,7 +3780,7 @@ msgstr "Discos locales"
 msgid "Local Filesystem"
 msgstr "Sistema de archivos local"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr ""
 
@@ -3706,7 +3880,7 @@ msgstr "El inicio de sesión ha aumentado los privilegios de administrador"
 msgid "Logout Successful"
 msgstr "Logout Exitoso"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Registros"
 
@@ -3734,15 +3908,15 @@ msgstr "Dirección MAC"
 msgid "MAC Address:"
 msgstr "Dirección MAC:"
 
-#: pkg/networkmanager/interfaces.js:1985
+#: pkg/networkmanager/interfaces.js:1994
 msgid "MII (Recommended)"
 msgstr "MII (Recomendado)"
 
-#: pkg/networkmanager/interfaces.js:2761
+#: pkg/networkmanager/interfaces.js:2773
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4545
+#: pkg/networkmanager/interfaces.js:4557
 msgid "MTU must be a positive number"
 msgstr "El MTU debe ser un número positivo"
 
@@ -3750,7 +3924,7 @@ msgstr "El MTU debe ser un número positivo"
 msgid "Mac"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:160
+#: pkg/machines/components/nicEdit.jsx:169
 msgid "Mac Address"
 msgstr "Dirección MAC"
 
@@ -3762,7 +3936,7 @@ msgstr "Id. de máquina"
 msgid "Machine SSH Key Fingerprints"
 msgstr "Huellas de clave SSH de la máquina"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "Maquinas"
 
@@ -3774,7 +3948,7 @@ msgstr "Chasis del Servidor Principal"
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Asegúrese de que la clave hash del servidor Tang coincida:"
 
-#: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
+#: pkg/networkmanager/interfaces.js:1967 pkg/networkmanager/interfaces.js:1977
 msgid "Manual"
 msgstr "Manual"
 
@@ -3794,15 +3968,30 @@ msgstr "Compruebe manualmente con SSH: "
 msgid "Marking $target as faulty"
 msgstr "Marcando $target como fallado"
 
-#: pkg/systemd/init.js:574
-msgid "Mask"
-msgstr "Enmascarar"
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
+msgid "Mask Service"
+msgstr ""
 
-#: pkg/systemd/init.js:575
-msgid "Mask Forcefully"
-msgstr "Enmascarar "
+#: pkg/machines/components/networks/createNetworkDialog.jsx:293
+msgid "Mask or Prefix Length"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2767
+#: pkg/machines/components/networks/createNetworkDialog.jsx:50
+msgid "Mask or Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:321
+msgid "Masked"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:200
+msgid ""
+"Masking service prevents all dependant units from running. This can have "
+"bigger impact than anticipated. Please confirm that you want to mask this "
+"unit."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2779
 msgid "Master"
 msgstr "Maestro"
 
@@ -3818,7 +4007,7 @@ msgstr ""
 msgid "Maximum memory could not be saved"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2865
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Maximum message age $max_age"
 msgstr "Edad máxima del mensaje $max_age"
 
@@ -3840,12 +4029,12 @@ msgstr "Miembro del dispositivo RAID $0"
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
-#: pkg/machines/components/vmOverviewTab.jsx:74
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
+#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "Memoria"
 
-#: pkg/systemd/host.js:1641
+#: pkg/systemd/host.js:1658
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Memoria"
@@ -3853,6 +4042,10 @@ msgstr "Memoria"
 #: pkg/systemd/index.html:205
 msgid "Memory & Swap"
 msgstr "Memoria e intercambio"
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Memory Technology"
+msgstr ""
 
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
@@ -3863,10 +4056,9 @@ msgstr ""
 msgid "Memory limit"
 msgstr "Limite de Memoria "
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
-#, fuzzy
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
-msgstr "Uso de memoria:"
+msgstr ""
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
@@ -3890,10 +4082,10 @@ msgid "Metadata Used"
 msgstr "Metadatos en uso"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
+#: pkg/machines/components/diskAdd.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
-#: pkg/machines/components/memorySelectRow.jsx:43
-#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -3905,11 +4097,11 @@ msgstr "Mini PC"
 msgid "Mini Tower"
 msgstr "Mini Torre"
 
-#: pkg/systemd/init.js:1338 pkg/systemd/init.js:1347 pkg/systemd/init.js:1356
+#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
 msgid "Minute needs to be a number between 0-59"
 msgstr "El minuto debe ser un número comprendido entre 0 y 59"
 
-#: pkg/systemd/services.html:464
+#: pkg/systemd/services.html:319
 msgid "Minutes"
 msgstr "Minutos"
 
@@ -3921,7 +4113,7 @@ msgstr ""
 msgid "Mode"
 msgstr "Modo"
 
-#: pkg/machines/components/nicEdit.jsx:54 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
 msgid "Model"
 msgstr "Modelo"
 
@@ -3934,7 +4126,7 @@ msgstr "Modelo tipo"
 msgid "Modifying $target"
 msgstr "Modificando $target"
 
-#: pkg/systemd/services.html:235
+#: pkg/systemd/services.html:127
 msgid "Monday"
 msgstr "Lunes"
 
@@ -3963,23 +4155,23 @@ msgstr "Mas información"
 msgid "More details"
 msgstr "Más detalles"
 
-#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
-#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
+#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
+#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
 msgid "Mount"
 msgstr "Montar"
 
-#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
-#: pkg/storaged/format-dialog.jsx:81
+#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
+#: pkg/storaged/nfs-details.jsx:172
 msgid "Mount Options"
 msgstr "Opciones de Montaje"
 
-#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/format-dialog.jsx:71
+#: pkg/storaged/nfs-panel.jsx:102
 msgid "Mount Point"
 msgstr "Punto de Montaje"
 
-#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
+#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
 msgid "Mount at boot"
 msgstr "Montar en el arranque"
 
@@ -3999,7 +4191,7 @@ msgstr "El punto de montaje no puede estar vacío."
 msgid "Mount point must start with \"/\"."
 msgstr "El punto de montaje debe empezar con \"/\"."
 
-#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
+#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
 msgid "Mount read only"
 msgstr "Montar en sólo lectura"
 
@@ -4040,11 +4232,11 @@ msgstr "No está instalado el soporte para NFS"
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2008
+#: pkg/networkmanager/interfaces.js:2017
 msgid "NSNA Ping"
 msgstr "«Ping» de NSNA"
 
-#: pkg/systemd/host.js:1514
+#: pkg/systemd/host.js:1531
 msgid "NTP Server"
 msgstr "Servidor NTP"
 
@@ -4055,22 +4247,24 @@ msgstr "Servidor NTP"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
+#: pkg/machines/components/diskAdd.jsx:126
+#: pkg/machines/components/networks/createNetworkDialog.jsx:122
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
-#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
-#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
+#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
+#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
 #: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
-#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "Nombre"
 
@@ -4103,7 +4297,8 @@ msgid "Name cannot contain whitespace."
 msgstr "El nombre no puede contener espacios."
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:41
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "El nombre no debería estar vacío"
 
@@ -4111,7 +4306,7 @@ msgstr "El nombre no debería estar vacío"
 msgid "Name: "
 msgstr ""
 
-#: pkg/systemd/host.js:1348
+#: pkg/systemd/host.js:1365
 msgid "Need at least one NTP server"
 msgstr "Se requiere al menos un servidor NTP"
 
@@ -4131,11 +4326,15 @@ msgstr ""
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+msgid "Network Boot is available only when using System connection"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "Sistema de archivos de red"
 
@@ -4143,11 +4342,11 @@ msgstr "Sistema de archivos de red"
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr ""
 
-#: pkg/systemd/host.js:550
+#: pkg/systemd/host.js:570
 msgid "Network Traffic"
 msgstr "Tránsito de redes"
 
@@ -4155,7 +4354,7 @@ msgstr "Tránsito de redes"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "Los dispositivos y gráficos de red requieren NetworkManager."
 
-#: pkg/machines/components/nicEdit.jsx:232
+#: pkg/machines/components/nicEdit.jsx:245
 msgid "Network interface settings could not be saved"
 msgstr ""
 
@@ -4165,11 +4364,11 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager no está funcionando."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:914
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Redes"
 
-#: pkg/networkmanager/interfaces.js:1625 pkg/networkmanager/interfaces.js:2207
+#: pkg/networkmanager/interfaces.js:1634 pkg/networkmanager/interfaces.js:2216
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Redes"
@@ -4178,8 +4377,8 @@ msgstr "Redes"
 msgid "Networking Logs"
 msgstr "Registros de redes"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/networks/networkList.jsx:46
+#: pkg/machines/components/networks/networkList.jsx:45
+#: pkg/machines/components/networks/networkList.jsx:49
 msgid "Networks"
 msgstr "Redes"
 
@@ -4213,7 +4412,7 @@ msgstr "Nuevo nombre de volumen"
 msgid "New passphrase"
 msgstr "Nueva frase de acceso"
 
-#: pkg/users/local.js:139 pkg/lib/credentials.js:237
+#: pkg/lib/credentials.js:237 pkg/users/local.js:139
 msgid "New password was not accepted"
 msgstr "Nueva contraseña no fue aceptada"
 
@@ -4221,16 +4420,16 @@ msgstr "Nueva contraseña no fue aceptada"
 msgid "Next"
 msgstr "Siguiente"
 
-#: pkg/systemd/init.js:283
+#: pkg/systemd/init.js:292
 msgid "Next Run"
 msgstr "En la próxima ejecución"
 
-#: pkg/systemd/index.html:226 pkg/systemd/host.js:1585
+#: pkg/systemd/index.html:226 pkg/systemd/host.js:1602
 msgid "Nice"
 msgstr "Bien"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2606
 msgid "No"
 msgstr "No"
 
@@ -4246,7 +4445,7 @@ msgstr "Ningún Sistema de Archivos"
 msgid "No Logical Volumes"
 msgstr "No hay ningún volumen lógico"
 
-#: pkg/systemd/services.html:192
+#: pkg/systemd/services.html:84
 msgid "No Matching Results"
 msgstr ""
 
@@ -4254,12 +4453,16 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Sin ajustes de montaje NFS"
 
-#: pkg/selinux/setroubleshoot-view.jsx:365
+#: pkg/machines/components/nicEdit.jsx:118
+msgid "No Network Devices"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
 msgstr "No hay ninguna alerta de SELinux."
 
-#: pkg/machines/components/diskAdd.jsx:204
-#: pkg/machines/components/diskAdd.jsx:216
+#: pkg/machines/components/diskAdd.jsx:209
+#: pkg/machines/components/diskAdd.jsx:221
 msgid "No Storage Pools available"
 msgstr ""
 
@@ -4269,15 +4472,19 @@ msgstr ""
 "No hay volúmenes de almacenamiento definidos para este grupo de "
 "almacenamiento"
 
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "No System Modifications"
+msgstr ""
+
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
 msgstr "No hay ninguna MV en ejecución o definida en este anfitrión"
 
-#: pkg/machines/components/nicEdit.jsx:110
+#: pkg/machines/components/nicEdit.jsx:116
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:926
+#: pkg/networkmanager/firewall.jsx:956
 msgid "No active zones"
 msgstr ""
 
@@ -4305,7 +4512,7 @@ msgstr "No hay ranuras disponibles"
 msgid "No boot device found"
 msgstr "No encontrado dispositivo de arranque"
 
-#: pkg/networkmanager/interfaces.js:1419
+#: pkg/networkmanager/interfaces.js:1428
 msgid "No carrier"
 msgstr "Ningún portador"
 
@@ -4329,7 +4536,7 @@ msgstr "No hay ningún contenedor"
 msgid "No containers that match the current filter"
 msgstr "Ningún contenedor corresponde al filtro actual"
 
-#: pkg/networkmanager/firewall.jsx:729
+#: pkg/networkmanager/firewall.jsx:759
 msgid "No description available"
 msgstr ""
 
@@ -4337,9 +4544,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "No se ha suministrado descripción."
 
-#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
-#: pkg/storaged/vgroup-details.jsx:54
+#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
+#: pkg/storaged/vgroups-panel.jsx:60
 msgid "No disks are available."
 msgstr "No hay discos disponibles."
 
@@ -4409,7 +4616,7 @@ msgstr ""
 msgid "No network interfaces defined for this VM"
 msgstr "No se han definido interfaces de red para esta VM"
 
-#: pkg/machines/components/networks/networkList.jsx:48
+#: pkg/machines/components/networks/networkList.jsx:51
 msgid "No network is defined on this host"
 msgstr ""
 
@@ -4417,7 +4624,7 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:939
+#: pkg/networkmanager/firewall.jsx:969
 msgid "No open ports"
 msgstr "Sin puertos abiertos"
 
@@ -4474,8 +4681,9 @@ msgid "No volume groups created"
 msgstr "No hay grupos de volumen creados"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
 #: pkg/kdump/kdump-view.jsx:419
+#: pkg/machines/components/networks/createNetworkDialog.jsx:204
+#: pkg/networkmanager/firewall.jsx:764 pkg/tuned/dialog.js:231
 msgid "None"
 msgstr "Ninguno"
 
@@ -4499,7 +4707,7 @@ msgstr "No esta autorizado a acceder a Docker en este sistema"
 msgid "Not authorized to upload-report"
 msgstr "No autorizado para cargar informe"
 
-#: pkg/networkmanager/interfaces.js:822
+#: pkg/networkmanager/interfaces.js:831
 msgid "Not available"
 msgstr "No disponible"
 
@@ -4523,7 +4731,7 @@ msgstr "No montado"
 msgid "Not permitted to perform this action."
 msgstr "No esta permitido ejecutar esta acción."
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "No esta corriendo"
 
@@ -4535,7 +4743,7 @@ msgstr "No sincronizado"
 msgid "Not yet synced"
 msgstr "Aún no sincronizado"
 
-#: pkg/systemd/services.html:357
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr "Nota"
 
@@ -4547,21 +4755,13 @@ msgstr "Portátil"
 msgid "Notice and above"
 msgstr "Aviso y arriba"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
-msgid "OS Vendor"
-msgstr "Proveedor de SO"
-
-#: pkg/selinux/setroubleshoot-view.jsx:394
+#: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
 msgstr "Ocurrió $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:389
+#: pkg/selinux/setroubleshoot-view.jsx:399
 msgid "Occurred between $0 and $1"
 msgstr "Ocurrió entre $0 y $1"
-
-#: pkg/lib/patterns.js:246
-msgid "Off"
-msgstr "Apagado"
 
 #: pkg/lib/cockpit-components-dialog.jsx:194
 msgid "Ok"
@@ -4576,19 +4776,15 @@ msgstr "Contraseña vieja"
 msgid "Old passphrase"
 msgstr "Frase de acceso vieja"
 
-#: pkg/users/local.js:86 pkg/lib/credentials.js:218
+#: pkg/lib/credentials.js:218 pkg/users/local.js:86
 msgid "Old password not accepted"
 msgstr "Contraseña antigua no aceptada"
-
-#: pkg/lib/patterns.js:246
-msgid "On"
-msgstr "Encencido"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:7
 msgid "On Build"
 msgstr "En Construcción"
 
-#: pkg/docker/index.html:549 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr "Al producirse un fallo"
 
@@ -4628,7 +4824,7 @@ msgstr "Sólo $0 de $1 fue usado."
 msgid "Only Emergency"
 msgstr "Solo Emergencia"
 
-#: pkg/systemd/init.js:1288
+#: pkg/systemd/init.js:1117
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "Solo se permiten caracteres alfanuméricos y  : , _ , . , @ , -."
 
@@ -4645,7 +4841,7 @@ msgid "Open"
 msgstr ""
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "Sistema Operativo"
 
@@ -4655,9 +4851,8 @@ msgstr "Actividad '$operation' en $target"
 
 #: pkg/machines/components/storagePools/storagePool.jsx:175
 #: pkg/machines/components/storagePools/storagePool.jsx:180
-#, fuzzy
 msgid "Operation is in progress"
-msgstr "oVirt acceso progresando"
+msgstr ""
 
 #: pkg/storaged/drives-panel.jsx:94
 msgctxt "storage"
@@ -4689,9 +4884,9 @@ msgstr "Otros dispositivos"
 msgid "Other Options"
 msgstr "Otras Opciones"
 
-#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
+#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/networks/network.jsx:72
+#: pkg/machines/components/vm/vm.jsx:47
 msgid "Overview"
 msgstr "Visión conjunta"
 
@@ -4699,7 +4894,7 @@ msgstr "Visión conjunta"
 msgid "Overwrite existing data with zeros"
 msgstr "Sobreescribir los datos existentes con ceros"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "PCI"
 msgstr "PCI"
 
@@ -4707,7 +4902,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "Información del paquete"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "PackageKit roto"
 
@@ -4719,20 +4914,24 @@ msgstr "PackageKit no está instalado"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit reportó error con código $0"
 
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "Paquetes"
+
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "Padre"
 
-#: pkg/networkmanager/interfaces.js:2903
+#: pkg/networkmanager/interfaces.js:2915
 msgid "Parent $parent"
 msgstr "Padre $parent"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/systemd/init.js:721
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr "Parte de"
 
-#: pkg/networkmanager/interfaces.js:1465
+#: pkg/networkmanager/interfaces.js:1474
 msgid "Part of "
 msgstr "Parte de"
 
@@ -4748,7 +4947,7 @@ msgstr "Partición de $0"
 msgid "Partitioning"
 msgstr "Particionamiento"
 
-#: pkg/networkmanager/interfaces.js:2000
+#: pkg/networkmanager/interfaces.js:2009
 msgid "Passive"
 msgstr "Pasivo"
 
@@ -4773,10 +4972,10 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Palabra de paso no coincide"
 
-#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
-#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
+#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
+#: pkg/users/index.html:173 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "Contraseña"
@@ -4816,7 +5015,8 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Pegue aquí el contenido de su archivo de clave SSH pública"
 
-#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "Trayecto"
 
@@ -4824,7 +5024,7 @@ msgstr "Trayecto"
 msgid "Path cost"
 msgstr "Costo de trayecto"
 
-#: pkg/networkmanager/interfaces.js:2885
+#: pkg/networkmanager/interfaces.js:2897
 msgid "Path cost $path_cost"
 msgstr "Costo de trayecto $path_cost"
 
@@ -4832,7 +5032,7 @@ msgstr "Costo de trayecto $path_cost"
 msgid "Path on Server"
 msgstr "Ruta sobre el Servidor"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "Ruta en el sistema de archivos del host"
 
@@ -4844,7 +5044,7 @@ msgstr "La ruta sobre el servidor no puede estar vacía"
 msgid "Path on server must start with \"/\"."
 msgstr "La ruta sobre el servidor debe empezar con \"/\"."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "Ruta al fichero ISO en el sistema de archivos del host"
 
@@ -4852,7 +5052,7 @@ msgstr "Ruta al fichero ISO en el sistema de archivos del host"
 msgid "Path to file"
 msgstr "Ruta al fichero"
 
-#: pkg/systemd/services.html:60
+#: pkg/systemd/services.jsx:42
 msgid "Paths"
 msgstr "Trayectos"
 
@@ -4868,7 +5068,7 @@ msgstr "Perfil de rendimiento"
 msgid "Peripheral Chassis"
 msgstr "Chasis Periférico"
 
-#: pkg/networkmanager/interfaces.js:3630
+#: pkg/networkmanager/interfaces.js:3642
 msgid "Permanent"
 msgstr "Permanente"
 
@@ -4876,12 +5076,16 @@ msgstr "Permanente"
 msgid "Permission denied"
 msgstr "Permiso denegado"
 
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Permissive"
+msgstr ""
+
 #: pkg/machines/components/diskAdd.jsx:110
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
 #: pkg/machines/components/networks/networkOverviewTab.jsx:83
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:66
 msgid "Persistent"
 msgstr ""
 
@@ -4889,7 +5093,7 @@ msgstr ""
 msgid "Physical"
 msgstr "Físico"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr ""
 
@@ -4901,7 +5105,7 @@ msgstr "Volumen físico"
 msgid "Physical Volumes"
 msgstr "Volúmenea Físicos"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -4925,9 +5129,9 @@ msgstr "Hacer Ping al Objetivo"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/details.js:290 pkg/docker/util.js:612
-#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
+#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Por favor confirmar la eliminación de $0"
@@ -4936,21 +5140,21 @@ msgstr "Por favor confirmar la eliminación de $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Por favor confirme, forzar el borrado de $0"
 
-#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
+#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
 msgid "Please confirm stopping of $0"
 msgstr "Por favor confirma la parada de $0"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:447
+#: pkg/machines/components/diskAdd.jsx:483
 msgid "Please enter new volume name"
 msgstr "Introduzca el nuevo nombre de volumen"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:450
+#: pkg/machines/components/diskAdd.jsx:486
 msgid "Please enter new volume size"
 msgstr "Introduzca el nuevo tamaño de volumen"
 
-#: pkg/networkmanager/firewall.jsx:864
+#: pkg/networkmanager/firewall.jsx:894
 msgid "Please install the $0 package"
 msgstr "Por favor instale el $0 paquete"
 
@@ -4970,14 +5174,15 @@ msgstr "Por favor arranque la maquina virtual para acceder a su consola."
 msgid "Please try another term"
 msgstr "Pruebe con otro término"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Plug"
 msgstr "Enchufe"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/deleteDialog.jsx:53
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
+#: pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr "Grupo"
 
@@ -4993,6 +5198,11 @@ msgstr "Grupo para Volúmenes Finos"
 msgid "Pool for thinly provisioned volumes"
 msgstr "Grupo para volúmenes poco aprovisionados"
 
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
+msgid "Pool's volumes are used by VMs "
+msgstr ""
+
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
@@ -5002,7 +5212,7 @@ msgstr "Grupo para volúmenes poco aprovisionados"
 msgid "Port"
 msgstr "Puerto"
 
-#: pkg/networkmanager/firewall.jsx:339
+#: pkg/networkmanager/firewall.jsx:364
 msgid "Port number and type do not match"
 msgstr ""
 
@@ -5013,7 +5223,7 @@ msgstr "Portable"
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
+#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2998
 msgid "Ports"
 msgstr "Puertos"
 
@@ -5033,29 +5243,37 @@ msgstr "Número preferido de sockets para exponer al invitado."
 msgid "Prefix"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/machines/components/networks/createNetworkDialog.jsx:337
+msgid "Prefix Length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:78
+msgid "Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length"
 msgstr "Tamaño del prefijo"
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr "Tamaño del prefijo o máscara de red"
 
-#: pkg/networkmanager/interfaces.js:826
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:835
 msgid "Preparing"
 msgstr "Preparando"
 
-#: pkg/networkmanager/interfaces.js:3631
+#: pkg/lib/machine-info.js:251
+msgid "Present"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3643
 msgid "Preserve"
 msgstr "Conservar"
-
-#: pkg/systemd/init.js:572
-msgid "Preset"
-msgstr "Ajustar"
-
-#: pkg/systemd/init.js:573
-msgid "Preset Forcefully"
-msgstr "Forzar pre-ajuste"
 
 #: pkg/systemd/index.html:295
 msgid "Pretty Host Name"
@@ -5074,7 +5292,7 @@ msgstr "Primario"
 msgid "Priority"
 msgstr "Prioridad"
 
-#: pkg/networkmanager/interfaces.js:2859 pkg/networkmanager/interfaces.js:2883
+#: pkg/networkmanager/interfaces.js:2871 pkg/networkmanager/interfaces.js:2895
 msgid "Priority $priority"
 msgstr "Prioridad $priority"
 
@@ -5124,7 +5342,7 @@ msgstr "Expiro el tiempo de espera vía ssh."
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Iniciando a través de ssh-keygen tiempo de espera agotado"
 
-#: pkg/systemd/init.js:734
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr "Propaga recargar a"
 
@@ -5134,7 +5352,7 @@ msgstr "Propaga recargar a"
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
+#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
 msgid "Public Key"
 msgstr "Llave pública"
 
@@ -5145,14 +5363,6 @@ msgstr "Repositorio de encuestas públicas"
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Proposito"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "Conexión del sistema QEMU / KVM"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "Conexión de usuario QEMU / KVM"
 
 #: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
@@ -5214,7 +5424,7 @@ msgstr "Chasis RAID"
 msgid "RAID Device"
 msgstr "Dispositivo RAID"
 
-#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
+#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
 msgid "RAID Device $0"
 msgstr "Dispositivo RAID $0"
 
@@ -5234,24 +5444,36 @@ msgstr "Miembro de RAID"
 msgid "Rack Mount Chassis"
 msgstr "Chasis Montado en Rack"
 
-#: pkg/networkmanager/interfaces.js:3632
+#: pkg/networkmanager/interfaces.js:3644
 msgid "Random"
 msgstr "Al azar"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:789
 msgid "Range"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:370
+#: pkg/networkmanager/firewall.jsx:395
 msgid "Range must be strictly ordered"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Rank"
 msgstr ""
 
 #: pkg/kdump/kdump-view.jsx:388
 msgid "Raw to a device"
 msgstr "Sin procesar a un dispositivo"
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:386
+msgid "Read-only"
 msgstr ""
 
 #: pkg/docker/index.html:365
@@ -5287,7 +5509,7 @@ msgstr "Preparado"
 msgid "Real Host Name"
 msgstr "Nombre de anfitrión real"
 
-#: pkg/systemd/host.js:1020
+#: pkg/systemd/host.js:1037
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
@@ -5295,7 +5517,7 @@ msgstr ""
 "El nombre real de anfitrión únicamente puede contener caracteres en "
 "minúscula, dígitos, guiones y puntos (con subdominios rellenados)"
 
-#: pkg/systemd/host.js:1021
+#: pkg/systemd/host.js:1038
 msgid "Real host name must be 64 characters or less"
 msgstr "El nombre real de anfitrión debe tener 64 caracteres o menos"
 
@@ -5317,7 +5539,7 @@ msgstr "Reciente"
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Reconectarse"
@@ -5350,19 +5572,19 @@ msgstr "Rechazando conexión. La clave de host no coincide"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Rechazando la conexión. La clave de host es desconocida"
 
-#: pkg/packagekit/updates.jsx:777
+#: pkg/packagekit/updates.jsx:779
 msgid "Register…"
 msgstr "Registro…"
 
-#: pkg/systemd/init.js:546
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Recargar"
 
-#: pkg/systemd/init.js:735
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr "Recargar propagado desde"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "URL Remota"
 
@@ -5384,13 +5606,13 @@ msgstr "Disco Removible"
 msgid "Removals:"
 msgstr "Eliminaciones:"
 
+#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
-#: pkg/apps/application.jsx:109
+#: pkg/storaged/nfs-details.jsx:308
 msgid "Remove"
 msgstr "Eliminar"
 
-#: pkg/networkmanager/interfaces.js:3055
+#: pkg/networkmanager/interfaces.js:3067
 msgid "Remove $0"
 msgstr "Quitar $0"
 
@@ -5417,11 +5639,11 @@ msgstr "Eliminar frase de acceso"
 msgid "Remove passphrase in $0?"
 msgstr "¿Eliminar frase de acceso en $0?"
 
-#: pkg/networkmanager/firewall.jsx:631
+#: pkg/networkmanager/firewall.jsx:661
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:610
+#: pkg/networkmanager/firewall.jsx:640
 msgid "Remove service from zones"
 msgstr ""
 
@@ -5438,7 +5660,7 @@ msgstr "Quitando $0"
 msgid "Removing $target from RAID Device"
 msgstr "Removiendo $target del Dispositivo RAID"
 
-#: pkg/networkmanager/interfaces.js:3054
+#: pkg/networkmanager/interfaces.js:3066
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5471,23 +5693,23 @@ msgstr "Renombrando $target"
 msgid "Repairing $target"
 msgstr "Reparando $target"
 
-#: pkg/systemd/services.html:489
+#: pkg/systemd/services.html:344
 msgid "Repeat Daily"
 msgstr "Repetir cada día"
 
-#: pkg/systemd/services.html:488
+#: pkg/systemd/services.html:343
 msgid "Repeat Hourly"
 msgstr "Repetir cada hora"
 
-#: pkg/systemd/services.html:491
+#: pkg/systemd/services.html:346
 msgid "Repeat Monthly"
 msgstr "Repetir cada mes"
 
-#: pkg/systemd/services.html:490
+#: pkg/systemd/services.html:345
 msgid "Repeat Weekly"
 msgstr "Repetir cada semana"
 
-#: pkg/systemd/services.html:492
+#: pkg/systemd/services.html:347
 msgid "Repeat Yearly"
 msgstr "Repetir cada año"
 
@@ -5527,20 +5749,28 @@ msgid "Require password change on $0"
 msgstr "Se requiere que la contraseña se cambie en $0"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/systemd/init.js:722
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr "Necesitado por"
 
+#: pkg/systemd/service-details.jsx:372
+msgid "Required by "
+msgstr ""
+
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/systemd/init.js:717
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr "Requiere"
 
-#: pkg/systemd/init.js:718
+#: pkg/systemd/service-details.jsx:387
+msgid "Requires administration access to edit"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr "Requisito"
 
-#: pkg/systemd/init.js:723
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr "Requisito de"
 
@@ -5578,8 +5808,9 @@ msgstr ""
 
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
-#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
+#: pkg/machines/components/vm/vmActions.jsx:42
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -5599,7 +5830,7 @@ msgstr "Normativa de reinicios:"
 msgid "Restart Recommended"
 msgstr "Reinicio Recomendado"
 
-#: pkg/packagekit/updates.jsx:864
+#: pkg/packagekit/updates.jsx:866
 msgid "Restarting"
 msgstr "Reiniciando"
 
@@ -5620,7 +5851,8 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Reutilizar mi contraseña para tareas privilegiadas"
 
 #: pkg/shell/index.html:159
-msgid "Reuse my password for privileged tasks and to connect to other machines"
+msgid ""
+"Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Reutilizar mi contraseña para tareas con privilegios y para conectar con "
 "otras máquinas"
@@ -5629,7 +5861,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Roles"
 
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1983 pkg/networkmanager/interfaces.js:2000
 msgid "Round Robin"
 msgstr "Round Robin"
 
@@ -5641,12 +5873,12 @@ msgstr ""
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3337
 msgid "Routes"
 msgstr "Rutas"
 
 #: pkg/docker/index.html:253 pkg/docker/index.html:566
-#: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
+#: pkg/systemd/services.html:296 pkg/machines/components/vm/vmActions.jsx:91
 msgid "Run"
 msgstr "Ejecutar"
 
@@ -5667,19 +5899,19 @@ msgstr ""
 msgid "Runner"
 msgstr "Ejecutor"
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr "Corriendo"
 
-#: pkg/systemd/services.html:123
-msgid "Running Since"
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:364
+#: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
 msgstr "Errores de control de acceso de SELinux"
 
-#: pkg/selinux/setroubleshoot-view.jsx:297
+#: pkg/selinux/setroubleshoot-view.jsx:301
 msgid "SELinux Policy"
 msgstr "Normativa de SELinux"
 
@@ -5687,15 +5919,15 @@ msgstr "Normativa de SELinux"
 msgid "SELinux Troubleshoot"
 msgstr "Solución de problemas de SELinux"
 
-#: pkg/selinux/setroubleshoot-view.jsx:356
+#: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "SELinux is disabled on the system"
 msgstr "Se ha desactivado SELinux en el sistema"
 
-#: pkg/selinux/setroubleshoot-view.jsx:284
+#: pkg/selinux/setroubleshoot-view.jsx:285
 msgid "SELinux is disabled on the system."
 msgstr "Se ha desactivado SELinux en el sistema."
 
-#: pkg/selinux/setroubleshoot-view.jsx:276
+#: pkg/selinux/setroubleshoot-view.jsx:277
 msgid "SELinux system status is unknown."
 msgstr "Se desconoce el estado de sistema de SELinux."
 
@@ -5735,7 +5967,7 @@ msgstr "Edad máxima del mensaje STP"
 msgid "STP Priority"
 msgstr "Prioridad STP"
 
-#: pkg/systemd/services.html:240
+#: pkg/systemd/services.html:132
 msgid "Saturday"
 msgstr "Sábado"
 
@@ -5743,11 +5975,10 @@ msgstr "Sábado"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
-#: pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Guardar"
 
@@ -5776,8 +6007,8 @@ msgstr ""
 msgid "Sealed-case PC"
 msgstr "PC de Caja Sellada"
 
-#: pkg/systemd/services.html:459 pkg/systemd/services.html:463
-#: pkg/systemd/init.js:1076
+#: pkg/systemd/services.html:314 pkg/systemd/services.html:318
+#: pkg/systemd/init.js:905
 msgid "Seconds"
 msgstr "Segundos"
 
@@ -5793,7 +6024,7 @@ msgstr "Borrando de forma segura $target"
 msgid "Security"
 msgstr "Seguridad"
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:506
 msgid "Security Updates Available"
 msgstr "Actualizaciones de Seguridad Disponibles"
 
@@ -5803,11 +6034,11 @@ msgstr "Seleccionar"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with "
+"{{#strong}}{{host}}{{/strong}}"
 msgstr ""
-"Seleccione el usuario con el que le gustaría sincronizar  {{#strong}}{{host}}"
-"{{/strong}}"
+"Seleccione el usuario con el que le gustaría sincronizar  "
+"{{#strong}}{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
@@ -5827,8 +6058,8 @@ msgstr "Enviando"
 msgid "Serial Console"
 msgstr "Consola Serie"
 
-#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
-#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
+#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
+#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
 msgid "Server"
 msgstr "Servidor"
 
@@ -5860,12 +6091,12 @@ msgstr "El server a cerrado la conexión"
 msgid "Servers"
 msgstr "Servidores"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:968
 #: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Servicio"
 
-#: pkg/systemd/services.html:337
+#: pkg/systemd/services.html:229
 msgid "Service Logs"
 msgstr "Bitácoras del Servicio"
 
@@ -5889,15 +6120,16 @@ msgstr "Se ha detenido el servicio"
 msgid "Service is stopping"
 msgstr "Se está deteniendo el servicio"
 
-#: pkg/systemd/services.html:399
+#: pkg/systemd/services.html:254
 msgid "Service name"
 msgstr "Nombre de servicio"
 
-#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:222
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Servicios"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sesión"
@@ -5906,7 +6138,11 @@ msgstr "Sesión"
 msgid "Set"
 msgstr "Establecer"
 
-#: pkg/systemd/host.js:764
+#: pkg/machines/components/networks/createNetworkDialog.jsx:231
+msgid "Set DHCP Range"
+msgstr ""
+
+#: pkg/systemd/host.js:781
 msgid "Set Host name"
 msgstr "Establecer nombre del sistema"
 
@@ -5930,7 +6166,7 @@ msgstr "Ajustar a"
 msgid "Set up"
 msgstr "Preparar"
 
-#: pkg/selinux/setroubleshoot-view.jsx:293
+#: pkg/selinux/setroubleshoot-view.jsx:294
 msgid ""
 "Setting deviates from the configured state and will revert on the next boot."
 msgstr ""
@@ -5953,15 +6189,19 @@ msgstr "Severidad"
 msgid "Severity:"
 msgstr "Severidad:"
 
-#: pkg/networkmanager/interfaces.js:1959
+#: pkg/networkmanager/interfaces.js:1968
 msgid "Shared"
 msgstr "Compartido"
+
+#: pkg/lib/cockpit-components-modifications.jsx:78
+msgid "Shell Script"
+msgstr ""
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Show Performance Options"
 msgstr ""
 
@@ -6002,16 +6242,21 @@ msgstr ""
 msgid "Shut Down"
 msgstr "Apagar"
 
+#: pkg/lib/machine-info.js:242
+msgid "Single Rank"
+msgstr ""
+
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
+#: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
-#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
-#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
-#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
+#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
+#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
+#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
+#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:259
 msgid "Size"
 msgstr "Tamaño"
 
@@ -6035,7 +6280,7 @@ msgstr "Tamaña debe ser un número"
 msgid "Size must be at least $0"
 msgstr "El tamaño debe ser al menos $0"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "Slot"
 msgstr "Espacio"
 
@@ -6043,11 +6288,11 @@ msgstr "Espacio"
 msgid "Slot $0"
 msgstr "Espacio $0"
 
-#: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
+#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:40
 msgid "Sockets"
 msgstr "Sockets"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Actualizaciones de Software"
 
@@ -6067,15 +6312,15 @@ msgctxt "storage"
 msgid "Solid-State Disk"
 msgstr "Disco en Estado Sólido"
 
-#: pkg/selinux/setroubleshoot-view.jsx:95
+#: pkg/selinux/setroubleshoot-view.jsx:96
 msgid "Solution applied successfully"
 msgstr "Solución aplicada con éxito"
 
-#: pkg/selinux/setroubleshoot-view.jsx:102
+#: pkg/selinux/setroubleshoot-view.jsx:103
 msgid "Solution failed"
 msgstr "Fallo en la solución"
 
-#: pkg/selinux/setroubleshoot-view.jsx:409
+#: pkg/selinux/setroubleshoot-view.jsx:419
 msgid "Solutions"
 msgstr "Soluciones"
 
@@ -6086,25 +6331,26 @@ msgstr ""
 "Algún otro programa está usando actualmente el gestor de paquetes, por favor "
 "espere..."
 
-#: pkg/networkmanager/firewall.jsx:709
+#: pkg/networkmanager/firewall.jsx:739
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:141
+#: pkg/machines/components/diskAdd.jsx:541
+#: pkg/machines/components/nicEdit.jsx:150
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
-#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Fuente"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
 msgid "Source Format"
 msgstr ""
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Dirección de origen"
 
@@ -6112,12 +6358,16 @@ msgstr "Dirección de origen"
 msgid "Source URL"
 msgstr "URL Fuente"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
+msgid "Source Volume Group"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "La ruta de origen no debe estar vacía"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "La fuente debería empezar con http, ftp o protocolo nfs"
 
@@ -6125,7 +6375,7 @@ msgstr "La fuente debería empezar con http, ftp o protocolo nfs"
 msgid "Space-saving Computer"
 msgstr "Ordenador que Ahorra Espacio"
 
-#: pkg/networkmanager/interfaces.js:2857
+#: pkg/networkmanager/interfaces.js:2869
 msgid "Spanning Tree Protocol"
 msgstr "Spanning Tree Protocol"
 
@@ -6141,13 +6391,18 @@ msgstr "Libre"
 msgid "Specific Time"
 msgstr "Hora Específica"
 
-#: pkg/networkmanager/interfaces.js:3633
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Speed"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3645
 msgid "Stable"
 msgstr "Estable"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
-#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
+#: pkg/machines/components/networks/createNetworkDialog.jsx:237
+#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Iniciar"
 
@@ -6160,17 +6415,26 @@ msgid "Start Multipath"
 msgstr "Inicio multitrayecto"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/networkmanager/index.html:44
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
 msgstr "Iniciar servicio"
+
+#: pkg/systemd/service-details.jsx:411
+msgid "Start and Enable"
+msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:105
 msgid "Start libvirt"
 msgstr "Inicar libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
 msgstr "Empezar el pool cuando el host arranque."
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:84
+msgid "Start should not be empty"
+msgstr ""
 
 #: pkg/storaged/jobs-panel.jsx:59
 msgid "Starting RAID Device $target"
@@ -6180,15 +6444,15 @@ msgstr "Iniciando dispositivo RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Iniciando espacio de swap $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "Puesta en marcha"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/init.js:285
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "Estado"
 
@@ -6196,11 +6460,12 @@ msgstr "Estado"
 msgid "State:"
 msgstr "Estado:"
 
-#: pkg/systemd/services.html:74 pkg/systemd/init.js:207
+#: pkg/systemd/services.html:68 pkg/systemd/init.js:212
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr "Estático"
 
-#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "Estado"
 
@@ -6213,15 +6478,19 @@ msgid "Sticky"
 msgstr "Pegajoso"
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
-#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
-#: pkg/systemd/init.js:542
+#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Detener"
 
 #: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Para Dispositivo"
+
+#: pkg/systemd/service-details.jsx:411
+msgid "Stop and Disable"
+msgstr ""
 
 #: pkg/storaged/nfs-details.jsx:259
 msgid "Stop and Unmount"
@@ -6253,8 +6522,8 @@ msgid "Stopping swapspace $target"
 msgstr "Deteniendo espacio de swap $target"
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Almacenamiento"
 
@@ -6270,11 +6539,11 @@ msgstr ""
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr "Nombre del grupo de almacenamiento"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr "No se pudo crear la agrupación de almacenamiento"
 
@@ -6298,6 +6567,10 @@ msgstr ""
 #: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Grupo de almacenamiento"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
+msgid "Storage size must not be 0"
+msgstr ""
 
 #: pkg/systemd/index.html:155
 msgid "Store Metrics"
@@ -6327,7 +6600,7 @@ msgstr "Sub Portátil"
 msgid "Summary"
 msgstr "Resumen"
 
-#: pkg/systemd/services.html:241
+#: pkg/systemd/services.html:133
 msgid "Sunday"
 msgstr "Domingo"
 
@@ -6348,19 +6621,19 @@ msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "Espacio de intercambio"
 
-#: pkg/systemd/index.html:248 pkg/systemd/host.js:1692
+#: pkg/systemd/index.html:248 pkg/systemd/host.js:1709
 msgid "Swap Used"
 msgstr "Swap utilizada"
 
-#: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
+#: pkg/networkmanager/interfaces.js:2504 pkg/networkmanager/interfaces.js:3051
 msgid "Switch off $0"
 msgstr "Apagar $0"
 
-#: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
+#: pkg/networkmanager/interfaces.js:2479 pkg/networkmanager/interfaces.js:3039
 msgid "Switch on $0"
 msgstr "Encender $0"
 
-#: pkg/networkmanager/interfaces.js:2491
+#: pkg/networkmanager/interfaces.js:2503
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6368,7 +6641,7 @@ msgstr ""
 "Apagando <b>$0</b>  romperá la conexión al servidor y hará la administración "
 "de UI no disponible."
 
-#: pkg/networkmanager/interfaces.js:3038
+#: pkg/networkmanager/interfaces.js:3050
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6376,7 +6649,7 @@ msgstr ""
 "Apagando <b>$0</b>  romperá la conexión al servidor y hará la administración "
 "de UI no disponible."
 
-#: pkg/networkmanager/interfaces.js:2466 pkg/networkmanager/interfaces.js:3026
+#: pkg/networkmanager/interfaces.js:2478 pkg/networkmanager/interfaces.js:3038
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6404,20 +6677,26 @@ msgstr "Sincronizado con {{Server}}"
 msgid "Synchronizing RAID Device $target"
 msgstr "Sincronizando el Dispositivo RAID $target"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:260
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "Sistema"
 
-#: pkg/systemd/hwinfo.jsx:264
+#: pkg/systemd/hwinfo.jsx:273
 msgid "System Information"
 msgstr "Información del Sistema"
 
-#: pkg/systemd/host.js:480
+#: pkg/selinux/setroubleshoot-view.jsx:467
+msgid "System Modifications"
+msgstr ""
+
+#: pkg/systemd/host.js:490
 msgid "System Not Registered"
 msgstr "Sistema No Registrado"
 
-#: pkg/systemd/services.html:57
+#: pkg/systemd/services.jsx:38
 msgid "System Services"
 msgstr "Servicios de Sistema"
 
@@ -6425,16 +6704,16 @@ msgstr "Servicios de Sistema"
 msgid "System Time"
 msgstr "Hora del Sistema"
 
-#: pkg/systemd/host.js:486
+#: pkg/systemd/host.js:496
 msgid "System Up To Date"
 msgstr "Sistema Actualizado"
 
-#: pkg/packagekit/updates.jsx:876
+#: pkg/packagekit/updates.jsx:878
 msgid "System is up to date"
 msgstr "El sistema está actualizado"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:968
 msgid "TCP"
 msgstr ""
 "TCP: Protocolo de Control de Transmisión, por sus siglas en ingles "
@@ -6464,25 +6743,25 @@ msgstr "Tang keyserver"
 msgid "Target"
 msgstr "Objetivo"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "Ruta de destino"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "La ruta de destino no debe estar vacía"
 
-#: pkg/systemd/services.html:56
+#: pkg/systemd/services.jsx:39
 msgid "Targets"
 msgstr "Objetivos"
 
-#: pkg/networkmanager/interfaces.js:2512 pkg/networkmanager/interfaces.js:2524
-#: pkg/networkmanager/interfaces.js:2814
+#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
+#: pkg/networkmanager/interfaces.js:2826
 msgid "Team"
 msgstr "Equipo"
 
-#: pkg/networkmanager/interfaces.js:2842
+#: pkg/networkmanager/interfaces.js:2854
 msgid "Team Port"
 msgstr "Puerto de Equipo"
 
@@ -6494,7 +6773,7 @@ msgstr "Ajustes de Puerto de Equipo"
 msgid "Team Settings"
 msgstr "Ajustes de Equipo"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -6544,8 +6823,8 @@ msgid "The RAID device must be running in order to remove disks."
 msgstr ""
 "El dispositivo RAID debe estar corriendo con el objetivo de quitar discos."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:80
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:84
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:125
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:129
 msgid "The Storage Pool could not be deleted"
 msgstr ""
 
@@ -6593,8 +6872,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
+" Are you sure you want to continue connecting?"
 msgstr ""
 "La autenticidad del host {{#strong}}{{host}}{{/strong}} no se ha podido "
 "establecer.¿Está seguro que desea continuar con la conexión?"
@@ -6603,7 +6882,7 @@ msgstr ""
 msgid "The collected information will be stored locally on the system."
 msgstr "La información recolectada será almacenada localmente en el sistema."
 
-#: pkg/selinux/setroubleshoot-view.jsx:291
+#: pkg/selinux/setroubleshoot-view.jsx:292
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 "El estado configurado es desconocido, podría cambiar en el próximo arranque."
@@ -6621,7 +6900,7 @@ msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr "El usuario actual no tiene permitido ver información de claves."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "El directorio en el servidor que se está exportando."
 
@@ -6634,7 +6913,8 @@ msgstr ""
 "servicios del sistema. Procediendo detendrá estos."
 
 #: pkg/storaged/dialog.jsx:1014
-msgid "The filesystem is in use by login sessions. Proceeding will stop these."
+msgid ""
+"The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "El sistema de archivos está en uso por sesiones de inicio de sesión. "
 "Procediendo detendrá estos."
@@ -6649,7 +6929,8 @@ msgstr ""
 
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
 #: pkg/docker/util.js:631
-msgid "The following containers depend on this image and will become unusable."
+msgid ""
+"The following containers depend on this image and will become unusable."
 msgstr ""
 "Los siguientes contenedores dependen de esta imagen y no podrán usarse."
 
@@ -6690,14 +6971,17 @@ msgstr "La última ranura de la llave no se puede quitar"
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "El último volumen físico de un grupo de volumen no puede ser quitado."
 
-#: pkg/shell/indexes.js:407
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "The logged in user is not permitted to view system modifications"
+msgstr ""
+
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "La máquina se está reiniciando"
 
 #: pkg/machines/components/networks/networkDelete.jsx:76
-#, fuzzy
 msgid "The network could not be deleted"
-msgstr "La ruta de destino no debe estar vacía"
+msgstr ""
 
 #: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
@@ -6720,6 +7004,15 @@ msgstr "El escaneo desde $time ($type) no encontró vulnerabilidades."
 msgid "The scan from $time ($type) was not successful."
 msgstr "El escaneo desde $time ($type) no tuvo éxito."
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
+msgid "The selected Operating System has minimum memory requirement of $0 $1"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+msgid ""
+"The selected Operating System has minimum storage size requirement of $0 $1"
+msgstr ""
+
 #: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
@@ -6736,7 +7029,7 @@ msgstr "El servido rehusó autenticar usando los métodos soportados."
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 
-#: pkg/systemd/init.js:922
+#: pkg/systemd/init.js:751
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "El usuario <b>$0</b> no tiene permisos para crear temporizadores"
 
@@ -6750,18 +7043,14 @@ msgstr "El usuario <b>$0</b> no puede cambiar perfiles"
 msgid "The user <b>$0</b> is not permitted to change the system time"
 msgstr "El usuario <b>$0</b> no puede cambiar la hora del sistema"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/systemd/init.js:614
-msgid "The user <b>$0</b> is not permitted to enable or disable services"
-msgstr "El usuario <b>$0</b> no puede activar ni desactivar servicios"
-
 #: pkg/dashboard/list.js:223
 msgid "The user <b>$0</b> is not permitted to manage servers"
 msgstr "El usuario <b>$0</b> no está autorizado para administrar servidores"
 
 #: pkg/storaged/storage-controls.jsx:73
 msgid "The user <b>$0</b> is not permitted to manage storage"
-msgstr "Al usuario <b>$0</b> no le es permitido administrar el almacenamiento "
+msgstr ""
+"Al usuario <b>$0</b> no le es permitido administrar el almacenamiento "
 
 #: pkg/users/local.js:43
 msgid "The user <b>$0</b> is not permitted to modify accounts"
@@ -6771,7 +7060,7 @@ msgstr "El usuario <b>$0</b> no tiene permisos para modificar cuentas"
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "El usuario <b>$0</b> no está autorizado a modificar dominios"
 
-#: pkg/networkmanager/interfaces.js:1516
+#: pkg/networkmanager/interfaces.js:1525
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
 "El usuario <b>$0</b> no está autorizado para modificar la configuración de "
@@ -6786,11 +7075,6 @@ msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr ""
 "El usuario <b>$0</b> no tiene permitido apagar o reiniciar este servidor"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/systemd/init.js:606 pkg/systemd/init.js:610
-msgid "The user <b>$0</b> is not permitted to start or stop services"
-msgstr "El usuario <b>$0</b> no puede iniciar ni parar servicios"
-
 #: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
@@ -6801,7 +7085,8 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible $0)"
+"The web browser configuration prevents Cockpit from running (inaccessible "
+"$0)"
 msgstr ""
 "La configuración del navegador evita que se ejecute Cockpit (inaccesible $0)"
 
@@ -6835,13 +7120,14 @@ msgstr "Volumen Lógico Delgado"
 
 #: pkg/storaged/nfs-details.jsx:118
 msgid "This NFS mount is in use and only its options can be changed."
-msgstr "Este montaje NFS está en uso y solo pueden ser cambiadas sus opciones."
+msgstr ""
+"Este montaje NFS está en uso y solo pueden ser cambiadas sus opciones."
 
 #: pkg/storaged/vdo-details.jsx:133
 msgid "This VDO device does not use all of its backing device."
 msgstr "Este dispositivo VDO no usa todos sus dispositivos de respaldo."
 
-#: pkg/systemd/init.js:1371
+#: pkg/systemd/init.js:1200
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -6849,7 +7135,7 @@ msgstr ""
 "Este día no existe todos los meses.<br> El temporizador solo será ejecutado "
 "en los meses que tengan 31."
 
-#: pkg/networkmanager/interfaces.js:2624
+#: pkg/networkmanager/interfaces.js:2636
 msgid "This device cannot be managed here."
 msgstr "Este dispositivo no se puede manejar aquí."
 
@@ -6898,7 +7184,7 @@ msgid "This disk cannot be removed while the device is recovering."
 msgstr ""
 "El disco no se puede quitar mientras el dispositivo se está recuperando."
 
-#: pkg/systemd/init.js:1283 pkg/systemd/init.js:1297 pkg/systemd/init.js:1306
+#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
 msgid "This field cannot be empty."
 msgstr "Este campo no puede estar vacío."
 
@@ -6927,7 +7213,11 @@ msgstr "Este paquete no es compatible con esta versión de Cockpit"
 msgid "This package requires Cockpit version %s or later"
 msgstr "Este paquete requiere Cockpit versión %s o posterior"
 
-#: pkg/packagekit/updates.jsx:772
+#: pkg/machines/components/diskAdd.jsx:215
+msgid "This pool type does not support Storage Volume creation"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:774
 msgid "This system is not registered"
 msgstr "Este sistema no está registrado"
 
@@ -6948,11 +7238,7 @@ msgstr ""
 "diagnóstico desde este sistema para su uso en la diagnosis de problemas con "
 "el sistema."
 
-#: pkg/systemd/init.js:685
-msgid "This unit is an instance of the $0 template."
-msgstr "Esta unidad es una instancia de la plantilla $0 "
-
-#: pkg/systemd/services.html:360
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Esta unidad no está diseñada para ser habilitada explícitamente."
 
@@ -6968,20 +7254,22 @@ msgstr ""
 "Esta versión de cockpit-ws no soporta conexiones a un servidor con un "
 "usuario o puerto alterno"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr ""
 
 #: pkg/storaged/lvol-tabs.jsx:186
 msgid "This volume needs to be activated before it can be resized."
-msgstr "Este volumen necesita ser activado antes de poder modificar el tamaño."
+msgstr ""
+"Este volumen necesita ser activado antes de poder modificar el tamaño."
 
 #: src/ws/login.js:122
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr ""
-"Este navegador web es demasiado viejo para ejecutar Cockpit (desaparecido $0)"
+"Este navegador web es demasiado viejo para ejecutar Cockpit (desaparecido "
+"$0)"
 
-#: pkg/packagekit/updates.jsx:832
+#: pkg/packagekit/updates.jsx:834
 msgid "This web console will be updated."
 msgstr "Esta consola web será actualizada."
 
@@ -7003,7 +7291,7 @@ msgstr "Esto probará la configuración kdump bloqueando el núcleo."
 msgid "Threads per core"
 msgstr "Hilos por núcleo"
 
-#: pkg/systemd/services.html:238
+#: pkg/systemd/services.html:130
 msgid "Thursday"
 msgstr "Jueves"
 
@@ -7015,7 +7303,7 @@ msgstr ""
 msgid "Time Zone"
 msgstr "Zona Horaria"
 
-#: pkg/systemd/services.html:59
+#: pkg/systemd/services.jsx:41
 msgid "Timers"
 msgstr "Temporizadores"
 
@@ -7027,7 +7315,7 @@ msgstr ""
 "Consejo: haga que coincidan su contraseña de clave y su contraseña de acceso "
 "para efectuar autenticaciones automáticamente en otros sistemas."
 
-#: pkg/packagekit/updates.jsx:773
+#: pkg/packagekit/updates.jsx:775
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
@@ -7073,15 +7361,19 @@ msgstr "Tamaño total: $0"
 msgid "Tower"
 msgstr "Torre"
 
-#: pkg/systemd/init.js:733
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr "Desencadenado por"
 
-#: pkg/systemd/init.js:732
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "Disparadores"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Soporte"
@@ -7090,7 +7382,7 @@ msgstr "Soporte"
 msgid "Trust key"
 msgstr "Clave de confianza"
 
-#: pkg/networkmanager/firewall.jsx:705
+#: pkg/networkmanager/firewall.jsx:735
 msgid "Trust level"
 msgstr ""
 
@@ -7110,7 +7402,7 @@ msgstr "Intentar reconectar"
 msgid "Trying to synchronize with {{Server}}"
 msgstr "Intentando sincronizar con {{Server}}"
 
-#: pkg/systemd/services.html:236
+#: pkg/systemd/services.html:128
 msgid "Tuesday"
 msgstr "Martes"
 
@@ -7134,17 +7426,19 @@ msgstr "Tuned no se esta ejecutando"
 msgid "Tuned is off"
 msgstr "Tuned esta apagado"
 
-#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
+#: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
-#: pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/vmnetworktab.jsx:114
+#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/systemd/hwinfo.jsx:259
 msgid "Type"
 msgstr "Tipo"
 
@@ -7160,13 +7454,13 @@ msgstr "Introduzca una contraseña"
 msgid "Type to filter…"
 msgstr "Escribir para filtrar..."
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:968
 msgid "UDP"
 msgstr ""
 "UDP:  Protocolo de Datagramas de Usuario, por sus siglas en ingles (User "
 "Datagram Protocol)"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "URL"
 
@@ -7178,7 +7472,7 @@ msgstr "UUID"
 msgid "Unable to apply settings: $0"
 msgstr "Incapaz de aplicar los ajustes: $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:119
+#: pkg/selinux/setroubleshoot-view.jsx:120
 msgid "Unable to apply this solution automatically"
 msgstr "Incapaz de aplicar esta solución automáticamente"
 
@@ -7190,8 +7484,8 @@ msgstr "Incapaz de conectar a esa dirección"
 msgid "Unable to delete root account"
 msgstr "No es posible eliminar la cuenta root"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Unable to get alert details."
 msgstr "Incapaz de obtener detalles de la alerta."
 
@@ -7232,12 +7526,16 @@ msgid "Unavailable"
 msgstr "No Disponible"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Error inesperado"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:128
+msgid "Unique Network Name"
+msgstr ""
+
 # auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "Nombre único"
 
@@ -7249,15 +7547,15 @@ msgstr "Unidad"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
+#: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
 #: pkg/machines/components/vmnetworktab.jsx:139
-#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
-#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1076
+#: pkg/networkmanager/interfaces.js:2544 pkg/networkmanager/interfaces.js:2546
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
-#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
+#: pkg/networkmanager/interfaces.js:2530 pkg/networkmanager/interfaces.js:2542
 msgid "Unknown \"$0\""
 msgstr "Desconocido \"$0\""
 
@@ -7273,7 +7571,7 @@ msgstr "Aplicación Desconocida"
 msgid "Unknown Host Key"
 msgstr "Host Key desconocido"
 
-#: pkg/networkmanager/interfaces.js:2640
+#: pkg/networkmanager/interfaces.js:2652
 msgid "Unknown configuration"
 msgstr "Configuración desconocida"
 
@@ -7281,7 +7579,7 @@ msgstr "Configuración desconocida"
 msgid "Unknown host name"
 msgstr "Nombre de host desconocido "
 
-#: pkg/networkmanager/firewall.jsx:333
+#: pkg/networkmanager/firewall.jsx:358
 msgid "Unknown service name"
 msgstr ""
 
@@ -7324,10 +7622,6 @@ msgstr "Desbloqueando disco..."
 msgid "Unmanaged Interfaces"
 msgstr "Interfaces No Manejadas"
 
-#: pkg/systemd/init.js:576
-msgid "Unmask"
-msgstr "Desenmascarar"
-
 #: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
 msgid "Unmount"
 msgstr "Desmontar"
@@ -7340,7 +7634,7 @@ msgstr "Desmontando $target"
 msgid "Unnamed"
 msgstr "Sin nombre"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Unplug"
 msgstr "Desenchufar"
 
@@ -7379,11 +7673,11 @@ msgstr "host inseguro"
 msgid "Up since $0"
 msgstr "En marcha desde $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -7408,7 +7702,7 @@ msgid "Updated packages may require a restart to take effect."
 msgstr ""
 "Los paquetes actualizados pueden requerir un reinicio para tener efecto."
 
-#: pkg/systemd/host.js:502
+#: pkg/systemd/host.js:512
 msgid "Updates Available"
 msgstr "Actualizaciones Disponibles"
 
@@ -7416,11 +7710,15 @@ msgstr "Actualizaciones Disponibles"
 msgid "Updating"
 msgstr "Actualizando"
 
+#: pkg/systemd/service-details.jsx:406
+msgid "Updating status..."
+msgstr ""
+
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Utilización"
 
-#: pkg/systemd/host.js:1613
+#: pkg/systemd/host.js:1630
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] "Utilización de $0 núcleo de CPU"
@@ -7431,7 +7729,7 @@ msgid "Use 512 Byte emulation"
 msgstr "Usar emulación de 512 Byte"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.6, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:524
+#: pkg/machines/components/diskAdd.jsx:561
 msgid "Use Existing"
 msgstr "Usar existente"
 
@@ -7443,7 +7741,7 @@ msgstr "Use la siguiente llave para autenticarse en otros sistemas"
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
-#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1678
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1695
 msgid "Used"
 msgstr "Usado"
 
@@ -7457,7 +7755,7 @@ msgstr "Utilizado por contenedores"
 
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1601
 msgid "User"
 msgstr "Usuario"
 
@@ -7470,7 +7768,7 @@ msgstr "Nombre de usuario"
 msgid "User Password"
 msgstr "Contraseña de usuario"
 
-#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
+#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Nombre de usuario"
@@ -7521,8 +7819,8 @@ msgstr "Los dispositivos de apoyo VDO no se pueden hacer más pequeños"
 msgid "VDO support not installed"
 msgstr "No está instalado el soporte para VDO"
 
-#: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
-#: pkg/networkmanager/interfaces.js:2906
+#: pkg/networkmanager/interfaces.js:2526 pkg/networkmanager/interfaces.js:2538
+#: pkg/networkmanager/interfaces.js:2918
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7550,7 +7848,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -7603,7 +7901,7 @@ msgid "Validating key"
 msgstr "Validando llave"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:250
 msgid "Vendor"
 msgstr "Proveedor"
 
@@ -7621,7 +7919,7 @@ msgid "Verifying"
 msgstr "Verificando"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
 msgid "Version"
 msgstr "Versión"
 
@@ -7629,14 +7927,22 @@ msgstr "Versión"
 msgid "Very securely erasing $target"
 msgstr "Borrando de forma muy segura $target"
 
+#: pkg/lib/cockpit-components-modifications.jsx:173
+msgid "View automation script"
+msgstr ""
+
+#: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/components/networks/networkList.jsx:39
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Máquinas Virtuales"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:422
+msgid "Virtual Network failed to be created"
 msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:80
@@ -7647,11 +7953,12 @@ msgstr "Servicio de Virtualización (libvirt) No Está Activo"
 msgid "Virtualization Service is Available"
 msgstr "El Servicio de Virtualización Está Disponible"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
+#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
+#: pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Volumen"
 
@@ -7662,6 +7969,14 @@ msgstr "Grupo de Volúmenes"
 #: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Grupo de volúmenes $0 "
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
+msgid "Volume Group name"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+msgid "Volume Group name should not be empty"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:113
 msgid "Volume Groups"
@@ -7685,12 +8000,12 @@ msgstr "Volúmenes:"
 msgid "WWPN"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:836
+#: pkg/networkmanager/interfaces.js:845
 msgid "Waiting"
 msgstr "Esperando"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Waiting for details..."
 msgstr "Esperando detalles..."
 
@@ -7705,11 +8020,11 @@ msgstr ""
 msgid "Waiting for other software management operations to finish"
 msgstr "Esperando a que finalicen otras operaciones de gestión de software"
 
-#: pkg/systemd/init.js:724
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr "Buscado por"
 
-#: pkg/systemd/init.js:719
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr "Quiere"
 
@@ -7721,7 +8036,7 @@ msgstr "Precaución y arriba"
 msgid "Web Console for Linux servers"
 msgstr "Consola web para servidores Linux"
 
-#: pkg/systemd/services.html:237
+#: pkg/systemd/services.html:129
 msgid "Wednesday"
 msgstr "Miércoles"
 
@@ -7729,7 +8044,7 @@ msgstr "Miércoles"
 msgid "Wednesdays"
 msgstr ""
 
-#: pkg/systemd/services.html:466
+#: pkg/systemd/services.html:321
 msgid "Weeks"
 msgstr "Semanas"
 
@@ -7757,11 +8072,11 @@ msgstr "Escribiendo"
 msgid "Wrong user name or password"
 msgstr "Nombre de usuario o contraseña equivocada"
 
-#: pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1985
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2605
 msgid "Yes"
 msgstr "Sí"
 
@@ -7781,8 +8096,8 @@ msgstr ""
 "Actualmente estás conectado directamente a este servidor. No puedes "
 "eliminarlo."
 
-#: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
+#: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
+#: pkg/networkmanager/firewall.jsx:903 pkg/networkmanager/firewall.jsx:909
 msgid "You are not authorized to modify the firewall."
 msgstr "Usted no está autorizado a modificar el cortafuegos."
 
@@ -7802,12 +8117,11 @@ msgstr ""
 msgid "You must wait longer to change your password"
 msgstr "Debes esperar más tiempo para cambiar tu contraseña"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
-msgid ""
-"You need to select the most closely matching OS vendor and Operating System"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
+msgid "You need to select the most closely matching Operating System"
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:834
+#: pkg/packagekit/updates.jsx:836
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
@@ -7816,7 +8130,7 @@ msgstr ""
 "actualización. Usted puede volver a conectar en breves momentos para "
 "continuar vigilando el progreso."
 
-#: pkg/packagekit/updates.jsx:865
+#: pkg/packagekit/updates.jsx:867
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
@@ -7832,11 +8146,11 @@ msgstr "Su sección ha sido terminada"
 msgid "Your session has expired. Please log in again."
 msgstr "Su sección a expirado. Por favor inicie sección otra vez"
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:955
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:968
 msgid "Zones"
 msgstr ""
 
@@ -7852,12 +8166,8 @@ msgstr "[datos binarios]"
 msgid "[no data]"
 msgstr "[no hay datos]"
 
-#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
-msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
-msgstr ""
-
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "activo"
@@ -7947,7 +8257,7 @@ msgstr "ethernet"
 msgid "every day"
 msgstr "cada día"
 
-#: pkg/systemd/host.js:886
+#: pkg/systemd/host.js:903
 msgid "failed to list ssh host keys: $0"
 msgstr "incapaz de mostrar llaves de host ssh: $0"
 
@@ -7963,11 +8273,11 @@ msgstr ""
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr ""
 
@@ -7975,11 +8285,11 @@ msgstr ""
 msgid "iSCSI Targets"
 msgstr "Objetivos iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:83
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -7987,8 +8297,8 @@ msgstr ""
 msgid "idle"
 msgstr "inactivo"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 msgid "inactive"
 msgstr "inactivo"
 
@@ -8024,9 +8334,9 @@ msgstr "red"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs dump target no tiene el formato de servidor: ruta"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "no"
@@ -8037,7 +8347,7 @@ msgstr "no"
 msgid "none"
 msgstr "ninguno"
 
-#: pkg/systemd/host.js:691
+#: pkg/systemd/host.js:712
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] "de $0 núcleo de CPU"
@@ -8046,16 +8356,6 @@ msgstr[1] "de $0 núcleos de CPU"
 #: pkg/machines/helpers.js:190
 msgid "paused"
 msgstr "en pausa"
-
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:154
-msgid "qcow2"
-msgstr "qcow2"
-
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#: pkg/machines/components/diskAdd.jsx:157
-msgid "raw"
-msgstr "raw"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -8105,7 +8405,7 @@ msgstr "apagar"
 msgid "shutdown"
 msgstr "apagar"
 
-#: pkg/selinux/setroubleshoot-view.jsx:123
+#: pkg/selinux/setroubleshoot-view.jsx:124
 msgid "solution details"
 msgstr "detalles de solución"
 
@@ -8147,7 +8447,7 @@ msgid "undefined"
 msgstr "sin definir"
 
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:249 pkg/systemd/init.js:263
+#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
 msgid "unknown"
 msgstr "desconocido"
 
@@ -8188,15 +8488,15 @@ msgstr "valor"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "sí"
@@ -8208,1425 +8508,3 @@ msgid ""
 msgstr ""
 "{{ condition.message }}. Marca de tiempo: {{ condition.lastTransitionTime }} "
 "Conteo de errores: {{ condition.generation }}"
-
-#~ msgid " 1\"Do you want to delete the following Nodes?"
-#~ msgstr " 1\"¿Quiere eliminar los nodos siguientes?"
-
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#~ msgid "$0 vCPU Details"
-#~ msgstr "$0 Detalles vCPU"
-
-#~ msgid "$0% Free"
-#~ msgid_plural "$0% Free"
-#~ msgstr[0] "$0 % disponible"
-#~ msgstr[1] "$0 % disponible"
-
-#~ msgid "$0% Used"
-#~ msgid_plural "$0% Used"
-#~ msgstr[0] "$0 % en uso"
-#~ msgstr[1] "$0 % en uso"
-
-#~ msgid "'Organization' required to register."
-#~ msgstr "Se necesita «Organización» para efectuar el registro."
-
-#~ msgid "'Organization' required when using activation keys."
-#~ msgstr "Se necesita «Organización» al utilizar claves de activación."
-
-#~ msgid "AWS Elastic Block Store"
-#~ msgstr "AWS Almacén Elástico de Bloque"
-
-#~ msgid "Access Modes"
-#~ msgstr "Modos de acceso"
-
-#~ msgid "Access denied"
-#~ msgstr "Acceso denegado"
-
-#~ msgid "Action"
-#~ msgstr "Acción"
-
-#~ msgid "Activation Key"
-#~ msgstr "Clave de activación"
-
-#~ msgid "Actual"
-#~ msgstr "Real"
-
-#~ msgid "Add Cluster Node"
-#~ msgstr "Añadir nodo de agrupación"
-
-#~ msgid "Add Group"
-#~ msgstr "Añadir grupo"
-
-#~ msgid "Add Kubernetes Node"
-#~ msgstr "Añadir nodo de Kubernetes"
-
-#~ msgid "Add Member"
-#~ msgstr "Añadir miembro"
-
-#~ msgid "Add Membership"
-#~ msgstr "Añadir afiliación"
-
-#~ msgid "Add New Cluster"
-#~ msgstr "Añadir agrupación nueva"
-
-#~ msgid "Add New User"
-#~ msgstr "Añadir usuario nuevo"
-
-#~ msgid "Add Role"
-#~ msgstr "Añadir rol"
-
-#~ msgid "Add User"
-#~ msgstr "Añadir usuario"
-
-#~ msgid "Add membership"
-#~ msgstr "Añadir afiliación"
-
-#~ msgid "Adjust"
-#~ msgstr "Ajustar"
-
-#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-#~ msgstr "Ajustar Volumen Persistente '{{ item.metadata.name }}'"
-
-#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
-#~ msgstr "Ajustar el Controlador de Replicación {{ item.metadata.name }}"
-
-#~ msgid "Adjust Route"
-#~ msgstr "Ajustar Ruta"
-
-#~ msgid "Adjust Service"
-#~ msgstr "Ajustar servicio"
-
-#~ msgid "Admin"
-#~ msgstr "Administración"
-
-#~ msgid "All Projects"
-#~ msgstr "Todos los Proyectos"
-
-#~ msgid "All Types"
-#~ msgstr "Todos los Tipos"
-
-#~ msgid "All healthy"
-#~ msgstr "Todo saludable"
-
-#~ msgid "All images"
-#~ msgstr "Todas las imágenes"
-
-#~ msgid "All in use"
-#~ msgstr "Todo en uso"
-
-#~ msgid "All running"
-#~ msgstr "Todo corriendo"
-
-#~ msgid "All running virtual machines will be turned off."
-#~ msgstr "Todas las máquinas virtuales corriendo serán apagadas."
-
-#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
-#~ msgstr ""
-#~ "Anónimo: Permite a todos los usuarios no autentificados tirar de las "
-#~ "imágenes"
-
-#~ msgid "Automatically selected host"
-#~ msgstr "Host seleccionado automáticamente"
-
-#~ msgid "Azure"
-#~ msgstr "Azure"
-
-#~ msgid "Base Template"
-#~ msgstr "Plantilla Base"
-
-#~ msgid "Base template"
-#~ msgstr "Plantilla base"
-
-#~ msgid "Base template:"
-#~ msgstr "Plantilla base:"
-
-#~ msgid "Boot ID"
-#~ msgstr "ID de Arranque"
-
-#~ msgid "CPU Utilization: $0%"
-#~ msgstr "Uso de CPU: $0%"
-
-#~ msgid "CREATE VM action failed"
-#~ msgstr "Fallo en la acción CREATE VM"
-
-#~ msgid "Cannot decrypt PEM-encoded private key"
-#~ msgstr "No se puede descifrar llave privada cifrada con PEM"
-
-#~ msgid "Ceph Filesystem Mount"
-#~ msgstr "Montaje del Sistema de Archivos Ceph"
-
-#~ msgid "Ceph Monitors"
-#~ msgstr "Monitores Ceph"
-
-#~ msgid "Change User"
-#~ msgstr "Cambiar Usuario"
-
-#~ msgid "Change image stream"
-#~ msgstr "Cambiar flujo de imagen"
-
-#~ msgid "Change project"
-#~ msgstr "Cambiar proyecto"
-
-#~ msgid "Cinder"
-#~ msgstr "Cinder"
-
-#~ msgid "Claim"
-#~ msgstr "Reclamación"
-
-#~ msgid "Claim Name"
-#~ msgstr "Nombre de Reclamación"
-
-#~ msgid "Client Certificate"
-#~ msgstr "Certificado de Cliente"
-
-#~ msgid "Cluster"
-#~ msgstr "Cluster"
-
-#~ msgid "Cluster Templates"
-#~ msgstr "Plantilla de Cluster"
-
-#~ msgid "Cluster Virtual Machines"
-#~ msgstr "Cluster de Máquinas Virtuales"
-
-#~ msgid "Configuration"
-#~ msgstr "Configuración"
-
-#~ msgid "Configure Flannel networking"
-#~ msgstr "Configurar la red Flannel"
-
-#~ msgid "Configure Kubelet and Proxy"
-#~ msgstr "Configurar Kubelet y proxy"
-
-#~ msgid "Confirm migration"
-#~ msgstr "Confirme migración"
-
-#~ msgid "Confirm reload:"
-#~ msgstr "Confirme recarga:"
-
-#~ msgid "Confirm save:"
-#~ msgstr "Confirme guardar:"
-
-#~ msgid "Connect to oVirt Engine"
-#~ msgstr "Conectar a oVirt Engine"
-
-#~ msgid "Connecting..."
-#~ msgstr "Conectando..."
-
-#~ msgid "Connection Error: $0"
-#~ msgstr "Error de conexión: $0"
-
-#~ msgid "Connection Settings"
-#~ msgstr "Ajustes de Conexión"
-
-#~ msgid "Container ID"
-#~ msgstr "ID de Contenedor"
-
-#~ msgid "Container Runtime Version"
-#~ msgstr "Contenedor de Versión en Tiempo de Ejecución"
-
-#~ msgid "Could not list services"
-#~ msgstr "No se pueden listar los servicios"
-
-#~ msgid "Could not parse PEM-encoded certificate"
-#~ msgstr "No es posible descifrar certificado codificado con PEM"
-
-#~ msgid "Could not parse PEM-encoded private key"
-#~ msgstr "No se puede resolver llave privada cifrada con PEM"
-
-#~ msgid "Couldn't connect to server"
-#~ msgstr "No se pudo conectar al servidor"
-
-#~ msgid "Couldn't find running API server"
-#~ msgstr "No se puede encontrar un servidor API ejecutandose"
-
-#~ msgid ""
-#~ "Couldn't get system subscription status. Please ensure subscription-"
-#~ "manager is installed."
-#~ msgstr ""
-#~ "No podría obtener el estado del sistema de suscripción. Por favor asegura "
-#~ "que el gestor de suscripción está instalado."
-
-#~ msgid "Create New VM"
-#~ msgstr "Crear Nueva VM"
-
-#~ msgid "Create empty image stream"
-#~ msgstr "Crea un flujo de imágenes vacío"
-
-#~ msgid "Create image stream"
-#~ msgstr "Crear un flujo de imagen"
-
-#~ msgid "Custom URL"
-#~ msgstr "URL personal"
-
-#~ msgid "DNS Policy"
-#~ msgstr "Política DNS"
-
-#~ msgid "Delete '{{ name }}'"
-#~ msgstr "Borrar '{{ nombre }}'"
-
-#~ msgid "Delete Node"
-#~ msgstr "Borrar Nodo"
-
-#~ msgid "Delete Persistent Volume"
-#~ msgstr "Borrar Volumen Persitente"
-
-#~ msgid "Delete Persistent Volume Claim"
-#~ msgstr "Eliminar la Reclamación de Volumen Persistente"
-
-#~ msgid "Delete Project"
-#~ msgstr "Borrar Proyecto"
-
-#~ msgid "Delete Selected"
-#~ msgstr "Borrar Seleccionado"
-
-#~ msgid "Delete image stream"
-#~ msgstr "Eliminar el flujo de imágenes"
-
-#~ msgid "Delete {{ item.kind }}"
-#~ msgstr "Eliminar {{ item.kind }}"
-
-#~ msgid ""
-#~ "Deleting a Pod will kill all associated containers. Pods may be "
-#~ "automatically created again in some cases."
-#~ msgstr ""
-#~ "Eliminando un Pod matará todos los contenedores asociados. Los Pods "
-#~ "pueden ser creados automáticamente otra vez en algunos casos."
-
-#~ msgid "Deploy"
-#~ msgstr "Desplegar"
-
-#~ msgid "Deploy Application"
-#~ msgstr "Desplegar aplicación"
-
-#~ msgid "Deployment Causes"
-#~ msgstr "Causas de Despliegue"
-
-#~ msgid "Deployment Config"
-#~ msgstr "Configuración de Despliegue"
-
-#~ msgid "Deployment Configs"
-#~ msgstr "Configuración de despliegue"
-
-#~ msgid "Description:"
-#~ msgstr "Descripción:"
-
-#~ msgid "Disk Utilization: $0%"
-#~ msgstr "Uso de disco: $0%"
-
-#~ msgid "Display name"
-#~ msgstr "Visualizar nombre"
-
-#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-#~ msgstr "¿Desea añadir el rol? '{{ fields.displayRole }}'?"
-
-#~ msgid ""
-#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
-#~ "metadata.name}}' image stream?"
-#~ msgstr ""
-#~ "¿Desea eliminar el flujo de imagen '{{stream.metadata.namespace}}/"
-#~ "{{stream.metadata.name}}' ?"
-
-#~ msgid ""
-#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-#~ msgstr "¿Desea eliminar el Volumen Persitente '{{item.metadata.name}}'?"
-
-#~ msgid ""
-#~ "Do you want to delete the Persistent Volume Claim '{{item.metadata."
-#~ "name}}'?"
-#~ msgstr ""
-#~ "¿Desea eliminar la Reclamación de Volumen Persistente '{{item.metadata."
-#~ "name}}'?"
-
-#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-#~ msgstr "¿Desea eliminar {{ item.kind }} '{{item.metadata.name}}'?"
-
-#~ msgid "Do you want to delete this Node?"
-#~ msgstr "¿Desea eliminar este Nodo?"
-
-#~ msgid ""
-#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
-#~ msgstr ""
-#~ "¿Desea borrar la imagen etiquetada como '{{stream.metadata.namespace}}/"
-#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
-
-#~ msgid ""
-#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
-#~ "{{ fields.member.metadata.name }}?"
-#~ msgstr ""
-#~ "¿Desea borrar el rol '{{ fields.displayRole }}' del miembro {{ fields."
-#~ "member.metadata.name }}?"
-
-#~ msgid "Don't pull images automatically"
-#~ msgstr "No tire de las imágenes automáticamente"
-
-#~ msgid "Driver"
-#~ msgstr "Driver"
-
-#~ msgid "Edit the vdsm.conf"
-#~ msgstr "Editar vdsm.conf"
-
-#~ msgid "Empty Directory"
-#~ msgstr "Directorio vació"
-
-#~ msgid "Endpoint"
-#~ msgstr "Punto final"
-
-#~ msgid "Endpoint Name"
-#~ msgstr "Nombre del Punto final"
-
-#~ msgid "Endpoints"
-#~ msgstr "Puntos finales"
-
-#~ msgid "Ends"
-#~ msgstr "Finales"
-
-#~ msgid "Enter New VM name"
-#~ msgstr "Introducir Nuevo nombre de VM"
-
-#~ msgid "Error getting certificate details: $0"
-#~ msgstr "Error al obtener los detalles del certificado: $0"
-
-#~ msgid "Error writing kubectl config"
-#~ msgstr "Error escribiendo configuración de kubectl"
-
-#~ msgid "FQDN"
-#~ msgstr "FQDN"
-
-#~ msgid "Fibre Channel"
-#~ msgstr "Canal de Fibra"
-
-#~ msgid "Filesystem Type"
-#~ msgstr "Tipo de Sistema de archivos"
-
-#~ msgid "Flex"
-#~ msgstr "Flex"
-
-#~ msgid "Flocker"
-#~ msgstr "Flocker"
-
-#~ msgid "Flocker Dataset Name"
-#~ msgstr "Nombre del Conjunto de Datos Flocker"
-
-#~ msgid "GCE Persistent Disk"
-#~ msgstr "Disco GCE Persistente"
-
-#~ msgid "Git Repository"
-#~ msgstr "Repositorio Git"
-
-#~ msgid "Gluster FS"
-#~ msgstr "Gluster FS"
-
-#~ msgid "GlusterFS"
-#~ msgstr "GlusterFS"
-
-#~ msgid "Grant additional push or admin access to specific members below."
-#~ msgstr ""
-#~ "Obtener empuje adicional o administrar el acceso a los miembros "
-#~ "específicos de abajo."
-
-#~ msgid "Group Members"
-#~ msgstr "Miembros del Grupo"
-
-#~ msgid "Group or Project"
-#~ msgstr "Grupo o Proyecto"
-
-#~ msgid "Groups"
-#~ msgstr "Grupos"
-
-#~ msgid "HA"
-#~ msgstr "HA"
-
-#~ msgid "HA:"
-#~ msgstr "HA:"
-
-#~ msgid "Host Path"
-#~ msgstr "Trayecto del anfitrión"
-
-#~ msgid "Host to Maintenance"
-#~ msgstr "Host para Mantenimiento"
-
-#~ msgid "IP"
-#~ msgstr "IP"
-
-#~ msgid "ISCSI"
-#~ msgstr "ISCSI"
-
-#~ msgid "Identities"
-#~ msgstr "Identidades"
-
-#~ msgid "Identity"
-#~ msgstr "Identidad"
-
-#~ msgid "Image ID"
-#~ msgstr "ID de Imagen"
-
-#~ msgid "Image Name"
-#~ msgstr "Nombre de Imagen"
-
-#~ msgid "Image Registry"
-#~ msgstr "Registro de Imagen"
-
-#~ msgid "Image Stream"
-#~ msgstr "Corriente de Imagen"
-
-#~ msgid "Image commands"
-#~ msgstr "Órdenes de imagen"
-
-#~ msgid "Images by project"
-#~ msgstr "Imágenes por proyecto"
-
-#~ msgid "Images pushed recently"
-#~ msgstr "Imágenes utilizadas recientemente"
-
-#~ msgid ""
-#~ "In order to begin pushing images to the registry, use the commands below."
-#~ msgstr ""
-#~ "Para comenzar a insertar imágenes en el registro, utilice las órdenes "
-#~ "siguientes."
-
-#~ msgid ""
-#~ "In order to begin pushing images to the registry, you need to create a "
-#~ "project."
-#~ msgstr ""
-#~ "Con el objetivo de llevar imágenes al registro, usted necesita crear un "
-#~ "proyecto."
-
-#~ msgid "Installed products"
-#~ msgstr "Productos instalados"
-
-#~ msgid "Interface"
-#~ msgstr "Interfaz"
-
-#~ msgid "Invalid credentials"
-#~ msgstr "Las credenciales no son válidas"
-
-#~ msgid "Kernel Version"
-#~ msgstr "Versión del núcleo"
-
-#~ msgid "Key Ring Path"
-#~ msgstr "Trayecto del llavero"
-
-#~ msgid "Kubelet Version"
-#~ msgstr "Versión de Kubelet"
-
-#~ msgid "Kubernetes Cluster"
-#~ msgstr "Cluster de Kubernetes"
-
-#~ msgid "Last Heartbeat"
-#~ msgstr "Último Heartbeat"
-
-#~ msgid "Last Status Change"
-#~ msgstr "Último Cambio de Estado"
-
-#~ msgid "Latest Version"
-#~ msgstr "Última Versión"
-
-#~ msgid "Loading data ..."
-#~ msgstr "Cargando datos ..."
-
-#~ msgid "Log into OpenShift command line tools:"
-#~ msgstr "Ingrese a las herramientas de consola de OpenShift:"
-
-#~ msgid "Log into the registry:"
-#~ msgstr "Iniciar sesión en el registro:"
-
-#~ msgid "Logical Unit Number"
-#~ msgstr "Número de unidad lógica"
-
-#~ msgid "Login"
-#~ msgstr "Ingresar"
-
-#~ msgid "Login commands"
-#~ msgstr "Órdenes de ingreso"
-
-#~ msgid "Login/password or activation key required to register."
-#~ msgstr ""
-#~ "Para registrarse es necesario un usuario y contraseña o una clave de "
-#~ "activación."
-
-#~ msgid "MIGRATE action failed"
-#~ msgstr "Fallo en acción MIGRATE"
-
-#~ msgid "Manifest"
-#~ msgstr "Manifiesto"
-
-#~ msgid "Medium"
-#~ msgstr "Medio"
-
-#~ msgid "Member of"
-#~ msgstr "Miembro de"
-
-#~ msgid "Members"
-#~ msgstr "Miembros"
-
-#~ msgid "Membership"
-#~ msgstr "Afiliación"
-
-#~ msgid "Memory Utilization: $0%"
-#~ msgstr "Uso de memoria: $0%"
-
-#~ msgid "Message"
-#~ msgstr "Mensaje"
-
-#~ msgid "Migrate To:"
-#~ msgstr "Migrar A:"
-
-#~ msgid "Modify"
-#~ msgstr "Modificar"
-
-#~ msgid "Monitors"
-#~ msgstr "Monitores"
-
-#~ msgid "Mount Location"
-#~ msgstr "Ubicación de montaje"
-
-#~ msgid "NFS"
-#~ msgstr "NFS"
-
-#~ msgid "Namespace"
-#~ msgstr "Espacio de Nombres"
-
-#~ msgid "Namespace cannot be empty."
-#~ msgstr "El nombre de espacio no puede estar vacio"
-
-#~ msgid "New Group"
-#~ msgstr "Grupo nuevo"
-
-#~ msgid "New Project"
-#~ msgstr "Proyecto nuevo"
-
-#~ msgid "New image stream"
-#~ msgstr "Flujo de imágenes nuevo"
-
-#~ msgid "New project"
-#~ msgstr "Nuevo proyecto"
-
-#~ msgid "No PEM-encoded certificate found"
-#~ msgstr "No se encontró certificado cifrado con PEM"
-
-#~ msgid "No PEM-encoded private key found"
-#~ msgstr "No se encontró llave privada cifrada con PEM"
-
-#~ msgid "No Pods are using this claim"
-#~ msgstr "Ningún Pods está usando este reclamo"
-
-#~ msgid "No VM found in oVirt."
-#~ msgstr "Mo se ha encontrado VM en oVirt."
-
-#~ msgid "No Volume Bound"
-#~ msgstr "No hay ningún vínculo de volumen"
-
-#~ msgid "No groups are present."
-#~ msgstr "No hay ningún grupo presente."
-
-#~ msgid "No images pushed"
-#~ msgstr "Sin imágenes empujadas"
-
-#~ msgid "No installed products on the system."
-#~ msgstr "No hay ningún producto instalado en el sistema."
-
-#~ msgid ""
-#~ "No metadata file was selected. Please select a Kubernetes metadata file."
-#~ msgstr ""
-#~ "No se seleccionó un archivo metadata. Por favor seleccione un archivo "
-#~ "metadata Kebernetes."
-
-#~ msgid "No nodes in cluster"
-#~ msgstr "No hay  nodos en el cluster"
-
-#~ msgid "No oVirt connection"
-#~ msgstr "Sin conexión oVirt"
-
-#~ msgid "No pods deployed"
-#~ msgstr "No se han desplegado pods"
-
-#~ msgid "No pods replicated"
-#~ msgstr "No se han replicado pods"
-
-#~ msgid "No pods scheduled"
-#~ msgstr "Sin pods planificados"
-
-#~ msgid "No pods selected"
-#~ msgstr "Sin pods seleccionados"
-
-#~ msgid "No projects are present."
-#~ msgstr "No hay proyectos presentes."
-
-#~ msgid "No users are present."
-#~ msgstr "No hay usuarios presentes."
-
-#~ msgid "No volumes are present."
-#~ msgstr "No hay volúmenes presentes."
-
-#~ msgid "No volumes in use"
-#~ msgstr "No hay volúmenes en uso"
-
-#~ msgid "Node"
-#~ msgstr "Nodo"
-
-#~ msgid "Nodes"
-#~ msgstr "Nodos"
-
-#~ msgid "Nodes are the machines that run your containers."
-#~ msgstr "Nodos son las computadoras que ejecutan sus contenedores"
-
-#~ msgid "Not a valid number of replicas"
-#~ msgstr "No es un número válido de réplicas"
-
-#~ msgid "Not a valid value for Host"
-#~ msgstr "No es un valor valido para el host"
-
-#~ msgid "Not deployed"
-#~ msgstr "No distribuido"
-
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#~ msgid "Number of virtual CPUs that gonna be used."
-#~ msgstr "Número de CPU virtuales que se usarán."
-
-#~ msgid "OK"
-#~ msgstr "OK"
-
-#~ msgid "OS"
-#~ msgstr "SO"
-
-#~ msgid "OS Type:"
-#~ msgstr "Tipo de SO:"
-
-#~ msgid "OS Versions"
-#~ msgstr "Versiones de SO"
-
-#~ msgid "Optimized for:"
-#~ msgstr "Optimizado para:"
-
-#~ msgid "Organization"
-#~ msgstr "Organización"
-
-#~ msgid "PD Name"
-#~ msgstr "Nombre de PD"
-
-#~ msgid "Pending Volume Claims"
-#~ msgstr "Reclamaciones de Volumen Pendientes"
-
-#~ msgid "Persistent Volumes"
-#~ msgstr "Volúmenes persistentes"
-
-#~ msgid "Phase"
-#~ msgstr "Fase"
-
-#~ msgid "Please confirm, the host shall be switched to maintenance mode."
-#~ msgstr "Por favor confirme que el host será conmutado a modo mantenimiento."
-
-#~ msgid "Please create another namespace for $0 \"$1\""
-#~ msgstr "Por favor cree otro nombre de espacio para $0 \"$1\""
-
-#~ msgid "Please provide a GlusterFS volume name"
-#~ msgstr "Por favor provea un nombre de volumen GlusterFS"
-
-#~ msgid "Please provide a username"
-#~ msgstr "Provea un nombre de usuario"
-
-#~ msgid "Please provide a valid NFS server"
-#~ msgstr "Por favor provea un servidos NFS valido"
-
-#~ msgid "Please provide a valid address"
-#~ msgstr "Provea una dirección valida"
-
-#~ msgid "Please provide a valid filesystem type"
-#~ msgstr "Por favor provea un tipo de sistema de archivos valido"
-
-#~ msgid "Please provide a valid interface"
-#~ msgstr "Por favor provea una interfaz valida"
-
-#~ msgid "Please provide a valid logical unit number"
-#~ msgstr "Por favor provea un número valido de unidad lógica"
-
-#~ msgid "Please provide a valid name"
-#~ msgstr "Por favor provea un nombre valido"
-
-#~ msgid "Please provide a valid namespace."
-#~ msgstr "Por favor provea un nombre de espacio valido"
-
-#~ msgid "Please provide a valid path"
-#~ msgstr "Proporcione un trayecto válido"
-
-#~ msgid "Please provide a valid qualified name"
-#~ msgstr "Por favor provea un nombre cualifica valido"
-
-#~ msgid "Please provide a valid storage capacity."
-#~ msgstr "Por favor provea una capacidad de almacenamiento valida."
-
-#~ msgid "Please provide a valid target"
-#~ msgstr "Por favor provea un objetivo valido"
-
-#~ msgid ""
-#~ "Please provide fully qualified domain name and port of the oVirt engine."
-#~ msgstr ""
-#~ "Por favor suministre el nombre completo de dominio y el puerto de la "
-#~ "máquina oVirt."
-
-#~ msgid ""
-#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-#~ "port (443 by default)"
-#~ msgstr ""
-#~ "Por favor suministre un nombre de dominio totalmente cualificado (FQDN) "
-#~ "de la máquina oVirt y puerto (443 por defecto)"
-
-#~ msgid ""
-#~ "Please refer to oVirt's $0 for more information about Remote Viewer setup."
-#~ msgstr ""
-#~ "Por favor vea $0 de oVirt para más información sobre el ajuste del "
-#~ "Visualizador Remoto."
-
-#~ msgid "Please select a valid access mode"
-#~ msgstr "Por favor seleccionar un modo de acceso valido"
-
-#~ msgid "Please select a valid endpoint"
-#~ msgstr "Por favor seleccione un punto final válido"
-
-#~ msgid "Please select a valid policy option."
-#~ msgstr "Por favor provea una opción de política valida."
-
-#~ msgid "Please type an address"
-#~ msgstr "Por favor escriba una dirección"
-
-#~ msgid "Please wait till VMs list is loaded from the server."
-#~ msgstr ""
-#~ "Por favor espere hasta que la lista VMs se cargue desde el servidor."
-
-#~ msgid "Please wait till list of templates is loaded from the server."
-#~ msgstr ""
-#~ "Por favor espere hasta que la lista de plantilla se cargue desde el "
-#~ "servidor."
-
-#~ msgid "Pod"
-#~ msgstr "Ranura"
-
-#~ msgid "Pod Address"
-#~ msgstr "Dirección del Pod"
-
-#~ msgid "Pod Endpoints"
-#~ msgstr "Puntos Finales del Pod"
-
-#~ msgid "Pod Replicated"
-#~ msgstr "Pod Replicado"
-
-#~ msgid "Pod Selector"
-#~ msgstr "Selector de Pod"
-
-#~ msgid "Pods"
-#~ msgstr "Ranuras"
-
-#~ msgid ""
-#~ "Pods contain one or more containers that run together on a node, "
-#~ "containing your application code."
-#~ msgstr ""
-#~ "Pods contienen uno o mas contenedores que corren juntos sobre un nodo, "
-#~ "conteniendo su código de aplicación."
-
-#~ msgid "Pool Name"
-#~ msgstr "Nombre del grupo"
-
-#~ msgid "Populate"
-#~ msgstr "Rellenar"
-
-#~ msgid "Preparing for Maintenance"
-#~ msgstr "Preparando para Mantenimiento"
-
-#~ msgid "Private: Allow only specific users or groups to pull images"
-#~ msgstr ""
-#~ "Privado: Permite sólo a usuarios o grupos específicos tirar imágenes"
-
-#~ msgid "Product ID"
-#~ msgstr "ID del Producto"
-
-#~ msgid "Product name"
-#~ msgstr "Nombre del Producto"
-
-#~ msgid "Project"
-#~ msgstr "Proyecto"
-
-#~ msgid "Project Members"
-#~ msgstr "Miembros del Proyecto"
-
-#~ msgid "Project access policy allows anonymous users to pull images."
-#~ msgstr ""
-#~ "Proyecto de política de acceso que permite a usuarios anónimos quitar "
-#~ "imágenes."
-
-#~ msgid "Project access policy allows any authenticated user to pull images."
-#~ msgstr ""
-#~ "Proyecto de política de acceso permite a cualquier usuario autenticado "
-#~ "quitar imágenes."
-
-#~ msgid "Project access policy only allows specific members to access images."
-#~ msgstr ""
-#~ "Proyecto de política de acceso permite sólo a miembros específicos "
-#~ "acceder a imágenes."
-
-#~ msgid "Project:"
-#~ msgstr "Proyecto:"
-
-#~ msgid "Projects"
-#~ msgstr "Proyectos"
-
-#~ msgid "Proxy"
-#~ msgstr "Proxy"
-
-#~ msgid "Proxy Version"
-#~ msgstr "Versión de Proxy"
-
-#~ msgid "Pull an image:"
-#~ msgstr "Halar una imagen:"
-
-#~ msgid "Pull from"
-#~ msgstr "Extraer desde"
-
-#~ msgid "Pull specific tags from another image repository"
-#~ msgstr "Extraer etiquetas específicas desde otro repositorio de imágenes"
-
-#~ msgid "Push an image:"
-#~ msgstr "Empujar una imagen:"
-
-#~ msgid "Qualified Name"
-#~ msgstr "Nombre Cualificado"
-
-#~ msgid "REBOOT action failed"
-#~ msgstr "REBOOT falló acción"
-
-#~ msgid "Rados Block Device"
-#~ msgstr "Dispositivo de Bloque Rados"
-
-#~ msgid "Read Only"
-#~ msgstr "Solo lectura"
-
-#~ msgid "Read and write from a single node"
-#~ msgstr "Lectura y escritura para un solo nodo."
-
-#~ msgid "Read and write from multiple nodes"
-#~ msgstr "Lectura y escritura para nodos multiples"
-
-#~ msgid "Read only from multiple nodes"
-#~ msgstr "Sólo lectura para nodos múltiples"
-
-#~ msgid "Reason"
-#~ msgstr "Razón"
-
-#~ msgid "Reclaim Policy"
-#~ msgstr "Normativa de reclamación"
-
-#~ msgid "Recycle"
-#~ msgstr "Reciclar"
-
-#~ msgid "Register"
-#~ msgstr "Registrar"
-
-#~ msgid "Register New Volume"
-#~ msgstr "Registrar volumen nuevo"
-
-#~ msgid "Register Persistent Volume"
-#~ msgstr "Registrar volumen persistente"
-
-#~ msgid "Register oVirt"
-#~ msgstr "Registrar oVirt"
-
-#~ msgid "Register system"
-#~ msgstr "Registrar sistema"
-
-#~ msgid "Registering oVirt to Cockpit"
-#~ msgstr "Registrando oVirt a Cockpit"
-
-#~ msgid "Remote registry is insecure"
-#~ msgstr "El registro remoto es inseguro"
-
-#~ msgid "Remove Group"
-#~ msgstr "Quitar Grupo"
-
-#~ msgid "Remove Member"
-#~ msgstr "Quitar miembro"
-
-#~ msgid "Remove Role"
-#~ msgstr "Quitar rol"
-
-#~ msgid "Remove User"
-#~ msgstr "Quitar usuario"
-
-#~ msgid "Remove image tag"
-#~ msgstr "Remover etiqueta de imagen"
-
-#~ msgid "Remove membership"
-#~ msgstr "Quitar afiliación"
-
-#~ msgid "Replicas"
-#~ msgstr "Réplicas"
-
-#~ msgid "Replication Controller"
-#~ msgstr "Contolador de replicación"
-
-#~ msgid "Replication Controllers"
-#~ msgstr "Controladores de replicación"
-
-#~ msgid ""
-#~ "Replication controllers dynamically create instances of pods from "
-#~ "templates, and remove pods when necessary."
-#~ msgstr ""
-#~ "Los controladores de replicación crean dinámicamente instancias de pods a "
-#~ "partir de plantillas y eliminan pods cuando es necesario."
-
-#~ msgid "Repository URL"
-#~ msgstr "URL del repositorio"
-
-#~ msgid "Requested"
-#~ msgstr "Solicitado"
-
-#~ msgid "Requests"
-#~ msgstr "Solicitudes"
-
-#~ msgid "Requires Authentication"
-#~ msgstr "Necesita autenticación"
-
-#~ msgid "Restart Count"
-#~ msgstr "Conteo de Reinicios"
-
-#~ msgid "Retain"
-#~ msgstr "Retener"
-
-#~ msgid "Retrieving subscription status..."
-#~ msgstr "Obteniendo el estado de la suscripción…"
-
-#~ msgid "Revision"
-#~ msgstr "Revisión"
-
-#~ msgid "Role"
-#~ msgstr "Rol"
-
-#~ msgid "Route"
-#~ msgstr "Ruta"
-
-#~ msgid "Run Here"
-#~ msgstr "Ejecutar Aquí"
-
-#~ msgid "Running Since:"
-#~ msgstr "Ejecutando Desde:"
-
-#~ msgid "SET VCPU SETTINGS action failed"
-#~ msgstr "Falló la acción SET VCPU SETTINGS"
-
-#~ msgid "SHUTDOWN action failed"
-#~ msgstr "SHUTDOWN acción fallada"
-
-#~ msgid "START action failed"
-#~ msgstr "START acción fallada"
-
-#~ msgid "SUSPEND action failed"
-#~ msgstr "SUSPEND acción fallada"
-
-#~ msgid "Scheduled Pods"
-#~ msgstr "Pods Programados"
-
-#~ msgid "Scheduling Disabled"
-#~ msgstr "Programación deshabilitada "
-
-#~ msgid "Secret"
-#~ msgstr "Secreto"
-
-#~ msgid "Secret File"
-#~ msgstr "Fichero Secreto"
-
-#~ msgid "Secret Name"
-#~ msgstr "Nombre Secreto"
-
-#~ msgid "Secret Volume"
-#~ msgstr "Volumen Secreto"
-
-#~ msgid "Select Manifest File..."
-#~ msgstr "Seleccione un archivo Manifiesto..."
-
-#~ msgid "Select Member"
-#~ msgstr "Seleccione Miembro"
-
-# auto translated by TM merge from project: Cockpit, version: rhel-8.0, DocId: cockpit
-#~ msgid "Select Role"
-#~ msgstr "Seleccionar Rol"
-
-#~ msgid "Select an object to see more details."
-#~ msgstr "Selecciona un objeto para ver mas detalles"
-
-#~ msgid "Service Account"
-#~ msgstr "Cuenta de servicio"
-
-#~ msgid ""
-#~ "Services group pods and provide a common DNS name and an optional, load-"
-#~ "balanced IP address to access them."
-#~ msgstr ""
-#~ "Agrupan pods de servicios y suministran un nombre DNS común y una "
-#~ "dirección IP opcional con balance de carga para acceder a ellos"
-
-#~ msgid "Session Affinity"
-#~ msgstr "Afinidad de Sesión"
-
-#~ msgid "Share Name"
-#~ msgstr "Nombre Compartido"
-
-#~ msgid "Shared: Allow any authenticated user to pull images"
-#~ msgstr ""
-#~ "Compartido: permitir a cualquier usuario autenticado extraer imágenes"
-
-#~ msgid "Shell"
-#~ msgstr "Shell"
-
-#~ msgid "Show all Containers"
-#~ msgstr "Mostrar todos los contenedores"
-
-#~ msgid "Show all Deployment Configs"
-#~ msgstr "Mostrar todas las configuraciones de distribución"
-
-#~ msgid "Show all Nodes"
-#~ msgstr "Mostrar todos los nodos"
-
-#~ msgid "Show all Persistent Volumes"
-#~ msgstr "Mostrar todos los volúmenes persistentes"
-
-#~ msgid "Show all Pod Containers"
-#~ msgstr "Mostrar todos los Pod Contenedores"
-
-#~ msgid "Show all Pods"
-#~ msgstr "Mostrar todos los Pods"
-
-#~ msgid "Show all Projects"
-#~ msgstr "Mostrar todos los proyectos"
-
-#~ msgid "Show all Replication Controllers"
-#~ msgstr "Mostrar todos los Controladores Replicantes"
-
-#~ msgid "Show all Routes"
-#~ msgstr "Mostrar todas las rutas"
-
-#~ msgid "Show all Services"
-#~ msgstr "Mostrar todos los servicios"
-
-#~ msgid "Show all image streams"
-#~ msgstr "Mostrar toda la secuencia de imagen"
-
-#~ msgid "Since"
-#~ msgstr "Desde"
-
-#~ msgid "Skip Certificate Verification"
-#~ msgstr "Saltar la Verificación de Certificado"
-
-#~ msgid "Sorry, I don't know how to modify this volume"
-#~ msgstr "Lo siento, no se como modificar este volumen"
-
-#~ msgid "Starts"
-#~ msgstr "Inicios"
-
-#~ msgid "Stateless"
-#~ msgstr "Sin estado"
-
-#~ msgid "Stateless:"
-#~ msgstr "Sin estado:"
-
-#~ msgid "Status: $0"
-#~ msgstr "Estado: $0"
-
-#~ msgid "Status: System isn't registered"
-#~ msgstr "Estado: El sistema no está registrado"
-
-#~ msgid "Strategy"
-#~ msgstr "Estrategia"
-
-#~ msgid "Subscriptions"
-#~ msgstr "Suscripciones"
-
-#~ msgid "Suspend"
-#~ msgstr "Suspendido"
-
-#~ msgid "Switch Host to Maintenance"
-#~ msgstr "Conmutar el Host para Mantenimiento"
-
-#~ msgid "Switching host to maintenance mode failed. Received error: "
-#~ msgstr ""
-#~ "La conmutación del host para modo de mantenimiento fallo. Error recibido:"
-
-#~ msgid "Switching host to maintenance mode in progress ..."
-#~ msgstr "La conmutación del host a modo mantenimiento progresando..."
-
-#~ msgid "Sync all tags from a remote image repository"
-#~ msgstr ""
-#~ "Sincronizar todas las etiquetas desde un repositorio de imagen remoto"
-
-#~ msgid "TLS Termination"
-#~ msgstr "Terminación TLS"
-
-#~ msgid "Target Portal"
-#~ msgstr "Portal Objetivo"
-
-#~ msgid "Target World Wide Names"
-#~ msgstr "Nombres Objetivo en todo el Mundo"
-
-#~ msgid "Template"
-#~ msgstr "Plantilla"
-
-#~ msgid "Templates"
-#~ msgstr "Plantillas"
-
-#~ msgid "Templates of $0 cluster"
-#~ msgstr "Plantilla de cluster $0"
-
-#~ msgid "The address contains invalid characters"
-#~ msgstr "La dirección contiene caracteres inválidos"
-
-#~ msgid "The container '{{ target }}' does not exist."
-#~ msgstr "El contenedor '{{ target }}' no existe."
-
-#~ msgid "The current user isn't allowed to access system subscription status."
-#~ msgstr ""
-#~ "El usuario actual no tiene permitido acceder al estado de suscripción al "
-#~ "sistema."
-
-#~ msgid "The deployment config '{{ target }}' does not exist."
-#~ msgstr "La configuración de despliegue '{{ target }}' no existe."
-
-#~ msgid "The group '{{ groupName }}' does not exist."
-#~ msgstr "El grupo '{{ groupName }}' no existe."
-
-#~ msgid "The maximum number of replicas is 128"
-#~ msgstr "El número maximo de replicas es 128"
-
-#~ msgid "The name contains invalid characters"
-#~ msgstr "El nombre contiene caracteres invalidos"
-
-#~ msgid "The node '{{ target }}' does not exist."
-#~ msgstr "El nodo '{{ target }}' no existe."
-
-#~ msgid "The node doesn't have enough disk space"
-#~ msgstr "El nodo no tiene bastante espacio de disco"
-
-#~ msgid "The node doesn't have enough free memory"
-#~ msgstr "El nodo no tiene bastante memoria libre"
-
-#~ msgid "The persistent volume '{{ target }}' does not exist."
-#~ msgstr "El volumen presistente '{{ target }}' no existe."
-
-#~ msgid "The pod '{{ target }}' does not exist."
-#~ msgstr "El pod '{{ target }}' no existe."
-
-#~ msgid "The project '{{ projName }}' does not exist."
-#~ msgstr "El proyecto '{{ projName }}' no existe."
-
-#~ msgid "The replication controller '{{ target }}' does not exist."
-#~ msgstr "El controlador de replica '{{ target }}' no existe."
-
-#~ msgid "The route '{{ target }}' does not exist."
-#~ msgstr "La ruta '{{ target }}' no existe."
-
-#~ msgid "The selected file is not a valid Kubernetes application manifest."
-#~ msgstr ""
-#~ "El archivo seleccionado no es un archivo de manifiesto de aplicación "
-#~ "kubernetes valido"
-
-#~ msgid "The server uses a certificate signed by an unknown authority."
-#~ msgstr ""
-#~ "El servidor usa un certificado firmado por una autoridad desconocida."
-
-#~ msgid "The service '{{ target }}' does not exist."
-#~ msgstr "El servicio '{{ target }}' no existe."
-
-#~ msgid "The user '{{ userName }}' does not exist."
-#~ msgstr "El usuario '{{ userName }}' no existe."
-
-#~ msgid ""
-#~ "This claim is in use. Deleting it may cause issues with the following pod:"
-#~ msgstr ""
-#~ "Esta reclamo está en uso. Borrarlo puede causar problemas con los "
-#~ "siguientes pod:"
-
-#~ msgid ""
-#~ "This host is managed by a virtualization manager, so creation of new VMs "
-#~ "from the host is not possible."
-#~ msgstr ""
-#~ "Este host está gestionado por un gestor de virtualización de modo que la "
-#~ "creación de nuevas VMs desde este host no es posible."
-
-#~ msgid ""
-#~ "This option is for single node testing only – local storage will not work "
-#~ "in a multi-node cluster"
-#~ msgstr ""
-#~ "Esta opción es para probar un único nodo solo – el almacenamiento local "
-#~ "no trabajará en un clúster multi nodo"
-
-#~ msgid "This virtual machine is not managed by oVirt"
-#~ msgstr "Esta máquina virtual no está gestionada por oVirt"
-
-#~ msgid ""
-#~ "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-#~ "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-#~ "may cause issues with any pods depending on it."
-#~ msgstr ""
-#~ "Este volumen ha sido reclamado por {{ item.item.spec.claimRef."
-#~ "namespace }} / {{ item.item.spec.claimRef.name }}. Eliminarlo romperá el "
-#~ "reclamo y puede causar problemas en cualquier pod que dependa de él."
-
-#~ msgid "This volume has not been claimed"
-#~ msgstr "Este volumen ni ha sido reclamado"
-
-#~ msgid "Token"
-#~ msgstr "Ficha"
-
-#~ msgid "Topology"
-#~ msgstr "Topología"
-
-#~ msgid "Trust this certificate for this connection"
-#~ msgstr "Confía en este certificado para esta conexión"
-
-#~ msgid "Type:"
-#~ msgstr "Teclear:"
-
-#~ msgid "Unable to connect"
-#~ msgstr "Incapaz de conectar"
-
-#~ msgid "Unable to decode Kubernetes application manifest."
-#~ msgstr "No es posible decodificar el manifiesto de Kubernetes."
-
-#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
-#~ msgstr ""
-#~ "No es posible leer el manifiesto de la aplicación Kubernetes. Código $0."
-
-#~ msgid "Unregister"
-#~ msgstr "No registrado"
-
-#~ msgid "Unregistering system..."
-#~ msgstr "Des-registrando sistema..."
-
-#~ msgid "Updating $0..."
-#~ msgstr "Actualizando $0..."
-
-#~ msgid "Use proxy server"
-#~ msgstr "Usar servidor proxy"
-
-#~ msgid "User or Group"
-#~ msgstr "Usuario o Grupo"
-
-#~ msgid "Users"
-#~ msgstr "Usuarios"
-
-#~ msgid "VDSM"
-#~ msgstr "VDSM"
-
-#~ msgid "VDSM Service Management"
-#~ msgstr "Gestión de Servicio VDSM"
-
-#~ msgid "VM icon"
-#~ msgstr "Icono VM"
-
-#~ msgid "Version num"
-#~ msgstr "Número de Versión"
-
-#~ msgid "Virtual Machines of $0 cluster"
-#~ msgstr "Máquinas Virtuales de $0 cluster"
-
-#~ msgid "Volume ID"
-#~ msgstr "ID de Volumen"
-
-#~ msgid "Volume Name"
-#~ msgstr "Nombre de Volumen"
-
-#~ msgid "Volume Type"
-#~ msgstr "Tipo de Volumen"
-
-#~ msgid "Warning:"
-#~ msgstr "Precaución:"
-
-#~ msgid "Welcome to the Image Registry"
-#~ msgstr "Bienvenidos al Registro de Imagen"
-
-#~ msgid "When"
-#~ msgstr "Cuando"
-
-#~ msgid ""
-#~ "You can bypass the certificate check, but any data you send to the server "
-#~ "could be intercepted by others."
-#~ msgstr ""
-#~ "Usted puede evitar la comprobación del certificado, pero cualquier datos "
-#~ "que envíe al servidor podría ser interceptado por otros."
-
-#~ msgid "You can deploy an application to your cluster."
-#~ msgstr "Tu puedes desplegar una aplicación a tu cluster"
-
-#~ msgid ""
-#~ "Your login credentials do not give you access to use the docker registry "
-#~ "from the command line."
-#~ msgstr ""
-#~ "Sus credenciales de acceso no le conceden acceso para utilizar el "
-#~ "registro de Docker a partir de la consola."
-
-#~ msgid "connecting"
-#~ msgstr "conectando"
-
-#~ msgid "cores"
-#~ msgstr "núcleos"
-
-#~ msgid "eg: my-image-stream"
-#~ msgstr "eg: mi secuencia de imagen"
-
-#~ msgid "error"
-#~ msgstr "error"
-
-#~ msgid "initializing"
-#~ msgstr "inicializando"
-
-#~ msgid "installation failed"
-#~ msgstr "instalación fallada"
-
-#~ msgid "installing OS"
-#~ msgstr "instalando SO"
-
-#~ msgid "kdumping"
-#~ msgstr "kdumping"
-
-#~ msgid "maintenance"
-#~ msgstr "mantenimiento"
-
-#~ msgid "non operational"
-#~ msgstr "no operativo"
-
-#~ msgid "non responsive"
-#~ msgstr "sin respuesta"
-
-#~ msgid "oVirt"
-#~ msgstr "oVirt"
-
-#~ msgid "oVirt Host State:"
-#~ msgstr "Estado del Huésped oVirt:"
-
-#~ msgid "oVirt Provider installation script failed due to missing arguments."
-#~ msgstr ""
-#~ "oVirt Provider el script de instalación falló debido a argumentos "
-#~ "perdidos."
-
-#~ msgid ""
-#~ "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-#~ "machines-ovirt.config, try as root."
-#~ msgstr ""
-#~ "oVirt Provider el script de instalación falló: No puede escribir en /etc/"
-#~ "cockpit/machines-ovirt.config, inténtelo como root."
-
-#~ msgid "oVirt installation script failed with following output: "
-#~ msgstr "oVirt script de instalación falló con la siguiente salida: "
-
-#~ msgid "pending approval"
-#~ msgstr "pendiente de aprobación"
-
-#~ msgid "pending volume claims"
-#~ msgstr "pendiente de reclamación de volumen"
-
-#~ msgid "reboot"
-#~ msgstr "reiniciar"
-
-#~ msgid "sockets"
-#~ msgstr "enchufes"
-
-#~ msgid "threads"
-#~ msgstr "hilos"
-
-#~ msgid "unassigned"
-#~ msgstr "no asignado"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 08:58+0200\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "PO-Revision-Date: 2018-05-12 02:23+0000\n"
 "Last-Translator: Jiri Grönroos <jiri.gronroos@iki.fi>\n"
 "Language-Team: Finnish\n"
 "Language: fi\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
@@ -49,7 +49,7 @@ msgid_plural "$0 Packages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/init.js:395 pkg/systemd/init.js:749
+#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "$0 mallipohja"
 
@@ -128,10 +128,10 @@ msgstr ""
 "GNOME Softwaresta, tai aja seuraava komento:"
 
 #: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
-#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
+#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
+#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
+#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
 msgid "$0 is in active use"
 msgstr "$0 on aktiivisessa käytössä"
 
@@ -143,7 +143,7 @@ msgstr ""
 msgid "$0 killed with signal $1"
 msgstr "$0 tapettu signaalilla $1"
 
-#: pkg/selinux/setroubleshoot-view.jsx:429
+#: pkg/selinux/setroubleshoot-view.jsx:439
 msgid "$0 occurrence"
 msgid_plural "$1 occurrences"
 msgstr[0] "$0 tapahtuma"
@@ -185,7 +185,7 @@ msgid_plural "$1 security fixes"
 msgstr[0] "$1 turvallisuuspäivitys"
 msgstr[1] "$1 turvallisuuspäivitykset"
 
-#: pkg/networkmanager/interfaces.js:2757
+#: pkg/networkmanager/interfaces.js:2769
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -201,11 +201,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:549
+#: pkg/networkmanager/firewall.jsx:574
 msgid "(Optional)"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
+#: pkg/networkmanager/firewall.jsx:499 pkg/networkmanager/firewall.jsx:648
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(oletus)"
@@ -244,7 +244,7 @@ msgstr "1 päivä"
 msgid "1 hour"
 msgstr "1 tunti"
 
-#: pkg/systemd/host.js:1669
+#: pkg/systemd/host.js:1686
 msgid "1 min"
 msgstr "1 min"
 
@@ -254,11 +254,11 @@ msgstr "1 min"
 msgid "1 week"
 msgstr "1 viikko"
 
-#: pkg/systemd/services.html:273
+#: pkg/systemd/services.html:165
 msgid "10th"
 msgstr "10."
 
-#: pkg/systemd/services.html:274
+#: pkg/systemd/services.html:166
 msgid "11th"
 msgstr "11."
 
@@ -266,19 +266,19 @@ msgstr "11."
 msgid "128 KiB"
 msgstr "128 KiB"
 
-#: pkg/systemd/services.html:275
+#: pkg/systemd/services.html:167
 msgid "12th"
 msgstr "12."
 
-#: pkg/systemd/services.html:276
+#: pkg/systemd/services.html:168
 msgid "13th"
 msgstr "13."
 
-#: pkg/systemd/services.html:277
+#: pkg/systemd/services.html:169
 msgid "14th"
 msgstr "14."
 
-#: pkg/systemd/services.html:278
+#: pkg/systemd/services.html:170
 msgid "15th"
 msgstr "15."
 
@@ -286,23 +286,23 @@ msgstr "15."
 msgid "16 KiB"
 msgstr "16 KiB"
 
-#: pkg/systemd/services.html:279
+#: pkg/systemd/services.html:171
 msgid "16th"
 msgstr "16."
 
-#: pkg/systemd/services.html:280
+#: pkg/systemd/services.html:172
 msgid "17th"
 msgstr "17."
 
-#: pkg/systemd/services.html:281
+#: pkg/systemd/services.html:173
 msgid "18th"
 msgstr "18."
 
-#: pkg/systemd/services.html:282
+#: pkg/systemd/services.html:174
 msgid "19th"
 msgstr "19."
 
-#: pkg/systemd/services.html:264
+#: pkg/systemd/services.html:156
 msgid "1st"
 msgstr "1."
 
@@ -310,7 +310,7 @@ msgstr "1."
 msgid "2 MiB"
 msgstr "2 MiB"
 
-#: pkg/systemd/host.js:1668
+#: pkg/systemd/host.js:1685
 msgid "2 min"
 msgstr "2 min"
 
@@ -318,59 +318,59 @@ msgstr "2 min"
 msgid "20 Minutes"
 msgstr "20 minuuttia"
 
-#: pkg/systemd/services.html:283
+#: pkg/systemd/services.html:175
 msgid "20th"
 msgstr "20."
 
-#: pkg/systemd/services.html:284
+#: pkg/systemd/services.html:176
 msgid "21st"
 msgstr "21."
 
-#: pkg/systemd/services.html:285
+#: pkg/systemd/services.html:177
 msgid "22nd"
 msgstr "22."
 
-#: pkg/systemd/services.html:286
+#: pkg/systemd/services.html:178
 msgid "23rd"
 msgstr "23."
 
-#: pkg/systemd/services.html:287
+#: pkg/systemd/services.html:179
 msgid "24th"
 msgstr "24."
 
-#: pkg/systemd/services.html:288
+#: pkg/systemd/services.html:180
 msgid "25th"
 msgstr "25."
 
-#: pkg/systemd/services.html:289
+#: pkg/systemd/services.html:181
 msgid "26th"
 msgstr "26."
 
-#: pkg/systemd/services.html:290
+#: pkg/systemd/services.html:182
 msgid "27th"
 msgstr "27."
 
-#: pkg/systemd/services.html:291
+#: pkg/systemd/services.html:183
 msgid "28th"
 msgstr "28."
 
-#: pkg/systemd/services.html:292
+#: pkg/systemd/services.html:184
 msgid "29th"
 msgstr "29."
 
-#: pkg/systemd/services.html:265
+#: pkg/systemd/services.html:157
 msgid "2nd"
 msgstr "2."
 
-#: pkg/systemd/host.js:1667
+#: pkg/systemd/host.js:1684
 msgid "3 min"
 msgstr "3 min"
 
-#: pkg/systemd/services.html:293
+#: pkg/systemd/services.html:185
 msgid "30th"
 msgstr "30."
 
-#: pkg/systemd/services.html:294
+#: pkg/systemd/services.html:186
 msgid "31st"
 msgstr "31."
 
@@ -378,7 +378,7 @@ msgstr "31."
 msgid "32 KiB"
 msgstr "32 KiB"
 
-#: pkg/systemd/services.html:266
+#: pkg/systemd/services.html:158
 msgid "3rd"
 msgstr "3."
 
@@ -386,7 +386,7 @@ msgstr "3."
 msgid "4 KiB"
 msgstr "4 KiB"
 
-#: pkg/systemd/host.js:1666
+#: pkg/systemd/host.js:1683
 msgid "4 min"
 msgstr "4 min"
 
@@ -394,7 +394,7 @@ msgstr "4 min"
 msgid "40 Minutes"
 msgstr "40 minuuttia"
 
-#: pkg/systemd/services.html:267
+#: pkg/systemd/services.html:159
 msgid "4th"
 msgstr "4."
 
@@ -402,7 +402,7 @@ msgstr "4."
 msgid "5 Minutes"
 msgstr "5 minuuttia"
 
-#: pkg/systemd/host.js:1665
+#: pkg/systemd/host.js:1682
 msgid "5 min"
 msgstr "5 min"
 
@@ -416,7 +416,7 @@ msgstr "5 minuuttia"
 msgid "512 KiB"
 msgstr "512 KiB"
 
-#: pkg/systemd/services.html:268
+#: pkg/systemd/services.html:160
 msgid "5th"
 msgstr "5."
 
@@ -434,11 +434,11 @@ msgstr "60 minuuttia"
 msgid "64 KiB"
 msgstr "64 KiB"
 
-#: pkg/systemd/services.html:269
+#: pkg/systemd/services.html:161
 msgid "6th"
 msgstr "6."
 
-#: pkg/systemd/services.html:270
+#: pkg/systemd/services.html:162
 msgid "7th"
 msgstr "7."
 
@@ -446,19 +446,19 @@ msgstr "7."
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1987
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:1995
+#: pkg/networkmanager/interfaces.js:2004
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
-#: pkg/systemd/services.html:271
+#: pkg/systemd/services.html:163
 msgid "8th"
 msgstr "8."
 
-#: pkg/systemd/services.html:272
+#: pkg/systemd/services.html:164
 msgid "9th"
 msgstr "9."
 
@@ -467,8 +467,8 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Yhteensopivaa versiota Cockpitistä ei ole asennettu kohteessa {{#strong}}"
-"{{host}}{{/strong}}."
+"Yhteensopivaa versiota Cockpitistä ei ole asennettu kohteessa "
+"{{#strong}}{{host}}{{/strong}}."
 
 #: pkg/storaged/vdos-panel.jsx:59
 msgid "A disk is needed."
@@ -483,15 +483,15 @@ msgstr ""
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "Varalevy pitää lisätä ennen kuin tämä levy voidaan poistaa."
 
-#: pkg/networkmanager/interfaces.js:1986
+#: pkg/networkmanager/interfaces.js:1995
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2786
+#: pkg/networkmanager/interfaces.js:2798
 msgid "ARP Monitoring"
 msgstr "ARP-monitorointi"
 
-#: pkg/networkmanager/interfaces.js:2007
+#: pkg/networkmanager/interfaces.js:2016
 msgid "ARP Ping"
 msgstr "ARP Ping"
 
@@ -499,6 +499,10 @@ msgstr "ARP Ping"
 #: pkg/shell/simple.html:58
 msgid "About Cockpit"
 msgstr "Lisää Cockpitistä"
+
+#: pkg/lib/machine-info.js:251
+msgid "Absent"
+msgstr ""
 
 #: pkg/users/index.html:104 pkg/users/index.html:190
 msgid "Access"
@@ -520,7 +524,7 @@ msgstr "Tilin asetukset"
 msgid "Account not available or cannot be edited."
 msgstr "Tili ei ole käytettävissä tai sitä ei voi muokata"
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Käyttäjätilit"
 
@@ -529,8 +533,8 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Käyttäjätilit"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:170
 #: pkg/machines/components/networks/network.jsx:148
+#: pkg/machines/components/storagePools/storagePool.jsx:170
 #: pkg/storaged/content-views.jsx:256
 msgid "Activate"
 msgstr "Aktivoi"
@@ -539,11 +543,11 @@ msgstr "Aktivoi"
 msgid "Activating $target"
 msgstr "Aktivoidaan $target"
 
-#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
+#: pkg/networkmanager/interfaces.js:847 pkg/networkmanager/interfaces.js:2010
 msgid "Active"
 msgstr "Aktiivinen"
 
-#: pkg/networkmanager/interfaces.js:1975 pkg/networkmanager/interfaces.js:1992
+#: pkg/networkmanager/interfaces.js:1984 pkg/networkmanager/interfaces.js:2001
 msgid "Active Backup"
 msgstr "Aktiivinen varmuuskopio"
 
@@ -555,27 +559,31 @@ msgstr "Aktiiviset sivut"
 msgid "Active since"
 msgstr "Aktiivinen lähtien"
 
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/systemd/service-details.jsx:352
+msgid "Active since "
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:954
 msgid "Active zones"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1980
+#: pkg/networkmanager/interfaces.js:1989
 msgid "Adaptive load balancing"
 msgstr "Mukautuva kuorman tasapainottaja (balance-alb)"
 
-#: pkg/networkmanager/interfaces.js:1979
+#: pkg/networkmanager/interfaces.js:1988
 msgid "Adaptive transmit load balancing"
 msgstr "Mukautuva lähtevän kuorman tasapainottaja (balance-tlb)"
 
-#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
+#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
+#: pkg/machines/components/diskAdd.jsx:600 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
+#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
 #: pkg/storaged/vgroup-details.jsx:63
 msgid "Add"
 msgstr "Lisää"
 
-#: pkg/networkmanager/interfaces.js:3103
+#: pkg/networkmanager/interfaces.js:3115
 msgid "Add $0"
 msgstr "Lisää $0"
 
@@ -591,7 +599,7 @@ msgstr ""
 msgid "Add Bridge"
 msgstr "Lisää silta"
 
-#: pkg/machines/components/diskAdd.jsx:360
+#: pkg/machines/components/diskAdd.jsx:368
 msgid "Add Disk"
 msgstr ""
 
@@ -607,12 +615,12 @@ msgstr ""
 msgid "Add Machine to Dashboard"
 msgstr "Lisää kone kojelaudalle"
 
-#: pkg/networkmanager/firewall.jsx:457
+#: pkg/networkmanager/firewall.jsx:482
 msgid "Add Ports"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
-#: pkg/networkmanager/firewall.jsx:886
+#: pkg/networkmanager/firewall.jsx:482 pkg/networkmanager/firewall.jsx:904
+#: pkg/networkmanager/firewall.jsx:916
 msgid "Add Services"
 msgstr "Lisää palveluja"
 
@@ -628,8 +636,8 @@ msgstr "Lisää tiimi"
 msgid "Add VLAN"
 msgstr "Lisää VLAN"
 
-#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
-#: pkg/networkmanager/firewall.jsx:891
+#: pkg/networkmanager/firewall.jsx:730 pkg/networkmanager/firewall.jsx:910
+#: pkg/networkmanager/firewall.jsx:921
 msgid "Add Zone"
 msgstr ""
 
@@ -641,7 +649,7 @@ msgstr "Lisää iSCSI Portaali"
 msgid "Add key"
 msgstr "Lisää avain"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add ports to the following zones:"
 msgstr ""
 
@@ -649,21 +657,27 @@ msgstr ""
 msgid "Add public key"
 msgstr "Lisää julkinen avain"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add services to following zones:"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:776
+#: pkg/networkmanager/firewall.jsx:806
 msgid "Add zone"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3102
+#: pkg/networkmanager/interfaces.js:3114
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
 msgstr ""
 "<b>$0</b>  lisääminen katkaisee yhteyden palvelimeen, jolloin "
 "hallintakäyttöliittymä ei ole saatavilla."
+
+#: pkg/networkmanager/firewall.jsx:586
+msgid ""
+"Adding custom ports will reload firewalld. A reload will result in the loss "
+"of any runtime-only configuration!"
+msgstr ""
 
 #: pkg/users/authorized-keys.js:113
 msgid "Adding key"
@@ -677,11 +691,11 @@ msgstr "Lisätään fyysinen taltio kohteeseen $target"
 msgid "Additional"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2668
 msgid "Additional DNS $val"
 msgstr "Uusi DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Additional DNS Search Domains $val"
 msgstr "Uusi DNS Search Domains $val"
 
@@ -689,7 +703,11 @@ msgstr "Uusi DNS Search Domains $val"
 msgid "Additional Storage"
 msgstr "Uusi tallennustila"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/systemd/service-details.jsx:209
+msgid "Additional actions"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2663
 msgid "Additional address $val"
 msgstr "Uusi osoite $val"
 
@@ -705,7 +723,7 @@ msgstr ""
 msgid "Address"
 msgstr "Osoite"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/networkmanager/interfaces.js:2663
 msgid "Address $val"
 msgstr "Osoite $val"
 
@@ -717,11 +735,18 @@ msgstr ""
 msgid "Address is not a valid URL"
 msgstr ""
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:60
+#: pkg/machines/components/networks/createNetworkDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:88
+#: pkg/machines/components/networks/createNetworkDialog.jsx:95
+msgid "Address not within subnet"
+msgstr ""
+
 #: pkg/machines/components/desktopConsole.jsx:153
 msgid "Address:"
 msgstr "Osoite:"
 
-#: pkg/networkmanager/interfaces.js:3309
+#: pkg/networkmanager/interfaces.js:3321
 msgid "Addresses"
 msgstr "Osoitteet"
 
@@ -737,7 +762,7 @@ msgstr "Ylläpidon salasana"
 msgid "Advanced TCA"
 msgstr ""
 
-#: pkg/systemd/services.html:455 pkg/systemd/init.js:730
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "Jälkeen"
 
@@ -748,8 +773,8 @@ msgid ""
 "settings and the list of trusted CAs may change."
 msgstr ""
 
-#: pkg/systemd/services.html:446 pkg/systemd/services.html:450
-#: pkg/systemd/init.js:1073
+#: pkg/systemd/services.html:301 pkg/systemd/services.html:305
+#: pkg/systemd/init.js:902
 msgid "After system boot"
 msgstr "Järjestelmän käynnistyksen jälkeen"
 
@@ -757,7 +782,7 @@ msgstr "Järjestelmän käynnistyksen jälkeen"
 msgid "Alert and above"
 msgstr ""
 
-#: pkg/systemd/services.html:71 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
 msgid "All"
 msgstr "Kaikki"
 
@@ -773,11 +798,15 @@ msgstr ""
 "Kaikki valituilla levyillä oleva data poistetaan ja levyt lisätään "
 "tallennuspooliin."
 
-#: pkg/networkmanager/firewall.jsx:751
+#: pkg/systemd/service-details.jsx:159
+msgid "Allow running (unmask)"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:781
 msgid "Allowed Addresses"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:967
 msgid "Allowed Services"
 msgstr "Sallitut palvelut"
 
@@ -793,12 +822,16 @@ msgstr ""
 msgid "Annotations"
 msgstr "Annotaatiot"
 
+#: pkg/lib/cockpit-components-modifications.jsx:82
+msgid "Ansible Playbook"
+msgstr ""
+
 #: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr ""
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Sovellukset"
 
@@ -806,10 +839,10 @@ msgstr "Sovellukset"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
-#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
-#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
-#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
+#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
+#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
+#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
+#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
 msgid "Apply"
 msgstr "Toteuta"
 
@@ -821,11 +854,11 @@ msgstr "Toteuta kaikki päivitykset"
 msgid "Apply security updates"
 msgstr "Toteuta tietoturvapäivitykset"
 
-#: pkg/selinux/setroubleshoot-view.jsx:112
+#: pkg/selinux/setroubleshoot-view.jsx:113
 msgid "Apply this solution"
 msgstr "Toteuta tämä ratkaisu"
 
-#: pkg/selinux/setroubleshoot-view.jsx:87
+#: pkg/selinux/setroubleshoot-view.jsx:88
 msgid "Applying solution..."
 msgstr "Toteutetaan ratkaisu..."
 
@@ -849,25 +882,25 @@ msgstr ""
 msgid "At least $0 disks are needed."
 msgstr "Vähintään $0 levyä tarvitaan."
 
-#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
-#: pkg/storaged/vgroup-details.jsx:57
+#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
+#: pkg/storaged/vgroups-panel.jsx:63
 msgid "At least one disk is needed."
 msgstr "Vähintään yksi levy tarvitaan."
 
-#: pkg/systemd/services.html:451
+#: pkg/systemd/services.html:306
 msgid "At specific time"
 msgstr "Tiettynä aikana"
 
-#: pkg/selinux/setroubleshoot-view.jsx:414
+#: pkg/selinux/setroubleshoot-view.jsx:424
 msgid "Audit log"
 msgstr "Audit-loki"
 
-#: pkg/networkmanager/interfaces.js:830
+#: pkg/networkmanager/interfaces.js:839
 msgid "Authenticating"
 msgstr "Tunnistaudutaan"
 
-#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
+#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
 msgid "Authentication"
 msgstr "Tunnistautuminen"
 
@@ -903,22 +936,23 @@ msgstr "Tekijä"
 msgid "Authorized Public SSH Keys"
 msgstr "Valtuutetut julkiset SSH-avaimet"
 
-#: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
-#: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
-#: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:338
+#: pkg/networkmanager/index.html:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:176
+#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:2771
+#: pkg/networkmanager/interfaces.js:3329 pkg/networkmanager/interfaces.js:3333
+#: pkg/networkmanager/interfaces.js:3339 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automaattinen"
 
-#: pkg/networkmanager/interfaces.js:1966
+#: pkg/networkmanager/interfaces.js:1975
 msgid "Automatic (DHCP only)"
 msgstr "Automaattinen (vain DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1956
+#: pkg/networkmanager/interfaces.js:1965
 msgid "Automatic (DHCP)"
 msgstr "Automaattinen (DHCP)"
 
-#: pkg/systemd/services.html:125 pkg/systemd/init.js:286
+#: pkg/systemd/init.js:295
 msgid "Automatic Startup"
 msgstr ""
 
@@ -930,6 +964,10 @@ msgstr "Automaattiset päivitykset"
 msgid "Automatically start libvirt on boot"
 msgstr "Käynnistä libvirt automaattisesti käynnistyksen yhteydessä"
 
+#: pkg/systemd/service-details.jsx:396
+msgid "Automatically starts"
+msgstr ""
+
 #: pkg/systemd/index.html:389
 msgid "Automatically using NTP"
 msgstr "Käytetään automaattisesti NTP:tä"
@@ -938,8 +976,12 @@ msgstr "Käytetään automaattisesti NTP:tä"
 msgid "Automatically using specific NTP servers"
 msgstr "Käytetään automaattisesti tiettyjä NTP-palvelimia"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/lib/cockpit-components-modifications.jsx:71
+msgid "Automation Script"
+msgstr ""
+
 #: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:69
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
@@ -950,7 +992,7 @@ msgstr ""
 msgid "Available"
 msgstr "Saatavilla"
 
-#: pkg/packagekit/updates.jsx:822
+#: pkg/packagekit/updates.jsx:824
 msgid "Available Updates"
 msgstr "Saatavilla olevat päivitykset"
 
@@ -990,11 +1032,11 @@ msgstr "Virheellistä dataa välitetty passwd1-mekanismille"
 msgid "Balancer"
 msgstr "Tasapainottaja"
 
-#: pkg/systemd/init.js:729
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr ""
 
-#: pkg/systemd/init.js:720
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr ""
 
@@ -1022,8 +1064,8 @@ msgstr "Lohkolaite tiedostojärjestelmille"
 msgid "Blocked"
 msgstr "Estetty"
 
-#: pkg/networkmanager/interfaces.js:2510 pkg/networkmanager/interfaces.js:2522
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
+#: pkg/networkmanager/interfaces.js:2803
 msgid "Bond"
 msgstr "Side"
 
@@ -1040,12 +1082,12 @@ msgstr ""
 msgid "Boot order settings could not be saved"
 msgstr ""
 
-#: pkg/systemd/init.js:725
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2528 pkg/networkmanager/interfaces.js:2540
+#: pkg/networkmanager/interfaces.js:2880
 msgid "Bridge"
 msgstr "Silta"
 
@@ -1057,19 +1099,19 @@ msgstr "Sillan porttiasetukset"
 msgid "Bridge Settings"
 msgstr "Sillan asetukset"
 
-#: pkg/networkmanager/interfaces.js:2889
+#: pkg/networkmanager/interfaces.js:2901
 msgid "Bridge port"
 msgstr "Sillan portti"
 
-#: pkg/networkmanager/interfaces.js:1977 pkg/networkmanager/interfaces.js:1994
+#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
 msgid "Broadcast"
 msgstr "Lähetys"
 
-#: pkg/networkmanager/interfaces.js:2804 pkg/networkmanager/interfaces.js:2838
+#: pkg/networkmanager/interfaces.js:2816 pkg/networkmanager/interfaces.js:2850
 msgid "Broken configuration"
 msgstr "Rikkinäinen asetus"
 
-#: pkg/systemd/host.js:498
+#: pkg/systemd/host.js:508
 msgid "Bug Fix Updates Available"
 msgstr ""
 
@@ -1104,7 +1146,7 @@ msgstr ""
 msgid "CPU Security Toggles"
 msgstr ""
 
-#: pkg/systemd/host.js:1548
+#: pkg/systemd/host.js:1565
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Prosessorin tila"
@@ -1121,12 +1163,12 @@ msgstr "Prosessorin prioriteetti"
 msgid "CPU usage:"
 msgstr "Prosessorin käyttö"
 
+#: pkg/machines/components/diskAdd.jsx:251
 #: pkg/machines/components/vmDiskColumns.jsx:75
-#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
-#: pkg/systemd/index.html:252 pkg/systemd/host.js:1679
+#: pkg/systemd/index.html:252 pkg/systemd/host.js:1696
 msgid "Cached"
 msgstr "Välimuistissa"
 
@@ -1145,39 +1187,41 @@ msgstr ""
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
+#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90
-#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
 #: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
-#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
-#: pkg/users/index.html:356 pkg/users/index.html:413
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
+#: pkg/systemd/index.html:487 pkg/systemd/services.html:377
+#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
+#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
+#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
+#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/diskAdd.jsx:597
+#: pkg/machines/components/networks/createNetworkDialog.jsx:486
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
+#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/vcpuModal.jsx:232
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
-#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
-#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
-#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
-#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
-#: pkg/packagekit/updates.jsx:179
+#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
+#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "Peru"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "Ei voida yhdistää tuntemattomaan koneeseen"
 
@@ -1193,7 +1237,7 @@ msgstr "Tapahtumaa ei voi aikatauluttaa menneisyyteen"
 msgid "Capacity"
 msgstr "Koko"
 
-#: pkg/networkmanager/interfaces.js:2590
+#: pkg/networkmanager/interfaces.js:2602
 msgid "Carrier"
 msgstr ""
 
@@ -1239,18 +1283,18 @@ msgstr "Muuta resurssin rajoja"
 msgid "Change resources limits"
 msgstr "Muuta resurssien rajoja"
 
-#: pkg/networkmanager/interfaces.js:3153
+#: pkg/networkmanager/interfaces.js:3165
 msgid "Change the settings"
 msgstr "Vaihda asetuksia"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
+#: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
-#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3152
+#: pkg/networkmanager/interfaces.js:3164
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1266,7 +1310,7 @@ msgstr "Etsi päivityksiä"
 msgid "Checking $target"
 msgstr "Tarkistetaan $target"
 
-#: pkg/networkmanager/interfaces.js:834
+#: pkg/networkmanager/interfaces.js:843
 msgid "Checking IP"
 msgstr "Tarkistetaan IP"
 
@@ -1286,12 +1330,16 @@ msgstr "Etsitään uusia sovelluksia"
 msgid "Checking for public keys"
 msgstr "Etsitään julkisia avaimia"
 
-#: pkg/systemd/host.js:517
+#: pkg/systemd/host.js:537
 msgid "Checking for updates…"
 msgstr "Etsitään päivityksiä…"
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:142
 msgid "Checking installed software"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
+msgid "Choose an operating system"
 msgstr ""
 
 #: pkg/shell/index.html:117 pkg/shell/simple.html:85
@@ -1302,7 +1350,7 @@ msgstr "Valitse sovelluksessa käytettävä kieli"
 msgid "Chunk Size"
 msgstr ""
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "Class"
 msgstr ""
 
@@ -1310,11 +1358,15 @@ msgstr ""
 msgid "Cleaning up for $target"
 msgstr "Siivotaan kohteelle $target"
 
-#: pkg/systemd/services.html:194
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
+
+#: pkg/systemd/services.html:86
 msgid "Clear All Filters"
 msgstr ""
 
-#: pkg/systemd/host.js:734
+#: pkg/systemd/host.js:750
 msgid "Click to see system hardware information"
 msgstr "Napsauta nähdäksesi järjestelmän laitteistotiedot"
 
@@ -1327,16 +1379,14 @@ msgstr "Painamalla \"Launch Remote Viewer\" lataat .vv-tiedoston ja avaat $0."
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
-#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
-#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
-#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
-#: pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
+#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
+#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
+#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
+#: pkg/systemd/index.html:278 pkg/users/index.html:45 pkg/apps/utils.jsx:108
+#: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
 #: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
-#: pkg/apps/utils.jsx:108
 msgid "Close"
 msgstr "Sulje"
 
@@ -1360,7 +1410,7 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit ei saanut yhteyttä hostiin."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1421,10 +1471,10 @@ msgstr "Cockpit ei saanut yhteyttä kohteeseen {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
+"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
+"sync_link}}.{{/can_sync}} For more authentication options and "
+"troubleshooting support please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit ei pystynyt kirjautumaan kohteeseen {{#strong}}{{host}}{{/strong}}. "
 "{{#can_sync}}Haluat ehkä kokeilla {{#sync_link}}käyttäjien synkronointia{{/"
@@ -1444,8 +1494,8 @@ msgid ""
 msgstr ""
 "Cockpit ei pystynyt kirjautumaan kohteeseen {{#strong}}{{host}}{{/strong}}. "
 "Käyttääksesi tätä konetta Cockpitin kanssa sinun tulee ottaa käyttöön jokin "
-"seuraavista todentamismetodeista sshd-konfiguraatiossa kohteessa {{#strong}}"
-"{{host}}{{/strong}}:"
+"seuraavista todentamismetodeista sshd-konfiguraatiossa kohteessa "
+"{{#strong}}{{host}}{{/strong}}:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1472,12 +1522,12 @@ msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Yhdistetty $0 CPU-ytimen käyttö"
 msgstr[1] "Yhdistetty $0 CPU-ydinten käyttö"
 
-#: pkg/networkmanager/firewall.jsx:529
+#: pkg/networkmanager/firewall.jsx:554
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
-#: pkg/docker/index.html:708 pkg/systemd/services.html:427
+#: pkg/docker/index.html:708 pkg/systemd/services.html:282
 #: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
@@ -1519,14 +1569,15 @@ msgstr "Yhteensopiva kaikkien järjestelmien ja laitteiden kanssa (MBR)"
 
 #: pkg/storaged/content-views.jsx:524
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
-msgstr "Yhteensopiva modernien järjestelmien ja kovalevyjen kanssa > 2TB (GPT)"
+msgstr ""
+"Yhteensopiva modernien järjestelmien ja kovalevyjen kanssa > 2TB (GPT)"
 
 #: pkg/kdump/kdump-view.jsx:162
 msgid "Compress crash dumps to save space"
 msgstr "Tiivistä crash dump säästääksesi tilaa"
 
-#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
-#: pkg/kdump/kdump-view.jsx:156
+#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
+#: pkg/storaged/vdos-panel.jsx:81
 msgid "Compression"
 msgstr "Pakkaus"
 
@@ -1534,15 +1585,15 @@ msgstr "Pakkaus"
 msgid "Computer OU"
 msgstr "Tietokone-OU"
 
-#: pkg/systemd/init.js:692
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr "Ehto $0=$1 ei toteutunut"
 
-#: pkg/systemd/services.html:143
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "Ehto epäonnistui"
 
-#: pkg/networkmanager/interfaces.js:2725
+#: pkg/networkmanager/interfaces.js:2737
 msgid "Configure"
 msgstr "Muokkaa asetuksia"
 
@@ -1550,11 +1601,11 @@ msgstr "Muokkaa asetuksia"
 msgid "Configure storage..."
 msgstr "Aseta tallennustila..."
 
-#: pkg/networkmanager/interfaces.js:828
+#: pkg/networkmanager/interfaces.js:837
 msgid "Configuring"
 msgstr "Asetetaan"
 
-#: pkg/networkmanager/interfaces.js:832
+#: pkg/networkmanager/interfaces.js:841
 msgid "Configuring IP"
 msgstr "Asetetaan IP"
 
@@ -1575,11 +1626,11 @@ msgstr ""
 msgid "Confirm removal with passphrase"
 msgstr ""
 
-#: pkg/systemd/init.js:728
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr ""
 
-#: pkg/systemd/init.js:727
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr ""
 
@@ -1587,7 +1638,7 @@ msgstr ""
 msgid "Connect"
 msgstr "Yhdistä"
 
-#: pkg/networkmanager/interfaces.js:2712
+#: pkg/networkmanager/interfaces.js:2724
 msgid "Connect automatically"
 msgstr "Yhdistä automaattisesti"
 
@@ -1618,7 +1669,7 @@ msgstr ""
 msgid "Connecting to Docker"
 msgstr "Yhdistetään Dockeriin"
 
-#: pkg/selinux/setroubleshoot-view.jsx:371
+#: pkg/selinux/setroubleshoot-view.jsx:381
 msgid "Connecting to SETroubleshoot daemon..."
 msgstr "Yhdistetään SETroubleshoot daemoniin..."
 
@@ -1626,14 +1677,14 @@ msgstr "Yhdistetään SETroubleshoot daemoniin..."
 msgid "Connecting to Virtualization Service"
 msgstr "Yhdistetään virtualisointipalveluun"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "Yhdistetään koneeseen"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
+#: pkg/machines/components/networks/createNetworkDialog.jsx:106
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Yhteys"
@@ -1650,7 +1701,7 @@ msgstr "Yhteys aikakatkaistiin."
 msgid "Connection will be lost"
 msgstr "Yhteys tulee katoamaan"
 
-#: pkg/systemd/init.js:726
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr ""
 
@@ -1728,6 +1779,10 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
+#: pkg/lib/cockpit-components-modifications.jsx:106
+msgid "Copy to clipboard"
+msgstr ""
+
 #: pkg/machines/components/vcpuModal.jsx:209
 msgid "Cores per socket"
 msgstr ""
@@ -1752,7 +1807,7 @@ msgstr "Ei voitu muuttaa käyttäjäryhmiä"
 msgid "Couldn't change user password"
 msgstr "Ei voitu muuttaa käyttäjän salasanaa"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "Ei saatu yhteyttä koneeseen"
 
@@ -1781,11 +1836,12 @@ msgid "Crash system"
 msgstr ""
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
-#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
-#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
+#: pkg/machines/components/networks/createNetworkDialog.jsx:491
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
+#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
+#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
+#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
 msgid "Create"
 msgstr "Luo"
 
@@ -1793,7 +1849,7 @@ msgstr "Luo"
 msgid "Create Logical Volume"
 msgstr "Luo looginen taltio"
 
-#: pkg/machines/components/diskAdd.jsx:515
+#: pkg/machines/components/diskAdd.jsx:552
 msgid "Create New"
 msgstr ""
 
@@ -1825,7 +1881,7 @@ msgstr "Luo raportti"
 msgid "Create Snapshot"
 msgstr "Luo tilannevedos"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr ""
 
@@ -1833,11 +1889,11 @@ msgstr ""
 msgid "Create Thin Volume"
 msgstr "Luo Thin-taltio"
 
-#: pkg/systemd/services.html:64
+#: pkg/systemd/services.html:58
 msgid "Create Timer"
 msgstr "Luo ajastin"
 
-#: pkg/systemd/services.html:393
+#: pkg/systemd/services.html:248
 msgid "Create Timers"
 msgstr "Luo ajastimet"
 
@@ -1845,9 +1901,14 @@ msgstr "Luo ajastimet"
 msgid "Create VDO Device"
 msgstr "Luo VDO-laite"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "Luo VM"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
+#: pkg/machines/components/networks/createNetworkDialog.jsx:525
+msgid "Create Virtual Network"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:53
 msgid "Create Volume Group"
@@ -1857,8 +1918,8 @@ msgstr "Luo taltioryhmä"
 msgid "Create diagnostic report"
 msgstr "Luo diagnostiikkaraportti"
 
-#: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
-#: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
+#: pkg/networkmanager/interfaces.js:3834 pkg/networkmanager/interfaces.js:4033
+#: pkg/networkmanager/interfaces.js:4287 pkg/networkmanager/interfaces.js:4492
 msgid "Create it"
 msgstr "Luo se"
 
@@ -1895,7 +1956,7 @@ msgstr "Luodaan osiota $target"
 msgid "Creating snapshot of $target"
 msgstr "Luodaan tilannevedos kohteesta $target"
 
-#: pkg/networkmanager/interfaces.js:4479
+#: pkg/networkmanager/interfaces.js:4491
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1903,13 +1964,13 @@ msgstr ""
 "Tämän VLANin luominen katkaisee yhteyden palvelimeen, jolloin "
 "hallintakäyttöliittymä ei ole saatavilla."
 
-#: pkg/networkmanager/interfaces.js:3821
+#: pkg/networkmanager/interfaces.js:3833
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:4274
+#: pkg/networkmanager/interfaces.js:4286
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1917,7 +1978,7 @@ msgstr ""
 "Tämän sillan luominen katkaisee yhteyden serverille, jolloin "
 "hallintakäyttöliittymä ei ole saatavilla."
 
-#: pkg/networkmanager/interfaces.js:4020
+#: pkg/networkmanager/interfaces.js:4032
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1927,7 +1988,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Luodaan taltioryhmä $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr ""
 
@@ -1955,7 +2016,7 @@ msgstr "Tämänhetkinen käynnistys"
 msgid "Custom"
 msgstr "Mukautettu"
 
-#: pkg/networkmanager/firewall.jsx:523
+#: pkg/networkmanager/firewall.jsx:548
 msgid "Custom Ports"
 msgstr ""
 
@@ -1963,11 +2024,11 @@ msgstr ""
 msgid "Custom encryption options"
 msgstr "Mukautetut salausvalinnat"
 
-#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
+#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
 msgid "Custom mount options"
 msgstr "Mukautetut liitosvalinnat"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:748
 msgid "Custom zones"
 msgstr ""
 
@@ -1980,19 +2041,19 @@ msgstr ""
 msgid "DISK IS FAILING"
 msgstr "LEVY ON PETTÄMÄSSÄ"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3328
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2668
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3320
+#: pkg/networkmanager/interfaces.js:3332
 msgid "DNS Search Domains"
 msgstr "DNS Search Domainit"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2671
 msgid "DNS Search Domains $val"
 msgstr "DNS Search Domainit $val"
 
@@ -2008,13 +2069,13 @@ msgstr "Kojelauta"
 msgid "Data Used"
 msgstr "Dataa käytetty"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:165
 #: pkg/machines/components/networks/network.jsx:144
+#: pkg/machines/components/storagePools/storagePool.jsx:165
 #: pkg/storaged/content-views.jsx:254
 msgid "Deactivate"
 msgstr "Deaktivoi"
 
-#: pkg/networkmanager/interfaces.js:840
+#: pkg/networkmanager/interfaces.js:849
 msgid "Deactivating"
 msgstr "Deaktivoidaan"
 
@@ -2042,26 +2103,27 @@ msgstr "Viive"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/docker/containers-view.jsx:202
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
+#: pkg/docker/details.js:292 pkg/docker/util.js:641
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
 #: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
+#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
 #: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
 msgid "Delete"
 msgstr "Poista"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2447 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Poista $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
 msgstr ""
 
@@ -2073,7 +2135,7 @@ msgstr "Poista tiedostot"
 msgid "Delete Network $0"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:217
 msgid "Delete Storage Pool $0"
 msgstr ""
 
@@ -2081,7 +2143,7 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:170
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
 
@@ -2089,7 +2151,7 @@ msgstr ""
 msgid "Deleting $target"
 msgstr "Poistetaan $target"
 
-#: pkg/networkmanager/interfaces.js:2434
+#: pkg/networkmanager/interfaces.js:2446
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2105,7 +2167,7 @@ msgstr "RAID-laitteen poistaminen tuhoaa kaiken sillä olevan datan."
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "VDO-laitteen poistaminen tuhoaa kaiken sillä olevan datan."
 
-#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
+#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
 msgid "Deleting a container will erase all data in it."
 msgstr "Kontin poistaminen tuhoaa kaiken sillä olevan datan."
 
@@ -2121,7 +2183,7 @@ msgstr "Osion poistaminen tuhoaa kaiken sillä olevan datan."
 msgid "Deleting a volume group will erase all data on it."
 msgstr "Taltion poistaminen tuhoaa kaiken sillä olevan datan."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:174
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
@@ -2131,15 +2193,25 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Tuhotaan taltioryhmä $target"
 
-#: pkg/systemd/services.html:413
+#: pkg/systemd/services.html:268
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
+#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
 msgid "Description"
 msgstr "Kuvaus"
+
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Työpöytä"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:151
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:187
+msgid ""
+"Detach the disks using this pool from any VMs before attempting deletion."
+msgstr ""
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2147,13 +2219,14 @@ msgstr ""
 
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:383
+#: pkg/systemd/host.js:762
 msgid "Details"
 msgstr "Yksityiskohdat"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:169
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
 msgid "Device"
@@ -2166,6 +2239,10 @@ msgstr "Laitetiedosto"
 #: pkg/storaged/content-views.jsx:551
 msgid "Device is read-only"
 msgstr "Laite on \"vain luku\"-muotoa"
+
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
@@ -2184,10 +2261,6 @@ msgstr "Hakemisto"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "Hakemistolle $0 ei voi kirjoittaa tai se ei ole olemassa."
 
-#: pkg/systemd/init.js:571
-msgid "Disable"
-msgstr "Poista käytöstä"
-
 #: pkg/systemd/hwinfo.jsx:191
 msgid "Disable simultaneous multithreading"
 msgstr ""
@@ -2196,17 +2269,21 @@ msgstr ""
 msgid "Disable tuned"
 msgstr "Poista tuned käytöstä"
 
-#: pkg/systemd/services.html:73 pkg/networkmanager/interfaces.js:1960
-#: pkg/systemd/init.js:213
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "Ei käytössä"
+
+#: pkg/systemd/service-details.jsx:192
+msgid "Disallow running (mask)"
+msgstr ""
 
 #: pkg/machines/components/serialConsole.jsx:136
 msgid "Disconnect"
 msgstr "Katkaise yhteys"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "Katkaistu"
 
@@ -2222,15 +2299,15 @@ msgstr "Levy"
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr ""
 
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:549
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:569
 msgid "Disk I/O"
 msgstr "Levyn I/O"
 
-#: pkg/machines/components/diskAdd.jsx:489
+#: pkg/machines/components/diskAdd.jsx:525
 msgid "Disk failed to be attached"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Disk failed to be created"
 msgstr ""
 
@@ -2242,9 +2319,9 @@ msgstr "Levy on OK"
 msgid "Disk passphrase"
 msgstr ""
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
-#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
+#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
+#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
+#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
 msgid "Disks"
 msgstr "Levyt"
 
@@ -2256,6 +2333,10 @@ msgstr ""
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Näytä kieli"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2294,8 +2375,8 @@ msgstr "Domain-ylläpitäjän nimi"
 msgid "Domain Administrator Password"
 msgstr "Domain-ylläpitäjän salasana"
 
-#: pkg/systemd/services.html:483 pkg/systemd/services.html:487
-#: pkg/systemd/init.js:1256
+#: pkg/systemd/services.html:338 pkg/systemd/services.html:342
+#: pkg/systemd/init.js:1085
 msgid "Don't Repeat"
 msgstr "Älä toista"
 
@@ -2348,6 +2429,10 @@ msgstr "Levy"
 msgid "Drives"
 msgstr "Levyt"
 
+#: pkg/lib/machine-info.js:244
+msgid "Dual Rank"
+msgstr ""
+
 #: pkg/docker/run.js:348
 msgid "Duplicate alias"
 msgstr "Aliaksen duplikaatti"
@@ -2356,7 +2441,7 @@ msgstr "Aliaksen duplikaatti"
 msgid "Duplicate port"
 msgstr "Portin duplikaatti"
 
-#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
+#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
 #: pkg/storaged/nfs-details.jsx:306
 msgid "Edit"
 msgstr "Muokkaa"
@@ -2404,14 +2489,6 @@ msgstr "Tyhjennetään $target"
 msgid "Emulated Machine"
 msgstr ""
 
-#: pkg/systemd/init.js:569
-msgid "Enable"
-msgstr "Ota käyttöön"
-
-#: pkg/systemd/init.js:570
-msgid "Enable Forcefully"
-msgstr "Ota käyttöön väkisin"
-
 #: pkg/networkmanager/index.html:50
 msgid "Enable Service"
 msgstr ""
@@ -2420,7 +2497,7 @@ msgstr ""
 msgid "Enable stored metrics…"
 msgstr ""
 
-#: pkg/systemd/services.html:72 pkg/systemd/init.js:210
+#: pkg/systemd/services.html:66 pkg/systemd/init.js:215
 msgid "Enabled"
 msgstr "Käytössä"
 
@@ -2463,11 +2540,20 @@ msgstr "Salaus"
 msgid "Encryption Options"
 msgstr "Salauksen valinnat"
 
-#: pkg/selinux/setroubleshoot-view.jsx:299
-msgid "Enforce policy:"
-msgstr "Toimeenpane käytäntö:"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:252
+msgid "End"
+msgstr ""
 
-#: pkg/systemd/host.js:500
+#: pkg/machines/components/networks/createNetworkDialog.jsx:63
+#: pkg/machines/components/networks/createNetworkDialog.jsx:91
+msgid "End should not be empty"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Enforcing"
+msgstr ""
+
+#: pkg/systemd/host.js:510
 msgid "Enhancement Updates Available"
 msgstr ""
 
@@ -2483,7 +2569,7 @@ msgstr ""
 "Erilaisen salasanan antaminen tässä tarkoittaa, että sinun tulee antaa "
 "salasana uudestaan joka kerta kun yhdistät uudelleen tähän koneeseen."
 
-#: pkg/networkmanager/firewall.jsx:754
+#: pkg/networkmanager/firewall.jsx:784
 msgid "Entire subnet"
 msgstr ""
 
@@ -2517,9 +2603,9 @@ msgid "Errata:"
 msgstr ""
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
+#: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
 #: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Virhe"
 
@@ -2534,6 +2620,10 @@ msgstr "Virhe ladattaessa käyttäjiä: {{perm_failed}}"
 #: pkg/docker/util.js:507
 msgid "Error message from Docker:"
 msgstr "Virheviesti Dockerilta:"
+
+#: pkg/lib/cockpit-components-modifications.jsx:145
+msgid "Error running semanage to discover system modifications"
+msgstr ""
 
 #: pkg/users/authorized-keys.js:121
 msgid "Error saving authorized keys: "
@@ -2555,7 +2645,7 @@ msgstr "Ethernet MAC"
 msgid "Ethernet MTU"
 msgstr "Ethernet MTU"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:2015
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2563,11 +2653,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Kaikki"
 
-#: pkg/networkmanager/firewall.jsx:536
+#: pkg/networkmanager/firewall.jsx:561
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:544
+#: pkg/networkmanager/firewall.jsx:569
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
@@ -2575,11 +2665,11 @@ msgstr ""
 msgid "Excellent password"
 msgstr "Erinomainen salasana"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
-msgid "Existing Disk Image"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -2603,7 +2693,7 @@ msgstr "Laajennettu osio"
 msgid "FAILED"
 msgstr "EPÄONNISTUI"
 
-#: pkg/networkmanager/interfaces.js:842
+#: pkg/networkmanager/interfaces.js:851
 msgid "Failed"
 msgstr "Epäonnistui"
 
@@ -2611,19 +2701,19 @@ msgstr "Epäonnistui"
 msgid "Failed to add machine: $0"
 msgstr "Ei voitu lisätä konetta: $0"
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add port"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:679
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
+#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
 msgid "Failed to change password"
 msgstr "Ei voitu vaihtaa salasanaa"
 
@@ -2655,8 +2745,12 @@ msgstr ""
 msgid "Failed to load authorized keys."
 msgstr "Ei voitu ladata valtuutettuja avaimia."
 
-#: pkg/networkmanager/firewall.jsx:591
+#: pkg/networkmanager/firewall.jsx:621
 msgid "Failed to remove service"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:340
+msgid "Failed to start"
 msgstr ""
 
 #: pkg/docker/containers.js:60
@@ -2684,7 +2778,7 @@ msgstr "Tiedosto"
 msgid "Filesystem"
 msgstr "Tiedostojärjestelmä"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr ""
 
@@ -2700,24 +2794,24 @@ msgstr "Tiedostojärjestelmän nimi"
 msgid "Filesystems"
 msgstr "Tiedostojärjestelmät"
 
-#: pkg/networkmanager/firewall.jsx:491
+#: pkg/networkmanager/firewall.jsx:516
 msgid "Filter Services"
 msgstr "Suodata palveluja"
 
-#: pkg/systemd/services.html:68
+#: pkg/systemd/services.html:62
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
+#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
 msgid "Fingerprint"
 msgstr "Sormenjälki"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
+#: pkg/networkmanager/firewall.jsx:945 pkg/networkmanager/firewall.jsx:948
 msgid "Firewall"
 msgstr "Palomuuri"
 
-#: pkg/networkmanager/firewall.jsx:863
+#: pkg/networkmanager/firewall.jsx:893
 msgid "Firewall is not available"
 msgstr "Palomuuri ei ole saatavilla"
 
@@ -2727,6 +2821,10 @@ msgstr "Seuraa docker-repoa"
 
 #: pkg/storaged/vdos-panel.jsx:88
 msgid "For legacy applications only. Reduces performance."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:322
+msgid "Forbidden from running"
 msgstr ""
 
 #: pkg/users/index.html:122
@@ -2753,9 +2851,10 @@ msgstr "Pakota salasanan vaihdos"
 msgid "Force remove passphrase in $0"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
-#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/diskAdd.jsx:157
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
+#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
+#: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
 msgstr "Alusta"
 
@@ -2775,11 +2874,15 @@ msgstr "Taltion alustaminen tuhoaa kaiken sillä olevan datan."
 msgid "Formatting a storage device will erase all data on it."
 msgstr "Levylaitteen alustaminen tuhoaa kaiken sillä olevan datan."
 
-#: pkg/networkmanager/interfaces.js:2861
+#: pkg/machines/components/networks/createNetworkDialog.jsx:147
+msgid "Forward Mode"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2873
 msgid "Forward delay $forward_delay"
 msgstr "Edelleenohjaa viive $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:50
 msgid "Forwarding mode"
 msgstr ""
 
@@ -2798,7 +2901,7 @@ msgid ""
 "another physical volume."
 msgstr ""
 
-#: pkg/systemd/services.html:239
+#: pkg/systemd/services.html:131
 msgid "Friday"
 msgstr "Perjantai"
 
@@ -2819,7 +2922,7 @@ msgid "Gateway:"
 msgstr "Yhdyskäytävä:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2703 pkg/systemd/logs.js:486
+#: pkg/networkmanager/interfaces.js:2715 pkg/systemd/logs.js:486
 msgid "General"
 msgstr "Yleiset"
 
@@ -2831,11 +2934,11 @@ msgstr "Luodaan raporttia"
 msgid "Get new image"
 msgstr "Hae uusi levykuva"
 
+#: pkg/machines/components/diskAdd.jsx:191
+#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
-#: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vmDisksTab.jsx:44
-#: pkg/machines/components/diskAdd.jsx:186
 msgid "GiB"
 msgstr "GiB"
 
@@ -2887,7 +2990,7 @@ msgstr ""
 msgid "Hair Pin mode"
 msgstr "Hair Pin -tila"
 
-#: pkg/networkmanager/interfaces.js:2887
+#: pkg/networkmanager/interfaces.js:2899
 msgid "Hairpin mode"
 msgstr "Hairpin-tila"
 
@@ -2908,22 +3011,22 @@ msgstr "Kiintolevy"
 msgid "Hardware"
 msgstr "Laitteisto"
 
-#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:261
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:270
 msgid "Hardware Information"
 msgstr "Laitteistotiedot"
 
-#: pkg/networkmanager/interfaces.js:2863
+#: pkg/networkmanager/interfaces.js:2875
 msgid "Hello time $hello_time"
 msgstr "Hello time $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "Kone"
 
@@ -2932,7 +3035,7 @@ msgid "Host Device"
 msgstr ""
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Koneen nimi"
 
@@ -2944,25 +3047,29 @@ msgstr "Koneen avain on väärin"
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr ""
 
-#: pkg/systemd/services.html:499
+#: pkg/systemd/services.html:354
 msgid "Hour : Minute"
 msgstr "Tunti : Minuutti"
 
-#: pkg/systemd/init.js:1332 pkg/systemd/init.js:1361
+#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
 msgid "Hour needs to be a number between 0-23"
 msgstr "Tunti tarvitsee numeron väliltä 0-23"
 
-#: pkg/systemd/services.html:465
+#: pkg/systemd/services.html:320
 msgid "Hours"
 msgstr "Tuntia"
 
-#: pkg/systemd/index.html:238 pkg/systemd/host.js:1582
+#: pkg/systemd/index.html:238 pkg/systemd/host.js:1599
 msgid "I/O Wait"
 msgstr "I/O Odottaa"
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "ID"
+msgstr ""
 
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
 #: pkg/machines/components/vmnetworktab.jsx:133
@@ -2973,11 +3080,15 @@ msgstr "IP-osoite"
 msgid "IP Address:"
 msgstr "IP-osoitteet:"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:197
+msgid "IP Configuration"
+msgstr ""
+
 #: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "IP Prefix Pituus:"
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:955
 msgid "IP Range"
 msgstr ""
 
@@ -2985,7 +3096,7 @@ msgstr ""
 msgid "IP Settings"
 msgstr "IP-asetukset"
 
-#: pkg/networkmanager/interfaces.js:2912
+#: pkg/networkmanager/interfaces.js:2924
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -2993,11 +3104,27 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+msgid "IPv4 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:45
+msgid "IPv4 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3371
 msgid "IPv4 Settings"
 msgstr "IPv4-asetukset"
 
-#: pkg/networkmanager/interfaces.js:2913
+#: pkg/machines/components/networks/createNetworkDialog.jsx:213
+msgid "IPv4 and IPv6"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:207
+msgid "IPv4 only"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2925
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3005,15 +3132,27 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+msgid "IPv6 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:73
+msgid "IPv6 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3371
 msgid "IPv6 Settings"
 msgstr "IPv6-asetukset"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:210
+msgid "IPv6 only"
+msgstr ""
 
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
 
-#: pkg/networkmanager/interfaces.js:2904
+#: pkg/networkmanager/interfaces.js:2916
 msgid "Id $id"
 msgstr "Id $id"
 
@@ -3030,7 +3169,7 @@ msgstr "Tunniste:"
 msgid "If tang-show-keys is not available, run the following:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1969 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1978 pkg/packagekit/updates.jsx:496
 msgid "Ignore"
 msgstr "Ohita"
 
@@ -3092,15 +3231,19 @@ msgstr "Levykuvia voidaan hakea tunnistamattomana käyttäjänä tai ryhmänä"
 msgid "Images may only be pulled by specific users or groups"
 msgstr "Levykuvia voivat hakea vain tietyt käyttäjät tai ryhmät"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Käynnistä VM välittömästi"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "Synkronoitu"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3114,8 +3257,8 @@ msgstr ""
 "Synkronoidaksesi käyttäjät, sinun tulee olla kirjautuneena kohteeseen "
 "{{#strong}}{{host}}{{/strong}}."
 
-#: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
-#: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
+#: pkg/networkmanager/interfaces.js:833 pkg/networkmanager/interfaces.js:1426
+#: pkg/networkmanager/interfaces.js:1433 pkg/networkmanager/interfaces.js:2618
 msgid "Inactive"
 msgstr "Epäaktiivinen"
 
@@ -3123,7 +3266,7 @@ msgstr "Epäaktiivinen"
 msgid "Inactive volume"
 msgstr "Epäaktiivinen taltio"
 
-#: pkg/networkmanager/firewall.jsx:732
+#: pkg/networkmanager/firewall.jsx:762
 msgid "Included services"
 msgstr ""
 
@@ -3147,21 +3290,21 @@ msgstr "Tieto Dockering tallentovarannosta ei ole saatavilla."
 msgid "Initializing..."
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/machines/components/vm/vmActions.jsx:98
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
+#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/machines/components/vm/vmActions.jsx:98
 msgid "Install"
 msgstr "Asenna"
 
-#: pkg/packagekit/updates.jsx:806
+#: pkg/packagekit/updates.jsx:808
 msgid "Install All Updates"
 msgstr "Asenna kaikki päivitykset"
 
@@ -3169,7 +3312,7 @@ msgstr "Asenna kaikki päivitykset"
 msgid "Install NFS Support"
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:806 pkg/packagekit/updates.jsx:812
+#: pkg/packagekit/updates.jsx:808 pkg/packagekit/updates.jsx:814
 msgid "Install Security Updates"
 msgstr "Asenna tietoturvapäivitykset"
 
@@ -3181,20 +3324,20 @@ msgstr ""
 msgid "Install VDO support"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:379
+#: pkg/selinux/setroubleshoot-view.jsx:389
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr ""
 "Asenna setroubleshoot-server tehdäksesi vianetsinnän SELinux-tapahtumista."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Asennuslähde"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Asennuslähteen tyyppi"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "Asennuslähteen ei tulisi olla tyhjä"
 
@@ -3211,17 +3354,21 @@ msgstr "Asennetaan"
 msgid "Installing $0"
 msgstr ""
 
-#: pkg/systemd/services.html:184
+#: pkg/systemd/service-details.jsx:487
+msgid "Instance of template: "
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:62
 msgid "Instantiate"
 msgstr "Instansoi"
 
-#: pkg/machines/components/nicEdit.jsx:123
+#: pkg/machines/components/nicEdit.jsx:132
 msgid "Interface Type"
 msgstr ""
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:767 pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/interfaces.js:2998
 msgid "Interfaces"
 msgstr "Liitännät"
 
@@ -3233,19 +3380,39 @@ msgstr ""
 msgid "Internal error"
 msgstr "Sisäinen virhe"
 
-#: pkg/networkmanager/utils.js:88 pkg/networkmanager/utils.js:171
+#: pkg/machines/components/networks/createNetworkDialog.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:58
+#: pkg/machines/components/networks/createNetworkDialog.jsx:65
+msgid "Invalid IPv4 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:52
+msgid "Invalid IPv4 mask or prefix length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:75
+#: pkg/machines/components/networks/createNetworkDialog.jsx:86
+#: pkg/machines/components/networks/createNetworkDialog.jsx:93
+msgid "Invalid IPv6 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:80
+msgid "Invalid IPv6 prefix"
+msgstr ""
+
+#: pkg/networkmanager/utils.js:90 pkg/networkmanager/utils.js:175
 msgid "Invalid address $0"
 msgstr "Virheellinen osoite $0"
 
-#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "Virheellinen päivämuoto"
 
-#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "Virheellinen päivämuoto ja aikamuoto"
 
-#: pkg/systemd/init.js:1367
+#: pkg/systemd/init.js:1196
 msgid "Invalid date format."
 msgstr "Virheellinen päivämuoto."
 
@@ -3257,7 +3424,7 @@ msgstr "Virheellinen vanhenemispäivä."
 msgid "Invalid file permissions"
 msgstr "Virheelliset tiedosto-oikeudet"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "Virheellinen tiedostonimi"
 
@@ -3273,7 +3440,7 @@ msgstr "Virheellinen metriikka $0"
 msgid "Invalid number of days"
 msgstr ""
 
-#: pkg/systemd/init.js:1314
+#: pkg/systemd/init.js:1143
 msgid "Invalid number."
 msgstr "Virheellinen numero."
 
@@ -3281,7 +3448,7 @@ msgstr "Virheellinen numero."
 msgid "Invalid port"
 msgstr "Virheellinen portti"
 
-#: pkg/networkmanager/firewall.jsx:335
+#: pkg/networkmanager/firewall.jsx:360
 msgid "Invalid port number"
 msgstr ""
 
@@ -3289,15 +3456,15 @@ msgstr ""
 msgid "Invalid prefix $0"
 msgstr "Virheellinen etuliite $0"
 
-#: pkg/networkmanager/utils.js:132
+#: pkg/networkmanager/utils.js:136
 msgid "Invalid prefix or netmask $0"
 msgstr "Virheellinen etuliite tai verkkopeite $0"
 
-#: pkg/networkmanager/firewall.jsx:362
+#: pkg/networkmanager/firewall.jsx:387
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "Virheellinen aikamuoto"
 
@@ -3341,7 +3508,7 @@ msgstr "Liity domainiin"
 msgid "Joining this domain is not supported"
 msgstr "Liittyminen tähän domainiin ei ole tuettu"
 
-#: pkg/systemd/init.js:736
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr ""
 
@@ -3376,11 +3543,11 @@ msgstr "Kerberos-pohjainen SSO"
 msgid "Kerberos Ticket"
 msgstr "Kerberos-tiketti"
 
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1583
+#: pkg/systemd/index.html:234 pkg/systemd/host.js:1600
 msgid "Kernel"
 msgstr "Kernel"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr ""
 
@@ -3412,6 +3579,10 @@ msgstr ""
 msgid "LACP Key"
 msgstr "LACP-avain"
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
+msgid "LVM Volume Group"
+msgstr ""
+
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr ""
@@ -3432,7 +3603,7 @@ msgstr "Viimeiset 7 päivää"
 msgid "Last Login"
 msgstr "Edellinen kirjautuminen"
 
-#: pkg/systemd/init.js:284
+#: pkg/systemd/init.js:293
 msgid "Last Trigger"
 msgstr "Edellinen liipaisin"
 
@@ -3467,6 +3638,7 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
+""
 msgstr ""
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66
@@ -3489,7 +3661,7 @@ msgstr ""
 msgid "Link down delay"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1957 pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1966 pkg/networkmanager/interfaces.js:1976
 msgid "Link local"
 msgstr ""
 
@@ -3509,7 +3681,7 @@ msgstr ""
 msgid "Links:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1993
+#: pkg/networkmanager/interfaces.js:2002
 msgid "Load Balancing"
 msgstr "Kuorman tasapainotus"
 
@@ -3529,9 +3701,13 @@ msgstr "Saatavilla olevien päivitysten lataus epäonnistui"
 msgid "Loading available updates, please wait..."
 msgstr "Ladataan saatavilla olevat päivitykset, odota hetki..."
 
-#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
-#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
-#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
+#: pkg/lib/cockpit-components-modifications.jsx:151
+msgid "Loading system modifications..."
+msgstr ""
+
+#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:367
+#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
+#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
 msgid "Loading..."
 msgstr "Ladataan..."
 
@@ -3547,7 +3723,7 @@ msgstr "Paikalliset levyt"
 msgid "Local Filesystem"
 msgstr "Paikallinen tiedostojärjestelmä"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr ""
 
@@ -3647,7 +3823,7 @@ msgstr ""
 msgid "Logout Successful"
 msgstr "Uloskirjautuminen onnistui"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Lokit"
 
@@ -3675,15 +3851,15 @@ msgstr "MAC-osoite"
 msgid "MAC Address:"
 msgstr "MAC-osoite:"
 
-#: pkg/networkmanager/interfaces.js:1985
+#: pkg/networkmanager/interfaces.js:1994
 msgid "MII (Recommended)"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2761
+#: pkg/networkmanager/interfaces.js:2773
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4545
+#: pkg/networkmanager/interfaces.js:4557
 msgid "MTU must be a positive number"
 msgstr "MTU:n tulee olla positiivinen numero"
 
@@ -3691,7 +3867,7 @@ msgstr "MTU:n tulee olla positiivinen numero"
 msgid "Mac"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:160
+#: pkg/machines/components/nicEdit.jsx:169
 msgid "Mac Address"
 msgstr ""
 
@@ -3703,7 +3879,7 @@ msgstr "Koneen ID"
 msgid "Machine SSH Key Fingerprints"
 msgstr "Koneen SSH-avaimen sormenjäljet"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "Koneet"
 
@@ -3715,7 +3891,7 @@ msgstr ""
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
+#: pkg/networkmanager/interfaces.js:1967 pkg/networkmanager/interfaces.js:1977
 msgid "Manual"
 msgstr ""
 
@@ -3735,15 +3911,30 @@ msgstr ""
 msgid "Marking $target as faulty"
 msgstr "Merkitään $target virheelliseksi"
 
-#: pkg/systemd/init.js:574
-msgid "Mask"
-msgstr "Peite"
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
+msgid "Mask Service"
+msgstr ""
 
-#: pkg/systemd/init.js:575
-msgid "Mask Forcefully"
-msgstr "Peitä väkisin"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:293
+msgid "Mask or Prefix Length"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2767
+#: pkg/machines/components/networks/createNetworkDialog.jsx:50
+msgid "Mask or Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:321
+msgid "Masked"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:200
+msgid ""
+"Masking service prevents all dependant units from running. This can have "
+"bigger impact than anticipated. Please confirm that you want to mask this "
+"unit."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2779
 msgid "Master"
 msgstr "Master"
 
@@ -3759,7 +3950,7 @@ msgstr ""
 msgid "Maximum memory could not be saved"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2865
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Maximum message age $max_age"
 msgstr ""
 
@@ -3780,18 +3971,22 @@ msgstr ""
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
-#: pkg/machines/components/vmOverviewTab.jsx:74
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
+#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "Muisti"
 
-#: pkg/systemd/host.js:1641
+#: pkg/systemd/host.js:1658
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Muisti"
 
 #: pkg/systemd/index.html:205
 msgid "Memory & Swap"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Memory Technology"
 msgstr ""
 
 #: pkg/machines/components/vm/memoryModal.jsx:103
@@ -3803,7 +3998,7 @@ msgstr ""
 msgid "Memory limit"
 msgstr "Muistiraja"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
 msgstr ""
 
@@ -3829,10 +4024,10 @@ msgid "Metadata Used"
 msgstr ""
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
+#: pkg/machines/components/diskAdd.jsx:188
+#: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
-#: pkg/machines/components/memorySelectRow.jsx:43
-#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -3844,11 +4039,11 @@ msgstr ""
 msgid "Mini Tower"
 msgstr ""
 
-#: pkg/systemd/init.js:1338 pkg/systemd/init.js:1347 pkg/systemd/init.js:1356
+#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
 msgid "Minute needs to be a number between 0-59"
 msgstr "Minuutit tulee olla esitetty numerovälillä 0-59"
 
-#: pkg/systemd/services.html:464
+#: pkg/systemd/services.html:319
 msgid "Minutes"
 msgstr "Minuutit"
 
@@ -3860,7 +4055,7 @@ msgstr ""
 msgid "Mode"
 msgstr "Tila"
 
-#: pkg/machines/components/nicEdit.jsx:54 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
 msgid "Model"
 msgstr "Malli"
 
@@ -3873,7 +4068,7 @@ msgstr "Mallityyppi"
 msgid "Modifying $target"
 msgstr "Muokataan $target"
 
-#: pkg/systemd/services.html:235
+#: pkg/systemd/services.html:127
 msgid "Monday"
 msgstr "Maanantai"
 
@@ -3902,23 +4097,23 @@ msgstr "Lisää tietoja"
 msgid "More details"
 msgstr "Lisätietoja"
 
-#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
-#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
+#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
+#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
 msgid "Mount"
 msgstr ""
 
-#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
-#: pkg/storaged/format-dialog.jsx:81
+#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
+#: pkg/storaged/nfs-details.jsx:172
 msgid "Mount Options"
 msgstr "Liitosvalinnat"
 
-#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/format-dialog.jsx:71
+#: pkg/storaged/nfs-panel.jsx:102
 msgid "Mount Point"
 msgstr "Liitospiste"
 
-#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
+#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
 msgid "Mount at boot"
 msgstr "Liitä käynnistyksen yhteydessä"
 
@@ -3938,7 +4133,7 @@ msgstr "Liitospiste ei voi olla tyhjä."
 msgid "Mount point must start with \"/\"."
 msgstr ""
 
-#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
+#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
 msgid "Mount read only"
 msgstr ""
 
@@ -3978,11 +4173,11 @@ msgstr ""
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2008
+#: pkg/networkmanager/interfaces.js:2017
 msgid "NSNA Ping"
 msgstr ""
 
-#: pkg/systemd/host.js:1514
+#: pkg/systemd/host.js:1531
 msgid "NTP Server"
 msgstr "NTP-palvelin"
 
@@ -3993,22 +4188,24 @@ msgstr "NTP-palvelin"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
+#: pkg/machines/components/diskAdd.jsx:126
+#: pkg/machines/components/networks/createNetworkDialog.jsx:122
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
-#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
-#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
+#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
+#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
+#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
 #: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
+#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
 #: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
-#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
+#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "Nimi"
 
@@ -4041,7 +4238,8 @@ msgid "Name cannot contain whitespace."
 msgstr ""
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:41
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "Nimen ei tule olla tyhjä."
 
@@ -4049,7 +4247,7 @@ msgstr "Nimen ei tule olla tyhjä."
 msgid "Name: "
 msgstr ""
 
-#: pkg/systemd/host.js:1348
+#: pkg/systemd/host.js:1365
 msgid "Need at least one NTP server"
 msgstr "Tarvitaan vähintään yksi NTP-palvelin"
 
@@ -4069,11 +4267,15 @@ msgstr ""
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+msgid "Network Boot is available only when using System connection"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr ""
 
@@ -4081,11 +4283,11 @@ msgstr ""
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr ""
 
-#: pkg/systemd/host.js:550
+#: pkg/systemd/host.js:570
 msgid "Network Traffic"
 msgstr "Verkkoliikenne"
 
@@ -4093,7 +4295,7 @@ msgstr "Verkkoliikenne"
 msgid "Network devices and graphs require NetworkManager."
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:232
+#: pkg/machines/components/nicEdit.jsx:245
 msgid "Network interface settings could not be saved"
 msgstr ""
 
@@ -4102,11 +4304,11 @@ msgid "NetworkManager is not running."
 msgstr ""
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:914
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Verkko"
 
-#: pkg/networkmanager/interfaces.js:1625 pkg/networkmanager/interfaces.js:2207
+#: pkg/networkmanager/interfaces.js:1634 pkg/networkmanager/interfaces.js:2216
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Verkko"
@@ -4115,8 +4317,8 @@ msgstr "Verkko"
 msgid "Networking Logs"
 msgstr "Verkkolokit"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/networks/networkList.jsx:46
+#: pkg/machines/components/networks/networkList.jsx:45
+#: pkg/machines/components/networks/networkList.jsx:49
 msgid "Networks"
 msgstr "Verkot"
 
@@ -4148,7 +4350,7 @@ msgstr ""
 msgid "New passphrase"
 msgstr ""
 
-#: pkg/users/local.js:139 pkg/lib/credentials.js:237
+#: pkg/lib/credentials.js:237 pkg/users/local.js:139
 msgid "New password was not accepted"
 msgstr "Uutta salasanaa ei hyväksytty"
 
@@ -4156,16 +4358,16 @@ msgstr "Uutta salasanaa ei hyväksytty"
 msgid "Next"
 msgstr "Seuraava"
 
-#: pkg/systemd/init.js:283
+#: pkg/systemd/init.js:292
 msgid "Next Run"
 msgstr ""
 
-#: pkg/systemd/index.html:226 pkg/systemd/host.js:1585
+#: pkg/systemd/index.html:226 pkg/systemd/host.js:1602
 msgid "Nice"
 msgstr ""
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2606
 msgid "No"
 msgstr ""
 
@@ -4181,7 +4383,7 @@ msgstr "Ei tiedostojärjestelmää"
 msgid "No Logical Volumes"
 msgstr "Ei loogisia taltioita"
 
-#: pkg/systemd/services.html:192
+#: pkg/systemd/services.html:84
 msgid "No Matching Results"
 msgstr ""
 
@@ -4189,12 +4391,16 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:365
+#: pkg/machines/components/nicEdit.jsx:118
+msgid "No Network Devices"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
 msgstr "Ei SELinux-hälytyksiä."
 
-#: pkg/machines/components/diskAdd.jsx:204
-#: pkg/machines/components/diskAdd.jsx:216
+#: pkg/machines/components/diskAdd.jsx:209
+#: pkg/machines/components/diskAdd.jsx:221
 msgid "No Storage Pools available"
 msgstr ""
 
@@ -4202,15 +4408,19 @@ msgstr ""
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr ""
 
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "No System Modifications"
+msgstr ""
+
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:110
+#: pkg/machines/components/nicEdit.jsx:116
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:926
+#: pkg/networkmanager/firewall.jsx:956
 msgid "No active zones"
 msgstr ""
 
@@ -4238,7 +4448,7 @@ msgstr ""
 msgid "No boot device found"
 msgstr "Käynnistyslaitetta ei löytynyt"
 
-#: pkg/networkmanager/interfaces.js:1419
+#: pkg/networkmanager/interfaces.js:1428
 msgid "No carrier"
 msgstr ""
 
@@ -4262,7 +4472,7 @@ msgstr "Ei kontteja"
 msgid "No containers that match the current filter"
 msgstr "Ei nykyistä suodatusta vastaavia kontteja"
 
-#: pkg/networkmanager/firewall.jsx:729
+#: pkg/networkmanager/firewall.jsx:759
 msgid "No description available"
 msgstr ""
 
@@ -4270,9 +4480,9 @@ msgstr ""
 msgid "No description provided."
 msgstr "Kuvausta ei annettu."
 
-#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
-#: pkg/storaged/vgroup-details.jsx:54
+#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
+#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
+#: pkg/storaged/vgroups-panel.jsx:60
 msgid "No disks are available."
 msgstr "Levyjä ei ole saatavilla."
 
@@ -4339,7 +4549,7 @@ msgstr ""
 msgid "No network interfaces defined for this VM"
 msgstr "Tälle virtuaalikoneelle ei ole määritetty verkkoliitäntöjä"
 
-#: pkg/machines/components/networks/networkList.jsx:48
+#: pkg/machines/components/networks/networkList.jsx:51
 msgid "No network is defined on this host"
 msgstr ""
 
@@ -4347,7 +4557,7 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:939
+#: pkg/networkmanager/firewall.jsx:969
 msgid "No open ports"
 msgstr "Ei avoimia portteja"
 
@@ -4404,8 +4614,9 @@ msgid "No volume groups created"
 msgstr "Taltioryhmiä ei ole luotu"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
 #: pkg/kdump/kdump-view.jsx:419
+#: pkg/machines/components/networks/createNetworkDialog.jsx:204
+#: pkg/networkmanager/firewall.jsx:764 pkg/tuned/dialog.js:231
 msgid "None"
 msgstr ""
 
@@ -4429,7 +4640,7 @@ msgstr ""
 msgid "Not authorized to upload-report"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:822
+#: pkg/networkmanager/interfaces.js:831
 msgid "Not available"
 msgstr ""
 
@@ -4453,7 +4664,7 @@ msgstr "Ei liitetty"
 msgid "Not permitted to perform this action."
 msgstr "Ei oikeutta suorittaa tätä toimintoa."
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "Ei käynnissä"
 
@@ -4465,7 +4676,7 @@ msgstr "Ei synkronisoitu"
 msgid "Not yet synced"
 msgstr "Ei vielä synkronisoitu"
 
-#: pkg/systemd/services.html:357
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr ""
 
@@ -4477,21 +4688,13 @@ msgstr ""
 msgid "Notice and above"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
-msgid "OS Vendor"
-msgstr "Käyttöjärjestelmän toimittaja"
-
-#: pkg/selinux/setroubleshoot-view.jsx:394
+#: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:389
+#: pkg/selinux/setroubleshoot-view.jsx:399
 msgid "Occurred between $0 and $1"
 msgstr ""
-
-#: pkg/lib/patterns.js:246
-msgid "Off"
-msgstr "Pois"
 
 #: pkg/lib/cockpit-components-dialog.jsx:194
 msgid "Ok"
@@ -4505,19 +4708,15 @@ msgstr "Vanha salasana"
 msgid "Old passphrase"
 msgstr ""
 
-#: pkg/users/local.js:86 pkg/lib/credentials.js:218
+#: pkg/lib/credentials.js:218 pkg/users/local.js:86
 msgid "Old password not accepted"
 msgstr "Vanhaa salasanaa ei hyväksytty"
-
-#: pkg/lib/patterns.js:246
-msgid "On"
-msgstr "Päällä"
 
 #: node_modules/registry-image-widgets/views/image-meta.html:7
 msgid "On Build"
 msgstr ""
 
-#: pkg/docker/index.html:549 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr ""
 
@@ -4555,7 +4754,7 @@ msgstr ""
 msgid "Only Emergency"
 msgstr ""
 
-#: pkg/systemd/init.js:1288
+#: pkg/systemd/init.js:1117
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr ""
 
@@ -4572,7 +4771,7 @@ msgid "Open"
 msgstr ""
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "Käyttöjärjestelmä"
 
@@ -4615,9 +4814,9 @@ msgstr "Muut laitteet"
 msgid "Other Options"
 msgstr "Muut valinnat"
 
-#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
+#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/networks/network.jsx:72
+#: pkg/machines/components/vm/vm.jsx:47
 msgid "Overview"
 msgstr ""
 
@@ -4625,7 +4824,7 @@ msgstr ""
 msgid "Overwrite existing data with zeros"
 msgstr ""
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "PCI"
 msgstr "PCI"
 
@@ -4633,7 +4832,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "Paketin tiedot"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "PackageKit kaatui"
 
@@ -4645,19 +4844,23 @@ msgstr "PackageKit ei ole asennettu"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit raportoi virhekoodin $0"
 
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "Paketit"
+
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2903
+#: pkg/networkmanager/interfaces.js:2915
 msgid "Parent $parent"
 msgstr ""
 
-#: pkg/systemd/init.js:721
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1465
+#: pkg/networkmanager/interfaces.js:1474
 msgid "Part of "
 msgstr ""
 
@@ -4673,7 +4876,7 @@ msgstr ""
 msgid "Partitioning"
 msgstr "Osiointi"
 
-#: pkg/networkmanager/interfaces.js:2000
+#: pkg/networkmanager/interfaces.js:2009
 msgid "Passive"
 msgstr ""
 
@@ -4697,10 +4900,10 @@ msgstr ""
 msgid "Passphrases do not match"
 msgstr "Tunnuslauseet eivät täsmää"
 
-#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
-#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
+#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
+#: pkg/users/index.html:173 src/ws/login.html:50
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
 msgid "Password"
 msgstr "Salasana"
@@ -4738,7 +4941,8 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Liitä julkisen SSH-avaintiedostosi sisältö tähän"
 
-#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "Polku"
 
@@ -4746,7 +4950,7 @@ msgstr "Polku"
 msgid "Path cost"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2885
+#: pkg/networkmanager/interfaces.js:2897
 msgid "Path cost $path_cost"
 msgstr ""
 
@@ -4754,7 +4958,7 @@ msgstr ""
 msgid "Path on Server"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr ""
 
@@ -4766,7 +4970,7 @@ msgstr ""
 msgid "Path on server must start with \"/\"."
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr ""
 
@@ -4774,7 +4978,7 @@ msgstr ""
 msgid "Path to file"
 msgstr ""
 
-#: pkg/systemd/services.html:60
+#: pkg/systemd/services.jsx:42
 msgid "Paths"
 msgstr "Polut"
 
@@ -4790,7 +4994,7 @@ msgstr "Suorituskykyprofiili"
 msgid "Peripheral Chassis"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3630
+#: pkg/networkmanager/interfaces.js:3642
 msgid "Permanent"
 msgstr ""
 
@@ -4798,12 +5002,16 @@ msgstr ""
 msgid "Permission denied"
 msgstr "Käyttö estetty"
 
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Permissive"
+msgstr ""
+
 #: pkg/machines/components/diskAdd.jsx:110
 msgid "Persistence"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
 #: pkg/machines/components/networks/networkOverviewTab.jsx:83
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:66
 msgid "Persistent"
 msgstr ""
 
@@ -4811,7 +5019,7 @@ msgstr ""
 msgid "Physical"
 msgstr "Fyysinen"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr ""
 
@@ -4823,7 +5031,7 @@ msgstr "Fyysinen taltio"
 msgid "Physical Volumes"
 msgstr "Fyysiset taltiot"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -4847,9 +5055,9 @@ msgstr ""
 msgid "Pizza Box"
 msgstr ""
 
-#: pkg/docker/details.js:290 pkg/docker/util.js:612
-#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
+#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
+#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
+#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
 #: pkg/storaged/vgroup-details.jsx:209
 msgid "Please confirm deletion of $0"
 msgstr "Vahvista kohteen $0 poistaminen"
@@ -4858,19 +5066,19 @@ msgstr "Vahvista kohteen $0 poistaminen"
 msgid "Please confirm forced deletion of $0"
 msgstr "Vahvista kohteen $0 pakotettu poistaminen"
 
-#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
+#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
 msgid "Please confirm stopping of $0"
 msgstr "Vahvista kohteen $0 pysäyttäminen"
 
-#: pkg/machines/components/diskAdd.jsx:447
+#: pkg/machines/components/diskAdd.jsx:483
 msgid "Please enter new volume name"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:450
+#: pkg/machines/components/diskAdd.jsx:486
 msgid "Please enter new volume size"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:864
+#: pkg/networkmanager/firewall.jsx:894
 msgid "Please install the $0 package"
 msgstr ""
 
@@ -4890,14 +5098,15 @@ msgstr "Käynnistä virtuaalikone päästäksesi sen konsoliin."
 msgid "Please try another term"
 msgstr ""
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Plug"
 msgstr ""
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/deleteDialog.jsx:53
+#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
+#: pkg/storaged/content-views.jsx:133
 msgid "Pool"
 msgstr ""
 
@@ -4913,6 +5122,11 @@ msgstr ""
 msgid "Pool for thinly provisioned volumes"
 msgstr ""
 
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
+msgid "Pool's volumes are used by VMs "
+msgstr ""
+
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
@@ -4922,7 +5136,7 @@ msgstr ""
 msgid "Port"
 msgstr "Portti"
 
-#: pkg/networkmanager/firewall.jsx:339
+#: pkg/networkmanager/firewall.jsx:364
 msgid "Port number and type do not match"
 msgstr ""
 
@@ -4933,7 +5147,7 @@ msgstr ""
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
 #: pkg/networkmanager/index.html:323
 #: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
+#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2998
 msgid "Ports"
 msgstr "Portit"
 
@@ -4953,28 +5167,36 @@ msgstr ""
 msgid "Prefix"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/machines/components/networks/createNetworkDialog.jsx:337
+msgid "Prefix Length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:78
+msgid "Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:826
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:835
 msgid "Preparing"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3631
+#: pkg/lib/machine-info.js:251
+msgid "Present"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3643
 msgid "Preserve"
-msgstr ""
-
-#: pkg/systemd/init.js:572
-msgid "Preset"
-msgstr ""
-
-#: pkg/systemd/init.js:573
-msgid "Preset Forcefully"
 msgstr ""
 
 #: pkg/systemd/index.html:295
@@ -4994,7 +5216,7 @@ msgstr "Ensisijainen"
 msgid "Priority"
 msgstr "Prioriteeetti"
 
-#: pkg/networkmanager/interfaces.js:2859 pkg/networkmanager/interfaces.js:2883
+#: pkg/networkmanager/interfaces.js:2871 pkg/networkmanager/interfaces.js:2895
 msgid "Priority $priority"
 msgstr "Prioriteetti $priority"
 
@@ -5043,7 +5265,7 @@ msgstr ""
 msgid "Prompting via ssh-keygen timed out"
 msgstr ""
 
-#: pkg/systemd/init.js:734
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr ""
 
@@ -5053,7 +5275,7 @@ msgstr ""
 msgid "Protocol"
 msgstr ""
 
-#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
+#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
 msgid "Public Key"
 msgstr "Julkinen avain"
 
@@ -5063,14 +5285,6 @@ msgstr ""
 
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
-msgstr ""
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr ""
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
 msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:185
@@ -5133,7 +5347,7 @@ msgstr ""
 msgid "RAID Device"
 msgstr "RAID-laite"
 
-#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
+#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
 msgid "RAID Device $0"
 msgstr "RAID-laite $0"
 
@@ -5153,24 +5367,36 @@ msgstr "RAID-jäsen"
 msgid "Rack Mount Chassis"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3632
+#: pkg/networkmanager/interfaces.js:3644
 msgid "Random"
 msgstr "Satunnainen"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:789
 msgid "Range"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:370
+#: pkg/networkmanager/firewall.jsx:395
 msgid "Range must be strictly ordered"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Rank"
 msgstr ""
 
 #: pkg/kdump/kdump-view.jsx:388
 msgid "Raw to a device"
 msgstr ""
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:386
+msgid "Read-only"
 msgstr ""
 
 #: pkg/docker/index.html:365
@@ -5206,13 +5432,13 @@ msgstr "Valmis"
 msgid "Real Host Name"
 msgstr ""
 
-#: pkg/systemd/host.js:1020
+#: pkg/systemd/host.js:1037
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
 msgstr ""
 
-#: pkg/systemd/host.js:1021
+#: pkg/systemd/host.js:1038
 msgid "Real host name must be 64 characters or less"
 msgstr ""
 
@@ -5234,7 +5460,7 @@ msgstr ""
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Yhdistä uudelleen"
@@ -5267,19 +5493,19 @@ msgstr ""
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:777
+#: pkg/packagekit/updates.jsx:779
 msgid "Register…"
 msgstr "Rekisteröi…"
 
-#: pkg/systemd/init.js:546
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Lataa uudelleen"
 
-#: pkg/systemd/init.js:735
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "Etä-URL"
 
@@ -5300,13 +5526,13 @@ msgstr ""
 msgid "Removals:"
 msgstr ""
 
+#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
-#: pkg/apps/application.jsx:109
+#: pkg/storaged/nfs-details.jsx:308
 msgid "Remove"
 msgstr "Poista"
 
-#: pkg/networkmanager/interfaces.js:3055
+#: pkg/networkmanager/interfaces.js:3067
 msgid "Remove $0"
 msgstr "Poista $0"
 
@@ -5330,11 +5556,11 @@ msgstr ""
 msgid "Remove passphrase in $0?"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:631
+#: pkg/networkmanager/firewall.jsx:661
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:610
+#: pkg/networkmanager/firewall.jsx:640
 msgid "Remove service from zones"
 msgstr ""
 
@@ -5350,7 +5576,7 @@ msgstr ""
 msgid "Removing $target from RAID Device"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3054
+#: pkg/networkmanager/interfaces.js:3066
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5381,23 +5607,23 @@ msgstr "Nimetään uudelleen $target"
 msgid "Repairing $target"
 msgstr "Korjataan $target"
 
-#: pkg/systemd/services.html:489
+#: pkg/systemd/services.html:344
 msgid "Repeat Daily"
 msgstr "Toista joka päivä"
 
-#: pkg/systemd/services.html:488
+#: pkg/systemd/services.html:343
 msgid "Repeat Hourly"
 msgstr "Toista joka tunti"
 
-#: pkg/systemd/services.html:491
+#: pkg/systemd/services.html:346
 msgid "Repeat Monthly"
 msgstr "Toista joka kuukausi"
 
-#: pkg/systemd/services.html:490
+#: pkg/systemd/services.html:345
 msgid "Repeat Weekly"
 msgstr "Toista joka viikko"
 
-#: pkg/systemd/services.html:492
+#: pkg/systemd/services.html:347
 msgid "Repeat Yearly"
 msgstr "Toista joka vuosi"
 
@@ -5435,19 +5661,27 @@ msgstr "Vaadi salasanan vaihto $0 päivän välein"
 msgid "Require password change on $0"
 msgstr "Vaadi salasanan vaihto $0"
 
-#: pkg/systemd/init.js:722
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr ""
 
-#: pkg/systemd/init.js:717
+#: pkg/systemd/service-details.jsx:372
+msgid "Required by "
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr ""
 
-#: pkg/systemd/init.js:718
+#: pkg/systemd/service-details.jsx:387
+msgid "Requires administration access to edit"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr ""
 
-#: pkg/systemd/init.js:723
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr ""
 
@@ -5483,8 +5717,9 @@ msgstr ""
 
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
-#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
+#: pkg/machines/components/vm/vmActions.jsx:42
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Käynnistä uudelleen"
 
@@ -5504,7 +5739,7 @@ msgstr "Uudelleenkäynnistyksen käytäntö:"
 msgid "Restart Recommended"
 msgstr "Uudelleenkäynnistystä suositellaan"
 
-#: pkg/packagekit/updates.jsx:864
+#: pkg/packagekit/updates.jsx:866
 msgid "Restarting"
 msgstr "Käynnistetään uudelleen"
 
@@ -5525,14 +5760,15 @@ msgid "Reuse my password for privileged tasks"
 msgstr ""
 
 #: pkg/shell/index.html:159
-msgid "Reuse my password for privileged tasks and to connect to other machines"
+msgid ""
+"Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 
 #: pkg/users/index.html:94
 msgid "Roles"
 msgstr "Roolit"
 
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1983 pkg/networkmanager/interfaces.js:2000
 msgid "Round Robin"
 msgstr ""
 
@@ -5544,12 +5780,12 @@ msgstr ""
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3337
 msgid "Routes"
 msgstr "Reitit"
 
 #: pkg/docker/index.html:253 pkg/docker/index.html:566
-#: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
+#: pkg/systemd/services.html:296 pkg/machines/components/vm/vmActions.jsx:91
 msgid "Run"
 msgstr ""
 
@@ -5570,19 +5806,19 @@ msgstr ""
 msgid "Runner"
 msgstr ""
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr ""
 
-#: pkg/systemd/services.html:123
-msgid "Running Since"
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:364
+#: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:297
+#: pkg/selinux/setroubleshoot-view.jsx:301
 msgid "SELinux Policy"
 msgstr "SELinux-käytäntö"
 
@@ -5590,15 +5826,15 @@ msgstr "SELinux-käytäntö"
 msgid "SELinux Troubleshoot"
 msgstr "SELinux-ongelmanratkaisu"
 
-#: pkg/selinux/setroubleshoot-view.jsx:356
+#: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "SELinux is disabled on the system"
 msgstr "SELinux on poistettu käytöstä järjestelmässä"
 
-#: pkg/selinux/setroubleshoot-view.jsx:284
+#: pkg/selinux/setroubleshoot-view.jsx:285
 msgid "SELinux is disabled on the system."
 msgstr "SELinux on poistettu käytöstä järjestelmässä."
 
-#: pkg/selinux/setroubleshoot-view.jsx:276
+#: pkg/selinux/setroubleshoot-view.jsx:277
 msgid "SELinux system status is unknown."
 msgstr "SELinux-järjestelmän tila on tuntematon."
 
@@ -5638,7 +5874,7 @@ msgstr ""
 msgid "STP Priority"
 msgstr ""
 
-#: pkg/systemd/services.html:240
+#: pkg/systemd/services.html:132
 msgid "Saturday"
 msgstr "Lauantai"
 
@@ -5646,11 +5882,10 @@ msgstr "Lauantai"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
-#: pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Tallenna"
 
@@ -5676,8 +5911,8 @@ msgstr ""
 msgid "Sealed-case PC"
 msgstr ""
 
-#: pkg/systemd/services.html:459 pkg/systemd/services.html:463
-#: pkg/systemd/init.js:1076
+#: pkg/systemd/services.html:314 pkg/systemd/services.html:318
+#: pkg/systemd/init.js:905
 msgid "Seconds"
 msgstr "Sekunnit"
 
@@ -5693,7 +5928,7 @@ msgstr ""
 msgid "Security"
 msgstr ""
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:506
 msgid "Security Updates Available"
 msgstr "Tietoturvapäivityksiä saatavilla"
 
@@ -5703,8 +5938,8 @@ msgstr "Valitse"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with "
+"{{#strong}}{{host}}{{/strong}}"
 msgstr ""
 
 #: pkg/machines/components/vm/vmActions.jsx:66
@@ -5725,8 +5960,8 @@ msgstr "Lähetetään"
 msgid "Serial Console"
 msgstr ""
 
-#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
-#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
+#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
+#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
 msgid "Server"
 msgstr "Palvelin"
 
@@ -5758,12 +5993,12 @@ msgstr "Palvelin on sulkenut yhteyden."
 msgid "Servers"
 msgstr "Palvelimet"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:968
 #: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "Palvelu"
 
-#: pkg/systemd/services.html:337
+#: pkg/systemd/services.html:229
 msgid "Service Logs"
 msgstr "Palvelulokit"
 
@@ -5787,15 +6022,16 @@ msgstr "Palvelu on pysäytetty"
 msgid "Service is stopping"
 msgstr "Palvelu pysähtyy"
 
-#: pkg/systemd/services.html:399
+#: pkg/systemd/services.html:254
 msgid "Service name"
 msgstr "Palvelun nimi"
 
-#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:222
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Palvelut"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Istunto"
@@ -5804,7 +6040,11 @@ msgstr "Istunto"
 msgid "Set"
 msgstr ""
 
-#: pkg/systemd/host.js:764
+#: pkg/machines/components/networks/createNetworkDialog.jsx:231
+msgid "Set DHCP Range"
+msgstr ""
+
+#: pkg/systemd/host.js:781
 msgid "Set Host name"
 msgstr ""
 
@@ -5828,7 +6068,7 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:293
+#: pkg/selinux/setroubleshoot-view.jsx:294
 msgid ""
 "Setting deviates from the configured state and will revert on the next boot."
 msgstr ""
@@ -5849,15 +6089,19 @@ msgstr ""
 msgid "Severity:"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1959
+#: pkg/networkmanager/interfaces.js:1968
 msgid "Shared"
 msgstr "Jaettu"
+
+#: pkg/lib/cockpit-components-modifications.jsx:78
+msgid "Shell Script"
+msgstr ""
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Show Performance Options"
 msgstr ""
 
@@ -5898,16 +6142,21 @@ msgstr ""
 msgid "Shut Down"
 msgstr "Sammuta"
 
+#: pkg/lib/machine-info.js:242
+msgid "Single Rank"
+msgstr ""
+
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
+#: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
-#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
-#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
-#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
+#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
+#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
+#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
+#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:259
 msgid "Size"
 msgstr "Koko"
 
@@ -5931,7 +6180,7 @@ msgstr "Koon tulee olla numero"
 msgid "Size must be at least $0"
 msgstr "Koon tulee olla vähintään $0"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:250
 msgid "Slot"
 msgstr ""
 
@@ -5939,11 +6188,11 @@ msgstr ""
 msgid "Slot $0"
 msgstr ""
 
-#: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
+#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:40
 msgid "Sockets"
 msgstr ""
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Ohjelmistopäivitykset"
 
@@ -5963,15 +6212,15 @@ msgctxt "storage"
 msgid "Solid-State Disk"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:95
+#: pkg/selinux/setroubleshoot-view.jsx:96
 msgid "Solution applied successfully"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:102
+#: pkg/selinux/setroubleshoot-view.jsx:103
 msgid "Solution failed"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:409
+#: pkg/selinux/setroubleshoot-view.jsx:419
 msgid "Solutions"
 msgstr ""
 
@@ -5980,25 +6229,26 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:709
+#: pkg/networkmanager/firewall.jsx:739
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:141
+#: pkg/machines/components/diskAdd.jsx:541
+#: pkg/machines/components/nicEdit.jsx:150
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
-#: pkg/machines/components/diskAdd.jsx:504
 msgid "Source"
 msgstr "Lähde"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
 msgid "Source Format"
 msgstr ""
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr ""
 
@@ -6006,12 +6256,16 @@ msgstr ""
 msgid "Source URL"
 msgstr "Lähdeosoite"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
+msgid "Source Volume Group"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr ""
 
@@ -6019,7 +6273,7 @@ msgstr ""
 msgid "Space-saving Computer"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2857
+#: pkg/networkmanager/interfaces.js:2869
 msgid "Spanning Tree Protocol"
 msgstr ""
 
@@ -6035,13 +6289,18 @@ msgstr ""
 msgid "Specific Time"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3633
+#: pkg/systemd/hwinfo.jsx:259
+msgid "Speed"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3645
 msgid "Stable"
 msgstr ""
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
-#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
+#: pkg/machines/components/networks/createNetworkDialog.jsx:237
+#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Käynnistä"
 
@@ -6053,16 +6312,25 @@ msgstr "Käynnistä Docker"
 msgid "Start Multipath"
 msgstr "Käynnistä Multipath"
 
-#: pkg/networkmanager/index.html:44
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:411
+msgid "Start and Enable"
 msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:105
 msgid "Start libvirt"
 msgstr "Käynnistä libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:84
+msgid "Start should not be empty"
 msgstr ""
 
 #: pkg/storaged/jobs-panel.jsx:59
@@ -6073,15 +6341,15 @@ msgstr "Käynnistetään RAID-laite $target"
 msgid "Starting swapspace $target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr ""
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/init.js:285
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "Tila"
 
@@ -6089,11 +6357,12 @@ msgstr "Tila"
 msgid "State:"
 msgstr "Tila:"
 
-#: pkg/systemd/services.html:74 pkg/systemd/init.js:207
+#: pkg/systemd/services.html:68 pkg/systemd/init.js:212
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr ""
 
-#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "Tila"
 
@@ -6106,15 +6375,19 @@ msgid "Sticky"
 msgstr ""
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
-#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
-#: pkg/systemd/init.js:542
+#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Pysäytä"
 
 #: pkg/storaged/mdraid-details.jsx:247
 msgid "Stop Device"
 msgstr "Pysäytä laite"
+
+#: pkg/systemd/service-details.jsx:411
+msgid "Stop and Disable"
+msgstr ""
 
 #: pkg/storaged/nfs-details.jsx:259
 msgid "Stop and Unmount"
@@ -6145,8 +6418,8 @@ msgid "Stopping swapspace $target"
 msgstr ""
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Tallennustila"
 
@@ -6162,11 +6435,11 @@ msgstr ""
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr ""
 
@@ -6189,6 +6462,10 @@ msgstr ""
 
 #: pkg/docker/index.html:304
 msgid "Storage pool"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
+msgid "Storage size must not be 0"
 msgstr ""
 
 #: pkg/systemd/index.html:155
@@ -6219,7 +6496,7 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
-#: pkg/systemd/services.html:241
+#: pkg/systemd/services.html:133
 msgid "Sunday"
 msgstr "Sunnuntai"
 
@@ -6240,31 +6517,31 @@ msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr ""
 
-#: pkg/systemd/index.html:248 pkg/systemd/host.js:1692
+#: pkg/systemd/index.html:248 pkg/systemd/host.js:1709
 msgid "Swap Used"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
+#: pkg/networkmanager/interfaces.js:2504 pkg/networkmanager/interfaces.js:3051
 msgid "Switch off $0"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
+#: pkg/networkmanager/interfaces.js:2479 pkg/networkmanager/interfaces.js:3039
 msgid "Switch on $0"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2491
+#: pkg/networkmanager/interfaces.js:2503
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3038
+#: pkg/networkmanager/interfaces.js:3050
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2466 pkg/networkmanager/interfaces.js:3026
+#: pkg/networkmanager/interfaces.js:2478 pkg/networkmanager/interfaces.js:3038
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6290,20 +6567,26 @@ msgstr "Synkronoi palvelimen {{Server}} kanssa"
 msgid "Synchronizing RAID Device $target"
 msgstr "Synkronoidaan RAID-laitetta $target"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:260
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "Järjestelmä"
 
-#: pkg/systemd/hwinfo.jsx:264
+#: pkg/systemd/hwinfo.jsx:273
 msgid "System Information"
 msgstr "Järjestelmätiedot"
 
-#: pkg/systemd/host.js:480
+#: pkg/selinux/setroubleshoot-view.jsx:467
+msgid "System Modifications"
+msgstr ""
+
+#: pkg/systemd/host.js:490
 msgid "System Not Registered"
 msgstr "Järjestelmää ei ole rekisteröity"
 
-#: pkg/systemd/services.html:57
+#: pkg/systemd/services.jsx:38
 msgid "System Services"
 msgstr "Järjestelmäpalvelut"
 
@@ -6311,16 +6594,16 @@ msgstr "Järjestelmäpalvelut"
 msgid "System Time"
 msgstr "Järjestelmän aika"
 
-#: pkg/systemd/host.js:486
+#: pkg/systemd/host.js:496
 msgid "System Up To Date"
 msgstr "Järjestelmä ajan tasalla"
 
-#: pkg/packagekit/updates.jsx:876
+#: pkg/packagekit/updates.jsx:878
 msgid "System is up to date"
 msgstr "Järjestelmä on ajan tasalla"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:968
 msgid "TCP"
 msgstr "TCP"
 
@@ -6348,25 +6631,25 @@ msgstr ""
 msgid "Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr ""
 
-#: pkg/systemd/services.html:56
+#: pkg/systemd/services.jsx:39
 msgid "Targets"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2512 pkg/networkmanager/interfaces.js:2524
-#: pkg/networkmanager/interfaces.js:2814
+#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
+#: pkg/networkmanager/interfaces.js:2826
 msgid "Team"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2842
+#: pkg/networkmanager/interfaces.js:2854
 msgid "Team Port"
 msgstr ""
 
@@ -6378,7 +6661,7 @@ msgstr ""
 msgid "Team Settings"
 msgstr ""
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr ""
 
@@ -6422,8 +6705,8 @@ msgstr ""
 msgid "The RAID device must be running in order to remove disks."
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:80
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:84
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:125
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:129
 msgid "The Storage Pool could not be deleted"
 msgstr ""
 
@@ -6471,15 +6754,15 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
+" Are you sure you want to continue connecting?"
 msgstr ""
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
 msgstr "Kerätyt tiedot tallennetaan paikallisesti järjestelmään."
 
-#: pkg/selinux/setroubleshoot-view.jsx:291
+#: pkg/selinux/setroubleshoot-view.jsx:292
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 
@@ -6493,7 +6776,7 @@ msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr ""
 
@@ -6504,7 +6787,8 @@ msgid ""
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1014
-msgid "The filesystem is in use by login sessions. Proceeding will stop these."
+msgid ""
+"The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 
 #: pkg/storaged/dialog.jsx:1016
@@ -6513,7 +6797,8 @@ msgid ""
 msgstr ""
 
 #: pkg/docker/util.js:631
-msgid "The following containers depend on this image and will become unusable."
+msgid ""
+"The following containers depend on this image and will become unusable."
 msgstr ""
 
 #: pkg/sosreport/index.html:51
@@ -6546,7 +6831,11 @@ msgstr ""
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr ""
 
-#: pkg/shell/indexes.js:407
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "The logged in user is not permitted to view system modifications"
+msgstr ""
+
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "Kone käynnistyy uudelleen"
 
@@ -6574,6 +6863,15 @@ msgstr ""
 msgid "The scan from $time ($type) was not successful."
 msgstr ""
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
+msgid "The selected Operating System has minimum memory requirement of $0 $1"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+msgid ""
+"The selected Operating System has minimum storage size requirement of $0 $1"
+msgstr ""
+
 #: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
@@ -6589,7 +6887,7 @@ msgstr ""
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 
-#: pkg/systemd/init.js:922
+#: pkg/systemd/init.js:751
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "Käyttäjällä <b>$0</b> ei ole oikeutta luoda ajastimia"
 
@@ -6599,10 +6897,6 @@ msgstr ""
 
 #: pkg/systemd/host.js:70
 msgid "The user <b>$0</b> is not permitted to change the system time"
-msgstr ""
-
-#: pkg/systemd/init.js:614
-msgid "The user <b>$0</b> is not permitted to enable or disable services"
 msgstr ""
 
 #: pkg/dashboard/list.js:223
@@ -6621,7 +6915,7 @@ msgstr "Käyttäjällä <b>$0</b> ei ole oikeutta muokata tilejä"
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1516
+#: pkg/networkmanager/interfaces.js:1525
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "Käyttäjällä <b>$0</b> ei ole oikeutta muokata verkkoasetuksia"
 
@@ -6635,10 +6929,6 @@ msgstr ""
 "Käyttäjällä <b>$0</b> ei ole oikeutta sammuttaa tai käynnistää uudelleen "
 "tätä palvelinta"
 
-#: pkg/systemd/init.js:606 pkg/systemd/init.js:610
-msgid "The user <b>$0</b> is not permitted to start or stop services"
-msgstr ""
-
 #: pkg/users/local.js:553
 msgid ""
 "The user name can only consist of letters from a-z, digits, dots, dashes and "
@@ -6647,7 +6937,8 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible $0)"
+"The web browser configuration prevents Cockpit from running (inaccessible "
+"$0)"
 msgstr ""
 
 #: pkg/shell/active-pages-dialog.jsx:58
@@ -6683,7 +6974,7 @@ msgstr ""
 msgid "This VDO device does not use all of its backing device."
 msgstr ""
 
-#: pkg/systemd/init.js:1371
+#: pkg/systemd/init.js:1200
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -6691,7 +6982,7 @@ msgstr ""
 "Tätä päivää ei ole kaikissa kuukausissa. <br> Ajastin ajetaan vain "
 "kuukausissa, joissa on 31. päivä."
 
-#: pkg/networkmanager/interfaces.js:2624
+#: pkg/networkmanager/interfaces.js:2636
 msgid "This device cannot be managed here."
 msgstr "Tätä laitetta ei voida hallita täällä."
 
@@ -6729,7 +7020,7 @@ msgstr ""
 msgid "This disk cannot be removed while the device is recovering."
 msgstr ""
 
-#: pkg/systemd/init.js:1283 pkg/systemd/init.js:1297 pkg/systemd/init.js:1306
+#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
 msgid "This field cannot be empty."
 msgstr "Tämä kenttä ei voi olla tyhjä."
 
@@ -6758,7 +7049,11 @@ msgstr "Tämä paketti ei ole yhteensopiva tämän Cockpitin version kanssa."
 msgid "This package requires Cockpit version %s or later"
 msgstr "Tämä paketti vaatii Cockpitin version %s tai uudemman"
 
-#: pkg/packagekit/updates.jsx:772
+#: pkg/machines/components/diskAdd.jsx:215
+msgid "This pool type does not support Storage Volume creation"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:774
 msgid "This system is not registered"
 msgstr "Tätä järjestelmää ei ole rekisteröity"
 
@@ -6776,11 +7071,7 @@ msgid ""
 "this system for use with diagnosing problems with the system."
 msgstr ""
 
-#: pkg/systemd/init.js:685
-msgid "This unit is an instance of the $0 template."
-msgstr ""
-
-#: pkg/systemd/services.html:360
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr ""
 
@@ -6794,7 +7085,7 @@ msgid ""
 "alternate user or port"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr ""
 
@@ -6806,7 +7097,7 @@ msgstr "Tämä taltio tulee aktivoida, ennen kuin sen kokoa voi muuttaa."
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:832
+#: pkg/packagekit/updates.jsx:834
 msgid "This web console will be updated."
 msgstr ""
 
@@ -6825,7 +7116,7 @@ msgstr ""
 msgid "Threads per core"
 msgstr ""
 
-#: pkg/systemd/services.html:238
+#: pkg/systemd/services.html:130
 msgid "Thursday"
 msgstr "Torstai"
 
@@ -6837,7 +7128,7 @@ msgstr ""
 msgid "Time Zone"
 msgstr "Aikavyöhyke"
 
-#: pkg/systemd/services.html:59
+#: pkg/systemd/services.jsx:41
 msgid "Timers"
 msgstr "Ajastimet"
 
@@ -6849,7 +7140,7 @@ msgstr ""
 "Vinkki: Luo avaimesi salasana vastaamaan käyttäjätunnuksesi salasanaa, jotta "
 "voit automaattisesti tunnistautua muita järjestelmiä kohden."
 
-#: pkg/packagekit/updates.jsx:773
+#: pkg/packagekit/updates.jsx:775
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
@@ -6891,15 +7182,19 @@ msgstr ""
 msgid "Tower"
 msgstr "Torni"
 
-#: pkg/systemd/init.js:733
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr ""
 
-#: pkg/systemd/init.js:732
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "Liipaisimet"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Vianetsintä"
@@ -6908,7 +7203,7 @@ msgstr "Vianetsintä"
 msgid "Trust key"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:705
+#: pkg/networkmanager/firewall.jsx:735
 msgid "Trust level"
 msgstr ""
 
@@ -6928,7 +7223,7 @@ msgstr "Yritä yhdistää uudelleen"
 msgid "Trying to synchronize with {{Server}}"
 msgstr "Yritetään synkronoida palvelimen {{Server}} kanssa"
 
-#: pkg/systemd/services.html:236
+#: pkg/systemd/services.html:128
 msgid "Tuesday"
 msgstr "Tiistai"
 
@@ -6952,17 +7247,19 @@ msgstr "Tuned ei ole käynnissä"
 msgid "Tuned is off"
 msgstr ""
 
-#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:265
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
+#: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
-#: pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/vmnetworktab.jsx:114
+#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
+#: pkg/systemd/hwinfo.jsx:259
 msgid "Type"
 msgstr "Tyyppi"
 
@@ -6978,11 +7275,11 @@ msgstr "Kirjoita salasana"
 msgid "Type to filter…"
 msgstr "Kirjoita suodattaaksesi..."
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:968
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "URL"
 
@@ -6994,7 +7291,7 @@ msgstr "UUID"
 msgid "Unable to apply settings: $0"
 msgstr "Asetusten asettaminen epäonnistui: $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:119
+#: pkg/selinux/setroubleshoot-view.jsx:120
 msgid "Unable to apply this solution automatically"
 msgstr "Tämän ratkaisun automaattinen asettaminen epäonnistui"
 
@@ -7006,8 +7303,8 @@ msgstr "Siihen osoitteeseen yhdistäminen epäonnistui"
 msgid "Unable to delete root account"
 msgstr "Root-käyttäjätilin poistaminen epäonnistui"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Unable to get alert details."
 msgstr "Virheen lisätietojen hakeminen epäonnistui."
 
@@ -7048,11 +7345,15 @@ msgid "Unavailable"
 msgstr "Ei käytettävissä"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Odottamaton virhe"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+#: pkg/machines/components/networks/createNetworkDialog.jsx:128
+msgid "Unique Network Name"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr ""
 
@@ -7064,15 +7365,15 @@ msgstr "Yksikkö"
 #: node_modules/registry-image-widgets/views/image-body.html:16
 #: node_modules/registry-image-widgets/views/imagestream-body.html:30
 #: node_modules/registry-image-widgets/views/imagestream-body.html:31
+#: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
 #: pkg/machines/components/vmnetworktab.jsx:139
-#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
-#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1076
+#: pkg/networkmanager/interfaces.js:2544 pkg/networkmanager/interfaces.js:2546
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
-#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
+#: pkg/networkmanager/interfaces.js:2530 pkg/networkmanager/interfaces.js:2542
 msgid "Unknown \"$0\""
 msgstr "Tuntematon \"$0\""
 
@@ -7088,7 +7389,7 @@ msgstr "Tuntematon sovellus"
 msgid "Unknown Host Key"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2640
+#: pkg/networkmanager/interfaces.js:2652
 msgid "Unknown configuration"
 msgstr "Tuntematon konfiguraatio"
 
@@ -7096,7 +7397,7 @@ msgstr "Tuntematon konfiguraatio"
 msgid "Unknown host name"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:333
+#: pkg/networkmanager/firewall.jsx:358
 msgid "Unknown service name"
 msgstr ""
 
@@ -7137,10 +7438,6 @@ msgstr ""
 msgid "Unmanaged Interfaces"
 msgstr "Hallitsemattomat liitännät"
 
-#: pkg/systemd/init.js:576
-msgid "Unmask"
-msgstr ""
-
 #: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
 msgid "Unmount"
 msgstr "Irroita"
@@ -7153,7 +7450,7 @@ msgstr "Irroitetaan $target"
 msgid "Unnamed"
 msgstr "Nimeämätön"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Unplug"
 msgstr ""
 
@@ -7191,11 +7488,11 @@ msgstr ""
 msgid "Up since $0"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -7221,7 +7518,7 @@ msgstr ""
 "Päivitetyt paketit saattavat vaatia uudelleenkäynnistyksen, jotta muutokset "
 "tulevat voimaan."
 
-#: pkg/systemd/host.js:502
+#: pkg/systemd/host.js:512
 msgid "Updates Available"
 msgstr "Päivityksiä saatavilla"
 
@@ -7229,11 +7526,15 @@ msgstr "Päivityksiä saatavilla"
 msgid "Updating"
 msgstr "Päivitetään"
 
+#: pkg/systemd/service-details.jsx:406
+msgid "Updating status..."
+msgstr ""
+
 #: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Käyttö"
 
-#: pkg/systemd/host.js:1613
+#: pkg/systemd/host.js:1630
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] ""
@@ -7243,7 +7544,7 @@ msgstr[1] ""
 msgid "Use 512 Byte emulation"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:524
+#: pkg/machines/components/diskAdd.jsx:561
 msgid "Use Existing"
 msgstr ""
 
@@ -7255,7 +7556,7 @@ msgstr "Käytä seuraavia avaimia todentamaan muita järjestelmiä kohden"
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
 #: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
-#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1678
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1695
 msgid "Used"
 msgstr "Käytetty"
 
@@ -7269,7 +7570,7 @@ msgstr ""
 
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/systemd/host.js:1584
+#: pkg/systemd/host.js:1601
 msgid "User"
 msgstr "Käyttäjä"
 
@@ -7282,7 +7583,7 @@ msgstr "Käyttäjätunnus"
 msgid "User Password"
 msgstr "Salasana"
 
-#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
+#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Käyttäjätunnus"
@@ -7332,8 +7633,8 @@ msgstr ""
 msgid "VDO support not installed"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
-#: pkg/networkmanager/interfaces.js:2906
+#: pkg/networkmanager/interfaces.js:2526 pkg/networkmanager/interfaces.js:2538
+#: pkg/networkmanager/interfaces.js:2918
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7361,7 +7662,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -7414,7 +7715,7 @@ msgid "Validating key"
 msgstr "Vahvistetaan avainta"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:250
 msgid "Vendor"
 msgstr "Toimittaja"
 
@@ -7431,7 +7732,7 @@ msgid "Verifying"
 msgstr "Vahvistetaan"
 
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
 msgid "Version"
 msgstr "Versio"
 
@@ -7439,14 +7740,22 @@ msgstr "Versio"
 msgid "Very securely erasing $target"
 msgstr "Poistetaan hyvin turvallisesti $target"
 
+#: pkg/lib/cockpit-components-modifications.jsx:173
+msgid "View automation script"
+msgstr ""
+
+#: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/components/networks/networkList.jsx:39
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Virtuaalikoneet"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:422
+msgid "Virtual Network failed to be created"
 msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:80
@@ -7457,11 +7766,12 @@ msgstr "Virtualisointipalvelu (libvirt) ei ole aktiivinen"
 msgid "Virtualization Service is Available"
 msgstr "Virtualisointipalvelu ei ole saatavilla"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
+#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
+#: pkg/storaged/content-views.jsx:136
 msgid "Volume"
 msgstr "Taltio"
 
@@ -7472,6 +7782,14 @@ msgstr "Taltioryhmä"
 #: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "Taltioryhmä $0"
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
+msgid "Volume Group name"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+msgid "Volume Group name should not be empty"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:113
 msgid "Volume Groups"
@@ -7494,12 +7812,12 @@ msgstr ""
 msgid "WWPN"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:836
+#: pkg/networkmanager/interfaces.js:845
 msgid "Waiting"
 msgstr "Odotetaan"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Waiting for details..."
 msgstr "Odotetaan lisätietoja..."
 
@@ -7512,11 +7830,11 @@ msgstr ""
 msgid "Waiting for other software management operations to finish"
 msgstr ""
 
-#: pkg/systemd/init.js:724
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr ""
 
-#: pkg/systemd/init.js:719
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr ""
 
@@ -7528,7 +7846,7 @@ msgstr ""
 msgid "Web Console for Linux servers"
 msgstr ""
 
-#: pkg/systemd/services.html:237
+#: pkg/systemd/services.html:129
 msgid "Wednesday"
 msgstr "Keskiviikko"
 
@@ -7536,7 +7854,7 @@ msgstr "Keskiviikko"
 msgid "Wednesdays"
 msgstr ""
 
-#: pkg/systemd/services.html:466
+#: pkg/systemd/services.html:321
 msgid "Weeks"
 msgstr "Viikot"
 
@@ -7564,11 +7882,11 @@ msgstr "Kirjoitetaan"
 msgid "Wrong user name or password"
 msgstr "Väärä käyttäjätunnus tai salasana"
 
-#: pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1985
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2605
 msgid "Yes"
 msgstr "Kyllä"
 
@@ -7587,8 +7905,8 @@ msgstr ""
 "Olet tällä hetkellä suoraan yhteydessä tähän palvelimeen. Et voi poistaa "
 "sitä."
 
-#: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
+#: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
+#: pkg/networkmanager/firewall.jsx:903 pkg/networkmanager/firewall.jsx:909
 msgid "You are not authorized to modify the firewall."
 msgstr "Sinulla ei ole valtuuksia muokata palomuuria."
 
@@ -7607,18 +7925,17 @@ msgstr "Sinulla ei ole oikeutta hallita Dockerin tallennusvarantoa."
 msgid "You must wait longer to change your password"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
-msgid ""
-"You need to select the most closely matching OS vendor and Operating System"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
+msgid "You need to select the most closely matching Operating System"
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:834
+#: pkg/packagekit/updates.jsx:836
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:865
+#: pkg/packagekit/updates.jsx:867
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
@@ -7632,11 +7949,11 @@ msgstr "Istuntosi on päätetty."
 msgid "Your session has expired. Please log in again."
 msgstr "Istuntosi on vahventunut. Ole hyvä ja kirjaudu uudelleen sisään."
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:955
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:968
 msgid "Zones"
 msgstr ""
 
@@ -7652,12 +7969,8 @@ msgstr "[binääridata]"
 msgid "[no data]"
 msgstr "[ei dataa]"
 
-#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
-msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
-msgstr ""
-
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr ""
@@ -7747,7 +8060,7 @@ msgstr "ethernet"
 msgid "every day"
 msgstr "päivittäin"
 
-#: pkg/systemd/host.js:886
+#: pkg/systemd/host.js:903
 msgid "failed to list ssh host keys: $0"
 msgstr ""
 
@@ -7763,11 +8076,11 @@ msgstr ""
 msgid "hostdev"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr ""
 
@@ -7775,11 +8088,11 @@ msgstr ""
 msgid "iSCSI Targets"
 msgstr "iSCSI-kohteet"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:83
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -7787,8 +8100,8 @@ msgstr ""
 msgid "idle"
 msgstr "jouten"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 msgid "inactive"
 msgstr ""
 
@@ -7824,9 +8137,9 @@ msgstr "verkko"
 msgid "nfs dump target isn't formated as server:path"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "ei"
@@ -7837,7 +8150,7 @@ msgstr "ei"
 msgid "none"
 msgstr "Ei mitään"
 
-#: pkg/systemd/host.js:691
+#: pkg/systemd/host.js:712
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] ""
@@ -7846,14 +8159,6 @@ msgstr[1] ""
 #: pkg/machines/helpers.js:190
 msgid "paused"
 msgstr "pysäytetty"
-
-#: pkg/machines/components/diskAdd.jsx:154
-msgid "qcow2"
-msgstr ""
-
-#: pkg/machines/components/diskAdd.jsx:157
-msgid "raw"
-msgstr ""
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -7903,7 +8208,7 @@ msgstr "sammutettu"
 msgid "shutdown"
 msgstr "sammuta"
 
-#: pkg/selinux/setroubleshoot-view.jsx:123
+#: pkg/selinux/setroubleshoot-view.jsx:124
 msgid "solution details"
 msgstr "ratkaisun yksityiskohdat"
 
@@ -7944,7 +8249,7 @@ msgid "undefined"
 msgstr "määrittämätön"
 
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:249 pkg/systemd/init.js:263
+#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
 msgid "unknown"
 msgstr "tuntematon"
 
@@ -7984,15 +8289,15 @@ msgstr "Arvo"
 msgid "vhostuser"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "kyllä"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-31 11:50+0000\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -51,7 +51,7 @@ msgstr[0] "$0 パッケージ\n"
 "\n"
 "$0 パッケージ"
 
-#: pkg/systemd/init.js:417 pkg/systemd/service-details.jsx:58
+#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "$0 テンプレート"
 
@@ -193,11 +193,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:549
+#: pkg/networkmanager/firewall.jsx:574
 msgid "(Optional)"
 msgstr "(オプション)"
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:623
+#: pkg/networkmanager/firewall.jsx:499 pkg/networkmanager/firewall.jsx:648
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "(デフォルト)"
@@ -513,7 +513,7 @@ msgstr "アカウント設定"
 msgid "Account not available or cannot be edited."
 msgstr "アカウントが利用可能でないか、アカウントを編集できません。"
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "アカウント"
 
@@ -548,11 +548,11 @@ msgstr "アクティブページ"
 msgid "Active since"
 msgstr "以降有効"
 
-#: pkg/systemd/service-details.jsx:348
+#: pkg/systemd/service-details.jsx:352
 msgid "Active since "
 msgstr "以下以降アクティブ"
 
-#: pkg/networkmanager/firewall.jsx:929
+#: pkg/networkmanager/firewall.jsx:954
 msgid "Active zones"
 msgstr "アクティブゾーン"
 
@@ -565,7 +565,7 @@ msgid "Adaptive transmit load balancing"
 msgstr "適応送信のロードバランス"
 
 #: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:566 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/machines/components/diskAdd.jsx:600 pkg/storaged/crypto-keyslots.jsx:228
 #: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
 #: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
 #: pkg/storaged/vgroup-details.jsx:63
@@ -588,7 +588,7 @@ msgstr "ボンドの追加"
 msgid "Add Bridge"
 msgstr "ブリッジの追加"
 
-#: pkg/machines/components/diskAdd.jsx:363
+#: pkg/machines/components/diskAdd.jsx:368
 msgid "Add Disk"
 msgstr "ディスクの追加"
 
@@ -604,12 +604,12 @@ msgstr "鍵の追加"
 msgid "Add Machine to Dashboard"
 msgstr "ダッシュボードへのマシンの追加"
 
-#: pkg/networkmanager/firewall.jsx:457
+#: pkg/networkmanager/firewall.jsx:482
 msgid "Add Ports"
 msgstr "ポートの追加"
 
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:879
-#: pkg/networkmanager/firewall.jsx:891
+#: pkg/networkmanager/firewall.jsx:482 pkg/networkmanager/firewall.jsx:904
+#: pkg/networkmanager/firewall.jsx:916
 msgid "Add Services"
 msgstr "サービスの追加"
 
@@ -625,8 +625,8 @@ msgstr "チームの追加"
 msgid "Add VLAN"
 msgstr "VLAN の追加"
 
-#: pkg/networkmanager/firewall.jsx:705 pkg/networkmanager/firewall.jsx:885
-#: pkg/networkmanager/firewall.jsx:896
+#: pkg/networkmanager/firewall.jsx:730 pkg/networkmanager/firewall.jsx:910
+#: pkg/networkmanager/firewall.jsx:921
 msgid "Add Zone"
 msgstr "ゾーンの追加"
 
@@ -638,7 +638,7 @@ msgstr "iSCSI ポータルの追加"
 msgid "Add key"
 msgstr "鍵の追加"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add ports to the following zones:"
 msgstr "以下のゾーンにポートを追加:"
 
@@ -646,11 +646,11 @@ msgstr "以下のゾーンにポートを追加:"
 msgid "Add public key"
 msgstr "公開鍵の追加"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add services to following zones:"
 msgstr "以下のゾーンにサービスを追加:"
 
-#: pkg/networkmanager/firewall.jsx:781
+#: pkg/networkmanager/firewall.jsx:806
 msgid "Add zone"
 msgstr "ゾーンの追加"
 
@@ -660,7 +660,7 @@ msgid ""
 "administration UI unavailable."
 msgstr "<b>$0</b> を追加すると、サーバーへの接続が切断され、管理 UI が利用できなくなります。"
 
-#: pkg/networkmanager/firewall.jsx:561
+#: pkg/networkmanager/firewall.jsx:586
 msgid ""
 "Adding custom ports will reload firewalld. A reload will result in the loss "
 "of any runtime-only configuration!"
@@ -722,6 +722,13 @@ msgstr "アドレスは空欄にできません"
 msgid "Address is not a valid URL"
 msgstr "アドレスは有効ではありません。"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:60
+#: pkg/machines/components/networks/createNetworkDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:88
+#: pkg/machines/components/networks/createNetworkDialog.jsx:95
+msgid "Address not within subnet"
+msgstr ""
+
 #: pkg/machines/components/desktopConsole.jsx:153
 msgid "Address:"
 msgstr "アドレス: "
@@ -742,7 +749,7 @@ msgstr "管理者パスワード"
 msgid "Advanced TCA"
 msgstr "高度な TCA"
 
-#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:424
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "後"
 
@@ -756,7 +763,7 @@ msgstr ""
 "の一覧が変更する可能性があるため、他のサービスにも影響を及ぼす場合があります。"
 
 #: pkg/systemd/services.html:301 pkg/systemd/services.html:305
-#: pkg/systemd/init.js:887
+#: pkg/systemd/init.js:902
 msgid "After system boot"
 msgstr "システムブート後"
 
@@ -782,11 +789,11 @@ msgstr "選択されたディスク上のすべてのデータが削除され、
 msgid "Allow running (unmask)"
 msgstr "実行を許可 (マスク解除)"
 
-#: pkg/networkmanager/firewall.jsx:756
+#: pkg/networkmanager/firewall.jsx:781
 msgid "Allowed Addresses"
 msgstr "許可されたアドレス"
 
-#: pkg/networkmanager/firewall.jsx:942
+#: pkg/networkmanager/firewall.jsx:967
 msgid "Allowed Services"
 msgstr "許可されたサービス"
 
@@ -811,7 +818,7 @@ msgid "Appearance:"
 msgstr "Appearance:"
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "アプリケーション"
 
@@ -916,10 +923,11 @@ msgstr "作成者"
 msgid "Authorized Public SSH Keys"
 msgstr "承認された公開 SSH 鍵"
 
-#: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1974
-#: pkg/networkmanager/interfaces.js:2771 pkg/networkmanager/interfaces.js:3329
-#: pkg/networkmanager/interfaces.js:3333 pkg/networkmanager/interfaces.js:3339
-#: pkg/realmd/operation.js:338
+#: pkg/networkmanager/index.html:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:176
+#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:2771
+#: pkg/networkmanager/interfaces.js:3329 pkg/networkmanager/interfaces.js:3333
+#: pkg/networkmanager/interfaces.js:3339 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "自動"
 
@@ -931,7 +939,7 @@ msgstr "自動 (DHCP のみ)"
 msgid "Automatic (DHCP)"
 msgstr "自動 (DHCP)"
 
-#: pkg/systemd/init.js:293
+#: pkg/systemd/init.js:295
 msgid "Automatic Startup"
 msgstr "自動起動"
 
@@ -943,7 +951,7 @@ msgstr "自動アップデート"
 msgid "Automatically start libvirt on boot"
 msgstr "起動時に libvirt を自動開始"
 
-#: pkg/systemd/service-details.jsx:392
+#: pkg/systemd/service-details.jsx:396
 msgid "Automatically starts"
 msgstr "自動起動"
 
@@ -960,7 +968,7 @@ msgid "Automation Script"
 msgstr "オートメーションスクリプト"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:86
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:69
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "自動起動"
@@ -1011,11 +1019,11 @@ msgstr "passwd1 メカニズムに間違ったデータが渡されました"
 msgid "Balancer"
 msgstr "バランサー"
 
-#: pkg/systemd/service-details.jsx:423
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr "前"
 
-#: pkg/systemd/service-details.jsx:414
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr "バインドする"
 
@@ -1061,7 +1069,7 @@ msgstr "ブート順序"
 msgid "Boot order settings could not be saved"
 msgstr "ブート順序の設定は保存できませんでした"
 
-#: pkg/systemd/service-details.jsx:419
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr "バインドされた"
 
@@ -1142,7 +1150,7 @@ msgstr "CPU 優先度"
 msgid "CPU usage:"
 msgstr "CPU 使用率:"
 
-#: pkg/machines/components/diskAdd.jsx:246
+#: pkg/machines/components/diskAdd.jsx:251
 #: pkg/machines/components/vmDiskColumns.jsx:75
 msgid "Cache"
 msgstr "キャッシュ"
@@ -1181,25 +1189,26 @@ msgstr "画像を読み込めません。"
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:752
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:563
+#: pkg/machines/components/diskAdd.jsx:597
+#: pkg/machines/components/networks/createNetworkDialog.jsx:486
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:565 pkg/networkmanager/firewall.jsx:633
-#: pkg/networkmanager/firewall.jsx:776 pkg/packagekit/updates.jsx:179
+#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
+#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
 #: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
-#: pkg/systemd/service-details.jsx:107
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "取り消し"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "不明なマシンには接続できません"
 
@@ -1265,7 +1274,7 @@ msgstr "リソース制限の変更"
 msgid "Change the settings"
 msgstr "設定の変更"
 
-#: pkg/machines/components/nicEdit.jsx:272
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
@@ -1314,6 +1323,10 @@ msgstr "更新の確認…"
 msgid "Checking installed software"
 msgstr "インストールされたソフトウェアの確認"
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
+msgid "Choose an operating system"
+msgstr ""
+
 #: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "アプリケーションで使用する言語の選択"
@@ -1329,6 +1342,10 @@ msgstr "クラス"
 #: pkg/storaged/jobs-panel.jsx:55
 msgid "Cleaning up for $target"
 msgstr "$target のクリーンアップ"
+
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
 
 #: pkg/systemd/services.html:86
 msgid "Clear All Filters"
@@ -1378,7 +1395,7 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit は該当するホストに接続できませんでした。"
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1479,7 +1496,7 @@ msgid "Combined usage of $0 CPU core"
 msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "$0 CPU コアの合計使用率"
 
-#: pkg/networkmanager/firewall.jsx:529
+#: pkg/networkmanager/firewall.jsx:554
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "コンマで区切られたポート、範囲、およびエイリアスは使用できます"
 
@@ -1541,11 +1558,11 @@ msgstr "圧縮"
 msgid "Computer OU"
 msgstr "コンピューター OU"
 
-#: pkg/systemd/service-details.jsx:438
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr "条件 $0=$1 を満たしていませんでした。"
 
-#: pkg/systemd/service-details.jsx:488
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "条件が満たされませんでした。"
 
@@ -1582,11 +1599,11 @@ msgstr "仮想ネットワークの削除を確定"
 msgid "Confirm removal with passphrase"
 msgstr "パスフレーズで削除を確認"
 
-#: pkg/systemd/service-details.jsx:422
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr "競合する"
 
-#: pkg/systemd/service-details.jsx:421
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr "競合"
 
@@ -1631,13 +1648,13 @@ msgstr "SETroubleshoot デーモンへの接続中 ..."
 msgid "Connecting to Virtualization Service"
 msgstr "仮想化サービスへの接続"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "マシンへの接続"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:667
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
+#: pkg/machines/components/networks/createNetworkDialog.jsx:106
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
@@ -1655,7 +1672,7 @@ msgstr "接続がタイムアウトしました。"
 msgid "Connection will be lost"
 msgstr "接続が失われます"
 
-#: pkg/systemd/service-details.jsx:420
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr "構成するもの"
 
@@ -1759,7 +1776,7 @@ msgstr "ユーザーグループを変更できませんでした"
 msgid "Couldn't change user password"
 msgstr "ユーザーパスワードを変更できませんでした"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "マシンに接続できませんでした"
 
@@ -1788,8 +1805,9 @@ msgid "Crash system"
 msgstr "クラッシュシステム"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:757
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
+#: pkg/machines/components/networks/createNetworkDialog.jsx:491
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
 #: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
 #: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
 #: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
@@ -1800,7 +1818,7 @@ msgstr "作成"
 msgid "Create Logical Volume"
 msgstr "論理ボリュームの作成"
 
-#: pkg/machines/components/diskAdd.jsx:518
+#: pkg/machines/components/diskAdd.jsx:552
 msgid "Create New"
 msgstr "新規作成"
 
@@ -1832,7 +1850,7 @@ msgstr "レポートの作成"
 msgid "Create Snapshot"
 msgstr "スナップショットの作成"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "ストレージプールの作成"
 
@@ -1852,9 +1870,14 @@ msgstr "タイマーの作成"
 msgid "Create VDO Device"
 msgstr "VDO デバイスの作成"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:799
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "仮想マシンの作成"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
+#: pkg/machines/components/networks/createNetworkDialog.jsx:525
+msgid "Create Virtual Network"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:53
 msgid "Create Volume Group"
@@ -1930,7 +1953,7 @@ msgstr "このチームを作成すると、サーバーへの接続が切断さ
 msgid "Creating volume group $target"
 msgstr "ボリュームグループ $target の作成"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr "VM $0 の作成に失敗"
 
@@ -1958,7 +1981,7 @@ msgstr "現在の起動"
 msgid "Custom"
 msgstr "Custom"
 
-#: pkg/networkmanager/firewall.jsx:523
+#: pkg/networkmanager/firewall.jsx:548
 msgid "Custom Ports"
 msgstr "カスタムポート"
 
@@ -1970,7 +1993,7 @@ msgstr "カスタムの暗号化オプション"
 msgid "Custom mount options"
 msgstr "カスタムのマウントオプション"
 
-#: pkg/networkmanager/firewall.jsx:723
+#: pkg/networkmanager/firewall.jsx:748
 msgid "Custom zones"
 msgstr "カスタムゾーン"
 
@@ -2051,8 +2074,9 @@ msgstr "遅延"
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
 #: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
@@ -2064,7 +2088,7 @@ msgstr "削除"
 msgid "Delete $0"
 msgstr "$0 の削除"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
 msgstr "コンテンツの削除"
 
@@ -2076,7 +2100,7 @@ msgstr "ファイルの削除"
 msgid "Delete Network $0"
 msgstr "ネットワーク $0 の削除"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:217
 msgid "Delete Storage Pool $0"
 msgstr "ストレージプール $0 の削除"
 
@@ -2084,7 +2108,7 @@ msgstr "ストレージプール $0 の削除"
 msgid "Delete associated storage files:"
 msgstr "関連するストレージファイルの削除:"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:170
 msgid "Delete the Volumes inside this Pool"
 msgstr "このプール内のボリュームを削除します"
 
@@ -2122,7 +2146,7 @@ msgstr "パーティションを削除すると、パーティション内のす
 msgid "Deleting a volume group will erase all data on it."
 msgstr "ボリュームグループを削除すると、ボリュームグループ上のすべてのデータが削除されます。"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:174
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
@@ -2134,13 +2158,23 @@ msgstr "ボリュームグループ $target の削除"
 
 #: pkg/systemd/services.html:268
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:732 pkg/systemd/init.js:287
+#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
 msgid "Description"
 msgstr "説明"
+
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "デスクトップ"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:151
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:187
+msgid ""
+"Detach the disks using this pool from any VMs before attempting deletion."
+msgstr ""
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2148,12 +2182,13 @@ msgstr "割り当て解除可能"
 
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:95
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:762
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:383
+#: pkg/systemd/host.js:762
 msgid "Details"
 msgstr "詳細"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:169
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
@@ -2167,6 +2202,10 @@ msgstr "デバイスファイル"
 #: pkg/storaged/content-views.jsx:551
 msgid "Device is read-only"
 msgstr "デバイスは読み取り専用です"
+
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
@@ -2194,11 +2233,11 @@ msgid "Disable tuned"
 msgstr "tuned の無効化"
 
 #: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
-#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:327
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "無効"
 
-#: pkg/systemd/service-details.jsx:196
+#: pkg/systemd/service-details.jsx:192
 msgid "Disallow running (mask)"
 msgstr "実行を禁止 (マスク)"
 
@@ -2207,7 +2246,7 @@ msgid "Disconnect"
 msgstr "切断"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "切断されています"
 
@@ -2227,11 +2266,11 @@ msgstr "ディスク $0 は、VM $1 からの切断に失敗しました"
 msgid "Disk I/O"
 msgstr "ディスク I/O"
 
-#: pkg/machines/components/diskAdd.jsx:492
+#: pkg/machines/components/diskAdd.jsx:525
 msgid "Disk failed to be attached"
 msgstr "ディスクの割り当てに失敗しました"
 
-#: pkg/machines/components/diskAdd.jsx:471
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Disk failed to be created"
 msgstr "ディスクの作成に失敗しました"
 
@@ -2257,6 +2296,10 @@ msgstr "$0 VM からディスクを削除できません"
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "言語の表示"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2296,7 +2339,7 @@ msgid "Domain Administrator Password"
 msgstr "ドメイン管理者パスワード"
 
 #: pkg/systemd/services.html:338 pkg/systemd/services.html:342
-#: pkg/systemd/init.js:1070
+#: pkg/systemd/init.js:1085
 msgid "Don't Repeat"
 msgstr "繰り返さないでください"
 
@@ -2361,7 +2404,7 @@ msgstr "重複するエイリアス"
 msgid "Duplicate port"
 msgstr "重複するポート"
 
-#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
+#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
 #: pkg/storaged/nfs-details.jsx:306
 msgid "Edit"
 msgstr "編集"
@@ -2458,6 +2501,15 @@ msgstr "暗号化"
 msgid "Encryption Options"
 msgstr "暗号化オプション"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:252
+msgid "End"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:63
+#: pkg/machines/components/networks/createNetworkDialog.jsx:91
+msgid "End should not be empty"
+msgstr ""
+
 #: pkg/selinux/setroubleshoot-view.jsx:296
 msgid "Enforcing"
 msgstr "強制"
@@ -2476,7 +2528,7 @@ msgid ""
 "time you reconnect to this machine"
 msgstr "ここで別のパスワードを入力すると、このマシンに接続するときに毎回そのパスワードを再入力する必要があります"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:784
 msgid "Entire subnet"
 msgstr "サブネット全体"
 
@@ -2512,7 +2564,7 @@ msgstr "エラータ:"
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
 #: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
 #: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/systemd/service-details.jsx:444 pkg/users/local.js:1476
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "エラー"
 
@@ -2560,11 +2612,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "すべて"
 
-#: pkg/networkmanager/firewall.jsx:536
+#: pkg/networkmanager/firewall.jsx:561
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "例: 22,ssh,8080,5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:544
+#: pkg/networkmanager/firewall.jsx:569
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "例: 88,2019,nfs,rsync"
 
@@ -2572,11 +2624,11 @@ msgstr "例: 88,2019,nfs,rsync"
 msgid "Excellent password"
 msgstr "優れたパスワード"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:282
-msgid "Existing Disk Image"
-msgstr "既存のディスクイメージ"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
+msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr "ホストファイルシステム上の既存のディスクイメージ"
 
@@ -2608,15 +2660,15 @@ msgstr "失敗"
 msgid "Failed to add machine: $0"
 msgstr "マシンの追加に失敗しました: $0"
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add port"
 msgstr "ポートの追加に失敗しました"
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add service"
 msgstr "サービスの追加に失敗しました"
 
-#: pkg/networkmanager/firewall.jsx:684
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Failed to add zone"
 msgstr "ゾーンの追加に失敗しました"
 
@@ -2652,11 +2704,11 @@ msgstr "$0 のインターフェイスの IP アドレスの取得に失敗し�
 msgid "Failed to load authorized keys."
 msgstr "承認された鍵のロードに失敗しました。"
 
-#: pkg/networkmanager/firewall.jsx:596
+#: pkg/networkmanager/firewall.jsx:621
 msgid "Failed to remove service"
 msgstr "サービスの削除に失敗しました"
 
-#: pkg/systemd/service-details.jsx:336
+#: pkg/systemd/service-details.jsx:340
 msgid "Failed to start"
 msgstr "起動に失敗しました"
 
@@ -2685,7 +2737,7 @@ msgstr "File"
 msgid "Filesystem"
 msgstr "ファイルシステム"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "ファイルシステムのディレクトリー"
 
@@ -2701,7 +2753,7 @@ msgstr "ファイルシステム名"
 msgid "Filesystems"
 msgstr "ファイルシステム"
 
-#: pkg/networkmanager/firewall.jsx:491
+#: pkg/networkmanager/firewall.jsx:516
 msgid "Filter Services"
 msgstr "フィルターサービス"
 
@@ -2714,11 +2766,11 @@ msgid "Fingerprint"
 msgstr "フィンガープリント"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:920 pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:945 pkg/networkmanager/firewall.jsx:948
 msgid "Firewall"
 msgstr "ファイアウォール"
 
-#: pkg/networkmanager/firewall.jsx:868
+#: pkg/networkmanager/firewall.jsx:893
 msgid "Firewall is not available"
 msgstr "ファイアウォールは利用できません"
 
@@ -2730,7 +2782,7 @@ msgstr "Docker リポジトリーに順守"
 msgid "For legacy applications only. Reduces performance."
 msgstr "レガシーアプリケーション専用です。パフォーマンスが低下します。"
 
-#: pkg/systemd/service-details.jsx:318
+#: pkg/systemd/service-details.jsx:322
 msgid "Forbidden from running"
 msgstr "実行が禁止されています"
 
@@ -2758,8 +2810,8 @@ msgstr "パスワード変更の強制"
 msgid "Force remove passphrase in $0"
 msgstr "$0 のパスフレーズの削除を強制します"
 
-#: pkg/machines/components/diskAdd.jsx:147
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:157
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
 #: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
 #: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
@@ -2781,11 +2833,15 @@ msgstr "ディスクをフォーマットすると、ディスク上のすべて
 msgid "Formatting a storage device will erase all data on it."
 msgstr "ストレージデバイスをフォーマットすると、そのデバイス上のすべてのデータが削除されます。"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:147
+msgid "Forward Mode"
+msgstr ""
+
 #: pkg/networkmanager/interfaces.js:2873
 msgid "Forward delay $forward_delay"
 msgstr "フォワード遅延 $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:50
 msgid "Forwarding mode"
 msgstr "転送モード"
 
@@ -2837,7 +2893,7 @@ msgstr "レポートの生成"
 msgid "Get new image"
 msgstr "新規イメージの取得"
 
-#: pkg/machines/components/diskAdd.jsx:186
+#: pkg/machines/components/diskAdd.jsx:191
 #: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
@@ -2922,14 +2978,14 @@ msgstr "ハードウェア情報"
 msgid "Hello time $hello_time"
 msgstr "Hello タイム $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Hide Performance Options"
 msgstr "パフォーマンスオプションを非表示にします"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "ホスト"
 
@@ -2938,7 +2994,7 @@ msgid "Host Device"
 msgstr "ホストデバイス"
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "ホスト名"
 
@@ -2950,7 +3006,7 @@ msgstr "ホスト鍵が正しくありません"
 msgid "Host name should not be changed in a domain"
 msgstr "ドメインでホスト名は変更できません"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "ホストは空にできません"
 
@@ -2958,7 +3014,7 @@ msgstr "ホストは空にできません"
 msgid "Hour : Minute"
 msgstr "時間: 分"
 
-#: pkg/systemd/init.js:1146 pkg/systemd/init.js:1175
+#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
 msgid "Hour needs to be a number between 0-23"
 msgstr "時間は 0〜23 の数字である必要があります"
 
@@ -2983,11 +3039,15 @@ msgstr "IP アドレス"
 msgid "IP Address:"
 msgstr "IP アドレス:"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:197
+msgid "IP Configuration"
+msgstr ""
+
 #: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "IP プレフィックスの長さ:"
 
-#: pkg/networkmanager/firewall.jsx:930
+#: pkg/networkmanager/firewall.jsx:955
 msgid "IP Range"
 msgstr "IP 範囲"
 
@@ -3003,9 +3063,25 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr "IPv4 アドレス"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+msgid "IPv4 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:45
+msgid "IPv4 Network should not be empty"
+msgstr ""
+
 #: pkg/networkmanager/interfaces.js:3371
 msgid "IPv4 Settings"
 msgstr "IPv4 のセッティング"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:213
+msgid "IPv4 and IPv6"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:207
+msgid "IPv4 only"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2925
 msgid "IPv6"
@@ -3015,9 +3091,21 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr "IPv6 アドレス"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+msgid "IPv6 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:73
+msgid "IPv6 Network should not be empty"
+msgstr ""
+
 #: pkg/networkmanager/interfaces.js:3371
 msgid "IPv6 Settings"
 msgstr "IPv6 のセッティング"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:210
+msgid "IPv6 only"
+msgstr ""
 
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
@@ -3102,15 +3190,19 @@ msgstr "イメージは認証済みユーザーまたはグループがプルで
 msgid "Images may only be pulled by specific users or groups"
 msgstr "イメージは特定のユーザーまたはグループのみがプルできます"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:735
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "仮想マシンをすぐに起動"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "同期"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:227
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3131,7 +3223,7 @@ msgstr "停止"
 msgid "Inactive volume"
 msgstr "非アクティブなボリューム"
 
-#: pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:762
 msgid "Included services"
 msgstr "含まれているサービス"
 
@@ -3155,11 +3247,11 @@ msgstr "Docker ストレージプールに関する情報は利用できませ�
 msgid "Initializing..."
 msgstr "初期化中..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr "イニシエーター"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr "イニシエーター IQN は空にできません"
 
@@ -3193,15 +3285,15 @@ msgstr "VDO サポートをインストール"
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "setroubleshoot-server をインストールして SELinux イベントをトラブルシュートします。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "インストールソース"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "インストールソースのタイプ"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "インストールソースは空欄にできません"
 
@@ -3218,7 +3310,7 @@ msgstr "インストール中"
 msgid "Installing $0"
 msgstr "$0 をインストール中"
 
-#: pkg/systemd/service-details.jsx:483
+#: pkg/systemd/service-details.jsx:487
 msgid "Instance of template: "
 msgstr ""
 
@@ -3226,12 +3318,12 @@ msgstr ""
 msgid "Instantiate"
 msgstr "インスタンス化"
 
-#: pkg/machines/components/nicEdit.jsx:123
+#: pkg/machines/components/nicEdit.jsx:132
 msgid "Interface Type"
 msgstr "インターフェース形式"
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:742 pkg/networkmanager/firewall.jsx:930
+#: pkg/networkmanager/firewall.jsx:767 pkg/networkmanager/firewall.jsx:955
 #: pkg/networkmanager/interfaces.js:2998
 msgid "Interfaces"
 msgstr "インターフェース"
@@ -3244,19 +3336,39 @@ msgstr "内部エラー: 無効なチャレンジヘッダー"
 msgid "Internal error"
 msgstr "内部エラー"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:58
+#: pkg/machines/components/networks/createNetworkDialog.jsx:65
+msgid "Invalid IPv4 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:52
+msgid "Invalid IPv4 mask or prefix length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:75
+#: pkg/machines/components/networks/createNetworkDialog.jsx:86
+#: pkg/machines/components/networks/createNetworkDialog.jsx:93
+msgid "Invalid IPv6 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:80
+msgid "Invalid IPv6 prefix"
+msgstr ""
+
 #: pkg/networkmanager/utils.js:90 pkg/networkmanager/utils.js:175
 msgid "Invalid address $0"
 msgstr "無効なアドレス $0"
 
-#: pkg/systemd/host.js:1469 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "無効な日付形式"
 
-#: pkg/systemd/host.js:1465 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "無効な日付形式と無効な時間形式"
 
-#: pkg/systemd/init.js:1181
+#: pkg/systemd/init.js:1196
 msgid "Invalid date format."
 msgstr "無効な日付形式。"
 
@@ -3268,7 +3380,7 @@ msgstr "無効な有効期限"
 msgid "Invalid file permissions"
 msgstr "無効なファイルパーミッション"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:140
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "無効なファイル名"
 
@@ -3284,7 +3396,7 @@ msgstr "無効なメトリック $0"
 msgid "Invalid number of days"
 msgstr "無効な日数"
 
-#: pkg/systemd/init.js:1128
+#: pkg/systemd/init.js:1143
 msgid "Invalid number."
 msgstr "無効な数字。"
 
@@ -3292,7 +3404,7 @@ msgstr "無効な数字。"
 msgid "Invalid port"
 msgstr "無効なポート"
 
-#: pkg/networkmanager/firewall.jsx:335
+#: pkg/networkmanager/firewall.jsx:360
 msgid "Invalid port number"
 msgstr "無効なポート番号"
 
@@ -3304,11 +3416,11 @@ msgstr "無効なプレフィックス $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "無効なプレフィックスまたはネットマスク $0"
 
-#: pkg/networkmanager/firewall.jsx:362
+#: pkg/networkmanager/firewall.jsx:387
 msgid "Invalid range"
 msgstr "無効な範囲"
 
-#: pkg/systemd/host.js:1467 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "無効な時間形式"
 
@@ -3352,7 +3464,7 @@ msgstr "ドメインの参加"
 msgid "Joining this domain is not supported"
 msgstr "このドメインの参加はサポートされていません"
 
-#: pkg/systemd/service-details.jsx:430
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr "名前空間に参加"
 
@@ -3389,7 +3501,7 @@ msgstr "Kerberos チケット"
 msgid "Kernel"
 msgstr "カーネル"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "カーネルダンプ"
 
@@ -3421,6 +3533,10 @@ msgstr "キーサーバーの削除により、$0 のロック解除ができな
 msgid "LACP Key"
 msgstr "LACP キー"
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
+msgid "LVM Volume Group"
+msgstr ""
+
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "ラベル"
@@ -3441,7 +3557,7 @@ msgstr "過去 7 日間"
 msgid "Last Login"
 msgstr "最終ログイン"
 
-#: pkg/systemd/init.js:291
+#: pkg/systemd/init.js:293
 msgid "Last Trigger"
 msgstr "最後のトリガー"
 
@@ -3561,7 +3677,7 @@ msgstr "ローカルディスク"
 msgid "Local Filesystem"
 msgstr "ローカルファイルシステム"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:274
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr "ローカルインストールメディア"
 
@@ -3661,7 +3777,7 @@ msgstr "ログインで、管理者の権限をエスカレートさせました
 msgid "Logout Successful"
 msgstr "ログアウトが正常に行われました"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "ログ"
 
@@ -3705,7 +3821,7 @@ msgstr "MTU は正の数値である必要があります"
 msgid "Mac"
 msgstr "Mac"
 
-#: pkg/machines/components/nicEdit.jsx:160
+#: pkg/machines/components/nicEdit.jsx:169
 msgid "Mac Address"
 msgstr "Mac アドレス"
 
@@ -3717,7 +3833,7 @@ msgstr "マシン ID"
 msgid "Machine SSH Key Fingerprints"
 msgstr "マシンSSH 鍵フィンガープリント"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "マシン"
 
@@ -3749,15 +3865,23 @@ msgstr "手動で SSH を確認します。"
 msgid "Marking $target as faulty"
 msgstr "$target を問題があるものとしてマークする"
 
-#: pkg/systemd/service-details.jsx:203 pkg/systemd/service-details.jsx:206
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
 msgid "Mask Service"
 msgstr "サービスのマスク"
 
-#: pkg/systemd/service-details.jsx:317
+#: pkg/machines/components/networks/createNetworkDialog.jsx:293
+msgid "Mask or Prefix Length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:50
+msgid "Mask or Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:321
 msgid "Masked"
 msgstr "マスク"
 
-#: pkg/systemd/service-details.jsx:204
+#: pkg/systemd/service-details.jsx:200
 msgid ""
 "Masking service prevents all dependant units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
@@ -3802,7 +3926,7 @@ msgstr "RAID デバイス $0 のメンバー"
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:372
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
 #: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "メモリ"
@@ -3829,7 +3953,7 @@ msgstr "メモリーは保存できませんでした"
 msgid "Memory limit"
 msgstr "メモリー制限"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:157
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
 msgstr "メモリは 0 以外である必要があります"
 
@@ -3855,7 +3979,7 @@ msgid "Metadata Used"
 msgstr "使用済みメタデータ"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
+#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
@@ -3870,7 +3994,7 @@ msgstr "ミニ PC"
 msgid "Mini Tower"
 msgstr "ミニタワー"
 
-#: pkg/systemd/init.js:1152 pkg/systemd/init.js:1161 pkg/systemd/init.js:1170
+#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
 msgid "Minute needs to be a number between 0-59"
 msgstr "分は 0〜59 の数字である必要があります"
 
@@ -3886,7 +4010,7 @@ msgstr "緩和"
 msgid "Mode"
 msgstr "モード"
 
-#: pkg/machines/components/nicEdit.jsx:54 pkg/systemd/hwinfo.jsx:250
+#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
 msgid "Model"
 msgstr "モデル"
 
@@ -4019,10 +4143,11 @@ msgstr "NTP サーバー"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:181
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
 #: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:122
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
@@ -4034,8 +4159,8 @@ msgstr "NTP サーバー"
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
 #: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:288
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "名前"
 
@@ -4067,8 +4192,9 @@ msgstr "名前には文字 '$0' を含めることができません。"
 msgid "Name cannot contain whitespace."
 msgstr "名前にはスペースを含めることができません。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:122
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
+#: pkg/machines/components/networks/createNetworkDialog.jsx:41
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "名前は空欄にできません"
 
@@ -4096,15 +4222,15 @@ msgstr "ネットワーク $0 のアクティベートに失敗しました"
 msgid "Network $0 failed to get deactivated"
 msgstr "ネットワーク $0 の停止に失敗しました"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr "ネットワークブート (PXE)"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:277
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
 msgid "Network Boot is available only when using System connection"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "ネットワークファイルシステム"
 
@@ -4112,7 +4238,7 @@ msgstr "ネットワークファイルシステム"
 msgid "Network Interfaces"
 msgstr "ネットワークインターフェース"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:233
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr "ネットワーク選択では PXE がサポートされていません。"
 
@@ -4124,7 +4250,7 @@ msgstr "ネットワークトラフィック"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "ネットワークデバイスおよびグラフには、NetworkManager が必要です。"
 
-#: pkg/machines/components/nicEdit.jsx:232
+#: pkg/machines/components/nicEdit.jsx:245
 msgid "Network interface settings could not be saved"
 msgstr "ネットワークインターフェース設定を保存できませんでした"
 
@@ -4133,7 +4259,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager が実行していません。"
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:919
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "ネットワーキング"
 
@@ -4146,8 +4272,8 @@ msgstr "ネットワーク"
 msgid "Networking Logs"
 msgstr "ネットワークログ"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/networks/networkList.jsx:46
+#: pkg/machines/components/networks/networkList.jsx:45
+#: pkg/machines/components/networks/networkList.jsx:49
 msgid "Networks"
 msgstr "ネットワーク"
 
@@ -4187,7 +4313,7 @@ msgstr "新規パスワードは受け入れられませんでした"
 msgid "Next"
 msgstr "次へ"
 
-#: pkg/systemd/init.js:290
+#: pkg/systemd/init.js:292
 msgid "Next Run"
 msgstr "次回の実行日時"
 
@@ -4220,12 +4346,16 @@ msgstr "一致する結果はありません"
 msgid "No NFS mounts set up"
 msgstr "NFS マウントが設定されていません"
 
+#: pkg/machines/components/nicEdit.jsx:118
+msgid "No Network Devices"
+msgstr ""
+
 #: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
 msgstr "SELinux アラートがありません。"
 
-#: pkg/machines/components/diskAdd.jsx:204
-#: pkg/machines/components/diskAdd.jsx:216
+#: pkg/machines/components/diskAdd.jsx:209
+#: pkg/machines/components/diskAdd.jsx:221
 msgid "No Storage Pools available"
 msgstr "利用可能なストレージプールはありません"
 
@@ -4241,11 +4371,11 @@ msgstr "システム変更がありません"
 msgid "No VM is running or defined on this host"
 msgstr "仮想マシンがこのホストで実行されていないか、定義されていません。"
 
-#: pkg/machines/components/nicEdit.jsx:110
+#: pkg/machines/components/nicEdit.jsx:116
 msgid "No Virtual Networks"
 msgstr "仮想ネットワークはありません"
 
-#: pkg/networkmanager/firewall.jsx:931
+#: pkg/networkmanager/firewall.jsx:956
 msgid "No active zones"
 msgstr "アクティブゾーンはありません"
 
@@ -4297,7 +4427,7 @@ msgstr "コンテナーなし"
 msgid "No containers that match the current filter"
 msgstr "現在のフィルターに一致するコンテナーがありません"
 
-#: pkg/networkmanager/firewall.jsx:734
+#: pkg/networkmanager/firewall.jsx:759
 msgid "No description available"
 msgstr "利用可能な説明はありません"
 
@@ -4376,7 +4506,7 @@ msgstr ""
 msgid "No network interfaces defined for this VM"
 msgstr "この仮想マシンにはネットワークインターフェースが定義されていません"
 
-#: pkg/machines/components/networks/networkList.jsx:48
+#: pkg/machines/components/networks/networkList.jsx:51
 msgid "No network is defined on this host"
 msgstr "このホストで定義されるネットワークはありません"
 
@@ -4384,7 +4514,7 @@ msgstr "このホストで定義されるネットワークはありません"
 msgid "No networks available"
 msgstr "利用可能なネットワークはありません"
 
-#: pkg/networkmanager/firewall.jsx:944
+#: pkg/networkmanager/firewall.jsx:969
 msgid "No open ports"
 msgstr "開いているポートはありません"
 
@@ -4441,8 +4571,9 @@ msgid "No volume groups created"
 msgstr "ボリュームグループが作成されていません"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:739
-#: pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
+#: pkg/machines/components/networks/createNetworkDialog.jsx:204
+#: pkg/networkmanager/firewall.jsx:764 pkg/tuned/dialog.js:231
 msgid "None"
 msgstr "なし"
 
@@ -4490,7 +4621,7 @@ msgstr "マウントされていません"
 msgid "Not permitted to perform this action."
 msgstr "このアクションを実行する権限がありません。"
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:355
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "実行中ではありません"
 
@@ -4502,7 +4633,7 @@ msgstr "同期されていません"
 msgid "Not yet synced"
 msgstr "同期されていません"
 
-#: pkg/systemd/service-details.jsx:444
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr "注記"
 
@@ -4513,10 +4644,6 @@ msgstr "ノートブック"
 #: pkg/systemd/logs.html:61
 msgid "Notice and above"
 msgstr "注意以上のレベル"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:334
-msgid "OS Vendor"
-msgstr "OS ベンダー"
 
 #: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
@@ -4546,7 +4673,7 @@ msgstr "古いパスワードは受け入れられません"
 msgid "On Build"
 msgstr "ビルド時"
 
-#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:425
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr "障害発生時"
 
@@ -4584,7 +4711,7 @@ msgstr "$1 のうち $0 だけが使用されています。"
 msgid "Only Emergency"
 msgstr "緊急時限定"
 
-#: pkg/systemd/init.js:1102
+#: pkg/systemd/init.js:1117
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "アルファベット、数字、:、 _ 、.、@、- のみを使用できます。"
 
@@ -4601,7 +4728,7 @@ msgid "Open"
 msgstr "開く"
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "オペレーティングシステム"
 
@@ -4662,7 +4789,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "パッケージ情報"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "PackageKit がクラッシュしました"
 
@@ -4674,6 +4801,10 @@ msgstr "PackageKit はインストールされていません"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit が、エラーコード $0 を報告しました"
 
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "パッケージ"
+
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "親"
@@ -4682,7 +4813,7 @@ msgstr "親"
 msgid "Parent $parent"
 msgstr "親 $parent"
 
-#: pkg/systemd/service-details.jsx:415
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr "一部"
 
@@ -4768,7 +4899,7 @@ msgid "Paste the contents of your public SSH key file here"
 msgstr "公開 SSH 鍵ファイルの内容をここに貼り付けます"
 
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/systemd/service-details.jsx:477
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "パス"
 
@@ -4784,7 +4915,7 @@ msgstr "パスコスト $path_cost"
 msgid "Path on Server"
 msgstr "サーバーのパス"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "ホストファイルシステム上のパス"
 
@@ -4796,7 +4927,7 @@ msgstr "サーバーのパスは空欄にはできません。"
 msgid "Path on server must start with \"/\"."
 msgstr "サーバーのパスは \"/\" で開始してください。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:210
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "ホストファイルシステムの ISO ファイルのパス"
 
@@ -4837,7 +4968,7 @@ msgid "Persistence"
 msgstr "永続"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:83
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:66
 msgid "Persistent"
 msgstr "永続"
 
@@ -4845,7 +4976,7 @@ msgstr "永続"
 msgid "Physical"
 msgstr "物理"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr "物理ディスクデバイス"
 
@@ -4857,7 +4988,7 @@ msgstr "物理ボリューム"
 msgid "Physical Volumes"
 msgstr "物理ボリューム"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr "ホスト上の物理ディスクデバイス"
 
@@ -4896,15 +5027,15 @@ msgstr "$0 の強制削除を確定してください"
 msgid "Please confirm stopping of $0"
 msgstr "$0 の停止を確認してください"
 
-#: pkg/machines/components/diskAdd.jsx:450
+#: pkg/machines/components/diskAdd.jsx:483
 msgid "Please enter new volume name"
 msgstr "新しいボリューム名を入力してください"
 
-#: pkg/machines/components/diskAdd.jsx:453
+#: pkg/machines/components/diskAdd.jsx:486
 msgid "Please enter new volume size"
 msgstr "新しいボリュームサイズを入力してください"
 
-#: pkg/networkmanager/firewall.jsx:869
+#: pkg/networkmanager/firewall.jsx:894
 msgid "Please install the $0 package"
 msgstr "$0 パッケージをインストールしてください"
 
@@ -4924,12 +5055,12 @@ msgstr "仮想マシンを起動して、コンソールにアクセスしてく
 msgid "Please try another term"
 msgstr "別の用語を試してください"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Plug"
 msgstr "プラグ"
 
 #: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
+#: pkg/machines/components/diskAdd.jsx:204
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
 #: pkg/storaged/content-views.jsx:133
@@ -4948,6 +5079,11 @@ msgstr "シンボリューム用プール"
 msgid "Pool for thinly provisioned volumes"
 msgstr "シンプロビジョニングされたボリューム用プール"
 
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
+msgid "Pool's volumes are used by VMs "
+msgstr ""
+
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
@@ -4957,7 +5093,7 @@ msgstr "シンプロビジョニングされたボリューム用プール"
 msgid "Port"
 msgstr "ポート"
 
-#: pkg/networkmanager/firewall.jsx:339
+#: pkg/networkmanager/firewall.jsx:364
 msgid "Port number and type do not match"
 msgstr "ポート番号とタイプが一致しません"
 
@@ -4988,6 +5124,14 @@ msgstr "ゲストへの公開用の推奨されるソケットの数。"
 msgid "Prefix"
 msgstr "プレフィックス"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:337
+msgid "Prefix Length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:78
+msgid "Prefix Length should not be empty"
+msgstr ""
+
 #: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length"
 msgstr "プレフィックス長"
@@ -4995,6 +5139,10 @@ msgstr "プレフィックス長"
 #: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr "プレフィックス長またはネットマスク"
+
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:835
 msgid "Preparing"
@@ -5074,7 +5222,7 @@ msgstr "ssh-add によるプロンプトがタイムアウトしました"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "ssh-keygen によるプロンプトがタイムアウトしました"
 
-#: pkg/systemd/service-details.jsx:428
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr "再読み込み先を伝搬"
 
@@ -5095,14 +5243,6 @@ msgstr "パブリックのプルリポジトリ－"
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "目的"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "QEMU/KVM システム接続"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "QEMU/KVM ユーザー接続"
 
 #: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
@@ -5188,11 +5328,11 @@ msgstr "ラックマウントシャーシ"
 msgid "Random"
 msgstr "ランダム"
 
-#: pkg/networkmanager/firewall.jsx:764
+#: pkg/networkmanager/firewall.jsx:789
 msgid "Range"
 msgstr "範囲"
 
-#: pkg/networkmanager/firewall.jsx:370
+#: pkg/networkmanager/firewall.jsx:395
 msgid "Range must be strictly ordered"
 msgstr "範囲の順序は厳密でなければなりません"
 
@@ -5204,11 +5344,15 @@ msgstr "ランク"
 msgid "Raw to a device"
 msgstr "デバイスに対する Raw"
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr "さらに読む..."
 
-#: pkg/systemd/service-details.jsx:382
+#: pkg/systemd/service-details.jsx:386
 msgid "Read-only"
 msgstr "読み取り専用"
 
@@ -5273,7 +5417,7 @@ msgstr "最近開いたファイル"
 msgid "Recommended default"
 msgstr "推奨されるデフォルト"
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "再接続"
@@ -5310,15 +5454,15 @@ msgstr "接続を拒否しています。ホストキーが不明です"
 msgid "Register…"
 msgstr "登録中…"
 
-#: pkg/systemd/service-details.jsx:185
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "再読み込み"
 
-#: pkg/systemd/service-details.jsx:429
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr "伝搬元を再読み込み"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:258
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "リモート URL"
 
@@ -5369,11 +5513,11 @@ msgstr "パスフレーズを削除"
 msgid "Remove passphrase in $0?"
 msgstr "$0 のパスフレーズを削除しますか?"
 
-#: pkg/networkmanager/firewall.jsx:636
+#: pkg/networkmanager/firewall.jsx:661
 msgid "Remove service"
 msgstr "サービスの削除"
 
-#: pkg/networkmanager/firewall.jsx:615
+#: pkg/networkmanager/firewall.jsx:640
 msgid "Remove service from zones"
 msgstr "ゾーンからのサービスの削除"
 
@@ -5474,27 +5618,27 @@ msgstr "$0 日ごとのパスワードの変更が必要"
 msgid "Require password change on $0"
 msgstr "$0 でパスワードの変更が必要"
 
-#: pkg/systemd/service-details.jsx:416
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr "必要とされる"
 
-#: pkg/systemd/service-details.jsx:368
+#: pkg/systemd/service-details.jsx:372
 msgid "Required by "
 msgstr "以下により必要"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr "必要"
 
-#: pkg/systemd/service-details.jsx:383
+#: pkg/systemd/service-details.jsx:387
 msgid "Requires administration access to edit"
 msgstr "編集には管理者アクセスが必要"
 
-#: pkg/systemd/service-details.jsx:412
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr "必須"
 
-#: pkg/systemd/service-details.jsx:417
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr "必須の"
 
@@ -5531,7 +5675,7 @@ msgstr "暗号化されたファイルシステムのサイズ変更には、デ
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
 #: pkg/machines/components/vm/vmActions.jsx:42
-#: pkg/systemd/service-details.jsx:176 pkg/systemd/shutdown.js:95
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
 #: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "再起動"
@@ -5619,9 +5763,13 @@ msgstr "ホスト起動時に実行します"
 msgid "Runner"
 msgstr "ランナー"
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:347
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr "実行中"
+
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
+msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
@@ -5691,7 +5839,7 @@ msgstr "土曜日"
 msgid "Saturdays"
 msgstr "毎週土曜日"
 
-#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
 #: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
@@ -5721,7 +5869,7 @@ msgid "Sealed-case PC"
 msgstr "シールドケース PC"
 
 #: pkg/systemd/services.html:314 pkg/systemd/services.html:318
-#: pkg/systemd/init.js:890
+#: pkg/systemd/init.js:905
 msgid "Seconds"
 msgstr "秒"
 
@@ -5802,7 +5950,7 @@ msgstr "サーバーの接続が終了しました。"
 msgid "Servers"
 msgstr "サーバー"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:943
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:968
 #: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "サービス"
@@ -5836,10 +5984,11 @@ msgid "Service name"
 msgstr "サービス名"
 
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "サービス"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "セッション"
@@ -5847,6 +5996,10 @@ msgstr "セッション"
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
 msgstr "セット"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:231
+msgid "Set DHCP Range"
+msgstr ""
 
 #: pkg/systemd/host.js:781
 msgid "Set Host name"
@@ -5905,7 +6058,7 @@ msgstr "シェルスクリプト"
 msgid "Shift+Insert"
 msgstr "Shift+Insert"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Show Performance Options"
 msgstr "パフォーマンスオプションを表示します"
 
@@ -5951,8 +6104,8 @@ msgid "Single Rank"
 msgstr "シングルランク"
 
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:450
-#: pkg/machines/components/diskAdd.jsx:167
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
+#: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
@@ -5996,7 +6149,7 @@ msgstr "スロット $0"
 msgid "Sockets"
 msgstr "ソケット"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "ソフトウェア更新"
 
@@ -6035,23 +6188,24 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr "別のプログラムがパッケージマネージャーを使用中です。しばらくお待ちください..."
 
-#: pkg/networkmanager/firewall.jsx:714
+#: pkg/networkmanager/firewall.jsx:739
 msgid "Sorted from least trusted to most trusted"
 msgstr "信頼性が最も低い順から最も高い順による並べ替え"
 
-#: pkg/machines/components/diskAdd.jsx:507
-#: pkg/machines/components/nicEdit.jsx:141
+#: pkg/machines/components/diskAdd.jsx:541
+#: pkg/machines/components/nicEdit.jsx:150
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
 msgid "Source"
 msgstr "ソース"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
 msgid "Source Format"
 msgstr "ソースフォーマット"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
@@ -6061,12 +6215,16 @@ msgstr "ソースパス"
 msgid "Source URL"
 msgstr "ソース URL"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
+msgid "Source Volume Group"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "ソースパスは空欄にできません"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:148
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "ソースは、http、ftp、または nfs プロトコルで開始する必要があります"
 
@@ -6099,8 +6257,9 @@ msgid "Stable"
 msgstr "安定"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/machines/components/networks/createNetworkDialog.jsx:237
 #: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:180
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "開始日"
 
@@ -6112,11 +6271,11 @@ msgstr "Docker の起動"
 msgid "Start Multipath"
 msgstr "マルチパスの開始"
 
-#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:337
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
 msgstr "サービスの開始"
 
-#: pkg/systemd/service-details.jsx:407
+#: pkg/systemd/service-details.jsx:411
 msgid "Start and Enable"
 msgstr "起動と有効化"
 
@@ -6124,9 +6283,14 @@ msgstr "起動と有効化"
 msgid "Start libvirt"
 msgstr "libvirt の開始"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
 msgstr "ホスト起動時にプールを開始します"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:84
+msgid "Start should not be empty"
+msgstr ""
 
 #: pkg/storaged/jobs-panel.jsx:59
 msgid "Starting RAID Device $target"
@@ -6136,15 +6300,15 @@ msgstr "RAID デバイス $target の起動"
 msgid "Starting swapspace $target"
 msgstr "スワップ領域 $target の起動"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "起動"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:259 pkg/systemd/init.js:292
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "状態"
 
@@ -6153,11 +6317,11 @@ msgid "State:"
 msgstr "状態:"
 
 #: pkg/systemd/services.html:68 pkg/systemd/init.js:212
-#: pkg/systemd/service-details.jsx:365
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr "静的"
 
-#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:472
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "状態"
 
@@ -6172,7 +6336,7 @@ msgstr "スティッキー"
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
 #: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
 #: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
-#: pkg/systemd/service-details.jsx:165
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "停止"
 
@@ -6180,7 +6344,7 @@ msgstr "停止"
 msgid "Stop Device"
 msgstr "デバイスの停止"
 
-#: pkg/systemd/service-details.jsx:407
+#: pkg/systemd/service-details.jsx:411
 msgid "Stop and Disable"
 msgstr "停止と無効化"
 
@@ -6213,8 +6377,8 @@ msgid "Stopping swapspace $target"
 msgstr "スワップ領域 $target の停止"
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "ストレージ"
 
@@ -6230,11 +6394,11 @@ msgstr "ストレージプール $0 は、アクティベートに失敗しま�
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr "ストレージプール $0 は、停止に失敗しました"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr "ストレージプール名"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr "ストレージプールの作成に失敗しました"
 
@@ -6258,6 +6422,10 @@ msgstr "ストレージは、このシステムで管理できません。"
 #: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "ストレージプール"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
+msgid "Storage size must not be 0"
+msgstr ""
 
 #: pkg/systemd/index.html:155
 msgid "Store Metrics"
@@ -6358,8 +6526,10 @@ msgstr "{{Server}} と同期済み"
 msgid "Synchronizing RAID Device $target"
 msgstr "RAID デバイス $target の同期"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "システム"
 
@@ -6392,7 +6562,7 @@ msgid "System is up to date"
 msgstr "システムは最新の状態です"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:943
+#: pkg/networkmanager/firewall.jsx:968
 msgid "TCP"
 msgstr "TCP"
 
@@ -6420,12 +6590,12 @@ msgstr "Tang キーサーバー"
 msgid "Target"
 msgstr "ターゲット"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "ターゲットパス"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "ターゲットパスは空欄にできません"
 
@@ -6450,7 +6620,7 @@ msgstr "チームポート設定"
 msgid "Team Settings"
 msgstr "チーム設定"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "端末"
 
@@ -6494,8 +6664,8 @@ msgstr "スペアディスクを追加する場合は、RAID デバイスが実�
 msgid "The RAID device must be running in order to remove disks."
 msgstr "ディスクを取り外す場合は、RAID デバイスが実行中である必要があります。"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:80
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:84
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:125
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:129
 msgid "The Storage Pool could not be deleted"
 msgstr "ストレージプールを削除できませんでした"
 
@@ -6563,7 +6733,7 @@ msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr "現在ログイン中のユーザーは、キーに関する情報を見ることを許可されていません。"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "サーバー上のディレクトリーをエクスポート中"
 
@@ -6624,7 +6794,7 @@ msgstr "ボリュームグループの最後の物理ボリュームは削除で
 msgid "The logged in user is not permitted to view system modifications"
 msgstr "ログインしているユーザーには、システム変更を表示する権限がありません"
 
-#: pkg/shell/indexes.js:407
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "マシンが再起動中です"
 
@@ -6652,9 +6822,14 @@ msgstr "$time ($type) のスキャンでは、脆弱性は見つかりません�
 msgid "The scan from $time ($type) was not successful."
 msgstr "$time ($type) のスキャンは成功しませんでした。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:165
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
 msgid "The selected Operating System has minimum memory requirement of $0 $1"
 msgstr "選択したオペレーティングシステムには、必要なメモリー $0 $1 があります"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+msgid ""
+"The selected Operating System has minimum storage size requirement of $0 $1"
+msgstr ""
 
 #: src/ws/login.js:645
 msgid ""
@@ -6670,7 +6845,7 @@ msgstr "サーバーはサポートされた方法を使用した認証を拒否
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr "ユーザー $0 は、cpu セキュリティー緩和の変更を許可されていません"
 
-#: pkg/systemd/init.js:736
+#: pkg/systemd/init.js:751
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "ユーザー <b>$0</b> はタイマーを作成するパーミッションを持っていません"
 
@@ -6754,7 +6929,7 @@ msgstr "この NFS マウントは使用中で、そのオプションだけを�
 msgid "This VDO device does not use all of its backing device."
 msgstr "この VDO デバイスは、そのバッキングデバイスをすべて使用していません。"
 
-#: pkg/systemd/init.js:1185
+#: pkg/systemd/init.js:1200
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -6798,7 +6973,7 @@ msgstr "このデバイスは現在ボリュームグループに使用されて
 msgid "This disk cannot be removed while the device is recovering."
 msgstr "このディスクは、デバイスが復旧中に取り外すことができません。"
 
-#: pkg/systemd/init.js:1097 pkg/systemd/init.js:1111 pkg/systemd/init.js:1120
+#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
 msgid "This field cannot be empty."
 msgstr "このフィールドは空にできません。"
 
@@ -6827,7 +7002,7 @@ msgstr "このパッケージには Cockpit のこのバージョンとの互換
 msgid "This package requires Cockpit version %s or later"
 msgstr "このパッケージには Cockpit バージョン %s 以降が必要です"
 
-#: pkg/machines/components/diskAdd.jsx:210
+#: pkg/machines/components/diskAdd.jsx:215
 msgid "This pool type does not support Storage Volume creation"
 msgstr "このプールタイプは、ストレージボリュームの作成に対応していません"
 
@@ -6849,7 +7024,7 @@ msgid ""
 "this system for use with diagnosing problems with the system."
 msgstr "このツールは、システムの問題の診断で使用するためにシステムからシステム設定と診断情報を収集します。"
 
-#: pkg/systemd/service-details.jsx:294
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "このユニットは明示的に有効にするよう設計されていません。"
 
@@ -6863,7 +7038,7 @@ msgid ""
 "alternate user or port"
 msgstr "cockpit-ws のこのバージョンでは、別のユーザーまたはポートによるホストへの接続がサポートされません"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:443
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr "このボリュームは、別の VM によってすでに使用されています。"
 
@@ -6960,15 +7135,19 @@ msgstr "合計サイズ: $0"
 msgid "Tower"
 msgstr "タワー"
 
-#: pkg/systemd/service-details.jsx:427
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr "トリガー元"
 
-#: pkg/systemd/service-details.jsx:426
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "トリガー"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "トラブルシュート"
@@ -6977,7 +7156,7 @@ msgstr "トラブルシュート"
 msgid "Trust key"
 msgstr "キーを信頼します"
 
-#: pkg/networkmanager/firewall.jsx:710
+#: pkg/networkmanager/firewall.jsx:735
 msgid "Trust level"
 msgstr "信頼レベル"
 
@@ -7022,8 +7201,8 @@ msgid "Tuned is off"
 msgstr "Tuned がオフです"
 
 #: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
@@ -7049,11 +7228,11 @@ msgstr "パスワードを入力します"
 msgid "Type to filter…"
 msgstr "フィルターのために入力します…"
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:943
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:968
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:275
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "URL"
 
@@ -7119,11 +7298,15 @@ msgid "Unavailable"
 msgstr "利用できません"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "予期しないエラー"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:188
+#: pkg/machines/components/networks/createNetworkDialog.jsx:128
+msgid "Unique Network Name"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "固有名"
 
@@ -7167,7 +7350,7 @@ msgstr "不明な設定"
 msgid "Unknown host name"
 msgstr "不明なホスト名"
 
-#: pkg/networkmanager/firewall.jsx:333
+#: pkg/networkmanager/firewall.jsx:358
 msgid "Unknown service name"
 msgstr "不明なサービス名"
 
@@ -7220,7 +7403,7 @@ msgstr "$target のアンマウント中"
 msgid "Unnamed"
 msgstr "名前なし"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Unplug"
 msgstr "アンプラグ"
 
@@ -7258,11 +7441,11 @@ msgstr "信用できないホスト"
 msgid "Up since $0"
 msgstr "$0 から稼働中"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:462
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr "デフォルトの場所では、最大 $0 $1 まで利用できます"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:385
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr "このホストでは最大 $0 $1 まで使用できます"
 
@@ -7294,7 +7477,7 @@ msgstr "更新を利用できます"
 msgid "Updating"
 msgstr "更新中"
 
-#: pkg/systemd/service-details.jsx:402
+#: pkg/systemd/service-details.jsx:406
 msgid "Updating status..."
 msgstr "ステータスを更新中..."
 
@@ -7311,7 +7494,7 @@ msgstr[0] "$0 CPU コアの使用率"
 msgid "Use 512 Byte emulation"
 msgstr "512 バイトのエミュレーションを使用します。"
 
-#: pkg/machines/components/diskAdd.jsx:527
+#: pkg/machines/components/diskAdd.jsx:561
 msgid "Use Existing"
 msgstr "既存の使用"
 
@@ -7429,7 +7612,7 @@ msgstr "VM $0 は、強制的にシャットダウンさせることに失敗し
 msgid "VM $0 failed to get deleted"
 msgstr "VM $0 の削除に失敗しました"
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1304
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
 msgid "VM $0 failed to get installed"
 msgstr "VM $0 のインストールに失敗しました"
 
@@ -7507,19 +7690,23 @@ msgstr "バージョン"
 msgid "Very securely erasing $target"
 msgstr "$target を非常に安全に削除"
 
-#: pkg/lib/cockpit-components-modifications.jsx:174
+#: pkg/lib/cockpit-components-modifications.jsx:173
 msgid "View automation script"
 msgstr "オートメーションスクリプトの表示"
 
-#: pkg/machines/components/networks/networkList.jsx:39
+#: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "仮想マシン"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
 msgstr "仮想ネットワーク"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:422
+msgid "Virtual Network failed to be created"
+msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:80
 msgid "Virtualization Service (libvirt) is Not Active"
@@ -7529,7 +7716,7 @@ msgstr "仮想化サービス (libvirt) は有効ではありません "
 msgid "Virtualization Service is Available"
 msgstr "仮想化サービスは利用可能です"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:433
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
@@ -7545,6 +7732,14 @@ msgstr "ボリュームグループ"
 #: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "ボリュームグループ $0"
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
+msgid "Volume Group name"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+msgid "Volume Group name should not be empty"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:113
 msgid "Volume Groups"
@@ -7585,11 +7780,11 @@ msgstr "パッケージマネージャーを使用して、その他のプログ
 msgid "Waiting for other software management operations to finish"
 msgstr "他のソフトウェア管理オペレーションが終了するまで待機中"
 
-#: pkg/systemd/service-details.jsx:418
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr "望まれる"
 
-#: pkg/systemd/service-details.jsx:413
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr "望む"
 
@@ -7658,8 +7853,8 @@ msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr "現在このサーバーに直接接続されています。削除できません。"
 
-#: pkg/networkmanager/firewall.jsx:70 pkg/networkmanager/firewall.jsx:116
-#: pkg/networkmanager/firewall.jsx:878 pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
+#: pkg/networkmanager/firewall.jsx:903 pkg/networkmanager/firewall.jsx:909
 msgid "You are not authorized to modify the firewall."
 msgstr "ファイアウォールを修正する権限がありません。"
 
@@ -7677,10 +7872,9 @@ msgstr "Docker ストレージプールを管理するパーミッションが�
 msgid "You must wait longer to change your password"
 msgstr "パスワードを変更するにはより長い時間の経過が必要です。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:129
-msgid ""
-"You need to select the most closely matching OS vendor and Operating System"
-msgstr "最も合致する OS ベンダーおよびオペレーティングシステムを選択しなければなりません"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
+msgid "You need to select the most closely matching Operating System"
+msgstr ""
 
 #: pkg/packagekit/updates.jsx:836
 msgid ""
@@ -7702,11 +7896,11 @@ msgstr "セッションが終了しました。"
 msgid "Your session has expired. Please log in again."
 msgstr "セッションの有効期限が切れました。再度ログインしてください。"
 
-#: pkg/networkmanager/firewall.jsx:930
+#: pkg/networkmanager/firewall.jsx:955
 msgid "Zone"
 msgstr "ゾーン"
 
-#: pkg/networkmanager/firewall.jsx:943
+#: pkg/networkmanager/firewall.jsx:968
 msgid "Zones"
 msgstr "ゾーン"
 
@@ -7829,11 +8023,11 @@ msgstr "ホストデバイス"
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr "iSCSI イニシエーター IQN"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr "iSCSI ターゲット"
 
@@ -7841,11 +8035,11 @@ msgstr "iSCSI ターゲット"
 msgid "iSCSI Targets"
 msgstr "iSCSI ターゲット"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:83
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr "iSCSI ダイレクトターゲット"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr "iSCSI ターゲット IQN"
 
@@ -7891,8 +8085,8 @@ msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs ダンプターゲットは server:path の形式になっていません"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "いいえ"
@@ -7911,14 +8105,6 @@ msgstr[0] "$0 CPU コアの"
 #: pkg/machines/helpers.js:190
 msgid "paused"
 msgstr "一時停止"
-
-#: pkg/machines/components/diskAdd.jsx:154
-msgid "qcow2"
-msgstr "qcow2"
-
-#: pkg/machines/components/diskAdd.jsx:157
-msgid "raw"
-msgstr "raw"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -8009,7 +8195,7 @@ msgid "undefined"
 msgstr "未定義"
 
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:254 pkg/systemd/init.js:268
+#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
 msgid "unknown"
 msgstr "不明"
 
@@ -8049,15 +8235,15 @@ msgstr "value"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:804
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr "新しい VM を作成するには、virt-install パッケージをシステムにインストールする必要があります"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "はい"

--- a/po/manifest2po
+++ b/po/manifest2po
@@ -70,7 +70,12 @@ function step() {
     if (path.basename(filename) != "manifest.json.in")
         return step();
 
-    fs.readFile(filename, { encoding: "utf-8"}, function(err, data) {
+    /* Qualify the filename if necessary */
+    var full = filename;
+    if (opts.directory)
+        full = path.join(opts.directory, filename);
+
+    fs.readFile(full, { encoding: "utf-8"}, function(err, data) {
         if (err)
             fatal(err.message);
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,11 +12,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-15 04:42+0000\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-08-10 04:08+0000\n"
+"PO-Revision-Date: 2019-08-15 01:44+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: pl\n"
@@ -541,7 +541,7 @@ msgstr "Ustawienia konta"
 msgid "Account not available or cannot be edited."
 msgstr "Konto jest niedostępne lub nie może być modyfikowane."
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Konta"
 
@@ -576,7 +576,7 @@ msgstr "Aktywne strony"
 msgid "Active since"
 msgstr "Aktywne od"
 
-#: pkg/systemd/service-details.jsx:336
+#: pkg/systemd/service-details.jsx:352
 msgid "Active since "
 msgstr "Aktywna od "
 
@@ -723,7 +723,7 @@ msgstr "Dodatkowe domeny wyszukiwania DNS $val"
 msgid "Additional Storage"
 msgstr "Dodatkowe urządzenia do przechowywania danych"
 
-#: pkg/systemd/service-details.jsx:198
+#: pkg/systemd/service-details.jsx:209
 msgid "Additional actions"
 msgstr "Dodatkowe działania"
 
@@ -782,7 +782,7 @@ msgstr "Hasło administratora"
 msgid "Advanced TCA"
 msgstr "Zaawansowane TCA"
 
-#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:412
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "Po"
 
@@ -822,7 +822,7 @@ msgstr ""
 "Wszystkie dane na wybranych dyskach zostaną usunięte, a dyski zostaną dodane "
 "do puli urządzeń do przechowywania danych."
 
-#: pkg/systemd/service-details.jsx:157
+#: pkg/systemd/service-details.jsx:159
 msgid "Allow running (unmask)"
 msgstr "Zezwolenie na uruchamianie (odmaskowanie)"
 
@@ -855,7 +855,7 @@ msgid "Appearance:"
 msgstr "Wygląd:"
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Aplikacje"
 
@@ -990,7 +990,7 @@ msgstr "Automatyczne aktualizacje"
 msgid "Automatically start libvirt on boot"
 msgstr "Automatyczne włączanie usługi libvirt podczas uruchamiania"
 
-#: pkg/systemd/service-details.jsx:380
+#: pkg/systemd/service-details.jsx:396
 msgid "Automatically starts"
 msgstr "Automatycznie się uruchamia"
 
@@ -1058,11 +1058,11 @@ msgstr "Przekazano błędne dane dla mechanizmu passwd1"
 msgid "Balancer"
 msgstr "Równoważenie"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr "Przed"
 
-#: pkg/systemd/service-details.jsx:402
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr "Dowiązuje do"
 
@@ -1108,7 +1108,7 @@ msgstr "Kolejność uruchamiania"
 msgid "Boot order settings could not be saved"
 msgstr "Nie można zapisać ustawień kolejności uruchamiania"
 
-#: pkg/systemd/service-details.jsx:407
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr "Dowiązane przez"
 
@@ -1228,25 +1228,26 @@ msgstr "Nie można wczytać obrazu"
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:785
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
 #: pkg/machines/components/diskAdd.jsx:597
 #: pkg/machines/components/networks/createNetworkDialog.jsx:486
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:523
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/machines/components/nicEdit.jsx:311 pkg/networkmanager/firewall.jsx:590
-#: pkg/networkmanager/firewall.jsx:658 pkg/networkmanager/firewall.jsx:801
-#: pkg/packagekit/updates.jsx:179 pkg/sosreport/index.js:51
-#: pkg/storaged/dialog.jsx:393 pkg/storaged/jobs-panel.jsx:123
-#: pkg/systemd/hwinfo.jsx:216 pkg/systemd/service-details.jsx:107
+#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
+#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "Nie można połączyć z nieznanym komputerem"
 
@@ -1312,10 +1313,10 @@ msgstr "Zmień ograniczenia zasobów"
 msgid "Change the settings"
 msgstr "Zmień ustawienia"
 
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
-#: pkg/machines/components/nicEdit.jsx:287
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Zmiany zostaną uwzględnione po wyłączeniu maszyny wirtualnej"
 
@@ -1363,7 +1364,7 @@ msgstr "Wyszukiwanie aktualizacji…"
 msgid "Checking installed software"
 msgstr "Sprawdzanie zainstalowanego oprogramowania"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:352
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
 msgid "Choose an operating system"
 msgstr "Wybierz system operacyjny"
 
@@ -1382,6 +1383,10 @@ msgstr "Klasa"
 #: pkg/storaged/jobs-panel.jsx:55
 msgid "Cleaning up for $target"
 msgstr "Czyszczenie dla $target"
+
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
 
 #: pkg/systemd/services.html:86
 msgid "Clear All Filters"
@@ -1433,7 +1438,7 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit nie może skontaktować się z podanym komputerem."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1606,11 +1611,11 @@ msgstr "Kompresja"
 msgid "Computer OU"
 msgstr "OU komputera"
 
-#: pkg/systemd/service-details.jsx:426
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr "Warunek $0=$1 nie został spełniony"
 
-#: pkg/systemd/service-details.jsx:476
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "Warunek się nie powiódł"
 
@@ -1647,11 +1652,11 @@ msgstr "Potwierdź usunięcie sieci wirtualnej"
 msgid "Confirm removal with passphrase"
 msgstr "Potwierdź usunięcie hasłem"
 
-#: pkg/systemd/service-details.jsx:410
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr "W konflikcie z"
 
-#: pkg/systemd/service-details.jsx:409
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr "Powoduje konflikt z"
 
@@ -1698,14 +1703,13 @@ msgstr "Łączenie z usługą SETroubleshoot…"
 msgid "Connecting to Virtualization Service"
 msgstr "Łączenie z usługą wirtualizacji"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "Łączenie z komputerem"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:699
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
 #: pkg/machines/components/networks/createNetworkDialog.jsx:106
 #: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
@@ -1723,7 +1727,7 @@ msgstr "Połączenie przekroczyło czas oczekiwania."
 msgid "Connection will be lost"
 msgstr "Połączenie zostanie utracone"
 
-#: pkg/systemd/service-details.jsx:408
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr "Składa się z"
 
@@ -1829,7 +1833,7 @@ msgstr "Nie można zmienić grup użytkownika"
 msgid "Couldn't change user password"
 msgstr "Nie można zmienić hasła użytkownika"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "Nie można połączyć z komputerem"
 
@@ -1858,9 +1862,9 @@ msgid "Crash system"
 msgstr "System awarii"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:790
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
 #: pkg/machines/components/networks/createNetworkDialog.jsx:491
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:526
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
 #: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
 #: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
 #: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
@@ -1903,7 +1907,7 @@ msgstr "Utwórz raport"
 msgid "Create Snapshot"
 msgstr "Utwórz migawkę"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:560
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "Utwórz pulę urządzeń do przechowywania danych"
 
@@ -1923,7 +1927,7 @@ msgstr "Utwórz liczniki"
 msgid "Create VDO Device"
 msgstr "Utwórz urządzenie VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:832
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "Utwórz maszynę wirtualną"
 
@@ -2014,7 +2018,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Tworzenie grupy woluminów $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:684
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr "Utworzenie maszyny wirtualnej $0 się nie powiodło"
 
@@ -2230,6 +2234,10 @@ msgstr "Usuwanie grupy woluminów $target"
 msgid "Description"
 msgstr "Opis"
 
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
+
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Komputer stacjonarny"
@@ -2239,6 +2247,8 @@ msgstr "Komputer stacjonarny"
 msgid ""
 "Detach the disks using this pool from any VMs before attempting deletion."
 msgstr ""
+"Przed próbą usunięcia należy odłączyć dyski używające tej puli ze wszystkich "
+"maszyn wirtualnych."
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2267,6 +2277,10 @@ msgstr "Plik urządzenia"
 msgid "Device is read-only"
 msgstr "Urządzenie jest tylko do odczytu"
 
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
+
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
 msgstr "Raporty diagnostyczne"
@@ -2293,11 +2307,11 @@ msgid "Disable tuned"
 msgstr "Wyłącz tuned"
 
 #: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
-#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:315
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "Wyłączone"
 
-#: pkg/systemd/service-details.jsx:185
+#: pkg/systemd/service-details.jsx:192
 msgid "Disallow running (mask)"
 msgstr "Bez zezwolenia na uruchamianie (zamaskowanie)"
 
@@ -2306,7 +2320,7 @@ msgid "Disconnect"
 msgstr "Rozłącz"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "Rozłączono"
 
@@ -2357,6 +2371,10 @@ msgstr "Nie można usuwać dysków z maszyn wirtualnych $0"
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Język"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2623,7 +2641,7 @@ msgstr "Poprawka:"
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
 #: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
 #: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/systemd/service-details.jsx:432 pkg/users/local.js:1476
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Błąd"
 
@@ -2684,11 +2702,11 @@ msgstr "Przykład: 88,2019,nfs,rsync"
 msgid "Excellent password"
 msgstr "Doskonałe hasło"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:295
-msgid "Existing Disk Image"
-msgstr "Istniejący obraz dysku"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
+msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:232
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr "Istniejący obraz dysku w systemie plików gospodarza"
 
@@ -2768,7 +2786,7 @@ msgstr "Wczytanie upoważnionych kluczy się nie powiodło."
 msgid "Failed to remove service"
 msgstr "Usunięcie usługi się nie powiodło"
 
-#: pkg/systemd/service-details.jsx:324
+#: pkg/systemd/service-details.jsx:340
 msgid "Failed to start"
 msgstr "Uruchomienie się nie powiodło"
 
@@ -2798,7 +2816,7 @@ msgstr "Plik"
 msgid "Filesystem"
 msgstr "System plików"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "Katalog systemu plików"
 
@@ -2843,7 +2861,7 @@ msgstr "Obserwuje repozytorium Dockera"
 msgid "For legacy applications only. Reduces performance."
 msgstr "Tylko dla przestarzałych programów. Zmniejsza wydajność."
 
-#: pkg/systemd/service-details.jsx:306
+#: pkg/systemd/service-details.jsx:322
 msgid "Forbidden from running"
 msgstr "Zabronione uruchamianie"
 
@@ -2872,7 +2890,7 @@ msgid "Force remove passphrase in $0"
 msgstr "Wymuś usunięcie hasła w $0"
 
 #: pkg/machines/components/diskAdd.jsx:157
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:263
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
 #: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
 #: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
@@ -3047,10 +3065,10 @@ msgstr "Czas powitania $hello_time"
 msgid "Hide Performance Options"
 msgstr "Ukryj opcje wydajności"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "Gospodarz"
 
@@ -3059,7 +3077,7 @@ msgid "Host Device"
 msgstr "Urządzenie gospodarza"
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Nazwa komputera"
 
@@ -3071,7 +3089,7 @@ msgstr "Klucz komputera jest niepoprawny"
 msgid "Host name should not be changed in a domain"
 msgstr "Nie należy zmieniać nazwy komputera w domenie"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "Gospodarz nie może być pusty"
 
@@ -3257,15 +3275,19 @@ msgstr ""
 msgid "Images may only be pulled by specific users or groups"
 msgstr "Obrazy mogą być pobierane tylko przez podanych użytkowników i grupy"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:768
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Od razu uruchom maszynę wirtualną"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "Zsynchronizowane"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:240
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3315,11 +3337,11 @@ msgstr ""
 msgid "Initializing..."
 msgstr "Inicjowanie…"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr "Inicjator"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr "Inicjator IQN nie może być pusty"
 
@@ -3355,15 +3377,15 @@ msgstr ""
 "Należy zainstalować setroubleshoot-server, aby rozwiązywać problemy ze "
 "zdarzeniami SELinuksa."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:299
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Źródło instalacji"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:281
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Typ źródła instalacji"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "Źródło instalacji nie może być puste"
 
@@ -3380,7 +3402,7 @@ msgstr "Instalowanie"
 msgid "Installing $0"
 msgstr "Instalowanie $0"
 
-#: pkg/systemd/service-details.jsx:471
+#: pkg/systemd/service-details.jsx:487
 msgid "Instance of template: "
 msgstr "Wystąpienie szablonu: "
 
@@ -3430,11 +3452,11 @@ msgstr "Nieprawidłowy przedrostek IPv6"
 msgid "Invalid address $0"
 msgstr "Nieprawidłowy adres $0"
 
-#: pkg/systemd/host.js:1469 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "Nieprawidłowy format daty"
 
-#: pkg/systemd/host.js:1465 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "Nieprawidłowy format daty i nieprawidłowy format czasu"
 
@@ -3450,7 +3472,7 @@ msgstr "Nieprawidłowa data wygaśnięcia"
 msgid "Invalid file permissions"
 msgstr "Nieprawidłowe uprawnienia pliku"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "Nieprawidłowa nazwa pliku"
 
@@ -3490,7 +3512,7 @@ msgstr "Nieprawidłowy przedrostek lub maska sieci $0"
 msgid "Invalid range"
 msgstr "Nieprawidłowy zakres"
 
-#: pkg/systemd/host.js:1467 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "Nieprawidłowy format czasu"
 
@@ -3534,7 +3556,7 @@ msgstr "Dołącz do domeny"
 msgid "Joining this domain is not supported"
 msgstr "Dołączenie do tej domeny jest nieobsługiwane"
 
-#: pkg/systemd/service-details.jsx:418
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr "Dołącza do przestrzeni nazw"
 
@@ -3573,7 +3595,7 @@ msgstr "Zgłoszenie Kerberos"
 msgid "Kernel"
 msgstr "Jądro"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "Zrzut jądra"
 
@@ -3606,7 +3628,7 @@ msgstr "Usunięcie serwera kluczy może uniemożliwić odblokowanie $0."
 msgid "LACP Key"
 msgstr "Klucz LACP"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:80
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
 msgid "LVM Volume Group"
 msgstr "Grupa woluminów LVM"
 
@@ -3754,7 +3776,7 @@ msgstr "Lokalne dyski"
 msgid "Local Filesystem"
 msgstr "Lokalny system plików"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr "Lokalny nośnik instalacji"
 
@@ -3854,7 +3876,7 @@ msgstr "Login uzyskał uprawnienia administratora"
 msgid "Logout Successful"
 msgstr "Pomyślnie wylogowano"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Dzienniki"
 
@@ -3910,7 +3932,7 @@ msgstr "Identyfikator komputera"
 msgid "Machine SSH Key Fingerprints"
 msgstr "Odciski kluczy SSH komputera"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "Komputery"
 
@@ -3943,7 +3965,7 @@ msgstr "Ręczne sprawdzenie za pomocą SSH:"
 msgid "Marking $target as faulty"
 msgstr "Oznaczanie $target jako wadliwe"
 
-#: pkg/systemd/service-details.jsx:192 pkg/systemd/service-details.jsx:195
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
 msgid "Mask Service"
 msgstr "Zamaskuj usługę"
 
@@ -3955,11 +3977,11 @@ msgstr "Długość maski lub przedrostka"
 msgid "Mask or Prefix Length should not be empty"
 msgstr "Długość maski lub przedrostka nie może być pusta"
 
-#: pkg/systemd/service-details.jsx:305
+#: pkg/systemd/service-details.jsx:321
 msgid "Masked"
 msgstr "Zamaskowana"
 
-#: pkg/systemd/service-details.jsx:193
+#: pkg/systemd/service-details.jsx:200
 msgid ""
 "Masking service prevents all dependant units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
@@ -4008,7 +4030,7 @@ msgstr "Element urządzenia RAID $0"
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:390
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
 #: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "Pamięć"
@@ -4035,7 +4057,7 @@ msgstr "Nie można zapisać pamięci"
 msgid "Memory limit"
 msgstr "Ograniczenie pamięci"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
 msgstr "Pamięć nie może wynosić 0"
 
@@ -4225,11 +4247,11 @@ msgstr "Serwer NTP"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:194
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
 #: pkg/machines/components/diskAdd.jsx:126
 #: pkg/machines/components/networks/createNetworkDialog.jsx:122
 #: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
@@ -4241,8 +4263,8 @@ msgstr "Serwer NTP"
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
 #: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:290
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "Nazwa"
 
@@ -4276,7 +4298,7 @@ msgstr "Nazwa nie może zawierać spacji."
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/networks/createNetworkDialog.jsx:41
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "Nazwa nie może być pusta"
 
@@ -4304,17 +4326,17 @@ msgstr "Aktywacja sieci $0 się nie powiodła"
 msgid "Network $0 failed to get deactivated"
 msgstr "Dezaktywacja sieci $0 się nie powiodła"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:293
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr "Uruchamianie sieciowe (PXE)"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:290
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
 msgid "Network Boot is available only when using System connection"
 msgstr ""
 "Uruchamianie sieciowe jest dostępne tylko podczas używania połączenia "
 "systemowego"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "NFS"
 
@@ -4322,7 +4344,7 @@ msgstr "NFS"
 msgid "Network Interfaces"
 msgstr "Interfejsy sieciowe"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:246
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr "Wybór sieci nie obsługuje PXE."
 
@@ -4343,7 +4365,7 @@ msgid "NetworkManager is not running."
 msgstr "Usługa NetworkManager nie jest uruchomiona."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:944
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Sieć"
 
@@ -4432,7 +4454,7 @@ msgstr "Nie ustawiono żadnych punktów montowania NFS"
 
 #: pkg/machines/components/nicEdit.jsx:118
 msgid "No Network Devices"
-msgstr ""
+msgstr "Brak urządzeń sieciowych"
 
 #: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
@@ -4712,7 +4734,7 @@ msgstr "Niezamontowane"
 msgid "Not permitted to perform this action."
 msgstr "Brak uprawnień do wykonania tego działania."
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "Niedziałające"
 
@@ -4724,7 +4746,7 @@ msgstr "Niesynchronizowane"
 msgid "Not yet synced"
 msgstr "Jeszcze nie zsynchronizowano"
 
-#: pkg/systemd/service-details.jsx:432
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr "Uwaga"
 
@@ -4764,7 +4786,7 @@ msgstr "Nie przyjęto poprzedniego hasła"
 msgid "On Build"
 msgstr "Podczas budowania"
 
-#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:413
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr "Podczas niepowodzenia"
 
@@ -4824,7 +4846,7 @@ msgid "Open"
 msgstr "Otwórz"
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:343
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "System operacyjny"
 
@@ -4885,7 +4907,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "Informacje o pakiecie"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "Usługa PackageKit uległa awarii"
 
@@ -4897,6 +4919,10 @@ msgstr "Usługa PackageKit nie jest zainstalowana"
 msgid "PackageKit reported error code $0"
 msgstr "Usługa PackageKit zgłosiła kod błędu $0"
 
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "Pakiety"
+
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "Nadrzędne"
@@ -4905,7 +4931,7 @@ msgstr "Nadrzędne"
 msgid "Parent $parent"
 msgstr "Nadrzędne $parent"
 
-#: pkg/systemd/service-details.jsx:403
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr "Część"
 
@@ -4993,7 +5019,7 @@ msgid "Paste the contents of your public SSH key file here"
 msgstr "Proszę tutaj wkleić zawartość pliku publicznego klucza SSH"
 
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/systemd/service-details.jsx:465
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "Ścieżka"
 
@@ -5009,7 +5035,7 @@ msgstr "Koszt ścieżki $path_cost"
 msgid "Path on Server"
 msgstr "Ścieżka na serwerze"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "Ścieżka w systemie plików gospodarza"
 
@@ -5021,7 +5047,7 @@ msgstr "Ścieżka na serwerze nie może być pusta."
 msgid "Path on server must start with \"/\"."
 msgstr "Ścieżka na serwerze musi zaczynać się od „/”."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:223
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "Ścieżka do pliku ISO w systemie plików gospodarza"
 
@@ -5070,7 +5096,7 @@ msgstr "Trwałe"
 msgid "Physical"
 msgstr "Fizyczny"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr "Fizyczne urządzenie dyskowe"
 
@@ -5082,7 +5108,7 @@ msgstr "Wolumin fizyczny"
 msgid "Physical Volumes"
 msgstr "Woluminy fizyczne"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr "Fizyczne urządzenie dyskowe na gospodarzu"
 
@@ -5177,7 +5203,7 @@ msgstr "Pula dla cienko nadzorowanych woluminów"
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
 msgid "Pool's volumes are used by VMs "
-msgstr ""
+msgstr "Woluminy puli są używane przez maszyny wirtualne "
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
@@ -5234,6 +5260,10 @@ msgstr "Długość przedrostka"
 #: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr "Długość przedrostka lub maska sieci"
+
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:835
 msgid "Preparing"
@@ -5313,7 +5343,7 @@ msgstr "Pytanie przez ssh-add przekroczyło czas oczekiwania"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Pytanie przez ssh-keygen przekroczyło czas oczekiwania"
 
-#: pkg/systemd/service-details.jsx:416
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr "Wysyła ponowne wczytanie do"
 
@@ -5334,14 +5364,6 @@ msgstr "Publiczne repozytorium do pobierania"
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Zastosowanie"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "Połączenie systemowe QEMU/KVM"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "Połączenie użytkownika QEMU/KVM"
 
 #: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
@@ -5443,11 +5465,15 @@ msgstr "Stopień"
 msgid "Raw to a device"
 msgstr "Surowe do urządzenia"
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr "Więcej informacji…"
 
-#: pkg/systemd/service-details.jsx:370
+#: pkg/systemd/service-details.jsx:386
 msgid "Read-only"
 msgstr "Tylko do odczytu"
 
@@ -5514,7 +5540,7 @@ msgstr "Ostatnie"
 msgid "Recommended default"
 msgstr "Zalecana wartość domyślna"
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Połącz ponownie"
@@ -5551,15 +5577,15 @@ msgstr "Odmowa połączenia. Klucz komputera jest nieznany"
 msgid "Register…"
 msgstr "Zarejestruj…"
 
-#: pkg/systemd/service-details.jsx:163
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Wczytaj ponownie"
 
-#: pkg/systemd/service-details.jsx:417
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr "Odebrano ponowne wczytanie z"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:271
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "Zdalny adres URL"
 
@@ -5717,27 +5743,27 @@ msgstr "Wymaganie zmiany hasła co $0 dni"
 msgid "Require password change on $0"
 msgstr "Wymaganie zmiany hasła w dniu $0"
 
-#: pkg/systemd/service-details.jsx:404
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr "Wymagane przez"
 
-#: pkg/systemd/service-details.jsx:356
+#: pkg/systemd/service-details.jsx:372
 msgid "Required by "
 msgstr "Wymagana przez "
 
-#: pkg/systemd/service-details.jsx:399
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr "Wymaga"
 
-#: pkg/systemd/service-details.jsx:371
+#: pkg/systemd/service-details.jsx:387
 msgid "Requires administration access to edit"
 msgstr "Modyfikacja wymaga dostępu administratora"
 
-#: pkg/systemd/service-details.jsx:400
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr "Potrzebne"
 
-#: pkg/systemd/service-details.jsx:405
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr "Potrzebne dla"
 
@@ -5778,7 +5804,7 @@ msgstr ""
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
 #: pkg/machines/components/vm/vmActions.jsx:42
-#: pkg/systemd/service-details.jsx:167 pkg/systemd/shutdown.js:95
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
 #: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Uruchom ponownie"
@@ -5868,9 +5894,13 @@ msgstr "Uruchamianie po włączeniu gospodarza"
 msgid "Runner"
 msgstr "Uruchamianie"
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:335
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr "Działające"
+
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
+msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
@@ -5940,11 +5970,10 @@ msgstr "sobota"
 msgid "Saturdays"
 msgstr "soboty"
 
-#: pkg/systemd/services.html:378
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/machines/components/nicEdit.jsx:314 pkg/storaged/crypto-keyslots.jsx:261
-#: pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Zapisz"
 
@@ -6091,10 +6120,11 @@ msgid "Service name"
 msgstr "Nazwa usługi"
 
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
-#: pkg/networkmanager/firewall.jsx:508
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Usługi"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sesja"
@@ -6212,7 +6242,7 @@ msgid "Single Rank"
 msgstr "Pojedynczy stopień"
 
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:476
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
 #: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
@@ -6257,7 +6287,7 @@ msgstr "Gniazdo $0"
 msgid "Sockets"
 msgstr "Gniazda"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Aktualizacje oprogramowania"
 
@@ -6302,9 +6332,9 @@ msgid "Sorted from least trusted to most trusted"
 msgstr "Uporządkowane od najmniej do najbardziej zaufanych"
 
 #: pkg/machines/components/diskAdd.jsx:541
+#: pkg/machines/components/nicEdit.jsx:150
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/nicEdit.jsx:150
 #: pkg/machines/components/vmnetworktab.jsx:148
 msgid "Source"
 msgstr "Źródło"
@@ -6313,8 +6343,8 @@ msgstr "Źródło"
 msgid "Source Format"
 msgstr "Format źródłowy"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:221
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:248
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
@@ -6324,16 +6354,16 @@ msgstr "Ścieżka źródłowa"
 msgid "Source URL"
 msgstr "Źródłowy adres URL"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
 msgid "Source Volume Group"
 msgstr "Źródłowa grupa woluminów"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:238
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:259
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "Ścieżka źródłowa nie może być pusta"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "Źródło musi zaczynać się od protokołu http, ftp lub nfs"
 
@@ -6368,7 +6398,7 @@ msgstr "Stabilna"
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
 #: pkg/machines/components/networks/createNetworkDialog.jsx:237
 #: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:174
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Rozpocznij"
 
@@ -6380,11 +6410,11 @@ msgstr "Uruchom Dockera"
 msgid "Start Multipath"
 msgstr "Uruchom urządzenie wielościeżkowe"
 
-#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:325
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
 msgstr "Uruchom usługę"
 
-#: pkg/systemd/service-details.jsx:395
+#: pkg/systemd/service-details.jsx:411
 msgid "Start and Enable"
 msgstr "Uruchom i włącz"
 
@@ -6392,7 +6422,7 @@ msgstr "Uruchom i włącz"
 msgid "Start libvirt"
 msgstr "Uruchom usługę libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:318
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
 msgstr "Włączanie puli po uruchomieniu gospodarza"
 
@@ -6409,7 +6439,7 @@ msgstr "Uruchamianie urządzenia RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Uruchamianie przestrzeni wymiany $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "Uruchamianie"
 
@@ -6417,7 +6447,7 @@ msgstr "Uruchamianie"
 #: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:259 pkg/systemd/init.js:294
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "Stan"
 
@@ -6426,11 +6456,11 @@ msgid "State:"
 msgstr "Stan:"
 
 #: pkg/systemd/services.html:68 pkg/systemd/init.js:212
-#: pkg/systemd/service-details.jsx:353
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr "Statyczne"
 
-#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:460
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "Stan"
 
@@ -6445,7 +6475,7 @@ msgstr "Lepkie"
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
 #: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
 #: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
-#: pkg/systemd/service-details.jsx:170
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Zatrzymaj"
 
@@ -6453,7 +6483,7 @@ msgstr "Zatrzymaj"
 msgid "Stop Device"
 msgstr "Zatrzymaj urządzenie"
 
-#: pkg/systemd/service-details.jsx:395
+#: pkg/systemd/service-details.jsx:411
 msgid "Stop and Disable"
 msgstr "Zatrzymaj i wyłącz"
 
@@ -6486,8 +6516,8 @@ msgid "Stopping swapspace $target"
 msgstr "Zatrzymywanie przestrzeni wymiany $target"
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:439
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Przechowywanie danych"
 
@@ -6504,11 +6534,11 @@ msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 "Dezaktywacja puli urządzeń do przechowywania danych $0 się nie powiodła"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr "Nazwa puli urządzeń do przechowywania danych"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:475
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr "Utworzenie puli urządzeń do przechowywania danych się nie powiodło"
 
@@ -6534,9 +6564,9 @@ msgstr ""
 msgid "Storage pool"
 msgstr "Pula urządzeń do przechowywania danych"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:172
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
 msgid "Storage size must not be 0"
-msgstr ""
+msgstr "Rozmiar urządzenia do przechowywania danych nie może wynosić 0"
 
 #: pkg/systemd/index.html:155
 msgid "Store Metrics"
@@ -6643,8 +6673,10 @@ msgstr "Synchronizowane z {{Server}}"
 msgid "Synchronizing RAID Device $target"
 msgstr "Synchronizowanie urządzenia RAID $target"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "System"
 
@@ -6705,12 +6737,12 @@ msgstr "Serwer kluczy Tang"
 msgid "Target"
 msgstr "Cel"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "Ścieżka docelowa"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "Ścieżka docelowa nie może być pusta"
 
@@ -6735,7 +6767,7 @@ msgstr "Ustawienia portu zespołu"
 msgid "Team Settings"
 msgstr "Ustawienia zespołu"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -6863,7 +6895,7 @@ msgstr ""
 "Obecnie zalogowany użytkownik nie ma zezwolenia na wyświetlanie informacji "
 "o kluczach."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "Eksportowany katalog na serwerze"
 
@@ -6934,7 +6966,7 @@ msgid "The logged in user is not permitted to view system modifications"
 msgstr ""
 "Zalogowany użytkownik nie ma zezwolenia na wyświetlanie modyfikacji systemu"
 
-#: pkg/shell/indexes.js:407
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "Komputer jest ponownie uruchamiany"
 
@@ -6962,14 +6994,16 @@ msgstr "Wyszukiwanie z $time ($type) nie zwróciło żadnych zagrożeń."
 msgid "The scan from $time ($type) was not successful."
 msgstr "Wyszukiwanie z $time ($type) się nie powiodło."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
 msgid "The selected Operating System has minimum memory requirement of $0 $1"
-msgstr "Wybrany system operacyjny minimalnie wymaga $0 $1 pamięci"
+msgstr "Wybrany system operacyjny wymaga co najmniej $0 $1 pamięci"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:178
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid ""
 "The selected Operating System has minimum storage size requirement of $0 $1"
 msgstr ""
+"Wybrany system operacyjny wymaga urządzenia do przechowywania danych "
+"o rozmiarze co najmniej $0 $1"
 
 #: src/ws/login.js:645
 msgid ""
@@ -7195,7 +7229,7 @@ msgstr ""
 "To narzędzie zbierze konfigurację systemu i informacje diagnostyczne z tego "
 "systemu do użycia w diagnozowaniu problemów z systemem."
 
-#: pkg/systemd/service-details.jsx:282
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Ta jednostka nie została zaprojektowana do bezpośredniego włączania."
 
@@ -7211,7 +7245,7 @@ msgstr ""
 "Ta wersja cockpit-ws nie obsługuje łączenia z komputerem z alternatywnym "
 "użytkownikiem lub portem"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:469
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr "Ten wolumin jest już używany przez inną maszynę wirtualną."
 
@@ -7314,15 +7348,19 @@ msgstr "Całkowity rozmiar: $0"
 msgid "Tower"
 msgstr "Tower"
 
-#: pkg/systemd/service-details.jsx:415
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr "Wyzwalane przez"
 
-#: pkg/systemd/service-details.jsx:414
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "Wyzwalacze"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Rozwiązywanie problemów"
@@ -7376,7 +7414,7 @@ msgid "Tuned is off"
 msgstr "tuned jest wyłączone"
 
 #: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
@@ -7407,7 +7445,7 @@ msgstr "Filtrowanie…"
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:288
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "Adres URL"
 
@@ -7473,7 +7511,7 @@ msgid "Unavailable"
 msgstr "Niedostępne"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Nieoczekiwany błąd"
 
@@ -7481,7 +7519,7 @@ msgstr "Nieoczekiwany błąd"
 msgid "Unique Network Name"
 msgstr "Unikalna nazwa sieci"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:201
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "Unikalna nazwa"
 
@@ -7616,11 +7654,11 @@ msgstr "Niezaufany komputer"
 msgid "Up since $0"
 msgstr "Działa od $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:490
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr "Do $0 $1 dostępnej w domyślnym położeniu"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:403
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr "Do $0 $1 dostępnej na gospodarzu"
 
@@ -7652,7 +7690,7 @@ msgstr "Dostępne są aktualizacje"
 msgid "Updating"
 msgstr "Aktualizowanie"
 
-#: pkg/systemd/service-details.jsx:390
+#: pkg/systemd/service-details.jsx:406
 msgid "Updating status..."
 msgstr "Aktualizowanie stanu…"
 
@@ -7790,7 +7828,7 @@ msgstr "Wymuszenie wyłączenia maszyny wirtualnej $0 się nie powiodło"
 msgid "VM $0 failed to get deleted"
 msgstr "Usunięcie maszyny wirtualnej $0 się nie powiodło"
 
-#: pkg/machines/libvirt-common.js:1308 pkg/machines/hostvmslist.jsx:110
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
 msgid "VM $0 failed to get installed"
 msgstr "Zainstalowanie maszyny wirtualnej $0 się nie powiodło"
 
@@ -7868,13 +7906,13 @@ msgstr "Wersja"
 msgid "Very securely erasing $target"
 msgstr "Bardzo bezpieczne usuwanie zawartości $target"
 
-#: pkg/lib/cockpit-components-modifications.jsx:174
+#: pkg/lib/cockpit-components-modifications.jsx:173
 msgid "View automation script"
 msgstr "Wyświetl skrypt automatyzacji"
 
 #: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Maszyny wirtualne"
 
@@ -7894,7 +7932,7 @@ msgstr "Usługa wirtualizacji (libvirt) nie jest aktywna"
 msgid "Virtualization Service is Available"
 msgstr "Usługa wirtualizacji jest dostępna"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:459
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
@@ -7911,11 +7949,11 @@ msgstr "Grupa woluminów"
 msgid "Volume Group $0"
 msgstr "Grupa woluminów $0"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:214
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
 msgid "Volume Group name"
 msgstr "Nazwa grupy woluminów"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:298
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
 msgid "Volume Group name should not be empty"
 msgstr "Nazwa grupy woluminów nie może być pusta"
 
@@ -7959,11 +7997,11 @@ msgid "Waiting for other software management operations to finish"
 msgstr ""
 "Oczekiwanie na ukończenie pozostałych działań zarządzania oprogramowaniem"
 
-#: pkg/systemd/service-details.jsx:406
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr "Chciane przez"
 
-#: pkg/systemd/service-details.jsx:401
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr "Chce"
 
@@ -8054,7 +8092,7 @@ msgstr ""
 msgid "You must wait longer to change your password"
 msgstr "Należy poczekać dłużej na zmianę hasła"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
 msgid "You need to select the most closely matching Operating System"
 msgstr "Należy wybrać najlepiej pasujący system operacyjny"
 
@@ -8209,11 +8247,11 @@ msgstr "urządzenie gospodarza"
 msgid "hostdev"
 msgstr "urządzenie gospodarza"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr "Inicjator IQN iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr "Cel iSCSI"
 
@@ -8221,11 +8259,11 @@ msgstr "Cel iSCSI"
 msgid "iSCSI Targets"
 msgstr "Cele iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:84
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr "Bezpośredni cel iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr "IQN celu iSCSI"
 
@@ -8423,7 +8461,7 @@ msgstr "wartość"
 msgid "vhostuser"
 msgstr "użytkownik gospodarza wirtualizacji"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:837
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-07 20:07+0000\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -57,7 +57,7 @@ msgid_plural "$0 Packages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pkg/systemd/init.js:417 pkg/systemd/service-details.jsx:58
+#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "Modelo $0 "
 
@@ -536,7 +536,7 @@ msgstr "Configurações de Conta"
 msgid "Account not available or cannot be edited."
 msgstr "Conta não disponível ou não pode ser editada."
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Contas"
 
@@ -571,7 +571,7 @@ msgstr "Páginas Ativas"
 msgid "Active since"
 msgstr "Ativo desde"
 
-#: pkg/systemd/service-details.jsx:347
+#: pkg/systemd/service-details.jsx:352
 msgid "Active since "
 msgstr ""
 
@@ -774,7 +774,7 @@ msgstr "Senha de Administrador"
 msgid "Advanced TCA"
 msgstr "TCA Avançado"
 
-#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:423
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "Após"
 
@@ -786,7 +786,7 @@ msgid ""
 msgstr ""
 
 #: pkg/systemd/services.html:301 pkg/systemd/services.html:305
-#: pkg/systemd/init.js:887
+#: pkg/systemd/init.js:902
 msgid "After system boot"
 msgstr "Após a inicialização do sistema"
 
@@ -843,7 +843,7 @@ msgid "Appearance:"
 msgstr ""
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Aplicações"
 
@@ -966,7 +966,7 @@ msgstr "Automático (apenas DHCP)"
 msgid "Automatic (DHCP)"
 msgstr "Automático (DHCP)"
 
-#: pkg/systemd/init.js:293
+#: pkg/systemd/init.js:295
 msgid "Automatic Startup"
 msgstr ""
 
@@ -978,7 +978,7 @@ msgstr "Atualizações automáticas"
 msgid "Automatically start libvirt on boot"
 msgstr "Iniciar automaticamente a libvirt na inicialização"
 
-#: pkg/systemd/service-details.jsx:391
+#: pkg/systemd/service-details.jsx:396
 msgid "Automatically starts"
 msgstr ""
 
@@ -1046,11 +1046,11 @@ msgstr "Dados corrompidos passaram por passwd1 mecanismo"
 msgid "Balancer"
 msgstr "Balanceador"
 
-#: pkg/systemd/service-details.jsx:422
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr "Antes"
 
-#: pkg/systemd/service-details.jsx:413
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr "Vincula a"
 
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Boot order settings could not be saved"
 msgstr ""
 
-#: pkg/systemd/service-details.jsx:418
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr "Vinculado pela"
 
@@ -1216,26 +1216,26 @@ msgstr "Não é possível carregar a imagem"
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:743
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
 #: pkg/machines/components/diskAdd.jsx:597
 #: pkg/machines/components/networks/createNetworkDialog.jsx:486
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:523
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
 #: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
 #: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
 #: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
-#: pkg/systemd/service-details.jsx:107
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "Não pode conectar a uma máquina desconhecida"
 
@@ -1301,7 +1301,7 @@ msgstr "Alterar limites de recursos"
 msgid "Change the settings"
 msgstr "Alterar as configurações"
 
-#: pkg/machines/components/nicEdit.jsx:272
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
@@ -1352,7 +1352,7 @@ msgstr "Verificando atualizações ..."
 msgid "Checking installed software"
 msgstr "Verificando o software instalado"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:337
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
 msgid "Choose an operating system"
 msgstr ""
 
@@ -1371,6 +1371,10 @@ msgstr "Classe"
 #: pkg/storaged/jobs-panel.jsx:55
 msgid "Cleaning up for $target"
 msgstr "Limpando $target"
+
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
 
 #: pkg/systemd/services.html:86
 msgid "Clear All Filters"
@@ -1422,7 +1426,7 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "O Cockpit não poderia entrar em contato com o host fornecido."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1597,11 +1601,11 @@ msgstr "Compressão"
 msgid "Computer OU"
 msgstr "Computador OU"
 
-#: pkg/systemd/service-details.jsx:437
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr "Condição $0=$1 não foi cumprida"
 
-#: pkg/systemd/service-details.jsx:487
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "Condição falhou"
 
@@ -1638,11 +1642,11 @@ msgstr ""
 msgid "Confirm removal with passphrase"
 msgstr "Confirme a remoção com a frase secreta"
 
-#: pkg/systemd/service-details.jsx:421
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr "Conflito por"
 
-#: pkg/systemd/service-details.jsx:420
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr "Conflitos"
 
@@ -1689,14 +1693,13 @@ msgstr "Conectando-se ao daemon SETroubleshoot..."
 msgid "Connecting to Virtualization Service"
 msgstr "Conectando-se ao serviço de virtualização"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "Conectando a máquina"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:659
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
 #: pkg/machines/components/networks/createNetworkDialog.jsx:106
 #: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
@@ -1714,7 +1717,7 @@ msgstr "A conexão expirou."
 msgid "Connection will be lost"
 msgstr "A conexão será perdida"
 
-#: pkg/systemd/service-details.jsx:419
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr "Consiste em"
 
@@ -1819,7 +1822,7 @@ msgstr "Não foi possível alterar os grupos de usuários"
 msgid "Couldn't change user password"
 msgstr "Não foi possível alterar a senha do usuário"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "Não pode conectar a máquina"
 
@@ -1848,9 +1851,9 @@ msgid "Crash system"
 msgstr "Sistema de travamento"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:748
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
 #: pkg/machines/components/networks/createNetworkDialog.jsx:491
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:526
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
 #: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
 #: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
 #: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
@@ -1893,7 +1896,7 @@ msgstr "Criar relatório"
 msgid "Create Snapshot"
 msgstr "Criar Snapshot"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:560
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "Criar pool de armazenamento"
 
@@ -1913,7 +1916,7 @@ msgstr "Criar Temporizadores"
 msgid "Create VDO Device"
 msgstr "Criar dispositivo VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:790
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "Criar VM"
 
@@ -2004,7 +2007,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Criando grupo de volume $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:641
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr ""
 
@@ -2125,8 +2128,9 @@ msgstr "Atraso"
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
 #: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
@@ -2138,7 +2142,7 @@ msgstr "Excluir"
 msgid "Delete $0"
 msgstr "Deletar $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
 msgstr ""
 
@@ -2150,7 +2154,7 @@ msgstr "Excluir Arquivos"
 msgid "Delete Network $0"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:217
 msgid "Delete Storage Pool $0"
 msgstr ""
 
@@ -2158,7 +2162,7 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr "Excluir arquivos de armazenamento associados:"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:170
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
 
@@ -2198,7 +2202,7 @@ msgstr "A exclusão de uma partição apaga todos os dados da mesma."
 msgid "Deleting a volume group will erase all data on it."
 msgstr "A exclusão de um grupo de volumes apaga todos os dados do mesmo."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:174
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
@@ -2210,13 +2214,23 @@ msgstr "Excluindo grupo de volume $target"
 
 #: pkg/systemd/services.html:268
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:287
+#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
 msgid "Description"
 msgstr "Descrição"
+
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Desktop"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:151
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:187
+msgid ""
+"Detach the disks using this pool from any VMs before attempting deletion."
+msgstr ""
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2245,6 +2259,10 @@ msgstr "Arquivo do dispositivo"
 msgid "Device is read-only"
 msgstr "Dispositivo é somente leitura"
 
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
+
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
 msgstr "Relatório de diagnostico"
@@ -2271,11 +2289,11 @@ msgid "Disable tuned"
 msgstr "Desabilitar tuned"
 
 #: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
-#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:326
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "Desabilitado"
 
-#: pkg/systemd/service-details.jsx:196
+#: pkg/systemd/service-details.jsx:192
 msgid "Disallow running (mask)"
 msgstr ""
 
@@ -2284,7 +2302,7 @@ msgid "Disconnect"
 msgstr "Desconectar"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "Desconectado"
 
@@ -2304,11 +2322,11 @@ msgstr ""
 msgid "Disk I/O"
 msgstr "Entrada e Saida de disco"
 
-#: pkg/machines/components/diskAdd.jsx:526
+#: pkg/machines/components/diskAdd.jsx:525
 msgid "Disk failed to be attached"
 msgstr "Disco falhou ao ser anexado"
 
-#: pkg/machines/components/diskAdd.jsx:505
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Disk failed to be created"
 msgstr "Disco falhou ao ser criado"
 
@@ -2334,6 +2352,10 @@ msgstr ""
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Linguagem Exibida"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2373,7 +2395,7 @@ msgid "Domain Administrator Password"
 msgstr "Senha do Administrador de Domínio"
 
 #: pkg/systemd/services.html:338 pkg/systemd/services.html:342
-#: pkg/systemd/init.js:1070
+#: pkg/systemd/init.js:1085
 msgid "Don't Repeat"
 msgstr "Não Repita"
 
@@ -2438,7 +2460,7 @@ msgstr "Apelido duplicado"
 msgid "Duplicate port"
 msgstr "Porta duplicada"
 
-#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
+#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
 #: pkg/storaged/nfs-details.jsx:306
 msgid "Edit"
 msgstr "Editar"
@@ -2602,7 +2624,7 @@ msgstr "Errata:"
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
 #: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
 #: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/systemd/service-details.jsx:443 pkg/users/local.js:1476
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Erro"
 
@@ -2662,11 +2684,11 @@ msgstr ""
 msgid "Excellent password"
 msgstr "Senha excelente"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
-msgid "Existing Disk Image"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:217
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -2746,7 +2768,7 @@ msgstr "Falha ao carregar as chaves autorizadas."
 msgid "Failed to remove service"
 msgstr ""
 
-#: pkg/systemd/service-details.jsx:335
+#: pkg/systemd/service-details.jsx:340
 msgid "Failed to start"
 msgstr ""
 
@@ -2775,7 +2797,7 @@ msgstr "Arquivo"
 msgid "Filesystem"
 msgstr "Sistema de arquivos"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "Diretório do sistema de arquivos"
 
@@ -2820,7 +2842,7 @@ msgstr "Segue o docker repo"
 msgid "For legacy applications only. Reduces performance."
 msgstr ""
 
-#: pkg/systemd/service-details.jsx:317
+#: pkg/systemd/service-details.jsx:322
 msgid "Forbidden from running"
 msgstr ""
 
@@ -2849,7 +2871,7 @@ msgid "Force remove passphrase in $0"
 msgstr "Forçar a remoção da senha em $0"
 
 #: pkg/machines/components/diskAdd.jsx:157
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:263
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
 #: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
 #: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
@@ -3020,10 +3042,10 @@ msgstr "Hello time $hello_time"
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "Máquina"
 
@@ -3032,7 +3054,7 @@ msgid "Host Device"
 msgstr ""
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Nome do host"
 
@@ -3044,7 +3066,7 @@ msgstr "Chave de Host incorreta"
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "Host não deve estar vazio"
 
@@ -3052,7 +3074,7 @@ msgstr "Host não deve estar vazio"
 msgid "Hour : Minute"
 msgstr "Hora : Minuto"
 
-#: pkg/systemd/init.js:1146 pkg/systemd/init.js:1175
+#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
 msgid "Hour needs to be a number between 0-23"
 msgstr "A hora precisa ser um número entre 0-23"
 
@@ -3229,15 +3251,19 @@ msgstr ""
 msgid "Images may only be pulled by specific users or groups"
 msgstr "As imagens só podem ser baixadas por usuários ou grupos específicos"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:726
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Imediatamente Iniciar VM"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "Em Sincronização"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:225
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3286,11 +3312,11 @@ msgstr ""
 msgid "Initializing..."
 msgstr "Inicializando ..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
@@ -3326,15 +3352,15 @@ msgstr ""
 "Instale o setroubleshoot-server para solucionar problemas de eventos SELinux."
 ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:284
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Fonte de Instalação"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:266
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Tipo de Fonte de Instalação"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "A fonte de instalação não deve estar vazia"
 
@@ -3351,7 +3377,7 @@ msgstr "Instalando"
 msgid "Installing $0"
 msgstr "Instalando $0"
 
-#: pkg/systemd/service-details.jsx:482
+#: pkg/systemd/service-details.jsx:487
 msgid "Instance of template: "
 msgstr ""
 
@@ -3359,7 +3385,7 @@ msgstr ""
 msgid "Instantiate"
 msgstr "Instanciar"
 
-#: pkg/machines/components/nicEdit.jsx:123
+#: pkg/machines/components/nicEdit.jsx:132
 msgid "Interface Type"
 msgstr ""
 
@@ -3401,15 +3427,15 @@ msgstr ""
 msgid "Invalid address $0"
 msgstr "Endereço inválido $0"
 
-#: pkg/systemd/host.js:1469 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "Formato de data inválido"
 
-#: pkg/systemd/host.js:1465 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "Formato de data inválido e formato de tempo inválido"
 
-#: pkg/systemd/init.js:1181
+#: pkg/systemd/init.js:1196
 msgid "Invalid date format."
 msgstr "Formato de data inválido."
 
@@ -3421,7 +3447,7 @@ msgstr "Data de validade inválida"
 msgid "Invalid file permissions"
 msgstr "Permissão de arquivos inválida"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "Nome de arquivo inválido"
 
@@ -3437,7 +3463,7 @@ msgstr "Métrica inválida $0"
 msgid "Invalid number of days"
 msgstr "Número inválido de dias"
 
-#: pkg/systemd/init.js:1128
+#: pkg/systemd/init.js:1143
 msgid "Invalid number."
 msgstr "Número inválido."
 
@@ -3461,7 +3487,7 @@ msgstr "Prefixo ou máscara de rede inválidos $0"
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/host.js:1467 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "Formato de tempo inválido"
 
@@ -3505,7 +3531,7 @@ msgstr "Ingressar em um domínio"
 msgid "Joining this domain is not supported"
 msgstr "A adesão à este domínio não é suportada"
 
-#: pkg/systemd/service-details.jsx:429
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr "Junte os espaços nos nomes de"
 
@@ -3544,7 +3570,7 @@ msgstr "Tíquete Kerberos"
 msgid "Kernel"
 msgstr "Kernel"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "Kernel Dump"
 
@@ -3576,7 +3602,7 @@ msgstr "A remoção do Keyserver pode impedir o desbloqueio de $0."
 msgid "LACP Key"
 msgstr "Chave LACP"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:80
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
 msgid "LVM Volume Group"
 msgstr ""
 
@@ -3600,7 +3626,7 @@ msgstr "Últimos 7 dias"
 msgid "Last Login"
 msgstr "Último Login"
 
-#: pkg/systemd/init.js:291
+#: pkg/systemd/init.js:293
 msgid "Last Trigger"
 msgstr "Último Trigger"
 
@@ -3724,7 +3750,7 @@ msgstr "Discos Locais"
 msgid "Local Filesystem"
 msgstr "Sistema de Arquivos Local"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:272
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr ""
 
@@ -3824,7 +3850,7 @@ msgstr "O login proveu privilégios de administrador"
 msgid "Logout Successful"
 msgstr "Login Bem Sucedido"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Logs"
 
@@ -3868,7 +3894,7 @@ msgstr "O MTU deve ser um número positivo"
 msgid "Mac"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:160
+#: pkg/machines/components/nicEdit.jsx:169
 msgid "Mac Address"
 msgstr "Endereço MAC"
 
@@ -3880,7 +3906,7 @@ msgstr "ID de Máquina"
 msgid "Machine SSH Key Fingerprints"
 msgstr "Máquina de Chaves SSH e Impressões digitais"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "Máquinas"
 
@@ -3912,7 +3938,7 @@ msgstr "Verificar manualmente com o SSH: "
 msgid "Marking $target as faulty"
 msgstr "Marcando $target como defeituoso"
 
-#: pkg/systemd/service-details.jsx:203 pkg/systemd/service-details.jsx:206
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
 msgid "Mask Service"
 msgstr ""
 
@@ -3924,11 +3950,11 @@ msgstr ""
 msgid "Mask or Prefix Length should not be empty"
 msgstr ""
 
-#: pkg/systemd/service-details.jsx:316
+#: pkg/systemd/service-details.jsx:321
 msgid "Masked"
 msgstr ""
 
-#: pkg/systemd/service-details.jsx:204
+#: pkg/systemd/service-details.jsx:200
 msgid ""
 "Masking service prevents all dependant units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
@@ -3974,7 +4000,7 @@ msgstr "Membro do Dispositivo RAID $0"
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:375
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
 #: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "Memória"
@@ -4001,7 +4027,7 @@ msgstr ""
 msgid "Memory limit"
 msgstr "Limite de Memória"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
 msgstr ""
 
@@ -4042,7 +4068,7 @@ msgstr "Mini PC"
 msgid "Mini Tower"
 msgstr "Mini Torre"
 
-#: pkg/systemd/init.js:1152 pkg/systemd/init.js:1161 pkg/systemd/init.js:1170
+#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
 msgid "Minute needs to be a number between 0-59"
 msgstr "Minutos precisam ser números entre 0-59"
 
@@ -4058,7 +4084,7 @@ msgstr ""
 msgid "Mode"
 msgstr "Modo"
 
-#: pkg/machines/components/nicEdit.jsx:54 pkg/systemd/hwinfo.jsx:250
+#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
 msgid "Model"
 msgstr "Modelo"
 
@@ -4191,11 +4217,11 @@ msgstr "Servidor NTP"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:179
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
 #: pkg/machines/components/diskAdd.jsx:126
 #: pkg/machines/components/networks/createNetworkDialog.jsx:122
 #: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
@@ -4207,8 +4233,8 @@ msgstr "Servidor NTP"
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
 #: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:288
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "Nome"
 
@@ -4242,7 +4268,7 @@ msgstr "Nome não pode conter espaço em branco."
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/networks/createNetworkDialog.jsx:41
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "O nome não deve estar vazio"
 
@@ -4270,15 +4296,15 @@ msgstr ""
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:278
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:275
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
 msgid "Network Boot is available only when using System connection"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "Sistema de arquivos de rede"
 
@@ -4286,7 +4312,7 @@ msgstr "Sistema de arquivos de rede"
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:231
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr ""
 
@@ -4298,7 +4324,7 @@ msgstr "Tráfego de Rede"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "Dispositivos de rede e gráficos requerem o NetworkManager."
 
-#: pkg/machines/components/nicEdit.jsx:232
+#: pkg/machines/components/nicEdit.jsx:245
 msgid "Network interface settings could not be saved"
 msgstr ""
 
@@ -4307,7 +4333,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager não está rodando."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:944
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Rede"
 
@@ -4361,7 +4387,7 @@ msgstr "Nova senha não foi aceita"
 msgid "Next"
 msgstr "Próximo"
 
-#: pkg/systemd/init.js:290
+#: pkg/systemd/init.js:292
 msgid "Next Run"
 msgstr "Próxima Execução"
 
@@ -4394,6 +4420,10 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Nenhum volume NFS montado"
 
+#: pkg/machines/components/nicEdit.jsx:118
+msgid "No Network Devices"
+msgstr ""
+
 #: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
 msgstr "Nenhum alerta SELinux."
@@ -4416,7 +4446,7 @@ msgstr ""
 msgid "No VM is running or defined on this host"
 msgstr "Nenhuma VM está sendo executada ou definida neste host"
 
-#: pkg/machines/components/nicEdit.jsx:110
+#: pkg/machines/components/nicEdit.jsx:116
 msgid "No Virtual Networks"
 msgstr ""
 
@@ -4667,7 +4697,7 @@ msgstr "Não montado"
 msgid "Not permitted to perform this action."
 msgstr "Não é permitido executar esta ação."
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:354
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "Não está rodando"
 
@@ -4679,7 +4709,7 @@ msgstr "Não sincronizado"
 msgid "Not yet synced"
 msgstr "Ainda não sincronizado"
 
-#: pkg/systemd/service-details.jsx:443
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr "Nota"
 
@@ -4719,7 +4749,7 @@ msgstr "Senha antiga não aceita"
 msgid "On Build"
 msgstr "Em Desenvolvimento"
 
-#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:424
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr "Em Falha"
 
@@ -4759,7 +4789,7 @@ msgstr "Somente $0 de $1 está em uso."
 msgid "Only Emergency"
 msgstr "Apenas emergência"
 
-#: pkg/systemd/init.js:1102
+#: pkg/systemd/init.js:1117
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "Apenas alfabetos, números,:, _,. , @,- são permitidos."
 
@@ -4776,7 +4806,7 @@ msgid "Open"
 msgstr ""
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:328
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "Sistema Operacional"
 
@@ -4837,7 +4867,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "Informações do pacote"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "PackageKit caiu"
 
@@ -4849,6 +4879,10 @@ msgstr "PackageKit não está instalado"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit reportou código de erro $0"
 
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "Pacotes"
+
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "Parente"
@@ -4857,7 +4891,7 @@ msgstr "Parente"
 msgid "Parent $parent"
 msgstr "Parent $parent"
 
-#: pkg/systemd/service-details.jsx:414
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr "Parte de"
 
@@ -4945,7 +4979,7 @@ msgid "Paste the contents of your public SSH key file here"
 msgstr "Cole o conteúdo do seu arquivo de chave pública SSH aqui"
 
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/systemd/service-details.jsx:476
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "Caminho"
 
@@ -4961,7 +4995,7 @@ msgstr "Path cost $path_cost"
 msgid "Path on Server"
 msgstr "Caminho no servidor"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "Caminho no sistema de arquivos do host"
 
@@ -4973,7 +5007,7 @@ msgstr "Caminho no servidor não pode estar vazio."
 msgid "Path on server must start with \"/\"."
 msgstr "Caminho no servidor deve começar com \"/\"."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:208
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "Caminho para o arquivo ISO no sistema de arquivos do host"
 
@@ -5022,7 +5056,7 @@ msgstr "Persistente"
 msgid "Physical"
 msgstr "Fisica"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr ""
 
@@ -5034,7 +5068,7 @@ msgstr "Volume Físico"
 msgid "Physical Volumes"
 msgstr "Volumes Físicos"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr ""
 
@@ -5073,11 +5107,11 @@ msgstr "Por favor, confirme a exclusão forçada de $0"
 msgid "Please confirm stopping of $0"
 msgstr "Por favor confirme a parada de $0"
 
-#: pkg/machines/components/diskAdd.jsx:484
+#: pkg/machines/components/diskAdd.jsx:483
 msgid "Please enter new volume name"
 msgstr "Por favor insira o novo nome do volume"
 
-#: pkg/machines/components/diskAdd.jsx:487
+#: pkg/machines/components/diskAdd.jsx:486
 msgid "Please enter new volume size"
 msgstr "Por favor insira o novo tamanho do volume"
 
@@ -5101,7 +5135,7 @@ msgstr "Por favor, inicie a máquina virtual para acessar seu console."
 msgid "Please try another term"
 msgstr "Por favor, tente outro termo"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Plug"
 msgstr "Plug"
 
@@ -5124,6 +5158,11 @@ msgstr "Pool para Volumes Finos"
 #: pkg/storaged/content-views.jsx:651
 msgid "Pool for thinly provisioned volumes"
 msgstr "Pool para volumes finamente provisionados"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
+msgid "Pool's volumes are used by VMs "
+msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
@@ -5180,6 +5219,10 @@ msgstr "Comprimento do prefixo"
 #: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr "Comprimento do prefixo ou máscara de rede"
+
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:835
 msgid "Preparing"
@@ -5259,7 +5302,7 @@ msgstr "A solicitação via ssh-add expirou"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Solicitação via ssh-keygen expirou"
 
-#: pkg/systemd/service-details.jsx:427
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr "Propaga Recarregar para"
 
@@ -5280,14 +5323,6 @@ msgstr "Publico pulling repo"
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Propósito"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "Conexão do sistema QEMU / KVM"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "Conexão do usuário QEMU / KVM"
 
 #: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
@@ -5389,11 +5424,15 @@ msgstr ""
 msgid "Raw to a device"
 msgstr "Raw para um dispositivo"
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr ""
 
-#: pkg/systemd/service-details.jsx:381
+#: pkg/systemd/service-details.jsx:386
 msgid "Read-only"
 msgstr ""
 
@@ -5460,7 +5499,7 @@ msgstr "Recente"
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Reconectar"
@@ -5497,15 +5536,15 @@ msgstr "Recusando-se a se conectar. A chave é desconhecida"
 msgid "Register…"
 msgstr "Registro…"
 
-#: pkg/systemd/service-details.jsx:185
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Recarregar"
 
-#: pkg/systemd/service-details.jsx:428
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr "Recarregar propagado de"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:256
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "URL remoto"
 
@@ -5664,27 +5703,27 @@ msgstr "Requer mudança de senha a cada $0 dias"
 msgid "Require password change on $0"
 msgstr "Exigir alteração de senha em $0"
 
-#: pkg/systemd/service-details.jsx:415
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr "Solicitado por"
 
-#: pkg/systemd/service-details.jsx:367
+#: pkg/systemd/service-details.jsx:372
 msgid "Required by "
 msgstr ""
 
-#: pkg/systemd/service-details.jsx:410
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr "Requere"
 
-#: pkg/systemd/service-details.jsx:382
+#: pkg/systemd/service-details.jsx:387
 msgid "Requires administration access to edit"
 msgstr ""
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr "Requisita"
 
-#: pkg/systemd/service-details.jsx:416
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr "Requisitode"
 
@@ -5723,7 +5762,7 @@ msgstr ""
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
 #: pkg/machines/components/vm/vmActions.jsx:42
-#: pkg/systemd/service-details.jsx:176 pkg/systemd/shutdown.js:95
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
 #: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Reiniciar"
@@ -5813,9 +5852,13 @@ msgstr ""
 msgid "Runner"
 msgstr "Executor"
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:346
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr "Executando"
+
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
+msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
@@ -5885,7 +5928,7 @@ msgstr "Sábado"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
 #: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
@@ -5917,7 +5960,7 @@ msgid "Sealed-case PC"
 msgstr "PC com caixa vedada"
 
 #: pkg/systemd/services.html:314 pkg/systemd/services.html:318
-#: pkg/systemd/init.js:890
+#: pkg/systemd/init.js:905
 msgid "Seconds"
 msgstr "Segundos"
 
@@ -6034,10 +6077,11 @@ msgid "Service name"
 msgstr "Nome do serviço"
 
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
-#: pkg/networkmanager/firewall.jsx:508
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Serviços"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Sessão"
@@ -6155,7 +6199,7 @@ msgid "Single Rank"
 msgstr ""
 
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:453
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
 #: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
@@ -6200,7 +6244,7 @@ msgstr "Slot $0"
 msgid "Sockets"
 msgstr "Sockets"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Atualizações de Software"
 
@@ -6244,7 +6288,7 @@ msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
 #: pkg/machines/components/diskAdd.jsx:541
-#: pkg/machines/components/nicEdit.jsx:141
+#: pkg/machines/components/nicEdit.jsx:150
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
@@ -6255,8 +6299,8 @@ msgstr "Fonte"
 msgid "Source Format"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:221
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:248
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
@@ -6266,16 +6310,16 @@ msgstr "Caminho da origem"
 msgid "Source URL"
 msgstr "URL Fonte"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
 msgid "Source Volume Group"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:238
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:259
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "O caminho da origem não deve estar vazio"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "A fonte deve começar com o protocolo http, ftp ou nfs"
 
@@ -6310,7 +6354,7 @@ msgstr "Estável"
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
 #: pkg/machines/components/networks/createNetworkDialog.jsx:237
 #: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:180
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Iniciar"
 
@@ -6322,11 +6366,11 @@ msgstr "Iniciar Docker"
 msgid "Start Multipath"
 msgstr "Iniciar Multipath"
 
-#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:336
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
 msgstr "Começar serviço"
 
-#: pkg/systemd/service-details.jsx:406
+#: pkg/systemd/service-details.jsx:411
 msgid "Start and Enable"
 msgstr ""
 
@@ -6334,7 +6378,7 @@ msgstr ""
 msgid "Start libvirt"
 msgstr "Iniciar libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:318
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
 msgstr "Iniciar pool quando o host inicializa"
 
@@ -6351,7 +6395,7 @@ msgstr "Iniciando o Dispositivo RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Iniciando swapspace $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "Comece"
 
@@ -6359,7 +6403,7 @@ msgstr "Comece"
 #: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:259 pkg/systemd/init.js:292
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "Estado"
 
@@ -6368,11 +6412,11 @@ msgid "State:"
 msgstr "Estado:"
 
 #: pkg/systemd/services.html:68 pkg/systemd/init.js:212
-#: pkg/systemd/service-details.jsx:364
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr "Estático"
 
-#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:471
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "Estado"
 
@@ -6387,7 +6431,7 @@ msgstr "Sticky"
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
 #: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
 #: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
-#: pkg/systemd/service-details.jsx:165
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Pare"
 
@@ -6395,7 +6439,7 @@ msgstr "Pare"
 msgid "Stop Device"
 msgstr "Parar dispositivo"
 
-#: pkg/systemd/service-details.jsx:406
+#: pkg/systemd/service-details.jsx:411
 msgid "Stop and Disable"
 msgstr ""
 
@@ -6428,8 +6472,8 @@ msgid "Stopping swapspace $target"
 msgstr "Parando swapspace $target"
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:416
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Armazenamento"
 
@@ -6445,11 +6489,11 @@ msgstr ""
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr "Nome do pool de armazenamento"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:475
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr "O pool de armazenamento não pôde ser criado"
 
@@ -6473,6 +6517,10 @@ msgstr "O armazenamento não pode ser gerenciado neste sistema."
 #: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "Pool de Armazenamento"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
+msgid "Storage size must not be 0"
+msgstr ""
 
 #: pkg/systemd/index.html:155
 msgid "Store Metrics"
@@ -6579,8 +6627,10 @@ msgstr "Sincronizado com {{Server}}"
 msgid "Synchronizing RAID Device $target"
 msgstr "Sincronizando Dispositivo RAID $target"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "Sistema"
 
@@ -6641,12 +6691,12 @@ msgstr "Tang keyserver"
 msgid "Target"
 msgstr "Alvo"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "Caminho de Destino"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "O caminho de destino não deve estar vazio"
 
@@ -6671,7 +6721,7 @@ msgstr "Configurações da Porta da Equipe"
 msgid "Team Settings"
 msgstr "Configurações da Equipe"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -6718,8 +6768,8 @@ msgstr ""
 msgid "The RAID device must be running in order to remove disks."
 msgstr "O dispositivo RAID deve estar em execução para remover discos."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:80
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:84
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:125
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:129
 msgid "The Storage Pool could not be deleted"
 msgstr ""
 
@@ -6795,7 +6845,7 @@ msgstr ""
 "O usuário atualmente conectado não tem permissão para ver informações sobre "
 "chaves."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "O diretório no servidor que está sendo exportado"
 
@@ -6867,7 +6917,7 @@ msgstr "O último volume físico de um grupo de volumes não pode ser removido."
 msgid "The logged in user is not permitted to view system modifications"
 msgstr ""
 
-#: pkg/shell/indexes.js:407
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "A máquina esta reiniciando"
 
@@ -6895,8 +6945,13 @@ msgstr "O scanner de  $time ($type) não detectou vulnerabilidades."
 msgid "The scan from $time ($type) was not successful."
 msgstr "O scanner de $time ($type) não funcionou."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
 msgid "The selected Operating System has minimum memory requirement of $0 $1"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+msgid ""
+"The selected Operating System has minimum storage size requirement of $0 $1"
 msgstr ""
 
 #: src/ws/login.js:645
@@ -6916,7 +6971,7 @@ msgstr ""
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 
-#: pkg/systemd/init.js:736
+#: pkg/systemd/init.js:751
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "O usuário <b>$0</b> não tem permissões para criar temporizadores"
 
@@ -7011,7 +7066,7 @@ msgstr ""
 msgid "This VDO device does not use all of its backing device."
 msgstr "Este dispositivo VDO não usa todo o seu dispositivo de apoio."
 
-#: pkg/systemd/init.js:1185
+#: pkg/systemd/init.js:1200
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -7064,7 +7119,7 @@ msgid "This disk cannot be removed while the device is recovering."
 msgstr ""
 "Este disco não pode ser removido enquanto o dispositivo está se recuperando."
 
-#: pkg/systemd/init.js:1097 pkg/systemd/init.js:1111 pkg/systemd/init.js:1120
+#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
 msgid "This field cannot be empty."
 msgstr "Este campo não pode estar vazio."
 
@@ -7117,7 +7172,7 @@ msgstr ""
 "Esta ferramenta irá coletar a configuração do sistema e informações "
 "diagnósticas deste sistema para diagnosticar problemas com o mesmo."
 
-#: pkg/systemd/service-details.jsx:293
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Esta unidade não foi projetada para ser habilitada explicitamente."
 
@@ -7133,7 +7188,7 @@ msgstr ""
 "Esta versão do cockpit-ws não suporta conectar a um host com um usuário ou "
 "porta alternativa"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:446
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr ""
 
@@ -7236,15 +7291,19 @@ msgstr "Tamanho total: $0"
 msgid "Tower"
 msgstr "Torre"
 
-#: pkg/systemd/service-details.jsx:426
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr "Disparado por"
 
-#: pkg/systemd/service-details.jsx:425
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "Triggers"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Solução de problemas"
@@ -7298,7 +7357,7 @@ msgid "Tuned is off"
 msgstr "Tuned está fora"
 
 #: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
@@ -7329,7 +7388,7 @@ msgstr "Tipo para filtrar..."
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:273
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "URL"
 
@@ -7395,7 +7454,7 @@ msgid "Unavailable"
 msgstr "Indisponível"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Erro inesperado"
 
@@ -7403,7 +7462,7 @@ msgstr "Erro inesperado"
 msgid "Unique Network Name"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:186
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "Nome único"
 
@@ -7500,7 +7559,7 @@ msgstr "Desmontando $target"
 msgid "Unnamed"
 msgstr "Não nomeado"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Unplug"
 msgstr "Desplugar"
 
@@ -7538,11 +7597,11 @@ msgstr "Host não confiável"
 msgid "Up since $0"
 msgstr "Ativo desde $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:465
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:388
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -7575,7 +7634,7 @@ msgstr "Atualizações disponíveis"
 msgid "Updating"
 msgstr "Atualizando"
 
-#: pkg/systemd/service-details.jsx:401
+#: pkg/systemd/service-details.jsx:406
 msgid "Updating status..."
 msgstr ""
 
@@ -7789,13 +7848,13 @@ msgstr "Versão"
 msgid "Very securely erasing $target"
 msgstr "Apagando com muita segurança $target"
 
-#: pkg/lib/cockpit-components-modifications.jsx:174
+#: pkg/lib/cockpit-components-modifications.jsx:173
 msgid "View automation script"
 msgstr ""
 
 #: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Máquinas Virtuais"
 
@@ -7815,7 +7874,7 @@ msgstr "Serviço de virtualização (libvirt) não está ativo"
 msgid "Virtualization Service is Available"
 msgstr "Serviço de virtualização disponível"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:436
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
@@ -7832,11 +7891,11 @@ msgstr "Grupo de volumes"
 msgid "Volume Group $0"
 msgstr "Grupo do Volume $0"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:214
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
 msgid "Volume Group name"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:298
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
 msgid "Volume Group name should not be empty"
 msgstr ""
 
@@ -7880,11 +7939,11 @@ msgstr ""
 msgid "Waiting for other software management operations to finish"
 msgstr "Aguardando que outras operações de gerenciamento de software terminem"
 
-#: pkg/systemd/service-details.jsx:417
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr "Requerido por"
 
-#: pkg/systemd/service-details.jsx:412
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr "Requer"
 
@@ -7977,7 +8036,7 @@ msgstr ""
 msgid "You must wait longer to change your password"
 msgstr "Você deve esperar mais tempo para alterar sua senha"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
 msgid "You need to select the most closely matching Operating System"
 msgstr ""
 
@@ -8133,11 +8192,11 @@ msgstr ""
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr ""
 
@@ -8145,11 +8204,11 @@ msgstr ""
 msgid "iSCSI Targets"
 msgstr "Alvos iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:84
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -8306,7 +8365,7 @@ msgid "undefined"
 msgstr "indefinido"
 
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:254 pkg/systemd/init.js:268
+#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
 msgid "unknown"
 msgstr "desconhecido"
 
@@ -8346,7 +8405,7 @@ msgstr "valor"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:795
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-15 04:42+0000\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-08-09 04:32+0000\n"
+"PO-Revision-Date: 2019-08-16 05:45+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
 "Language: uk\n"
@@ -538,7 +538,7 @@ msgstr "Параметри облікового запису"
 msgid "Account not available or cannot be edited."
 msgstr "Обліковий запис недоступний або його не можна редагувати."
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Облікові записи"
 
@@ -573,7 +573,7 @@ msgstr "Активні сторінки"
 msgid "Active since"
 msgstr "Активний з"
 
-#: pkg/systemd/service-details.jsx:336
+#: pkg/systemd/service-details.jsx:352
 msgid "Active since "
 msgstr "Активний з "
 
@@ -719,7 +719,7 @@ msgstr "Додаткові домени пошуку DNS $val"
 msgid "Additional Storage"
 msgstr "Додаткове сховище"
 
-#: pkg/systemd/service-details.jsx:198
+#: pkg/systemd/service-details.jsx:209
 msgid "Additional actions"
 msgstr "Додаткові дії"
 
@@ -778,7 +778,7 @@ msgstr "Пароль адміністратора"
 msgid "Advanced TCA"
 msgstr "Розширене TCA"
 
-#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:412
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "Після"
 
@@ -818,7 +818,7 @@ msgstr ""
 "Всі дані на позначених дисках буде витерто, а диски буде додано до "
 "резервного сховища даних."
 
-#: pkg/systemd/service-details.jsx:157
+#: pkg/systemd/service-details.jsx:159
 msgid "Allow running (unmask)"
 msgstr "Дозволити запуск (зняти маску)"
 
@@ -851,7 +851,7 @@ msgid "Appearance:"
 msgstr "Вигляд:"
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Програми"
 
@@ -986,7 +986,7 @@ msgstr "Автоматичні оновлення"
 msgid "Automatically start libvirt on boot"
 msgstr "Автоматично запускати libvirt при завантаженні"
 
-#: pkg/systemd/service-details.jsx:380
+#: pkg/systemd/service-details.jsx:396
 msgid "Automatically starts"
 msgstr "Запускати автоматично"
 
@@ -1054,11 +1054,11 @@ msgstr "Механізму passwd1 передано помилкові дані"
 msgid "Balancer"
 msgstr "Балансир"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr "До"
 
-#: pkg/systemd/service-details.jsx:402
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr "Пов'язано з"
 
@@ -1104,7 +1104,7 @@ msgstr "Порядок завантаження"
 msgid "Boot order settings could not be saved"
 msgstr "Не вдалося зберегти параметри порядку завантаження"
 
-#: pkg/systemd/service-details.jsx:407
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr "Пов'язано"
 
@@ -1224,25 +1224,26 @@ msgstr "Не вдалося завантажити образ"
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:785
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
 #: pkg/machines/components/diskAdd.jsx:597
 #: pkg/machines/components/networks/createNetworkDialog.jsx:486
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:523
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/machines/components/nicEdit.jsx:311 pkg/networkmanager/firewall.jsx:590
-#: pkg/networkmanager/firewall.jsx:658 pkg/networkmanager/firewall.jsx:801
-#: pkg/packagekit/updates.jsx:179 pkg/sosreport/index.js:51
-#: pkg/storaged/dialog.jsx:393 pkg/storaged/jobs-panel.jsx:123
-#: pkg/systemd/hwinfo.jsx:216 pkg/systemd/service-details.jsx:107
+#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
+#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "Неможливо встановити з’єднання із невідомим комп’ютером"
 
@@ -1308,10 +1309,10 @@ msgstr "Змінити обмеження ресурсів"
 msgid "Change the settings"
 msgstr "Змінити параметри"
 
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
-#: pkg/machines/components/nicEdit.jsx:287
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Зміни буде застосовано після завершення роботи ВМ"
 
@@ -1359,7 +1360,7 @@ msgstr "Шукаємо оновлення…"
 msgid "Checking installed software"
 msgstr "Перевіряємо встановлене програмне забезпечення"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:352
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
 msgid "Choose an operating system"
 msgstr "Виберіть операційну систему"
 
@@ -1378,6 +1379,10 @@ msgstr "Клас"
 #: pkg/storaged/jobs-panel.jsx:55
 msgid "Cleaning up for $target"
 msgstr "Спорожнюємо для $target"
+
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
 
 #: pkg/systemd/services.html:86
 msgid "Clear All Filters"
@@ -1429,7 +1434,7 @@ msgstr ""
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit не вдалося встановити зв’язок із вказаним вузлом."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1608,11 +1613,11 @@ msgstr "Стискання"
 msgid "Computer OU"
 msgstr "OU комп’ютера"
 
-#: pkg/systemd/service-details.jsx:426
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr "Умову $0=$1 не виконано"
 
-#: pkg/systemd/service-details.jsx:476
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "Не виконано умову"
 
@@ -1649,11 +1654,11 @@ msgstr "Підтвердження вилучення віртуальної м�
 msgid "Confirm removal with passphrase"
 msgstr "Підтвердьте вилучення введенням пароля"
 
-#: pkg/systemd/service-details.jsx:410
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr "Конфліктує за"
 
-#: pkg/systemd/service-details.jsx:409
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr "Конфліктує"
 
@@ -1700,14 +1705,13 @@ msgstr "Встановлюємо з’єднання із фоновою слу�
 msgid "Connecting to Virtualization Service"
 msgstr "Встановлюємо зв'язок із службою віртуалізації"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "Встановлюємо з’єднання із комп’ютером"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:699
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
 #: pkg/machines/components/networks/createNetworkDialog.jsx:106
 #: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
@@ -1725,7 +1729,7 @@ msgstr "Вичерпано час очікування на з’єднання.
 msgid "Connection will be lost"
 msgstr "З’єднання буде розірвано"
 
-#: pkg/systemd/service-details.jsx:408
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr "Складається з"
 
@@ -1831,7 +1835,7 @@ msgstr "Не вдалося змінити групи користувачів"
 msgid "Couldn't change user password"
 msgstr "Не вдалося змінити пароль користувача"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "Не вдалося встановити з’єднання із комп’ютером"
 
@@ -1860,9 +1864,9 @@ msgid "Crash system"
 msgstr "Аварійно завершити роботу системи"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:790
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
 #: pkg/machines/components/networks/createNetworkDialog.jsx:491
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:526
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
 #: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
 #: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
 #: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
@@ -1905,7 +1909,7 @@ msgstr "Створити звіт"
 msgid "Create Snapshot"
 msgstr "Створення знімка"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:560
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "Створити резервне сховище"
 
@@ -1925,7 +1929,7 @@ msgstr "Створити таймери"
 msgid "Create VDO Device"
 msgstr "Створити пристрій VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:832
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "Створення ВМ"
 
@@ -2016,7 +2020,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Створюємо групу томів $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:684
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr "Не вдалося створити ВМ $0"
 
@@ -2237,6 +2241,10 @@ msgstr "Вилучаємо групу томів $target"
 msgid "Description"
 msgstr "Опис"
 
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
+
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Робоча станція"
@@ -2246,6 +2254,8 @@ msgstr "Робоча станція"
 msgid ""
 "Detach the disks using this pool from any VMs before attempting deletion."
 msgstr ""
+"Від'єднайте диски, які використовують цей буфер від усіх віртуальних машин, "
+"перш ніж намагатися їх вилучити."
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2274,6 +2284,10 @@ msgstr "Файл пристрою"
 msgid "Device is read-only"
 msgstr "Пристрій придатний лише для читання"
 
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
+
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
 msgstr "Діагностичні звіти"
@@ -2300,11 +2314,11 @@ msgid "Disable tuned"
 msgstr "Вимкнути tuned"
 
 #: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
-#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:315
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "Вимкнено"
 
-#: pkg/systemd/service-details.jsx:185
+#: pkg/systemd/service-details.jsx:192
 msgid "Disallow running (mask)"
 msgstr "Заборонити запуск (замаскувати)"
 
@@ -2313,7 +2327,7 @@ msgid "Disconnect"
 msgstr "Від’єднатися"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "Роз'єднано"
 
@@ -2364,6 +2378,10 @@ msgstr "Не можна вилучати диски з ВМ $0"
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "Мова перекладу"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2633,7 +2651,7 @@ msgstr "Помилки:"
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
 #: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
 #: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/systemd/service-details.jsx:432 pkg/users/local.js:1476
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Помилка"
 
@@ -2693,11 +2711,11 @@ msgstr "Приклад: 88,2019,nfs,rsync"
 msgid "Excellent password"
 msgstr "Чудовий пароль"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:295
-msgid "Existing Disk Image"
-msgstr "Наявний образ диска"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
+msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:232
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr "Наявний образ диска у файловій системі основної системи"
 
@@ -2777,7 +2795,7 @@ msgstr "Не вдалося завантажити уповноважені кл
 msgid "Failed to remove service"
 msgstr "Не вдалося вилучити службу"
 
-#: pkg/systemd/service-details.jsx:324
+#: pkg/systemd/service-details.jsx:340
 msgid "Failed to start"
 msgstr "Не вдалося запустити"
 
@@ -2807,7 +2825,7 @@ msgstr "Файл"
 msgid "Filesystem"
 msgstr "Файлова система"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "Каталог файлової системи"
 
@@ -2852,7 +2870,7 @@ msgstr "Стежить за сховищем docker"
 msgid "For legacy applications only. Reduces performance."
 msgstr "Лише для застарілих програм. Знижує швидкодію."
 
-#: pkg/systemd/service-details.jsx:306
+#: pkg/systemd/service-details.jsx:322
 msgid "Forbidden from running"
 msgstr "Заборонено запускати"
 
@@ -2881,7 +2899,7 @@ msgid "Force remove passphrase in $0"
 msgstr "Примусово вилучити пароль у $0"
 
 #: pkg/machines/components/diskAdd.jsx:157
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:263
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
 #: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
 #: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
@@ -3057,10 +3075,10 @@ msgstr "Час вітання $hello_time"
 msgid "Hide Performance Options"
 msgstr "Приховати параметри швидкодії"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "Вузол"
 
@@ -3069,7 +3087,7 @@ msgid "Host Device"
 msgstr "Пристрій основної системи"
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Назва вузла"
 
@@ -3081,7 +3099,7 @@ msgstr "Ключ вузла є неправильним"
 msgid "Host name should not be changed in a domain"
 msgstr "У домені не слід змінювати назву вузла"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "Вузол не повинен бути порожнім"
 
@@ -3268,15 +3286,19 @@ msgid "Images may only be pulled by specific users or groups"
 msgstr ""
 "Образи може бути отримано лише вказаними користувачами або учасниками груп"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:768
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Негайно запустити ВМ"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "Синхронізовано"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:240
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3325,11 +3347,11 @@ msgstr "Немає доступу до даних щодо резервного 
 msgid "Initializing..."
 msgstr "Ініціалізація…"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr "Ініціатор"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr "IQN ініціатора має бути непорожнімy"
 
@@ -3365,15 +3387,15 @@ msgstr ""
 "Встановіть setroubleshoot-server, щоб мати змогу діагностувати причини подій "
 "SELinux."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:299
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Джерело для встановлення"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:281
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Тип джерела для встановлення"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "Запис джерела для встановлення має бути непорожнім"
 
@@ -3390,7 +3412,7 @@ msgstr "Встановлення"
 msgid "Installing $0"
 msgstr "Встановлюємо $0"
 
-#: pkg/systemd/service-details.jsx:471
+#: pkg/systemd/service-details.jsx:487
 msgid "Instance of template: "
 msgstr "Екземпляр шаблона: "
 
@@ -3440,11 +3462,11 @@ msgstr "Некоректний префікс IPv6"
 msgid "Invalid address $0"
 msgstr "Некоректна адреса $0"
 
-#: pkg/systemd/host.js:1469 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "Некоректний формат дати"
 
-#: pkg/systemd/host.js:1465 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "Некоректний формат дати і часу"
 
@@ -3460,7 +3482,7 @@ msgstr "Некоректна дата строку завершення дії"
 msgid "Invalid file permissions"
 msgstr "Некоректні права доступу до файла"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "Некоректна назва файла"
 
@@ -3500,7 +3522,7 @@ msgstr "Некоректний префікс або маска мережі $0"
 msgid "Invalid range"
 msgstr "Некоректний діапазон"
 
-#: pkg/systemd/host.js:1467 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "Некоректний формат визначення часу"
 
@@ -3544,7 +3566,7 @@ msgstr "Долучитися до домену"
 msgid "Joining this domain is not supported"
 msgstr "Підтримки долучення до цього домену не передбачено"
 
-#: pkg/systemd/service-details.jsx:418
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr "Долучається до простору назв"
 
@@ -3583,7 +3605,7 @@ msgstr "Квиток Kerberos"
 msgid "Kernel"
 msgstr "Ядро"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "Дамп ядра"
 
@@ -3615,7 +3637,7 @@ msgstr "Вилучення сервера ключів може завадити
 msgid "LACP Key"
 msgstr "Ключ LACP"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:80
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
 msgid "LVM Volume Group"
 msgstr "Група томів LVM"
 
@@ -3763,7 +3785,7 @@ msgstr "Локальні диски"
 msgid "Local Filesystem"
 msgstr "Локальна файлова система"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr "Локальні носії для встановлення"
 
@@ -3863,7 +3885,7 @@ msgstr "Обліковий запис розширив права доступу
 msgid "Logout Successful"
 msgstr "Успішний вихід"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Журнали"
 
@@ -3919,7 +3941,7 @@ msgstr "Ід. комп’ютера"
 msgid "Machine SSH Key Fingerprints"
 msgstr "Відбитки ключів SSH комп’ютерів"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "Машини"
 
@@ -3951,7 +3973,7 @@ msgstr "Перевірка вручну за допомогою SSH: "
 msgid "Marking $target as faulty"
 msgstr "Позначаємо $target як помилковий"
 
-#: pkg/systemd/service-details.jsx:192 pkg/systemd/service-details.jsx:195
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
 msgid "Mask Service"
 msgstr "Замаскувати службу"
 
@@ -3963,11 +3985,11 @@ msgstr "Довжина маски або префікса"
 msgid "Mask or Prefix Length should not be empty"
 msgstr "Довжина маски або префікса повинна бути непорожньою"
 
-#: pkg/systemd/service-details.jsx:305
+#: pkg/systemd/service-details.jsx:321
 msgid "Masked"
 msgstr "Замасковано"
 
-#: pkg/systemd/service-details.jsx:193
+#: pkg/systemd/service-details.jsx:200
 msgid ""
 "Masking service prevents all dependant units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
@@ -4016,7 +4038,7 @@ msgstr "Елемент пристрою RAID $0"
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:390
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
 #: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "Пам'ять"
@@ -4043,7 +4065,7 @@ msgstr "Не вдалося зберегти дані щодо обсягу па
 msgid "Memory limit"
 msgstr "Обмеження пам’яті"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
 msgstr "Об'єм пам'яті не може бути нульовим"
 
@@ -4233,11 +4255,11 @@ msgstr "Сервер NTP"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:194
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
 #: pkg/machines/components/diskAdd.jsx:126
 #: pkg/machines/components/networks/createNetworkDialog.jsx:122
 #: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
@@ -4249,8 +4271,8 @@ msgstr "Сервер NTP"
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
 #: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:290
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "Назва"
 
@@ -4284,7 +4306,7 @@ msgstr "У назві не повинно бути пробілів"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
 #: pkg/machines/components/networks/createNetworkDialog.jsx:41
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "Назва має бути непорожньою"
 
@@ -4312,16 +4334,16 @@ msgstr "Не вдалося активувати мережу $0"
 msgid "Network $0 failed to get deactivated"
 msgstr "Не вдалося деактивувати мережу $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:293
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr "Мережеве завантаження (PXE)"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:290
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
 msgid "Network Boot is available only when using System connection"
 msgstr ""
 "Завантаження з мережі доступне, лише якщо використано з'єднання «Система»"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "Мережева файлова система"
 
@@ -4329,7 +4351,7 @@ msgstr "Мережева файлова система"
 msgid "Network Interfaces"
 msgstr "Інтерфейси мережі"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:246
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr "Для вибору мережі не передбачено підтримки PXE."
 
@@ -4352,7 +4374,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager не запущено."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:944
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Робота у мережі"
 
@@ -4441,7 +4463,7 @@ msgstr "Монтувань NFS не налаштовано"
 
 #: pkg/machines/components/nicEdit.jsx:118
 msgid "No Network Devices"
-msgstr ""
+msgstr "Немає пристроїв мережі"
 
 #: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
@@ -4715,7 +4737,7 @@ msgstr "Не змонтовано"
 msgid "Not permitted to perform this action."
 msgstr "Немає дозволу на виконання цієї дії."
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:343
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "Зупинено"
 
@@ -4727,7 +4749,7 @@ msgstr "Не синхронізовано"
 msgid "Not yet synced"
 msgstr "Ще не синхронізовано"
 
-#: pkg/systemd/service-details.jsx:432
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr "Примітка"
 
@@ -4767,7 +4789,7 @@ msgstr "Старий пароль не прийнято"
 msgid "On Build"
 msgstr "Збирання"
 
-#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:413
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr "Якщо помилка"
 
@@ -4827,7 +4849,7 @@ msgid "Open"
 msgstr "Відкрита"
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:343
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "Операційна система"
 
@@ -4888,7 +4910,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "Дані щодо пакунка"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "Аварійне завершення роботи PackageKit"
 
@@ -4900,6 +4922,10 @@ msgstr "PackageKit не встановлено"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit повідомлено про помилку із кодом $0"
 
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "Пакунки"
+
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "Батьківський"
@@ -4908,7 +4934,7 @@ msgstr "Батьківський"
 msgid "Parent $parent"
 msgstr "Батьківський $parent"
 
-#: pkg/systemd/service-details.jsx:403
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr "Частина"
 
@@ -4996,7 +5022,7 @@ msgid "Paste the contents of your public SSH key file here"
 msgstr "Сюди слід вставити вміст файла вашого відкритого ключа SSH"
 
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/systemd/service-details.jsx:465
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "Шлях"
 
@@ -5012,7 +5038,7 @@ msgstr "Вартість шляху $path_cost"
 msgid "Path on Server"
 msgstr "Шлях на сервері"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "Шлях у файловій системі вузла"
 
@@ -5024,7 +5050,7 @@ msgstr "Шлях на сервері не може бути порожнім."
 msgid "Path on server must start with \"/\"."
 msgstr "Шлях на сервері має починатися з «/»."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:223
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "Шлях до ISO у файловій системі основної системи"
 
@@ -5073,7 +5099,7 @@ msgstr "Постійний"
 msgid "Physical"
 msgstr "Фізичний"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr "Фізичний пристрій диска"
 
@@ -5085,7 +5111,7 @@ msgstr "Фізичний том"
 msgid "Physical Volumes"
 msgstr "Фізичні томи"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr "Фізичний пристрій у основній системі"
 
@@ -5180,7 +5206,7 @@ msgstr "Буфер для тонких резервованих томів"
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
 msgid "Pool's volumes are used by VMs "
-msgstr ""
+msgstr "Томи буфера використовуються ВМ"
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
@@ -5237,6 +5263,10 @@ msgstr "Довжина префікса"
 #: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr "Довжина префікса або маска мережі"
+
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:835
 msgid "Preparing"
@@ -5316,7 +5346,7 @@ msgstr "Час очікування відповіді на запит за до
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Час очікування відповіді на запит за допомогою ssh-keygen вичерпано"
 
-#: pkg/systemd/service-details.jsx:416
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr "Поширює перезавантаження на"
 
@@ -5337,14 +5367,6 @@ msgstr "Відкрите сховище для отримання"
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "Призначення"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "З'єднання системи QEMU/KVM"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "З'єднання користувача QEMU/KVM"
 
 #: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
@@ -5446,11 +5468,15 @@ msgstr "Ранг"
 msgid "Raw to a device"
 msgstr "Без обробки на пристрій"
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr "Докладніше…"
 
-#: pkg/systemd/service-details.jsx:370
+#: pkg/systemd/service-details.jsx:386
 msgid "Read-only"
 msgstr "Лише читання"
 
@@ -5517,7 +5543,7 @@ msgstr "Нещодавні"
 msgid "Recommended default"
 msgstr "Рекомендоване типове значення"
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Повторно з’єднатися"
@@ -5554,15 +5580,15 @@ msgstr "Відмовляємо у з’єднанні. Невідомий клю
 msgid "Register…"
 msgstr "Зареєструвати…"
 
-#: pkg/systemd/service-details.jsx:163
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Перезавантажити"
 
-#: pkg/systemd/service-details.jsx:417
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr "Поширене перезавантаження з"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:271
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "Віддалена адреса"
 
@@ -5721,27 +5747,27 @@ msgstr "Вимагати зміну пароля кожні $0 днів"
 msgid "Require password change on $0"
 msgstr "Вимагати зміну пароля $0"
 
-#: pkg/systemd/service-details.jsx:404
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr "Потрібен для"
 
-#: pkg/systemd/service-details.jsx:356
+#: pkg/systemd/service-details.jsx:372
 msgid "Required by "
 msgstr "Потрібен для"
 
-#: pkg/systemd/service-details.jsx:399
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr "Потребує"
 
-#: pkg/systemd/service-details.jsx:371
+#: pkg/systemd/service-details.jsx:387
 msgid "Requires administration access to edit"
 msgstr "Потребує адміністративного доступу для редагування"
 
-#: pkg/systemd/service-details.jsx:400
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr "Потрібний"
 
-#: pkg/systemd/service-details.jsx:405
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr "Потрібний для"
 
@@ -5782,7 +5808,7 @@ msgstr ""
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
 #: pkg/machines/components/vm/vmActions.jsx:42
-#: pkg/systemd/service-details.jsx:167 pkg/systemd/shutdown.js:95
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
 #: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Перезапустити"
@@ -5872,9 +5898,13 @@ msgstr "Запустити під час завантаження основно
 msgid "Runner"
 msgstr "Засіб для запуску"
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:335
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr "Працює"
+
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
+msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
@@ -5944,11 +5974,10 @@ msgstr "субота"
 msgid "Saturdays"
 msgstr "Суботи"
 
-#: pkg/systemd/services.html:378
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/machines/components/nicEdit.jsx:314 pkg/storaged/crypto-keyslots.jsx:261
-#: pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Save"
 msgstr "Зберегти"
 
@@ -6094,10 +6123,11 @@ msgid "Service name"
 msgstr "Назва служби"
 
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
-#: pkg/networkmanager/firewall.jsx:508
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Служби"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "Сеанс"
@@ -6215,7 +6245,7 @@ msgid "Single Rank"
 msgstr "Єдиний ранг"
 
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:476
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
 #: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
@@ -6260,7 +6290,7 @@ msgstr "Слот $0"
 msgid "Sockets"
 msgstr "Сокети"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Оновлення програм"
 
@@ -6307,9 +6337,9 @@ msgid "Sorted from least trusted to most trusted"
 msgstr "Упорядковано від найменшої до найбільшої довіри"
 
 #: pkg/machines/components/diskAdd.jsx:541
+#: pkg/machines/components/nicEdit.jsx:150
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/nicEdit.jsx:150
 #: pkg/machines/components/vmnetworktab.jsx:148
 msgid "Source"
 msgstr "Джерело"
@@ -6318,8 +6348,8 @@ msgstr "Джерело"
 msgid "Source Format"
 msgstr "Початковий формат"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:221
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:248
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
@@ -6329,16 +6359,16 @@ msgstr "Шлях до джерела"
 msgid "Source URL"
 msgstr "Початкова адреса"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
 msgid "Source Volume Group"
 msgstr "Початкова група томів"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:238
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:259
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "Шлях до джерела не може бути порожнім"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "Адреса джерела має починатися із назви протоколу — http, ftp або nfs"
 
@@ -6373,7 +6403,7 @@ msgstr "Стабільний"
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
 #: pkg/machines/components/networks/createNetworkDialog.jsx:237
 #: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:174
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Почати"
 
@@ -6385,11 +6415,11 @@ msgstr "Запустити Docker"
 msgid "Start Multipath"
 msgstr "Запустити Multipath"
 
-#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:325
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
 msgstr "Запустити службу"
 
-#: pkg/systemd/service-details.jsx:395
+#: pkg/systemd/service-details.jsx:411
 msgid "Start and Enable"
 msgstr "Запустити і увімкнути"
 
@@ -6397,7 +6427,7 @@ msgstr "Запустити і увімкнути"
 msgid "Start libvirt"
 msgstr "Запустити libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:318
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
 msgstr "Запускати резервне сховище після завантаження вузла"
 
@@ -6414,7 +6444,7 @@ msgstr "Зупиняємо пристрій RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Запускаємо резервну область пам’яті $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "Запуск"
 
@@ -6422,7 +6452,7 @@ msgstr "Запуск"
 #: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:259 pkg/systemd/init.js:294
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "Стан"
 
@@ -6431,11 +6461,11 @@ msgid "State:"
 msgstr "Стан:"
 
 #: pkg/systemd/services.html:68 pkg/systemd/init.js:212
-#: pkg/systemd/service-details.jsx:353
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr "Статичний"
 
-#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:460
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "Стан"
 
@@ -6450,7 +6480,7 @@ msgstr "Липкий"
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
 #: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
 #: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
-#: pkg/systemd/service-details.jsx:170
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Зупинити"
 
@@ -6458,7 +6488,7 @@ msgstr "Зупинити"
 msgid "Stop Device"
 msgstr "Зупинити пристрій"
 
-#: pkg/systemd/service-details.jsx:395
+#: pkg/systemd/service-details.jsx:411
 msgid "Stop and Disable"
 msgstr "Зупинити і вимкнути"
 
@@ -6491,8 +6521,8 @@ msgid "Stopping swapspace $target"
 msgstr "Зупиняємо резервну область пам’яті $target"
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:439
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Сховище даних"
 
@@ -6508,11 +6538,11 @@ msgstr "Не вдалося активувати буфер сховища $0"
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr "Не вдалося деактивувати буфер сховища $0"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr "Назва резервного сховища"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:475
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr "Не вдалося створити резервне сховище"
 
@@ -6537,9 +6567,9 @@ msgstr "У цій системі не можна керувати сховище
 msgid "Storage pool"
 msgstr "Буфер сховища"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:172
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
 msgid "Storage size must not be 0"
-msgstr ""
+msgstr "Розмір сховища має бути ненульовим"
 
 #: pkg/systemd/index.html:155
 msgid "Store Metrics"
@@ -6646,8 +6676,10 @@ msgstr "Синхронізовано із {{Server}}"
 msgid "Synchronizing RAID Device $target"
 msgstr "Синхронізуємо пристрій RAID $target"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "Система"
 
@@ -6708,12 +6740,12 @@ msgstr "Сервер ключів Tang"
 msgid "Target"
 msgstr "Призначення"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "Шлях призначення"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "Шлях призначення не може бути порожнім"
 
@@ -6738,7 +6770,7 @@ msgstr "Параметри порту команди"
 msgid "Team Settings"
 msgstr "Параметри команди"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "Термінал"
 
@@ -6864,7 +6896,7 @@ msgstr ""
 "Поточний користувач, від імені якого було здійснено вхід до системи, не має "
 "права перегляду даних щодо ключів."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "Каталог на сервері, який експортується"
 
@@ -6939,7 +6971,7 @@ msgstr ""
 "Користувач, який увійшов до системи, не має права переглядати модифікації "
 "системи"
 
-#: pkg/shell/indexes.js:407
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "Комп’ютер перезавантажується"
 
@@ -6967,14 +6999,16 @@ msgstr "Скануванням від $time ($type) вразливостей н�
 msgid "The scan from $time ($type) was not successful."
 msgstr "Сканування $time ($type) виконати не вдалося."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:163
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
 msgid "The selected Operating System has minimum memory requirement of $0 $1"
 msgstr "Для вибраної операційної системи мінімальним обсягом пам'яті є $0 $1"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:178
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
 msgid ""
 "The selected Operating System has minimum storage size requirement of $0 $1"
 msgstr ""
+"Для вибраної операційної системи мінімальним об'ємом пристрою накопичення "
+"даних є $0 $1"
 
 #: src/ws/login.js:645
 msgid ""
@@ -7197,7 +7231,7 @@ msgstr ""
 "Ця програма збере дані щодо налаштувань системи і діагностичні дані з цієї "
 "системи для виявлення причин проблем у системі."
 
-#: pkg/systemd/service-details.jsx:282
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Цей модуль не створено для вмикання явним чином."
 
@@ -7213,7 +7247,7 @@ msgstr ""
 "У цій версії cockpit-ws не передбачено підтримки встановлення з’єднання із "
 "вузлом від альтернативного користувача або на альтернативному порті."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:469
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr "Цей том вже використано іншою ВМ."
 
@@ -7317,15 +7351,19 @@ msgstr "Загальний розмір: $0"
 msgid "Tower"
 msgstr "Башточка"
 
-#: pkg/systemd/service-details.jsx:415
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr "Причина вмикання"
 
-#: pkg/systemd/service-details.jsx:414
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "Умовні зміни"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Діагностика проблем"
@@ -7379,7 +7417,7 @@ msgid "Tuned is off"
 msgstr "Tuned вимкнено"
 
 #: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
@@ -7410,7 +7448,7 @@ msgstr "Введіть щось для фільтрування…"
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:288
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "Адреса"
 
@@ -7476,7 +7514,7 @@ msgid "Unavailable"
 msgstr "Недоступний"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Неочікувана помилка"
 
@@ -7484,7 +7522,7 @@ msgstr "Неочікувана помилка"
 msgid "Unique Network Name"
 msgstr "Унікальна назва мережі"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:201
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "Унікальна назва"
 
@@ -7619,11 +7657,11 @@ msgstr "Ненадійний вузол"
 msgid "Up since $0"
 msgstr "Працює з $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:490
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr "У типовому місці доступно до $0 $1"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:403
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr "У основній системі доступними є до $0 $1"
 
@@ -7655,7 +7693,7 @@ msgstr "Доступні оновлення"
 msgid "Updating"
 msgstr "Оновлення"
 
-#: pkg/systemd/service-details.jsx:390
+#: pkg/systemd/service-details.jsx:406
 msgid "Updating status..."
 msgstr "Оновлюємо стан…"
 
@@ -7792,7 +7830,7 @@ msgstr "Не вдалося примусово вимкнути віртуаль
 msgid "VM $0 failed to get deleted"
 msgstr "Не вдалося вилучити віртуальну машину $0"
 
-#: pkg/machines/libvirt-common.js:1308 pkg/machines/hostvmslist.jsx:110
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
 msgid "VM $0 failed to get installed"
 msgstr "Не вдалося встановити віртуальну машину $0"
 
@@ -7870,13 +7908,13 @@ msgstr "Версія"
 msgid "Very securely erasing $target"
 msgstr "Дуже безпечно витираємо $target"
 
-#: pkg/lib/cockpit-components-modifications.jsx:174
+#: pkg/lib/cockpit-components-modifications.jsx:173
 msgid "View automation script"
 msgstr "Переглянути скрипт автоматизації"
 
 #: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Віртуальні машини"
 
@@ -7896,7 +7934,7 @@ msgstr "Служба віртуалізації (libvirt) не є активно
 msgid "Virtualization Service is Available"
 msgstr "Доступна служба віртуалізації"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:459
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
@@ -7913,11 +7951,11 @@ msgstr "Група томів"
 msgid "Volume Group $0"
 msgstr "Група томів $0"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:214
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
 msgid "Volume Group name"
 msgstr "Назва групи томів"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:298
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
 msgid "Volume Group name should not be empty"
 msgstr "Назва групи томів має бути непорожньою"
 
@@ -7962,11 +8000,11 @@ msgstr ""
 msgid "Waiting for other software management operations to finish"
 msgstr "Очікуємо на завершення інших дій із програмним забезпеченням"
 
-#: pkg/systemd/service-details.jsx:406
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr "Бажаний для"
 
-#: pkg/systemd/service-details.jsx:401
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr "Бажає"
 
@@ -8060,7 +8098,7 @@ msgstr ""
 msgid "You must wait longer to change your password"
 msgstr "Для зміни вашого пароля вам доведеться ще почекати"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
 msgid "You need to select the most closely matching Operating System"
 msgstr "Вам слід вибрати найвідповіднішу операційну систему"
 
@@ -8218,11 +8256,11 @@ msgstr "пристрій основної системи"
 msgid "hostdev"
 msgstr "пристрій осн. системи"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr "IQN ініціатора iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr "Ціль iSCSI"
 
@@ -8230,11 +8268,11 @@ msgstr "Ціль iSCSI"
 msgid "iSCSI Targets"
 msgstr "Призначення iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:84
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr "Безпосереднє призначення iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr "IQN цілі iSCSI"
 
@@ -8433,7 +8471,7 @@ msgstr "значення"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:837
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-31 11:50+0000\n"
+"POT-Creation-Date: 2019-08-22 07:51+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -56,7 +56,7 @@ msgid "$0 Package"
 msgid_plural "$0 Packages"
 msgstr[0] "$0 软件包"
 
-#: pkg/systemd/init.js:417 pkg/systemd/service-details.jsx:58
+#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "$0 模板"
 
@@ -198,11 +198,11 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:549
+#: pkg/networkmanager/firewall.jsx:574
 msgid "(Optional)"
 msgstr "(可选)"
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:623
+#: pkg/networkmanager/firewall.jsx:499 pkg/networkmanager/firewall.jsx:648
 #: pkg/storaged/fsys-tab.jsx:160
 msgid "(default)"
 msgstr "（默认）"
@@ -518,7 +518,7 @@ msgstr "账户设置"
 msgid "Account not available or cannot be edited."
 msgstr "帐户不可用或不可编辑."
 
-#: pkg/users/index.html:71
+#: pkg/users/index.html:71 pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "账户"
 
@@ -553,11 +553,11 @@ msgstr "激活页面"
 msgid "Active since"
 msgstr "活跃自"
 
-#: pkg/systemd/service-details.jsx:348
+#: pkg/systemd/service-details.jsx:352
 msgid "Active since "
 msgstr "活跃自"
 
-#: pkg/networkmanager/firewall.jsx:929
+#: pkg/networkmanager/firewall.jsx:954
 msgid "Active zones"
 msgstr "活动区域"
 
@@ -570,7 +570,7 @@ msgid "Adaptive transmit load balancing"
 msgstr "自适应传输负载均衡"
 
 #: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:566 pkg/storaged/crypto-keyslots.jsx:228
+#: pkg/machines/components/diskAdd.jsx:600 pkg/storaged/crypto-keyslots.jsx:228
 #: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
 #: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
 #: pkg/storaged/vgroup-details.jsx:63
@@ -593,7 +593,7 @@ msgstr "添加绑定"
 msgid "Add Bridge"
 msgstr "添加网桥"
 
-#: pkg/machines/components/diskAdd.jsx:363
+#: pkg/machines/components/diskAdd.jsx:368
 msgid "Add Disk"
 msgstr "添加磁盘"
 
@@ -609,12 +609,12 @@ msgstr "添加密钥"
 msgid "Add Machine to Dashboard"
 msgstr "把机器添加到仪表板"
 
-#: pkg/networkmanager/firewall.jsx:457
+#: pkg/networkmanager/firewall.jsx:482
 msgid "Add Ports"
 msgstr "添加端口"
 
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:879
-#: pkg/networkmanager/firewall.jsx:891
+#: pkg/networkmanager/firewall.jsx:482 pkg/networkmanager/firewall.jsx:904
+#: pkg/networkmanager/firewall.jsx:916
 msgid "Add Services"
 msgstr "添加服务"
 
@@ -630,8 +630,8 @@ msgstr "添加组"
 msgid "Add VLAN"
 msgstr "添加 VLAN"
 
-#: pkg/networkmanager/firewall.jsx:705 pkg/networkmanager/firewall.jsx:885
-#: pkg/networkmanager/firewall.jsx:896
+#: pkg/networkmanager/firewall.jsx:730 pkg/networkmanager/firewall.jsx:910
+#: pkg/networkmanager/firewall.jsx:921
 msgid "Add Zone"
 msgstr "添加区域"
 
@@ -643,7 +643,7 @@ msgstr "添加 iSCSI 门户"
 msgid "Add key"
 msgstr "添加密钥"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add ports to the following zones:"
 msgstr "把端口添加到以下域："
 
@@ -651,11 +651,11 @@ msgstr "把端口添加到以下域："
 msgid "Add public key"
 msgstr "添加公钥"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:483
 msgid "Add services to following zones:"
 msgstr "把服务添加到以下区："
 
-#: pkg/networkmanager/firewall.jsx:781
+#: pkg/networkmanager/firewall.jsx:806
 msgid "Add zone"
 msgstr "添加区域"
 
@@ -665,7 +665,7 @@ msgid ""
 "administration UI unavailable."
 msgstr "添加 <b>$0</b> 将会中断与服务器的连接，并且将导致管理界面不可用。"
 
-#: pkg/networkmanager/firewall.jsx:561
+#: pkg/networkmanager/firewall.jsx:586
 msgid ""
 "Adding custom ports will reload firewalld. A reload will result in the loss "
 "of any runtime-only configuration!"
@@ -727,6 +727,13 @@ msgstr "地址不能为空"
 msgid "Address is not a valid URL"
 msgstr "该地址无效"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:60
+#: pkg/machines/components/networks/createNetworkDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:88
+#: pkg/machines/components/networks/createNetworkDialog.jsx:95
+msgid "Address not within subnet"
+msgstr ""
+
 #: pkg/machines/components/desktopConsole.jsx:153
 msgid "Address:"
 msgstr "地址："
@@ -747,7 +754,7 @@ msgstr "管理员密码"
 msgid "Advanced TCA"
 msgstr "高级 TCA"
 
-#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:424
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
 msgid "After"
 msgstr "后"
 
@@ -759,7 +766,7 @@ msgid ""
 msgstr "从域离开后，仅有使用本地凭据的用户可以登录到该主机。这也可能影响到包括DNS解析设置以及信任的CA在内的一系列设置"
 
 #: pkg/systemd/services.html:301 pkg/systemd/services.html:305
-#: pkg/systemd/init.js:887
+#: pkg/systemd/init.js:902
 msgid "After system boot"
 msgstr "系统启动后"
 
@@ -785,11 +792,11 @@ msgstr "所选磁盘上的所有数据将会被删除，磁盘将会被添加到
 msgid "Allow running (unmask)"
 msgstr "允许运行 (非掩盖)"
 
-#: pkg/networkmanager/firewall.jsx:756
+#: pkg/networkmanager/firewall.jsx:781
 msgid "Allowed Addresses"
 msgstr "允许的地址"
 
-#: pkg/networkmanager/firewall.jsx:942
+#: pkg/networkmanager/firewall.jsx:967
 msgid "Allowed Services"
 msgstr "允许的服务"
 
@@ -814,7 +821,7 @@ msgid "Appearance:"
 msgstr "外观："
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "应用"
 
@@ -919,10 +926,11 @@ msgstr "作者"
 msgid "Authorized Public SSH Keys"
 msgstr "授权公共 SSH 密钥"
 
-#: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1974
-#: pkg/networkmanager/interfaces.js:2771 pkg/networkmanager/interfaces.js:3329
-#: pkg/networkmanager/interfaces.js:3333 pkg/networkmanager/interfaces.js:3339
-#: pkg/realmd/operation.js:338
+#: pkg/networkmanager/index.html:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:176
+#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:2771
+#: pkg/networkmanager/interfaces.js:3329 pkg/networkmanager/interfaces.js:3333
+#: pkg/networkmanager/interfaces.js:3339 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "自动"
 
@@ -934,7 +942,7 @@ msgstr "自动 (仅 DHCP)"
 msgid "Automatic (DHCP)"
 msgstr "自动 (DHCP)"
 
-#: pkg/systemd/init.js:293
+#: pkg/systemd/init.js:295
 msgid "Automatic Startup"
 msgstr "自动启动"
 
@@ -946,7 +954,7 @@ msgstr "自动更新"
 msgid "Automatically start libvirt on boot"
 msgstr "在引导时自动启动 libvirt"
 
-#: pkg/systemd/service-details.jsx:392
+#: pkg/systemd/service-details.jsx:396
 msgid "Automatically starts"
 msgstr "自动开始"
 
@@ -963,7 +971,7 @@ msgid "Automation Script"
 msgstr "自动化脚本"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:86
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:69
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "自动启动"
@@ -1014,11 +1022,11 @@ msgstr "为 passwd1 传递了坏数据"
 msgid "Balancer"
 msgstr "平衡器"
 
-#: pkg/systemd/service-details.jsx:423
+#: pkg/systemd/service-details.jsx:427
 msgid "Before"
 msgstr "之前"
 
-#: pkg/systemd/service-details.jsx:414
+#: pkg/systemd/service-details.jsx:418
 msgid "Binds To"
 msgstr "绑定到"
 
@@ -1064,7 +1072,7 @@ msgstr "启动顺序"
 msgid "Boot order settings could not be saved"
 msgstr "无法保存启动顺序"
 
-#: pkg/systemd/service-details.jsx:419
+#: pkg/systemd/service-details.jsx:423
 msgid "Bound By"
 msgstr "边界为"
 
@@ -1145,7 +1153,7 @@ msgstr "CPU 优先级"
 msgid "CPU usage:"
 msgstr "CPU 使用率："
 
-#: pkg/machines/components/diskAdd.jsx:246
+#: pkg/machines/components/diskAdd.jsx:251
 #: pkg/machines/components/vmDiskColumns.jsx:75
 msgid "Cache"
 msgstr "缓存"
@@ -1184,25 +1192,26 @@ msgstr "无法加载镜像"
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:752
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:563
+#: pkg/machines/components/diskAdd.jsx:597
+#: pkg/machines/components/networks/createNetworkDialog.jsx:486
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
+#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:565 pkg/networkmanager/firewall.jsx:633
-#: pkg/networkmanager/firewall.jsx:776 pkg/packagekit/updates.jsx:179
+#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
+#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
 #: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:216
-#: pkg/systemd/service-details.jsx:107
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
+#: pkg/systemd/hwinfo.jsx:216
 msgid "Cancel"
 msgstr "取消"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:421
 msgid "Cannot connect to an unknown machine"
 msgstr "不能连接至未知主机"
 
@@ -1268,7 +1277,7 @@ msgstr "修改资源限制"
 msgid "Change the settings"
 msgstr "修改设置"
 
-#: pkg/machines/components/nicEdit.jsx:272
+#: pkg/machines/components/nicEdit.jsx:287
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
@@ -1317,6 +1326,10 @@ msgstr "检查更新"
 msgid "Checking installed software"
 msgstr "检查安装的软件"
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
+msgid "Choose an operating system"
+msgstr ""
+
 #: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "选择应用程序使用的语言"
@@ -1332,6 +1345,10 @@ msgstr "等级"
 #: pkg/storaged/jobs-panel.jsx:55
 msgid "Cleaning up for $target"
 msgstr "清理 $target"
+
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
 
 #: pkg/systemd/services.html:86
 msgid "Clear All Filters"
@@ -1379,7 +1396,7 @@ msgstr "Cockpit 无法与指定主机 $0 联系。请确认已经在端口 $1 �
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit 无法联系指定的主机。"
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:752
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1477,7 +1494,7 @@ msgid "Combined usage of $0 CPU core"
 msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "总计使用 $0 CPU 内核"
 
-#: pkg/networkmanager/firewall.jsx:529
+#: pkg/networkmanager/firewall.jsx:554
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "可以使用逗号隔开的端口、范围和别名"
 
@@ -1539,11 +1556,11 @@ msgstr "压缩"
 msgid "Computer OU"
 msgstr "计算机 OU"
 
-#: pkg/systemd/service-details.jsx:438
+#: pkg/systemd/service-details.jsx:442
 msgid "Condition $0=$1 was not met"
 msgstr "条件 $0=$1 不满足"
 
-#: pkg/systemd/service-details.jsx:488
+#: pkg/systemd/service-details.jsx:492
 msgid "Condition failed"
 msgstr "条件失败"
 
@@ -1580,11 +1597,11 @@ msgstr "确认删除虚拟网络"
 msgid "Confirm removal with passphrase"
 msgstr "使用密码确认删除"
 
-#: pkg/systemd/service-details.jsx:422
+#: pkg/systemd/service-details.jsx:426
 msgid "Conflicted By"
 msgstr "冲突"
 
-#: pkg/systemd/service-details.jsx:421
+#: pkg/systemd/service-details.jsx:425
 msgid "Conflicts"
 msgstr "冲突"
 
@@ -1629,13 +1646,13 @@ msgstr "连接到 SETroubleshoot 守护进程..."
 msgid "Connecting to Virtualization Service"
 msgstr "连接虚拟化服务"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:416
 msgid "Connecting to the machine"
 msgstr "正在连接至主机"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:667
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
+#: pkg/machines/components/networks/createNetworkDialog.jsx:106
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
@@ -1653,7 +1670,7 @@ msgstr "连接超时。"
 msgid "Connection will be lost"
 msgstr "连接将丢失"
 
-#: pkg/systemd/service-details.jsx:420
+#: pkg/systemd/service-details.jsx:424
 msgid "Consists Of"
 msgstr "组成"
 
@@ -1757,7 +1774,7 @@ msgstr "不能修改用户组"
 msgid "Couldn't change user password"
 msgstr "不能修改用户密码"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:419
 msgid "Couldn't connect to the machine"
 msgstr "不能连接至主机"
 
@@ -1786,8 +1803,9 @@ msgid "Crash system"
 msgstr "导致系统崩溃"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:757
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
+#: pkg/machines/components/networks/createNetworkDialog.jsx:491
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
 #: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
 #: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
 #: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
@@ -1798,7 +1816,7 @@ msgstr "创建"
 msgid "Create Logical Volume"
 msgstr "创建逻辑卷"
 
-#: pkg/machines/components/diskAdd.jsx:518
+#: pkg/machines/components/diskAdd.jsx:552
 msgid "Create New"
 msgstr "新建"
 
@@ -1830,7 +1848,7 @@ msgstr "创建报表"
 msgid "Create Snapshot"
 msgstr "创建快照"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "创建存储池"
 
@@ -1850,9 +1868,14 @@ msgstr "创建定时器"
 msgid "Create VDO Device"
 msgstr "创建 VDO 设备"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:799
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "创建虚拟机"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
+#: pkg/machines/components/networks/createNetworkDialog.jsx:525
+msgid "Create Virtual Network"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:53
 msgid "Create Volume Group"
@@ -1928,7 +1951,7 @@ msgstr "创建该组将断开与服务器的连接，并且将会导致管理界
 msgid "Creating volume group $target"
 msgstr "创建卷组 $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr "虚拟机$0创建失败"
 
@@ -1956,7 +1979,7 @@ msgstr "当前启动"
 msgid "Custom"
 msgstr "自定义"
 
-#: pkg/networkmanager/firewall.jsx:523
+#: pkg/networkmanager/firewall.jsx:548
 msgid "Custom Ports"
 msgstr "自定义端口"
 
@@ -1968,7 +1991,7 @@ msgstr "自定义加密选项"
 msgid "Custom mount options"
 msgstr "自定义挂载选项"
 
-#: pkg/networkmanager/firewall.jsx:723
+#: pkg/networkmanager/firewall.jsx:748
 msgid "Custom zones"
 msgstr "自定义区域"
 
@@ -2049,8 +2072,9 @@ msgstr "延时"
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
 #: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
 #: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
 #: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
@@ -2062,7 +2086,7 @@ msgstr "删除"
 msgid "Delete $0"
 msgstr "删除 $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
 msgstr "删除内容"
 
@@ -2074,7 +2098,7 @@ msgstr "删除文件"
 msgid "Delete Network $0"
 msgstr "删除网络 $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:217
 msgid "Delete Storage Pool $0"
 msgstr "删除存储池$0"
 
@@ -2082,7 +2106,7 @@ msgstr "删除存储池$0"
 msgid "Delete associated storage files:"
 msgstr "删除关联的存储文件："
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:170
 msgid "Delete the Volumes inside this Pool"
 msgstr "删除这个存储池中的卷"
 
@@ -2120,7 +2144,7 @@ msgstr "删除分区将擦除其中的所有数据。"
 msgid "Deleting a volume group will erase all data on it."
 msgstr "删除卷组将擦除其中的所有数据。"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:174
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
@@ -2132,13 +2156,23 @@ msgstr "删除卷组 $target"
 
 #: pkg/systemd/services.html:268
 #: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:732 pkg/systemd/init.js:287
+#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
 msgid "Description"
 msgstr "描述"
+
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "桌面"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:151
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:187
+msgid ""
+"Detach the disks using this pool from any VMs before attempting deletion."
+msgstr ""
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2146,12 +2180,13 @@ msgstr "可拆开"
 
 #: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:95
-#: pkg/packagekit/updates.jsx:383 pkg/systemd/host.js:762
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:383
+#: pkg/systemd/host.js:762
 msgid "Details"
 msgstr "详情"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:169
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
 #: pkg/machines/components/vmDiskColumns.jsx:43
 #: pkg/machines/components/vmDisksTab.jsx:58
@@ -2165,6 +2200,10 @@ msgstr "设备文件"
 #: pkg/storaged/content-views.jsx:551
 msgid "Device is read-only"
 msgstr "设备只读"
+
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
@@ -2192,11 +2231,11 @@ msgid "Disable tuned"
 msgstr "禁用 tuned"
 
 #: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
-#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:327
+#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
 msgid "Disabled"
 msgstr "禁用"
 
-#: pkg/systemd/service-details.jsx:196
+#: pkg/systemd/service-details.jsx:192
 msgid "Disallow running (mask)"
 msgstr "不允许运行 (掩盖)"
 
@@ -2205,7 +2244,7 @@ msgid "Disconnect"
 msgstr "断开"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
 msgid "Disconnected"
 msgstr "已断开连接"
 
@@ -2225,11 +2264,11 @@ msgstr "磁盘$0无法从虚拟机$1上分离"
 msgid "Disk I/O"
 msgstr "磁盘 I/O"
 
-#: pkg/machines/components/diskAdd.jsx:492
+#: pkg/machines/components/diskAdd.jsx:525
 msgid "Disk failed to be attached"
 msgstr "挂载磁盘失败"
 
-#: pkg/machines/components/diskAdd.jsx:471
+#: pkg/machines/components/diskAdd.jsx:504
 msgid "Disk failed to be created"
 msgstr "创建磁盘失败"
 
@@ -2255,6 +2294,10 @@ msgstr "磁盘不能从 $0 VM 删除"
 #: pkg/shell/simple.html:82
 msgid "Display Language"
 msgstr "显示语言"
+
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: node_modules/registry-image-widgets/views/image-meta.html:10
 msgid "Docker Version"
@@ -2294,7 +2337,7 @@ msgid "Domain Administrator Password"
 msgstr "域管理员密码"
 
 #: pkg/systemd/services.html:338 pkg/systemd/services.html:342
-#: pkg/systemd/init.js:1070
+#: pkg/systemd/init.js:1085
 msgid "Don't Repeat"
 msgstr "不要重复"
 
@@ -2359,7 +2402,7 @@ msgstr "重复别名"
 msgid "Duplicate port"
 msgstr "重复端口"
 
-#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
+#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
 #: pkg/storaged/nfs-details.jsx:306
 msgid "Edit"
 msgstr "编辑"
@@ -2456,6 +2499,15 @@ msgstr "加密"
 msgid "Encryption Options"
 msgstr "加密选项"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:252
+msgid "End"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:63
+#: pkg/machines/components/networks/createNetworkDialog.jsx:91
+msgid "End should not be empty"
+msgstr ""
+
 #: pkg/selinux/setroubleshoot-view.jsx:296
 msgid "Enforcing"
 msgstr "强制"
@@ -2474,7 +2526,7 @@ msgid ""
 "time you reconnect to this machine"
 msgstr "在这里输入不同的密码意味着将要在每次重新连接该主机时重新输入"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:784
 msgid "Entire subnet"
 msgstr "整个子网"
 
@@ -2510,7 +2562,7 @@ msgstr "勘误："
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
 #: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
 #: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/systemd/service-details.jsx:444 pkg/users/local.js:1476
+#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
 msgid "Error"
 msgstr "错误"
 
@@ -2558,11 +2610,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "所有"
 
-#: pkg/networkmanager/firewall.jsx:536
+#: pkg/networkmanager/firewall.jsx:561
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "例如: 22,ssh,8080,5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:544
+#: pkg/networkmanager/firewall.jsx:569
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "例如: 88,2019,nfs,rsync"
 
@@ -2570,11 +2622,11 @@ msgstr "例如: 88,2019,nfs,rsync"
 msgid "Excellent password"
 msgstr "密码强度良好"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:282
-msgid "Existing Disk Image"
-msgstr "现有磁盘镜像"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
+msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:219
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr "主机文件系统上存在的磁盘镜像"
 
@@ -2606,15 +2658,15 @@ msgstr "已失败"
 msgid "Failed to add machine: $0"
 msgstr "添加主机失败: $0"
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add port"
 msgstr "添加端口失败"
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add service"
 msgstr "添加服务失败"
 
-#: pkg/networkmanager/firewall.jsx:684
+#: pkg/networkmanager/firewall.jsx:709
 msgid "Failed to add zone"
 msgstr "添加区域失败"
 
@@ -2650,11 +2702,11 @@ msgstr "获取在 $0 中的接口的 IP 地址失败"
 msgid "Failed to load authorized keys."
 msgstr "载入 authorized key 失败。"
 
-#: pkg/networkmanager/firewall.jsx:596
+#: pkg/networkmanager/firewall.jsx:621
 msgid "Failed to remove service"
 msgstr "删除服务失败"
 
-#: pkg/systemd/service-details.jsx:336
+#: pkg/systemd/service-details.jsx:340
 msgid "Failed to start"
 msgstr "启动失败"
 
@@ -2683,7 +2735,7 @@ msgstr "文件"
 msgid "Filesystem"
 msgstr "文件系统"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "文件系统目录"
 
@@ -2699,7 +2751,7 @@ msgstr "文件系统名称"
 msgid "Filesystems"
 msgstr "文件系统"
 
-#: pkg/networkmanager/firewall.jsx:491
+#: pkg/networkmanager/firewall.jsx:516
 msgid "Filter Services"
 msgstr "过滤服务"
 
@@ -2712,11 +2764,11 @@ msgid "Fingerprint"
 msgstr "指纹"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:920 pkg/networkmanager/firewall.jsx:923
+#: pkg/networkmanager/firewall.jsx:945 pkg/networkmanager/firewall.jsx:948
 msgid "Firewall"
 msgstr "防火墙"
 
-#: pkg/networkmanager/firewall.jsx:868
+#: pkg/networkmanager/firewall.jsx:893
 msgid "Firewall is not available"
 msgstr "防火墙不可用"
 
@@ -2728,7 +2780,7 @@ msgstr "跟随容器仓库"
 msgid "For legacy applications only. Reduces performance."
 msgstr "只适用老的应用程序。性能会减小。"
 
-#: pkg/systemd/service-details.jsx:318
+#: pkg/systemd/service-details.jsx:322
 msgid "Forbidden from running"
 msgstr "禁止运行"
 
@@ -2756,8 +2808,8 @@ msgstr "强制密码变更"
 msgid "Force remove passphrase in $0"
 msgstr "强制删除 $0 中的密码"
 
-#: pkg/machines/components/diskAdd.jsx:147
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
+#: pkg/machines/components/diskAdd.jsx:157
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
 #: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
 #: pkg/storaged/format-dialog.jsx:323
 msgid "Format"
@@ -2779,11 +2831,15 @@ msgstr "格式化磁盘将擦除其中的所有数据。"
 msgid "Formatting a storage device will erase all data on it."
 msgstr "格式化存储设备将擦除其中的所有数据."
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:147
+msgid "Forward Mode"
+msgstr ""
+
 #: pkg/networkmanager/interfaces.js:2873
 msgid "Forward delay $forward_delay"
 msgstr "转发延迟 $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:50
 msgid "Forwarding mode"
 msgstr "转发模式"
 
@@ -2835,7 +2891,7 @@ msgstr "正在生成报告"
 msgid "Get new image"
 msgstr "获取新镜像"
 
-#: pkg/machines/components/diskAdd.jsx:186
+#: pkg/machines/components/diskAdd.jsx:191
 #: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
@@ -2920,14 +2976,14 @@ msgstr "硬件信息"
 msgid "Hello time $hello_time"
 msgstr "Hello 时间 $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Hide Performance Options"
 msgstr "隐藏性能选项"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
 msgid "Host"
 msgstr "主机"
 
@@ -2936,7 +2992,7 @@ msgid "Host Device"
 msgstr "主机设备"
 
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "主机名"
 
@@ -2948,7 +3004,7 @@ msgstr "主机密钥不正确"
 msgid "Host name should not be changed in a domain"
 msgstr "在域内的主机不可更改主机名"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "主机不能为空"
 
@@ -2956,7 +3012,7 @@ msgstr "主机不能为空"
 msgid "Hour : Minute"
 msgstr "小时：分钟"
 
-#: pkg/systemd/init.js:1146 pkg/systemd/init.js:1175
+#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
 msgid "Hour needs to be a number between 0-23"
 msgstr "小时需要是在 0-23 间的数字"
 
@@ -2981,11 +3037,15 @@ msgstr "IP 地址"
 msgid "IP Address:"
 msgstr "IP 地址:"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:197
+msgid "IP Configuration"
+msgstr ""
+
 #: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "IP 前缀长度:"
 
-#: pkg/networkmanager/firewall.jsx:930
+#: pkg/networkmanager/firewall.jsx:955
 msgid "IP Range"
 msgstr "IP 地址范围"
 
@@ -3001,9 +3061,25 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr "IPv4 地址"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+msgid "IPv4 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:45
+msgid "IPv4 Network should not be empty"
+msgstr ""
+
 #: pkg/networkmanager/interfaces.js:3371
 msgid "IPv4 Settings"
 msgstr "IPv4 设置"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:213
+msgid "IPv4 and IPv6"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:207
+msgid "IPv4 only"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:2925
 msgid "IPv6"
@@ -3013,9 +3089,21 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr "IPv6 地址"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+msgid "IPv6 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:73
+msgid "IPv6 Network should not be empty"
+msgstr ""
+
 #: pkg/networkmanager/interfaces.js:3371
 msgid "IPv6 Settings"
 msgstr "IPv6 设置"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:210
+msgid "IPv6 only"
+msgstr ""
 
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
@@ -3100,15 +3188,19 @@ msgstr "镜像可以被任何已验证的用户或组获取"
 msgid "Images may only be pulled by specific users or groups"
 msgstr "镜像仅可被指定用户或组获取"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:735
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "立即启动 VM"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
 
 #: pkg/storaged/mdraid-details.jsx:100
 msgid "In Sync"
 msgstr "同步中"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:227
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3129,7 +3221,7 @@ msgstr "未激活"
 msgid "Inactive volume"
 msgstr "暂停卷"
 
-#: pkg/networkmanager/firewall.jsx:737
+#: pkg/networkmanager/firewall.jsx:762
 msgid "Included services"
 msgstr "包括的服务"
 
@@ -3153,11 +3245,11 @@ msgstr "关于容器存储池的信息不可用。"
 msgid "Initializing..."
 msgstr "初始化中..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr "启动器"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr "启动器 IQN 不能为空"
 
@@ -3191,15 +3283,15 @@ msgstr "安装 VDO 支持"
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "安装 setroubleshoot-server 来排查 SELinux 事件。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "安装源"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "安装源类型"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "安装源不应为空"
 
@@ -3216,7 +3308,7 @@ msgstr "正在安装"
 msgid "Installing $0"
 msgstr "正在安装 $0"
 
-#: pkg/systemd/service-details.jsx:483
+#: pkg/systemd/service-details.jsx:487
 msgid "Instance of template: "
 msgstr ""
 
@@ -3224,12 +3316,12 @@ msgstr ""
 msgid "Instantiate"
 msgstr "实例"
 
-#: pkg/machines/components/nicEdit.jsx:123
+#: pkg/machines/components/nicEdit.jsx:132
 msgid "Interface Type"
 msgstr "接口类型"
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:742 pkg/networkmanager/firewall.jsx:930
+#: pkg/networkmanager/firewall.jsx:767 pkg/networkmanager/firewall.jsx:955
 #: pkg/networkmanager/interfaces.js:2998
 msgid "Interfaces"
 msgstr "接口"
@@ -3242,19 +3334,39 @@ msgstr "内部错误：无效的挑战字头部"
 msgid "Internal error"
 msgstr "内部错误"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:58
+#: pkg/machines/components/networks/createNetworkDialog.jsx:65
+msgid "Invalid IPv4 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:52
+msgid "Invalid IPv4 mask or prefix length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:75
+#: pkg/machines/components/networks/createNetworkDialog.jsx:86
+#: pkg/machines/components/networks/createNetworkDialog.jsx:93
+msgid "Invalid IPv6 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:80
+msgid "Invalid IPv6 prefix"
+msgstr ""
+
 #: pkg/networkmanager/utils.js:90 pkg/networkmanager/utils.js:175
 msgid "Invalid address $0"
 msgstr "无效的地址 $0"
 
-#: pkg/systemd/host.js:1469 pkg/systemd/shutdown.js:143
+#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
 msgid "Invalid date format"
 msgstr "无效的日期格式"
 
-#: pkg/systemd/host.js:1465 pkg/systemd/shutdown.js:139
+#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
 msgid "Invalid date format and invalid time format"
 msgstr "无效的日期格式和时间格式"
 
-#: pkg/systemd/init.js:1181
+#: pkg/systemd/init.js:1196
 msgid "Invalid date format."
 msgstr "无效的数据格式。"
 
@@ -3266,7 +3378,7 @@ msgstr "无效的过期时间"
 msgid "Invalid file permissions"
 msgstr "无效的文件权限"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:140
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "无效的文件名"
 
@@ -3282,7 +3394,7 @@ msgstr "无效的度量 $0"
 msgid "Invalid number of days"
 msgstr "无效的天数"
 
-#: pkg/systemd/init.js:1128
+#: pkg/systemd/init.js:1143
 msgid "Invalid number."
 msgstr "无效的编号。"
 
@@ -3290,7 +3402,7 @@ msgstr "无效的编号。"
 msgid "Invalid port"
 msgstr "无效端口"
 
-#: pkg/networkmanager/firewall.jsx:335
+#: pkg/networkmanager/firewall.jsx:360
 msgid "Invalid port number"
 msgstr "无效的端口号"
 
@@ -3302,11 +3414,11 @@ msgstr "无效的前缀 $0"
 msgid "Invalid prefix or netmask $0"
 msgstr "无效的前缀或掩码 $0"
 
-#: pkg/networkmanager/firewall.jsx:362
+#: pkg/networkmanager/firewall.jsx:387
 msgid "Invalid range"
 msgstr "无效范围"
 
-#: pkg/systemd/host.js:1467 pkg/systemd/shutdown.js:141
+#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
 msgid "Invalid time format"
 msgstr "无效的时间格式"
 
@@ -3350,7 +3462,7 @@ msgstr "加入域"
 msgid "Joining this domain is not supported"
 msgstr "不支持加入该域"
 
-#: pkg/systemd/service-details.jsx:430
+#: pkg/systemd/service-details.jsx:434
 msgid "Joins Namespace Of"
 msgstr "加入命名空间"
 
@@ -3387,7 +3499,7 @@ msgstr "Kerberos 权证"
 msgid "Kernel"
 msgstr "内核"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "内核转储"
 
@@ -3419,6 +3531,10 @@ msgstr "删除 keyserver 可能会阻止解锁 $0。"
 msgid "LACP Key"
 msgstr "LACP 密钥"
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
+msgid "LVM Volume Group"
+msgstr ""
+
 #: node_modules/registry-image-widgets/views/image-meta.html:3
 msgid "Labels"
 msgstr "标签"
@@ -3439,7 +3555,7 @@ msgstr "最近 7 天"
 msgid "Last Login"
 msgstr "最近登陆"
 
-#: pkg/systemd/init.js:291
+#: pkg/systemd/init.js:293
 msgid "Last Trigger"
 msgstr "最近的触发器"
 
@@ -3558,7 +3674,7 @@ msgstr "本地磁盘"
 msgid "Local Filesystem"
 msgstr "本地文件系统"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:274
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr "本地安装介质"
 
@@ -3658,7 +3774,7 @@ msgstr "登录已升级管理员权限"
 msgid "Logout Successful"
 msgstr "注销成功"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "日志"
 
@@ -3702,7 +3818,7 @@ msgstr "MTU 必须是正整数"
 msgid "Mac"
 msgstr "Mac"
 
-#: pkg/machines/components/nicEdit.jsx:160
+#: pkg/machines/components/nicEdit.jsx:169
 msgid "Mac Address"
 msgstr "MAC 地址"
 
@@ -3714,7 +3830,7 @@ msgstr "机器编号"
 msgid "Machine SSH Key Fingerprints"
 msgstr "主机 SSH 密钥指纹"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:302
 msgid "Machines"
 msgstr "主机"
 
@@ -3746,15 +3862,23 @@ msgstr "用 SSH 手动检查： "
 msgid "Marking $target as faulty"
 msgstr "标记 $target 为故障"
 
-#: pkg/systemd/service-details.jsx:203 pkg/systemd/service-details.jsx:206
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
 msgid "Mask Service"
 msgstr "掩盖服务"
 
-#: pkg/systemd/service-details.jsx:317
+#: pkg/machines/components/networks/createNetworkDialog.jsx:293
+msgid "Mask or Prefix Length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:50
+msgid "Mask or Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:321
 msgid "Masked"
 msgstr "掩盖的"
 
-#: pkg/systemd/service-details.jsx:204
+#: pkg/systemd/service-details.jsx:200
 msgid ""
 "Masking service prevents all dependant units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
@@ -3798,7 +3922,7 @@ msgstr "RAID 设备 $0 的成员"
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:204
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:372
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
 #: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
 msgid "Memory"
 msgstr "内存"
@@ -3825,7 +3949,7 @@ msgstr "内存不能被保存"
 msgid "Memory limit"
 msgstr "内存限制"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:157
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
 msgstr "内存不能为 0"
 
@@ -3851,7 +3975,7 @@ msgid "Metadata Used"
 msgstr "已使用的元数据"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:183
+#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
@@ -3866,7 +3990,7 @@ msgstr "迷你电脑"
 msgid "Mini Tower"
 msgstr "迷你塔式主机"
 
-#: pkg/systemd/init.js:1152 pkg/systemd/init.js:1161 pkg/systemd/init.js:1170
+#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
 msgid "Minute needs to be a number between 0-59"
 msgstr "分钟需要是 0-59 间的数字"
 
@@ -3882,7 +4006,7 @@ msgstr "缓解"
 msgid "Mode"
 msgstr "模式"
 
-#: pkg/machines/components/nicEdit.jsx:54 pkg/systemd/hwinfo.jsx:250
+#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
 msgid "Model"
 msgstr "型号"
 
@@ -4015,10 +4139,11 @@ msgstr "NTP 服务器"
 #: node_modules/registry-image-widgets/views/image-body.html:2
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:5
 #: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:181
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
 #: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:122
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
@@ -4030,8 +4155,8 @@ msgstr "NTP 服务器"
 #: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
 #: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
 #: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:288
+#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
+#: pkg/systemd/hwinfo.jsx:79
 msgid "Name"
 msgstr "名称"
 
@@ -4063,8 +4188,9 @@ msgstr "名称不能包含字符 '$0'。"
 msgid "Name cannot contain whitespace."
 msgstr "名称不能包含空格。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:122
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
+#: pkg/machines/components/networks/createNetworkDialog.jsx:41
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "名称不应为空"
 
@@ -4092,15 +4218,15 @@ msgstr "网络 $0 激活失败"
 msgid "Network $0 failed to get deactivated"
 msgstr "网络 $0 取消激活失败"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr "网络引导 (PXE)"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:277
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
 msgid "Network Boot is available only when using System connection"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "网络文件系统"
 
@@ -4108,7 +4234,7 @@ msgstr "网络文件系统"
 msgid "Network Interfaces"
 msgstr "网络接口"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:233
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr "网络选择不支持 PXE。"
 
@@ -4120,7 +4246,7 @@ msgstr "网络流量"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "网络设备和图形需要 NetworkManager。"
 
-#: pkg/machines/components/nicEdit.jsx:232
+#: pkg/machines/components/nicEdit.jsx:245
 msgid "Network interface settings could not be saved"
 msgstr "网络接口设置不能被保存"
 
@@ -4129,7 +4255,7 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager 没有运行。"
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:919
+#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "网络"
 
@@ -4142,8 +4268,8 @@ msgstr "网络"
 msgid "Networking Logs"
 msgstr "网络日志"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/networks/networkList.jsx:46
+#: pkg/machines/components/networks/networkList.jsx:45
+#: pkg/machines/components/networks/networkList.jsx:49
 msgid "Networks"
 msgstr "网络"
 
@@ -4183,7 +4309,7 @@ msgstr "新密码不被接受"
 msgid "Next"
 msgstr "下一步"
 
-#: pkg/systemd/init.js:290
+#: pkg/systemd/init.js:292
 msgid "Next Run"
 msgstr "下次运行"
 
@@ -4216,12 +4342,16 @@ msgstr "没有找到匹配的结果"
 msgid "No NFS mounts set up"
 msgstr "没有设置 NFS 挂载"
 
+#: pkg/machines/components/nicEdit.jsx:118
+msgid "No Network Devices"
+msgstr ""
+
 #: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
 msgstr "没有 SELinux 警告。"
 
-#: pkg/machines/components/diskAdd.jsx:204
-#: pkg/machines/components/diskAdd.jsx:216
+#: pkg/machines/components/diskAdd.jsx:209
+#: pkg/machines/components/diskAdd.jsx:221
 msgid "No Storage Pools available"
 msgstr "没有可用的存储池"
 
@@ -4237,11 +4367,11 @@ msgstr "没有系统改变"
 msgid "No VM is running or defined on this host"
 msgstr "该主机上没有定义或运行虚拟机。"
 
-#: pkg/machines/components/nicEdit.jsx:110
+#: pkg/machines/components/nicEdit.jsx:116
 msgid "No Virtual Networks"
 msgstr "没有虚拟网络"
 
-#: pkg/networkmanager/firewall.jsx:931
+#: pkg/networkmanager/firewall.jsx:956
 msgid "No active zones"
 msgstr "没有活动区域"
 
@@ -4293,7 +4423,7 @@ msgstr "没有容器"
 msgid "No containers that match the current filter"
 msgstr "没有容器匹配当前的过滤条件"
 
-#: pkg/networkmanager/firewall.jsx:734
+#: pkg/networkmanager/firewall.jsx:759
 msgid "No description available"
 msgstr "没有可用描述"
 
@@ -4372,7 +4502,7 @@ msgstr ""
 msgid "No network interfaces defined for this VM"
 msgstr "没有为此 VM 定义网络接口"
 
-#: pkg/machines/components/networks/networkList.jsx:48
+#: pkg/machines/components/networks/networkList.jsx:51
 msgid "No network is defined on this host"
 msgstr "没有在这个主机上定义网络"
 
@@ -4380,7 +4510,7 @@ msgstr "没有在这个主机上定义网络"
 msgid "No networks available"
 msgstr "没有可用的网络"
 
-#: pkg/networkmanager/firewall.jsx:944
+#: pkg/networkmanager/firewall.jsx:969
 msgid "No open ports"
 msgstr "没有开放的端口"
 
@@ -4437,8 +4567,9 @@ msgid "No volume groups created"
 msgstr "没有创建的卷组"
 
 #: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419 pkg/networkmanager/firewall.jsx:739
-#: pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:419
+#: pkg/machines/components/networks/createNetworkDialog.jsx:204
+#: pkg/networkmanager/firewall.jsx:764 pkg/tuned/dialog.js:231
 msgid "None"
 msgstr "无"
 
@@ -4486,7 +4617,7 @@ msgstr "未加载"
 msgid "Not permitted to perform this action."
 msgstr "不允许执行该操作。"
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:355
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
 msgid "Not running"
 msgstr "未运行"
 
@@ -4498,7 +4629,7 @@ msgstr "未同步"
 msgid "Not yet synced"
 msgstr "未同步"
 
-#: pkg/systemd/service-details.jsx:444
+#: pkg/systemd/service-details.jsx:448
 msgid "Note"
 msgstr "注意"
 
@@ -4509,10 +4640,6 @@ msgstr "笔记本"
 #: pkg/systemd/logs.html:61
 msgid "Notice and above"
 msgstr "Notice 及以上"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:334
-msgid "OS Vendor"
-msgstr "操作系统厂商"
 
 #: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
@@ -4542,7 +4669,7 @@ msgstr "旧密码不被接受"
 msgid "On Build"
 msgstr "构建中"
 
-#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:425
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
 msgid "On Failure"
 msgstr "失败时"
 
@@ -4579,7 +4706,7 @@ msgstr "仅使用 $1 中的 $0。"
 msgid "Only Emergency"
 msgstr "只有紧急情况"
 
-#: pkg/systemd/init.js:1102
+#: pkg/systemd/init.js:1117
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "只有许使用字母、数字、 : 、 _ 、 . 、 @ 、 - 。"
 
@@ -4596,7 +4723,7 @@ msgid "Open"
 msgstr "打开"
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "操作系统"
 
@@ -4657,7 +4784,7 @@ msgstr "PCI"
 msgid "Package information"
 msgstr "软件包信息"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "PackageKit 已崩溃"
 
@@ -4669,6 +4796,10 @@ msgstr "PackageKit 未安装"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit 已报告错误码 $0"
 
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "软件包"
+
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "父"
@@ -4677,7 +4808,7 @@ msgstr "父"
 msgid "Parent $parent"
 msgstr "父 $parent"
 
-#: pkg/systemd/service-details.jsx:415
+#: pkg/systemd/service-details.jsx:419
 msgid "Part Of"
 msgstr "部分"
 
@@ -4763,7 +4894,7 @@ msgid "Paste the contents of your public SSH key file here"
 msgstr "在这里粘贴 SSH 公钥文件内容"
 
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/systemd/service-details.jsx:477
+#: pkg/systemd/service-details.jsx:481
 msgid "Path"
 msgstr "路径"
 
@@ -4779,7 +4910,7 @@ msgstr "路径开销 $path_cost"
 msgid "Path on Server"
 msgstr "服务器上的路径"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "主机文件系统上的路径"
 
@@ -4791,7 +4922,7 @@ msgstr "服务器上的路径不能为空。"
 msgid "Path on server must start with \"/\"."
 msgstr "服务器上的路径必须以“/”开头。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:210
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "主机文件系统中到 ISO 文件的路径"
 
@@ -4832,7 +4963,7 @@ msgid "Persistence"
 msgstr "持久"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:83
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:66
 msgid "Persistent"
 msgstr "持久"
 
@@ -4840,7 +4971,7 @@ msgstr "持久"
 msgid "Physical"
 msgstr "物理"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr "物理磁盘设备"
 
@@ -4852,7 +4983,7 @@ msgstr "物理卷"
 msgid "Physical Volumes"
 msgstr "物理卷"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr "主机上的物理磁盘设备"
 
@@ -4891,15 +5022,15 @@ msgstr "请确认强制删除 $0"
 msgid "Please confirm stopping of $0"
 msgstr "请确认停止$0"
 
-#: pkg/machines/components/diskAdd.jsx:450
+#: pkg/machines/components/diskAdd.jsx:483
 msgid "Please enter new volume name"
 msgstr "请输入新的卷名"
 
-#: pkg/machines/components/diskAdd.jsx:453
+#: pkg/machines/components/diskAdd.jsx:486
 msgid "Please enter new volume size"
 msgstr "请输入新的卷大小"
 
-#: pkg/networkmanager/firewall.jsx:869
+#: pkg/networkmanager/firewall.jsx:894
 msgid "Please install the $0 package"
 msgstr "请安装 $0 软件包"
 
@@ -4919,12 +5050,12 @@ msgstr "请启动虚拟机来访问其控制台。"
 msgid "Please try another term"
 msgstr "请尝试另一个终端"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Plug"
 msgstr "插"
 
 #: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:199
+#: pkg/machines/components/diskAdd.jsx:204
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
 #: pkg/storaged/content-views.jsx:133
@@ -4943,6 +5074,11 @@ msgstr "瘦卷的池"
 msgid "Pool for thinly provisioned volumes"
 msgstr "瘦分配配置卷的池"
 
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
+msgid "Pool's volumes are used by VMs "
+msgstr ""
+
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
@@ -4952,7 +5088,7 @@ msgstr "瘦分配配置卷的池"
 msgid "Port"
 msgstr "端口"
 
-#: pkg/networkmanager/firewall.jsx:339
+#: pkg/networkmanager/firewall.jsx:364
 msgid "Port number and type do not match"
 msgstr "端口号和类型不匹配"
 
@@ -4983,6 +5119,14 @@ msgstr "向客户机公开的首选插槽数。"
 msgid "Prefix"
 msgstr "前缀"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:337
+msgid "Prefix Length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:78
+msgid "Prefix Length should not be empty"
+msgstr ""
+
 #: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length"
 msgstr "前缀长度"
@@ -4990,6 +5134,10 @@ msgstr "前缀长度"
 #: pkg/networkmanager/interfaces.js:3318
 msgid "Prefix length or Netmask"
 msgstr "前缀长度或网络掩码"
+
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
 
 #: pkg/networkmanager/interfaces.js:835
 msgid "Preparing"
@@ -5069,7 +5217,7 @@ msgstr "通过 ssh-add 提示超时"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "通过 ssh-keygen 提示超时"
 
-#: pkg/systemd/service-details.jsx:428
+#: pkg/systemd/service-details.jsx:432
 msgid "Propagates Reload To"
 msgstr "传播重新加载到"
 
@@ -5090,14 +5238,6 @@ msgstr "公开的拉取 repo"
 #: pkg/storaged/content-views.jsx:645
 msgid "Purpose"
 msgstr "目的"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "QEMU/KVM 系统连接"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "QEMU/KVM 用户连接"
 
 #: pkg/storaged/mdraid-details.jsx:185
 msgid "RAID ($0)"
@@ -5183,11 +5323,11 @@ msgstr "机架式机箱"
 msgid "Random"
 msgstr "随机"
 
-#: pkg/networkmanager/firewall.jsx:764
+#: pkg/networkmanager/firewall.jsx:789
 msgid "Range"
 msgstr "范围"
 
-#: pkg/networkmanager/firewall.jsx:370
+#: pkg/networkmanager/firewall.jsx:395
 msgid "Range must be strictly ordered"
 msgstr "范围必须排序"
 
@@ -5199,11 +5339,15 @@ msgstr "Rank"
 msgid "Raw to a device"
 msgstr "格式化设备"
 
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
 #: pkg/systemd/hwinfo.jsx:193
 msgid "Read more..."
 msgstr "了解更多..."
 
-#: pkg/systemd/service-details.jsx:382
+#: pkg/systemd/service-details.jsx:386
 msgid "Read-only"
 msgstr "只读"
 
@@ -5268,7 +5412,7 @@ msgstr "最近"
 msgid "Recommended default"
 msgstr "推荐的默认"
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:381 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "重新连接"
@@ -5305,15 +5449,15 @@ msgstr "拒绝连接。未知主机密钥"
 msgid "Register…"
 msgstr "注册…"
 
-#: pkg/systemd/service-details.jsx:185
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "重载"
 
-#: pkg/systemd/service-details.jsx:429
+#: pkg/systemd/service-details.jsx:433
 msgid "Reload Propagated From"
 msgstr "重新加载的传播来自"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:258
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "远程 URL"
 
@@ -5364,11 +5508,11 @@ msgstr "删除密码"
 msgid "Remove passphrase in $0?"
 msgstr "在 $0 中删除密码？"
 
-#: pkg/networkmanager/firewall.jsx:636
+#: pkg/networkmanager/firewall.jsx:661
 msgid "Remove service"
 msgstr "删除服务"
 
-#: pkg/networkmanager/firewall.jsx:615
+#: pkg/networkmanager/firewall.jsx:640
 msgid "Remove service from zones"
 msgstr "从区中删除服务"
 
@@ -5469,27 +5613,27 @@ msgstr "要求每 $0 天修改密码"
 msgid "Require password change on $0"
 msgstr "要求于 $0 修改密码"
 
-#: pkg/systemd/service-details.jsx:416
+#: pkg/systemd/service-details.jsx:420
 msgid "Required By"
 msgstr "要求的"
 
-#: pkg/systemd/service-details.jsx:368
+#: pkg/systemd/service-details.jsx:372
 msgid "Required by "
 msgstr "要求自"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:415
 msgid "Requires"
 msgstr "要求"
 
-#: pkg/systemd/service-details.jsx:383
+#: pkg/systemd/service-details.jsx:387
 msgid "Requires administration access to edit"
 msgstr "需要管理访问权限进行编辑"
 
-#: pkg/systemd/service-details.jsx:412
+#: pkg/systemd/service-details.jsx:416
 msgid "Requisite"
 msgstr "必要"
 
-#: pkg/systemd/service-details.jsx:417
+#: pkg/systemd/service-details.jsx:421
 msgid "Requisite Of"
 msgstr "必备的"
 
@@ -5526,7 +5670,7 @@ msgstr "对一个加密的文件系统调整大小需要解锁磁盘。请提供
 #: pkg/docker/index.html:138 pkg/systemd/index.html:134
 #: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
 #: pkg/machines/components/vm/vmActions.jsx:42
-#: pkg/systemd/service-details.jsx:176 pkg/systemd/shutdown.js:95
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
 #: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "重启"
@@ -5614,9 +5758,13 @@ msgstr "在主机引导时运行"
 msgid "Runner"
 msgstr "运行者"
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:347
+#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
 msgid "Running"
 msgstr "运行中"
+
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
+msgstr ""
 
 #: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
@@ -5686,7 +5834,7 @@ msgstr "星期六"
 msgid "Saturdays"
 msgstr "周六"
 
-#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:299
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
 #: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
@@ -5716,7 +5864,7 @@ msgid "Sealed-case PC"
 msgstr "密封式 PC"
 
 #: pkg/systemd/services.html:314 pkg/systemd/services.html:318
-#: pkg/systemd/init.js:890
+#: pkg/systemd/init.js:905
 msgid "Seconds"
 msgstr "秒"
 
@@ -5797,7 +5945,7 @@ msgstr "服务器关闭了连接。"
 msgid "Servers"
 msgstr "服务器"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:943
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:968
 #: pkg/storaged/dialog.jsx:1047
 msgid "Service"
 msgstr "服务"
@@ -5831,10 +5979,11 @@ msgid "Service name"
 msgstr "服务名称"
 
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "服务"
 
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
 #: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
 msgid "Session"
 msgstr "会话"
@@ -5842,6 +5991,10 @@ msgstr "会话"
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
 msgstr "设置"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:231
+msgid "Set DHCP Range"
+msgstr ""
 
 #: pkg/systemd/host.js:781
 msgid "Set Host name"
@@ -5900,7 +6053,7 @@ msgstr "Shell 脚本"
 msgid "Shift+Insert"
 msgstr "Shift+Insert"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:243
 msgid "Show Performance Options"
 msgstr "显示性能选项"
 
@@ -5946,8 +6099,8 @@ msgid "Single Rank"
 msgstr "Single Rank"
 
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:450
-#: pkg/machines/components/diskAdd.jsx:167
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
+#: pkg/machines/components/diskAdd.jsx:172
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
 #: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
@@ -5991,7 +6144,7 @@ msgstr "插槽 $0"
 msgid "Sockets"
 msgstr "套接字"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "软件更新"
 
@@ -6028,23 +6181,24 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr "某些其他程序正在使用软件包管理器，请等待..."
 
-#: pkg/networkmanager/firewall.jsx:714
+#: pkg/networkmanager/firewall.jsx:739
 msgid "Sorted from least trusted to most trusted"
 msgstr "按最不被信任到最被信任的顺序排序"
 
-#: pkg/machines/components/diskAdd.jsx:507
-#: pkg/machines/components/nicEdit.jsx:141
+#: pkg/machines/components/diskAdd.jsx:541
+#: pkg/machines/components/nicEdit.jsx:150
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:76
 #: pkg/machines/components/vmnetworktab.jsx:148
 msgid "Source"
 msgstr "源"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
 msgid "Source Format"
 msgstr "源格式"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
@@ -6054,12 +6208,16 @@ msgstr "源路径"
 msgid "Source URL"
 msgstr "源 URL"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
+msgid "Source Volume Group"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "源路径不能为空"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:148
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "源应该以 http、ftp 或 nfs 协议开头"
 
@@ -6092,8 +6250,9 @@ msgid "Stable"
 msgstr "稳定的"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
+#: pkg/machines/components/networks/createNetworkDialog.jsx:237
 #: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:180
+#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "启动"
 
@@ -6105,11 +6264,11 @@ msgstr "启动 Docker"
 msgid "Start Multipath"
 msgstr "启用多路径"
 
-#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:337
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
 msgid "Start Service"
 msgstr "启动服务"
 
-#: pkg/systemd/service-details.jsx:407
+#: pkg/systemd/service-details.jsx:411
 msgid "Start and Enable"
 msgstr "开始并启用"
 
@@ -6117,9 +6276,14 @@ msgstr "开始并启用"
 msgid "Start libvirt"
 msgstr "启动 libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
 msgstr "在主机引导时启动池"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:84
+msgid "Start should not be empty"
+msgstr ""
 
 #: pkg/storaged/jobs-panel.jsx:59
 msgid "Starting RAID Device $target"
@@ -6129,15 +6293,15 @@ msgstr "启动 RAID 设备 $target"
 msgid "Starting swapspace $target"
 msgstr "启动交换空间 $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "启动"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:50
 #: pkg/machines/components/storagePools/storagePoolList.jsx:49
 #: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:259 pkg/systemd/init.js:292
+#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
 msgid "State"
 msgstr "状态"
 
@@ -6146,11 +6310,11 @@ msgid "State:"
 msgstr "阶段："
 
 #: pkg/systemd/services.html:68 pkg/systemd/init.js:212
-#: pkg/systemd/service-details.jsx:365
+#: pkg/systemd/service-details.jsx:369
 msgid "Static"
 msgstr "静态"
 
-#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:472
+#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
 msgid "Status"
 msgstr "状态"
 
@@ -6165,7 +6329,7 @@ msgstr "Sticky"
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
 #: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
 #: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
-#: pkg/systemd/service-details.jsx:165
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "停止"
 
@@ -6173,7 +6337,7 @@ msgstr "停止"
 msgid "Stop Device"
 msgstr "停止设备"
 
-#: pkg/systemd/service-details.jsx:407
+#: pkg/systemd/service-details.jsx:411
 msgid "Stop and Disable"
 msgstr "停止并禁用"
 
@@ -6206,8 +6370,8 @@ msgid "Stopping swapspace $target"
 msgstr "停止启动交换空间 $target"
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "存储"
 
@@ -6223,11 +6387,11 @@ msgstr "存储池 $0 激活失败"
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr "存储池 $0 取消激活失败"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr "存储池名"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr "创建存储池失败"
 
@@ -6251,6 +6415,10 @@ msgstr "存储不能在这个系统上管理。"
 #: pkg/docker/index.html:304
 msgid "Storage pool"
 msgstr "存储池"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
+msgid "Storage size must not be 0"
+msgstr ""
 
 #: pkg/systemd/index.html:155
 msgid "Store Metrics"
@@ -6351,8 +6519,10 @@ msgstr "与 {{Server}} 同步"
 msgid "Synchronizing RAID Device $target"
 msgstr "同步 RAID 设备 $target"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "系统"
 
@@ -6385,7 +6555,7 @@ msgid "System is up to date"
 msgstr "系统已更新到最新"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:943
+#: pkg/networkmanager/firewall.jsx:968
 msgid "TCP"
 msgstr "TCP"
 
@@ -6413,12 +6583,12 @@ msgstr "Tang keyserver"
 msgid "Target"
 msgstr "目标"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "目标路径"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "目标路径不能为空"
 
@@ -6443,7 +6613,7 @@ msgstr "组端口设置"
 msgid "Team Settings"
 msgstr "组设置"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "终端"
 
@@ -6487,8 +6657,8 @@ msgstr "为了添加备用的磁盘，RAID 设备必须在运行。"
 msgid "The RAID device must be running in order to remove disks."
 msgstr "为了移除磁盘，RAID 设备必须在运行。"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:80
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:84
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:125
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:129
 msgid "The Storage Pool could not be deleted"
 msgstr "存储池不能被删除"
 
@@ -6556,7 +6726,7 @@ msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr "当前登录的用户不允许查看有关密钥的信息。"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "服务器上的目录被导出"
 
@@ -6616,7 +6786,7 @@ msgstr "不能删除一个卷组的最后一个物理卷。"
 msgid "The logged in user is not permitted to view system modifications"
 msgstr "登陆的用户没有权限查看系统改变"
 
-#: pkg/shell/indexes.js:407
+#: pkg/shell/indexes.js:413
 msgid "The machine is restarting"
 msgstr "正在重启主机"
 
@@ -6644,9 +6814,14 @@ msgstr "从 $time ($type) 开始的扫描没有找到漏洞。"
 msgid "The scan from $time ($type) was not successful."
 msgstr "从 $time ($type) 开始的扫描未成功。"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:165
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
 msgid "The selected Operating System has minimum memory requirement of $0 $1"
 msgstr "所选操作系统的最小内存要求是 $0 $1"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+msgid ""
+"The selected Operating System has minimum storage size requirement of $0 $1"
+msgstr ""
 
 #: src/ws/login.js:645
 msgid ""
@@ -6662,7 +6837,7 @@ msgstr "服务器拒绝使用任何支持的方式来验证。"
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr "用户 $0 没有权限修改 cpu 安全缓解方案设置"
 
-#: pkg/systemd/init.js:736
+#: pkg/systemd/init.js:751
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "用户 <b>$0</b> 没有权限创建定时器"
 
@@ -6746,7 +6921,7 @@ msgstr "此 NFS 挂载正在使用中，只能更改其选项。"
 msgid "This VDO device does not use all of its backing device."
 msgstr "此 VDO 设备不使用其所有后台设备。"
 
-#: pkg/systemd/init.js:1185
+#: pkg/systemd/init.js:1200
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -6790,7 +6965,7 @@ msgstr "该设备正在被卷组使用。继续进行将从卷组中移除它。
 msgid "This disk cannot be removed while the device is recovering."
 msgstr "当设备正在恢复时，该磁盘不能被移除。"
 
-#: pkg/systemd/init.js:1097 pkg/systemd/init.js:1111 pkg/systemd/init.js:1120
+#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
 msgid "This field cannot be empty."
 msgstr "该字段不能为空。"
 
@@ -6819,7 +6994,7 @@ msgstr "该软件包与该版本的 Cockpit 不兼容"
 msgid "This package requires Cockpit version %s or later"
 msgstr "该软件包需要  %s 版本或以后的 Cockpit"
 
-#: pkg/machines/components/diskAdd.jsx:210
+#: pkg/machines/components/diskAdd.jsx:215
 msgid "This pool type does not support Storage Volume creation"
 msgstr "这个池类型不支持创建存储卷"
 
@@ -6841,7 +7016,7 @@ msgid ""
 "this system for use with diagnosing problems with the system."
 msgstr "该工具会从该系统搜集系统配置和诊断信息用于诊断系统问题。"
 
-#: pkg/systemd/service-details.jsx:294
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "该单元没有设计为需要明确启用。"
 
@@ -6855,7 +7030,7 @@ msgid ""
 "alternate user or port"
 msgstr "该版本的 cockpit-ws 不支持连接到有交替的用户或端口的主机"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:443
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr "这个卷已被另外一个虚拟机使用"
 
@@ -6948,15 +7123,19 @@ msgstr "总大小：$0"
 msgid "Tower"
 msgstr "Tower"
 
-#: pkg/systemd/service-details.jsx:427
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:431
 msgid "Triggered By"
 msgstr "触发于"
 
-#: pkg/systemd/service-details.jsx:426
+#: pkg/systemd/service-details.jsx:430
 msgid "Triggers"
 msgstr "触发器"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:382 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "排错"
@@ -6965,7 +7144,7 @@ msgstr "排错"
 msgid "Trust key"
 msgstr "信任密钥"
 
-#: pkg/networkmanager/firewall.jsx:710
+#: pkg/networkmanager/firewall.jsx:735
 msgid "Trust level"
 msgstr "信任级别"
 
@@ -7010,8 +7189,8 @@ msgid "Tuned is off"
 msgstr "Tuned 已关闭"
 
 #: pkg/shell/index.html:265
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
@@ -7037,11 +7216,11 @@ msgstr "输入密码"
 msgid "Type to filter…"
 msgstr "输入内容来过滤…"
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:943
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:968
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:275
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "URL"
 
@@ -7107,11 +7286,15 @@ msgid "Unavailable"
 msgstr "不可用"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "意外的错误"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:188
+#: pkg/machines/components/networks/createNetworkDialog.jsx:128
+msgid "Unique Network Name"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "唯一名称"
 
@@ -7155,7 +7338,7 @@ msgstr "未知配置"
 msgid "Unknown host name"
 msgstr "未知主机名"
 
-#: pkg/networkmanager/firewall.jsx:333
+#: pkg/networkmanager/firewall.jsx:358
 msgid "Unknown service name"
 msgstr "未知的服务名"
 
@@ -7208,7 +7391,7 @@ msgstr "卸载 $target"
 msgid "Unnamed"
 msgstr "未命名"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:190
 msgid "Unplug"
 msgstr "拔"
 
@@ -7246,11 +7429,11 @@ msgstr "不可信的主机"
 msgid "Up since $0"
 msgstr "运行自 $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:462
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr "在默认位置中最多有 $0 $1可用"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:385
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr "在主机上最多有 $0 $1 可用"
 
@@ -7282,7 +7465,7 @@ msgstr "可用的更新"
 msgid "Updating"
 msgstr "更新"
 
-#: pkg/systemd/service-details.jsx:402
+#: pkg/systemd/service-details.jsx:406
 msgid "Updating status..."
 msgstr "更新状态 ..."
 
@@ -7299,7 +7482,7 @@ msgstr[0] "使用 $0 CPU 内核"
 msgid "Use 512 Byte emulation"
 msgstr "使用 512 字节模拟"
 
-#: pkg/machines/components/diskAdd.jsx:527
+#: pkg/machines/components/diskAdd.jsx:561
 msgid "Use Existing"
 msgstr "使用现有的"
 
@@ -7417,7 +7600,7 @@ msgstr "VM $0 强制关闭失败"
 msgid "VM $0 failed to get deleted"
 msgstr "VM $0 删除失败"
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1304
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
 msgid "VM $0 failed to get installed"
 msgstr "VM $0 安装失败"
 
@@ -7495,19 +7678,23 @@ msgstr "版本"
 msgid "Very securely erasing $target"
 msgstr "非常安全地擦除 $target"
 
-#: pkg/lib/cockpit-components-modifications.jsx:174
+#: pkg/lib/cockpit-components-modifications.jsx:173
 msgid "View automation script"
 msgstr "查看自动化脚本"
 
-#: pkg/machines/components/networks/networkList.jsx:39
+#: pkg/machines/components/networks/networkList.jsx:42
 #: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "虚拟机"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
 msgstr "虚拟网络"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:422
+msgid "Virtual Network failed to be created"
+msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:80
 msgid "Virtualization Service (libvirt) is Not Active"
@@ -7517,7 +7704,7 @@ msgstr "虚拟化服务（libvirt）未激活"
 msgid "Virtualization Service is Available"
 msgstr "虚拟化服务可用"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:433
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:89
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
@@ -7533,6 +7720,14 @@ msgstr "卷组"
 #: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
 msgid "Volume Group $0"
 msgstr "卷组 $0"
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
+msgid "Volume Group name"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+msgid "Volume Group name should not be empty"
+msgstr ""
 
 #: pkg/storaged/vgroups-panel.jsx:113
 msgid "Volume Groups"
@@ -7573,11 +7768,11 @@ msgstr "正在等待其他程序来结束使用中的软件包管理器"
 msgid "Waiting for other software management operations to finish"
 msgstr "等待其他软件管理操作完成"
 
-#: pkg/systemd/service-details.jsx:418
+#: pkg/systemd/service-details.jsx:422
 msgid "Wanted By"
 msgstr "需要于"
 
-#: pkg/systemd/service-details.jsx:413
+#: pkg/systemd/service-details.jsx:417
 msgid "Wants"
 msgstr "需要"
 
@@ -7644,8 +7839,8 @@ msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr "您当前已直接连接到该服务器。您不能删除它。"
 
-#: pkg/networkmanager/firewall.jsx:70 pkg/networkmanager/firewall.jsx:116
-#: pkg/networkmanager/firewall.jsx:878 pkg/networkmanager/firewall.jsx:884
+#: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
+#: pkg/networkmanager/firewall.jsx:903 pkg/networkmanager/firewall.jsx:909
 msgid "You are not authorized to modify the firewall."
 msgstr "您无权修改防火墙。"
 
@@ -7663,10 +7858,9 @@ msgstr "您没有权限管理 Docker 存储池"
 msgid "You must wait longer to change your password"
 msgstr "您需要等待更长时间来修改您的密码"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:129
-msgid ""
-"You need to select the most closely matching OS vendor and Operating System"
-msgstr "您需要选择最接近的 OS 厂商和操作系统"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
+msgid "You need to select the most closely matching Operating System"
+msgstr ""
 
 #: pkg/packagekit/updates.jsx:836
 msgid ""
@@ -7688,11 +7882,11 @@ msgstr "会话被终止。"
 msgid "Your session has expired. Please log in again."
 msgstr "会话超时。请重新登录。"
 
-#: pkg/networkmanager/firewall.jsx:930
+#: pkg/networkmanager/firewall.jsx:955
 msgid "Zone"
 msgstr "区域"
 
-#: pkg/networkmanager/firewall.jsx:943
+#: pkg/networkmanager/firewall.jsx:968
 msgid "Zones"
 msgstr "区域"
 
@@ -7815,11 +8009,11 @@ msgstr "主机设备"
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr "iSCSI Initiator IQN"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr "iSCSI 目标"
 
@@ -7827,11 +8021,11 @@ msgstr "iSCSI 目标"
 msgid "iSCSI Targets"
 msgstr "iSCSI 目标"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:83
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr "iSCSI 直接目标"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr "iSCSI 目标 IQN"
 
@@ -7877,8 +8071,8 @@ msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs dump 目标的格式不是 server:path"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "否"
@@ -7897,14 +8091,6 @@ msgstr[0] "$0 CPU 内核"
 #: pkg/machines/helpers.js:190
 msgid "paused"
 msgstr "已暂停"
-
-#: pkg/machines/components/diskAdd.jsx:154
-msgid "qcow2"
-msgstr "qcow2"
-
-#: pkg/machines/components/diskAdd.jsx:157
-msgid "raw"
-msgstr "raw"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -7995,7 +8181,7 @@ msgid "undefined"
 msgstr "未定义"
 
 #: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:254 pkg/systemd/init.js:268
+#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
 msgid "unknown"
 msgstr "未知"
 
@@ -8035,15 +8221,15 @@ msgstr "值"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:804
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr "为了创建新虚拟机需要在系统上安装 virt-install 软件包"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
 #: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "是"


### PR DESCRIPTION
`html2po` does the same.
Noticed on #12617, from logs it executes `bots/make-source update-po`

Works both with : 
- `bots/make-source update-po` (how bots do it on refresh)
- `./autogen && make po-update` (how normally one would do it locally)

Hopefully this can be tests:
 * [x] po-refresh