### PR TITLE
tls: Fix GnuTLS version check for TLS 1.3 in test

### DIFF
--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -466,8 +466,8 @@ test_tls_client_cert_disabled (TestCase *tc, gconstpointer data)
 static void
 test_tls_client_cert_expired (TestCase *tc, gconstpointer data)
 {
-#if GNUTLS_VERSION_NUMBER >= 0x030605
-  /* GnuTLS 3.6.5 introduces TLS 1.3 by default, which has only a two-step
+#if GNUTLS_VERSION_NUMBER >= 0x030604
+  /* GnuTLS 3.6.4 introduces TLS 1.3 by default, which has only a two-step
    * handshake: that does not pick up the server's late failing handshake from the
    * verify function, only the next read attempt does */
   assert_https_outcome (tc, CLIENT_EXPIRED_CERTFILE, CLIENT_KEYFILE, 1, GNUTLS_E_SUCCESS, GNUTLS_E_PULL_ERROR);


### PR DESCRIPTION
TLS 1.3 was really introduced into 3.6.4 (see
https://gitlab.com/gnutls/gnutls/blob/master/NEWS), not 3.6.5 (as the
referenced blog entry in commit e5a6366f3cf4 says).

Correct the version check, so that the test works properly in the
`rhelbeta-8-x86_64` mock environment. This fixes a build failure on
COPR.