### PR TITLE
lib: Expose type-specific systemd unit details

### DIFF
--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -47,10 +47,14 @@ import cockpit from "cockpit";
  * service.
  *
  * - proxy.unit
+ * - proxy.details
+ *
+ * The raw org.freedesktop.systemd1.Unit and type-specific D-Bus
+ * interface proxies for the service.
+ *
  * - proxy.service
  *
- * The raw org.freedesktop.systemd1.Unit and Service D-Bus
- * interface proxies for the service.
+ * The deprecated name for proxy.details
  *
  * - promise = proxy.start()
  *
@@ -105,7 +109,7 @@ function with_systemd_manager(done) {
     wait_valid(systemd_manager, done);
 }
 
-export function proxy(name) {
+export function proxy(name, kind) {
     var self = {
         exists: null,
         state: null,
@@ -124,11 +128,13 @@ export function proxy(name) {
 
     cockpit.event_target(self);
 
-    var unit, service;
+    var unit, details;
     var wait_callbacks = cockpit.defer();
 
     if (name.indexOf(".") == -1)
         name = name + ".service";
+    if (kind === undefined)
+        kind = "Service";
 
     function update_from_unit() {
         self.exists = (unit.LoadState != "not-found" || unit.ActiveState != "inactive");
@@ -159,8 +165,9 @@ export function proxy(name) {
         wait_callbacks.resolve();
     }
 
-    function update_from_service() {
-        self.service = service;
+    function update_from_details() {
+        self.details = details;
+        self.service = details;
         self.dispatchEvent("changed");
     }
 
@@ -171,9 +178,9 @@ export function proxy(name) {
                     unit.addEventListener('changed', update_from_unit);
                     wait_valid(unit, update_from_unit);
 
-                    service = systemd_client.proxy('org.freedesktop.systemd1.Service', path);
-                    service.addEventListener('changed', update_from_service);
-                    wait_valid(service, update_from_service);
+                    details = systemd_client.proxy('org.freedesktop.systemd1.' + kind, path);
+                    details.addEventListener('changed', update_from_details);
+                    wait_valid(details, update_from_details);
                 })
                 .fail(function () {
                     self.exists = false;
@@ -182,7 +189,7 @@ export function proxy(name) {
     });
 
     function refresh() {
-        if (!unit || !service)
+        if (!unit || !details)
             return;
 
         function refresh_interface(path, iface) {
@@ -204,7 +211,7 @@ export function proxy(name) {
         }
 
         refresh_interface(unit.path, "org.freedesktop.systemd1.Unit");
-        refresh_interface(service.path, "org.freedesktop.systemd1.Service");
+        refresh_interface(details.path, "org.freedesktop.systemd1." + kind);
     }
 
     function on_job_new_removed_refresh(event, number, path, unit_id, result) {


### PR DESCRIPTION
This makes the proxies useful for other kinds, such as timers.