### PR TITLE
packagekit, systemd: Use notifications for available updates info

### DIFF
--- a/pkg/packagekit/manifest.json.in
+++ b/pkg/packagekit/manifest.json.in
@@ -7,10 +7,12 @@
     },
 
     "tools": {
-        "updates": {
-            "label": "Software Updates",
-            "path": "index.html"
+        "index": {
+            "label": "Software Updates"
         }
     },
-  "content-security-policy": "default-src 'self'; img-src 'self' data:; font-src 'self' data:;"
+
+    "preload": [ "index" ],
+
+    "content-security-policy": "default-src 'self'; img-src 'self' data:; font-src 'self' data:;"
 }

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -278,13 +278,8 @@ body {
     word-wrap: break-word;
 }
 
-.system-information-updates > .fa,
-.system-information-updates > .spinner {
+.system-information-updates > .fa {
     line-height: inherit;
-}
-.system-information-updates > .spinner {
-    /* Offset for alignment: 3px = 16px - 12px height - 1px border */
-    margin: 3px 0 0;
 }
 
 #system_machine_id {

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -100,7 +100,7 @@
 
                 <div role="group" class="system-information-updates">
                   <div>
-                    <span id="system_information_updates_icon" hidden></span>
+                    <span id="system_information_updates_icon"></span>
                     <span id="system_information_updates_text"></span>
                   </div>
                   <br>

--- a/test/verify/check-active-pages
+++ b/test/verify/check-active-pages
@@ -29,12 +29,15 @@ class TestActivePages(MachineCase):
 
         self.login_and_go("/system")
 
-        # Preloading of playground/preloaded only happens with #12534
+        # Preloading via manifests only happens with #12534
         if m.image in [ "rhel-8-1-distropkg" ]:
             n_extra_preloaded = 0
-        else:
-            # playground/preloaded and system/services
+        elif "atomic" in m.image:
+            # /playground/preloaded and /system/services
             n_extra_preloaded = 2
+        else:
+            # /playground/preloaded, /system/services, and /updates
+            n_extra_preloaded = 3
 
         b.wait_present("#server")
 

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -88,6 +88,14 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
         b = self.browser
         m = self.machine
 
+        # HACK - There is something about page pre-loading that breaks
+        # the CDP of Chromium completely, so we avoid packagekit
+        # completely on machine2.
+        #
+        machine2 = self.machines["machine2"]
+        machine2.needs_writable_usr()
+        machine2.execute("rm -rf /usr/share/cockpit/packagekit")
+
         self.login_and_go("/dashboard")
 
         self.wait_dashboard_addresses(b, ["localhost"])

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -107,6 +107,13 @@ class TestMultiMachineKeyAuth(MachineCase):
             "( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service", direct=True)
         self.machine2.wait_execute()
 
+        # HACK - There is something about page pre-loading that breaks
+        # the CDP of Chromium completely, so we avoid packagekit
+        # completely on machine2.
+        #
+        self.machine2.needs_writable_usr()
+        self.machine2.execute("rm -rf /usr/share/cockpit/packagekit")
+
     def testBasic(self):
         b = self.browser
         m1 = self.machine

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -160,8 +160,7 @@ class TestUpdates(PackageCase):
         b.go("/system")
         b.enter_page("/system")
         self.wait_checking_updates()
-        # PackageKit's dnf backend misparses severities (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
-        if self.backend == "dnf":
+        if m.image == "rhel-8-1-distropkg": #12620
             b.wait_text("#system_information_updates_text", "Updates Available")
         else:
             b.wait_text("#system_information_updates_text", "Bug Fix Updates Available")
@@ -322,13 +321,8 @@ class TestUpdates(PackageCase):
         b.go("/system")
         b.enter_page("/system")
         self.wait_checking_updates()
-        if self.backend == 'dnf':
-            # PackageKit's dnf backend mis-parses severity (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
+        if m.image == "rhel-8-1-distropkg": #12620
             b.wait_text("#system_information_updates_text", "Updates Available")
-            self.assertIn("bug", b.attr("#system_information_updates_icon", "class"))
-        elif self.backend == 'apt':
-            # PackageKit's deb backend always reports "normal"
-            b.wait_text("#system_information_updates_text", "Bug Fix Updates Available")
             self.assertIn("bug", b.attr("#system_information_updates_icon", "class"))
         else:
             b.wait_text("#system_information_updates_text", "Security Updates Available")
@@ -631,8 +625,6 @@ class TestUpdates(PackageCase):
                      rm /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service
                      systemctl daemon-reload''')
 
-        self.allow_browser_errors("loading available updates failed:.*not-found")
-
         m.start_cockpit()
         b.login_and_go("/updates")
 
@@ -642,8 +634,12 @@ class TestUpdates(PackageCase):
         # update status on front page should be invisible
         b.go("/system")
         b.enter_page("/system")
-        b.wait_not_visible("#system_information_updates_text")
-        self.assertEqual(b.attr("#system_information_updates_icon", "class"), "")
+        if m.image == "rhel-8-1-distropkg": #12620
+            b.wait_not_visible("#system_information_updates_text")
+            self.assertEqual(b.attr("#system_information_updates_icon", "class"), "")
+        else:
+            b.wait_text("#system_information_updates_text", "Loading available updates failed")
+            self.assertIn("exclamation", b.attr("#system_information_updates_icon", "class"))
 
 
 @skipImage("Image uses OSTree", "fedora-atomic")
@@ -772,8 +768,7 @@ class TestUpdatesSubscriptions(PackageCase):
         # show available updates on system page too
         b.go("/system")
         b.enter_page("/system")
-        # PackageKit's dnf backend misparses severities (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
-        if self.backend == "dnf":
+        if m.image == "rhel-8-1-distropkg": #12620
             b.wait_text("#system_information_updates_text", "Updates Available")
         else:
             b.wait_text("#system_information_updates_text", "Bug Fix Updates Available")


### PR DESCRIPTION
Now the host overview page gets all information about available
software updates from the "Software Updates" page itself, via page
status notifications.