### PR TITLE
bots: Declare rhel-8-1-distropkg test

### DIFF
--- a/bots/task/testmap.py
+++ b/bots/task/testmap.py
@@ -46,6 +46,7 @@ REPO_BRANCH_CONTEXT = {
             'fedora-i386',
             'fedora-testing',
             'fedora-31',
+            'rhel-8-1-distropkg',
         ],
     },
     'cockpit-project/starter-kit': {


### PR DESCRIPTION
We will soon at that image mode, as 8-0-distropkg is obsolete now.