### PR TITLE
build: Introduce make rules for npm install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,9 @@ nodist_systemdunit_DATA =
 
 TESTS = $(NULL)
 
+# dependency on "npm install"
+NODE_MODULES_STAMP = package-lock.json
+
 CLEANFILES = \
 	$(man_MANS) \
 	valgrind-suppressions \
@@ -35,6 +38,7 @@ MAINTAINERCLEANFILES = \
 
 EXTRA_DIST = \
 	package.json \
+	$(NODE_MODULES_STAMP) \
 	README.md \
 	$(NULL)
 
@@ -89,13 +93,13 @@ LESSC = $(srcdir)/node_modules/.bin/lessc
 
 MIN_JS_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(srcdir)/tools/missing $(UGLIFY_JS) $(filter-out %.deps, $^) --mangle --comments 'preserve' --beautify \
+	$(srcdir)/tools/missing $(UGLIFY_JS) $(filter-out %.deps %.json, $^) --mangle --comments 'preserve' --beautify \
 		--source-map url=$(notdir $@).map,includeSources --output $@
 
 MIN_CSS_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	$(srcdir)/tools/missing $(CLEAN_CSS) --keep-line-breaks --output=$@ \
-		--source-map --source-map-inline-sources $^
+		--source-map --source-map-inline-sources $(filter %.css, $^)
 
 ESLINT_RULE = \
 	$(V_CHECK) eslint $<
@@ -146,6 +150,12 @@ SUBST_RULE = \
 	$(GZ_RULE)
 .woff.woff.gz:
 	$(GZ_RULE)
+
+# node_modules installation
+$(NODE_MODULES_STAMP): package.json
+	tools/npm-install
+
+MAINTAINERCLEANFILES += $(NODE_MODULES_STAMP)
 
 # Webpack related
 
@@ -205,7 +215,7 @@ dist/%/Makefile.deps:
 
 # This is the primary rule for running webpack; some pkgs like ssh or pcp only
 # have a manifest, no actual webpack, so don't call webpack-make for these
-dist/%/stamp: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make
+dist/%/stamp: $(NODE_MODULES_STAMP) $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make
 	$(V_WEBPACK) $(MKDIR_P) dist/$* && \
 	(if ls $(srcdir)/pkg/$*/*.html >/dev/null 2>&1; then $(WEBPACK_MAKE) -d dist/$*/Makefile.deps $(WEBPACK_CONFIG); else touch dist/$*/Makefile.deps; fi ) && \
 	  touch $@
@@ -344,15 +354,15 @@ REDHATDISPLAY_FONTS = \
 	$(FONTSDIR)/RedHatDisplay-Regular.woff2 \
 	$(NULL)
 
-$(FONTSDIR)/OpenSans-%.woff:
+$(FONTSDIR)/OpenSans-%.woff: $(NODE_MODULES_STAMP)
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cp -L $(subst $(FONTSDIR),$(srcdir)/node_modules/patternfly/dist/fonts,$@) $@.tmp && $(MV) $@.tmp $@
 
-$(FONTSDIR)/RedHatText-%.woff2:
+$(FONTSDIR)/RedHatText-%.woff2: $(NODE_MODULES_STAMP)
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cp -L $(subst $(FONTSDIR),$(srcdir)/node_modules/@redhat/redhat-font/webfonts/RedHatText,$@) $@.tmp && $(MV) $@.tmp $@
 
-$(FONTSDIR)/RedHatDisplay-%.woff2:
+$(FONTSDIR)/RedHatDisplay-%.woff2: $(NODE_MODULES_STAMP)
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cp -L $(subst $(FONTSDIR),$(srcdir)/node_modules/@redhat/redhat-font/webfonts/RedHatDisplay,$@) $@.tmp && $(MV) $@.tmp $@
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -41,22 +41,7 @@ if test ${npm_version%%.*} -lt 3; then
   exit 1
 fi
 
