### PR TITLE
storage: Remove support for old versions of UDisks2

### DIFF
--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -87,13 +87,9 @@ class TestStorage(StorageCase):
 
         check_type("xfs", 12)
         check_type("ext4", 16)
+        check_type("vfat", 11)
 
-        if self.storaged_is_old_udisks:
-            check_unsupported_type("vfat")
-        else:
-            check_type("vfat", 11)
-
-        if self.storaged_is_old_udisks or m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
+        if m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
             check_unsupported_type("ntfs")
         else:
             check_type("ntfs", 128)

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -53,79 +53,68 @@ class TestStorage(StorageCase):
         self.dialog_set_val("name", "ENCRYPTED")
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
-        if not self.storaged_is_old_udisks:
-            self.dialog_set_val("crypto_options.store_passphrase", True)
-            self.dialog_set_val("crypto_options.extra", "crypto,options")
-            self.dialog_set_val("mounting", "custom")
-            self.dialog_set_val("mount_point", mount_point_secret)
+        self.dialog_set_val("crypto_options.store_passphrase", True)
+        self.dialog_set_val("crypto_options.extra", "crypto,options")
+        self.dialog_set_val("mounting", "custom")
+        self.dialog_set_val("mount_point", mount_point_secret)
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 1, "Encrypted data")
         self.content_row_wait_in_col(2, 1, "ext4 File System")
 
-        if not self.storaged_is_old_udisks:
-            self.wait_in_storaged_configuration(mount_point_secret)
-            self.wait_in_storaged_configuration("crypto,options")
-            # HACK: Put /etc/crypttab in the journal, in order to debug updating issues
-            assert m.execute("cat /etc/crypttab | logger -s 2>&1 | grep 'UUID='") != ""
-            assert m.execute("grep %s /etc/fstab" % mount_point_secret) != ""
-            assert m.execute("cat /etc/luks-keys/*") == "vainu-reku-toma-rolle-kaja"
+        self.wait_in_storaged_configuration(mount_point_secret)
+        self.wait_in_storaged_configuration("crypto,options")
+        # HACK: Put /etc/crypttab in the journal, in order to debug updating issues
+        assert m.execute("cat /etc/crypttab | logger -s 2>&1 | grep 'UUID='") != ""
+        assert m.execute("grep %s /etc/fstab" % mount_point_secret) != ""
+        assert m.execute("cat /etc/luks-keys/*") == "vainu-reku-toma-rolle-kaja"
 
         # Lock it
         self.content_head_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "ext4 File System")
 
-        if not self.storaged_is_old_udisks:
+        # Unlock, this uses the stored passphrase
+        self.content_head_action(1, "Unlock")
+        self.content_row_wait_in_col(2, 1, "ext4 File System")
 
-            # Unlock, this uses the stored passphrase
-            self.content_head_action(1, "Unlock")
-            self.content_row_wait_in_col(2, 1, "ext4 File System")
+        # Change options.  We keep trying until the stack has synched
+        # up with crypttab and we see the old options.
+        self.dialog_with_retry(trigger=lambda: self.content_tab_info_action(1, 2, "Options"),
+                               expect={"crypto_options.extra": "crypto,options"},
+                               values={"crypto_options.extra": "weird,options"})
 
-            # Change options.  We keep trying until the stack has synched
-            # up with crypttab and we see the old options.
-            self.dialog_with_retry(trigger=lambda: self.content_tab_info_action(1, 2, "Options"),
-                                   expect={"crypto_options.extra": "crypto,options"},
-                                   values={"crypto_options.extra": "weird,options"})
+        assert m.execute("grep 'weird,options' /etc/crypttab") != ""
+        self.wait_in_storaged_configuration("weird,options")
 
-            assert m.execute("grep 'weird,options' /etc/crypttab") != ""
-            self.wait_in_storaged_configuration("weird,options")
+        # Change passphrase
+        edit_button = self.content_tab_info_label(1, 2, "Stored passphrase") + " + div button"
+        self.dialog_with_retry(trigger=lambda: b.click(edit_button),
+                               expect={"passphrase": "vainu-reku-toma-rolle-kaja"},
+                               values={"passphrase": "wrong-passphrase"})
 
