### PR TITLE
machines: Fix disk add and storage volume create buttons

### DIFF
--- a/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
+++ b/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
@@ -110,9 +110,9 @@ export class StoragePoolVolumesTab extends React.Component {
 
         if (volumes.length === 0) {
             return (<div id={`${storagePoolIdPrefix}-storage-volumes-list`}>
+                {_("No Storage Volumes defined for this Storage Pool")}
                 <StorageVolumeCreate key='volume-create-action'
                 storagePool={storagePool} />
-                {_("No Storage Volumes defined for this Storage Pool")}
             </div>);
         }
 

--- a/pkg/machines/components/storagePools/storageVolumeCreate.jsx
+++ b/pkg/machines/components/storagePools/storageVolumeCreate.jsx
@@ -130,6 +130,7 @@ export class StorageVolumeCreate extends React.Component {
                 return (
                     <Button id={`${idPrefix}-button`}
                         bsStyle='default'
+                        className='pull-right'
                         onClick={this.open}>
                         {_("Create Volume")}
                     </Button>

--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -116,7 +116,12 @@ class VmDisksTab extends React.Component {
                 columnTitles.push(_("Additional"));
             columnTitles.push({ title: actions });
         } else {
-            return _("No disks defined for this VM");
+            return (
+                <>
+                    {_("No disks defined for this VM")}
+                    {actions}
+                </>
+            );
         }
 
         const rows = disks.map(disk => {

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -2174,6 +2174,7 @@ class TestMachines(NetworkCase):
                     raise AssertionError("Unknown disk device")
             else:
                 b.wait_in_text("div.listing-ct-body", "No disks defined")
+                b.wait_present("#vm-{0}-disks-adddisk".format(name))
             return self
 
         def assertScriptFinished(self):


### PR DESCRIPTION
Disk add button would get hidden if there were no disks available,
beucase that button was used as part of content table.
Storage volume create button should be put on the right side of the
volumes tab.