### PR TITLE
Use Promise.all() instead of cockpit.all()

### DIFF
--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -878,11 +878,7 @@ export function unknownConnectionName(action, libvirtServiceName) {
                         // https://bugzilla.redhat.com/show_bug.cgi?id=1045069
                         connectionName => canLoggedUserConnectSession(connectionName, loggedUser))
                     .map(connectionName => dispatch(action(connectionName, libvirtServiceName)));
-
-            // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-            // https://github.com/cockpit-project/cockpit/issues/10956
-            // eslint-disable-next-line cockpit/no-cockpit-all
-            return cockpit.all(promises);
+            return Promise.all(promises);
         });
     };
 }

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -372,8 +372,7 @@ LIBVIRT_DBUS_PROVIDER = {
                 }
             }
 
-            // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-            // https://github.com/cockpit-project/cockpit/issues/10956
+            // FIXME: use Promise.all() here; but that causes "Error: Actions must be plain objects"
             // eslint-disable-next-line cockpit/no-cockpit-all
             return cockpit.all(storageVolPromises)
                     .then(() => {
@@ -441,10 +440,7 @@ LIBVIRT_DBUS_PROVIDER = {
         return dispatch => {
             call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListNetworks', [0], TIMEOUT)
                     .then(objPaths => {
-                        // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                        // https://github.com/cockpit-project/cockpit/issues/10956
-                        // eslint-disable-next-line cockpit/no-cockpit-all
-                        return cockpit.all(objPaths[0].map((path) => dispatch(getNetwork({ connectionName, id:path }))));
+                        return Promise.all(objPaths[0].map((path) => dispatch(getNetwork({ connectionName, id:path }))));
                     })
                     .fail(ex => console.warn('GET_ALL_NETWORKS action failed:', JSON.stringify(ex)));
         };
@@ -455,10 +451,7 @@ LIBVIRT_DBUS_PROVIDER = {
     }) {
         return dispatch => {
             call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListNodeDevices', [0], TIMEOUT)
-                    // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                    // https://github.com/cockpit-project/cockpit/issues/10956
-                    // eslint-disable-next-line cockpit/no-cockpit-all
-                    .then(objPaths => cockpit.all(objPaths[0].map(path => dispatch(getNodeDevice({ connectionName, id:path })))))
+                    .then(objPaths => Promise.all(objPaths[0].map(path => dispatch(getNodeDevice({ connectionName, id:path })))))
                     .fail(ex => console.warn('GET_ALL_NODE_DEVICES action failed:', JSON.stringify(ex)));
         };
     },
@@ -469,10 +462,7 @@ LIBVIRT_DBUS_PROVIDER = {
         return dispatch => {
             return call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListStoragePools', [0], TIMEOUT)
                     .then(objPaths => {
-                        // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                        // https://github.com/cockpit-project/cockpit/issues/10956
-                        // eslint-disable-next-line cockpit/no-cockpit-all
-                        return cockpit.all(objPaths[0].map(path => {
+                        return Promise.all(objPaths[0].map(path => {
                             return call(connectionName, path, 'org.freedesktop.DBus.Properties', 'Get', ['org.libvirt.StoragePool', 'Active'], TIMEOUT)
                                     .then(active => {
                                         if (active[0].v)
@@ -491,11 +481,7 @@ LIBVIRT_DBUS_PROVIDER = {
             call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListDomains', [0], TIMEOUT)
                     .then(objPaths => {
                         dispatch(deleteUnlistedVMs(connectionName, [], objPaths[0]));
-
-                        // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                        // https://github.com/cockpit-project/cockpit/issues/10956
-                        // eslint-disable-next-line cockpit/no-cockpit-all
-                        return cockpit.all(objPaths[0].map((path) => dispatch(getVm({ connectionName, id:path }))));
+                        return Promise.all(objPaths[0].map((path) => dispatch(getVm({ connectionName, id:path }))));
                     })
                     .fail(ex => console.warn('GET_ALL_VMS action failed:', JSON.stringify(ex)));
         };

--- a/pkg/machines/libvirt-virsh.js
+++ b/pkg/machines/libvirt-virsh.js
@@ -204,10 +204,7 @@ LIBVIRT_PROVIDER = {
             });
             logDebug(`GET_ALL_STORAGE_POOLS: vmNames: ${JSON.stringify(storagePoolNames)}`);
 
-            // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-            // https://github.com/cockpit-project/cockpit/issues/10956
-            // eslint-disable-next-line cockpit/no-cockpit-all
-            return cockpit.all(storagePoolNames.map((name) => dispatch(getStoragePool({ connectionName, name }))));
+            return Promise.all(storagePoolNames.map((name) => dispatch(getStoragePool({ connectionName, name }))));
         });
     },
 
@@ -226,10 +223,7 @@ LIBVIRT_PROVIDER = {
             // remove undefined domains
             dispatch(deleteUnlistedVMs(connectionName, vmNames));
 
-            // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-            // https://github.com/cockpit-project/cockpit/issues/10956
-            // eslint-disable-next-line cockpit/no-cockpit-all
-            return cockpit.all(vmNames.map((name) => dispatch(getVm({ connectionName, name }))));
+            return Promise.all(vmNames.map((name) => dispatch(getVm({ connectionName, name }))));
         });
     },
 

--- a/pkg/machines/manifest.json.in
+++ b/pkg/machines/manifest.json.in
@@ -2,7 +2,7 @@
   "version": 0,
   "priority": 0,
   "requires": {
-       "cockpit": "122"
+       "cockpit": "186"
   },
   "menu": {
      "vms": {

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2425,17 +2425,11 @@ PageNetworkInterface.prototype = {
         var self = this;
 
         function delete_connection_and_slaves(con) {
-            // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-            // https://github.com/cockpit-project/cockpit/issues/10956
-            // eslint-disable-next-line cockpit/no-cockpit-all
-            return cockpit.all(con.Slaves.map(s => free_slave_connection(s))).then(() => con.delete_());
+            return Promise.all(con.Slaves.map(s => free_slave_connection(s))).then(() => con.delete_());
         }
 
         function delete_connections(cons) {
-            // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-            // https://github.com/cockpit-project/cockpit/issues/10956
-            // eslint-disable-next-line cockpit/no-cockpit-all
-            return cockpit.all(cons.map(delete_connection_and_slaves));
+            return Promise.all(cons.map(delete_connection_and_slaves));
         }
 
         function delete_iface_connections(iface) {

--- a/pkg/networkmanager/manifest.json.in
+++ b/pkg/networkmanager/manifest.json.in
@@ -2,7 +2,7 @@
     "version": "@VERSION@",
     "name": "network",
     "requires": {
-	"cockpit": "122"
+        "cockpit": "186"
     },
 
     "menu": {

--- a/pkg/networkmanager/utils.js
+++ b/pkg/networkmanager/utils.js
@@ -223,14 +223,8 @@ export function list_interfaces() {
                        'org.freedesktop.NetworkManager',
                        'GetAllDevices', [])
             .then(reply => {
-                // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                // https://github.com/cockpit-project/cockpit/issues/10956
-                // eslint-disable-next-line cockpit/no-cockpit-all
-                const promises = cockpit.all(reply[0].map(device => {
-                    // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                    // https://github.com/cockpit-project/cockpit/issues/10956
-                    // eslint-disable-next-line cockpit/no-cockpit-all
-                    const devicePromises = cockpit.all([
+                return Promise.all(reply[0].map(device => {
+                    return Promise.all([
                         client.call(device,
                                     'org.freedesktop.DBus.Properties',
                                     'Get', ['org.freedesktop.NetworkManager.Device', 'Interface'])
@@ -240,17 +234,7 @@ export function list_interfaces() {
                                     'Get', ['org.freedesktop.NetworkManager.Device', 'Capabilities'])
                                 .then(reply => reply[0])
                     ]);
-                    return devicePromises.then(function (device) {
-                        if (Array.isArray(device) && device.length === 0)
-                            return [];
-                        return Array.prototype.slice.call(arguments);
-                    });
                 }));
-                return promises.then(function (devices) {
-                    if (Array.isArray(devices) && devices.length === 0)
-                        return [];
-                    return Array.prototype.slice.call(arguments);
-                });
             })
             .then(interfaces => {
                 client.close();

--- a/pkg/packagekit/manifest.json.in
+++ b/pkg/packagekit/manifest.json.in
@@ -3,7 +3,7 @@
     "name": "updates",
     "priority": 0,
     "requires": {
-        "cockpit": "138"
+        "cockpit": "186"
     },
 
     "tools": {

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -537,14 +537,11 @@ class OsUpdates extends React.Component {
                     const promises = transactions.map(transactionPath => PK.call(
                         transactionPath, "org.freedesktop.DBus.Properties", "Get", [PK.transactionInterface, "Role"]));
 
-                    // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                    // https://github.com/cockpit-project/cockpit/issues/10956
-                    // eslint-disable-next-line cockpit/no-cockpit-all
-                    cockpit.all(promises)
+                    Promise.all(promises)
                             .then(roles => {
                                 // any transaction with UPDATE_PACKAGES role?
                                 for (let idx = 0; idx < roles.length; ++idx) {
-                                    if (roles[idx].v === PK.Enum.ROLE_UPDATE_PACKAGES) {
+                                    if (roles[idx][0].v === PK.Enum.ROLE_UPDATE_PACKAGES) {
                                         this.watchUpdates(transactions[idx]);
                                         return;
                                     }

--- a/pkg/storaged/manifest.json.in
+++ b/pkg/storaged/manifest.json.in
@@ -2,7 +2,7 @@
     "version": "@VERSION@",
     "name": "storage",
     "requires": {
-	"cockpit": "122"
+        "cockpit": "186"
     },
 
     "menu": {

--- a/pkg/storaged/mdraid-details.jsx
+++ b/pkg/storaged/mdraid-details.jsx
@@ -57,16 +57,8 @@ class MDRaidSidebar extends React.Component {
                 Action: {
                     Title: _("Add"),
                     action: function(vals) {
-                        return utils.prepare_available_spaces(client, vals.disks).then(function() {
-                            var paths = Array.prototype.slice.call(arguments);
-
-                            // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                            // https://github.com/cockpit-project/cockpit/issues/10956
-                            // eslint-disable-next-line cockpit/no-cockpit-all
-                            return cockpit.all(paths.map(function(p) {
-                                return mdraid.AddDevice(p, {});
-                            }));
-                        });
+                        return utils.prepare_available_spaces(client, vals.disks).then(paths =>
+                            Promise.all(paths.map(p => mdraid.AddDevice(p, {}))));
                     }
                 }
             });
@@ -276,10 +268,7 @@ export class MDRaidDetails extends React.Component {
                 // members.
 
                 function wipe_members() {
-                    // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                    // https://github.com/cockpit-project/cockpit/issues/10956
-                    // eslint-disable-next-line cockpit/no-cockpit-all
-                    return cockpit.all(client.mdraids_members[mdraid.path].map(member => member.Format('empty', { })));
+                    return Promise.all(client.mdraids_members[mdraid.path].map(member => member.Format('empty', { })));
                 }
 
                 if (mdraid.ActiveDevices && mdraid.ActiveDevices.length > 0)

--- a/pkg/storaged/mdraids-panel.jsx
+++ b/pkg/storaged/mdraids-panel.jsx
@@ -102,12 +102,10 @@ export class MDRaidsPanel extends React.Component {
                 Action: {
                     Title: _("Create"),
                     action: function (vals) {
-                        return prepare_available_spaces(client, vals.disks).then(function () {
-                            var paths = Array.prototype.slice.call(arguments);
-                            return client.manager.MDRaidCreate(paths, vals.level,
-                                                               vals.name, (vals.chunk || 0) * 1024,
-                                                               { });
-                        });
+                        return prepare_available_spaces(client, vals.disks).then(paths =>
+                            client.manager.MDRaidCreate(paths, vals.level,
+                                                        vals.name, (vals.chunk || 0) * 1024,
+                                                        { }));
                     }
                 }
             });

--- a/pkg/storaged/vdos-panel.jsx
+++ b/pkg/storaged/vdos-panel.jsx
@@ -112,8 +112,8 @@ export class VDOsPanel extends React.Component {
                 Action: {
                     Title: _("Create"),
                     action: function (vals) {
-                        return prepare_available_spaces(client, [vals.space]).then(function (path) {
-                            var block = client.blocks[path];
+                        return prepare_available_spaces(client, [vals.space]).then(paths => {
+                            const block = client.blocks[paths[0]];
                             return cockpit.spawn(["wipefs", "-a", decode_filename(block.PreferredDevice)],
                                                  {
                                                      superuser: true,

--- a/pkg/storaged/vgroup-details.jsx
+++ b/pkg/storaged/vgroup-details.jsx
@@ -64,16 +64,8 @@ class VGroupSidebar extends React.Component {
                 Action: {
                     Title: _("Add"),
                     action: function(vals) {
-                        return utils.prepare_available_spaces(client, vals.disks).then(function() {
-                            var paths = Array.prototype.slice.call(arguments);
-
-                            // We can't use Promise.all() here until cockpit is able to dispatch es2015 promises
-                            // https://github.com/cockpit-project/cockpit/issues/10956
-                            // eslint-disable-next-line cockpit/no-cockpit-all
-                            return cockpit.all(paths.map(function(p) {
-                                return vgroup.AddDevice(p, {});
-                            }));
-                        });
+                        return utils.prepare_available_spaces(client, vals.disks).then(paths =>
+                            Promise.all(paths.map(p => vgroup.AddDevice(p, {}))));
                     }
                 }
             });

--- a/pkg/storaged/vgroups-panel.jsx
+++ b/pkg/storaged/vgroups-panel.jsx
@@ -71,10 +71,8 @@ export class VGroupsPanel extends React.Component {
                 Action: {
                     Title: _("Create"),
                     action: function (vals) {
-                        return prepare_available_spaces(client, vals.disks).then(function () {
-                            var paths = Array.prototype.slice.call(arguments);
-                            return client.manager_lvm2.VolumeGroupCreate(vals.name, paths, { });
-                        });
+                        return prepare_available_spaces(client, vals.disks).then(paths =>
+                            client.manager_lvm2.VolumeGroupCreate(vals.name, paths, { }));
                     }
                 }
             });


### PR DESCRIPTION
This was fixed properly in Cockpit 186. The earliest version that we
still support anywhere (RHEL 7.7) is 195, so it is safe to use
Promise.all() now. To ensure this, bump the manifest's cockpit
dependencies accordingly.

This still leaves some cases where `cockpit.all()` is being used to
deliver promises with a progress() method. These need to wait until the
pages get ported to React.