### PR TITLE
machines: Fix handling of getOSList.py failures

### DIFF
--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -1254,8 +1254,8 @@ export function GET_OS_INFO_LIST () {
                 parseOsInfoList(dispatch, osList);
             })
             .fail((exception, data) => {
-                parseOsInfoList(dispatch, '');
                 console.error(`get os list returned error: "${JSON.stringify(exception)}", data: "${JSON.stringify(data)}"`);
+                parseOsInfoList(dispatch, '[]');
             });
 }
 


### PR DESCRIPTION
Call `parseOsInfoList()` with a valid empty list JSON instead of an
empty string; the latter causes

    SyntaxError: JSON.parse: unexpected end of data at line 1 column 1 of the JSON data

Log the error before this, to make sure it can be seen even if the
`parseOsInfoList()` dispatch fails.