### PR TITLE
RHEL 8 - systemd: Warn if not connected to Insights

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -545,6 +545,22 @@ PageServer.prototype = {
             refresh_os_updates_state();
         });
 
+        var insights_client_timer = service.proxy("insights-client.timer");
+
+        function refresh_insights_status() {
+            let subfeats = (cockpit.manifests["subscriptions"] && cockpit.manifests["subscriptions"].features) || { };
+            if (subfeats["insights"] && insights_client_timer.exists && !insights_client_timer.enabled) {
+                $("#insights_icon").attr("class", "pficon pficon-warning-triangle-o");
+                set_page_link("#insights_text", "subscriptions", _("Not connected to Insights"));
+                $("#insights_icon, #insights_text").show();
+            } else {
+                $("#insights_icon, #insights_text").hide();
+            }
+        }
+
+        $(insights_client_timer).on("changed", refresh_insights_status);
+        refresh_insights_status();
+
         // Only link from graphs to available pages
         set_page_link("#link-disk", "storage", _("Disk I/O"));
         set_page_link("#link-network", "network", _("Network Traffic"));

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -99,8 +99,15 @@
                 <span id="system_information_os_text"></span>
 
                 <div role="group" class="system-information-updates">
+                  <div>
                     <span id="system_information_updates_icon" hidden></span>
                     <span id="system_information_updates_text"></span>
+                  </div>
+                  <br>
+                  <div>
+                    <span id="insights_icon"></span>
+                    <span id="insights_text"></span>
+                  </div>
                 </div>
 
                 <label class="control-label" for="system-ssh-keys-link" translatable="yes">Secure Shell Keys</label>

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -541,6 +541,21 @@ fi
         self.allow_authorize_journal_messages()
         self.allow_restart_journal_messages()
 
+    def testInsightsWarning(self):
+        m = self.machine
+        b = self.browser
+
+        # Pretend that the Subscriptions page can do Insights stuff
+        m.write("/usr/share/cockpit/subscription-manager/override.json", '{ "features": { "insights": true } }')
+
+        self.login_and_go('/system')
+
+        m.execute("systemctl disable insights-client.timer")
+        b.wait_text("#insights_text", "Not connected to Insights")
+
+        m.execute("systemctl enable insights-client.timer")
+        b.wait_not_visible("#insights_text")
+
 class TestPcp(packagelib.PackageCase):
 
     @skipImage("cockpit-system doesn't have the install-on-demand feature")
@@ -593,7 +608,6 @@ class TestPcp(packagelib.PackageCase):
         m.execute("touch /tmp/pmlogger.start")
         b.wait_present("#server-pmlogger-switch input:not(:disabled)")
         b.wait_present("#server-pmlogger-switch input:checked")
-
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
The warning will only appear when the Subscriptions page announces in
its manifest that it actually supports connecting to Insights.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1745964