### PR TITLE
naughty: Close 12228: SELinux is preventing mdadm from 'read' 

### DIFF
--- a/bots/naughty/fedora-30/12228-selinux-mdadm-read
+++ b/bots/naughty/fedora-30/12228-selinux-mdadm-read
@@ -1,1 +1,0 @@
-audit: type=1400 * avc:  denied  { read } * comm="mdadm"


### PR DESCRIPTION
Known issue which has not occurred in 21 days

SELinux is preventing mdadm from 'read' 

Fixes #12228