-            # Change passphrase
-            edit_button = self.content_tab_info_label(1, 2, "Stored passphrase") + " + div button"
-            self.dialog_with_retry(trigger=lambda: b.click(edit_button),
-                                   expect={"passphrase": "vainu-reku-toma-rolle-kaja"},
-                                   values={"passphrase": "wrong-passphrase"})
+        assert m.execute("cat /etc/luks-keys/*") == "wrong-passphrase"
 
-            assert m.execute("cat /etc/luks-keys/*") == "wrong-passphrase"
+        # Remove passphrase
+        edit_button = self.content_tab_info_label(1, 2, "Stored passphrase") + " + div button"
+        self.dialog_with_retry(trigger=lambda: b.click(edit_button),
+                               expect={"passphrase": "wrong-passphrase"},
+                               values={"passphrase": ""})
+        self.wait_in_storaged_configuration("'passphrase-path': <b''>")
 
-            # Remove passphrase
-            edit_button = self.content_tab_info_label(1, 2, "Stored passphrase") + " + div button"
-            self.dialog_with_retry(trigger=lambda: b.click(edit_button),
-                                   expect={"passphrase": "wrong-passphrase"},
-                                   values={"passphrase": ""})
-            self.wait_in_storaged_configuration("'passphrase-path': <b''>")
+        # Lock it
+        self.content_head_action(1, "Lock")
+        b.wait_not_in_text("#detail-content", "ext4 File System")
 
-            # Lock it
-            self.content_head_action(1, "Lock")
-            b.wait_not_in_text("#detail-content", "ext4 File System")
+        # Unlock, this asks for a passphrase
+        self.content_head_action(1, "Unlock")
+        self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
+        self.content_row_wait_in_col(2, 1, "ext4 File System")
 
-            # Unlock, this asks for a passphrase
-            self.content_head_action(1, "Unlock")
-            self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-            self.content_row_wait_in_col(2, 1, "ext4 File System")
-
-            # Delete the partition.
-            self.content_head_action(1, "Delete")
-            self.confirm()
-            self.content_row_wait_in_col(1, 1, "Free Space")
-            b.wait_not_in_text("#detail-content", "ext4 File System")
-
-        else:
-
-            # Unlock, this asks for a passphrase because we don't store one with older UDisks2.
-            self.content_head_action(1, "Unlock")
-            self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-            self.content_row_wait_in_col(2, 1, "ext4 File System")
+        # Delete the partition.
+        self.content_head_action(1, "Delete")
+        self.confirm()
+        self.content_row_wait_in_col(1, 1, "Free Space")
+        b.wait_not_in_text("#detail-content", "ext4 File System")
 
         assert m.execute("grep -v ^# /etc/crypttab || true").strip() == ""
         assert m.execute("grep %s /etc/fstab || true" % mount_point_secret) == ""

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -40,14 +40,8 @@ class TestStorage(StorageCase):
         m = self.machine
         b = self.browser
 
-        if not self.storaged_is_old_udisks:
-            mount_point_foo = "/run/foo"
-            mount_point_bar = "/run/bar"
-        else:
-            # We don't get to set the mountpoint with old UDisks so we
-            # expect UDisks default.  (XXX - I think this is Ubuntu specific.)
-            mount_point_foo = self.mount_root + "/admin/FILESYSTEM"
-            mount_point_bar = self.mount_root + "/admin/FILESYSTEM"
+        mount_point_foo = "/run/foo"
+        mount_point_bar = "/run/bar"
 
         self.login_and_go("/storage")
 
@@ -63,37 +57,30 @@ class TestStorage(StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val("type", "ext4")
         self.dialog_set_val("name", "FILESYSTEM")
-        if not self.storaged_is_old_udisks:
-            self.dialog_set_val("mounting", "custom")
-            self.dialog_set_val("mount_point", mount_point_foo)
+        self.dialog_set_val("mounting", "custom")
+        self.dialog_set_val("mount_point", mount_point_foo)
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 1, "ext4 File System")
         self.content_tab_wait_in_info(1, 1, "Name", "FILESYSTEM")
-        if not self.storaged_is_old_udisks:
-            self.wait_in_storaged_configuration(mount_point_foo)
+        self.wait_in_storaged_configuration(mount_point_foo)
 
