### PR TITLE
[no-test] WIP - system: Show subscription page status in host overview

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -32,6 +32,7 @@ import * as plot from "plot.js";
 import * as service from "service.js";
 import { shutdown } from "./shutdown.js";
 import host_keys_script from "raw-loader!./ssh-list-host-keys.sh";
+import { page_status } from "notifications";
 
 import "form-layout.less";
 
@@ -488,7 +489,7 @@ PageServer.prototype = {
             // if system is unregistered, always show that
             if (self.unregistered) {
                 self.os_updates_icon.className = "pficon pficon-warning-triangle-o";
-                set_page_link("#system_information_updates_text", "subscriptions", _("System Not Registered"));
+                set_page_link("#system_information_updates_text", "subscriptions", _("System Does Not Receive Updates"));
                 return;
             }
 
@@ -565,6 +566,20 @@ PageServer.prototype = {
             self.unregistered = !subscribed;
             refresh_os_updates_state();
         });
+
+        function refresh_insights_state() {
+            const status = page_status.get("subscriptions") || { };
+            if (status.type) {
+                $("#insights_icon").attr("class", "pficon pficon-warning-triangle-o");
+                set_page_link("#insights_text", "subscriptions", status.title);
+                $("#insights_icon, #insights_text").show();
+            } else {
+                $("#insights_icon, #insights_text").hide();
+            }
+        }
+
+        refresh_insights_state();
+        $(page_status).on("changed", refresh_insights_state);
 
         // Only link from graphs to available pages
         set_page_link("#link-disk", "storage", _("Disk I/O"));

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -99,8 +99,15 @@
                 <span id="system_information_os_text"></span>
 
                 <div role="group" class="system-information-updates">
-                    <span id="system_information_updates_icon" hidden></span>
-                    <span id="system_information_updates_text"></span>
+                    <div>
+                      <span id="system_information_updates_icon" hidden></span>
+                      <span id="system_information_updates_text"></span>
+                    </div>
+                    <br>
+                    <div>
+                      <span id="insights_icon"></span>
+                      <span id="insights_text"></span>
+                    </div>
                 </div>
 
                 <label class="control-label" for="system-ssh-keys-link" translatable="yes">Secure Shell Keys</label>


### PR DESCRIPTION
This is how we would pull the "Not connected to Insights" warning from the Subscriptions page to the Host Overview page.

See https://github.com/candlepin/subscription-manager/pull/2154 for the code that generates the warning.