### PR TITLE
packagekit: Eliminiate react-remarkable

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "react-bootstrap": "0.32.4",
     "react-dom": "16.8.6",
     "react-redux": "6.0.1",
-    "react-remarkable": "1.1.3",
     "redux": "4.0.4",
     "redux-thunk": "2.3.0",
     "registry-image-widgets": "0.0.17",
     "term.js-cockpit": "0.0.11",
+    "remarkable": "2.0.0",
     "throttle-debounce": "2.1.0",
     "uuid": "3.3.3",
     "xterm": "3.13.1"

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -24,7 +24,7 @@ import ReactDOM from 'react-dom';
 
 import moment from "moment";
 import { OverlayTrigger, Tooltip } from "patternfly-react";
-import Markdown from "react-remarkable";
+import { Remarkable } from "remarkable";
 import AutoUpdates from "./autoupdates.jsx";
 import { History, PackageList } from "./history.jsx";
 
@@ -214,6 +214,7 @@ class UpdateItem extends React.Component {
     constructor() {
         super();
         this.state = { expanded: false };
+        this.remarkable = new Remarkable();
     }
 
     render() {
@@ -290,8 +291,8 @@ class UpdateItem extends React.Component {
         descriptionFirstLine = cleanupChangelogLine(descriptionFirstLine);
         var description;
         if (info.markdown) {
-            descriptionFirstLine = <Markdown source={descriptionFirstLine} />;
-            description = <Markdown source={info.description} />;
+            descriptionFirstLine = <span dangerouslySetInnerHTML={{ __html: this.remarkable.render(descriptionFirstLine) }} />;
+            description = <div dangerouslySetInnerHTML={{ __html: this.remarkable.render(info.description) }} />;
         } else {
             description = <div className="changelog">{info.description}</div>;
         }


### PR DESCRIPTION
This npm module has not been updated in two years, and is using an old
version of remarkable that pulls in deprecated stuff:

    npm WARN deprecated gulp-header@1.8.12: Removed event-stream from gulp-header

It's also not really giving us much aside from not making the
`dangerouslySetInnerHTML` explicit. So use the current version of
remarkable directly instead.