### PR TITLE
po: Fix building PO template

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -49,7 +49,6 @@ uninstall-local::
 # General code packages to translate
 TRANSLATE = \
 	pkg/ \
-	node_modules/registry-image-widgets/ \
 	src/ws/ \
 	$(NULL)
 


### PR DESCRIPTION
Since dropping registry-image-widgets npm module in commit 42cf3774,
building po/cockpit.pot has failed with

    find: ‘node_modules/registry-image-widgets/’: No such file or directory

Drop it from the list of directories to translate.