### PR TITLE
naughty: Close 11441: Listing timezones fails on Fedora 30

### DIFF
--- a/bots/naughty/fedora-30/11441-listing-timezones-fail
+++ b/bots/naughty/fedora-30/11441-listing-timezones-fail
@@ -1,1 +1,0 @@
-Failed to request list of time zones: No such method “ListTimezones”


### PR DESCRIPTION
Known issue which has not occurred in 27 days

Listing timezones fails on Fedora 30

Fixes #11441