### PR TITLE
bots: Adjust tests for openshift images

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -75,8 +75,8 @@ TRIGGERS = {
         "ubuntu-stable"
     ],
     "openshift": [
-        "fedora-30/container-kubernetes@cockpit-project/cockpit/rhel-7.7",
         "rhel-7-7@cockpit-project/cockpit/rhel-7.7",
+        "rhel-7-8@cockpit-project/cockpit/rhel-7.8",
     ],
     "ipa": [
         "fedora-30",

--- a/bots/task/testmap.py
+++ b/bots/task/testmap.py
@@ -24,8 +24,8 @@ REPO_BRANCH_CONTEXT = {
             'fedora-30', 'fedora-atomic',
             'rhel-8-0-distropkg', 'rhel-8-1',
         ],
-        'rhel-7.7': ['fedora-30/container-kubernetes',
-            'fedora-30/container-bastion', 'fedora-30/selenium-firefox', 'fedora-30/selenium-chrome', 'rhel-7-7',
+        'rhel-7.7': ['rhel-7-7',
+            'fedora-30/container-bastion', 'fedora-30/selenium-firefox', 'fedora-30/selenium-chrome',
             'rhel-atomic', 'continuous-atomic',
         ],
         'rhel-8.0': ['fedora-30/container-bastion',
@@ -38,8 +38,8 @@ REPO_BRANCH_CONTEXT = {
         'rhel-8.1': ['fedora-30/container-bastion',
             'fedora-30/selenium-firefox', 'fedora-30/selenium-chrome', 'rhel-8-1',
         ],
-        'rhel-7.8': ['fedora-30/container-kubernetes',
-            'fedora-30/container-bastion', 'fedora-30/selenium-firefox', 'fedora-30/selenium-chrome', 'rhel-7-8',
+        'rhel-7.8': ['rhel-7-8',
+            'fedora-30/container-bastion', 'fedora-30/selenium-firefox', 'fedora-30/selenium-chrome',
         ],
         # These can be triggered manually with bots/tests-trigger
         '_manual': [


### PR DESCRIPTION
There is no way to run fedora-30/container-kubernetes any more, as that
package was dropped after Fedora 29. So drop it from the rhel-7.{7,8}
tests.

Test rhel-7-8 on openshift refreshes as well.