### PR TITLE
test: Don't test that loopback network traffic is ignored

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -128,15 +128,6 @@ class TestMetrics(MachineCase):
         b.wait_js_func("ph_flot_data_plateau", "#server_disk_io_graph", 100 * 1024, None, 5, "disk io")
         m.execute("kill %d" % disk_pid)
 
-        # Network traffic through loopback. Should be ignored
-        m.spawn("ping -f -c 10000000 -s 50000  127.0.0.1", "load-net-lo.log")
-        try:
-            b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300 * 1000, None, 5, "net io")
-            self.fail("Unexpected traffic graph for localhost")
-        except Error as ex:
-            if not ex.msg.startswith('timeout'):
-                raise
-
         # Network traffic through Ethernet.  Anything above 300 kb/s is good for now.
         #
         ifaces = m.execute(r"ip -o a | awk '{print $2}'")


### PR DESCRIPTION
We can't guarantee that the traffic graph is otherwise idle.