### PR TITLE
tls: don't kill() a pid we just got from waitpid()

### DIFF
--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -253,7 +253,7 @@ connection_init_ws (Connection *c)
     {
       /* cockpit-ws crashed? */
       warn ("failed to connect to cockpit-ws");
-      ws_instance_free (ws);
+      ws_instance_free (ws, true);
       return;
     }
 
@@ -637,11 +637,11 @@ server_cleanup (void)
   for (WsInstance *ws = server.wss; ws; )
     {
       WsInstance *wsnext = ws->next;
-      ws_instance_free (ws);
+      ws_instance_free (ws, true);
       ws = wsnext;
     }
   if (server.ws_notls)
-    ws_instance_free (server.ws_notls);
+    ws_instance_free (server.ws_notls, true);
 
   if (server.x509_cred)
     {
@@ -768,7 +768,7 @@ server_remove_ws (pid_t ws_pid)
   debug ("server_remove_ws: pid %u is ws %s", ws_pid, ws->socket.sun_path);
 
   remove_connection (-1, ws);
-  ws_instance_free (ws);
+  ws_instance_free (ws, false);
 }
 
 unsigned

--- a/src/tls/test-wsinstance.c
+++ b/src/tls/test-wsinstance.c
@@ -88,7 +88,7 @@ teardown (TestCase *tc, gconstpointer data)
   pid_t ws_pid = tc->ws->pid;
   g_autofree char *socket_path = g_strdup (tc->ws->socket.sun_path);
 
-  ws_instance_free (tc->ws);
+  ws_instance_free (tc->ws, true);
   /* process is not running any more */
   g_assert_cmpint (kill (ws_pid, 0), ==, -1);
   g_assert_cmpint (errno, ==, ESRCH);

--- a/src/tls/wsinstance.h
+++ b/src/tls/wsinstance.h
@@ -41,5 +41,5 @@ WsInstance* ws_instance_new (const char *ws_path,
                              enum WsInstanceMode mode,
                              const gnutls_datum_t *client_cert_der,
                              const char *state_dir);
-void ws_instance_free (WsInstance *ws);
+void ws_instance_free (WsInstance *ws, bool terminate);
 bool ws_instance_has_peer_cert (WsInstance *ws, const gnutls_datum_t *der);


### PR DESCRIPTION
After waitpid() has returned a pid to us, it has been freed up for
reuse.  We shouldn't be calling kill() on it in this case.

This removes a strange condition on `if (ws->pid)` which was always
true.  We could also have set ws->pid to 0 in the case of SIGCHLD, but
this would have disrupted debugging output.