### PR TITLE
naughty: Close 12355: SELinux is preventing sssd_be and cockpit_ssh from search access to krb5

### DIFF
--- a/bots/naughty/rhel-8/12355-selinux-search-krb5
+++ b/bots/naughty/rhel-8/12355-selinux-search-krb5
@@ -1,1 +1,0 @@
-*type=1400 audit(*): avc:  denied  { search } for * comm="sssd_be" name="krb5"

--- a/bots/naughty/rhel-8/12355-selinux-search-krb5-2
+++ b/bots/naughty/rhel-8/12355-selinux-search-krb5-2
@@ -1,1 +1,0 @@
-*type=1400 audit(*): avc:  denied  { search } for * comm="cockpit-ssh" name="krb5"


### PR DESCRIPTION
Known issue which has not occurred in 27 days

SELinux is preventing sssd_be and cockpit_ssh from search access to krb5

Fixes #12355