### PR TITLE
tools: Fail on untranslatable `` strings

### DIFF
--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -49,7 +49,7 @@ fi
 # wrongly marked translatable strings
 #
 
-if out=$(find src/ pkg/ -name '*.js' -o -name '*.jsx' | xargs grep "_('"); then
+if out=$(find src/ pkg/ -name '*.js' -o -name '*.jsx' | xargs grep "_(['\`]"); then
     echo 'ERROR: translatable strings must be marked with _("")' >&2
     echo "$out" >&2
     echo "not ok 3 js-translatable-strings"


### PR DESCRIPTION
` is a valid string delimiter in JS, but xgettext does not recognize
this. Let's fail on these similarly to single quotes.

Related to issue #12835