### PR TITLE
test: Stop assuming RTC module in testbed kernel

### DIFF
--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -252,6 +252,7 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         # Now reboot things
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
         m.wait_reboot()
+        m.execute("timedatectl set-time '2038-01-01 00:05:00'")
         m.execute("logger -p user.err --tag check-journal AFTER BOOT")
 
         m.start_cockpit()


### PR DESCRIPTION
Setting the time to year 2038 will not persist across reboots if the
testbed kernel does not have RTC enabled. This is the case on e. g. the
Debian cloud kernel.

Thus set the time back to the expected time after rebooting the test VM.