### PR TITLE
test: Fix rhsmd cleanup in check-packagekit

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -48,6 +48,7 @@ class TestUpdates(PackageCase):
         # On other OSes (Fedora/CentOS) we expect sub-man to be disabled in yum, so it should not get in the way there
         if self.machine.image.startswith("rhel"):
             self.machine.execute("mv /usr/libexec/rhsmd /usr/libexec/rhsmd.disabled")
+            self.addCleanup(self.machine.execute, "mv /usr/libexec/rhsmd.disabled /usr/libexec/rhsmd")
 
         # only the yum backend properly recognizes "enhancement" severity; apt
         # does not have that metadata and PackageKit-dnf does not parse it


### PR DESCRIPTION
When disabling /usr/libexec/rhsmd (on RHEL images), re-enable it at the
end of the test. This unbreaks running more than one check-packagekit
test on an external testbed.

Cherry-picked from master commit cd50b4d6063