### PR TITLE
package.json: Enforce version on transitively dependant bootstrap-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "patternfly": "3.59.4",
     "patternfly-bootstrap-combobox": "1.1.7",
     "patternfly-react": "2.38.1",
+    "bootstrap-select": "1.13.6",
     "prop-types": "15.7.2",
     "qunit": "2.9.2",
     "qunit-tap": "1.5.1",


### PR DESCRIPTION
Brought by `(patternfly-react >) patternfly > bootstrap-select` chain.
It brought version `1.12.2` which has at least two XSS vulnerabilities.

Fixes #12818

Checked manually and selects work just fine. I'll let bots check it and will see if they agree :)