-        if not self.storaged_is_old_udisks:
-            self.content_tab_wait_in_info(1, 1, "Mount Point", mount_point_foo)
+        self.content_tab_wait_in_info(1, 1, "Mount Point", mount_point_foo)
         self.content_tab_action(1, 1, "Mount")
         self.content_tab_wait_in_info(1, 1, "Mounted At", mount_point_foo)
 
         self.content_tab_action(1, 1, "Unmount")
-        if not self.storaged_is_old_udisks:
-            b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
+        b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
 
         self.content_tab_info_action(1, 1, "Name")
         self.dialog({"name": "filesystem"})
         self.content_tab_wait_in_info(1, 1, "Name", "filesystem")
 
-        if not self.storaged_is_old_udisks:
-            self.dialog_with_retry(trigger=lambda: self.content_tab_info_action(1, 1, "Mount Point", wrapped=True),
-                                   expect={"mounting": "custom",
-                                           "mount_point": mount_point_foo},
-                                   values={"mount_point": mount_point_bar})
-            self.wait_in_storaged_configuration(mount_point_bar)
-        else:
-            mount_point_bar = self.mount_root + "/admin/filesystem"
+        self.dialog_with_retry(trigger=lambda: self.content_tab_info_action(1, 1, "Mount Point", wrapped=True),
+                               expect={"mounting": "custom",
+                                       "mount_point": mount_point_foo},
+                               values={"mount_point": mount_point_bar})
+        self.wait_in_storaged_configuration(mount_point_bar)
 
         self.content_tab_action(1, 1, "Mount")
         self.content_tab_wait_in_info(1, 1, "Mounted At", mount_point_bar)
@@ -129,17 +116,16 @@ class TestStorage(StorageCase):
 
         wait_info_field_value("Serial Number", "MYDISK")
 
-        if not self.storaged_is_old_udisks:
-            b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
-            self.content_tab_info_action(1, 1, "Mount Point", wrapped=True)
-            self.dialog(values={"mounting": "default"})
-            self.wait_not_in_storaged_configuration(mount_point_bar)
+        b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
+        self.content_tab_info_action(1, 1, "Mount Point", wrapped=True)
+        self.dialog(values={"mounting": "default"})
+        self.wait_not_in_storaged_configuration(mount_point_bar)
 
-            self.content_tab_action(1, 1, "Mount")
-            self.content_tab_wait_in_info(1, 1, "Mounted At", self.mount_root + "/admin/filesystem")
+        self.content_tab_action(1, 1, "Mount")
+        self.content_tab_wait_in_info(1, 1, "Mounted At", self.mount_root + "/admin/filesystem")
 
-            self.content_tab_action(1, 1, "Unmount")
-            b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
+        self.content_tab_action(1, 1, "Unmount")
+        b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
 
         self.content_head_action(1, "Format")
         self.dialog({"type": "empty"})
@@ -148,9 +134,6 @@ class TestStorage(StorageCase):
     def testMountOptions(self):
         m = self.machine
         b = self.browser
-
-        if self.storaged_is_old_udisks:
-            self.skipTest("No mount/crypto options with old UDisks")
 
         self.login_and_go("/storage")
 

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -54,10 +54,6 @@ class TestStorage(StorageCase):
         self.dialog_cancel()
         self.dialog_wait_close()
 
-        # Further tear down doesn't work with the old UDisks2
-        if self.storaged_is_old_udisks:
-            return
-
         self.content_head_action(1, "Delete")
         self.dialog_wait_open()
         b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -44,7 +44,8 @@ class StorageCase(MachineCase):
         else:
             self.storaged_version = [0]
 
-        self.storaged_is_old_udisks = ("udisksctl" in self.storagectl_cmd and self.storaged_version < [2, 6, 0])
+        # We don't support old UDisks2 anymore
+        self.assertFalse("udisksctl" in self.storagectl_cmd and self.storaged_version < [2, 6, 0])
 
         if "debian" in self.machine.image or "ubuntu" in self.machine.image:
             # Debian's udisks has a patch to use FHS /media directory


### PR DESCRIPTION
We now require at least UDisks2 version 2.7, which can clean out fstab
recursively.

This PR is mainly to see what happens, in preparation to the removal of the "Default" mounting option.

- [ ] Remove the actual code, not just the test branches.