### PR TITLE
backport: machines: add missing updateOnly parameter in getStoragePool action

### DIFF
--- a/pkg/machines/actions/provider-actions.js
+++ b/pkg/machines/actions/provider-actions.js
@@ -190,8 +190,8 @@ export function getNodeMaxMemory(connectionName) {
     return virt(GET_NODE_MAX_MEMORY, { connectionName });
 }
 
-export function getStoragePool({ connectionName, id, name }) {
-    return virt(GET_STORAGE_POOL, { connectionName, id, name });
+export function getStoragePool({ connectionName, id, name, updateOnly }) {
+    return virt(GET_STORAGE_POOL, { connectionName, id, name, updateOnly });
 }
 
 export function getStorageVolumes({ connectionName, poolName }) {

--- a/test/README.md
+++ b/test/README.md
@@ -77,6 +77,7 @@ You can set these environment variables to configure the test suite:
                   "rhel-8-0"
                   "rhel-8-0-distropkg"
                   "rhel-8-1"
+                  "rhel-8-1-distropkg"
                   "ubuntu-1804"
                   "ubuntu-stable"
                "fedora-30" is the default (bots/machine/machine_core/constants.py)

--- a/test/verify/check-active-pages
+++ b/test/verify/check-active-pages
@@ -60,7 +60,7 @@ class TestActivePages(MachineCase):
         b.focus(".terminal")
 
         def line_sel(i):
-            if m.image in ["rhel-8-0-distropkg"]:
+            if m.image in ["rhel-8-0-distropkg", "rhel-8-1-distropkg"]:
                 return '.terminal div:nth-child(%d)' % i
             else:
                 return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -436,8 +436,8 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 
     @skipImage("missing socat", "fedora-atomic")
-    @skipImage("Added in PR #11813", "rhel-8-0-distropkg")
-    def testReverseTlsProxy(self):
+    @skipImage("Added in PR #11813 and #12141", "rhel-8-0-distropkg", "rhel-8-1-distropkg")
+    def testReverseProxy(self):
         m = self.machine
         b = self.browser
 

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -26,7 +26,7 @@ from testlib import *
 
 
 @skipPackage("cockpit-docker")
-@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
 class TestDocker(MachineCase):
 
     def setUp(self):
@@ -548,7 +548,7 @@ CMD ["/bin/sh"]
 
     @skipImage("No cockpit-docker on i386", "fedora-i386")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-1804", "fedora-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+               "ubuntu-1804", "fedora-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
     def testContainerProblems(self):
         b = self.browser
         m = self.machine
@@ -590,7 +590,7 @@ CMD ["/bin/sh"]
 
 @skipImage("Skip on systems without atomic and ones with missing deps", "debian-stable",
            "debian-testing", "ubuntu-1804", "ubuntu-stable", "fedora-atomic", "fedora-i386")
-@skipImage("No docker packaged", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+@skipImage("No docker packaged", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
 @skipPackage("cockpit-docker")
 class TestAtomicScan(MachineCase):
 

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -36,7 +36,7 @@ def can_manage(machine):
 
 
 @skipImage("No cockpit-docker on i386", "fedora-i386")
-@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
 @skipPackage("cockpit-docker")
 class TestDockerStorageDirect(MachineCase):
 
@@ -55,7 +55,7 @@ class TestDockerStorageDirect(MachineCase):
 
 
 @skipImage("No cockpit-docker on i386", "fedora-i386")
-@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+@skipImage("No docker packaged", "debian-stable", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
 @skipPackage("cockpit-docker")
 class TestDockerStorage(MachineCase):
     provision = {"machine1": {"address": "10.111.113.1/20"}}

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -388,7 +388,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
 
     @skipImage("ABRT does not work on i386", "fedora-i386")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-1804", "fedora-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+               "ubuntu-1804", "fedora-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
     def testAbrtSegv(self):
         self.allow_core_dumps = True
         b = self.browser
@@ -428,7 +428,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
 
     @skipImage("ABRT does not work on i386", "fedora-i386")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-1804", "fedora-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+               "ubuntu-1804", "fedora-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
     def testAbrtDelete(self):
         self.allow_core_dumps = True
         b = self.browser
@@ -459,7 +459,7 @@ s.send(b"PRIORITY=3\\nFOO=bar\\n")'
 
     @skipImage("ABRT does not work on i386", "fedora-i386")
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-1804", "fedora-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+               "ubuntu-1804", "fedora-atomic", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
     def testAbrtReport(self):
         self.allow_core_dumps = True
         # The testing server is located at verify/files/mock-faf-server.py

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -37,7 +37,7 @@ class TestKdump(MachineCase):
             contents = self.machine.execute(command="cat /boot/grub2/grub.cfg", quiet=True)
             self.assertIn("crashkernel=auto", contents)
             self.machine.write("/boot/grub2/grub.cfg", contents.replace("crashkernel=auto", "crashkernel=256M"))
-        elif self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
+        elif self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg"]:
             # these images use BootLoaderSpec and grubenv
             self.machine.execute(
                 "sed -i '/^kernelopts=/ { s/crashkernel=[^ ]*//; s/$/ crashkernel=256M/; }' /boot/grub2/grubenv")
@@ -83,7 +83,7 @@ class TestKdump(MachineCase):
             else:
                 b.wait_present(".onoff-ct input" + (active and ":checked" or ":not(:checked)"))
 
-        if m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
+        if m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg"]:
             # some OSes have kdump enabled by default (crashkernel=auto)
             b.wait_in_text("#app", "Service is running")
             assertActive(True)

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -154,7 +154,7 @@ class TestFirewall(NetworkCase):
         b.click("caption #add-services-button")
         b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='pop3']")
         # rhel-8 comes with an extra preconfigured libvirt zone
-        if m.image not in ["rhel-8-0", "rhel-8-1", "rhel-8-0-distropkg"]:
+        if m.image not in ["rhel-8-0", "rhel-8-1", "rhel-8-0-distropkg", "rhel-8-1-distropkg"]:
             b.wait_not_present("#cockpit_modal_dialog input[value='public']")
 
         # filter for pop3
@@ -224,7 +224,7 @@ class TestFirewall(NetworkCase):
         # the service which belong to both libvirt and public (and thus
         # requiring checkboxes to be clicked), then remove all the services
         # belonging either libvirt or public
-        if m.image in ["rhel-8-0", "rhel-8-1", "rhel-8-0-distropkg"]:
+        if m.image in ["rhel-8-0", "rhel-8-1", "rhel-8-0-distropkg", "rhel-8-1-distropkg"]:
             libvirt_services = set(m.execute("firewall-cmd --zone=libvirt --list-services").strip().split(" "))
             for service in libvirt_services & services:
                 removeService(service, zones=["libvirt", "public"])
@@ -235,7 +235,7 @@ class TestFirewall(NetworkCase):
                 removeService(service)
 
         self.assertEqual(m.execute("firewall-cmd --list-services").strip(), "")
-        if m.image in ["rhel-8-0", "rhel-8-1", "rhel-8-0-distropkg"]:
+        if m.image in ["rhel-8-0", "rhel-8-1", "rhel-8-0-distropkg", "rhel-8-1-distropkg"]:
             self.assertEqual(m.execute("firewall-cmd --zone=libvirt --list-services").strip(), "")
 
         # test error handling
@@ -269,7 +269,7 @@ class TestFirewall(NetworkCase):
             b.wait_present("#tcp-ports")
             b.wait_visible("#tcp-ports")
             # rhel-8 comes with an extra preconfigured libvirt zone
-            if m.image in ["rhel-8-0", "rhel-8-1", "rhel-8-0-distropkg"]:
+            if m.image in ["rhel-8-0", "rhel-8-1", "rhel-8-0-distropkg", "rhel-8-1-distropkg"]:
                 b.click("#add-services-dialog input[value='public']")
 
         def set_field(sel, val, expected):

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -94,7 +94,7 @@ class TestStorage(StorageCase):
         else:
             check_type("vfat", 11)
 
-        if self.storaged_is_old_udisks or m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
+        if self.storaged_is_old_udisks or m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg"]:
             check_unsupported_type("ntfs")
         else:
             check_type("ntfs", 128)

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -235,7 +235,7 @@ class TestStorage(StorageCase):
         m = self.machine
         b = self.browser
 
-        luks_2 = m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]
+        luks_2 = m.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg"]
         error_base = "Error unlocking /dev/sda: Failed to activate device: "
         error_messages = [error_base + "Operation not permitted",
                           error_base + "Incorrect passphrase."]

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -123,7 +123,7 @@ class TestStorage(StorageCase):
                          can_shrink=False,
                          can_grow=True, grow_needs_unmount=False)
 
-    @skipImage("No NTFS support installed", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+    @skipImage("No NTFS support installed", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
     def testResizeNtfs(self):
         self.checkResize("ntfs", None,
                          can_shrink=True, shrink_needs_unmount=True,
@@ -139,7 +139,7 @@ class TestStorage(StorageCase):
             self.checkResize("ext4", True,
                              can_shrink=True, shrink_needs_unmount=True,
                              can_grow=True, grow_needs_unmount=False,
-                             need_passphrase=(self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]))
+                             need_passphrase=(self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg"]))
 
     def wait_not_present_with_udev_trigger(self, selector):
         # This is fundamentally the same as Brower.wait, but uses a
@@ -272,7 +272,7 @@ class TestStorage(StorageCase):
 
         b.wait_present(vol_tab + " button:contains(Grow Content)")
         self.content_tab_action(1, 1, "Grow Content")
-        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
+        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg"]:
             confirm_with_passphrase()
         self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Grow Content)")
         size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
@@ -287,7 +287,7 @@ class TestStorage(StorageCase):
 
         b.wait_present(vol_tab + " button:contains(Shrink Volume)")
         self.content_tab_action(1, 1, "Shrink Volume")
-        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
+        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg"]:
             confirm_with_passphrase()
         self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Shrink Volume)")
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))
@@ -300,7 +300,7 @@ class TestStorage(StorageCase):
 
         b.wait_present(vol_tab + " button:contains(Grow Content)")
         self.content_tab_action(1, 1, "Grow Content")
-        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
+        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg"]:
             confirm_with_passphrase()
         self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Grow Content)")
         size = int(m.execute("df -k --output=size %s | tail -1" % mountpoint).strip())
