### PR TITLE
Fix paths in .css files that import from pkg/lib

### DIFF
--- a/pkg/apps/application.css
+++ b/pkg/apps/application.css
@@ -1,6 +1,6 @@
 /* Application list */
 
-@import "/table.css";
+@import "../lib/table.css";
 
 .app-list caption h2 {
     margin: 0px;

--- a/pkg/kdump/kdump.css
+++ b/pkg/kdump/kdump.css
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-@import "/page.css";
+@import "../lib/page.css";
 
 .container-fluid {
     margin: 50px auto auto;

--- a/pkg/selinux/setroubleshoot.css
+++ b/pkg/selinux/setroubleshoot.css
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-@import "/page.css";
+@import "../lib/page.css";
 
 .setroubleshoot-log {
     font-family: monospace;

--- a/pkg/sosreport/sosreport.css
+++ b/pkg/sosreport/sosreport.css
@@ -1,5 +1,5 @@
-@import "/page.css";
-@import "/table.css";
+@import "../lib/page.css";
+@import "../lib/table.css";
 
 #sos-error-extra {
     width:      100%;

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -1,10 +1,10 @@
-@import "/page.css";
+@import "../lib/page.css";
 
-@import "/console.css";
-@import "/journal.css";
-@import "/plot.css";
-@import "/table.css";
-@import "/tooltip.css";
+@import "../lib/console.css";
+@import "../lib/journal.css";
+@import "../lib/plot.css";
+@import "../lib/table.css";
+@import "../lib/tooltip.css";
 
 @import "./timer.css";
 

--- a/pkg/systemd/hwinfo.css
+++ b/pkg/systemd/hwinfo.css
@@ -1,4 +1,4 @@
-@import "/table.css";
+@import "../lib/table.css";
 
 /* show tbodys side by side on wide screens */
 @media screen and (min-width: 70rem) {

--- a/pkg/users/users.css
+++ b/pkg/users/users.css
@@ -1,5 +1,5 @@
-@import "/page.css";
-@import "/table.css";
+@import "../lib/page.css";
+@import "../lib/table.css";
 
 #accounts-list {
     --ct-account-pic-size: 3rem;


### PR DESCRIPTION
This was no longer correct after https://github.com/cockpit-project/cockpit/commit/dabebcab

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1749586

Please can someone test this? Please don't forget to do it VM or clean your current builds.