-# Development dependencies: See node_modules/README
-npm prune
-
-retries='3'
-while ! npm install; do
-  # npm install is flaky, and when it fails, it usually leaves
-  # node_modules in a corrupt state, so if that happens, start over
-  # again from scratch
-  retries=$((${retries}-1))
-  if test ${retries} -eq 0; then
-    echo 'failed to install nodejs modules'
-    exit 1
-  fi
-
-  find node_modules -mindepth 1 -not -path node_modules/README -delete
-done
+tools/npm-install
 
 rm -rf autom4te.cache
 

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -27,7 +27,7 @@ src/ws/%.po: po/%.po
 	$(COPY_RULE)
 
 # Build a javascript file from a po
-po.%.js: %.po
+po.%.js: %.po $(NODE_MODULES_STAMP)
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	$(srcdir)/tools/missing $(srcdir)/po/po2json -m $(srcdir)/po/po.empty.js -o $@.js.tmp $< && \
 	mv $@.js.tmp $@
@@ -79,8 +79,8 @@ po/cockpit.c.pot: po/POTFILES.c.in
 		--from-code=UTF-8 --directory=$(srcdir) --files-from=$^
 
 # Extract translate attribute, Glade style, angular-gettext HTML translations
-po/cockpit.html.pot: po/POTFILES.html.in
-	$(srcdir)/tools/missing $(srcdir)/po/html2po -d $(srcdir) -f $^ -o $@
+po/cockpit.html.pot: po/POTFILES.html.in $(NODE_MODULES_STAMP)
+	$(srcdir)/tools/missing $(srcdir)/po/html2po -d $(srcdir) -f $< -o $@
 
 # Extract cockpit style javascript translations
 po/cockpit.js.pot: po/POTFILES.js.in
@@ -93,8 +93,8 @@ po/cockpit.js.pot: po/POTFILES.js.in
 		--from-code=UTF-8 --directory=$(srcdir) --files-from=$^ | \
 		sed '/^#/ s/, c-format//' > $@
 
-po/cockpit.manifest.pot: po/POTFILES.manifest.in
-	$(srcdir)/tools/missing $(srcdir)/po/manifest2po -d $(srcdir) -f $^ -o $@
+po/cockpit.manifest.pot: po/POTFILES.manifest.in $(NODE_MODULES_STAMP)
+	$(srcdir)/tools/missing $(srcdir)/po/manifest2po -d $(srcdir) -f $< -o $@
 
 # Extract pre-processed prepare-po data in tmp/
 po/cockpit.pre.pot: po/POTFILES.pre.in

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -23,22 +23,22 @@ basedebug_DATA = \
 
 AM_TESTS_ENVIRONMENT = export G_DEBUG=fatal-criticals,fatal-warnings ; export XDG_CACHE_HOME=$$(mktemp -d) ; export XDG_RUNTIME_DIR=$$XDG_CACHE_HOME ;
 
-dist/base1/cockpit.min.css: src/base1/cockpit.css
+dist/base1/cockpit.min.css: src/base1/cockpit.css $(NODE_MODULES_STAMP)
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(srcdir)/tools/missing $(CLEAN_CSS) --keep-line-breaks --output=$@ --inline none --source-map --source-map-inline-sources $^
+	$(srcdir)/tools/missing $(CLEAN_CSS) --keep-line-breaks --output=$@ --inline none --source-map --source-map-inline-sources $<
 dist/base1/patternfly.min.css: dist/base1/patternfly-base.css dist/base1/patternfly-additions.css
 	$(MIN_CSS_RULE)
-dist/base1/jquery.js:
+dist/base1/jquery.js: $(NODE_MODULES_STAMP)
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	cat $(srcdir)/node_modules/jquery/dist/jquery.js $(srcdir)/node_modules/bootstrap/dist/js/bootstrap.js $(srcdir)/node_modules/patternfly/dist/js/patternfly.js > $@.tmp && $(MV) $@.tmp $@
-dist/base1/jquery.min.js: dist/base1/jquery.js
+dist/base1/jquery.min.js: dist/base1/jquery.js $(NODE_MODULES_STAMP)
 	$(MIN_JS_RULE)
