### PR TITLE
bots: Specify cafile for requests to learn-cockpit

### DIFF
--- a/bots/flakes-refresh
+++ b/bots/flakes-refresh
@@ -23,10 +23,13 @@ import os
 import urllib
 import json
 import re
+import ssl
 
 sys.dont_write_bytecode = True
 
 import task
+
+BOTS = os.path.dirname(os.path.realpath(__file__))
 
 NUMBER_OPEN_ISSUES = 7            # How many issues do we want to have open at a given time?
 
@@ -102,12 +105,14 @@ def run(context, verbose=False, **kwargs):
     host = os.environ.get("COCKPIT_LEARN_SERVICE_HOST", "learn-cockpit.apps.ci.centos.org")
     port = os.environ.get("COCKPIT_LEARN_SERVICE_PORT", "443")
     url = "{0}://{1}:{2}/active/".format("https" if port == "443" else "http", host, port)
+    cafile = os.path.join(BOTS, "images", "files", "ca.pem")
+    context = ssl.create_default_context(cafile=cafile)
 
     failure_logs = slurp_failure_logs(url)
 
     # Retrieve the URL
     statistics = [ ]
-    with urllib.request.urlopen(url + "statistics.jsonl") as f:
+    with urllib.request.urlopen(url + "statistics.jsonl", context=context) as f:
         for line in f.readlines():
             try:
                 record = json.loads(line.decode('utf-8'))

--- a/bots/learn-tests
+++ b/bots/learn-tests
@@ -27,6 +27,7 @@ SINCE = 21
 
 import os
 import socket
+import ssl
 import subprocess
 import sys
 import time
@@ -72,7 +73,9 @@ def tail(url, until, verbose=False):
 
         try:
             req = urllib.request.Request(url, headers={ "Range": "bytes={0}-".format(at) })
-            with urllib.request.urlopen(req, cafile=os.path.join(BOTS, "images", "files", "ca.pem")) as f:
+            cafile = os.path.join(BOTS, "images", "files", "ca.pem")
+            context = ssl.create_default_context(cafile=cafile)
+            with urllib.request.urlopen(req, context=context) as f:
                 while True:
                     data = f.read(2048)
                     if not data:

--- a/bots/tests-policy
+++ b/bots/tests-policy
@@ -24,6 +24,7 @@ import json
 import re
 import os
 import socket
+import ssl
 import sys
 import time
 import traceback
@@ -160,9 +161,11 @@ def guessFlake(output, context, verbose=False):
     flake = False
 
     url = "{0}://{1}:{2}/predict".format("https" if port == "443" else "http", host, port)
+    cafile = os.path.join(BOTS, "images", "files", "ca.pem")
+    context = ssl.create_default_context(cafile=cafile)
     jsonl = json.dumps(item) + "\n"
     try:
-        data = urllib.request.urlopen(url, data=jsonl.encode('utf-8')).read()
+        data = urllib.request.urlopen(url, data=jsonl.encode('utf-8'), context=context).read()
     except (ConnectionResetError, urllib.error.URLError, socket.gaierror) as ex:
         sys.stderr.write("{0}: {1}\n".format(url, ex))
         data = b"{ }"

--- a/bots/tests-score
+++ b/bots/tests-score
@@ -20,12 +20,15 @@
 import json
 import os
 import socket
+import ssl
 import sys
 import urllib
 
 sys.dont_write_bytecode = True
 
 import task
+
+BOTS = os.path.dirname(os.path.realpath(__file__))
 
 # This parses the output JSONL format discussed here, where various
 # values are grouped:
@@ -49,17 +52,20 @@ def count(record, field, only):
     return 0
 
 def run(url, verbose=False, dry=False, **kwargs):
+    cafile = None
     if not url:
         host = os.environ.get("COCKPIT_LEARN_SERVICE_HOST", "learn-cockpit.apps.ci.centos.org")
         port = os.environ.get("COCKPIT_LEARN_SERVICE_PORT", "443")
         url = "{0}://{1}:{2}/active/statistics.jsonl".format("https" if port == "443" else "http", host, port)
+        cafile = os.path.join(BOTS, "images", "files", "ca.pem")
+        context = ssl.create_default_context(cafile=cafile)
 
     statistics = [ ]
 
     # Retrieve the URL
     try:
         req = urllib.request.Request(url)
-        with urllib.request.urlopen(req) as f:
+        with urllib.request.urlopen(req, context=context) as f:
             for line in f.readlines():
                 try:
                     record = json.loads(line.decode('utf-8'))


### PR DESCRIPTION
This should solve the SSL errors in test logs, we already do this for the learn-tests task
