### PR TITLE
storage: No default mounting

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -863,4 +863,21 @@ client.init = function init_storaged(callback) {
     });
 };
 
+client.wait_for = function wait_for(cond) {
+    var dfd = cockpit.defer();
+
+    function check() {
+        var res = cond();
+        if (res) {
+            client.removeEventListener("changed", check);
+            dfd.resolve(res);
+        }
+    }
+
+    client.addEventListener("changed", check);
+    check();
+
+    return dfd.promise();
+};
+
 export default client;

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -452,6 +452,9 @@ export const dialog_open = (def) => {
             });
         },
 
+        close: () => {
+            dlg.footerProps.dialog_done();
+        }
     };
 
     return self;

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -18,15 +18,271 @@
  */
 
 import React from "react";
+import { Alert } from "@patternfly/react-core";
 
 import cockpit from "cockpit";
 import * as utils from "./utils.js";
 
-import { dialog_open, TextInput } from "./dialog.jsx";
+import { dialog_open, TextInput, CheckBoxes } from "./dialog.jsx";
 import { StorageButton, StorageLink } from "./storage-controls.jsx";
-import * as FormatDialog from "./format-dialog.jsx";
+import { initial_tab_options, parse_options, unparse_options, extract_option } from "./format-dialog.jsx";
 
 const _ = cockpit.gettext;
