### PR TITLE
test: Run Selenium Edge test without cockpit-tls

### DIFF
--- a/test/selenium/run-tests
+++ b/test/selenium/run-tests
@@ -239,6 +239,7 @@ class SeleniumTestSuite(AvocadoTestSuite):
                       ]
 
     def __init__(self, browser, **kwargs):
+        self.browser = browser
         super().__init__(**kwargs)
         self.env["HUB"] = self.ipaddr_selenium
         self.env["GUEST"] = self.ipaddr_cockpit
@@ -250,6 +251,9 @@ class SeleniumTestSuite(AvocadoTestSuite):
         super()._cockpit_prepare()
         self._prepare_kdump_test()
         self._prepare_machines_test_env()
+        if self.browser == 'edge':
+            # HACK: Edge does not get along with cockpit-tls async buffering; will be fixed with https://projects.engineering.redhat.com/browse/COCKPIT-473
+            self.machine_cockpit.execute("sed -i 's/cockpit-tls/cockpit-ws/' /etc/systemd/system/cockpit.service.d/notls.conf; systemctl daemon-reload")
 
     def cleanup(self):
         super().cleanup()


### PR DESCRIPTION
cockpit-tls handles packet I/O asynchronously and single-threaded, which
causes the individual packets to have some pauses in between. This
triggers a bug in Edge that overzealously starts parsing the input
before reading the input is complet, and then sometimes stumbles over
alleged syntax errors like "SCRIPT ERROR: Expected ;" (which will be in
the subsequent packet).

This will be fixed with making cockpit-tls handle each connection in a
new thread (COCKPIT-473).

In the meantime, run the Edge test with cockpit-ws, to stop the
selenium-edge test from failing consistently.