### PR TITLE
tools: Fix release-guide test mode

### DIFF
--- a/tools/release-guide
+++ b/tools/release-guide
@@ -57,7 +57,7 @@ parse_version()
 
 check()
 {
-    "$(dirname $0)/check-git-rw" git@github.com "$REPO"
+    check-git-rw git@github.com "$REPO"
 }
 
 prepare()


### PR DESCRIPTION
check-git-rw moved to cockpituous release/ many years ago. It's
installed into $PATH in the release container.