+
+export function is_mounted(client, block) {
+    const block_fsys = client.blocks_fsys[block.path];
+    const mounted_at = block_fsys ? block_fsys.MountPoints : [];
+    const config = utils.array_find(block.Configuration, function (c) { return c[0] == "fstab" });
+    if (config && config[1].dir.v) {
+        let dir = utils.decode_filename(config[1].dir.v);
+        if (dir[0] != "/")
+            dir = "/" + dir;
+        return mounted_at.map(utils.decode_filename).indexOf(dir) >= 0;
+    } else
+        return null;
+}
+
+export function get_fstab_config(block) {
+    const config = utils.array_find(block.Configuration, function (c) { return c[0] == "fstab" });
+    if (config) {
+        let dir = utils.decode_filename(config[1].dir.v);
+        const opts = (utils.decode_filename(config[1].opts.v)
+                .split(",")
+                .filter(function (s) { return s.indexOf("x-parent") !== 0 })
+                .join(","));
+        const parents = (utils.decode_filename(config[1].opts.v)
+                .split(",")
+                .filter(function (s) { return s.indexOf("x-parent") === 0 })
+                .join(","));
+        if (dir[0] != "/")
+            dir = "/" + dir;
+        return [config, dir, opts, parents];
+    } else
+        return [];
+}
+
+export function check_mismounted_fsys(client, path, enter_warning) {
+    const block = client.blocks[path];
+    const block_fsys = client.blocks_fsys[path];
+
+    if (!block || !block_fsys)
+        return;
+
+    const mounted_at = block_fsys ? block_fsys.MountPoints.map(utils.decode_filename) : [];
+    const [, dir, opts] = get_fstab_config(block);
+    const split_options = parse_options(opts);
+    const opt_noauto = extract_option(split_options, "noauto");
+    const is_mounted = mounted_at.indexOf(dir) >= 0;
+    const other_mounts = mounted_at.filter(m => m != dir);
+
+    let type;
+    if (dir) {
+        if (!is_mounted && other_mounts.length > 0) {
+            if (!opt_noauto)
+                type = "change-mount-on-boot";
+            else
+                type = "mounted-no-config";
+        } else if (!is_mounted && !opt_noauto)
+            type = "mount-on-boot";
+        else if (is_mounted && opt_noauto)
+            type = "no-mount-on-boot";
+    } else if (other_mounts.length > 0) {
+        type = "mounted-no-config";
+    }
+
+    if (type)
+        enter_warning(path, { warning: "mismounted-fsys", type: type, other: other_mounts[0] });
+}
+
+export function mounting_dialog(client, block, mode) {
+    const block_fsys = client.blocks_fsys[block.path];
+    var [old_config, old_dir, old_opts, old_parents] = get_fstab_config(block);
+    var options = old_config ? old_opts : initial_tab_options(client, block, true);
+
+    var split_options = parse_options(options == "defaults" ? "" : options);
+    var opt_noauto = extract_option(split_options, "noauto");
+    var opt_ro = extract_option(split_options, "ro");
+    var extra_options = unparse_options(split_options);
+
+    var is_filesystem_mounted = is_mounted(client, block);
+
+    function maybe_update_config(new_dir, new_opts) {
+        var new_config = null;
+        var all_new_opts;
+
+        if (old_config) {
+            if (new_opts && old_parents)
+                all_new_opts = new_opts + "," + old_parents;
+            else if (new_opts)
+                all_new_opts = new_opts;
+            else
+                all_new_opts = old_parents;
+        }
+
+        if (new_dir != "") {
+            if (new_dir[0] != "/")
+                new_dir = "/" + new_dir;
+            new_config = [
+                "fstab", {
+                    fsname: old_config ? old_config[1].fsname : undefined,
+                    dir: { t: 'ay', v: utils.encode_filename(new_dir) },
+                    type: { t: 'ay', v: utils.encode_filename("auto") },
+                    opts: { t: 'ay', v: utils.encode_filename(all_new_opts || "defaults") },
+                    freq: { t: 'i', v: 0 },
+                    passno: { t: 'i', v: 0 },
+                    "track-parents": { t: 'b', v: !old_config }
+                }];
+        }
+
+        function undo() {
+            if (!old_config && new_config)
+                return block.RemoveConfigurationItem(new_config, {});
+            else if (old_config && !new_config)
+                return block.AddConfigurationItem(old_config, {});
+            else if (old_config && new_config && (new_dir != old_dir || new_opts != old_opts)) {
+                return block.UpdateConfigurationItem(new_config, old_config, {});
+            }
+        }
+
+        function maybe_unmount() {
+            if (block_fsys.MountPoints.length > 0)
+                return block_fsys.Unmount({ });
+            else
+                return Promise.resolve();
+        }
+
+        function maybe_mount() {
+            if (mode == "mount" || (mode == "update" && is_filesystem_mounted)) {
+                return (block_fsys.Mount({ })
+                        .catch(error => {
+                            return (undo()
+                                    .then(() => block_fsys.Mount({ }))
+                                    .then(() => Promise.reject(error))
+                                    .catch(ignored_error => {
+                                        console.warn("Error during undo:", ignored_error);
+                                        return Promise.reject(error);
+                                    }));
+                        }));
+            } else
+                return Promise.resolve();
+        }
+
+        // We need to reload systemd twice: Once at the beginning so
+        // that it is up to date with whatever is currently in fstab,
+        // and once at the end to make it see our changes.  Otherwise
+        // systemd might do some uexpected mounts/unmounts behind our
+        // backs.
+
+        return (utils.reload_systemd()
+                .then(maybe_unmount)
+                .then(() => {
+                    if (!old_config && new_config)
+                        return (block.AddConfigurationItem(new_config, {})
+                                .then(maybe_mount)
+                                .then(utils.reload_systemd));
+                    else if (old_config && !new_config)
+                        return block.RemoveConfigurationItem(old_config, {}).then(utils.reload_systemd);
+                    else if (old_config && new_config && (new_dir != old_dir || new_opts != old_opts))
+                        return (block.UpdateConfigurationItem(old_config, new_config, {})
+                                .then(maybe_mount)
+                                .then(utils.reload_systemd));
+                    else if (new_config && !is_mounted(client, block))
+                        return maybe_mount();
+                }));
+    }
+
+    function remove() {
+        dlg.run(null, maybe_update_config("", "").then(() => dlg.close()));
+    }
+
+    let fields = null;
+    if (mode == "mount" || mode == "update")
+        fields = [
+            TextInput("mount_point", _("Mount Point"),
+                      {
+                          value: old_dir,
+                          validate: function (val) {
+                              if (val === "")
+                                  return _("Mount point cannot be empty");
+                          }
+                      }),
+            CheckBoxes("mount_options", _("Mount Options"),
+                       {
+                           value: {
+                               ro: opt_ro,
+                               extra: extra_options === "" ? false : extra_options
+                           },
+                           fields: [
+                               { title: _("Mount read only"), tag: "ro" },
+                               { title: _("Custom mount options"), tag: "extra", type: "checkboxWithInput" },
+                           ]
+                       },
+            ),
+        ];
+
+    let footer = null;
+    const show_clear_button = false;
+    if (old_dir && mode == "update" && show_clear_button)
+        footer = <div className="modal-footer-teardown"><a onClick={remove}>{_("Clear mount point configuration")}</a></div>;
+    if (!is_filesystem_mounted && block_fsys.MountPoints.length > 0)
+        footer = (
+            <>
+                {footer}
+                <div className="modal-footer-teardown">
+                    <p>{cockpit.format(_("The filesystem is already mounted at $0.  Proceeding will unmount it."),
+                                       utils.decode_filename(block_fsys.MountPoints[0]))}</p>
+                </div>
+            </>);
+
+    const mode_title = {
+        mount: _("Mount Filesystem"),
+        unmount: _("Unmount Filesystem"),
+        update: _("Mount Configuration")
+    };
+
+    const mode_action = {
+        mount: _("Mount"),
+        unmount: _("Unmount"),
+        update: _("Apply")
+    };
+
+    function do_unmount() {
+        var opts = [];
+        opts.push("noauto");
+        if (opt_ro)
+            opts.push("ro");
+        opts = opts.concat(extra_options);
+        return maybe_update_config(old_dir, unparse_options(opts));
+    }
+
+    if (mode == "unmount") {
+        client.run(do_unmount).catch(error => dialog_open({ Title: _("Error"), Body: error.toString() }));
+        return;
+    }
+
+    const dlg = dialog_open({
+        Title: mode_title[mode],
+        Fields: fields,
+        Footer: footer,
+        Action: {
+            Title: mode_action[mode],
+            action: function (vals) {
+                if (mode == "unmount") {
+                    return do_unmount();
+                } else if (mode == "mount" || mode == "update") {
+                    var opts = [];
+                    if (mode == "update" && opt_noauto)
+                        opts.push("noauto");
+                    if (vals.mount_options.ro)
+                        opts.push("ro");
+                    if (vals.mount_options.extra !== false)
+                        opts = opts.concat(parse_options(vals.mount_options.extra));
+                    return maybe_update_config(vals.mount_point, unparse_options(opts));
+                }
+            }
+        }
+    });
+}
 
 export class FilesystemTab extends React.Component {
     constructor(props) {
@@ -35,7 +291,8 @@ export class FilesystemTab extends React.Component {
     }
 
     onSamplesChanged() {
-        this.setState({});
+        if (!this.props.client.busy)
+            this.setState({});
     }
 
     componentDidMount() {
@@ -50,21 +307,7 @@ export class FilesystemTab extends React.Component {
         var self = this;
         var block = self.props.block;
         var block_fsys = block && self.props.client.blocks_fsys[block.path];
-        var is_filesystem_mounted = (block_fsys && block_fsys.MountPoints.length > 0);
-        var used;
-
-        if (is_filesystem_mounted) {
-            var m = utils.decode_filename(block_fsys.MountPoints[0]);
-            var samples = self.props.client.fsys_sizes.data[m];
-            if (samples)
-                used = cockpit.format(_("$0 of $1"),
-                                      utils.fmt_size(samples[0]),
-                                      utils.fmt_size(samples[1]));
-            else
-                used = _("Unknown");
-        } else {
-            used = "-";
-        }
+        var mismounted_fsys_warning = self.props.warnings.find(w => w.warning == "mismounted-fsys");
 
         function rename_dialog() {
             dialog_open({
@@ -85,67 +328,139 @@ export class FilesystemTab extends React.Component {
             });
         }
 
-        var old_config, old_dir, old_opts;
+        var is_filesystem_mounted = is_mounted(self.props.client, block);
+        var [old_config, old_dir, old_opts, old_parents] = get_fstab_config(block);
+        var split_options = parse_options(old_opts == "defaults" ? "" : old_opts);
+        extract_option(split_options, "noauto");
+        var opt_ro = extract_option(split_options, "ro");
 
-        old_config = utils.array_find(block.Configuration, function (c) { return c[0] == "fstab" });
-        if (old_config) {
-            old_dir = utils.decode_filename(old_config[1].dir.v);
-            old_opts = (utils.decode_filename(old_config[1].opts.v)
-                    .split(",")
-                    .filter(function (s) { return s.indexOf("x-parent") !== 0 })
-                    .join(","));
+        var used;
+        if (is_filesystem_mounted) {
+            var samples = self.props.client.fsys_sizes.data[old_dir];
+            if (samples)
+                used = cockpit.format(_("$0 of $1"),
+                                      utils.fmt_size(samples[0]),
+                                      utils.fmt_size(samples[1]));
+            else
+                used = _("Unknown");
+        } else {
+            used = "-";
         }
 
-        var mounted_at = block_fsys ? block_fsys.MountPoints.map(utils.decode_filename) : [];
+        var mount_point_text = null;
+        if (old_dir) {
+            if (old_opts && old_opts != "defaults") {
+                var opt_texts = [];
+                if (opt_ro)
+                    opt_texts.push(_("read only"));
+                opt_texts = opt_texts.concat(split_options);
+                if (opt_texts.length)
+                    mount_point_text = cockpit.format("$0 ($1)", old_dir, opt_texts.join(", "));
+                else
+                    mount_point_text = old_dir;
+            } else
+                mount_point_text = old_dir;
+        }
 
-        function maybe_update_config(new_is_custom, new_dir, new_opts) {
-            var new_config = null;
-            if (new_is_custom) {
-                new_config = [
-                    "fstab", {
-                        dir: { t: 'ay', v: utils.encode_filename(new_dir) },
-                        type: { t: 'ay', v: utils.encode_filename("auto") },
-                        opts: { t: 'ay', v: utils.encode_filename(new_opts || "defaults") },
-                        freq: { t: 'i', v: 0 },
-                        passno: { t: 'i', v: 0 },
-                        "track-parents": { t: 'b', v: true }
-                    }];
+        var extra_text = null;
+        if (!is_filesystem_mounted) {
+            if (!old_dir)
+                extra_text = _("The filesystem has no permanent mount point.");
+            else
+                extra_text = _("The filesystem is not mounted.");
+        }
+        if (extra_text && mount_point_text)
+            extra_text = <><br />{extra_text}</>;
+
+        function fix_config() {
+            const { type, other } = mismounted_fsys_warning;
+
+            const opts = [];
+            if (type == "mount-on-boot")
+                opts.push("noauto");
+            if (opt_ro)
+                opts.push("ro");
+
+            const new_opts = unparse_options(opts.concat(split_options));
+            let all_new_opts;
+            if (new_opts && old_parents)
+                all_new_opts = new_opts + "," + old_parents;
+            else if (new_opts)
+                all_new_opts = new_opts;
+            else
+                all_new_opts = old_parents;
+
+            let new_dir = old_dir;
+            if (type == "change-mount-on-boot" || type == "mounted-no-config")
+                new_dir = other;
+
+            const new_config = [
+                "fstab", {
+                    fsname: old_config ? old_config[1].fsname : undefined,
+                    dir: { t: 'ay', v: utils.encode_filename(new_dir) },
+                    type: { t: 'ay', v: utils.encode_filename("auto") },
+                    opts: { t: 'ay', v: utils.encode_filename(all_new_opts || "defaults") },
+                    freq: { t: 'i', v: 0 },
+                    passno: { t: 'i', v: 0 }
+                }];
+
+            if (old_config)
+                return block.UpdateConfigurationItem(old_config, new_config, {}).then(utils.reload_systemd);
+            else
+                return block.AddConfigurationItem(new_config, {}).then(utils.reload_systemd);
+        }
+
+        function fix_mount() {
+            const { type } = mismounted_fsys_warning;
+            if (type == "change-mount-on-boot")
+                return block_fsys.Unmount({}).then(() => block_fsys.Mount({}));
+            else if (type == "mount-on-boot")
+                return block_fsys.Mount({});
+            else if (type == "no-mount-on-boot")
+                return block_fsys.Unmount({});
+            else if (type == "mounted-no-config")
+                return block_fsys.Unmount({});
+        }
+
+        var mismounted_section = null;
+        if (mismounted_fsys_warning) {
+            const { type, other } = mismounted_fsys_warning;
+            let text;
+            let fix_config_text;
+            let fix_mount_text;
+
+            if (type == "change-mount-on-boot") {
+                text = cockpit.format(_("The filesystem is currently mounted on $0 but will be mounted on $1 on the next boot."), other, old_dir);
+                fix_config_text = cockpit.format(_("Mount automatically on $0 on boot"), other);
+                fix_mount_text = cockpit.format(_("Mount on $0 now"), old_dir);
+            } else if (type == "mount-on-boot") {
+                text = _("The filesystem is currently not mounted but will be mounted on the next boot.");
+                fix_config_text = _("Do not mount automatically on boot");
+                fix_mount_text = _("Mount now");
+            } else if (type == "no-mount-on-boot") {
+                text = _("The filesystem is currently mounted but will not be mounted after the next boot.");
+                fix_config_text = _("Mount also automatically on boot");
+                fix_mount_text = _("Unmount now");
+            } else if (type == "mounted-no-config") {
+                text = cockpit.format(_("The filesystem is currently mounted on $0 but will not be mounted after the next boot."), other);
+                fix_config_text = cockpit.format(_("Mount automatically on $0 on boot"), other);
+                fix_mount_text = _("Unmount now");
             }
 
-            if (!old_config && new_config)
-                return block.AddConfigurationItem(new_config, {});
-            else if (old_config && !new_config)
-                return block.RemoveConfigurationItem(old_config, {});
-            else if (old_config && new_config && (new_dir != old_dir || new_opts != old_opts))
-                return block.UpdateConfigurationItem(old_config, new_config, {});
+            mismounted_section = (
+                <>
+                    <br />
+                    <Alert variant="warning"
+                           isInline
+                           title={text}
+                           action={<>
+                               <StorageButton onClick={fix_config}>{fix_config_text}</StorageButton>
+                               { "\n" }
+                               <StorageButton onClick={fix_mount}>{fix_mount_text}</StorageButton>
+                           </>}
+                    />
+                </>);
         }
-
-        function mounting_dialog() {
-            var options = old_config ? old_opts : FormatDialog.initial_tab_options(self.props.client, block, true);
-            dialog_open({
-                Title: _("Filesystem Mounting"),
-                Fields: FormatDialog.mounting_dialog_fields(!!old_config, old_dir, options),
-                Action: {
-                    Title: _("Apply"),
-                    action: function (vals) {
-                        return maybe_update_config(vals.mounting == "custom",
-                                                   vals.mount_point,
-                                                   FormatDialog.mounting_dialog_options(vals));
-                    }
-                }
-            });
-        }
-
-        function mount() {
-            return block_fsys.Mount({});
-        }
-
-        function unmount() {
-            return block_fsys.Unmount({});
-        }
-
-        // See format-dialog.jsx for why we don't offer editing
-        // fstab for the old UDisks2
 
         return (
             <div>
@@ -156,41 +471,16 @@ export class FilesystemTab extends React.Component {
                     </StorageLink>
                     <label className="control-label">{_("Mount Point")}</label>
                     <div>
-                        <StorageLink onClick={mounting_dialog}>
-                            {old_dir || _("(default)")}
-                        </StorageLink>
-                        <div className="tab-row-actions">
-                            { !is_filesystem_mounted && <StorageButton onClick={mount}>{_("Mount")}</StorageButton> }
-                        </div>
+                        { mount_point_text &&
+                        <StorageLink onClick={() => mounting_dialog(self.props.client, block, "update")}>
+                            { mount_point_text }
+                        </StorageLink> }
+                        { extra_text }
                     </div>
-
-                    { old_opts && (
-                        <>
-                            <label className="control-label">{_("Mount Options")}</label>
-                            <StorageLink onClick={mounting_dialog}>
-                                {old_opts}
-                            </StorageLink>
-                        </>
-                    )}
-
-                    { (mounted_at.length > 0) && (
-                        <>
-                            <label className="control-label">{_("Mounted At")}</label>
-                            <div>
-                                {mounted_at.join(", ")}
-                                <div className="tab-row-actions">
-                                    { (mounted_at.length > 0)
-                                        ? <StorageButton onClick={unmount}>{_("Unmount")}</StorageButton>
-                                        : <StorageButton onClick={mount}>{_("Mount")}</StorageButton>
-                                    }
-                                </div>
-                            </div>
-                        </>
-                    )}
-
                     <label className="control-label">{_("Used")}</label>
                     <div>{used}</div>
                 </div>
+                { mismounted_section }
             </div>
         );
     }

--- a/pkg/storaged/lvol-tabs.jsx
+++ b/pkg/storaged/lvol-tabs.jsx
@@ -21,6 +21,7 @@ import cockpit from "cockpit";
 import * as utils from "./utils.js";
 
 import React from "react";
+import { Alert } from "@patternfly/react-core";
 import { StorageButton, StorageLink } from "./storage-controls.jsx";
 import { existing_passphrase_fields, get_existing_passphrase } from "./crypto-keyslots.jsx";
 import { dialog_open, TextInput, SizeSlider, BlockingMessage, TeardownMessage } from "./dialog.jsx";
@@ -411,20 +412,21 @@ export class BlockVolTab extends React.Component {
                     }
                 </div>
                 { unused_space &&
-                <div>
+                <>
                     <br />
-                    <strong>{_("This logical volume is not completely used by its content.")}</strong>
-                    <br />
-                    {cockpit.format(_("Volume size is $0. Content size is $1."),
-                                    utils.fmt_size(unused_space_warning.volume_size),
-                                    utils.fmt_size(unused_space_warning.content_size))}
-                    { "\n" }
-                    <div className="pull-right">
-                        <StorageButton excuse={shrink_excuse} onClick={shrink}>{_("Shrink Volume")}</StorageButton>
-                        {"\n"}
-                        <StorageButton excuse={grow_excuse} onClick={grow}>{_("Grow Content")}</StorageButton>
-                    </div>
-                </div>
+                    <Alert variant="warning"
+                           isInline
+                           title={_("This logical volume is not completely used by its content.")}
+                           action={<>
+                               <StorageButton excuse={shrink_excuse} onClick={shrink}>{_("Shrink Volume")}</StorageButton>
+                               {"\n"}
+                               <StorageButton excuse={grow_excuse} onClick={grow}>{_("Grow Content")}</StorageButton>
+                           </>}>
+                        {cockpit.format(_("Volume size is $0. Content size is $1."),
+                                        utils.fmt_size(unused_space_warning.volume_size),
+                                        utils.fmt_size(unused_space_warning.content_size))}
+                    </Alert>
+                </>
                 }
             </div>
         );

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -253,7 +253,7 @@ export class StorageUsageBar extends React.Component {
 
 export class StorageMenuItem extends React.Component {
     render() {
-        return <li><a onClick={this.props.onClick}>{this.props.children}</a></li>;
+        return <li><a onClick={checked(this.props.onClick)}>{this.props.children}</a></li>;
     }
 }
 
@@ -270,7 +270,7 @@ export class StorageBarMenu extends React.Component {
         }
 
         return (
-            <div className="dropdown">
+            <div className="dropdown btn-group">
                 <StorageControl content={toggle} excuse_placement="bottom" />
                 <ul className="dropdown-menu dropdown-menu-right" role="menu">
                     {children}

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -755,3 +755,7 @@ export function fmt_to_array(fmt, arg) {
     else
         return [fmt];
 }
+
+export function reload_systemd() {
+    return cockpit.spawn(["systemctl", "daemon-reload"], { superuser: "require", err: "message" });
+}

--- a/pkg/storaged/vdo-details.jsx
+++ b/pkg/storaged/vdo-details.jsx
@@ -31,23 +31,6 @@ import vdo_monitor_py from "raw-loader!./vdo-monitor.py";
 
 const _ = cockpit.gettext;
 
-function wait_for(client, cond) {
-    var dfd = cockpit.defer();
-
-    function check() {
-        var res = cond();
-        if (res) {
-            client.removeEventListener("changed", check);
-            dfd.resolve(res);
-        }
-    }
-
-    client.addEventListener("changed", check);
-    check();
-
-    return dfd.promise();
-}
-
 export class VDODetails extends React.Component {
     constructor() {
         super();
@@ -185,7 +168,7 @@ export class VDODetails extends React.Component {
                 } else {
                     return vdo.start()
                             .then(function () {
-                                wait_for(client, () => client.slashdevs_block[vdo.dev])
+                                client.wait_for(() => client.slashdevs_block[vdo.dev])
                                         .then(function (block) {
                                             return block.Format("empty", { 'tear-down': { t: 'b', v: true } });
                                         });

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -28,12 +28,6 @@ class TestStorage(StorageCase):
         m = self.machine
         b = self.browser
 
-        # Some day storaged/udisks will support the "dry-run-first" option.
-        #
-        # https://github.com/storaged-project/storaged/pull/82
-
-        storaged_supports_dry_run = (self.storaged_version >= [2, 6, 3])
-
         self.login_and_go("/storage")
         b.wait_in_text("#drives", "VirtIO")
 
@@ -47,12 +41,11 @@ class TestStorage(StorageCase):
         self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("type", "xfs")
+        self.dialog_set_val("mount_point", "/foo")
+        self.dialog_set_val("mount_options.auto", False)
         self.dialog_apply()
 
-        if storaged_supports_dry_run:
-            b.wait_in_text(".modal-footer > div.pf-m-danger:nth-child(1)", "Error creating file system")
-        else:
-            self.dialog_wait_close()
+        b.wait_in_text(".modal-footer > div.pf-m-danger:nth-child(1)", "Error creating file system")
 
     def testFormatTypes(self):
         m = self.machine
@@ -66,10 +59,15 @@ class TestStorage(StorageCase):
         b.click('#drives tr:contains("DISK1")')
         b.wait_present('#storage-detail')
 
-        def check_type(type, label_limit):
-            self.content_head_action(1, "Format")
+        def check_type(type, label_limit, head_action=False):
+            if head_action:
+                self.content_head_action(1, "Format")
+            else:
+                self.content_dropdown_action(1, "Format")
             self.dialog_wait_open()
             self.dialog_set_val("type", type)
+            self.dialog_set_val("mount_point", "/foo")
+            self.dialog_set_val("mount_options.auto", False)
             self.dialog_set_val("name", "X" * (label_limit + 1))
             self.dialog_apply()
             self.dialog_wait_error("name", "Name cannot be longer than %d characters" % label_limit)
@@ -79,16 +77,15 @@ class TestStorage(StorageCase):
             self.content_row_wait_in_col(1, 1, type + " File System")
 
         def check_unsupported_type(type):
-            self.content_head_action(1, "Format")
+            self.content_dropdown_action(1, "Format")
             self.dialog_wait_open()
             b.wait_not_present('#dialog li[value=%s]' % type)
             self.dialog_cancel()
             self.dialog_wait_close()
 
-        check_type("xfs", 12)
+        check_type("xfs", 12, head_action=True)
         check_type("ext4", 16)
         check_type("vfat", 11)
-
 
         if m.image in ["rhel-8-1", "rhel-8-1-distropkg", "rhel-8-2"]:
             check_unsupported_type("ntfs")

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -62,8 +62,8 @@ class TestStorage(StorageCase):
                      "name": "FS",
                      "passphrase": "einszweidrei",
                      "passphrase2": "einszweidrei",
-                     "mounting": "custom",
                      "mount_point": mount_point_1,
+                     "mount_options.auto": False,
                      "crypto_options.extra": "my-crypto-tag"})
         self.content_row_wait_in_col(2, 1, "ext4 File System")
         self.wait_in_storaged_configuration(mount_point_1)
@@ -71,9 +71,9 @@ class TestStorage(StorageCase):
 
         # Now doubly hide the clear text block device by locking the
         # crypto backing device and deactivating /dev/TEST/lvol
-        self.content_head_action(1, "Lock")
+        self.content_dropdown_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "Filesystem")
-        self.content_head_action(1, "Deactivate")
+        self.content_dropdown_action(1, "Deactivate")
         self.content_row_wait_in_col(1, 1, "48 MiB Inactive volume")
 
         # HACK - https://github.com/storaged-project/storaged/issues/17
@@ -123,7 +123,6 @@ class TestStorage(StorageCase):
         self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
                      "name": "FS2",
-                     "mounting": "custom",
                      "mount_point": mount_point_2})
         self.content_row_wait_in_col(1, 1, "ext4 File System")
         self.wait_in_storaged_configuration(mount_point_2)

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -101,11 +101,10 @@ class TestStorage(StorageCase):
         self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
                      "name": "FILESYSTEM",
-                     "mounting": "custom",
                      "mount_point": "/data"})
         self.content_row_wait_in_col(1, 1, "ext4 File System")
         # _netdev should have been prefilled
-        self.content_tab_wait_in_info(1, 1, "Mount Options", "_netdev")
+        self.content_tab_wait_in_info(1, 1, "Mount Point", "_netdev")
 
         # Add the target a second time, just to check that the sorting function works
         b.click('#storage-detail .breadcrumb button')

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -55,8 +55,8 @@ class TestStorage(StorageCase):
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("crypto_options.store_passphrase", True)
         self.dialog_set_val("crypto_options.extra", "crypto,options")
-        self.dialog_set_val("mounting", "custom")
         self.dialog_set_val("mount_point", mount_point_secret)
+        self.dialog_set_val("mount_options.auto", False)
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 1, "Encrypted data")
@@ -70,7 +70,7 @@ class TestStorage(StorageCase):
         assert m.execute("cat /etc/luks-keys/*") == "vainu-reku-toma-rolle-kaja"
 
         # Lock it
-        self.content_head_action(1, "Lock")
+        self.content_dropdown_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "ext4 File System")
 
         # Unlock, this uses the stored passphrase
@@ -102,7 +102,7 @@ class TestStorage(StorageCase):
         self.wait_in_storaged_configuration("'passphrase-path': <b''>")
 
         # Lock it
-        self.content_head_action(1, "Lock")
+        self.content_dropdown_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "ext4 File System")
 
         # Unlock, this asks for a passphrase
@@ -111,7 +111,7 @@ class TestStorage(StorageCase):
         self.content_row_wait_in_col(2, 1, "ext4 File System")
 
         # Delete the partition.
-        self.content_head_action(1, "Delete")
+        self.content_dropdown_action(1, "Delete")
         self.confirm()
         self.content_row_wait_in_col(1, 1, "Free Space")
         b.wait_not_in_text("#detail-content", "ext4 File System")
@@ -162,6 +162,8 @@ class TestStorage(StorageCase):
         self.dialog({"type": "ext4",
                      "crypto.on": True,
                      "name": "ENCRYPTED",
+                     "mount_point": "/foo",
+                     "mount_options.auto": False,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
         self.content_row_wait_in_col(1, 1, "Encrypted data")
@@ -169,7 +171,7 @@ class TestStorage(StorageCase):
 
         # Lock the disk
         #
-        self.content_head_action(1, "Lock")
+        self.content_dropdown_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "ext4 File System")
 
         self.content_tab_wait_in_info(1, 1, "Options", "(none)")
@@ -241,6 +243,8 @@ class TestStorage(StorageCase):
         self.dialog({"type": "ext4",
                      "crypto.on": True,
                      "name": "ENCRYPTED",
+                     "mount_point": "/foo",
+                     "mount_options.auto": False,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
         self.content_row_wait_in_col(1, 1, "Encrypted data")
@@ -260,13 +264,13 @@ class TestStorage(StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         # unlock with first passphrase
-        self.content_head_action(1, "Lock")
+        self.content_dropdown_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "ext4 File System")
         self.content_head_action(1, "Unlock")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
         self.content_row_wait_in_col(2, 1, "ext4 File System")
         # unlock with second passphrase
-        self.content_head_action(1, "Lock")
+        self.content_dropdown_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "ext4 File System")
         self.content_head_action(1, "Unlock")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-1"})
@@ -278,7 +282,7 @@ class TestStorage(StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         # check that it is not possible to unlock with deleted passphrase
-        self.content_head_action(1, "Lock")
+        self.content_dropdown_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "ext4 File System")
         self.content_head_action(1, "Unlock")
         self.dialog_wait_open()

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -148,23 +148,21 @@ class TestStorage(StorageCase):
         # format and mount it
         self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
-                     "mounting": "custom",
                      "mount_point": mount_point_one})
         self.content_row_wait_in_col(1, 1, "ext4 File System")
         self.wait_in_storaged_configuration(mount_point_one)
-        self.content_tab_action(1, 2, "Mount")
-        self.content_tab_wait_in_info(1, 2, "Mounted At", mount_point_one)
+        self.content_tab_wait_in_info(1, 2, "Mount Point", mount_point_one)
 
         # unmount it
-        self.content_tab_action(1, 2, "Unmount")
-        b.wait_not_present(self.content_tab_info_label(1, 2, "Mounted At"))
+        self.content_dropdown_action(1, "Unmount")
+        self.content_tab_wait_in_info(1, 2, "Mount Point", "The filesystem is not mounted.")
 
         # shrink it, this time with a filesystem.
         self.content_tab_action(1, 1, "Shrink")
         self.dialog({"size": 10})
 
         # delete it
-        self.content_head_action(1, "Delete")
+        self.content_dropdown_action(1, "Delete")
         self.confirm()
         b.wait_not_in_text("#detail-content", "/dev/vgroup0/lvol0")
         self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_one), "")
@@ -209,7 +207,6 @@ class TestStorage(StorageCase):
         self.content_head_action(2, "Format")
         self.dialog({"erase": "zero",
                      "type": "ext4",
-                     "mounting": "custom",
                      "mount_point": mount_point_thin})
         self.content_row_wait_in_col(2, 1, "ext4 File System")
         self.wait_in_storaged_configuration(mount_point_thin)

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -191,6 +191,8 @@ class TestStorage(StorageCase):
         self.content_row_action(1, "Create Partition")
         self.dialog({"size": 20,
                      "type": "ext4",
+                     "mount_point": "/foo",
+                     "mount_options.auto": False,
                      "name": "One"})
         self.content_row_wait_in_col(1, 1, "ext4 File System")
         self.content_row_wait_in_col(1, 2, part_prefix + "1")
@@ -198,6 +200,8 @@ class TestStorage(StorageCase):
         # Create second partition
         self.content_row_action(2, "Create Partition")
         self.dialog({"type": "ext4",
+                     "mount_point": "/foo",
+                     "mount_options.auto": False,
                      "name": "Two"})
 
         self.content_row_wait_in_col(2, 1, "ext4 File System")

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -57,7 +57,9 @@ class TestStorage(StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val("type", "ext4")
         self.dialog_set_val("name", "FILESYSTEM")
-        self.dialog_set_val("mounting", "custom")
+        self.dialog_set_val("mount_point", "")
+        self.dialog_apply()
+        self.dialog_wait_error("mount_point", "Mount point cannot be empty")
         self.dialog_set_val("mount_point", mount_point_foo)
         self.dialog_apply()
         self.dialog_wait_close()
@@ -66,24 +68,23 @@ class TestStorage(StorageCase):
         self.wait_in_storaged_configuration(mount_point_foo)
 
         self.content_tab_wait_in_info(1, 1, "Mount Point", mount_point_foo)
-        self.content_tab_action(1, 1, "Mount")
-        self.content_tab_wait_in_info(1, 1, "Mounted At", mount_point_foo)
 
-        self.content_tab_action(1, 1, "Unmount")
-        b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
+        self.content_dropdown_action(1, "Unmount")
+        self.content_tab_wait_in_info(1, 1, "Mount Point", "The filesystem is not mounted")
 
         self.content_tab_info_action(1, 1, "Name")
         self.dialog({"name": "filesystem"})
         self.content_tab_wait_in_info(1, 1, "Name", "filesystem")
 
         self.dialog_with_retry(trigger=lambda: self.content_tab_info_action(1, 1, "Mount Point", wrapped=True),
-                               expect={"mounting": "custom",
-                                       "mount_point": mount_point_foo},
+                               expect={"mount_point": mount_point_foo},
                                values={"mount_point": mount_point_bar})
         self.wait_in_storaged_configuration(mount_point_bar)
+        self.content_tab_wait_in_info(1, 1, "Mount Point", mount_point_bar)
 
-        self.content_tab_action(1, 1, "Mount")
-        self.content_tab_wait_in_info(1, 1, "Mounted At", mount_point_bar)
+        self.content_head_action(1, "Mount")
+        self.confirm()
+        self.wait_mounted(1, 1)
 
         # Go to overview page and check that the filesystem usage is
         # displayed correctly.
@@ -106,8 +107,6 @@ class TestStorage(StorageCase):
         wait_ratio_in_range(bar_selector, 0.5, 1.0)
         m.execute("rm %s/zero" % mount_point_bar)
         wait_ratio_in_range(bar_selector, 0.0, 0.1)
-        m.execute("umount %s" % mount_point_bar)
-        b.wait_not_in_text("table[aria-label=Filesystems]", mount_point_bar)
         b.mousedown('table[aria-label=Filesystems] tr:contains("filesystem")')
         b.wait_visible("#storage-detail")
 
@@ -115,21 +114,6 @@ class TestStorage(StorageCase):
             return b.wait_text('#detail-header label:contains("%s") + div' % name, value)
 
         wait_info_field_value("Serial Number", "MYDISK")
-
-        b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
-        self.content_tab_info_action(1, 1, "Mount Point", wrapped=True)
-        self.dialog(values={"mounting": "default"})
-        self.wait_not_in_storaged_configuration(mount_point_bar)
-
-        self.content_tab_action(1, 1, "Mount")
-        self.content_tab_wait_in_info(1, 1, "Mounted At", self.mount_root + "/admin/filesystem")
-
-        self.content_tab_action(1, 1, "Unmount")
-        b.wait_not_present(self.content_tab_info_label(1, 1, "Mounted At"))
-
-        self.content_head_action(1, "Format")
-        self.dialog({"type": "empty"})
-        self.content_row_wait_in_col(1, 1, "Unrecognized Data")
 
     def testMountOptions(self):
         m = self.machine
@@ -149,7 +133,6 @@ class TestStorage(StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val("type", "ext4")
         self.dialog_set_val("crypto.on", True)
-        self.dialog_set_val("mounting", "custom")
 
         def wait_checked(field):
             b.wait_present(self.dialog_field(field) + ":checked")
@@ -200,6 +183,72 @@ class TestStorage(StorageCase):
         m.execute("grep 'noauto,readonly,foo' /etc/crypttab")
         m.execute("grep 'noauto,ro,foo' /etc/fstab")
 
+
+    def testMountingHelp(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        # Add a disk
+        m.add_disk("50M", serial="MYDISK")
+        b.wait_in_text("#drives", "MYDISK")
+        b.click('#drives tr:contains("MYDISK")')
+        b.wait_present('#storage-detail')
+
+        # Format it
+
+        self.content_head_action(1, "Format")
+        self.dialog_wait_open()
+        self.dialog_set_val("type", "ext4")
+        self.dialog_set_val("name", "FILESYSTEM")
+        self.dialog_set_val("mount_point", "/run/foo")
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.content_row_wait_in_col(1, 1, "ext4 File System")
+        self.content_tab_wait_in_info(1, 1, "Name", "FILESYSTEM")
+        self.content_tab_wait_in_info(1, 1, "Mount Point", "/run/foo")
+
+        fsys_tab = self.content_tab_expand(1, 1)
+
+        # Unmount externally, remount with Cockpit
+
+        m.execute("umount /run/foo")
+        b.click(fsys_tab + " button:contains(Mount now)")
+        b.wait_not_present(fsys_tab + " button:contains(Mount now)")
+        self.wait_mounted(1, 1)
+
+        # Unmount externally, adjust fstab with Cockpit
+
+        m.execute("umount /run/foo")
+        b.click(fsys_tab + " button:contains(Do not mount automatically on boot)")
+        b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically on boot)")
+
+        # Mount externally, unmount with Cockpit
+
+        m.execute("mount /run/foo")
+        b.click(fsys_tab + " button:contains(Unmount now)")
+        b.wait_not_present(fsys_tab + " button:contains(Unmount now)")
+
+        # Mount externally, adjust fstab with Cockpit
+
+        m.execute("mount /run/foo")
+        b.click(fsys_tab + " button:contains(Mount also automatically on boot)")
+        b.wait_not_present(fsys_tab + " button:contains(Mount also automatically on boot)")
+
+        # Move mount point externally, move back with Cockpit
+
+        m.execute("umount /run/foo")
+        m.execute("mkdir -p /run/bar && mount /dev/sda /run/bar")
+        b.click(fsys_tab + " button:contains(Mount on /run/foo now)")
+        b.wait_not_present(fsys_tab + " button:contains(Mount on /run/foo now)")
+
+        # Move mount point externally, adjust fstab with Cockpit
+
+        m.execute("umount /run/foo")
+        m.execute("mkdir -p /run/bar && mount /dev/sda /run/bar")
+        b.click(fsys_tab + " button:contains(Mount automatically on /run/bar on boot)")
+        b.wait_not_present(fsys_tab + " button:contains(Mount automatically on /run/bar on boot)")
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -45,12 +45,14 @@ class TestStorage(StorageCase):
         self.content_row_action(1, "Create Partition")
         self.dialog({"size": 10,
                      "type": "ext4",
+                     "mount_point": "/foo",
+                     "mount_options.auto": False,
                      "name": "FIRST"})
         self.content_row_wait_in_col(1, 1, "ext4 File System")
         self.content_tab_wait_in_info(1, 2, "Name", "FIRST")
 
         # Open dialog for formatting the primary partition and check that "dos-extended" is not offered.
-        self.content_head_action(1, "Format")
+        self.content_dropdown_action(1, "Format")
         self.dialog_wait_open()
         b.wait_not_present("select option[value='dos-extended']")
         self.dialog_cancel()
@@ -62,9 +64,8 @@ class TestStorage(StorageCase):
         b.wait_present("option[value='dos-extended']")
         self.dialog_set_val("type", "dos-extended")
         self.dialog_wait_not_present("name")
-        self.dialog_wait_not_present("mounting")
         self.dialog_wait_not_present("mount_point")
-        self.dialog_wait_not_present("mount_auto")
+        self.dialog_wait_not_present("mount_options")
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_row_wait_in_col(2, 1, "Extended Partition")
@@ -75,13 +76,12 @@ class TestStorage(StorageCase):
         self.content_row_action(3, "Create Partition")
         self.dialog_wait_open()
         b.wait_not_present("select option[value='dos-extended']")
-        self.dialog_apply()
+        self.dialog_cancel()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(3, 1, "xfs File System")
 
         # Delete it
 
-        self.content_head_action(2, "Delete")
+        self.content_dropdown_action(2, "Delete")
         self.confirm()
 
         self.content_row_wait_in_col(2, 1, "Free Space")

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -52,10 +52,12 @@ class TestStorage(StorageCase):
         self.content_row_wait_in_col(1, 1, "Free Space")
 
         self.content_row_action(1, "Create Partition")
-        self.dialog({"type": "ext4"})
+        self.dialog({"type": "ext4",
+                     "mount_point": "/foo",
+                     "mount_options.auto": False})
         self.content_row_wait_in_col(1, 1, "ext4 File System")
 
-        self.content_head_action(1, "Delete")
+        self.content_dropdown_action(1, "Delete")
         self.confirm()
         self.content_row_wait_in_col(1, 1, "Free Space")
 

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -55,6 +55,7 @@ class TestStorage(StorageCase):
         self.dialog_wait_apply_enabled()
         self.dialog_set_val("name", "FSYS")
         self.dialog_set_val("type", fsys)
+        self.dialog_set_val("mount_point", "/run/foo")
         if crypto:
             self.dialog_set_val("crypto.on", crypto)
             self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
@@ -62,10 +63,7 @@ class TestStorage(StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_tab_wait_in_info(fsys_row, fsys_tab, "Name", "FSYS")
-
-        mountpoint = self.mount_root + "/admin/FSYS"
-        self.content_tab_action(fsys_row, fsys_tab, "Mount")
-        self.content_tab_wait_in_info(fsys_row, fsys_tab, "Mounted At", mountpoint)
+        self.content_tab_wait_in_info(fsys_row, fsys_tab, "Mount Point", "/run/foo")
 
         if can_grow:
             self.content_tab_action(1, 1, "Grow")
@@ -82,9 +80,10 @@ class TestStorage(StorageCase):
             m.execute("udevadm trigger")
             self.content_tab_wait_in_info(1, 1, "Size", "400 MiB")
             if grow_needs_unmount:
-                self.content_tab_action(fsys_row, fsys_tab, "Mount")
-                self.content_tab_wait_in_info(fsys_row, fsys_tab, "Mounted At", mountpoint)
-            size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
+                self.content_head_action(fsys_row, "Mount")
+                self.confirm()
+                self.wait_mounted(fsys_row, fsys_tab)
+            size = int(m.execute("df -k --output=size /run/foo | tail -1").strip())
             assert (size > 300000)
         else:
             self.wait_content_tab_action_disabled(1, 1, "Grow")
@@ -104,9 +103,10 @@ class TestStorage(StorageCase):
             m.execute("udevadm trigger")
             self.content_tab_wait_in_info(1, 1, "Size", "200 MiB")
             if shrink_needs_unmount:
-                self.content_tab_action(fsys_row, fsys_tab, "Mount")
-                self.content_tab_wait_in_info(fsys_row, fsys_tab, "Mounted At", mountpoint)
-            size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
+                self.content_head_action(fsys_row, "Mount")
+                self.confirm()
+                self.wait_mounted(fsys_row, fsys_tab)
+            size = int(m.execute("df -k --output=size /run/foo | tail -1").strip())
             assert (size < 300000)
         else:
             self.wait_content_tab_action_disabled(1, 1, "Shrink")
@@ -185,17 +185,16 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
         self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
 
+        mountpoint = "/run/foo"
         self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("name", "FSYS")
         self.dialog_set_val("type", "ext4")
+        self.dialog_set_val("mount_point", mountpoint)
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_tab_wait_in_info(1, 2, "Name", "FSYS")
-
-        mountpoint = self.mount_root + "/admin/FSYS"
-        self.content_tab_action(1, 2, "Mount")
-        self.content_tab_wait_in_info(1, 2, "Mounted At", mountpoint)
+        self.content_tab_wait_in_info(1, 2, "Mount Point", mountpoint)
 
         vol_tab = self.content_tab_expand(1, 1)
 
@@ -213,8 +212,9 @@ class TestStorage(StorageCase):
         fs_dev = m.execute("lsblk -pnl /dev/TEST/vol -o NAME | tail -1").strip()
         self.shrink_extfs(fs_dev, "200M")
 
-        self.content_tab_action(1, 2, "Mount")
-        self.content_tab_wait_in_info(1, 2, "Mounted At", mountpoint)
+        self.content_head_action(1, "Mount")
+        self.confirm()
+        self.wait_mounted(1, 2)
         b.wait_present(vol_tab + " button:contains(Shrink Volume)")
         self.content_tab_action(1, 1, "Shrink Volume")
         self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Shrink Volume)")
@@ -240,6 +240,7 @@ class TestStorage(StorageCase):
         b.wait_visible("#storage-detail")
         self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
 
+        mountpoint = "/run/foo"
         self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("name", "FSYS")
@@ -247,13 +248,11 @@ class TestStorage(StorageCase):
         self.dialog_set_val("crypto.on", True)
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
+        self.dialog_set_val("mount_point", mountpoint)
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_tab_wait_in_info(2, 1, "Name", "FSYS")
-
-        mountpoint = self.mount_root + "/admin/FSYS"
-        self.content_tab_action(2, 1, "Mount")
-        self.content_tab_wait_in_info(2, 1, "Mounted At", mountpoint)
+        self.content_tab_wait_in_info(2, 1, "Mount Point", mountpoint)
 
         vol_tab = self.content_tab_expand(1, 1)
 
@@ -280,8 +279,9 @@ class TestStorage(StorageCase):
 
         fs_dev = m.execute("lsblk -pnl /dev/TEST/vol -o NAME | tail -1").strip()
         self.shrink_extfs(fs_dev, "200M")
-        self.content_tab_action(2, 1, "Mount")
-        self.content_tab_wait_in_info(2, 1, "Mounted At", mountpoint)
+        self.content_head_action(2, "Mount")
+        self.confirm()
+        self.wait_mounted(2, 1)
 
         b.wait_present(vol_tab + " button:contains(Shrink Volume)")
         self.content_tab_action(1, 1, "Shrink Volume")
@@ -308,8 +308,9 @@ class TestStorage(StorageCase):
 
         self.shrink_extfs(fs_dev, "198M")
         m.execute("echo vainu-reku-toma-rolle-kaja | cryptsetup resize '%s' 200M" % fs_dev)
-        self.content_tab_action(2, 1, "Mount")
-        self.content_tab_wait_in_info(2, 1, "Mounted At", mountpoint)
+        self.content_head_action(2, "Mount")
+        self.confirm()
+        self.wait_mounted(2, 1)
 
         b.wait_present(vol_tab + " button:contains(Shrink Volume)")
         self.content_tab_action(1, 1, "Shrink Volume")

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -46,15 +46,14 @@ class TestStorage(StorageCase):
 
         b.click('tr:contains("DISK1")')
         b.wait_visible("#storage-detail")
-        self.content_tab_wait_in_info(2, 1, "Mounted At", "/mnt")
 
-        self.content_head_action(2, "Format")
+        self.content_dropdown_action(2, "Format")
         self.dialog_wait_open()
         b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")
         self.dialog_cancel()
         self.dialog_wait_close()
 
-        self.content_head_action(1, "Delete")
+        self.content_dropdown_action(1, "Delete")
         self.dialog_wait_open()
         b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")
         self.dialog_cancel()

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -77,15 +77,12 @@ class TestStorage(StorageCase):
         self.content_head_action(1, "Format")
         self.dialog({"type": "xfs",
                      "name": "FILESYSTEM",
-                     "mounting": "custom",
                      "mount_point": "/run/data"})
         self.content_row_wait_in_col(1, 1, "xfs File System")
         # _netdev etc should have been prefilled
-        self.content_tab_wait_in_info(1, 1, "Mount Options", "_netdev")
-        self.content_tab_wait_in_info(1, 1, "Mount Options", "x-systemd.device-timeout=0")
-        self.content_tab_wait_in_info(1, 1, "Mount Options", "x-systemd.requires=vdo.service")
-        self.content_tab_action(1, 1, "Mount")
-        self.content_tab_wait_in_info(1, 1, "Mounted At", "/run/data")
+        self.content_tab_wait_in_info(1, 1, "Mount Point", "_netdev")
+        self.content_tab_wait_in_info(1, 1, "Mount Point", "x-systemd.device-timeout=0")
+        self.content_tab_wait_in_info(1, 1, "Mount Point", "x-systemd.requires=vdo.service")
         self.content_tab_wait_in_info(1, 1, "Used", "of 4.99 GiB", "of 5.0 GiB")
 
         # Grow physical

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -85,7 +85,7 @@ class StorageCase(MachineCase):
     # temporarily disappearing element, so we use self.retry.
 
     def content_row_wait_in_col(self, row_index, col_index, val):
-        col = self.content_row_tbody(row_index) + " .listing-ct-item :nth-child(%d)" % (col_index + 1)
+        col = self.content_row_tbody(row_index) + " .listing-ct-item > :nth-child(%d)" % (col_index + 1)
         self.retry(None, lambda: self.browser.is_present(col) and val in self.browser.text(col), None)
 
     def content_head_action(self, index, title):
@@ -93,8 +93,14 @@ class StorageCase(MachineCase):
         btn = self.content_row_tbody(index) + " .listing-ct-head .listing-ct-actions button:contains(%s)" % title
         self.browser.click(btn)
 
+    def content_dropdown_action(self, index, title):
+        self.content_row_expand(index)
+        dropdown = self.content_row_tbody(index) + " .listing-ct-head .listing-ct-actions .dropdown"
+        self.browser.click(dropdown + " [data-toggle=dropdown]")
+        self.browser.click(dropdown + " a:contains('%s')" % title)
+
     def content_tab_expand(self, row_index, tab_index):
-        tab_btn = self.content_row_tbody(row_index) + " .listing-ct-head li:nth-child(%d) a" % tab_index
+        tab_btn = self.content_row_tbody(row_index) + " .listing-ct-head > ul li:nth-child(%d) a" % tab_index
         tab = self.content_row_tbody(row_index) + " .listing-ct-body:nth-child(%d)" % (tab_index + 1)
         self.content_row_expand(row_index)
         self.browser.click(tab_btn)
@@ -125,7 +131,7 @@ class StorageCase(MachineCase):
     # XXX - Clicking a button in a tab has the same problem, but we
     # ignore that for now.
 
-    def content_tab_wait_in_info(self, row_index, tab_index, title, val, alternate_val=None):
+    def content_tab_wait_in_info(self, row_index, tab_index, title, val=None, alternate_val=None, cond=None):
         b = self.browser
 
         def setup():
@@ -134,7 +140,7 @@ class StorageCase(MachineCase):
         def check():
             row = self.content_row_tbody(row_index)
             row_item = row + " tr.listing-ct-item"
-            tab_btn = row + " .listing-ct-head li:nth-child(%d) a" % tab_index
+            tab_btn = row + " .listing-ct-head > ul li:nth-child(%d) a" % tab_index
             tab = row + " .listing-ct-body:nth-child(%d)" % (tab_index + 1)
             cell = tab + " div.ct-form label:contains(%s) + *" % title
 
@@ -145,16 +151,22 @@ class StorageCase(MachineCase):
                 if not b.is_present(row + ".open"):
                     return False
 
-            if not b.is_present(tab):
+            if not b.is_present(tab) or not b.is_visible(tab):
                 if not b.is_present(tab_btn):
                     return False
                 b.click(tab_btn)
-                if not b.is_present(tab):
+                if not b.is_visible(tab):
                     return False
 
-            if not b.is_present(cell):
+            if not b.is_present(cell) or not b.is_visible(cell):
                 return False
-            return val in b.text(cell) or (alternate_val is not None and alternate_val in b.text(cell))
+            if val is not None and val in b.text(cell):
+                return True
+            if alternate_val is not None and alternate_val in b.text(cell):
+                return True
+            if cond is not None and cond(cell):
+                return True
+            return False
 
         def teardown():
             pass
@@ -383,3 +395,7 @@ class StorageCase(MachineCase):
 
     def wait_not_in_storaged_configuration(self, mount_point):
         wait(lambda: mount_point not in self.machine.execute("%s dump | grep Configuration" % self.storagectl_cmd))
+
+    def wait_mounted(self, row, col):
+        self.content_tab_wait_in_info(row, col, "Mount Point",
+                                      cond=lambda cell: "The filesystem is not mounted" not in self.browser.text(cell))


### PR DESCRIPTION
Demo: https://www.youtube.com/watch?v=g8_zFpi9Cz0
Demo of "Format" dialog: https://youtu.be/FjgB9SFCR4g

## For release notes

Cockpit no longer offers the confusing "Default" choice when mounting a filesystem.  Now every new filesystem requires the specification of a mount point.  Additionally, Cockpit hides the distinction between configuration (/etc/fstab) and run-time state (/proc/mounts).  Changes made in Cockpit always apply to both the configuration and run-time state.  When configuration and run-time state differ from each other, Cockpit will warn about that and will let you bring them back in sync.

