### PR TITLE
test: Be happy with "Network" title in the networks card

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -481,8 +481,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("body", "Virtual Machines")
 
         # Click on Networks card
-        b.wait_in_text(".cards-pf #card-pf-networks .card-pf-title-link", "Networks")
-        b.click(".cards-pf .card-pf-title span:contains(Networks)")
+        b.wait_in_text(".cards-pf #card-pf-networks .card-pf-title-link", "Network")
+        b.click(".cards-pf .card-pf-title span:contains(Network)")
 
         # Check that all networks are there
         b.wait_in_text("body", "Networks")
@@ -527,8 +527,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("body", "Virtual Machines")
 
         # Click on Networks card
-        b.wait_in_text(".cards-pf #card-pf-networks .card-pf-title-link", "Networks")
-        b.click(".cards-pf .card-pf-title span:contains(Networks)")
+        b.wait_in_text(".cards-pf #card-pf-networks .card-pf-title-link", "Network")
+        b.click(".cards-pf .card-pf-title span:contains(Network)")
 
         # Check that all networks are there
         b.wait_in_text("body", "Networks")
@@ -855,8 +855,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("body", "Virtual Machines")
 
         # Click on Networks card
-        b.wait_in_text(".cards-pf #card-pf-networks .card-pf-title-link", "Networks")
-        b.click(".cards-pf .card-pf-title span:contains(Networks)")
+        b.wait_in_text(".cards-pf #card-pf-networks .card-pf-title-link", "Network")
+        b.click(".cards-pf .card-pf-title span:contains(Network)")
 
         class NetworkCreateDialog(object):
             def __init__(


### PR DESCRIPTION
The stable state of the card is "1 Network", but while loading it
briefly shows "0 Networks".

Thus, waiting for it to contain "Networks" is a race: most of the time
we catch it while it still shows "0 Networks" and the test continues,
but sometimes it already shows "1 Network" and the test fails.

In some cases, waiting for "Networks" is correct, since we know that
the title is "2 Networks".