### PR TITLE
machines: Some small fixes related to storage pools

### DIFF
--- a/pkg/machines/components/storagePools/storagePool.jsx
+++ b/pkg/machines/components/storagePools/storagePool.jsx
@@ -60,7 +60,7 @@ export class StoragePool extends React.Component {
         );
         const sizeLabel = (
             <React.Fragment>
-                {`${allocation} / ${capacity} GB`}
+                {`${allocation} / ${capacity} GiB`}
             </React.Fragment>
         );
         const state = (

--- a/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
+++ b/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
@@ -101,7 +101,7 @@ export class StoragePoolVolumesTab extends React.Component {
                             { name: (<div id={`${storagePoolIdPrefix}-volume-${volume.name}-usedby`}>{(isVolumeUsed[volume.name] || []).join(', ')}</div>), }
                         );
                         columns.push(
-                            { name: (<div id={`${storagePoolIdPrefix}-volume-${volume.name}-size`}>{`${allocation} / ${capacity} GB`}</div>), }
+                            { name: (<div id={`${storagePoolIdPrefix}-volume-${volume.name}-size`}>{`${allocation} / ${capacity} GiB`}</div>), }
                         );
                         let selectCallback = this.selectedChanged.bind(this, volume.name);
 

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -305,7 +305,10 @@ LIBVIRT_DBUS_PROVIDER = {
 
         return (dispatch) => call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'StoragePoolLookupByName', [poolName], TIMEOUT)
                 .then((storagePoolPath) => {
-                    return call(connectionName, storagePoolPath[0], 'org.libvirt.StoragePool', 'StorageVolCreateXML', [volXmlDesc, 0], TIMEOUT);
+                    return call(connectionName, storagePoolPath[0], 'org.libvirt.StoragePool', 'StorageVolCreateXML', [volXmlDesc, 0], TIMEOUT)
+                            .then(() => {
+                                return storagePoolRefresh(connectionName, storagePoolPath[0]);
+                            });
                 })
                 .then((volPath) => {
                     return dispatch(attachDisk({ connectionName, poolName, volumeName, format, target, vmId, permanent, hotplug, cacheMode }));

--- a/pkg/machines/xmlCreator.js
+++ b/pkg/machines/xmlCreator.js
@@ -104,7 +104,7 @@ export function getVolumeXML(volumeName, size, format, target) {
     volElem.appendChild(nameElem);
 
     var allocationElem = doc.createElement('capacity');
-    allocationElem.setAttribute('unit', 'MB');
+    allocationElem.setAttribute('unit', 'MiB');
     allocationElem.appendChild(doc.createTextNode(size));
     volElem.appendChild(allocationElem);
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -686,6 +686,21 @@ class TestMachines(NetworkCase):
                 b.wait_in_text("#vm-{0}-disks-{1}-bus".format(self.vm_name, self.expected_target), "virtio")
                 b.wait_in_text("#vm-{0}-disks-{1}-device".format(self.vm_name, self.expected_target), "disk")
 
+                # Check volume was added to pool's volume list
+                if self.test_obj.provider == "libvirt-dbus" and not self.use_existing_volume:
+                    b.click(".cards-pf .card-pf-title span:contains(Storage Pools)")
+
+                    b.wait_present("tbody tr[data-row-id=pool-{0}-system] th".format(self.pool_name))
+                    b.click("tbody tr[data-row-id=pool-{0}-system] th".format(self.pool_name))
+
+                    b.wait_present("#pool-{0}-system-storage-volumes".format(self.pool_name))
+                    b.click("#pool-{0}-system-storage-volumes".format(self.pool_name)) # open the "Storage Volumes" subtab
+                    b.wait_present("#pool-{0}-system-volume-{1}-name".format(self.pool_name, self.volume_name))
+
+                    b.click(".machines-listing-breadcrumb li a:contains(Virtual Machines)")
+                    b.click("tbody tr[data-row-id=vm-subVmTest1] th")
+                    b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
+
                 # Detect volume format
                 detect_format_cmd = "virsh vol-dumpxml {0} {1} | xmllint --xpath '/volume/target/format' -".format(self.volume_name, self.pool_name)
 


### PR DESCRIPTION
**Refresh pool after volume has been created during disk attachment**
When user creates a new disk in Add Disk dialog, pool would not get refreshed. In order to show new volume in pool's volume list in Storage Pools page, user has to reload the page. Fix this by refreshing pool after creating volume.
￼
**Fix size units confusion for storage pools and volumes**
When creating disk, we incorrectly label size as MB instead of MiB, which leads libvirt to create volume of incorrect size. (e.g. when user inputted 1GiB as disk size, disk of 0.95GiB would get created). Also we incorrectly show GB value for storage pool size and storage
volume in Storage Pools page.