### PR TITLE
test: Wait for NetworkManager to be online before PackageKit operations

### DIFF
--- a/bots/images/scripts/lib/debian.install
+++ b/bots/images/scripts/lib/debian.install
@@ -84,6 +84,9 @@ if [ -n "$do_install" ]; then
     # HACK: tuned breaks QEMU (https://launchpad.net/bugs/1774000)
     systemctl disable tuned.service 2>/dev/null || true
 
+    # avoid random dpkg database locks, they break our package related tests
+    systemctl disable apt-daily-upgrade.timer
+
     firewall-cmd --add-service=cockpit --permanent
     # not managed by NM, so enable interface manually
     firewall-cmd --zone=public --permanent --add-interface=eth1


### PR DESCRIPTION
When trying `pkcon refresh` or similar operations, PackageKit fails with

    Fatal error: Cannot refresh cache whilst offline

while NetworkManager is still busy with setting up connections.

Wait until NetworkManager's connectivity is at least
`NM_CONNECTIVITY_LIMITED` [1], so that PackageKit is happy. (This is
unfortunately not what `nm-online` does.)

This is supposed to replace the ubuntu-stable specific hack with setting
a fake manual route. But this does not work because
/etc/NetworkManager/conf.d/noauto.conf is somehow missing from that
image, so that NetworkManager still forever tries to connect to the
disconnected eth1. Until this is fixed on the image, keep the hack in
place, but update its documentation.

[1] https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NMConnectivityState