### PR TITLE
bots: Always keep mock cache for Fedora images

### DIFF
--- a/bots/images/fedora-testing
+++ b/bots/images/fedora-testing
@@ -1,1 +1,1 @@
-fedora-testing-96bb6befc9e4608a4c187bf86fd5455e6ed5256105a01bdea3d272575be8f992.qcow2
+fedora-testing-fedf1d06768b7cb69efbb2ef27ae665161c938d94f844d63de3c3fb20f509b8f.qcow2

--- a/bots/images/scripts/fedora.setup
+++ b/bots/images/scripts/fedora.setup
@@ -187,12 +187,7 @@ fi
 
 # reduce image size
 dnf clean all
-zd_opts=
-# Offline Mock with dnf isn't happy anymore without a cache
-if [ "$IMAGE" = fedora-31 ]; then
-    zd_opts="--keep-mock-cache"
-fi
-/var/lib/testvm/zero-disk.setup $zd_opts
+/var/lib/testvm/zero-disk.setup --keep-mock-cache
 
 ln -sf ../selinux/config /etc/sysconfig/selinux
 printf "SELINUX=enforcing\nSELINUXTYPE=targeted\n" > /etc/selinux/config


### PR DESCRIPTION
Fedora 31 needs this cache, Fedora testing needs it so soon also
Fedora-30 will need it. I think it is just more maintainable to always
keep it.

 * [x] image-refresh fedora-testing

Fixes #12836