### PR TITLE
bots: Fix pyflakes errors

### DIFF
--- a/bots/image-prune
+++ b/bots/image-prune
@@ -25,8 +25,6 @@ import os
 import subprocess
 import sys
 import time
-import urllib
-import re
 
 from contextlib import contextmanager
 

--- a/bots/image-refresh
+++ b/bots/image-refresh
@@ -20,7 +20,6 @@
 import os
 import subprocess
 import sys
-import time
 
 import task
 from task import github, REDHAT_STORE


### PR DESCRIPTION
Spotted by tools/test-static-code on current Fedora 30:

```
bots/image-prune:28: 'urllib' imported but unused
bots/image-prune:29: 're' imported but unused
bots/image-refresh:23: 'time' imported but unused
```