-dist/base1/cockpit.js: src/base1/cockpit.js
+dist/base1/cockpit.js: src/base1/cockpit.js $(NODE_MODULES_STAMP)
 	$(ESLINT_RULE)
 	$(COPY_RULE)
 dist/base1/cockpit.min.js: dist/base1/cockpit.js
 	$(MIN_JS_RULE)
-dist/base1/mustache.js: src/base1/deprecated.js
+dist/base1/mustache.js: src/base1/deprecated.js $(NODE_MODULES_STAMP)
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cat $(srcdir)/src/base1/deprecated.js $(srcdir)/node_modules/mustache/mustache.js > $@.tmp && $(MV) $@.tmp $@
 dist/base1/mustache.min.js: dist/base1/mustache.js
@@ -59,7 +59,7 @@ dist/base1/patternfly.min.css.map: dist/base1/patternfly.min.css
 
 # Modify the patternfly files appropriately
 dist/base1/patternfly.css.map: dist/base1/patternfly-base.css
-dist/base1/patternfly-base.css: src/base1/patternfly-overrides.less
+dist/base1/patternfly-base.css: src/base1/patternfly-overrides.less $(NODE_MODULES_STAMP)
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	F=$(srcdir)/node_modules/patternfly/dist/less/patternfly.less && \
 	sed '/@import "variables.less"/ s^$$^\n@import "../../../../src/base1/patternfly-overrides.less";^' $$F > $$F.patched && \
@@ -69,7 +69,7 @@ dist/base1/patternfly-base.css: src/base1/patternfly-overrides.less
 	$(MV) $@.tmp $@
 
 dist/base1/patternfly-additions.css.map: dist/base1/patternfly-additions.css
-dist/base1/patternfly-additions.css: src/base1/patternfly-overrides.less
+dist/base1/patternfly-additions.css: src/base1/patternfly-overrides.less $(NODE_MODULES_STAMP)
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	F=$(srcdir)/node_modules/patternfly/dist/less/patternfly-additions.less && \
 	sed '/@import "variables.less"/ s^$$^\n@import "../../../../src/base1/patternfly-overrides.less";^' $$F > $$F.patched && \
@@ -78,13 +78,13 @@ dist/base1/patternfly-additions.css: src/base1/patternfly-overrides.less
 	rm $$F.patched && \
 	$(MV) $@.tmp $@
 
-dist/base1/fonts/fontawesome.woff:
+dist/base1/fonts/fontawesome.woff: $(NODE_MODULES_STAMP)
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cp $(srcdir)/node_modules/patternfly/dist/fonts/fontawesome-webfont.woff $@.tmp && $(MV) $@.tmp $@
-dist/base1/fonts/glyphicons.woff:
+dist/base1/fonts/glyphicons.woff: $(NODE_MODULES_STAMP)
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cp $(srcdir)/node_modules/patternfly/dist/fonts/glyphicons-halflings-regular.woff $@.tmp && $(MV) $@.tmp $@
-dist/base1/fonts/patternfly.woff:
+dist/base1/fonts/patternfly.woff: $(NODE_MODULES_STAMP)
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cp $(srcdir)/node_modules/patternfly/dist/fonts/PatternFlyIcons-webfont.woff $@.tmp && $(MV) $@.tmp $@
 
@@ -133,17 +133,17 @@ base_QUNIT_DEPS = \
 	src/base1/test-dbus-common.js \
 	$(NULL)
 
-dist/base1/qunit.js:
+dist/base1/qunit.js: $(NODE_MODULES_STAMP)
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cat $(srcdir)/node_modules/qunit/qunit/qunit.js \
 	    $(srcdir)/node_modules/qunit-tap/lib/qunit-tap.js \
             $(srcdir)/pkg/lib/qunit-config.js > $@.tmp && $(MV) $@.tmp $@
 
