### PR TITLE
test: Fix expected error message when failing to stop a MDRAID

### DIFF
--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -77,7 +77,7 @@ class TestStorage(StorageCase):
                         raise
                     print("Stopping failed, retrying...")
                     if self.browser.is_present("#dialog"):
-                        self.browser.wait_in_text("#dialog", "Error stopping RAID array /dev/md127")
+                        self.browser.wait_in_text("#dialog", "Error stopping RAID array")
                         self.dialog_cancel()
                         self.dialog_wait_close()
                     do_click()


### PR DESCRIPTION
The actual text includes quotes around the device name and wouldn't
match.  Let's not look for that part of the sentence at all.