### PR TITLE
machines: When receiving *EVENT_DEFINED add a minimal representation of the resource to the state

### DIFF
--- a/pkg/machines/components/networks/networkList.jsx
+++ b/pkg/machines/components/networks/networkList.jsx
@@ -28,6 +28,11 @@ import { networkId } from '../../helpers.js';
 const _ = cockpit.gettext;
 
 export class NetworkList extends React.Component {
+    shouldComponentUpdate(nextProps, _) {
+        const networks = nextProps.networks;
+        return !networks.find(network => !network.name);
+    }
+
     render() {
         const { dispatch, networks, resourceHasError, onAddErrorNotification } = this.props;
         const sortFunction = (networkA, networkB) => networkA.name.localeCompare(networkB.name);

--- a/pkg/machines/components/storagePools/storagePoolList.jsx
+++ b/pkg/machines/components/storagePools/storagePoolList.jsx
@@ -29,6 +29,11 @@ import { CreateStoragePoolAction } from './createStoragePoolDialog.jsx';
 const _ = cockpit.gettext;
 
 export class StoragePoolList extends React.Component {
+    shouldComponentUpdate(nextProps, _) {
+        const storagePools = nextProps.storagePools;
+        return !storagePools.find(pool => !pool.name);
+    }
+
     render() {
         const { storagePools, dispatch, loggedUser, vms, resourceHasError, onAddErrorNotification, libvirtVersion } = this.props;
         const sortFunction = (storagePoolA, storagePoolB) => storagePoolA.name.localeCompare(storagePoolB.name);
@@ -55,7 +60,7 @@ export class StoragePoolList extends React.Component {
                                     const filterVmsByConnection = vms.filter(vm => vm.connectionName == storagePool.connectionName);
 
                                     return (
-                                        <StoragePool key={`${storagePoolId(storagePool.name, storagePool.connectionName)}`}
+                                        <StoragePool key={`${storagePoolId(storagePool.id, storagePool.connectionName)}`}
                                             storagePool={storagePool}
                                             vms={filterVmsByConnection}
                                             resourceHasError={resourceHasError}

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -1154,7 +1154,8 @@ function startEventMonitorStoragePools(connectionName, dispatch) {
             case Enum.VIR_STORAGE_POOL_EVENT_DEFINED:
             case Enum.VIR_STORAGE_POOL_EVENT_STARTED:
             case Enum.VIR_STORAGE_POOL_EVENT_CREATED:
-                dispatch(getStoragePool({ connectionName, id:objPath }));
+                dispatch(updateOrAddStoragePool({ connectionName, id: objPath }));
+                dispatch(getStoragePool({ connectionName, id:objPath, updateOnly: true }));
                 break;
             case Enum.VIR_STORAGE_POOL_EVENT_STOPPED:
                 dispatch(getStoragePool({ connectionName, id:objPath, updateOnly: true }));

--- a/pkg/machines/reducers.js
+++ b/pkg/machines/reducers.js
@@ -112,9 +112,11 @@ function networks(state, action) {
         const connectionName = network.connectionName;
         const index = network.id ? getFirstIndexOfResource(state, 'id', network.id, connectionName)
             : getFirstIndexOfResource(state, 'name', network.name, connectionName);
-        if (index < 0 && !updateOnly) { // add
-            return [...state, network];
-        }
+        if (index < 0)
+            if (!updateOnly)
+                return [...state, network];
+            else
+                return state;
 
         const updatedNetwork = Object.assign({}, state[index], network);
         return replaceResource({ state, updatedResource: updatedNetwork, index });
@@ -277,11 +279,13 @@ function storagePools(state, action) {
         const { storagePool, updateOnly, } = action.payload;
         const connectionName = storagePool.connectionName;
         const index = getFirstIndexOfResource(state, 'id', storagePool.id, connectionName);
-        if (index < 0 && !updateOnly) {
-            return [...state, storagePool];
-        }
-        const updatedStoragePool = Object.assign({}, state[index], storagePool);
+        if (index < 0)
+            if (!updateOnly)
+                return [...state, storagePool];
+            else
+                return state;
 
+        const updatedStoragePool = Object.assign({}, state[index], storagePool);
         return replaceResource({ state, updatedResource: updatedStoragePool, index });
     }
     case UPDATE_STORAGE_VOLUMES: {

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -888,6 +888,10 @@ class TestMachinesDBus(machineslib.TestMachines):
 
                     self.cancel()
 
+                    # If pool creation failed make sure that the pool is not shown in the UI
+                    if self.xfail_error and 'already exists' not in self.xfail_error:
+                        b.wait_not_present("tbody tr[data-row-id=pool-{0}-system] th".format(self.name))
+
             def verify_dialog(self):
                 # Check that the defined pools is now visible
                 b.wait_in_text("body", "Storage Pools")


### PR DESCRIPTION
This will prevent the race condition, where the *EVENT_UNDEFINED
signal will get handled before *EVENT_DEFINED resulting
in the resource whose creation failed to appear in the UI anyway.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1715388

Cherry-picked from master commit 2f67e6a3d.