-dist/base1/qunit.css:
+dist/base1/qunit.css:  $(NODE_MODULES_STAMP)
 	$(V_COPY) $(MKDIR_P) $(dir $@) && \
 	cp $(srcdir)/node_modules/qunit/qunit/qunit.css $@.tmp && $(MV) $@.tmp $@
 
-dist/base1/test-dbus-common.js: src/base1/test-dbus-common.js
+dist/base1/test-dbus-common.js: src/base1/test-dbus-common.js $(NODE_MODULES_STAMP)
 	$(ESLINT_RULE)
 	$(COPY_RULE)
 
@@ -168,7 +168,7 @@ base_SIMPLE_DEPS = \
 	src/base1/simple-tap.js \
 	$(NULL)
 
-dist/base1/simple-tap.js: src/base1/simple-tap.js
+dist/base1/simple-tap.js: src/base1/simple-tap.js $(NODE_MODULES_STAMP)
 	$(ESLINT_RULE)
 	$(COPY_RULE)
 

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -6,14 +6,14 @@ LOGIN_PO_FILES = $(patsubst %,dist/static/login.po.%.html,$(LINGUAS))
 staticdir = $(datadir)/cockpit/static
 nodist_static_DATA = dist/static/login.min.html dist/static/login.po.html $(LOGIN_PO_FILES)
 
-dist/static/login.js: src/ws/login.js
+dist/static/login.js: src/ws/login.js $(NODE_MODULES_STAMP)
 	$(ESHINT_RULE)
 	$(COPY_RULE)
 dist/static/login.min.js: dist/static/login.js
 	$(MIN_JS_RULE)
 dist/static/login.css: src/ws/login.css
 	$(COPY_RULE)
-dist/static/login.min.css: dist/static/login.css
+dist/static/login.min.css: dist/static/login.css $(NODE_MODULES_STAMP)
 	$(MIN_CSS_RULE)
 dist/static/login.html: src/ws/login.html dist/static/login.js dist/static/login.css
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
@@ -29,7 +29,7 @@ dist/static/login.min.html: src/ws/login.html dist/static/login.min.js dist/stat
 dist/static/login.po.html: src/ws/po.empty.html
 	$(COPY_RULE)
 
-dist/static/login.po.%.html: src/ws/%.po src/ws/po.empty.html
+dist/static/login.po.%.html: src/ws/%.po src/ws/po.empty.html $(NODE_MODULES_STAMP)
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	$(srcdir)/tools/missing $(srcdir)/po/po2json -m $(srcdir)/src/ws/po.empty.html -o $@.tmp src/ws/$*.po && \
 	$(MV) $@.tmp $@

--- a/tools/npm-install
+++ b/tools/npm-install
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+# skips devDependencies otherwise
+unset NODE_ENV
+
+STAMP=package-lock.json
+
+# if package-lock.json exists already, npm install won't update it;
+# enforce that we always get up-to-date packages
+rm -f "$STAMP"
+
+npm prune
+
+# npm install is flaky, and when it fails, it usually leaves
+# node_modules in a corrupt state, so if that happens, start over
+for retry in `seq 3`; do
+    if env -u NODE_ENV npm install; then
+        break
+    fi
+    find node_modules -mindepth 1 -not -path node_modules/README -delete
+    rm -f "$STAMP"
+done
+
+if ! [ -e "$STAMP" ]; then
+    echo 'failed to install nodejs modules' >&2
+    exit 1
+fi


### PR DESCRIPTION
Running `npm install` just once in autogen.sh will cause our HTML/CSS
pages to not get rebuilt when package.json changes. This can happen when
switching branches in git, or during development when
introducing/updating/dropping NPM modules.

Move npm installation into tools/npm-install, and hook it into the
Makefiles, together with proper dependencies of everything that requires
it. Still keep it in autogen.sh so that a normal `make` will not access
the network.

Ship package-lock.json in our release tarballs. This ensures that
building release tarballs will not try to npm install/webpack again; it
allows consumers of them to reconstruct the exact node_modules/ as it
was on release time (as an alternative of downloading
cockpit-cache-XXX.tar.gz).