@@ -315,7 +315,7 @@ class TestStorage(StorageCase):
 
         b.wait_present(vol_tab + " button:contains(Shrink Volume)")
         self.content_tab_action(1, 1, "Shrink Volume")
-        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
+        if self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg"]:
             confirm_with_passphrase()
         self.wait_not_present_with_udev_trigger(vol_tab + " button:contains(Shrink Volume)")
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -273,7 +273,7 @@ class TestSystemInfo(MachineCase):
         b.mouse('#systime-tooltip', 'mouseout')
         b.wait_not_present('#systime-tooltip ~ div.tooltip')
 
-    @skipImage("No NTP servers config", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1")
+    @skipImage("No NTP servers config", "rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1", "rhel-8-1-distropkg")
     def testTimeServers(self):
         m = self.machine
         b = self.browser
@@ -388,7 +388,7 @@ class TestSystemInfo(MachineCase):
         b.enter_page("/system")
 
         # now pretend this is a system without DMI; fixed in PR #11005
-        if self.machine.image in ['rhel-8-0-distropkg']:
+        if self.machine.image in ['rhel-8-0-distropkg', 'rhel-8-1-distropkg']:
             return
 
         b.logout()

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -36,7 +36,7 @@ class PackageCase(MachineCase):
         # expected backend; hardcode this on image names to check the auto-detection
         if self.machine.image.startswith("debian") or self.machine.image.startswith("ubuntu"):
             self.backend = "apt"
-        elif self.machine.image.startswith("fedora") or self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
+        elif self.machine.image.startswith("fedora") or self.machine.image.startswith("rhel-8"):
             self.backend = "dnf"
         else:
             raise NotImplementedError("unknown image " + self.machine.image)


### PR DESCRIPTION
This missing parameter was causing TestMachines.testStoragePools to fail
sometimes since deleting a pool sometimes didn't remove the entry from the UI.
This reflects a real race condition when deleting an active resource, since
'Stopped' and 'Undefined' events get emited close to each other, which
makes state updates a bit cumbersome.
    
Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1715388
Cherry-picked from maste commit afae77.
    
Closes #12848
