### PR TITLE
bots: Fix rpmlint script in fedora installs

### DIFF
--- a/bots/images/scripts/lib/fedora.install
+++ b/bots/images/scripts/lib/fedora.install
@@ -73,7 +73,8 @@ if [ -n "$do_build" ]; then
     srpm=$(/var/lib/testvm/make-srpm "$tar")
     LC_ALL=C.UTF-8 su builder -c "/usr/bin/mock --offline --no-clean --resultdir build-results $mock_opts --rebuild $srpm"
 
-    su builder -c "/usr/bin/mock --offline --shell" <<EOF
+    cat <<EOF >/tmp/rpmlint
+#! /bin/bash
 rm -rf /builddir/build
 if type rpmlint >/dev/null 2>&1; then
     # blacklist "E: no-changelogname-tag" rpmlint error, expected due to our template cockpit.spec
@@ -91,6 +92,9 @@ else
     echo '====== skipping rpmlint check, not installed ====='
 fi
 EOF
+    chmod +x /tmp/rpmlint
+    su builder -c "/usr/bin/mock --offline --copyin /tmp/rpmlint /var/tmp/rpmlint"
+    su builder -c "/usr/bin/mock --offline --shell /var/tmp/rpmlint"
 fi
 
 # Install


### PR DESCRIPTION
First copy the the script into the chroot, then execute it.