### PR TITLE
tests: Don't rely on resolving "localhost" in test-webserver

### DIFF
--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -87,7 +87,8 @@ setup (TestCase *tc,
 
   /* Automatically chosen by the web server */
   g_object_get (tc->web_server, "port", &port, NULL);
-  tc->localport = g_strdup_printf ("localhost:%d", port);
+  /* HACK: this should be "localhost", but this fails on COPR; https://github.com/cockpit-project/cockpit/issues/12423 */
+  tc->localport = g_strdup_printf ("127.0.0.1:%d", port);
   if (str)
     tc->hostport = g_strdup_printf ("%s:%d", str, port);
   if (inet)


### PR DESCRIPTION
This is essentially commit 9f22c8ce37 again, but now because this has
kept failing in COPR fedora-30 build environments for a while (Fedora
proper or local builds are fine, and so is the COPR rhel-8 environment).

There is no obvious mis-configuration of /etc/hosts or nsswitch.conf
there, so this will take some more time to debug. Until then, stop
breaking our releases due to that.

See issue #12423