### PR TITLE
eslint: Introduce jsx-a11y plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,6 @@
         "space-before-function-paren": "off",
         "standard/no-callback-literal": "off",
 
-        "jsx-a11y/no-noninteractive-tabindex": "off",
         "jsx-a11y/no-static-element-interactions": "off",
         "jsx-a11y/click-events-have-key-events": "off",
         "jsx-a11y/label-has-associated-control": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
         "browser": true,
         "es6": true
     },
-    "extends": ["eslint:recommended", "standard", "standard-react"],
+    "extends": ["eslint:recommended", "standard", "standard-react", "plugin:jsx-a11y/recommended"],
     "parser": "babel-eslint",
     "parserOptions": {
         "ecmaVersion": "7",
@@ -13,7 +13,7 @@
         },
         "sourceType": "module"
     },
-    "plugins": ["flowtype", "react", "cockpit"],
+    "plugins": ["flowtype", "react", "cockpit", "jsx-a11y"],
     "rules": {
         "indent": ["error", 4,
             {
@@ -46,6 +46,17 @@
         "react/prop-types": "off",
         "space-before-function-paren": "off",
         "standard/no-callback-literal": "off",
+
+        "jsx-a11y/no-noninteractive-tabindex": "off",
+        "jsx-a11y/no-static-element-interactions": "off",
+        "jsx-a11y/click-events-have-key-events": "off",
+        "jsx-a11y/label-has-associated-control": "off",
+        "jsx-a11y/anchor-is-valid": "off",
+        "jsx-a11y/alt-text": "off",
+        "jsx-a11y/no-autofocus": "off",
+        "jsx-a11y/no-noninteractive-element-interactions": "off",
+        "jsx-a11y/no-interactive-element-to-noninteractive-role": "off",
+        "jsx-a11y/no-onchange": "off",
 
         "eqeqeq": "off",
         "import/no-webpack-loader-syntax": "off",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.15.1",
     "eslint-plugin-standard": "^4.0.1",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
     "html-webpack-plugin": "^3.2.0",
     "htmlparser": "^1.7.7",
     "imports-loader": "^0.6.5",

--- a/pkg/lib/cockpit-components-context-menu.jsx
+++ b/pkg/lib/cockpit-components-context-menu.jsx
@@ -99,14 +99,14 @@ export class ContextMenu extends React.Component {
     render() {
         return this.state.visible &&
             <div ref={ ref => { this.root = ref } } className="contextMenu">
-                <div className="contextMenuOption" onClick={this.props.getText}>
+                <button className="contextMenuOption" onClick={this.props.getText}>
                     <div className="contextMenuName"> { _("Copy") } </div>
                     <div className="contextMenuShortcut">{ _("Ctrl+Insert") }</div>
-                </div>
-                <div className="contextMenuOption" onClick={this.props.setText}>
+                </button>
+                <button className="contextMenuOption" onClick={this.props.setText}>
                     <div className="contextMenuName"> { _("Paste") } </div>
                     <div className="contextMenuShortcut">{ _("Shift+Insert") }</div>
-                </div>
+                </button>
             </div>;
     }
 }

--- a/pkg/lib/context-menu.css
+++ b/pkg/lib/context-menu.css
@@ -16,6 +16,8 @@
     font-size: 13px;
     display: flex;
     justify-content: space-between;
+    background-color: transparent;
+    border: none;
 }
 
 .contextMenuOption:hover,

--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -158,11 +158,11 @@ class VmNetworkTab extends React.Component {
             },
             {
                 name: _("Source"), value: (network, networkId) => {
-                    const setSourceClass = (source) => checkDeviceAviability(source) ? "machines-network-source-link" : undefined;
+                    const setSourceClass = (source) => checkDeviceAviability(source) ? "machines-network-source-link link-button" : undefined;
                     const mapSource = {
-                        direct: (source) => <span className={setSourceClass(source.dev)} onClick={sourceJump(source.dev)}>{source.dev}</span>,
-                        network: (source) => <span className={setSourceClass(source.network)} onClick={sourceJump(source.network)}>{source.network}</span>,
-                        bridge: (source) => <span className={setSourceClass(source.bridge)} onClick={sourceJump(source.bridge)}>{source.bridge}</span>,
+                        direct: (source) => <button role="link" className={setSourceClass(source.dev)} onClick={sourceJump(source.dev)}>{source.dev}</button>,
+                        network: (source) => <button role="link" className={setSourceClass(source.network)} onClick={sourceJump(source.network)}>{source.network}</button>,
+                        bridge: (source) => <button role="link" className={setSourceClass(source.bridge)} onClick={sourceJump(source.bridge)}>{source.bridge}</button>,
                         mcast: addressPortSource,
                         server: addressPortSource,
                         client: addressPortSource,

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -119,15 +119,14 @@ class Expander extends React.Component {
     }
 
     render() {
-        const title = <button className="link-button">{this.props.title}</button>;
         const cls = "expander-caret fa " + (this.state.expanded ? "fa-angle-down" : "fa-angle-right");
         return (
             <>
                 <div className="expander-title">
                     <hr />
-                    <span onClick={() => this.setState({ expanded: !this.state.expanded })}>
-                        <i className={cls} />{title}
-                    </span>
+                    <button className="link-button" onClick={() => this.setState({ expanded: !this.state.expanded })}>
+                        <i className={cls} />{this.props.title}
+                    </button>
                     <hr />
                 </div>
                 {this.state.expanded ? this.props.children : null}

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -55,7 +55,7 @@ export class PageStatusNotifications extends React.Component {
             const jump = () => cockpit.jump("/" + page);
             return (
                 <span>
-                    <span className={icon_class_for_type(status.type)} /> <a onClick={jump}>{status.title}</a>
+                    <span className={icon_class_for_type(status.type)} /> <button className="link-button" role="link" onClick={jump}>{status.title}</button>
                 </span>);
         } else {
             this.props.toggle_label(false);

--- a/pkg/tuned/change-profile.jsx
+++ b/pkg/tuned/change-profile.jsx
@@ -106,31 +106,3 @@ TunedDialogBody.propTypes = {
     change_selected: PropTypes.func.isRequired,
     profiles: PropTypes.array.isRequired,
 };
-
-export class TunedLink extends React.Component {
-    render() {
-        var self = this;
-
-        var text = self.props.active;
-        var disabled = false;
-
-        if (self.props.failed) {
-            text = _("tuned-failure", "error");
-            disabled = true;
-        } else if (self.props.state != "running") {
-            text = _("tuned-not-running", "none");
-        }
-
-        if (self.props.state == "not-installed")
-            disabled = true;
-
-        var opts = { };
-        var classes = "action-trigger";
-        if (disabled) {
-            opts.disabled = 'disabled';
-            classes += " disabled";
-        }
-
-        return <a tabIndex="0" className={ classes } {...opts}>{ text }</a>;
-    }
-}

--- a/pkg/tuned/change-profile.jsx
+++ b/pkg/tuned/change-profile.jsx
@@ -41,11 +41,11 @@ class TunedDialogProfile extends React.Component {
         if (this.props.recommended)
             recommended = <span className="badge pull-right">{ _("recommended") }</span>;
         return (
-            <div className={ classes } key={ this.props.name } onClick={ this.props.click }>
+            <button className={ classes } key={ this.props.name } onClick={ this.props.click }>
                 {recommended}
                 <p>{ this.props.title }</p>
                 <small>{ this.props.description }</small>
-            </div>
+            </button>
         );
     }
 }

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -192,7 +192,7 @@ class TestUpdates(PackageCase):
         # update log only exists in the expander, collapsed by default
         self.assertFalse(b.is_present("#update-log"))
         # expand it
-        b.click(".expander-title span")
+        b.click(".expander-title button")
         # should eventually show chocolate when vanilla starts installing
         b.wait_in_text("#update-log", "chocolate")
 
@@ -350,7 +350,7 @@ class TestUpdates(PackageCase):
             self.assertFalse(b.is_present(selector.format(len(updates) + 1)))
 
         # history on restart page should show the three security updates
-        b.click(".expander-title span")
+        b.click(".expander-title button")
         assertHistory("ul", ["secdeclare", "secparse", "sevcritical"])
 
         # ignore restarting
@@ -390,7 +390,7 @@ class TestUpdates(PackageCase):
         m.execute("test -f /stamp-norefs-bin-2-1 && test -f /stamp-norefs-doc-2-1")
 
         # history on restart page should show the three non-security updates
-        b.click(".expander-title span")
+        b.click(".expander-title button")
         assertHistory("ul", ["buggy", "norefs-bin", "norefs-doc"])
 
         # do the reboot; this will disconnect the web UI


### PR DESCRIPTION
I found this eslint plugin which can check accessibility in jsx elements.
I thought it could be useful for us - I know it can only check react components, but as we write new things in react and also slowly port some older stuff into react as well, in a long run it could be able to check bigger and bigger part of Cockpit accessibility.

~Currently it found 121 issues in 11 rules:~ (some fixed in #12879)
Currently it found 62 issues in 10 rules:
`jsx-a11y/click-events-have-key-events` 16 times 
`jsx-a11y/anchor-is-valid` 13 times                                                                                
`jsx-a11y/no-static-element-interactions` 11 times                            
`jsx-a11y/alt-text` 8 times   
`jsx-a11y/label-has-associated-control` 5 times 
`jsx-a11y/no-autofocus` 3 times                                                          
`jsx-a11y/no-noninteractive-tabindex` 2 times     
 `jsx-a11y/no-noninteractive-element-interactions` 2 times                                                                          
`jsx-a11y/no-interactive-element-to-noninteractive-role` 1 time                                         
`jsx-a11y/no-onchange` 1 time     

The rules are explained [here](https://github.com/evcohen/eslint-plugin-jsx-a11y#supported-rules)
For example, the rule we break the most is related to an open issue we have https://github.com/cockpit-project/cockpit/issues/8627

I disabled all rules, but that is not the state I want to land this in. When/If this lands, at least some rules should be fixed and others fixed in follow ups.

@jgiardino @garrett what do you think about this?
We "have" axe testing (which is run on one test and we don't check the result), which would possibly make this unnecessary - but this seems like easy way how to get better and how to immediately see when writing some a11y-broken elements.