### PR TITLE
bots: When unknown branch do not trigger any contexts

### DIFF
--- a/bots/tests-scan
+++ b/bots/tests-scan
@@ -365,7 +365,7 @@ def cockpit_tasks(api, update, branch_contexts, repo, pull_data, pull_number, sh
             if is_valid_context(status):
                 todos[status] = statuses[status]
         if not statuses: # If none defined in github add basic set of contexts
-            for context in branch_contexts.get(base, contexts):
+            for context in branch_contexts.get(base, []):
                 todos[context] = {}
         if trigger_externals():
             for context in get_externals():


### PR DESCRIPTION
Fixes #12633

@Gundersanne can you think of any usecase where we want all contexts when the branch does not exist in our map? I have small voice in back of my head saying something about external projects, but I cannot find any usecase where this would be true.