### PR TITLE
tls: Fix building on RHEL/CentOS 7

### DIFF
--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -335,7 +335,11 @@ verify_peer_certificate (gnutls_session_t session)
             errx (1, "Failed to print verification status: %s", gnutls_strerror (ret));
           warnx ("Invalid TLS peer certificate: %s", msg.data);
           gnutls_free (msg.data);
+#ifdef GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR
           return GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR;
+#else  /* fallback for GnuTLS < 3.4.4 */
+          return GNUTLS_E_CERTIFICATE_ERROR;
+#endif
         }
     }
   else if (ret != GNUTLS_E_NO_CERTIFICATE_FOUND)

--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -471,9 +471,11 @@ test_tls_client_cert_expired (TestCase *tc, gconstpointer data)
    * handshake: that does not pick up the server's late failing handshake from the
    * verify function, only the next read attempt does */
   assert_https_outcome (tc, CLIENT_EXPIRED_CERTFILE, CLIENT_KEYFILE, 1, GNUTLS_E_SUCCESS, GNUTLS_E_PULL_ERROR);
-#else
+#elif GNUTLS_VERSION_NUMBER >= 0x030403
   /* TLS < 1.3 has a three-step handshake which picks up the invalid cert in gnutls_handshake() */
   assert_https_outcome (tc, CLIENT_EXPIRED_CERTFILE, CLIENT_KEYFILE, 1, GNUTLS_E_PULL_ERROR, 0);
+#else
+  g_test_skip ("too old GnuTLS, cannot validate certificate properties");
 #endif
 }
 


### PR DESCRIPTION
This uses GnuTLS 3.3.x, which does not yet know about
`GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR` yet (this was introduced in
3.4.3).

With this GnuTLS version our validation function also does not actually
cause the connection to fail, so that /server/tls/client-cert-expired
fails. As we don't support master on these old releases, just skip the
test there. Nothing is using the validation in practice yet, and once we
do, sssd will validate the certificate by itself anyway, so this is
safe.

Fixes #12713