### PR TITLE
tls: make accept() errors non-fatal

### DIFF
--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -293,9 +293,9 @@ handle_accept (void)
   fd = accept4 (server.listen_fd, NULL, NULL, SOCK_CLOEXEC);
   if (fd < 0)
     {
-      if (errno == EINTR)
-        return;
-      err (1, "failed to accept connection");
+      if (errno != EINTR)
+        warn ("failed to accept connection");
+      return;
     }
   con = connection_new (fd);
 


### PR DESCRIPTION
The manpage says this about error returns from accept():

  Linux accept() (and accept4()) passes already-pending network  er‐
  rors  on  the new socket as an error code from accept().  This be‐
  havior differs from other BSD socket implementations.   For  reli‐
  able  operation  the  application should detect the network errors
  defined for the protocol after accept() and treat them like EAGAIN
  by  retrying.   In the case of TCP/IP, these are ENETDOWN, EPROTO,
  ENOPROTOOPT, EHOSTDOWN, ENONET, EHOSTUNREACH, EOPNOTSUPP, and ENE‐
  TUNREACH.

As such, we shouldn't be treating failure to accept() as a fatal error
and terminating the server.