### PR TITLE
bots: Move selenium image to CentOS-7 and virt-install

### DIFF
--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -86,6 +86,10 @@ TRIGGERS = {
     "selenium": [
         "fedora-30/selenium-chrome",
         "fedora-30/selenium-firefox",
+        "fedora-30/chrome@weldr/cockpit-composer",
+        "fedora-30/firefox@weldr/cockpit-composer",
+        "rhel-7-7/firefox@weldr/cockpit-composer",
+        "rhel-8-1/chrome@weldr/cockpit-composer",
     ],
     "rhel-7-7": [
         "rhel-7-7/firefox@weldr/cockpit-composer",

--- a/bots/images/scripts/selenium.bootstrap
+++ b/bots/images/scripts/selenium.bootstrap
@@ -22,4 +22,4 @@ set -ex
 
 BASE=$(dirname $0)
 
-$BASE/virt-builder-fedora "$1" fedora-30 x86_64
+$BASE/virt-install-fedora "$1" x86_64 "http://mirror.centos.org/centos/7/os/x86_64/"

--- a/bots/images/scripts/selenium.setup
+++ b/bots/images/scripts/selenium.setup
@@ -24,8 +24,8 @@ SELENIUM_DEPS="\
 docker \
 "
 
-dnf -y upgrade
-dnf -y install $SELENIUM_DEPS
+yum -y upgrade
+yum -y install docker
 
 systemctl disable firewalld
 
@@ -40,5 +40,5 @@ docker pull selenium/node-chrome-debug:3
 docker pull selenium/node-firefox-debug:3
 
 # reduce image size
-dnf clean all
+yum clean all
 /var/lib/testvm/zero-disk.setup

--- a/bots/images/selenium
+++ b/bots/images/selenium
@@ -1,1 +1,1 @@
-selenium-96c4414185c49d45d6522ad9b1cdfa88fa817921c827c7d73e5f6b6cc58b4fc6.qcow2
+selenium-51bd1a8db6923e2bfd4eba0e36c53ca978f0a4109b31a9c1ffb6ff2ca23bf7d4.qcow2


### PR DESCRIPTION
Use CentOS 7 as a base image, so that we don't need to upgrade it to
latest Fedora twice a year.

Move to virt-install-fedora to get rid of the libguestfs dependency and
be able to build this image in an unprivileged podman container.

 * [x] image-refresh selenium