### PR TITLE
naughty: Close 12405: SELinux is preventing qemu-kvm to access /proc when running in tcg mode

### DIFF
--- a/bots/naughty/rhel-8/12405-selinux-qemu-kvm-tcg
+++ b/bots/naughty/rhel-8/12405-selinux-qemu-kvm-tcg
@@ -1,1 +1,0 @@
-audit: type=1400 * avc:  denied  { search } * comm="qemu-kvm" * dev="proc"


### PR DESCRIPTION
Known issue which has not occurred in 27 days

SELinux is preventing qemu-kvm to access /proc when running in tcg mode

Fixes #12405