### PR TITLE
naughty: Close 12086: rhel-8-1 Adding service into permanent configuration via DBus api suddenly requires 9 values

### DIFF
--- a/bots/naughty/rhel-8/12086-firewall-addservice-fails
+++ b/bots/naughty/rhel-8/12086-firewall-addservice-fails
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-networking-firewall", line *, in testAddCustomServices
-    save("custom--https-irc-50000", "https, irc, 50000", "443", "194, 50000")


### PR DESCRIPTION
Known issue which has not occurred in 25 days

rhel-8-1 Adding service into permanent configuration via DBus api suddenly requires 9 values

Fixes #12086