### PR TITLE
firewall: Only reload firewall when adding custom services

### DIFF
--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -109,12 +109,7 @@ function initFirewalldDbus() {
         member: 'Reloaded'
     }, () => getZones().then(() => getServices()));
 
-    getDefaultZonePath()
-            .then(path => firewalld_dbus.subscribe({
-                interface: 'org.fedoraproject.FirewallD1.config.zone',
-                path: path,
-                member: 'Updated'
-            }, firewall.reload));
+    getDefaultZonePath();
 }
 
 firewalld_service.addEventListener('changed', () => {
@@ -286,6 +281,10 @@ firewall.getAvailableServices = () => {
             .catch(error => console.warn(error));
 };
 
+/*
+ * Only call this after defining a new service, as it will remove existing
+ * non-permanent configurations.
+ */
 firewall.reload = () => {
     return firewalld_dbus.call('/org/fedoraproject/FirewallD1',
                                'org.fedoraproject.FirewallD1',
@@ -324,29 +323,21 @@ firewall.removeService = (zone, service) => {
  * Create new firewalld service.
  *
  * Returns a promise that resolves when the service is created.
+ * It will also reload firewalld and enable the new service.
  */
-firewall.createService = (service, name, ports) => {
+firewall.createService = (service, name, ports, zones) => {
+    let subscription = firewalld_dbus.subscribe({
+        interface: 'org.fedoraproject.FirewallD1',
+        path: '/org/fedoraproject/FirewallD1',
+        member: 'Reloaded'
+    }, () => {
+        firewall.addServices(zones, [service]);
+        subscription.remove();
+    });
     return firewalld_dbus.call('/org/fedoraproject/FirewallD1/config',
                                'org.fedoraproject.FirewallD1.config',
-                               'addService', [service,
-                                   ["", name, "", ports, [], {}, [], []]
-                               ]);
-};
-
-firewall.enableService = (zones, service) => {
-    // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-    // https://github.com/cockpit-project/cockpit/issues/10956
-    // eslint-disable-next-line cockpit/no-cockpit-all
-    let promises = cockpit.all(
-        zones.map(z => firewalld_dbus.call('/org/fedoraproject/FirewallD1/config',
-                                           'org.fedoraproject.FirewallD1.config',
-                                           'getZoneByName', [z])
-                .then(path => firewalld_dbus.call(path[0], 'org.fedoraproject.FirewallD1.config.zone',
-                                                  'addService', [service]))));
-    return promises.then(() => fetchZoneInfos(zones))
-            .then(() => fetchServiceInfos([service]))
-            .then(info => firewall.enabledServices.add(info[0].id))
-            .then(() => firewall.debouncedEvent('changed'));
+                               'addService', [service, ["", name, "", ports, [], {}, [], []]])
+            .then(() => firewall.reload());
 };
 
 /*

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -21,6 +21,7 @@ import cockpit from "cockpit";
 import React from "react";
 import ReactDOM from "react-dom";
 import {
+    Alert,
     Button,
     ListView,
     Modal,
@@ -251,8 +252,7 @@ class AddServicesModal extends React.Component {
     save() {
         let p;
         if (this.state.custom) {
-            p = firewall.createService(this.state.custom_id, this.state.custom_name, this.createPorts())
-                    .then(firewall.enableService(this.state.zones, this.state.custom_id));
+            p = firewall.createService(this.state.custom_id, this.state.custom_name, this.createPorts(), this.state.zones);
         } else {
             p = firewall.addServices(this.state.zones, [...this.state.selected]);
         }
@@ -580,6 +580,11 @@ class AddServicesModal extends React.Component {
                 <Modal.Footer>
                     {
                         this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />
+                    }
+                    { !this.state.custom ||
+                        <Alert type="warning">
+                            { _("Adding custom ports will reload firewalld. A reload will result in the loss of any runtime-only configuration!")}
+                        </Alert>
                     }
                     <Button bsStyle='default' className='btn-cancel' onClick={this.props.close}>
                         {_("Cancel")}

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -150,6 +150,11 @@ class TestFirewall(NetworkCase):
         b.wait_in_text("#zones-listing", "Public")
         b.wait_in_text("#zones-listing", "default")
 
+        # add a service to the runtime configuration via the cli, after all the
+        # operations it should still be there, indicating no reload took place
+        m.execute("firewall-cmd --add-service=http")
+        b.wait_present("tr[data-row-id='http']")
+
         # click on the "Add Services" button
         b.wait_present("caption #add-services-button:enabled")
         b.click("caption #add-services-button")
@@ -218,6 +223,9 @@ class TestFirewall(NetworkCase):
         b.click("#add-services-dialog .modal-footer .btn-cancel")
         b.wait_not_present("#cockpit_modal_dialog")
 
+        # should still be here
+        b.wait_present("tr[data-row-id='http']")
+
         # Service without name should appear in the dialog
         if m.image != "rhel-7-6-distropkg": # Fixed in #11318
             m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload")
@@ -262,7 +270,7 @@ class TestFirewall(NetworkCase):
         # remove service while the dialog is open
         m.execute("firewall-cmd --remove-service=pop3")
         b.click("#remove-services-dialog button.btn-primary")
-        b.wait_in_text("#remove-services-dialog div.alert", "org.fedoraproject.FirewallD1.Exception: NOT_ENABLED: 'pop3' not in 'public'")
+        b.wait_in_text("#remove-services-dialog div.alert-danger", "org.fedoraproject.FirewallD1.Exception: NOT_ENABLED: 'pop3' not in 'public'")
 
     @skipImage("Custom ports were introduced in #11420", "rhel-7-6-distropkg", "rhel-8-0-distropkg")
     def testAddCustomServices(self):
@@ -277,6 +285,11 @@ class TestFirewall(NetworkCase):
         self.login_and_go("/network/firewall")
         b.wait_in_text("#zones-listing", "Public")
         b.wait_in_text("#zones-listing", "default")
+
+        # add a service to the runtime configuration via the cli, after all the
+        # operations it should be removed, indicating a reload took place
+        m.execute("firewall-cmd --add-service=http")
+        b.wait_present("tr[data-row-id='http']")
 
         def open_dialog():
             b.wait_present("caption #add-services-button:enabled")
@@ -359,7 +372,10 @@ class TestFirewall(NetworkCase):
         open_dialog()
         set_field("#udp-ports", "19834", "19834")
         b.click("#add-services-dialog button.btn-primary")
-        b.wait_in_text("#add-services-dialog div.alert", "org.fedoraproject.FirewallD1.Exception: NAME_CONFLICT: new_service(): 'custom--19834'")
+        b.wait_in_text("#add-services-dialog div.alert-danger", "org.fedoraproject.FirewallD1.Exception: NAME_CONFLICT: new_service(): 'custom--19834'")
+
+        # should have been removed in the reload
+        b.wait_not_present("tr[data-row-id='http']")
 
 
     @skipImage("Zones were introduced in #11745", "rhel-7-6-distropkg", "rhel-8-0-distropkg")
@@ -391,7 +407,7 @@ class TestFirewall(NetworkCase):
             b.click("#add-zone-dialog .modal-footer button.btn-primary:enabled")
 
             if error:
-                b.wait_in_text("#add-zone-dialog div.alert", error)
+                b.wait_in_text("#add-zone-dialog div.alert-danger", error)
                 b.click("#add-zone-dialog .modal-footer button.btn-cancel")
                 b.wait_not_present("#add-zone-dialog")
                 return


### PR DESCRIPTION
Add a warning as well that adding a custom service will reload
firewalld, resulting in a loss of runtime-only configuration.

This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1725094 as
well.

Cherry-picked from master commit 75d22ea.